### PR TITLE
fix(subscription): Fix generating invoice with pending downgrade

### DIFF
--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -633,9 +633,9 @@ RSpec.describe Invoice, type: :model do
   end
 
   describe '#charge_pay_in_advance_proration_range' do
-    let(:invoice_subscription) { create(:invoice_subscription) }
+    let(:invoice_subscription) { create(:invoice_subscription, subscription:) }
     let(:invoice) { invoice_subscription.invoice }
-    let(:subscription) { invoice_subscription.subscription }
+    let(:subscription) { create(:subscription, started_at: timestamp - 1.year) }
     let(:timestamp) { DateTime.parse('2023-07-25 00:00:00 UTC') }
     let(:event) { create(:event, subscription_id: subscription.id, timestamp:) }
     let(:billable_metric) { create(:sum_billable_metric, organization: subscription.organization, recurring: true) }

--- a/spec/scenarios/subscriptions/terminate_ended_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_spec.rb
@@ -18,9 +18,9 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
     )
   end
 
-  let(:creation_time) { DateTime.new(2023, 9, 5, 0, 0) }
-  let(:subscription_at) { DateTime.new(2023, 9, 5, 0, 0) }
-  let(:ending_at) { DateTime.new(2023, 9, 6, 0, 0) }
+  let(:creation_time) { Time.zone.parse('2023-09-05T00:00:00') }
+  let(:subscription_at) { Time.zone.parse('2023-09-05T00:00:00') }
+  let(:ending_at) { Time.zone.parse('2023-09-06T00:00:00') }
 
   context 'when timezone is Europe/Paris' do
     it 'terminates the subscription when it reaches its ending date' do

--- a/spec/services/subscriptions/dates/quarterly_service_spec.rb
+++ b/spec/services/subscriptions/dates/quarterly_service_spec.rb
@@ -222,14 +222,14 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
         end
 
         it 'returns the termination date' do
-          expect(result).to eq(subscription.terminated_at.utc.to_s)
+          expect(result).to match_datetime(subscription.terminated_at.utc)
         end
 
         context 'with customer timezone' do
           let(:timezone) { 'America/New_York' }
 
           it 'returns the termination date' do
-            expect(result).to eq(subscription.terminated_at.utc.to_s)
+            expect(result).to match_datetime(subscription.terminated_at.utc)
           end
         end
       end
@@ -295,7 +295,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
         end
 
         it 'returns the termination date' do
-          expect(result).to eq(subscription.terminated_at.utc.to_s)
+          expect(result).to match_datetime(subscription.terminated_at.utc)
         end
       end
     end

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -159,14 +159,14 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         end
 
         it 'returns the termination date' do
-          expect(result).to eq(subscription.terminated_at.utc.to_s)
+          expect(result).to match_datetime(subscription.terminated_at.utc)
         end
 
         context 'with customer timezone' do
           let(:timezone) { 'America/New_York' }
 
           it 'returns the termination date' do
-            expect(result).to eq(subscription.terminated_at.utc.to_s)
+            expect(result).to match_datetime(subscription.terminated_at.utc)
           end
         end
       end
@@ -197,7 +197,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         end
 
         it 'returns the termination date' do
-          expect(result).to eq(subscription.terminated_at.utc.to_s)
+          expect(result).to match_datetime(subscription.terminated_at.utc)
         end
       end
     end

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -181,14 +181,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         it 'returns the termination date' do
-          expect(result).to eq(subscription.terminated_at.utc.to_s)
+          expect(result).to match_datetime(subscription.terminated_at.utc)
         end
 
         context 'with customer timezone' do
           let(:timezone) { 'America/New_York' }
 
           it 'returns the termination date' do
-            expect(result).to eq(subscription.terminated_at.utc.to_s)
+            expect(result).to match_datetime(subscription.terminated_at.utc)
           end
         end
       end
@@ -246,7 +246,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         it 'returns the termination date' do
-          expect(result).to eq(subscription.terminated_at.utc.to_s)
+          expect(result).to match_datetime(subscription.terminated_at.utc)
         end
       end
     end


### PR DESCRIPTION
## Context

Invoice for subscription termination are stuck in a `generating` status  when the subscription is attached to a next subscription with `pending` status.

NOTE: A `terminated` subscription should never be attached to a pending subscription, as next possible status should be either, `active` or `canceled`. The initial issue seems to be related to a race condition with multiple simultaneous upgrades and downgrades.

## Description

This PR does not fixes the initial issue but it makes sure that the `Subscriptions::DatesService#to_datetime` cannot returns a date before the start date of the subscription
