### PR TITLE
feat(DynamicPricing) - Add precise_total_amount_cents to Event

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -64,26 +64,28 @@ end
 #
 # Table name: events
 #
-#  id                       :uuid             not null, primary key
-#  code                     :string           not null
-#  deleted_at               :datetime
-#  metadata                 :jsonb            not null
-#  properties               :jsonb            not null
-#  timestamp                :datetime
-#  created_at               :datetime         not null
-#  updated_at               :datetime         not null
-#  customer_id              :uuid
-#  external_customer_id     :string
-#  external_subscription_id :string
-#  organization_id          :uuid             not null
-#  subscription_id          :uuid
-#  transaction_id           :string           not null
+#  id                         :uuid             not null, primary key
+#  code                       :string           not null
+#  deleted_at                 :datetime
+#  metadata                   :jsonb            not null
+#  precise_total_amount_cents :decimal(40, 15)
+#  properties                 :jsonb            not null
+#  timestamp                  :datetime
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  customer_id                :uuid
+#  external_customer_id       :string
+#  external_subscription_id   :string
+#  organization_id            :uuid             not null
+#  subscription_id            :uuid
+#  transaction_id             :string           not null
 #
 # Indexes
 #
 #  index_events_on_customer_id                                      (customer_id)
 #  index_events_on_deleted_at                                       (deleted_at)
 #  index_events_on_external_subscription_id_and_code_and_timestamp  (organization_id,external_subscription_id,code,timestamp) WHERE (deleted_at IS NULL)
+#  index_events_on_external_subscription_id_precise_amount          (external_subscription_id,code,timestamp) WHERE ((deleted_at IS NULL) AND (precise_total_amount_cents IS NOT NULL))
 #  index_events_on_external_subscription_id_with_included           (external_subscription_id,code,timestamp) WHERE (deleted_at IS NULL)
 #  index_events_on_organization_id                                  (organization_id)
 #  index_events_on_organization_id_and_code                         (organization_id,code)

--- a/db/migrate/20240917144243_add_precise_total_amount_cents_to_event.rb
+++ b/db/migrate/20240917144243_add_precise_total_amount_cents_to_event.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPreciseTotalAmountCentsToEvent < ActiveRecord::Migration[7.1]
+  def change
+    add_column :events, :precise_total_amount_cents, :decimal, precision: 40, scale: 15
+  end
+end

--- a/db/migrate/20240917145042_add_index_on_precise_total_amount_cents.rb
+++ b/db/migrate/20240917145042_add_index_on_precise_total_amount_cents.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddIndexOnPreciseTotalAmountCents < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+  def change
+    add_index :events, %i[external_subscription_id code timestamp],
+      name: 'index_events_on_external_subscription_id_precise_amount',
+      where: 'deleted_at IS NULL AND precise_total_amount_cents IS NOT NULL',
+      algorithm: :concurrently,
+      if_not_exists: true,
+      include: %i[organization_id precise_total_amount_cents]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_10_111203) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_17_145042) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -506,8 +506,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_10_111203) do
     t.datetime "deleted_at"
     t.string "external_customer_id"
     t.string "external_subscription_id"
+    t.decimal "precise_total_amount_cents", precision: 40, scale: 15
     t.index ["customer_id"], name: "index_events_on_customer_id"
     t.index ["deleted_at"], name: "index_events_on_deleted_at"
+    t.index ["external_subscription_id", "code", "timestamp"], name: "index_events_on_external_subscription_id_precise_amount", where: "((deleted_at IS NULL) AND (precise_total_amount_cents IS NOT NULL))", include: ["organization_id", "precise_total_amount_cents"]
     t.index ["external_subscription_id", "code", "timestamp"], name: "index_events_on_external_subscription_id_with_included", where: "(deleted_at IS NULL)", include: ["organization_id", "properties"]
     t.index ["organization_id", "code", "created_at"], name: "index_events_on_organization_id_and_code_and_created_at", where: "(deleted_at IS NULL)"
     t.index ["organization_id", "code"], name: "index_events_on_organization_id_and_code"


### PR DESCRIPTION
## Context

AI, CPaaS and Fintech customers can apply a price to a unit that fluctuates over time. Currently Lago does not support this usecase.

## Description

Adds `precise_total_amount_cents` to Event. Includes an index similar to the one added recently for quick calculations 