### PR TITLE
Fix: save fees with taxes_rate when creating one off invoice

### DIFF
--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -109,6 +109,7 @@ module Fees
 
         res = Fees::ApplyProviderTaxesService.call(fee:, fee_taxes:)
         res.raise_if_error!
+        fee.save
       end
 
       taxes_result

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -109,7 +109,7 @@ module Fees
 
         res = Fees::ApplyProviderTaxesService.call(fee:, fee_taxes:)
         res.raise_if_error!
-        fee.save
+        fee.save!
       end
 
       taxes_result

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -177,8 +177,8 @@ RSpec.describe Fees::OneOffService do
       it 'creates fees' do
         result = one_off_service.create
 
-        first_fee = result.fees[0]
-        second_fee = result.fees[1]
+        first_fee = result.fees[0].reload
+        second_fee = result.fees[1].reload
 
         aggregate_failures do
           expect(result).to be_success

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -194,7 +194,8 @@ RSpec.describe Fees::OneOffService do
             amount_cents: 2400,
             amount_currency: 'EUR',
             fee_type: 'add_on',
-            payment_status: 'pending'
+            payment_status: 'pending',
+            taxes_rate: 10
           )
           expect(first_fee.applied_taxes.first.amount_cents).to eq(240)
           expect(first_fee.applied_taxes.first.precise_amount_cents).to eq(240.0)
@@ -211,7 +212,8 @@ RSpec.describe Fees::OneOffService do
             precise_amount_cents: 400.0,
             amount_currency: 'EUR',
             fee_type: 'add_on',
-            payment_status: 'pending'
+            payment_status: 'pending',
+            taxes_rate: 15
           )
           expect(second_fee.applied_taxes.first.amount_cents).to eq(60)
           expect(second_fee.applied_taxes.first.precise_amount_cents).to eq(60.0)

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -172,6 +172,15 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
         end
       end
 
+      it 'saves applies taxes on fees and on invoice' do
+        result = create_service.call
+        invoice = result.invoice.reload
+
+        expect(invoice.applied_taxes.count).to eq(2)
+        expect(invoice.fees.map(&:applied_taxes).flatten.count).to eq(2)
+        expect(invoice.fees.map(&:taxes_rate).sort).to eq([10.0, 15.0])
+      end
+
       context 'when there is error received from the provider' do
         let(:body) do
           p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')


### PR DESCRIPTION
When creating one off invoice and applying taxes on fee, we need to save fee, otherwise calculated values on fees are set, but not saved