### PR TITLE
feat(tax-integration): add logic for reporting credit note to the tax provider

### DIFF
--- a/app/jobs/credit_notes/provider_taxes/report_job.rb
+++ b/app/jobs/credit_notes/provider_taxes/report_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  module ProviderTaxes
+    class ReportJob < ApplicationJob
+      queue_as 'integrations'
+
+      def perform(credit_note:)
+        return unless credit_note.customer.anrok_customer
+
+        # NOTE: We don't want to raise error here.
+        #       If sync fails, invoice would be marked and retry option would be available in the UI
+        CreditNotes::ProviderTaxes::ReportService.call(credit_note:)
+      end
+    end
+  end
+end

--- a/app/services/credit_notes/provider_taxes/report_service.rb
+++ b/app/services/credit_notes/provider_taxes/report_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  module ProviderTaxes
+    class ReportService < BaseService
+      def initialize(credit_note:)
+        @credit_note = credit_note
+
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: 'credit_note') unless credit_note
+
+        credit_note.error_details.tax_error.discard_all
+
+        tax_result = Integrations::Aggregator::Taxes::CreditNotes::CreateService.new(credit_note:).call
+
+        unless tax_result.success?
+          create_error_detail(tax_result.error.code)
+
+          return result.validation_failure!(errors: {tax_error: [tax_result.error.code]})
+        end
+
+        result.credit_note = credit_note
+
+        result
+      end
+
+      private
+
+      attr_reader :credit_note
+
+      delegate :customer, to: :credit_note
+
+      def create_error_detail(code)
+        error_result = ErrorDetails::CreateService.call(
+          owner: credit_note,
+          organization: credit_note.organization,
+          params: {
+            error_code: :tax_error,
+            details: {
+              tax_error: code
+            }
+          }
+        )
+        error_result.raise_if_error!
+      end
+    end
+  end
+end

--- a/spec/factories/credit_notes.rb
+++ b/spec/factories/credit_notes.rb
@@ -31,5 +31,11 @@ FactoryBot.define do
     trait :draft do
       status { :draft }
     end
+
+    trait :with_tax_error do
+      after :create do |i|
+        create(:error_detail, owner: i, error_code: 'tax_error')
+      end
+    end
   end
 end

--- a/spec/jobs/credit_notes/provider_taxes/report_job_spec.rb
+++ b/spec/jobs/credit_notes/provider_taxes/report_job_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::ProviderTaxes::ReportJob, type: :job do
+  let(:organization) { create(:organization) }
+  let(:credit_note) { create(:credit_note, customer:) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:result) { BaseService::Result.new }
+
+  before do
+    allow(CreditNotes::ProviderTaxes::ReportService).to receive(:call)
+      .with(credit_note:)
+      .and_return(result)
+  end
+
+  context 'when there is anrok customer' do
+    let(:integration) { create(:anrok_integration, organization:) }
+    let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+
+    before { integration_customer }
+
+    it 'calls successfully report service' do
+      described_class.perform_now(credit_note:)
+
+      expect(CreditNotes::ProviderTaxes::ReportService).to have_received(:call)
+    end
+  end
+
+  context 'when there is NOT anrok customer' do
+    it 'does not call report service' do
+      described_class.perform_now(credit_note:)
+
+      expect(CreditNotes::ProviderTaxes::ReportService).not_to have_received(:call)
+    end
+  end
+end

--- a/spec/services/credit_notes/provider_taxes/report_service_spec.rb
+++ b/spec/services/credit_notes/provider_taxes/report_service_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe CreditNotes::ProviderTaxes::ReportService, type: :service do
         aggregate_failures do
           expect(credit_note.error_details.tax_error.order(created_at: :asc).last.id).not_to eql(old_error_id)
           expect(credit_note.error_details.tax_error.count).to be(1)
