### PR TITLE
feat(customer-type): Update anrok and xero payloads with new fields

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -82,8 +82,9 @@ class Customer < ApplicationRecord
     %w[id name firstname lastname external_id email]
   end
 
-  def display_name
-    names = [legal_name.presence || name.presence]
+  def display_name(prefer_legal_name: true)
+    names = prefer_legal_name ? [legal_name.presence || name.presence] : [name.presence]
+
     if firstname.present? || lastname.present?
       names << '-' if names.compact.present?
       names << firstname

--- a/app/services/integrations/aggregator/contacts/payloads/anrok.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/anrok.rb
@@ -5,6 +5,34 @@ module Integrations
     module Contacts
       module Payloads
         class Anrok < BasePayload
+          def create_body
+            [
+              {
+                'name' => customer.display_name(prefer_legal_name: false),
+                'city' => customer.city,
+                'zip' => customer.zipcode,
+                'country' => customer.country,
+                'state' => customer.state,
+                'email' => email,
+                'phone' => phone
+              }
+            ]
+          end
+
+          def update_body
+            [
+              {
+                'id' => integration_customer.external_customer_id,
+                'name' => customer.display_name(prefer_legal_name: false),
+                'city' => customer.city,
+                'zip' => customer.zipcode,
+                'country' => customer.country,
+                'state' => customer.state,
+                'email' => email,
+                'phone' => phone
+              }
+            ]
+          end
         end
       end
     end

