### PR TITLE
feat(customer_portal): Remove premium restriction

### DIFF
--- a/app/services/customer_portal/generate_url_service.rb
+++ b/app/services/customer_portal/generate_url_service.rb
@@ -9,7 +9,6 @@ module CustomerPortal
     end
 
     def call
-      return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: 'customer') if customer.blank?
 
       public_authenticator = ActiveSupport::MessageVerifier.new(ENV['SECRET_KEY_BASE'])

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -241,43 +241,28 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     let(:customer) { create(:customer, organization:) }
     let(:organization) { create(:organization) }
 
-    context 'when licence is premium' do
-      around { |test| lago_premium!(&test) }
+    it 'returns the portal url' do
+      get_with_token(
+        organization,
+        "/api/v1/customers/#{customer.external_id}/portal_url"
+      )
 
-      it 'returns the portal url' do
-        get_with_token(
-          organization,
-          "/api/v1/customers/#{customer.external_id}/portal_url"
-        )
-
-        aggregate_failures do
-          expect(response).to have_http_status(:success)
-          expect(json[:customer][:portal_url]).to include('/customer-portal/')
-        end
-      end
-
-      context 'when customer does not belongs to the organization' do
-        let(:customer) { create(:customer) }
-
-        it 'returns not found error' do
-          get_with_token(
-            organization,
-            "/api/v1/customers/#{customer.external_id}/portal_url"
-          )
-
-          expect(response).to have_http_status(:not_found)
-        end
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:customer][:portal_url]).to include('/customer-portal/')
       end
     end
 
-    context 'when licence is not premium' do
-      it 'returns error' do
+    context 'when customer does not belongs to the organization' do
+      let(:customer) { create(:customer) }
+
+      it 'returns not found error' do
         get_with_token(
           organization,
           "/api/v1/customers/#{customer.external_id}/portal_url"
         )
 
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/services/customer_portal/generate_url_service_spec.rb
+++ b/spec/services/customer_portal/generate_url_service_spec.rb
@@ -8,39 +8,26 @@ RSpec.describe CustomerPortal::GenerateUrlService, type: :service do
   let(:customer) { create(:customer) }
 
   describe '#call' do
-    context 'when licence is premium' do
-      around { |test| lago_premium!(&test) }
+    it 'generates valid customer portal url' do
+      result = generate_url_service.call
 
-      it 'generates valid customer portal url' do
-        result = generate_url_service.call
+      message = result.url.split('/customer-portal/')[1]
+      public_authenticator = ActiveSupport::MessageVerifier.new(ENV['SECRET_KEY_BASE'])
 
-        message = result.url.split('/customer-portal/')[1]
-        public_authenticator = ActiveSupport::MessageVerifier.new(ENV['SECRET_KEY_BASE'])
-
-        aggregate_failures do
-          expect(result.url).to include('/customer-portal/')
-          expect(public_authenticator.verify(message)).to eq(customer.id)
-        end
-      end
-
-      context 'when customer does not exist' do
-        let(:customer) { nil }
-
-        it 'returns an error' do
-          result = generate_url_service.call
-
-          expect(result).not_to be_success
-          expect(result.error.error_code).to eq('customer_not_found')
-        end
+      aggregate_failures do
+        expect(result.url).to include('/customer-portal/')
+        expect(public_authenticator.verify(message)).to eq(customer.id)
       end
     end
 
-    context 'when licence is not premium' do
+    context 'when customer does not exist' do
+      let(:customer) { nil }
+
       it 'returns an error' do
         result = generate_url_service.call
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('feature_unavailable')
+        expect(result.error.error_code).to eq('customer_not_found')
       end
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/{{FEATURE_SLUG}}](https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal)

## Context

We got feedback that this portal is too limited in terms of features and information. Why?

**1st reason:** the number of information displayed is limited

**2nd reason:** the end user cannot take actions out of it (change info, add payment method)

**3rd reason:** the UI and display is not customizable

## Description

The goal of this PR is to make accessible to all our users (free and premium) the customer portal URL.