-          expect(credit_note.error_details.tax_error.order(created_at: :asc).last.discarded?).to be(false)
+          expect(credit_note.error_details.tax_error.order(created_at: :asc).last).not_to be_discarded
         end
       end
     end

--- a/spec/services/credit_notes/provider_taxes/report_service_spec.rb
+++ b/spec/services/credit_notes/provider_taxes/report_service_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::ProviderTaxes::ReportService, type: :service do
+  subject(:report_service) { described_class.new(credit_note:) }
+
+  describe '#call' do
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+
+    let(:invoice) do
+      create(
+        :invoice,
+        :voided,
+        customer:,
+        organization:,
+        subscriptions: [subscription],
+        currency: 'EUR',
+        issuing_date: Time.zone.at(timestamp).to_date
+      )
+    end
+    let(:credit_note) do
+      create(
+        :credit_note,
+        :with_tax_error,
+        customer:,
+        organization:,
+        invoice:
+      )
+    end
+
+    let(:subscription) do
+      create(
+        :subscription,
+        plan:,
+        subscription_at: started_at,
+        started_at:,
+        created_at: started_at
+      )
+    end
+
+    let(:timestamp) { Time.zone.now - 1.year }
+    let(:started_at) { Time.zone.now - 2.years }
+    let(:plan) { create(:plan, organization:, interval: 'monthly') }
+    let(:billable_metric) { create(:billable_metric, aggregation_type: 'count_agg') }
+    let(:charge) { create(:standard_charge, plan: subscription.plan, charge_model: 'standard', billable_metric:) }
+
+    let(:fee_subscription) do
+      create(
+        :fee,
+        invoice:,
+        subscription:,
+        fee_type: :subscription,
+        amount_cents: 2_000
+      )
+    end
+    let(:fee_charge) do
+      create(
+        :fee,
+        invoice:,
+        charge:,
+        fee_type: :charge,
+        total_aggregated_units: 100,
+        amount_cents: 1_000
+      )
+    end
+
+    let(:integration) { create(:anrok_integration, organization:) }
+    let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+    let(:response) { instance_double(Net::HTTPOK) }
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+    let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+    let(:body) do
+      path = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response_multiple_fees.json')
+      File.read(path)
+    end
+    let(:integration_collection_mapping) do
+      create(
+        :netsuite_collection_mapping,
+        integration:,
+        mapping_type: :fallback_item,
+        settings: {external_id: '1', external_account_code: '11', external_name: ''}
+      )
+    end
+
+    before do
+      integration_collection_mapping
+      fee_subscription
+      fee_charge
+      integration_customer
+
+      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response).and_return(response)
+      allow(response).to receive(:body).and_return(body)
+    end
+
+    context 'when credit note does not exist' do
+      it 'returns an error' do
+        result = described_class.new(credit_note: nil).call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('credit_note_not_found')
+        end
+      end
+    end
+
+    context 'when credit note is successfully synced' do
+      it 'returns successful result' do
+        result = report_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.credit_note.id).to eq(credit_note.id)
+        end
+      end
+
+      it 'discards previous tax errors' do
+        expect { report_service.call }
+          .to change(credit_note.error_details.tax_error, :count).from(1).to(0)
+      end
+    end
+
+    context 'when failed result is returned' do
+      let(:body) do
+        path = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+        File.read(path)
+      end
+
+      it 'returns validation error' do
+        result = report_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        end
+      end
+
+      it 'resolves old tax error and creates new one' do
+        old_error_id = credit_note.reload.error_details.order(created_at: :asc).last.id
+
+        report_service.call
+
+        aggregate_failures do
+          expect(credit_note.error_details.tax_error.order(created_at: :asc).last.id).not_to eql(old_error_id)
+          expect(credit_note.error_details.tax_error.count).to be(1)
+          expect(credit_note.error_details.tax_error.order(created_at: :asc).last.discarded?).to be(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently Lago is working on integration with tax provider Anrok.

## Description

This PR covers sending credit notes to the tax provider and handling tax provider errors
