### PR TITLE
feat (tax-integrations): support endpoint for reporting credit notes in tax provider

### DIFF
--- a/app/services/integrations/aggregator/taxes/credit_notes/create_service.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/create_service.rb
@@ -38,46 +38,12 @@ module Integrations
           attr_reader :credit_note
 
           def payload
-            [
-              {
-                'id' => "cn_#{credit_note.id}",
-                'issuing_date' => credit_note.issuing_date,
-                'currency' => credit_note.currency,
-                'contact' => {
-                  'external_id' => integration_customer&.external_customer_id || customer.external_id,
-                  'name' => customer.name,
-                  'address_line_1' => customer.shipping_address_line1 || customer.address_line1,
-                  'city' => customer.shipping_city || customer.city,
-                  'zip' => customer.shipping_zipcode || customer.zipcode,
-                  'country' => customer.shipping_country || customer.country,
-                  'taxable' => customer.tax_identification_number.present?,
-                  'tax_number' => customer.tax_identification_number
-                },
-                'fees' => credit_note.items.order(created_at: :asc).map { |item| cn_item(item) }
-              }
-            ]
-          end
-
-          def cn_item(item)
-            fee = item.fee
-            base_payload = Integrations::Aggregator::BasePayload.new(integration:)
-
-            mapped_item = if fee.charge?
-              base_payload.billable_metric_item(fee)
-            elsif fee.add_on_id.present?
-              base_payload.add_on_item(fee)
-            elsif fee.commitment?
-              base_payload.commitment_item
-            elsif fee.subscription?
-              base_payload.subscription_item
-            end
-            mapped_item ||= OpenStruct.new
-
-            {
-              'item_id' => fee.item_id,
-              'item_code' => mapped_item.external_id,
-              'amount_cents' => (fee.sub_total_excluding_taxes_amount_cents&.to_i || 0) * -1
-            }
+            Integrations::Aggregator::Taxes::CreditNotes::Payload.new(
+              integration:,
+              customer:,
+              integration_customer:,
+              credit_note:
+            ).body
           end
         end
       end

