### PR TITLE
fix (accounting-integrations): send webhook for incomplete payload

### DIFF
--- a/app/services/integrations/aggregator/base_payload.rb
+++ b/app/services/integrations/aggregator/base_payload.rb
@@ -3,6 +3,16 @@
 module Integrations
   module Aggregator
     class BasePayload
+      class Failure < BaseService::FailedResult
+        attr_reader :code
+
+        def initialize(result, code:)
+          @code = code
+
+          super(result, code)
+        end
+      end
+
       def initialize(integration:)
         @integration = integration
       end

--- a/app/services/integrations/aggregator/credit_notes/create_service.rb
+++ b/app/services/integrations/aggregator/credit_notes/create_service.rb
@@ -50,6 +50,8 @@ module Integrations
           return result if e.error_code.to_i < 500
 
           raise e
+        rescue Integrations::Aggregator::BasePayload::Failure => e
+          deliver_error_webhook(customer:, code: e.code, message: e.code.humanize)
         end
 
         def call_async

--- a/app/services/integrations/aggregator/credit_notes/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/credit_notes/payloads/base_payload.rb
@@ -66,7 +66,9 @@ module Integrations
               subscription_item
             end
 
-            return {} unless mapped_item
+            unless mapped_item
+              raise Integrations::Aggregator::BasePayload::Failure.new(nil, code: 'invalid_mapping')
+            end
 
             precise_unit_amount = credit_note_item.amount_cents
 

--- a/app/services/integrations/aggregator/credit_notes/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/credit_notes/payloads/netsuite.rb
@@ -48,7 +48,9 @@ module Integrations
               subscription_item
             end
 
