### PR TITLE
feat(dunning): Remove dunning feature from premium addon

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -51,7 +51,7 @@ class Organization < ApplicationRecord
     :per_organization
   ].freeze
 
-  INTEGRATIONS = %w[netsuite okta anrok xero progressive_billing dunning hubspot].freeze
+  INTEGRATIONS = %w[netsuite okta anrok xero progressive_billing hubspot].freeze
   PREMIUM_INTEGRATIONS = INTEGRATIONS - %w[anrok]
 
   enum document_numbering: DOCUMENT_NUMBERINGS

--- a/app/services/payment_requests/create_service.rb
+++ b/app/services/payment_requests/create_service.rb
@@ -39,17 +39,14 @@ module PaymentRequests
 
     def check_preconditions
       # NOTE: Prevent creation of payment request if:
-      # - the organization does not have the premium dunning integration
+      # - the organization is not premium
       # - the customer does not exist
       # - there are no invoices
       # - the invoices are not overdue
       # - the invoices have different currencies
       # - the invoices are not ready for payment processing
 
-      unless License.premium? && organization.premium_integrations.include?("dunning")
-        return result.not_allowed_failure!(code: "premium_addon_feature_missing")
-      end
-
+      return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "customer") unless customer
       return result.not_found_failure!(resource: "invoice") if invoices.empty?
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -4015,7 +4015,6 @@ enum IntegrationItemTypeEnum {
 
 enum IntegrationTypeEnum {
   anrok
-  dunning
   hubspot
   netsuite
   okta
@@ -5741,7 +5740,6 @@ input PlanOverridesInput {
 }
 
 enum PremiumIntegrationTypeEnum {
-  dunning
   hubspot
   netsuite
   okta

--- a/schema.json
+++ b/schema.json
@@ -18507,12 +18507,6 @@
               "deprecationReason": null
             },
             {
-              "name": "dunning",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "hubspot",
               "description": null,
               "isDeprecated": false,
@@ -27999,12 +27993,6 @@
             },
             {
               "name": "progressive_billing",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "dunning",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Organization, type: :model do
 
     it "does not return the organization for another premium integration" do
       organization.update!(premium_integrations: ['progressive_billing'])
-      expect(described_class.with_dunning_support).to be_empty
+      expect(described_class.with_okta_support).to be_empty
       expect(described_class.with_progressive_billing_support).to eq([organization])
     end
   end

--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -21,34 +21,17 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
 
   around { |test| lago_premium!(&test) }
 
-  before { organization.update!(premium_integrations: ["dunning"]) }
-
   describe "#call" do
     context "when organization is not premium" do
       before do
         allow(License).to receive(:premium?).and_return(false)
       end
 
-      it "returns not allowed failure", :aggregate_failures do
+      it "returns forbidden failure", :aggregate_failures do
         result = create_service.call
 
         expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-        expect(result.error.code).to eq("premium_addon_feature_missing")
-      end
-    end
-
-    context "when organization does not have premium dunning integration" do
-      before do
-        allow(organization).to receive(:premium_integrations).and_return([])
-      end
-
-      it "returns not allowed failure", :aggregate_failures do
-        result = create_service.call
-
-        expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-        expect(result.error.code).to eq("premium_addon_feature_missing")
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
       end
     end
 


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

 ## Description

The goal of this PR is to remove the dunning feature from the premium addon features.