### PR TITLE
fix(subscription): Make sure terminated invoice always comes with the right boundaries

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -222,8 +222,8 @@ class Invoice < ApplicationRecord
       charge: fee.charge,
       subscription: fee.subscription,
       boundaries: {
-        from_datetime: DateTime.parse(fee.properties['charges_from_datetime']),
-        to_datetime: DateTime.parse(fee.properties['charges_to_datetime']),
+        from_datetime: Time.zone.parse(fee.properties['charges_from_datetime']),
+        to_datetime: Time.zone.parse(fee.properties['charges_to_datetime']),
         charges_duration: fee.properties['charges_duration']
       },
       filters:

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -169,7 +169,11 @@ class Subscription < ApplicationRecord
     return false unless terminated?
     return false if terminated_at.nil? || timestamp.nil?
 
-    terminated_at <= timestamp
+    # TODO: should be cleaued up to only use Time
+    timestamp = timestamp.to_time if [Date, DateTime, String].include?(timestamp.class)
+    timestamp = Time.zone.at(timestamp) if timestamp.is_a?(Integer)
+
+    terminated_at.round <= timestamp.round
   end
 end
 

--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -51,7 +51,7 @@ module Fees
 
       @date_service ||= Subscriptions::DatesService.new_instance(
         subscription,
-        boundaries.timestamp || Time.current,
+        boundaries.timestamp ? Time.zone.parse(boundaries.timestamp) : Time.current,
         current_usage: subscription.terminated? && subscription.upgraded?
       )
     end

--- a/app/services/invoices/create_invoice_subscription_service.rb
+++ b/app/services/invoices/create_invoice_subscription_service.rb
@@ -133,7 +133,7 @@ module Invoices
       # NOTE: upgrading is used as a not persisted reason as it means
       #       one subscription starting and a second one terminating
       return invoicing_reason if invoicing_reason.to_sym != :upgrading
-      return :subscription_terminating if subscription.terminated? && subscription.terminated_at <= timestamp
+      return :subscription_terminating if subscription.terminated_at?(timestamp)
 
       :subscription_starting
     end

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -15,7 +15,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     let(:plan) { create(:plan, organization:, amount_cents: 3500, pay_in_advance: true, trial_period: 7) }
 
     it 'creates an invoice for the expected period' do
-      travel_to(DateTime.new(2024, 3, 4, 21)) do
+      travel_to(Time.zone.parse('2024-03-04T21:00:00')) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -28,14 +28,14 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
       expect(subscription.invoices.count).to eq(0)
 
-      travel_to(DateTime.new(2024, 3, 11, 22)) do
+      travel_to(Time.zone.parse('2024-03-11T22:00:00')) do
         perform_billing
       end
 
       invoice = subscription.invoices.first
       expect(invoice.total_amount_cents).to eq(2371) # (31 - 3 - 7) * 35 / 31
 
-      travel_to(DateTime.new(2024, 3, 11, 23)) do
+      travel_to(Time.zone.parse('2024-03-11T23:00:00')) do
         terminate_subscription(subscription)
       end
 
@@ -45,7 +45,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       expect(invoice.reload.credit_notes.count).to eq(1)
       expect(invoice.credit_notes.first.total_amount_cents).to eq(2371)
 
-      travel_to(DateTime.new(2024, 3, 11, 23, 5)) do
+      travel_to(Time.zone.parse('2024-03-11T23:05:00')) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -68,7 +68,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: 'weekly') }
 
     it 'creates an invoice for the expected period' do
-      travel_to(DateTime.new(2023, 6, 16, 5)) do
+      travel_to(Time.zone.parse('2023-06-16T05:00:00')) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -91,7 +91,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: 'weekly') }
 
     it 'creates an invoice for the expected period' do
-      travel_to(DateTime.new(2023, 6, 16, 5)) do
+      travel_to(Time.zone.parse('2023-06-16T05:00:00')) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -114,7 +114,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: 'weekly') }
 
     it 'creates an invoice for the expected period' do
-      travel_to(DateTime.new(2023, 6, 16, 20)) do
+      travel_to(Time.zone.parse('2023-06-16T20:00:00')) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -137,7 +137,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: 'weekly') }
 
     it 'creates an invoice for the expected period' do
-      travel_to(DateTime.new(2023, 6, 16, 20)) do
+      travel_to(Time.zone.parse('2023-06-16T20:00:00')) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -160,7 +160,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: 'monthly') }
 
     it 'creates an invoice for the expected period' do
-      travel_to(DateTime.new(2023, 6, 16, 5)) do
+      travel_to(Time.zone.parse('2023-06-16T05:00:00')) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -173,7 +173,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       subscription = customer.subscriptions.first
 
-      travel_to(DateTime.new(2024, 2, 1, 12, 12)) do
+      travel_to(Time.zone.parse('2024-02-01T12:12:00')) do
         Subscriptions::BillingService.call
         perform_all_enqueued_jobs
 
@@ -198,7 +198,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
     it 'creates invoices with correctly attached amounts and reasons' do
       ### 24 Apr: Create subscription + charge.
