### PR TITLE
misc: Disable GraphQL introspection

### DIFF
--- a/app/graphql/lago_api_schema.rb
+++ b/app/graphql/lago_api_schema.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class LagoApiSchema < GraphQL::Schema
+  disable_introspection_entry_points if Rails.env.production?
+
   mutation(Types::MutationType)
   query(Types::QueryType)
 


### PR DESCRIPTION
## Description

This pull request is turning off GraphQL introspection as it represents a potential security risk and is not required for production purpose.