### PR TITLE
feat(customer-type):  Update stripe customer name with new fields

### DIFF
--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -153,6 +153,10 @@ module PaymentProviderCustomers
       stripe_payment_provider.secret_key
     end
 
+    def name
+      customer.name.presence || [customer.firstname, customer.lastname].join(' ')
+    end
+
     def checkout_link_params
       {
         success_url: success_redirect_url,
@@ -203,7 +207,7 @@ module PaymentProviderCustomers
           state: customer.state
         },
         email: customer.email&.strip&.split(',')&.first,
-        name: customer.name,
+        name:,
         metadata: {
           lago_customer_id: customer.id,
           customer_id: customer.external_id
@@ -223,7 +227,7 @@ module PaymentProviderCustomers
           state: customer.state
         },
         email: customer.email&.strip&.split(',')&.first,
-        name: customer.name,
+        name:,
         phone: customer.phone
       }
     end

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -154,7 +154,7 @@ module PaymentProviderCustomers
     end
 
     def name
-      customer.name.presence || [customer.firstname, customer.lastname].join(' ')
+      customer.name.presence || [customer.firstname, customer.lastname].compact.join(' ')
     end
 
     def checkout_link_params

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
     context 'when customer name is not present' do
       it 'creates a stripe customer with the customer firstname and lastname' do
         allow(Stripe::Customer).to receive(:create)
-                                     .and_return(Stripe::Customer.new(id: 'cus_123456'))
+          .and_return(Stripe::Customer.new(id: 'cus_123456'))
         stripe_service.create
 
         expected_name = "#{customer.firstname} #{customer.lastname}"

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -5,15 +5,39 @@ require 'rails_helper'
 RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
   subject(:stripe_service) { described_class.new(stripe_customer) }
 
-  let(:customer) { create(:customer, organization:) }
+  let(:customer) { create(:customer, name: customer_name, organization:) }
   let(:stripe_provider) { create(:stripe_provider) }
   let(:organization) { stripe_provider.organization }
+  let(:customer_name) { nil }
 
   let(:stripe_customer) do
     create(:stripe_customer, customer:, provider_customer_id: nil)
   end
 
   describe '#create' do
+    context 'when customer name is present' do
+      let(:customer_name) { 'Big inc' }
+
+      it 'creates a stripe customer with the customer name' do
+        allow(Stripe::Customer).to receive(:create)
+          .and_return(Stripe::Customer.new(id: 'cus_123456'))
+        stripe_service.create
+
+        expect(Stripe::Customer).to have_received(:create).with(hash_including(name: customer_name), anything)
+      end
+    end
+
+    context 'when customer name is not present' do
+      it 'creates a stripe customer with the customer firstname and lastname' do
+        allow(Stripe::Customer).to receive(:create)
+                                     .and_return(Stripe::Customer.new(id: 'cus_123456'))
+        stripe_service.create
+
+        expected_name = "#{customer.firstname} #{customer.lastname}"
+        expect(Stripe::Customer).to have_received(:create).with(hash_including(name: expected_name), anything)
+      end
+    end
+
     it 'creates the stripe customer' do
       allow(Stripe::Customer).to receive(:create)
         .and_return(Stripe::Customer.new(id: 'cus_123456'))


### PR DESCRIPTION
## Context
We currently only create Lago customers as **companies**, but there is a need to support both **companies** and **individuals**. This change is motivated by scenarios where customers may be a mix of B2B and B2C, and where external integrations require handling both **Contacts** and **Companies**.

To address this, we are introducing a new field, `customer_type`, to distinguish whether a customer is a **company** or an **individual**. Existing customers will remain unaffected with `customer_type` set to the default `nil`. 

## Description
In this PR we're adding the new fields: `lastname`, `firstname` to both create and update stripe payloads when the name on the customer is not defined.