### PR TITLE
misc: Remove months restriction from gross revenues

### DIFF
--- a/app/graphql/resolvers/analytics/gross_revenues_resolver.rb
+++ b/app/graphql/resolvers/analytics/gross_revenues_resolver.rb
@@ -12,13 +12,14 @@ module Resolvers
 
       argument :currency, Types::CurrencyEnum, required: false
       argument :external_customer_id, String, required: false
+      argument :months, Integer, required: false
 
       argument :expire_cache, Boolean, required: false
 
       type Types::Analytics::GrossRevenues::Object.collection_type, null: false
 
       def resolve(**args)
-        ::Analytics::GrossRevenue.find_all_by(current_organization.id, **args.merge(months: 12))
+        ::Analytics::GrossRevenue.find_all_by(current_organization.id, **args)
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -5917,7 +5917,7 @@ type Query {
   """
   Query gross revenue of an organization
   """
-  grossRevenues(currency: CurrencyEnum, expireCache: Boolean, externalCustomerId: String): GrossRevenueCollection!
+  grossRevenues(currency: CurrencyEnum, expireCache: Boolean, externalCustomerId: String, months: Int): GrossRevenueCollection!
 
   """
   Query a single integration

--- a/schema.json
+++ b/schema.json
@@ -29447,6 +29447,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "months",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "expireCache",
                   "description": null,
                   "type": {


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

 ## Description

The goal of this change is to not setting `months: 12` each time we're fetching gross revenues from graphql.