--- a/app/services/integrations/aggregator/contacts/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/base_payload.rb
@@ -17,6 +17,8 @@ module Integrations
             [
               {
                 'name' => customer.name,
+                'firstname' => customer.firstname,
+                'lastname' => customer.lastname,
                 'city' => customer.city,
                 'zip' => customer.zipcode,
                 'country' => customer.country,
@@ -32,6 +34,8 @@ module Integrations
               {
                 'id' => integration_customer.external_customer_id,
                 'name' => customer.name,
+                'firstname' => customer.firstname,
+                'lastname' => customer.lastname,
                 'city' => customer.city,
                 'zip' => customer.zipcode,
                 'country' => customer.country,

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -117,7 +117,10 @@ RSpec.describe Customer, type: :model do
       let(:legal_name) { nil }
 
       it 'returns name with firstname and lastname' do
-        expect(customer.display_name).to eq('ACME Inc - Thomas Anderson')
+        aggregate_failures do
+          expect(customer.display_name).to eq('ACME Inc - Thomas Anderson')
+          expect(customer.display_name(prefer_legal_name: false)).to eq('ACME Inc - Thomas Anderson')
+        end
       end
     end
 
@@ -125,13 +128,19 @@ RSpec.describe Customer, type: :model do
       let(:name) { nil }
 
       it 'returns legal_name with firstname and lastname' do
-        expect(customer.display_name).to eq('ACME International Corporation - Thomas Anderson')
+        aggregate_failures do
+          expect(customer.display_name).to eq('ACME International Corporation - Thomas Anderson')
+          expect(customer.display_name(prefer_legal_name: false)).to eq('Thomas Anderson')
+        end
       end
     end
 
     context 'when all fields are present' do
-      it 'returns legal_name with firstname and lastname' do
-        expect(customer.display_name).to eq('ACME International Corporation - Thomas Anderson')
+      it 'returns display name' do
+        aggregate_failures do
+          expect(customer.display_name).to eq('ACME International Corporation - Thomas Anderson')
+          expect(customer.display_name(prefer_legal_name: false)).to eq('ACME Inc - Thomas Anderson')
+        end
       end
     end
   end

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -115,6 +115,8 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
           [
             {
               'name' => customer.name,
+              'firstname' => customer.firstname,
+              'lastname' => customer.lastname,
               'email' => customer.email,
               'city' => customer.city,
               'zip' => customer.zipcode,

--- a/spec/services/integrations/aggregator/contacts/payloads/anrok_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/anrok_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::Contacts::Payloads::Anrok do
+  let(:integration) { integration_customer.integration }
+  let(:integration_customer) { FactoryBot.create(:anrok_customer, customer:) }
+  let(:customer) { create(:customer) }
+  let(:payload) { described_class.new(integration:, customer:, integration_customer:) }
+  let(:customer_link) { payload.__send__(:customer_url) }
+
+  describe "#create_body" do
+    subject(:create_body_call) { payload.create_body }
+
+    let(:payload_body) do
+      [
+        {
+          'name' => customer.display_name(prefer_legal_name: false),
+          'city' => customer.city,
+          'zip' => customer.zipcode,
+          'country' => customer.country,
+          'state' => customer.state,
+          'email' => customer.email,
+          'phone' => customer.phone
+        }
+      ]
+    end
+
+    it 'returns the payload body' do
+      expect(subject).to eq payload_body
+    end
+  end
+
+  describe "#update_body" do
+    subject(:update_body_call) { payload.update_body }
+
+    let(:payload_body) do
+      [
+        {
+          'id' => integration_customer.external_customer_id,
+          'name' => customer.display_name(prefer_legal_name: false),
+          'city' => customer.city,
+          'zip' => customer.zipcode,
+          'country' => customer.country,
+          'state' => customer.state,
+          'email' => customer.email,
+          'phone' => customer.phone
+        }
+      ]
+    end
+
+    it "returns the payload body" do
+      expect(subject).to eq payload_body
+    end
+  end
+end

--- a/spec/services/integrations/aggregator/contacts/payloads/factory_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/factory_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Factory do
       let(:integration_customer) { FactoryBot.create(:anrok_customer) }
 
       it 'returns payload body' do
-        expect(subject.first['name']).to eq(customer.name)
+        expect(subject.first['name']).to eq(customer.display_name(prefer_legal_name: false))
       end
     end
   end
@@ -100,7 +100,7 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Factory do
       it 'returns payload body' do
         aggregate_failures do
           expect(subject.first['id']).to eq(integration_customer.external_customer_id)
-          expect(subject.first['name']).to eq(customer.name)
+          expect(subject.first['name']).to eq(customer.display_name(prefer_legal_name: false))
         end
       end
     end

--- a/spec/services/integrations/aggregator/contacts/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/xero_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::Contacts::Payloads::Xero do
+  let(:integration) { integration_customer.integration }
+  let(:integration_customer) { FactoryBot.create(:xero_customer, customer:) }
+  let(:customer) { create(:customer) }
+  let(:payload) { described_class.new(integration:, customer:, integration_customer:) }
+  let(:customer_link) { payload.__send__(:customer_url) }
+
+  describe "#create_body" do
+    subject(:create_body_call) { payload.create_body }
+
+    let(:payload_body) do
+      [
+        {
+          'name' => customer.name,
+          'firstname' => customer.firstname,
+          'lastname' => customer.lastname,
+          'city' => customer.city,
+          'zip' => customer.zipcode,
+          'country' => customer.country,
+          'state' => customer.state,
+          'email' => customer.email,
+          'phone' => customer.phone
+        }
+      ]
+    end
+
+    it 'returns the payload body' do
+      expect(subject).to eq payload_body
+    end
+  end
+
+  describe "#update_body" do
+    subject(:update_body_call) { payload.update_body }
+
+    let(:payload_body) do
+      [
+        {
+          'id' => integration_customer.external_customer_id,
+          'name' => customer.name,
+          'firstname' => customer.firstname,
+          'lastname' => customer.lastname,
+          'city' => customer.city,
+          'zip' => customer.zipcode,
+          'country' => customer.country,
+          'state' => customer.state,
+          'email' => customer.email,
+          'phone' => customer.phone
+        }
+      ]
+    end
+
+    it "returns the payload body" do
+      expect(subject).to eq payload_body
+    end
+  end
+end

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -89,6 +89,8 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
             {
               'id' => integration_customer.external_customer_id,
               'name' => customer.name,
+              'firstname' => customer.firstname,
+              'lastname' => customer.lastname,
               'email' => customer.email,
               'city' => customer.city,
               'zip' => customer.zipcode,


### PR DESCRIPTION
## Context
We currently only create Lago customers as **companies**, but there is a need to support both **companies** and **individuals**. This change is motivated by scenarios where customers may be a mix of B2B and B2C, and where external integrations require handling both **Contacts** and **Companies**.

To address this, we are introducing a new field, `customer_type`, to distinguish whether a customer is a **company** or an **individual**. Existing customers will remain unaffected with `customer_type` set to the default `nil`. 

## Description
In this PR we're adding the new fields: to both create and update anrok and xero payloads.