--- a/app/services/integrations/aggregator/taxes/credit_notes/create_service.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/create_service.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    module Taxes
+      module CreditNotes
+        class CreateService < Integrations::Aggregator::Taxes::Invoices::BaseService
+          def initialize(credit_note:)
+            @credit_note = credit_note
+
+            super(invoice: credit_note.invoice)
+          end
+
+          def action_path
+            "v1/#{provider}/finalized_invoices"
+          end
+
+          def call
+            return result unless integration
+            return result unless integration.type == 'Integrations::AnrokIntegration'
+
+            response = http_client.post_with_response(payload, headers)
+            body = JSON.parse(response.body)
+
+            process_response(body)
+            assign_external_customer_id
+
+            result
+          rescue LagoHttpClient::HttpError => e
+            code = code(e)
+            message = message(e)
+
+            result.service_failure!(code:, message:)
+          end
+
+          private
+
+          attr_reader :credit_note
+
+          def payload
+            [
+              {
+                'id' => "cn_#{credit_note.id}",
+                'issuing_date' => credit_note.issuing_date,
+                'currency' => credit_note.currency,
+                'contact' => {
+                  'external_id' => integration_customer&.external_customer_id || customer.external_id,
+                  'name' => customer.name,
+                  'address_line_1' => customer.shipping_address_line1 || customer.address_line1,
+                  'city' => customer.shipping_city || customer.city,
+                  'zip' => customer.shipping_zipcode || customer.zipcode,
+                  'country' => customer.shipping_country || customer.country,
+                  'taxable' => customer.tax_identification_number.present?,
+                  'tax_number' => customer.tax_identification_number
+                },
+                'fees' => credit_note.items.order(created_at: :asc).map { |item| cn_item(item) }
+              }
+            ]
+          end
+
+          def cn_item(item)
+            fee = item.fee
+            base_payload = Integrations::Aggregator::BasePayload.new(integration:)
+
+            mapped_item = if fee.charge?
+              base_payload.billable_metric_item(fee)
+            elsif fee.add_on_id.present?
+              base_payload.add_on_item(fee)
+            elsif fee.commitment?
+              base_payload.commitment_item
+            elsif fee.subscription?
+              base_payload.subscription_item
+            end
+            mapped_item ||= OpenStruct.new
+
+            {
+              'item_id' => fee.item_id,
+              'item_code' => mapped_item.external_id,
+              'amount_cents' => (fee.sub_total_excluding_taxes_amount_cents&.to_i || 0) * -1
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/integrations/aggregator/taxes/credit_notes/payload.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/payload.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    module Taxes
+      module CreditNotes
+        class Payload < BasePayload
+          def initialize(integration:, customer:, integration_customer:, credit_note:)
+            super(integration:)
+
+            @customer = customer
+            @integration_customer = integration_customer
+            @credit_note = credit_note
+          end
+
+          def body
+            [
+              {
+                'id' => "cn_#{credit_note.id}",
+                'issuing_date' => credit_note.issuing_date,
+                'currency' => credit_note.currency,
+                'contact' => {
+                  'external_id' => integration_customer&.external_customer_id || customer.external_id,
+                  'name' => customer.name,
+                  'address_line_1' => customer.shipping_address_line1 || customer.address_line1,
+                  'city' => customer.shipping_city || customer.city,
+                  'zip' => customer.shipping_zipcode || customer.zipcode,
+                  'country' => customer.shipping_country || customer.country,
+                  'taxable' => customer.tax_identification_number.present?,
+                  'tax_number' => customer.tax_identification_number
+                },
+                'fees' => credit_note.items.order(created_at: :asc).map { |item| cn_item(item) }
+              }
+            ]
+          end
+
+          def cn_item(item)
+            fee = item.fee
+
+            mapped_item = if fee.charge?
+              billable_metric_item(fee)
+            elsif fee.add_on_id.present?
+              add_on_item(fee)
+            elsif fee.commitment?
+              commitment_item
+            elsif fee.subscription?
+              subscription_item
+            end
+            mapped_item ||= OpenStruct.new
+
+            {
+              'item_id' => fee.item_id,
+              'item_code' => mapped_item.external_id,
+              'amount_cents' => (fee.sub_total_excluding_taxes_amount_cents&.to_i || 0) * -1
+            }
+          end
+
+          private
+
+          attr_reader :customer, :integration_customer, :credit_note
+        end
+      end
+    end
+  end
+end

--- a/app/services/integrations/aggregator/taxes/invoices/base_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/base_service.rb
@@ -41,6 +41,13 @@ module Integrations
             }
           end
 
+          def assign_external_customer_id
+            return unless result.success?
+            return if integration_customer.external_customer_id
+
+            integration_customer.update!(external_customer_id: customer.external_id)
+          end
+
           def process_response(body)
             fees = body['succeededInvoices']&.first.try(:[], 'fees')
 

--- a/app/services/integrations/aggregator/taxes/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_service.rb
@@ -17,10 +17,7 @@ module Integrations
             body = JSON.parse(response.body)
 
             process_response(body)
-
-            if result.success? && integration_customer.external_customer_id.blank?
-              integration_customer.update!(external_customer_id: customer.external_id)
-            end
+            assign_external_customer_id
 
             result
           rescue LagoHttpClient::HttpError => e

