### PR TITLE
Feat(anrok): calculate remaining amounts per item for credit note

### DIFF
--- a/app/services/credit_notes/calculate_items_available_amounts_service.rb
+++ b/app/services/credit_notes/calculate_items_available_amounts_service.rb
@@ -9,13 +9,13 @@ module CreditNotes
     end
 
     def call
-      if credit_note_is_not_applied?
+      if should_return_full_items_amounts?
         result.available_amounts = initial_items_amounts
         return result
       end
 
-      clear_items_available_amounts = calculate_items_sum_without_taxes
-      result.available_amounts = split_sum_into_items(clear_items_available_amounts)
+      items_sum_without_taxes = calculate_items_sum_without_taxes
+      result.available_amounts = split_sum_into_items(items_sum_without_taxes)
       result
     end
 
@@ -23,8 +23,8 @@ module CreditNotes
 
     attr_reader :credit_note
 
-    def credit_note_is_not_applied?
-      credit_note.balance_amount_cents == credit_note.credit_amount_cents
+    def should_return_full_items_amounts?
+      credit_note.balance_amount_cents == credit_note.total_amount_cents
     end
 
     def initial_items_amounts
@@ -47,7 +47,7 @@ module CreditNotes
     end
 
     def credit_note_original_amount_without_taxes
-      @credit_note_original_amount_without_taxes ||= credit_note.credit_amount_cents - credit_note.taxes_amount_cents
+      @credit_note_original_amount_without_taxes ||= credit_note.total_amount_cents - credit_note.taxes_amount_cents
     end
   end
 end

--- a/app/services/credit_notes/calculate_items_available_amounts_service.rb
+++ b/app/services/credit_notes/calculate_items_available_amounts_service.rb
@@ -9,6 +9,11 @@ module CreditNotes
     end
 
     def call
+      if credit_note_is_not_applied?
+        result.available_amounts = initial_items_amounts
+        return result
+      end
+
       clear_items_available_amounts = calculate_items_sum_without_taxes
       result.available_amounts = split_sum_into_items(clear_items_available_amounts)
       result
@@ -17,6 +22,14 @@ module CreditNotes
     private
 
     attr_reader :credit_note
+
+    def credit_note_is_not_applied?
+      credit_note.balance_amount_cents == credit_note.credit_amount_cents
+    end
+
+    def initial_items_amounts
+      credit_note.items.map { |item| [item.id, item.amount_cents] }.to_h
+    end
 
     # balance_amount_cents includes items_sum + their taxes,
     # but taxes_rate is the percentage, not decimal

--- a/app/services/credit_notes/calculate_items_available_amounts_service.rb
+++ b/app/services/credit_notes/calculate_items_available_amounts_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class CalculateItemsAvailableAmountsService < BaseService
+    def initialize(credit_note:)
+      @credit_note = credit_note
+
+      super
+    end
+
+    def call
+      clear_items_available_amounts = calculate_items_sum_without_taxes
+      result.available_amounts = split_sum_into_items(clear_items_available_amounts)
+      result
+    end
+
+    private
+
+    attr_reader :credit_note
+
+    # balance_amount_cents includes items_sum + their taxes,
+    # but taxes_rate is the percentage, not decimal
+    def calculate_items_sum_without_taxes
+      (credit_note.balance_amount_cents / (100 + credit_note.taxes_rate)) * 100
+    end
+
+    def split_sum_into_items(clear_items_available_amounts)
+      item_values = {}
+      credit_note.items.each do |item|
+        item_weight = item.amount_cents / credit_note_original_amount_without_taxes.to_f
+        item_values[item.id] = item_weight * clear_items_available_amounts
+      end
+      item_values
+    end
+
+    def credit_note_original_amount_without_taxes
+      @credit_note_original_amount_without_taxes ||= credit_note.credit_amount_cents - credit_note.taxes_amount_cents
+    end
+  end
+end

--- a/spec/services/credit_notes/calculate_items_available_amounts_service_spec.rb
+++ b/spec/services/credit_notes/calculate_items_available_amounts_service_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::CalculateItemsAvailableAmountsService, type: :service do
+  subject(:credit_service) { described_class.new(credit_note: ) }
+
+  let(:credit_note) do
+    create(:credit_note, balance_amount_cents: 60000, credit_amount_cents: 60000, taxes_amount_cents: 10000, taxes_rate: 20)
+  end
+  let(:item1) { create(:credit_note_item, credit_note: credit_note, amount_cents: 20000) }
+  let(:item2) { create(:credit_note_item, credit_note: credit_note, amount_cents: 30000) }
+
+  before do
+    item1
+    item2
+    credit_note.reload
+  end
+
+  context 'when credit_note has balance_amount_cents equal to taxes_amount_cents' do
+    it 'calculates items available amounts' do
+      result = credit_service.call
+      expect(result.available_amounts).to eq({ item1.id => 20000, item2.id => 30000 })
+    end
+  end
+
+  context 'when credit_note has balance_amount_cents not equal to taxes_amount_cents' do
+    let(:credit_note) do
+      create(:credit_note, balance_amount_cents: 36000, credit_amount_cents: 60000, taxes_amount_cents: 10000, taxes_rate: 20)
+    end
+
+    it 'calculates items available amounts' do
+      result = credit_service.call
+      expect(result.available_amounts).to eq({ item1.id => 12000, item2.id => 18000 })
+    end
+  end
+end

