### PR TITLE
fix(customer-type): Do not add empty firstname and lastname to xero payload

### DIFF
--- a/app/services/integrations/aggregator/contacts/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/base_payload.rb
@@ -17,15 +17,13 @@ module Integrations
             [
               {
                 'name' => customer.name,
-                'firstname' => customer.firstname,
-                'lastname' => customer.lastname,
                 'city' => customer.city,
                 'zip' => customer.zipcode,
                 'country' => customer.country,
                 'state' => customer.state,
                 'email' => email,
                 'phone' => phone
-              }
+              }.merge(contact_names)
             ]
           end
 
@@ -34,21 +32,23 @@ module Integrations
               {
                 'id' => integration_customer.external_customer_id,
                 'name' => customer.name,
-                'firstname' => customer.firstname,
-                'lastname' => customer.lastname,
                 'city' => customer.city,
                 'zip' => customer.zipcode,
                 'country' => customer.country,
                 'state' => customer.state,
                 'email' => email,
                 'phone' => phone
-              }
+              }.merge(contact_names)
             ]
           end
 
           private
 
           attr_reader :customer, :integration_customer, :subsidiary_id
+
+          def contact_names
+            {'firstname' => customer.firstname, 'lastname' => customer.lastname}.compact_blank
+          end
 
           def email
             customer.email.to_s.split(',').first&.strip

--- a/spec/services/integrations/aggregator/contacts/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/xero_spec.rb
@@ -5,9 +5,10 @@ require 'rails_helper'
 RSpec.describe Integrations::Aggregator::Contacts::Payloads::Xero do
   let(:integration) { integration_customer.integration }
   let(:integration_customer) { FactoryBot.create(:xero_customer, customer:) }
-  let(:customer) { create(:customer) }
+  let(:customer) { create(:customer, firstname:, lastname:) }
   let(:payload) { described_class.new(integration:, customer:, integration_customer:) }
   let(:customer_link) { payload.__send__(:customer_url) }
+  let(:contact_names) { {'firstname' => firstname, 'lastname' => lastname}.compact_blank }
 
   describe "#create_body" do
     subject(:create_body_call) { payload.create_body }
@@ -16,20 +17,50 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Xero do
       [
         {
           'name' => customer.name,
-          'firstname' => customer.firstname,
-          'lastname' => customer.lastname,
           'city' => customer.city,
           'zip' => customer.zipcode,
           'country' => customer.country,
           'state' => customer.state,
           'email' => customer.email,
           'phone' => customer.phone
-        }
+        }.merge(contact_names)
       ]
     end
 
-    it 'returns the payload body' do
-      expect(subject).to eq payload_body
+    context 'when firstname and lastname are blank' do
+      let(:firstname) { [nil, ''].sample }
+      let(:lastname) { [nil, ''].sample }
+
+      it 'returns the payload body' do
+        expect(subject).to eq payload_body
+      end
+    end
+
+    context 'when both firstname and lastname are present' do
+      let(:firstname) { Faker::Name.first_name }
+      let(:lastname) { Faker::Name.last_name }
+
+      it 'returns the payload body' do
+        expect(subject).to eq payload_body
+      end
+    end
+
+    context 'when firstname is present' do
+      let(:firstname) { Faker::Name.first_name }
+      let(:lastname) { [nil, ''].sample }
+
+      it 'returns the payload body' do
+        expect(subject).to eq payload_body
+      end
+    end
+
+    context 'when lastname is present' do
+      let(:firstname) { [nil, ''].sample }
+      let(:lastname) { Faker::Name.last_name }
+
+      it 'returns the payload body' do
+        expect(subject).to eq payload_body
+      end
     end
   end
 
@@ -41,20 +72,50 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Xero do
         {
           'id' => integration_customer.external_customer_id,
           'name' => customer.name,
-          'firstname' => customer.firstname,
-          'lastname' => customer.lastname,
           'city' => customer.city,
           'zip' => customer.zipcode,
           'country' => customer.country,
           'state' => customer.state,
           'email' => customer.email,
           'phone' => customer.phone
-        }
+        }.merge(contact_names)
       ]
     end
 
-    it "returns the payload body" do
-      expect(subject).to eq payload_body
+    context 'when firstname and lastname are blank' do
+      let(:firstname) { [nil, ''].sample }
+      let(:lastname) { [nil, ''].sample }
+
+      it 'returns the payload body' do
+        expect(subject).to eq payload_body
+      end
+    end
+
+    context 'when both firstname and lastname are present' do
+      let(:firstname) { Faker::Name.first_name }
+      let(:lastname) { Faker::Name.last_name }
+
+      it 'returns the payload body' do
+        expect(subject).to eq payload_body
+      end
+    end
+
+    context 'when firstname is present' do
+      let(:firstname) { Faker::Name.first_name }
+      let(:lastname) { [nil, ''].sample }
+
+      it 'returns the payload body' do
+        expect(subject).to eq payload_body
+      end
+    end
+
+    context 'when lastname is present' do
+      let(:firstname) { [nil, ''].sample }
+      let(:lastname) { Faker::Name.last_name }
+
+      it 'returns the payload body' do
+        expect(subject).to eq payload_body
+      end
     end
   end
 end


### PR DESCRIPTION
## Context
We currently only create Lago customers as **companies**, but there is a need to support both **companies** and **individuals**. This change is motivated by scenarios where customers may be a mix of B2B and B2C, and where external integrations require handling both **Contacts** and **Companies**.

To address this, we are introducing a new field, `customer_type`, to distinguish whether a customer is a **company** or an **individual**. Existing customers will remain unaffected with `customer_type` set to the default `nil`. 

## Description
We should not send empty firstnme and lastname to Xero, because in that case a contact (instead of a customer) is created.
If we don't send those empty attributes at all a customer is created which is the expected behaviour.