--- a/spec/services/integrations/aggregator/taxes/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/create_service_spec.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::CreateService do
+  subject(:service_call) { described_class.call(credit_note:) }
+
+  let(:integration) { create(:anrok_integration, organization:) }
+  let(:integration_customer) { create(:anrok_customer, integration:, customer:, external_customer_id: nil) }
+  let(:customer) { create(:customer, organization:) }
+  let(:organization) { create(:organization) }
+  let(:lago_client) { instance_double(LagoHttpClient::Client) }
+  let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:add_on_two) { create(:add_on, organization:) }
+  let(:current_time) { Time.current }
+
+  let(:integration_collection_mapping1) do
+    create(
+      :netsuite_collection_mapping,
+      integration:,
+      mapping_type: :fallback_item,
+      settings: {external_id: '1', external_account_code: '11', external_name: ''}
+    )
+  end
+  let(:integration_mapping_add_on) do
+    create(
+      :netsuite_mapping,
+      integration:,
+      mappable_type: 'AddOn',
+      mappable_id: add_on.id,
+      settings: {external_id: 'm1', external_account_code: 'm11', external_name: ''}
+    )
+  end
+
+  let(:invoice) do
+    create(
+      :invoice,
+      customer:,
+      organization:
+    )
+  end
+  let(:fee_add_on) do
+    create(
+      :fee,
+      invoice:,
+      add_on:,
+      created_at: current_time - 3.seconds
+    )
+  end
+  let(:fee_add_on_two) do
+    create(
+      :fee,
+      invoice:,
+      add_on: add_on_two,
+      created_at: current_time - 2.seconds
+    )
+  end
+  let(:credit_note) do
+    create(
+      :credit_note,
+      customer:,
+      invoice:,
+      status: 'finalized',
+      organization:
+    )
+  end
+
+  let(:credit_note_item1) do
+    create(:credit_note_item, credit_note:, fee: fee_add_on, amount_cents: fee_add_on.amount_cents)
+  end
+  let(:credit_note_item2) do
+    create(:credit_note_item, credit_note:, fee: fee_add_on_two, amount_cents: fee_add_on_two.amount_cents)
+  end
+
+  let(:headers) do
+    {
+      'Connection-Id' => integration.connection_id,
+      'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
+      'Provider-Config-Key' => 'anrok'
+    }
+  end
+
+  let(:params) do
+    [
+      {
+        'id' => "cn_#{credit_note.id}",
+        'issuing_date' => credit_note.issuing_date,
+        'currency' => credit_note.currency,
+        'contact' => {
+          'external_id' => customer.external_id,
+          'name' => customer.name,
+          'address_line_1' => customer.address_line1,
+          'city' => customer.city,
+          'zip' => customer.zipcode,
+          'country' => customer.country,
+          'taxable' => false,
+          'tax_number' => nil
+        },
+        'fees' => [
+          {
+            'item_id' => fee_add_on.item_id,
+            'item_code' => 'm1',
+            'amount_cents' => -200
+          },
+          {
+            'item_id' => fee_add_on_two.item_id,
+            'item_code' => '1',
+            'amount_cents' => -200
+          }
+        ]
+      }
+    ]
+  end
+
+  before do
+    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+
+    integration_customer
+    integration_collection_mapping1
+    integration_mapping_add_on
+    fee_add_on
+    fee_add_on_two
+    credit_note_item1
+    credit_note_item2
+  end
+
+  describe '#call' do
+    context 'when service call is successful' do
+      let(:response) { instance_double(Net::HTTPOK) }
+
+      before do
+        allow(lago_client).to receive(:post_with_response).with(params, headers).and_return(response)
+        allow(response).to receive(:body).and_return(body)
+      end
+
+      context 'when transaction is created and taxes are successfully fetched for credit note' do
+        let(:body) do
+          path = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
+          File.read(path)
+        end
+
+        it 'returns fees' do
+          result = service_call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.fees.first['tax_breakdown'].first['rate']).to eq('0.10')
+            expect(result.fees.first['tax_breakdown'].first['name']).to eq('GST/HST')
+            expect(result.fees.first['tax_breakdown'].last['name']).to eq('Reverse charge')
+            expect(result.fees.first['tax_breakdown'].last['type']).to eq('exempt')
+            expect(result.fees.first['tax_breakdown'].last['rate']).to eq('0.00')
+          end
+        end
+
+        it 'sets integration customer external id' do
+          service_call
+
+          expect(integration_customer.reload.external_customer_id).to eq(customer.external_id)
+        end
+      end
+
+      context 'when taxes are not successfully reported' do
+        let(:body) do
+          path = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+          File.read(path)
+        end
+
+        it 'does not return fees' do
+          result = service_call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.fees).to be(nil)
+            expect(result.error).to be_a(BaseService::ServiceFailure)
+            expect(result.error.code).to eq('taxDateTooFarInFuture')
+          end
+        end
+
+        it 'delivers an error webhook' do
+          expect { service_call }.to enqueue_job(SendWebhookJob)
+            .with(
+              'customer.tax_provider_error',
+              customer,
+              provider: 'anrok',
+              provider_code: integration.code,
+              provider_error: {
+                message: 'Service failure',
+                error_code: 'taxDateTooFarInFuture'
+              }
+            )
+        end
+
+        it 'does not set integration customer external id' do
+          service_call
+
+          expect(integration_customer.reload.external_customer_id).to eq(nil)
+        end
+      end
+    end
+
+    context 'when service call is not successful' do
+      let(:body) do
+        path = Rails.root.join('spec/fixtures/integration_aggregator/error_response.json')
+        File.read(path)
+      end
+
+      let(:http_error) { LagoHttpClient::HttpError.new(error_code, body, nil) }
+
+      before do
+        allow(lago_client).to receive(:post_with_response).with(params, headers).and_raise(http_error)
+      end
+
+      context 'when it is a server error' do
+        let(:error_code) { Faker::Number.between(from: 500, to: 599) }
+
+        it 'returns an error' do
+          result = service_call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.fees).to be(nil)
+            expect(result.error).to be_a(BaseService::ServiceFailure)
+            expect(result.error.code).to eq('action_script_runtime_error')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/integrations/aggregator/taxes/credit_notes/payload_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/payload_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payload do
+  subject(:service_call) { payload.body }
+
+  let(:payload) { described_class.new(integration:, customer:, integration_customer:, credit_note:) }
+  let(:integration) { create(:anrok_integration, organization:) }
+  let(:integration_customer) { create(:anrok_customer, integration:, customer:, external_customer_id: nil) }
+  let(:customer) { create(:customer, organization:) }
+  let(:organization) { create(:organization) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:add_on_two) { create(:add_on, organization:) }
+  let(:current_time) { Time.current }
+
+  let(:integration_collection_mapping1) do
+    create(
+      :netsuite_collection_mapping,
+      integration:,
+      mapping_type: :fallback_item,
+      settings: {external_id: '1', external_account_code: '11', external_name: ''}
+    )
+  end
+  let(:integration_mapping_add_on) do
+    create(
+      :netsuite_mapping,
+      integration:,
+      mappable_type: 'AddOn',
+      mappable_id: add_on.id,
+      settings: {external_id: 'm1', external_account_code: 'm11', external_name: ''}
+    )
+  end
+
+  let(:invoice) do
+    create(
+      :invoice,
+      customer:,
+      organization:
+    )
+  end
+  let(:fee_add_on) do
+    create(
+      :fee,
+      invoice:,
+      add_on:,
+      created_at: current_time - 3.seconds
+    )
+  end
+  let(:fee_add_on_two) do
+    create(
+      :fee,
+      invoice:,
+      add_on: add_on_two,
+      created_at: current_time - 2.seconds
+    )
+  end
+  let(:credit_note) do
+    create(
+      :credit_note,
+      customer:,
+      invoice:,
+      status: 'finalized',
+      organization:
+    )
+  end
+
+  let(:credit_note_item1) do
+    create(:credit_note_item, credit_note:, fee: fee_add_on, amount_cents: fee_add_on.amount_cents)
+  end
+  let(:credit_note_item2) do
+    create(:credit_note_item, credit_note:, fee: fee_add_on_two, amount_cents: fee_add_on_two.amount_cents)
+  end
+
+  let(:body) do
+    [
+      {
+        'id' => "cn_#{credit_note.id}",
+        'issuing_date' => credit_note.issuing_date,
+        'currency' => credit_note.currency,
+        'contact' => {
+          'external_id' => customer.external_id,
+          'name' => customer.name,
+          'address_line_1' => customer.address_line1,
+          'city' => customer.city,
+          'zip' => customer.zipcode,
+          'country' => customer.country,
+          'taxable' => false,
+          'tax_number' => nil
+        },
+        'fees' => [
+          {
+            'item_id' => fee_add_on.item_id,
+            'item_code' => 'm1',
+            'amount_cents' => -200
+          },
+          {
+            'item_id' => fee_add_on_two.item_id,
+            'item_code' => '1',
+            'amount_cents' => -200
+          }
+        ]
+      }
+    ]
+  end
+
+  before do
+    integration_customer
+    integration_collection_mapping1
+    integration_mapping_add_on
+    fee_add_on
+    fee_add_on_two
+    credit_note_item1
+    credit_note_item2
+  end
+
+  describe '#body' do
+    it 'returns payload' do
+      expect(service_call).to eq(body)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently Lago is implementing integration with tax provider Anrok

## Description

This PR adds base service which sends credit note to the Anrok and creates transaction there.
