### PR TITLE
fix(invoice): avoid failure on error not related to taxes

### DIFF
--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -139,7 +139,10 @@ module Invoices
     end
 
     def tax_error?(fee_result)
-      !fee_result.success? && fee_result&.error&.code == 'tax_error'
+      return false if fee_result.success?
+      return false unless fee_result.error.is_a?(BaseService::ServiceFailure)
+
+      fee_result.error.code == 'tax_error'
     end
   end
 end


### PR DESCRIPTION
## Description

This PR is fixing a regression recently introduced by the external tax management feature. A test was added to handle `tax_error` and was testing a specific error code on a service failure, but not all `BaseService::FailedResult` are responding to the `error` method