-            return {} unless mapped_item
+            unless mapped_item
+              raise Integrations::Aggregator::BasePayload::Failure.new(nil, code: 'invalid_mapping')
+            end
 
             {
               'item' => mapped_item.external_id,

--- a/app/services/integrations/aggregator/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/invoices/create_service.rb
@@ -44,6 +44,8 @@ module Integrations
           return result if e.error_code.to_i < 500
 
           raise e
+        rescue Integrations::Aggregator::BasePayload::Failure => e
+          deliver_error_webhook(customer:, code: e.code, message: e.code.humanize)
         end
 
         def call_async

--- a/app/services/integrations/aggregator/invoices/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/base_payload.rb
@@ -66,7 +66,9 @@ module Integrations
               subscription_item
             end
 
-            return {} unless mapped_item
+            unless mapped_item
+              raise Integrations::Aggregator::BasePayload::Failure.new(nil, code: 'invalid_mapping')
+            end
 
             {
               'external_id' => mapped_item.external_id,

--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -71,7 +71,9 @@ module Integrations
               subscription_item
             end
 
-            return {} unless mapped_item
+            unless mapped_item
+              raise Integrations::Aggregator::BasePayload::Failure.new(nil, code: 'invalid_mapping')
+            end
 
             {
               'item' => mapped_item.external_id,

--- a/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
         'tranid' => credit_note.number,
         'entity' => integration_customer.external_customer_id,
         'istaxable' => true,
-        'taxitem' => integration_collection_mapping5.external_id,
+        'taxitem' => integration_collection_mapping5&.external_id,
         'taxamountoverride' => 80.0,
         'otherrefnum' => credit_note.number,
         'custbody_lago_id' => credit_note.id,
@@ -338,6 +338,42 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
         it 'enqueues a SendWebhookJob' do
           expect { service_call }.to have_enqueued_job(SendWebhookJob)
         end
+      end
+    end
+
+    context 'when there is payload error' do
+      let(:integration) { create(:xero_integration, organization:) }
+      let(:integration_customer) { create(:xero_customer, integration:, customer:) }
+      let(:lago_client) { instance_double(LagoHttpClient::Client) }
+      let(:endpoint) { 'https://api.nango.dev/v1/xero/creditnotes' }
+      let(:integration_collection_mapping1) { nil }
+      let(:integration_collection_mapping2) { nil }
+      let(:integration_collection_mapping3) { nil }
+      let(:integration_collection_mapping4) { nil }
+      let(:integration_collection_mapping5) { nil }
+      let(:integration_collection_mapping6){ nil }
+      let(:integration_mapping_add_on) { nil }
+      let(:integration_mapping_bm) { nil }
+      let(:response) { instance_double(Net::HTTPOK) }
+      let(:headers) do
+        {
+          'Connection-Id' => integration.connection_id,
+          'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
+          'Provider-Config-Key' => 'xero'
+        }
+      end
+      let(:body) do
+        path = Rails.root.join('spec/fixtures/integration_aggregator/credit_notes/success_hash_response.json')
+        File.read(path)
+      end
+
+      before do
+        allow(lago_client).to receive(:post_with_response).with(params, headers).and_return(response)
+        allow(response).to receive(:body).and_return(body)
+      end
+
+      it 'sends error webhook' do
+        expect { service_call }.to have_enqueued_job(SendWebhookJob)
       end
     end
   end

--- a/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
       let(:integration_collection_mapping3) { nil }
       let(:integration_collection_mapping4) { nil }
       let(:integration_collection_mapping5) { nil }
-      let(:integration_collection_mapping6){ nil }
+      let(:integration_collection_mapping6) { nil }
       let(:integration_mapping_add_on) { nil }
       let(:integration_mapping_bm) { nil }
       let(:response) { instance_double(Net::HTTPOK) }

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -382,7 +382,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
       let(:integration_collection_mapping3) { nil }
       let(:integration_collection_mapping4) { nil }
       let(:integration_collection_mapping5) { nil }
-      let(:integration_collection_mapping6){ nil }
+      let(:integration_collection_mapping6) { nil }
       let(:integration_mapping_add_on) { nil }
       let(:integration_mapping_bm) { nil }
       let(:response) { instance_double(Net::HTTPOK) }

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
         'tranid' => invoice.id,
         'entity' => integration_customer.external_customer_id,
         'istaxable' => true,
-        'taxitem' => integration_collection_mapping5.external_id,
+        'taxitem' => integration_collection_mapping5&.external_id,
         'taxamountoverride' => 80.0,
         'otherrefnum' => invoice.number,
         'custbody_lago_id' => invoice.id,
@@ -369,6 +369,42 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
         it 'enqueues a SendWebhookJob' do
           expect { service_call }.to have_enqueued_job(SendWebhookJob)
         end
+      end
+    end
+
+    context 'when there is payload error' do
+      let(:integration) { create(:xero_integration, organization:) }
+      let(:integration_customer) { create(:xero_customer, integration:, customer:) }
+      let(:lago_client) { instance_double(LagoHttpClient::Client) }
+      let(:endpoint) { 'https://api.nango.dev/v1/xero/invoices' }
+      let(:integration_collection_mapping1) { nil }
+      let(:integration_collection_mapping2) { nil }
+      let(:integration_collection_mapping3) { nil }
+      let(:integration_collection_mapping4) { nil }
+      let(:integration_collection_mapping5) { nil }
+      let(:integration_collection_mapping6){ nil }
+      let(:integration_mapping_add_on) { nil }
+      let(:integration_mapping_bm) { nil }
+      let(:response) { instance_double(Net::HTTPOK) }
+      let(:headers) do
+        {
+          'Connection-Id' => integration.connection_id,
+          'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
+          'Provider-Config-Key' => 'xero'
+        }
+      end
+      let(:body) do
+        path = Rails.root.join('spec/fixtures/integration_aggregator/invoices/success_hash_response.json')
+        File.read(path)
+      end
+
+      before do
+        allow(lago_client).to receive(:post_with_response).with(params, headers).and_return(response)
+        allow(response).to receive(:body).and_return(body)
+      end
+
+      it 'sends error webhook' do
+        expect { service_call }.to have_enqueued_job(SendWebhookJob)
       end
     end
   end


### PR DESCRIPTION
## Context

For invalid payload due to incomplete configuration, we raise error (500) instead of silently notifying users via webhooks.

## Description

This PR covers described scenario