-      apr24_10 = DateTime.parse('2024-4-24 10:00:00')
+      apr24_10 = Time.zone.parse('2024-04-24T10:00:00')
 
       travel_to(apr24_10) do
         create(
@@ -227,7 +227,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.active.first
 
       ### 24 Apr: Upgrade subscription
-      apr24_11 = DateTime.parse('2024-4-24 11:00:00')
+      apr24_11 = Time.zone.parse('2024-04-24T11:00:00')
 
       travel_to(apr24_11) do
         expect {
@@ -256,7 +256,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       latest_subscription = customer.subscriptions.active.order(created_at: :desc).first
 
       ### 26 Apr: Terminate subscription
-      apr26_11 = DateTime.parse('2024-4-26 11:00:00')
+      apr26_11 = Time.zone.parse('2024-04-26T11:00:00')
 
       travel_to(apr26_11) do
         expect {
@@ -285,7 +285,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
     it 'does not update the invoice amount on refresh' do
       ### 15 Dec: Create subscription + charge.
-      dec15 = DateTime.new(2022, 12, 15)
+      dec15 = Time.zone.parse('2022-12-15')
 
       travel_to(dec15) do
         create_subscription(
@@ -302,7 +302,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = DateTime.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse('2022-12-20T06:00:00')
 
       travel_to(dec20) do
         expect {
@@ -330,7 +330,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
     it 'does bill the charges' do
       ### 15 Dec: Create subscription + charge.
-      dec15 = DateTime.new(2022, 12, 15)
+      dec15 = Time.zone.parse('2022-12-15')
 
       travel_to(dec15) do
         create(
@@ -354,7 +354,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = DateTime.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse('2022-12-20 06:00:00')
 
       travel_to(dec20) do
         expect {
@@ -377,7 +377,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
     it 'does bill the charges' do
       ### 15 Dec: Create subscription + charge.
-      dec15 = DateTime.new(2022, 12, 15)
+      dec15 = Time.zone.parse('2022-12-15')
 
       travel_to(dec15) do
         create(
@@ -401,7 +401,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = DateTime.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse('2022-12-20 06:00:00')
 
       travel_to(dec20) do
         expect {
@@ -421,7 +421,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
     it 'creates subscription fee and adds it to the invoice' do
       ### 15 Dec: Create subscription + charge.
-      dec15 = DateTime.new(2022, 12, 15)
+      dec15 = Time.zone.parse('2022-12-15')
 
       travel_to(dec15) do
         create_subscription(
@@ -436,7 +436,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = DateTime.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse('2022-12-20 06:00:00')
 
       travel_to(dec20) do
         expect {
@@ -460,7 +460,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
     it 'does bill the charges' do
       ### 15 Dec: Create subscription + charge.
-      dec15 = DateTime.new(2022, 12, 15)
+      dec15 = Time.zone.parse('2022-12-15')
 
       travel_to(dec15) do
         create(
@@ -484,7 +484,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Upgrade subscription
-      dec20 = DateTime.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse('2022-12-20 06:00:00')
 
       travel_to(dec20) do
         expect {
@@ -514,7 +514,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
     it 'does not bill the charges' do
       ### 15 Dec: Create subscription + charge.
-      dec15 = DateTime.new(2022, 12, 15)
+      dec15 = Time.zone.parse('2022-12-15')
 
       travel_to(dec15) do
         create(
@@ -538,7 +538,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Upgrade subscription
-      dec20 = DateTime.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse('2022-12-20 06:00:00')
 
       travel_to(dec20) do
         create(
@@ -576,7 +576,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
     it 'does not bill the charges' do
       ### 15 Dec: Create subscription + charge.
-      dec15 = DateTime.new(2022, 12, 15)
+      dec15 = Time.zone.parse('2022-12-15')
 
       travel_to(dec15) do
         create(
@@ -600,7 +600,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = DateTime.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse('2022-12-20 06:00:00')
 
       travel_to(dec20) do
         expect {
@@ -624,7 +624,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
 
     it 'bills fees correctly' do
-      travel_to(DateTime.new(2024, 1, 1)) do
+      travel_to(Time.zone.parse('2024-01-01T00:00:00')) do
         create(
           :standard_charge,
           plan:,
@@ -655,7 +655,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       subscription = customer.subscriptions.first
 
-      travel_to(DateTime.new(2024, 1, 2)) do
+      travel_to(Time.zone.parse('2024-01-02T00:00:00')) do
         create_event(
           {
             code: metric.code,
@@ -666,12 +666,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         )
       end
 
-      travel_to(DateTime.new(2024, 2, 1)) do
+      travel_to(Time.zone.parse('2024-02-01T00:00:00')) do
         Subscriptions::BillingService.call
         perform_all_enqueued_jobs
       end
 
-      travel_to(DateTime.parse('2024-02-12 06:00:00')) do
+      travel_to(Time.zone.parse('2024-02-12T06:00:00')) do
         expect {
           create_subscription(
             {
@@ -692,7 +692,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         expect(invoice.total_amount_cents).to eq(18_000 + 190 - 1_800) # 11/29 x 500 = 172
       end
 
-      travel_to(DateTime.new(2024, 3, 1, 12, 12)) do
+      travel_to(Time.zone.parse('2024-03-01T12:12:00')) do
         Subscriptions::BillingService.call
         perform_all_enqueued_jobs
 
@@ -713,7 +713,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
 
     it 'bills fees correctly' do
-      travel_to(DateTime.new(2024, 1, 1)) do
+      travel_to(Time.zone.parse('2024-01-01T00:00:00')) do
         create(
           :standard_charge,
           plan:,
@@ -744,7 +744,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       subscription = customer.subscriptions.first
 
-      travel_to(DateTime.new(2024, 1, 2)) do
+      travel_to(Time.zone.parse('2024-01-02T00:00:00')) do
         create_event(
           {
             code: metric.code,
@@ -755,12 +755,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         )
       end
 
-      travel_to(DateTime.new(2024, 2, 1)) do
+      travel_to(Time.zone.parse('2024-02-01T00:00:00')) do
         Subscriptions::BillingService.call
         perform_all_enqueued_jobs
       end
 
-      travel_to(DateTime.parse('2024-02-12 06:00:00')) do
+      travel_to(Time.zone.parse('2024-02-12T06:00:00')) do
         expect {
           create_subscription(
             {
@@ -779,7 +779,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         expect(terminated_invoice.total_amount_cents).to eq((1_100 + (11.fdiv(29) * 500)).round) # 11 + 10/29 x 5
       end
 
-      travel_to(DateTime.new(2024, 3, 1, 12, 12)) do
+      travel_to(Time.zone.parse('2024-03-01T12:12:00')) do
         Subscriptions::BillingService.call
         perform_all_enqueued_jobs
 
@@ -800,7 +800,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
 
     it 'bills fees correctly' do
-      travel_to(DateTime.new(2024, 1, 10, 6, 20)) do
+      travel_to(Time.zone.parse('2024-01-10T06:20:00')) do
         create(
           :standard_charge,
           plan:,
@@ -831,7 +831,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       subscription = customer.subscriptions.first
 
-      travel_to(DateTime.new(2024, 1, 10, 8, 20)) do
+      travel_to(Time.zone.parse('2024-01-10T08:20:00')) do
         create_event(
           {
             code: metric.code,
@@ -847,7 +847,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         expect(json[:customer_usage][:charges_usage][0][:units]).to eq('10.0')
       end
 
-      travel_to(DateTime.new(2024, 1, 10, 8, 30)) do
+      travel_to(Time.zone.parse('2024-01-10T08:30:00')) do
         expect {
           create_subscription(
             {
@@ -874,7 +874,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       active_subscription = customer.subscriptions.active.first
 
-      travel_to(DateTime.new(2024, 1, 10, 8, 35)) do
+      travel_to(Time.zone.parse('2024-01-10T08:35:00')) do
         create_event(
           {
             code: metric.code,
@@ -890,7 +890,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         expect(json[:customer_usage][:charges_usage][0][:units]).to eq('10000.0')
       end
 
-      travel_to(DateTime.new(2024, 1, 10, 8, 40)) do
+      travel_to(Time.zone.parse('2024-01-10T08:40:00')) do
         expect {
           create_subscription(
             {
@@ -927,7 +927,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
 
     it 'bills fees correctly' do
-      travel_to(DateTime.new(2024, 1, 1)) do
+      travel_to(Time.zone.parse('2024-01-01T00:00:00')) do
         create(
           :standard_charge,
           plan:,
@@ -958,7 +958,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       subscription = customer.subscriptions.first
 
-      travel_to(DateTime.new(2024, 1, 2)) do
+      travel_to(Time.zone.parse('2024-01-02T00:00:00')) do
         create_event(
           {
             code: metric.code,
@@ -969,12 +969,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         )
       end
 
-      travel_to(DateTime.new(2024, 2, 1)) do
+      travel_to(Time.zone.parse('2024-02-01T00:00:00')) do
         Subscriptions::BillingService.call
         perform_all_enqueued_jobs
       end
 
-      travel_to(DateTime.parse('2024-02-12 06:00:00')) do
+      travel_to(Time.zone.parse('2024-02-12T06:00:00')) do
         expect {
           terminate_subscription(subscription)
           perform_all_enqueued_jobs
@@ -999,7 +999,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     let(:metric) { create(:billable_metric, organization:) }
 
     it 'bills fees correctly' do
-      travel_to(DateTime.parse('2024-02-01 03:00:00')) do
+      travel_to(Time.zone.parse('2024-02-01T03:00:00')) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -1013,7 +1013,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
       first_invoice = subscription.invoices.first
 
-      travel_to(DateTime.parse('2024-02-01 18:00:00')) do
+      travel_to(Time.zone.parse('2024-02-01T18:00:00')) do
         expect {
           terminate_subscription(subscription)
           perform_all_enqueued_jobs
@@ -1033,7 +1033,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       it 'bills the usage correctly' do
         create(:standard_charge, plan:, billable_metric: metric, properties: {amount: '12'})
 
-        travel_to(DateTime.parse('2024-02-01 03:00:00')) do
+        travel_to(Time.zone.parse('2024-02-01 03:00:00')) do
           create_subscription(
             {
               external_customer_id: customer.external_id,
@@ -1046,7 +1046,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         subscription = customer.subscriptions.first
         first_invoice = subscription.invoices.first
 
-        travel_to(DateTime.parse('2024-02-01 10:00:00')) do
+        travel_to(Time.zone.parse('2024-02-01 10:00:00')) do
           create_event(
             {
               code: metric.code,
@@ -1057,7 +1057,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           )
         end
 
-        travel_to(DateTime.parse('2024-02-01 18:00:00')) do
+        travel_to(Time.zone.parse('2024-02-01 18:00:00')) do
           expect {
             terminate_subscription(subscription)
             perform_all_enqueued_jobs
@@ -1092,7 +1092,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     around { |test| lago_premium!(&test) }
 
     it 'bills fees correctly' do
-      travel_to(DateTime.new(2024, 1, 1)) do
+      travel_to(Time.zone.parse('2024-01-01T00:00:00')) do
         create(
           :standard_charge,
           plan:,
@@ -1117,7 +1117,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       finalize_invoice(first_invoice)
 
-      travel_to(DateTime.new(2024, 1, 2)) do
+      travel_to(Time.zone.parse('2024-01-02T00:00:00')) do
         create_event(
           {
             code: metric.code,
@@ -1128,14 +1128,14 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         )
       end
 
-      travel_to(DateTime.new(2024, 2, 1)) do
+      travel_to(Time.zone.parse('2024-02-01T00:00:00')) do
         Subscriptions::BillingService.call
         perform_all_enqueued_jobs
 
         finalize_invoice(subscription.invoices.order(created_at: :desc).first)
       end
 
-      travel_to(DateTime.parse('2024-02-12 06:00:00')) do
+      travel_to(Time.zone.parse('2024-02-12T06:00:00')) do
         expect {
           terminate_subscription(subscription)
           perform_all_enqueued_jobs
@@ -1187,7 +1187,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       it 'bills fees correctly' do
-        travel_to(DateTime.parse('2024-02-12 06:00:00')) do
+        travel_to(Time.zone.parse('2024-02-12T06:00:00')) do
           create(
             :standard_charge,
             plan:,
@@ -1215,7 +1215,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
         subscription = customer.subscriptions.first
 
-        travel_to(DateTime.parse('2024-02-12 21:00:00')) do
+        travel_to(Time.zone.parse('2024-02-12T21:00:00')) do
           expect {
             terminate_subscription(subscription)
             perform_all_enqueued_jobs
@@ -1268,7 +1268,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       it 'bills fees correctly' do
-        travel_to(DateTime.parse('2024-02-12 06:00:00')) do
+        travel_to(Time.zone.parse('2024-02-12 06:00:00')) do
           create(
             :standard_charge,
             plan:,
@@ -1296,7 +1296,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
         subscription = customer.subscriptions.first
 
-        travel_to(DateTime.parse('2024-02-12 21:00:00')) do
+        travel_to(Time.zone.parse('2024-02-12T21:00:00')) do
           expect {
             terminate_subscription(subscription)
             perform_all_enqueued_jobs
@@ -1351,7 +1351,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
 
     it 'bills fees correctly' do
-      travel_to(DateTime.new(2024, 1, 1)) do
+      travel_to(Time.zone.parse('2024-01-01T00:00:00')) do
         create(
           :standard_charge,
           plan:,
@@ -1382,7 +1382,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       subscription = customer.subscriptions.first
 
-      travel_to(DateTime.new(2024, 1, 2)) do
+      travel_to(Time.zone.parse('2024-01-02T00:00:00')) do
         create_event(
           {
             code: metric.code,
@@ -1393,7 +1393,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         )
       end
 
-      travel_to(DateTime.parse('2024-02-12 06:00:00')) do
+      travel_to(Time.zone.parse('2024-02-12T06:00:00')) do
         expect {
           terminate_subscription(subscription)
           perform_all_enqueued_jobs
@@ -1414,7 +1414,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
     it 'terminates the pay in advance subscription with credit note lesser than amount' do
       ### 15 Dec: Create subscription + charge.
-      dec15 = DateTime.new(2022, 12, 15)
+      dec15 = Time.zone.parse('2022-12-15')
 
       travel_to(dec15) do
         create_subscription(
@@ -1433,7 +1433,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       expect(subscription_invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
 
       ### 17 Dec: Create event + refresh.
-      travel_to(DateTime.new(2022, 12, 17)) do
+      travel_to(Time.zone.parse('2022-12-17')) do
         create(
           :event,
           organization_id: organization.id,
@@ -1453,7 +1453,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = DateTime.new(2022, 12, 20)
+      dec20 = Time.zone.parse('2022-12-20')
 
       travel_to(dec20) do
         expect {
@@ -1508,7 +1508,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
     it 'terminates the pay in advance subscription with credit note greater than amount' do
       ### 15 Dec: Create subscription + charge.
-      dec15 = DateTime.new(2022, 12, 15)
+      dec15 = Time.zone.parse('2022-12-15')
 
       travel_to(dec15) do
         create_subscription(
@@ -1528,7 +1528,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       expect(subscription_invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
 
       ### 17 Dec: Create event + refresh.
-      travel_to(DateTime.new(2022, 12, 17)) do
+      travel_to(Time.zone.parse('2022-12-17')) do
         create(
           :event,
           organization_id: organization.id,
@@ -1542,7 +1542,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = DateTime.new(2022, 12, 20)
+      dec20 = Time.zone.parse('2022-12-20')
 
       travel_to(dec20) do
         expect {
@@ -1595,7 +1595,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
     it 'refreshes and finalizes invoices' do
       ### 15 Dec: Create subscription + charge.
-      dec15 = DateTime.new(2022, 12, 15)
+      dec15 = Time.zone.parse('2022-12-15')
 
       travel_to(dec15) do
         create(:standard_charge, plan:, billable_metric: metric, properties: {amount: '1'})
@@ -1614,7 +1614,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       expect(invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
 
       ### 16 Dec: Create event + refresh.
-      travel_to(DateTime.new(2022, 12, 16)) do
+      travel_to(Time.zone.parse('2022-12-16')) do
         create_event(
           {
             code: metric.code,
@@ -1631,7 +1631,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       ### 17 Dec: Create event + refresh.
-      travel_to(DateTime.new(2022, 12, 17)) do
+      travel_to(Time.zone.parse('2022-12-17')) do
         create_event(
           {
             code: metric.code,
@@ -1648,7 +1648,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       ### 1 Jan: Billing + refresh + finalize.
-      travel_to(DateTime.new(2023, 1, 1)) do
+      travel_to(Time.zone.parse('2023-01-01')) do
         perform_billing
 
         expect(subscription.invoices.count).to eq(2)
@@ -1660,7 +1660,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            timestamp: DateTime.parse('2022-12-18').to_i,
+            timestamp: Time.zone.parse('2022-12-18').to_i,
             organization_id: organization.id,
             external_subscription_id: subscription.external_id
           }

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
     )
   end
 
-  let(:subscription_at) { DateTime.parse('2022-12-01 00:00:00') }
+  let(:subscription_at) { Time.zone.parse('2022-12-01 00:00:00') }
   let(:started_at) { subscription_at }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
@@ -54,8 +54,8 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
     )
   end
 
-  let(:from_datetime) { DateTime.parse('2023-05-01 00:00:00') }
-  let(:to_datetime) { DateTime.parse('2023-05-31 23:59:59') }
+  let(:from_datetime) { Time.zone.parse('2023-05-01 00:00:00') }
+  let(:to_datetime) { Time.zone.parse('2023-05-31 23:59:59') }
 
   let(:old_events) do
     create_list(
@@ -126,7 +126,7 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
             status: :terminated
           )
         end
-        let(:to_datetime) { DateTime.parse('2023-05-30 23:59:59') }
+        let(:to_datetime) { Time.zone.parse('2023-05-30 23:59:59') }
 
         it 'returns the detail the persisted metrics' do
           aggregate_failures do
@@ -143,7 +143,7 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
       end
 
       context 'when subscription was started in the period' do
-        let(:started_at) { DateTime.parse('2023-05-03') }
+        let(:started_at) { Time.zone.parse('2023-05-03') }
         let(:old_events) { nil }
         let(:from_datetime) { started_at }
 

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
   describe '#call' do
     context 'when subscription is billed on anniversary date' do
-      let(:timestamp) { DateTime.parse('07 Mar 2022') }
-      let(:started_at) { DateTime.parse('06 Jun 2021').to_date }
+      let(:timestamp) { Time.zone.parse('07 Mar 2022') }
+      let(:started_at) { Time.zone.parse('06 Jun 2021').to_date }
       let(:subscription_at) { started_at }
       let(:billing_time) { :anniversary }
 
@@ -110,8 +110,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
           invoice_subscription = invoice.invoice_subscriptions.first
           expect(invoice_subscription).to have_attributes(
-            to_datetime: match_datetime(DateTime.parse('2022-03-05 23:59:59')),
-            from_datetime: match_datetime(DateTime.parse('2022-02-06 00:00:00'))
+            to_datetime: match_datetime(Time.zone.parse('2022-03-05 23:59:59')),
+            from_datetime: match_datetime(Time.zone.parse('2022-02-06 00:00:00'))
           )
         end
       end
@@ -849,8 +849,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       end
 
       context 'when subscription is billed on anniversary date' do
-        let(:timestamp) { DateTime.parse('22 Mar 2022') }
-        let(:started_at) { DateTime.parse('2021-06-06 05:00:00') }
+        let(:timestamp) { Time.zone.parse('22 Mar 2022') }
+        let(:started_at) { Time.zone.parse('2021-06-06 05:00:00') }
         let(:subscription_at) { started_at }
         let(:billing_time) { 'anniversary' }
 
@@ -865,7 +865,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
                 to_datetime: match_datetime(terminated_at),
-                from_datetime: match_datetime(DateTime.parse('2022-03-06 00:00:00'))
+                from_datetime: match_datetime(Time.zone.parse('2022-03-06 00:00:00'))
               )
             end
           end
@@ -896,7 +896,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
                 to_datetime: match_datetime(terminated_at),
-                from_datetime: match_datetime(DateTime.parse('2022-03-06 00:00:00'))
+                from_datetime: match_datetime(Time.zone.parse('2022-03-06 00:00:00'))
               )
             end
           end
@@ -918,8 +918,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       let(:pay_in_advance) { true }
 
       context 'when billed on anniversary date' do
-        let(:timestamp) { DateTime.parse('07 Mar 2022') }
-        let(:started_at) { DateTime.parse('06 Jun 2021').to_date }
+        let(:timestamp) { Time.zone.parse('07 Mar 2022') }
+        let(:started_at) { Time.zone.parse('06 Jun 2021').to_date }
         let(:subscription_at) { started_at }
         let(:billing_time) { :anniversary }
 
@@ -936,8 +936,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
-                to_datetime: match_datetime(DateTime.parse('2022-04-05 23:59:59')),
-                from_datetime: match_datetime(DateTime.parse('2022-03-06 00:00:00'))
+                to_datetime: match_datetime(Time.zone.parse('2022-04-05 23:59:59')),
+                from_datetime: match_datetime(Time.zone.parse('2022-03-06 00:00:00'))
               )
             end
           end
@@ -970,8 +970,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
-                to_datetime: match_datetime(DateTime.parse('2022-04-05 23:59:59')),
-                from_datetime: match_datetime(DateTime.parse('2022-03-06 00:00:00'))
+                to_datetime: match_datetime(Time.zone.parse('2022-04-05 23:59:59')),
+                from_datetime: match_datetime(Time.zone.parse('2022-03-06 00:00:00'))
               )
             end
           end
@@ -1196,9 +1196,9 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           )
         end
 
-        let(:started_at) { DateTime.parse('07 Mar 2022') }
-        let(:terminated_at) { DateTime.parse('17 Oct 2022 12:35:12') }
-        let(:timestamp) { DateTime.parse('17 Oct 2022 15:00') }
+        let(:started_at) { Time.zone.parse('07 Mar 2022') }
+        let(:terminated_at) { Time.zone.parse('17 Oct 2022 12:35:12') }
+        let(:timestamp) { Time.zone.parse('17 Oct 2022 15:00') }
 
         let(:subscription) do
           create(
@@ -1228,7 +1228,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
-                charges_from_datetime: match_datetime(DateTime.parse('2022-10-01 00:00:00')),
+                charges_from_datetime: match_datetime(Time.zone.parse('2022-10-01 00:00:00')),
                 charges_to_datetime: match_datetime(terminated_at)
               )
             end
@@ -1262,7 +1262,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
                 invoice_subscription = invoice.invoice_subscriptions.first
                 expect(invoice_subscription).to have_attributes(
-                  charges_from_datetime: match_datetime(DateTime.parse('2022-10-01 00:00:00')),
+                  charges_from_datetime: match_datetime(Time.zone.parse('2022-10-01 00:00:00')),
                   charges_to_datetime: match_datetime(terminated_at)
                 )
               end
@@ -1305,8 +1305,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       end
 
       context 'when subscription is billed on anniversary date' do
-        let(:timestamp) { DateTime.parse('07 Jun 2022') }
-        let(:started_at) { DateTime.parse('06 Jun 2020').to_date }
+        let(:timestamp) { Time.zone.parse('07 Jun 2022') }
+        let(:started_at) { Time.zone.parse('06 Jun 2020').to_date }
         let(:subscription_at) { started_at }
         let(:billing_time) { :anniversary }
 
@@ -1322,14 +1322,14 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
             invoice_subscription = invoice.invoice_subscriptions.first
             expect(invoice_subscription).to have_attributes(
-              to_datetime: match_datetime(DateTime.parse('2022-06-05 23:59:59')),
-              from_datetime: match_datetime(DateTime.parse('2021-06-06 00:00:00'))
+              to_datetime: match_datetime(Time.zone.parse('2022-06-05 23:59:59')),
+              from_datetime: match_datetime(Time.zone.parse('2021-06-06 00:00:00'))
             )
           end
         end
 
         context 'when started_at in the past' do
-          let(:timestamp) { DateTime.parse(started_at.to_s).end_of_year + 1.day }
+          let(:timestamp) { Time.zone.parse(started_at.to_s).end_of_year + 1.day }
           let(:started_at) { Time.current - 2.months }
           let(:created_at) { Time.current }
 
@@ -1361,8 +1361,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
-                to_datetime: match_datetime(DateTime.parse('2023-06-05 23:59:59')),
-                from_datetime: match_datetime(DateTime.parse('2022-06-06 00:00:00'))
+                to_datetime: match_datetime(Time.zone.parse('2023-06-05 23:59:59')),
+                from_datetime: match_datetime(Time.zone.parse('2022-06-06 00:00:00'))
               )
             end
           end
@@ -1408,7 +1408,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       end
 
       context 'when billed yearly on first year' do
-        let(:timestamp) { DateTime.parse(started_at.to_s).end_of_year + 1.day }
+        let(:timestamp) { Time.zone.parse(started_at.to_s).end_of_year + 1.day }
         let(:started_at) { Time.zone.today - 3.months }
 
         it 'updates the invoice accordingly' do
@@ -1457,8 +1457,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       end
 
       context 'when subscription is billed on anniversary date' do
-        let(:timestamp) { DateTime.parse('07 Jun 2022') }
-        let(:started_at) { DateTime.parse('06 Jun 2020').to_date }
+        let(:timestamp) { Time.zone.parse('07 Jun 2022') }
+        let(:started_at) { Time.zone.parse('06 Jun 2020').to_date }
         let(:subscription_at) { started_at }
         let(:billing_time) { :anniversary }
 
@@ -1474,10 +1474,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
             invoice_subscription = invoice.invoice_subscriptions.first
             expect(invoice_subscription).to have_attributes(
-              to_datetime: match_datetime(DateTime.parse('2022-06-05 23:59:59')),
-              from_datetime: match_datetime(DateTime.parse('2022-03-06 00:00:00')),
-              charges_to_datetime: match_datetime(DateTime.parse('2022-06-05 23:59:59')),
-              charges_from_datetime: match_datetime(DateTime.parse('2022-03-06 00:00:00'))
+              to_datetime: match_datetime(Time.zone.parse('2022-06-05 23:59:59')),
+              from_datetime: match_datetime(Time.zone.parse('2022-03-06 00:00:00')),
+              charges_to_datetime: match_datetime(Time.zone.parse('2022-06-05 23:59:59')),
+              charges_from_datetime: match_datetime(Time.zone.parse('2022-03-06 00:00:00'))
             )
           end
         end
@@ -1508,10 +1508,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
-                to_datetime: match_datetime(DateTime.parse('2022-09-05 23:59:59')),
-                from_datetime: match_datetime(DateTime.parse('2022-06-06 00:00:00')),
-                charges_to_datetime: match_datetime(DateTime.parse('2022-06-05 23:59:59')),
-                charges_from_datetime: match_datetime(DateTime.parse('2022-03-06 00:00:00'))
+                to_datetime: match_datetime(Time.zone.parse('2022-09-05 23:59:59')),
+                from_datetime: match_datetime(Time.zone.parse('2022-06-06 00:00:00')),
+                charges_to_datetime: match_datetime(Time.zone.parse('2022-06-05 23:59:59')),
+                charges_from_datetime: match_datetime(Time.zone.parse('2022-03-06 00:00:00'))
               )
             end
           end
@@ -1519,8 +1519,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       end
 
       context 'when billed quarterly on first billing day' do
-        let(:timestamp) { DateTime.parse('01 Jan 2022') }
-        let(:started_at) { DateTime.parse('12 Nov 2021').to_date }
+        let(:timestamp) { Time.zone.parse('01 Jan 2022') }
+        let(:started_at) { Time.zone.parse('12 Nov 2021').to_date }
         let(:subscription_at) { started_at }
 
         it 'updates the invoice accordingly' do

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
   let(:plan) { create(:plan, interval: :monthly, pay_in_advance:) }
   let(:pay_in_advance) { false }
 
-  let(:subscription_at) { DateTime.parse('02 Feb 2021') }
-  let(:billing_at) { DateTime.parse('07 Mar 2022') }
+  let(:subscription_at) { Time.zone.parse('02 Feb 2021') }
+  let(:billing_at) { Time.zone.parse('07 Mar 2022') }
   let(:started_at) { subscription_at }
   let(:timezone) { 'UTC' }
 
@@ -33,7 +33,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Mar 2022') }
+      let(:billing_at) { Time.zone.parse('01 Mar 2022') }
 
       it 'returns the beginning of the previous month' do
         expect(result).to eq('2022-02-01 00:00:00 UTC')
@@ -48,7 +48,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when date is before the start date' do
-        let(:started_at) { DateTime.parse('07 Feb 2022 05:00:00') }
+        let(:started_at) { Time.zone.parse('07 Feb 2022 05:00:00') }
 
         it 'returns the start date' do
           expect(result).to eq(started_at.beginning_of_day.utc.to_s)
@@ -64,7 +64,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_at) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { Time.zone.parse('10 Mar 2022') }
 
         before { subscription.mark_as_terminated!('9 Mar 2022') }
 
@@ -84,14 +84,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 Mar 2022') }
+      let(:billing_at) { Time.zone.parse('02 Mar 2022') }
 
       it 'returns the day in the previous month day' do
         expect(result).to eq('2022-02-02 00:00:00 UTC')
       end
 
       context 'when date is before the start date' do
-        let(:started_at) { DateTime.parse('08 Feb 2022') }
+        let(:started_at) { Time.zone.parse('08 Feb 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(started_at.utc.to_s)
@@ -99,7 +99,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_at) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { Time.zone.parse('10 Mar 2022') }
 
         before { subscription.mark_as_terminated!('9 Mar 2022') }
 
@@ -116,8 +116,8 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         end
 
         context 'when billing day after last day of billing month' do
-          let(:billing_at) { DateTime.parse('29 Mar 2022') }
-          let(:subscription_at) { DateTime.parse('31 Mar 2021') }
+          let(:billing_at) { Time.zone.parse('29 Mar 2022') }
+          let(:subscription_at) { Time.zone.parse('31 Mar 2021') }
 
           it 'returns the previous month last day' do
             expect(result).to eq('2022-02-28 00:00:00 UTC')
@@ -127,8 +127,8 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         context 'when billing day on first month of the year' do
           before { subscription.mark_as_terminated!('27 Jan 2022') }
 
-          let(:billing_at) { DateTime.parse('28 Jan 2022') }
-          let(:subscription_at) { DateTime.parse('27 Mar 2021') }
+          let(:billing_at) { Time.zone.parse('28 Jan 2022') }
+          let(:subscription_at) { Time.zone.parse('27 Mar 2021') }
 
           it 'returns the previous month last day' do
             expect(result).to eq('2021-12-27 00:00:00 UTC')
@@ -139,16 +139,16 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       context 'when plan is in advance and date is on the last day of month' do
         let(:pay_in_advance) { true }
 
-        let(:billing_at) { DateTime.parse('30 apr 2021') }
-        let(:subscription_at) { DateTime.parse('31 mar 2021') }
+        let(:billing_at) { Time.zone.parse('30 apr 2021') }
+        let(:subscription_at) { Time.zone.parse('31 mar 2021') }
 
         it 'returns the current day' do
           expect(result).to eq('2021-04-30 00:00:00 UTC')
         end
 
         context 'when billing month is longer than subscription one' do
-          let(:billing_at) { DateTime.parse('29 feb 2020') }
-          let(:subscription_at) { DateTime.parse('31 jan 2020') }
+          let(:billing_at) { Time.zone.parse('29 feb 2020') }
+          let(:subscription_at) { Time.zone.parse('31 jan 2020') }
 
           it 'returns the durrent day' do
             expect(result).to eq('2020-02-29 00:00:00 UTC')
@@ -157,16 +157,16 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when plan is in arrear and date is on the last day of month' do
-        let(:billing_at) { DateTime.parse('30 apr 2021') }
-        let(:subscription_at) { DateTime.parse('31 mar 2021') }
+        let(:billing_at) { Time.zone.parse('30 apr 2021') }
+        let(:subscription_at) { Time.zone.parse('31 mar 2021') }
 
         it 'returns the day current billing day' do
           expect(result).to eq('2021-03-31 00:00:00 UTC')
         end
 
         context 'when subscription month is shorter than billing one' do
-          let(:billing_at) { DateTime.parse('30 mar 2020') }
-          let(:subscription_at) { DateTime.parse('30 apr 2019') }
+          let(:billing_at) { Time.zone.parse('30 mar 2020') }
+          let(:subscription_at) { Time.zone.parse('30 apr 2019') }
 
           it 'returns the current billing day' do
             expect(result).to eq('2020-02-29 00:00:00 UTC')
@@ -181,7 +181,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Mar 2022') }
+      let(:billing_at) { Time.zone.parse('01 Mar 2022') }
 
       it 'returns the end of the previous month' do
         expect(result).to eq('2022-02-28 23:59:59 UTC')
@@ -204,12 +204,12 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_at) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { Time.zone.parse('10 Mar 2022') }
 
         before do
           subscription.update!(
             status: :terminated,
-            terminated_at: DateTime.parse('02 Mar 2022')
+            terminated_at: Time.zone.parse('02 Mar 2022')
           )
         end
 
@@ -229,14 +229,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 Mar 2022') }
+      let(:billing_at) { Time.zone.parse('02 Mar 2022') }
 
       it 'returns the day in the previous month' do
         expect(result).to eq('2022-03-01 23:59:59 UTC')
       end
 
       context 'when billing last month of year' do
-        let(:billing_at) { DateTime.parse('04 Jan 2022') }
+        let(:billing_at) { Time.zone.parse('04 Jan 2022') }
 
         it 'returns the day in the previous month' do
           expect(result).to eq('2022-01-01 23:59:59 UTC')
@@ -244,15 +244,15 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when billing subscription day does not exist in the month' do
-        let(:subscription_at) { DateTime.parse('31 Jan 2022') }
-        let(:billing_at) { DateTime.parse('28 Feb 2022') }
+        let(:subscription_at) { Time.zone.parse('31 Jan 2022') }
+        let(:billing_at) { Time.zone.parse('28 Feb 2022') }
 
         it 'returns the last day of the month' do
           expect(result).to eq('2022-02-27 23:59:59 UTC')
         end
 
         context 'when subscription is not the last day of the month' do
-          let(:subscription_at) { DateTime.parse('30 Jan 2022') }
+          let(:subscription_at) { Time.zone.parse('30 Jan 2022') }
 
           it 'returns the last day of the month' do
             expect(result).to eq('2022-02-27 23:59:59 UTC')
@@ -261,8 +261,8 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when anniversary date is first day of the month' do
-        let(:subscription_at) { DateTime.parse('01 Jan 2022') }
-        let(:billing_at) { DateTime.parse('02 Mar 2022') }
+        let(:subscription_at) { Time.zone.parse('01 Jan 2022') }
+        let(:billing_at) { Time.zone.parse('02 Mar 2022') }
 
         it 'returns the last day of the month' do
           expect(result).to eq('2022-02-28 23:59:59 UTC')
@@ -278,12 +278,12 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_at) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { Time.zone.parse('10 Mar 2022') }
 
         before do
           subscription.update!(
             status: :terminated,
-            terminated_at: DateTime.parse('02 Mar 2022')
+            terminated_at: Time.zone.parse('02 Mar 2022')
           )
         end
 
@@ -299,7 +299,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Mar 2022') }
+      let(:billing_at) { Time.zone.parse('01 Mar 2022') }
 
       it 'returns from_datetime' do
         expect(result).to eq(date_service.from_datetime.to_s)
@@ -313,7 +313,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         end
 
         context 'when timezone has changed' do
-          let(:billing_at) { DateTime.parse('02 Mar 2022') }
+          let(:billing_at) { Time.zone.parse('02 Mar 2022') }
 
           let(:previous_invoice_subscription) do
             create(
@@ -334,7 +334,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         end
 
         context 'when timezone has changed and there are no invoices generated in the past' do
-          let(:billing_at) { DateTime.parse('02 Mar 2022') }
+          let(:billing_at) { Time.zone.parse('02 Mar 2022') }
 
           before do
             subscription.customer.update!(timezone: 'America/Los_Angeles')
@@ -347,7 +347,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when subscription started in the middle of a period' do
-        let(:started_at) { DateTime.parse('03 Mar 2022') }
+        let(:started_at) { Time.zone.parse('03 Mar 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(subscription.started_at.utc.to_s)
@@ -356,7 +356,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       context 'when plan is pay in advance' do
         let(:pay_in_advance) { true }
-        let(:subscription_at) { DateTime.parse('02 Feb 2020') }
+        let(:subscription_at) { Time.zone.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
           expect(result).to eq('2022-02-01 00:00:00 UTC')
@@ -382,14 +382,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 Mar 2022') }
+      let(:billing_at) { Time.zone.parse('02 Mar 2022') }
 
       it 'returns from_datetime' do
         expect(result).to eq(date_service.from_datetime.to_s)
       end
 
       context 'when subscription started in the middle of a period' do
-        let(:started_at) { DateTime.parse('03 Mar 2022') }
+        let(:started_at) { Time.zone.parse('03 Mar 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(subscription.started_at.utc.to_s)
@@ -398,7 +398,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       context 'when plan is pay in advance' do
         let(:pay_in_advance) { true }
-        let(:subscription_at) { DateTime.parse('02 Feb 2020') }
+        let(:subscription_at) { Time.zone.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
           expect(result).to eq('2022-02-02 00:00:00 UTC')
@@ -471,14 +471,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 Mar 2022') }
+      let(:billing_at) { Time.zone.parse('02 Mar 2022') }
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_datetime.to_s)
       end
 
       context 'when subscription is terminated in the middle of a period' do
-        let(:terminated_at) { DateTime.parse('1 Mar 2022') }
+        let(:terminated_at) { Time.zone.parse('1 Mar 2022') }
 
         before { subscription.mark_as_terminated!(terminated_at) }
 
@@ -532,13 +532,13 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when end of billing month is in next year' do
-        let(:billing_at) { DateTime.parse('07 Dec 2021') }
+        let(:billing_at) { Time.zone.parse('07 Dec 2021') }
 
         it { expect(result).to eq('2022-01-01 23:59:59 UTC') }
       end
 
       context 'when date is the end of the period' do
-        let(:billing_at) { DateTime.parse('01 Mar 2022') }
+        let(:billing_at) { Time.zone.parse('01 Mar 2022') }
 
         it 'returns the date' do
           expect(result).to eq(billing_at.utc.end_of_day.to_s)
@@ -620,8 +620,8 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_at) { DateTime.parse('28 Feb 2019') }
-        let(:billing_at) { DateTime.parse('01 Mar 2020') }
+        let(:subscription_at) { Time.zone.parse('28 Feb 2019') }
+        let(:billing_at) { Time.zone.parse('01 Mar 2020') }
 
         it 'returns the price of single day' do
           expect(result).to eq(plan.amount_cents.fdiv(29))
@@ -637,8 +637,8 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_at) { DateTime.parse('02 Feb 2019') }
-        let(:billing_at) { DateTime.parse('08 Mar 2020') }
+        let(:subscription_at) { Time.zone.parse('02 Feb 2019') }
+        let(:billing_at) { Time.zone.parse('08 Mar 2020') }
 
         it 'returns the price of single day' do
           expect(result).to eq(plan.amount_cents.fdiv(29))
@@ -658,8 +658,8 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_at) { DateTime.parse('28 Feb 2019') }
-        let(:billing_at) { DateTime.parse('01 Mar 2020') }
+        let(:subscription_at) { Time.zone.parse('28 Feb 2019') }
+        let(:billing_at) { Time.zone.parse('01 Mar 2020') }
 
         it 'returns the month duration' do
           expect(result).to eq(29)
@@ -675,8 +675,8 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_at) { DateTime.parse('02 Feb 2019') }
-        let(:billing_at) { DateTime.parse('08 Mar 2020') }
+        let(:subscription_at) { Time.zone.parse('02 Feb 2019') }
+        let(:billing_at) { Time.zone.parse('08 Mar 2020') }
 
         it 'returns the month duration' do
           expect(result).to eq(29)

--- a/spec/services/subscriptions/dates/quarterly_service_spec.rb
+++ b/spec/services/subscriptions/dates/quarterly_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
   let(:pay_in_advance) { false }
   let(:current_usage) { false }
 
-  let(:subscription_at) { DateTime.parse('02 Feb 2021') }
-  let(:billing_at) { DateTime.parse('07 Mar 2022') }
+  let(:subscription_at) { Time.zone.parse('02 Feb 2021') }
+  let(:billing_at) { Time.zone.parse('07 Mar 2022') }
   let(:started_at) { subscription_at }
   let(:timezone) { 'UTC' }
 
@@ -31,7 +31,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Jul 2022') }
+      let(:billing_at) { Time.zone.parse('01 Jul 2022') }
 
       it 'returns the beginning of the previous quarter' do
         expect(result).to eq('2022-04-01 00:00:00 UTC')
@@ -46,7 +46,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when date is before the start date' do
-        let(:started_at) { DateTime.parse('07 Apr 2022') }
+        let(:started_at) { Time.zone.parse('07 Apr 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(started_at.beginning_of_day.utc.to_s)
@@ -62,7 +62,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_at) { DateTime.parse('10 Jul 2022') }
+        let(:billing_at) { Time.zone.parse('10 Jul 2022') }
 
         before { subscription.mark_as_terminated!('9 Jul 2022') }
 
@@ -82,14 +82,14 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 May 2022') }
+      let(:billing_at) { Time.zone.parse('02 May 2022') }
 
       it 'returns the same day in the previous quarter' do
         expect(result).to eq('2022-02-02 00:00:00 UTC')
       end
 
       context 'when date is before the start date' do
-        let(:started_at) { DateTime.parse('08 Feb 2022') }
+        let(:started_at) { Time.zone.parse('08 Feb 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(started_at.utc.to_s)
@@ -97,7 +97,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when date is in first quarter' do
-        let(:billing_at) { DateTime.parse('02 Feb 2022') }
+        let(:billing_at) { Time.zone.parse('02 Feb 2022') }
 
         it 'returns the correct day in the previous year' do
           expect(result).to eq('2021-11-02 00:00:00 UTC')
@@ -105,8 +105,8 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when date is on the last day of the month' do
-        let(:billing_at) { DateTime.parse('31 May 2022') }
-        let(:subscription_at) { DateTime.parse('28 Feb 2021') }
+        let(:billing_at) { Time.zone.parse('31 May 2022') }
+        let(:subscription_at) { Time.zone.parse('28 Feb 2021') }
 
         it 'returns the last day in the previous quarter' do
           expect(result).to eq('2022-02-28 00:00:00 UTC')
@@ -114,7 +114,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_at) { DateTime.parse('10 May 2022') }
+        let(:billing_at) { Time.zone.parse('10 May 2022') }
 
         before { subscription.mark_as_terminated!('9 May 2022') }
 
@@ -131,8 +131,8 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
         end
 
         context 'when billing day after last day of billing month' do
-          let(:billing_at) { DateTime.parse('29 May 2022') }
-          let(:subscription_at) { DateTime.parse('30 May 2021') }
+          let(:billing_at) { Time.zone.parse('29 May 2022') }
+          let(:subscription_at) { Time.zone.parse('30 May 2021') }
 
           it 'returns the previous quarter last day' do
             expect(result).to eq('2022-02-28 00:00:00 UTC')
@@ -140,8 +140,8 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
         end
 
         context 'when billing day in the second month of the year' do
-          let(:billing_at) { DateTime.parse('27 Feb 2022') }
-          let(:subscription_at) { DateTime.parse('28 Feb 2021') }
+          let(:billing_at) { Time.zone.parse('27 Feb 2022') }
+          let(:subscription_at) { Time.zone.parse('28 Feb 2021') }
 
           before { subscription.mark_as_terminated!('25 Feb 2022') }
 
@@ -154,8 +154,8 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       context 'when plan is in advance and date is on the last day of month' do
         let(:pay_in_advance) { true }
 
-        let(:billing_at) { DateTime.parse('30 Apr 2021') }
-        let(:subscription_at) { DateTime.parse('31 Jan 2021') }
+        let(:billing_at) { Time.zone.parse('30 Apr 2021') }
+        let(:subscription_at) { Time.zone.parse('31 Jan 2021') }
 
         it 'returns the current day' do
           expect(result).to eq('2021-04-30 00:00:00 UTC')
@@ -163,8 +163,8 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when date is not on a billing month' do
-        let(:billing_at) { DateTime.parse('8 Aug 2023') }
-        let(:subscription_at) { DateTime.parse('6 Apr 2023') }
+        let(:billing_at) { Time.zone.parse('8 Aug 2023') }
+        let(:subscription_at) { Time.zone.parse('6 Apr 2023') }
         let(:current_usage) { true }
 
         it 'returns the date in previous billing month' do
@@ -173,8 +173,8 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when date is not on a billing month and day is less than subscription day' do
-        let(:billing_at) { DateTime.parse('4 Aug 2023') }
-        let(:subscription_at) { DateTime.parse('6 Apr 2023') }
+        let(:billing_at) { Time.zone.parse('4 Aug 2023') }
+        let(:subscription_at) { Time.zone.parse('6 Apr 2023') }
         let(:current_usage) { true }
 
         it 'returns the date in previous billing month' do
@@ -189,7 +189,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Jul 2022') }
+      let(:billing_at) { Time.zone.parse('01 Jul 2022') }
 
       it 'returns the end of the previous quarter' do
         expect(result).to eq('2022-06-30 23:59:59 UTC')
@@ -212,12 +212,12 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_at) { DateTime.parse('01 Jul 2022') }
+        let(:billing_at) { Time.zone.parse('01 Jul 2022') }
 
         before do
           subscription.update!(
             status: :terminated,
-            terminated_at: DateTime.parse('27 Jun 2022')
+            terminated_at: Time.zone.parse('27 Jun 2022')
           )
         end
 
@@ -237,14 +237,14 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 May 2022') }
+      let(:billing_at) { Time.zone.parse('02 May 2022') }
 
       it 'returns the day in the previous month' do
         expect(result).to eq('2022-05-01 23:59:59 UTC')
       end
 
       context 'when billing last quarter of the year' do
-        let(:billing_at) { DateTime.parse('02 Feb 2022') }
+        let(:billing_at) { Time.zone.parse('02 Feb 2022') }
 
         it 'returns the day in the previous month' do
           expect(result).to eq('2022-02-01 23:59:59 UTC')
@@ -252,16 +252,16 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when billing subscription day does not exist in the month' do
-        let(:subscription_at) { DateTime.parse('30 Nov 2021') }
-        let(:billing_at) { DateTime.parse('01 Mar 2022') }
+        let(:subscription_at) { Time.zone.parse('30 Nov 2021') }
+        let(:billing_at) { Time.zone.parse('01 Mar 2022') }
 
         it 'returns the last day of the previous month' do
           expect(result).to eq('2022-02-27 23:59:59 UTC')
         end
 
         context 'when subscription is not the last day of the month' do
-          let(:subscription_at) { DateTime.parse('30 Jan 2022') }
-          let(:billing_at) { DateTime.parse('30 Apr 2022') }
+          let(:subscription_at) { Time.zone.parse('30 Jan 2022') }
+          let(:billing_at) { Time.zone.parse('30 Apr 2022') }
 
           it 'returns the last day of the month' do
             expect(result).to eq('2022-04-29 23:59:59 UTC')
@@ -270,8 +270,8 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when anniversary date is first day of the quarter' do
-        let(:subscription_at) { DateTime.parse('01 Oct 2021') }
-        let(:billing_at) { DateTime.parse('02 Apr 2022') }
+        let(:subscription_at) { Time.zone.parse('01 Oct 2021') }
+        let(:billing_at) { Time.zone.parse('02 Apr 2022') }
 
         it 'returns the last day of the previous quarter' do
           expect(result).to eq('2022-03-31 23:59:59 UTC')
@@ -290,7 +290,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
         before do
           subscription.update!(
             status: :terminated,
-            terminated_at: DateTime.parse('30 Apr 2022')
+            terminated_at: Time.zone.parse('30 Apr 2022')
           )
         end
 
@@ -306,7 +306,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Apr 2022') }
+      let(:billing_at) { Time.zone.parse('01 Apr 2022') }
 
       it 'returns from_datetime' do
         expect(result).to eq(date_service.from_datetime.to_s)
@@ -320,7 +320,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
         end
 
         context 'when timezone has changed' do
-          let(:billing_at) { DateTime.parse('02 Apr 2022') }
+          let(:billing_at) { Time.zone.parse('02 Apr 2022') }
 
           let(:previous_invoice_subscription) do
             create(
@@ -342,7 +342,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when subscription started in the middle of a period' do
-        let(:started_at) { DateTime.parse('03 Apr 2022') }
+        let(:started_at) { Time.zone.parse('03 Apr 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(subscription.started_at.utc.to_s)
@@ -351,7 +351,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
       context 'when plan is pay in advance' do
         let(:pay_in_advance) { true }
-        let(:subscription_at) { DateTime.parse('01 Jan 2020') }
+        let(:subscription_at) { Time.zone.parse('01 Jan 2020') }
 
         it 'returns the start of the previous period' do
           expect(result).to eq('2022-01-01 00:00:00 UTC')
@@ -361,14 +361,14 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 May 2022') }
+      let(:billing_at) { Time.zone.parse('02 May 2022') }
 
       it 'returns from_datetime' do
         expect(result).to eq(date_service.from_datetime.to_s)
       end
 
       context 'when subscription started in the middle of a period' do
-        let(:started_at) { DateTime.parse('03 May 2022') }
+        let(:started_at) { Time.zone.parse('03 May 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(subscription.started_at.utc.to_s)
@@ -377,7 +377,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
       context 'when plan is pay in advance' do
         let(:pay_in_advance) { true }
-        let(:subscription_at) { DateTime.parse('02 Feb 2020') }
+        let(:subscription_at) { Time.zone.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
           expect(result).to eq('2022-02-02 00:00:00 UTC')
@@ -391,7 +391,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Jul 2022') }
+      let(:billing_at) { Time.zone.parse('01 Jul 2022') }
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_datetime.to_s)
@@ -406,7 +406,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when subscription is terminated in the middle of a period' do
-        let(:terminated_at) { DateTime.parse('15 Jun 2022') }
+        let(:terminated_at) { Time.zone.parse('15 Jun 2022') }
 
         before do
           subscription.update!(status: :terminated, terminated_at:)
@@ -428,14 +428,14 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 May 2022') }
+      let(:billing_at) { Time.zone.parse('02 May 2022') }
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_datetime.to_s)
       end
 
       context 'when subscription is terminated in the middle of a period' do
-        let(:terminated_at) { DateTime.parse('15 Apr 2022') }
+        let(:terminated_at) { Time.zone.parse('15 Apr 2022') }
 
         before do
           subscription.update!(status: :terminated, terminated_at:)
@@ -461,7 +461,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('02 Jul 2022') }
+      let(:billing_at) { Time.zone.parse('02 Jul 2022') }
 
       it 'returns the last day of the month' do
         expect(result).to eq('2022-09-30 23:59:59 UTC')
@@ -478,7 +478,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('07 May 2022') }
+      let(:billing_at) { Time.zone.parse('07 May 2022') }
 
       it 'returns the end of the billing month' do
         expect(result).to eq('2022-08-01 23:59:59 UTC')
@@ -493,13 +493,13 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
 
       context 'when end of billing month is in next year' do
-        let(:billing_at) { DateTime.parse('02 Nov 2021') }
+        let(:billing_at) { Time.zone.parse('02 Nov 2021') }
 
         it { expect(result).to eq('2022-02-01 23:59:59 UTC') }
       end
 
       context 'when date is the end of the period' do
-        let(:billing_at) { DateTime.parse('01 May 2022') }
+        let(:billing_at) { Time.zone.parse('01 May 2022') }
 
         it 'returns the date' do
           expect(result).to eq(billing_at.utc.end_of_day.to_s)
@@ -515,7 +515,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('02 Jul 2022') }
+      let(:billing_at) { Time.zone.parse('02 Jul 2022') }
 
       it 'returns the first day of the previous month' do
         expect(result).to eq('2022-04-01 00:00:00 UTC')
@@ -540,7 +540,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('03 May 2022') }
+      let(:billing_at) { Time.zone.parse('03 May 2022') }
 
       it 'returns the beginning of the previous period' do
         expect(result).to eq('2022-02-02 00:00:00 UTC')
@@ -569,15 +569,15 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Jul 2022') }
+      let(:billing_at) { Time.zone.parse('01 Jul 2022') }
 
       it 'returns the price of single day' do
         expect(result).to eq(plan.amount_cents.fdiv(91))
       end
 
       context 'when on a leap year' do
-        let(:subscription_at) { DateTime.parse('28 Feb 2019') }
-        let(:billing_at) { DateTime.parse('01 Apr 2020') }
+        let(:subscription_at) { Time.zone.parse('28 Feb 2019') }
+        let(:billing_at) { Time.zone.parse('01 Apr 2020') }
 
         it 'returns the price of single day' do
           expect(result).to eq(plan.amount_cents.fdiv(91))
@@ -587,14 +587,14 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 May 2020') }
+      let(:billing_at) { Time.zone.parse('02 May 2020') }
 
       it 'returns the price of single day' do
         expect(result).to eq(plan.amount_cents.fdiv(90))
       end
 
       context 'when not on a leap year' do
-        let(:billing_at) { DateTime.parse('02 May 2021') }
+        let(:billing_at) { Time.zone.parse('02 May 2021') }
 
         it 'returns the month duration' do
           expect(result).to eq(plan.amount_cents.fdiv(89))
@@ -608,15 +608,15 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Jul 2022') }
+      let(:billing_at) { Time.zone.parse('01 Jul 2022') }
 
       it 'returns the quarter duration' do
         expect(result).to eq(91)
       end
 
       context 'when on a leap year' do
-        let(:subscription_at) { DateTime.parse('28 Feb 2019') }
-        let(:billing_at) { DateTime.parse('01 Apr 2020') }
+        let(:subscription_at) { Time.zone.parse('28 Feb 2019') }
+        let(:billing_at) { Time.zone.parse('01 Apr 2020') }
 
         it 'returns the duration in days' do
           expect(result).to eq(91)
@@ -626,15 +626,15 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 May 2020') }
+      let(:billing_at) { Time.zone.parse('02 May 2020') }
 
       it 'returns the month duration' do
         expect(result).to eq(90)
       end
 
       context 'when not on a leap year' do
-        let(:subscription_at) { DateTime.parse('02 Feb 2019') }
-        let(:billing_at) { DateTime.parse('02 May 2021') }
+        let(:subscription_at) { Time.zone.parse('02 Feb 2019') }
+        let(:billing_at) { Time.zone.parse('02 May 2021') }
 
         it 'returns the duration in days' do
           expect(result).to eq(89)

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
   let(:plan) { create(:plan, interval: :weekly, pay_in_advance:) }
   let(:pay_in_advance) { false }
 
-  let(:subscription_at) { DateTime.parse('02 Feb 2021') }
-  let(:billing_at) { DateTime.parse('07 Mar 2022') }
+  let(:subscription_at) { Time.zone.parse('02 Feb 2021') }
+  let(:billing_at) { Time.zone.parse('07 Mar 2022') }
   let(:started_at) { subscription_at }
   let(:timezone) { 'UTC' }
 
@@ -45,7 +45,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       end
 
       context 'when date is before the start date' do
-        let(:started_at) { DateTime.parse('01 Mar 2022 05:00:00') }
+        let(:started_at) { Time.zone.parse('01 Mar 2022 05:00:00') }
 
         it 'returns the start date' do
           expect(result).to eq(started_at.beginning_of_day.utc.to_s)
@@ -61,7 +61,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_at) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { Time.zone.parse('10 Mar 2022') }
 
         before { subscription.mark_as_terminated!('9 Mar 2022') }
 
@@ -83,7 +83,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('09 Mar 2022') }
+      let(:billing_at) { Time.zone.parse('09 Mar 2022') }
 
       it 'returns the previous week week day' do
         expect(result).to eq('2022-03-01 00:00:00 UTC')
@@ -91,7 +91,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       end
 
       context 'when date is before the start date' do
-        let(:started_at) { DateTime.parse('08 Mar 2022') }
+        let(:started_at) { Time.zone.parse('08 Mar 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(started_at.utc.to_s)
@@ -124,7 +124,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('07 Mar 2022') }
+      let(:billing_at) { Time.zone.parse('07 Mar 2022') }
 
       it 'returns the end of the previous week' do
         expect(result).to eq('2022-03-06 23:59:59 UTC')
@@ -148,8 +148,8 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_at) { DateTime.parse('07 Mar 2022') }
-        let(:terminated_at) { DateTime.parse('02 Mar 2022') }
+        let(:billing_at) { Time.zone.parse('07 Mar 2022') }
+        let(:terminated_at) { Time.zone.parse('02 Mar 2022') }
 
         before do
           subscription.update!(
@@ -174,7 +174,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('09 Mar 2022') }
+      let(:billing_at) { Time.zone.parse('09 Mar 2022') }
 
       it 'returns the previous week week day' do
         expect(result).to eq('2022-03-07 23:59:59 UTC')
@@ -192,7 +192,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         before do
           subscription.update!(
             status: :terminated,
-            terminated_at: DateTime.parse('02 Mar 2022')
+            terminated_at: Time.zone.parse('02 Mar 2022')
           )
         end
 
@@ -221,7 +221,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         end
 
         context 'when timezone has changed' do
-          let(:billing_at) { DateTime.parse('08 Mar 2022') }
+          let(:billing_at) { Time.zone.parse('08 Mar 2022') }
 
           let(:previous_invoice_subscription) do
             create(
@@ -243,7 +243,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       end
 
       context 'when subscription started in the middle of a period' do
-        let(:started_at) { DateTime.parse('03 Mar 2022') }
+        let(:started_at) { Time.zone.parse('03 Mar 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(subscription.started_at.utc.to_s)
@@ -261,14 +261,14 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('09 Mar 2022') }
+      let(:billing_at) { Time.zone.parse('09 Mar 2022') }
 
       it 'returns from_date' do
         expect(result).to eq(date_service.from_datetime.to_s)
       end
 
       context 'when subscription started in the middle of a period' do
-        let(:started_at) { DateTime.parse('03 Mar 2022') }
+        let(:started_at) { Time.zone.parse('03 Mar 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(subscription.started_at.utc.to_s)
@@ -304,7 +304,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       end
 
       context 'when subscription is terminated in the middle of a period' do
-        let(:terminated_at) { DateTime.parse('06 Mar 2022') }
+        let(:terminated_at) { Time.zone.parse('06 Mar 2022') }
 
         before do
           subscription.update!(status: :terminated, terminated_at:)
@@ -326,14 +326,14 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('09 Mar 2022') }
+      let(:billing_at) { Time.zone.parse('09 Mar 2022') }
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_datetime.to_s)
       end
 
       context 'when subscription is terminated in the middle of a period' do
-        let(:terminated_at) { DateTime.parse('06 Mar 2022') }
+        let(:terminated_at) { Time.zone.parse('06 Mar 2022') }
 
         before do
           subscription.update!(status: :terminated, terminated_at:)
@@ -375,7 +375,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('08 Mar 2022 20:00:00') }
+      let(:billing_at) { Time.zone.parse('08 Mar 2022 20:00:00') }
 
       it 'returns the end of the billing week' do
         expect(result).to eq('2022-03-14 23:59:59 UTC')
@@ -390,7 +390,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       end
 
       context 'when date is the end of the period' do
-        let(:billing_at) { DateTime.parse('07 Mar 2022') }
+        let(:billing_at) { Time.zone.parse('07 Mar 2022') }
 
         it 'returns the date' do
           expect(result).to eq(billing_at.utc.end_of_day.to_s)
@@ -455,7 +455,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
   describe 'single_day_price' do
     let(:billing_time) { :anniversary }
-    let(:billing_at) { DateTime.parse('08 Mar 2022') }
+    let(:billing_at) { Time.zone.parse('08 Mar 2022') }
     let(:result) { date_service.single_day_price }
 
     it 'returns the price of single day' do
@@ -465,7 +465,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
   describe 'charges_duration_in_days' do
     let(:billing_time) { :anniversary }
-    let(:billing_at) { DateTime.parse('08 Mar 2022') }
+    let(:billing_at) { Time.zone.parse('08 Mar 2022') }
     let(:result) { date_service.charges_duration_in_days }
 
     it 'returns the duration of the period' do

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
   let(:pay_in_advance) { false }
   let(:current_usage) { false }
 
-  let(:subscription_at) { DateTime.parse('02 Feb 2021') }
-  let(:billing_at) { DateTime.parse('07 Mar 2022') }
+  let(:subscription_at) { Time.zone.parse('02 Feb 2021') }
+  let(:billing_at) { Time.zone.parse('07 Mar 2022') }
   let(:started_at) { subscription_at }
   let(:timezone) { 'UTC' }
 
@@ -31,8 +31,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Jan 2022') }
-      let(:subscription_at) { DateTime.parse('02 Feb 2019') }
+      let(:billing_at) { Time.zone.parse('01 Jan 2022') }
+      let(:subscription_at) { Time.zone.parse('02 Feb 2019') }
 
       it 'returns the beginning of the previous year' do
         expect(result).to eq('2021-01-01 00:00:00 UTC')
@@ -47,7 +47,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when date is before the start date' do
-        let(:started_at) { DateTime.parse('07 Feb 2021') }
+        let(:started_at) { Time.zone.parse('07 Feb 2021') }
 
         it 'returns the start date' do
           expect(result).to eq(started_at.utc.to_s)
@@ -63,7 +63,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_at) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { Time.zone.parse('10 Mar 2022') }
 
         before { subscription.mark_as_terminated!('9 Mar 2022') }
 
@@ -83,7 +83,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 Feb 2022') }
+      let(:billing_at) { Time.zone.parse('02 Feb 2022') }
 
       it 'returns the previous year day and month' do
         expect(result).to eq('2021-02-02 00:00:00 UTC')
@@ -91,8 +91,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       context 'when current usage is true and current month is the same as starting month' do
         let(:current_usage) { true }
-        let(:subscription_at) { DateTime.parse('29 Mar 2023') }
-        let(:billing_at) { DateTime.parse('15 Mar 2024') }
+        let(:subscription_at) { Time.zone.parse('29 Mar 2023') }
+        let(:billing_at) { Time.zone.parse('15 Mar 2024') }
 
         it 'returns the previous year day and month' do
           expect(result).to eq('2023-03-29 00:00:00 UTC')
@@ -100,7 +100,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when date is before the start date' do
-        let(:started_at) { DateTime.parse('02 Sep 2022') }
+        let(:started_at) { Time.zone.parse('02 Sep 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(started_at.utc.to_s)
@@ -123,8 +123,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         context 'when subscription date on 29/02 of a leap year' do
-          let(:subscription_at) { DateTime.parse('29 Feb 2020') }
-          let(:billing_at) { DateTime.parse('28 Mar 2022') }
+          let(:subscription_at) { Time.zone.parse('29 Feb 2020') }
+          let(:billing_at) { Time.zone.parse('28 Mar 2022') }
 
           it 'returns the previous month last day' do
             expect(result).to eq('2022-02-28 00:00:00 UTC')
@@ -132,7 +132,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         context 'when billing month is before subscription month' do
-          let(:billing_at) { DateTime.parse('03 Jan 2022') }
+          let(:billing_at) { Time.zone.parse('03 Jan 2022') }
 
           it 'returns the previous year day' do
             expect(result).to eq('2021-02-02 00:00:00 UTC')
@@ -147,8 +147,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Jan 2022') }
-      let(:subscription_at) { DateTime.parse('02 Feb 2020') }
+      let(:billing_at) { Time.zone.parse('01 Jan 2022') }
+      let(:subscription_at) { Time.zone.parse('02 Feb 2020') }
 
       it 'returns the end of the previous year' do
         expect(result).to eq('2021-12-31 23:59:59 UTC')
@@ -171,12 +171,12 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_at) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { Time.zone.parse('10 Mar 2022') }
 
         before do
           subscription.update!(
             status: :terminated,
-            terminated_at: DateTime.parse('02 Mar 2022')
+            terminated_at: Time.zone.parse('02 Mar 2022')
           )
         end
 
@@ -196,15 +196,15 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 Feb 2022') }
+      let(:billing_at) { Time.zone.parse('02 Feb 2022') }
 
       it 'returns the previous year day and month' do
         expect(result).to eq('2022-02-01 23:59:59 UTC')
       end
 
       context 'when subscription date on 29/02 of a leap year' do
-        let(:subscription_at) { DateTime.parse('29 Feb 2020') }
-        let(:billing_at) { DateTime.parse('01 Mar 2022') }
+        let(:subscription_at) { Time.zone.parse('29 Feb 2020') }
+        let(:billing_at) { Time.zone.parse('01 Mar 2022') }
 
         it 'returns the previous month last day' do
           expect(result).to eq('2022-02-28 23:59:59 UTC')
@@ -212,8 +212,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when anniversary date is first day of the year' do
-        let(:subscription_at) { DateTime.parse('01 Jan 2021') }
-        let(:billing_at) { DateTime.parse('02 Mar 2022') }
+        let(:subscription_at) { Time.zone.parse('01 Jan 2021') }
+        let(:billing_at) { Time.zone.parse('02 Mar 2022') }
 
         it 'returns the last day of the year' do
           expect(result).to eq('2021-12-31 23:59:59 UTC')
@@ -221,8 +221,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when anniversary date is first day of a month' do
-        let(:subscription_at) { DateTime.parse('01 Dec 2022') }
-        let(:billing_at) { DateTime.parse('02 Jan 2024') }
+        let(:subscription_at) { Time.zone.parse('01 Dec 2022') }
+        let(:billing_at) { Time.zone.parse('02 Jan 2024') }
 
         it 'returns the last day of the previous month on next year' do
           expect(result).to eq('2023-11-30 23:59:59 UTC')
@@ -241,7 +241,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         before do
           subscription.update!(
             status: :terminated,
-            terminated_at: DateTime.parse('02 Jan 2022')
+            terminated_at: Time.zone.parse('02 Jan 2022')
           )
         end
 
@@ -257,8 +257,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Jan 2023') }
-      let(:subscription_at) { DateTime.parse('02 Feb 2020') }
+      let(:billing_at) { Time.zone.parse('01 Jan 2023') }
+      let(:subscription_at) { Time.zone.parse('02 Feb 2020') }
 
       it 'returns from_date' do
         expect(result).to eq(date_service.from_datetime.to_s)
@@ -272,7 +272,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         context 'when timezone has changed' do
-          let(:billing_at) { DateTime.parse('02 Jan 2022') }
+          let(:billing_at) { Time.zone.parse('02 Jan 2022') }
 
           let(:previous_invoice_subscription) do
             create(
@@ -294,7 +294,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when subscription started in the middle of a period' do
-        let(:started_at) { DateTime.parse('03 Mar 2022') }
+        let(:started_at) { Time.zone.parse('03 Mar 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(subscription.started_at.utc.to_s)
@@ -303,7 +303,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       context 'when plan is pay in advance' do
         let(:pay_in_advance) { true }
-        let(:subscription_at) { DateTime.parse('02 Feb 2020') }
+        let(:subscription_at) { Time.zone.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
           expect(result).to eq('2022-01-01 00:00:00 UTC')
@@ -318,8 +318,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         context 'when subscription started in the middle of a period' do
-          let(:billing_at) { DateTime.parse('01 Jan 2022') }
-          let(:started_at) { DateTime.parse('03 Mar 2022') }
+          let(:billing_at) { Time.zone.parse('01 Jan 2022') }
+          let(:started_at) { Time.zone.parse('03 Mar 2022') }
 
           it 'returns the start date' do
             expect(result).to eq(subscription.started_at.utc.to_s)
@@ -330,14 +330,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 Feb 2022') }
+      let(:billing_at) { Time.zone.parse('02 Feb 2022') }
 
       it 'returns from_date' do
         expect(result).to eq(date_service.from_datetime.to_s)
       end
 
       context 'when subscription started in the middle of a period' do
-        let(:started_at) { DateTime.parse('03 Mar 2022') }
+        let(:started_at) { Time.zone.parse('03 Mar 2022') }
 
         it 'returns the start date' do
           expect(result).to eq(subscription.started_at.utc.to_s)
@@ -346,7 +346,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       context 'when plan is pay in advance' do
         let(:pay_in_advance) { true }
-        let(:subscription_at) { DateTime.parse('02 Feb 2020') }
+        let(:subscription_at) { Time.zone.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
           expect(result).to eq('2021-02-02 00:00:00 UTC')
@@ -361,7 +361,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         context 'when subscription started in the middle of a period' do
-          let(:started_at) { DateTime.parse('03 Mar 2022') }
+          let(:started_at) { Time.zone.parse('03 Mar 2022') }
 
           it 'returns the start date' do
             expect(result).to eq(subscription.started_at.utc.to_s)
@@ -390,7 +390,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when subscription is terminated in the middle of a period' do
-        let(:terminated_at) { DateTime.parse('06 Mar 2022') }
+        let(:terminated_at) { Time.zone.parse('06 Mar 2022') }
 
         before do
           subscription.update!(status: :terminated, terminated_at:)
@@ -410,7 +410,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when billing charge monthly' do
-        let(:billing_at) { DateTime.parse('01 Jan 2022') }
+        let(:billing_at) { Time.zone.parse('01 Jan 2022') }
 
         before { plan.update!(bill_charges_monthly: true) }
 
@@ -419,8 +419,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         context 'when subscription terminated in the middle of a period' do
-          let(:terminated_at) { DateTime.parse('05 Mar 2022') }
-          let(:billing_at) { DateTime.parse('07 Mar 2022') }
+          let(:terminated_at) { Time.zone.parse('05 Mar 2022') }
+          let(:billing_at) { Time.zone.parse('07 Mar 2022') }
 
           before { subscription.mark_as_terminated!(terminated_at) }
 
@@ -431,8 +431,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
         context 'when plan is pay in advance' do
           let(:pay_in_advance) { true }
-          let(:subscription_at) { DateTime.parse('02 Feb 2020') }
-          let(:billing_at) { DateTime.parse('07 Mar 2022') }
+          let(:subscription_at) { Time.zone.parse('02 Feb 2020') }
+          let(:billing_at) { Time.zone.parse('07 Mar 2022') }
 
           it 'returns the end of the current period' do
             expect(result).to eq('2022-02-28 23:59:59 UTC')
@@ -443,14 +443,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_at) { DateTime.parse('02 Feb 2022') }
+      let(:billing_at) { Time.zone.parse('02 Feb 2022') }
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_datetime.to_s)
       end
 
       context 'when subscription is terminated in the middle of a period' do
-        let(:terminated_at) { DateTime.parse('6 Jan 2022') }
+        let(:terminated_at) { Time.zone.parse('6 Jan 2022') }
 
         before { subscription.mark_as_terminated!(terminated_at) }
 
@@ -504,7 +504,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when date is the end of the period' do
-        let(:billing_at) { DateTime.parse('01 Feb 2022') }
+        let(:billing_at) { Time.zone.parse('01 Feb 2022') }
 
         it 'returns the date' do
           expect(result).to eq(billing_at.utc.end_of_day.to_s)
@@ -578,8 +578,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_at) { DateTime.parse('28 Feb 2019') }
-        let(:billing_at) { DateTime.parse('01 Jan 2021') }
+        let(:subscription_at) { Time.zone.parse('28 Feb 2019') }
+        let(:billing_at) { Time.zone.parse('01 Jan 2021') }
 
         it 'returns the price of single day' do
           expect(result).to eq(plan.amount_cents.fdiv(366))
@@ -595,8 +595,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_at) { DateTime.parse('02 Feb 2019') }
-        let(:billing_at) { DateTime.parse('08 Mar 2021') }
+        let(:subscription_at) { Time.zone.parse('02 Feb 2019') }
+        let(:billing_at) { Time.zone.parse('08 Mar 2021') }
 
         it 'returns the price of single day' do
           expect(result).to eq(plan.amount_cents.fdiv(366))
@@ -616,8 +616,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_at) { DateTime.parse('28 Feb 2019') }
-        let(:billing_at) { DateTime.parse('01 Jan 2021') }
+        let(:subscription_at) { Time.zone.parse('28 Feb 2019') }
+        let(:billing_at) { Time.zone.parse('01 Jan 2021') }
 
         it 'returns the year duration' do
           expect(result).to eq(366)
@@ -641,8 +641,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_at) { DateTime.parse('02 Feb 2019') }
-        let(:billing_at) { DateTime.parse('08 Mar 2021') }
+        let(:subscription_at) { Time.zone.parse('02 Feb 2019') }
+        let(:billing_at) { Time.zone.parse('08 Mar 2021') }
 
         it 'returns the year duration' do
           expect(result).to eq(366)


### PR DESCRIPTION
## Context

Some termination invoices failed to refresh or are generated with the wrong boundaries.
This is related to a small mismatch with the time comparison when looking if the subscription was terminated before the invoice timestamp.

## Description

This PR fixes the `subscription#terminated_at?` comparison so that it always compare time with the second precision, to avoid side effects related to rounding when persisting `ActiveRecord` objects.

A lot of `DateTime` objects are also converted into proper `Time.zone` to fix potential issues around time management as DateTime should not be used in Lago's context (see https://docs.datadoghq.com/code_analysis/static_analysis_rules/ruby-best-practices/no-datetime/)