--- a/spec/services/credit_notes/calculate_items_available_amounts_service_spec.rb
+++ b/spec/services/credit_notes/calculate_items_available_amounts_service_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe CreditNotes::CalculateItemsAvailableAmountsService, type: :servic
   subject(:credit_service) { described_class.new(credit_note: ) }
 
   let(:credit_note) do
-    create(:credit_note, balance_amount_cents: 60000, credit_amount_cents: 60000, taxes_amount_cents: 10000, taxes_rate: 20)
+    create(:credit_note,
+      balance_amount_cents: 60000,
+      credit_amount_cents: 60000,
+      total_amount_cents: 60000,
+      taxes_amount_cents: 10000,
+      taxes_rate: 20)
   end
   let(:item1) { create(:credit_note_item, credit_note: credit_note, amount_cents: 20000) }
   let(:item2) { create(:credit_note_item, credit_note: credit_note, amount_cents: 30000) }
@@ -26,10 +31,35 @@ RSpec.describe CreditNotes::CalculateItemsAvailableAmountsService, type: :servic
 
   context 'when credit_note has balance_amount_cents not equal to taxes_amount_cents' do
     let(:credit_note) do
-      create(:credit_note, balance_amount_cents: 36000, credit_amount_cents: 60000, taxes_amount_cents: 10000, taxes_rate: 20)
+      create(:credit_note,
+        balance_amount_cents: 36000,
+        credit_amount_cents: 60000,
+        total_amount_cents: 60000,
+        taxes_amount_cents: 10000,
+        taxes_rate: 20
+      )
     end
 
     it 'calculates items available amounts' do
+      result = credit_service.call
+      expect(result.available_amounts).to eq({ item1.id => 12000, item2.id => 18000 })
+    end
+  end
+
+  context 'when credit_note has been partially refunded' do
+    let(:credit_note) do
+      create(:credit_note,
+        balance_amount_cents: 36000,
+        credit_amount_cents: 60000,
+        total_amount_cents: 120000,
+        taxes_amount_cents: 20000,
+        taxes_rate: 20
+      )
+    end
+    let(:item1) { create(:credit_note_item, credit_note: credit_note, amount_cents: 40000) }
+    let(:item2) { create(:credit_note_item, credit_note: credit_note, amount_cents: 60000) }
+
+    it 'calculates items available amounts with info that they are partially refunded' do
       result = credit_service.call
       expect(result.available_amounts).to eq({ item1.id => 12000, item2.id => 18000 })
     end

--- a/spec/services/credit_notes/calculate_items_available_amounts_service_spec.rb
+++ b/spec/services/credit_notes/calculate_items_available_amounts_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CreditNotes::CalculateItemsAvailableAmountsService, type: :service do
-  subject(:credit_service) { described_class.new(credit_note: ) }
+  subject(:credit_service) { described_class.new(credit_note:) }
 
   let(:credit_note) do
     create(:credit_note,
@@ -25,7 +25,7 @@ RSpec.describe CreditNotes::CalculateItemsAvailableAmountsService, type: :servic
   context 'when credit_note has balance_amount_cents equal to taxes_amount_cents' do
     it 'calculates items available amounts' do
       result = credit_service.call
-      expect(result.available_amounts).to eq({ item1.id => 20000, item2.id => 30000 })
+      expect(result.available_amounts).to eq({item1.id => 20000, item2.id => 30000})
     end
   end
 
@@ -36,13 +36,12 @@ RSpec.describe CreditNotes::CalculateItemsAvailableAmountsService, type: :servic
         credit_amount_cents: 60000,
         total_amount_cents: 60000,
         taxes_amount_cents: 10000,
-        taxes_rate: 20
-      )
+        taxes_rate: 20)
     end
 
     it 'calculates items available amounts' do
       result = credit_service.call
-      expect(result.available_amounts).to eq({ item1.id => 12000, item2.id => 18000 })
+      expect(result.available_amounts).to eq({item1.id => 12000, item2.id => 18000})
     end
   end
 
@@ -53,15 +52,14 @@ RSpec.describe CreditNotes::CalculateItemsAvailableAmountsService, type: :servic
         credit_amount_cents: 60000,
         total_amount_cents: 120000,
         taxes_amount_cents: 20000,
-        taxes_rate: 20
-      )
+        taxes_rate: 20)
     end
     let(:item1) { create(:credit_note_item, credit_note: credit_note, amount_cents: 40000) }
     let(:item2) { create(:credit_note_item, credit_note: credit_note, amount_cents: 60000) }
 
     it 'calculates items available amounts with info that they are partially refunded' do
       result = credit_service.call
-      expect(result.available_amounts).to eq({ item1.id => 12000, item2.id => 18000 })
+      expect(result.available_amounts).to eq({item1.id => 12000, item2.id => 18000})
     end
   end
 end


### PR DESCRIPTION
## Context

When voiding a partially applied credit note or partially refunded credit_note, we need to report it to tax service. When reporting to tax service, we need to send item's remaining amounts without taxes.

Currently we're storing only initial amount of items without taxes at credit_note_items, and in credit note we store `total_amount_cents`, which equals sum of items with their taxes, `credited_amount_cents`, which equals to the amount that was credited, `balance_amount_cents`, which is the remaining part of credit note, that still can be used to apply on invoices

## Description

Added a service that calculates "remaining" items amounts, based on initial credit_note amount, remaining credit note amount, tax_rate on the total credit note