### PR TITLE
feat(event): Add event list API

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -60,6 +60,21 @@ module Api
         )
       end
 
+      def index
+        events = current_organization.events
+          .page(params[:page])
+          .per(params[:per_page] || PER_PAGE)
+
+        render(
+          json: ::CollectionSerializer.new(
+            events,
+            ::V1::EventSerializer,
+            collection_name: 'events',
+            meta: pagination_metadata(events),
+          )
+        )
+      end
+
       def estimate_fees
         result = Fees::EstimatePayInAdvanceService.call(
           organization: current_organization,

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class EventsQuery < BaseQuery
+  def call
+    events = organization.events
+    events = paginate(events)
+    events = events.order(created_at: :desc)
+
+    events = with_code(events) if filters.code
+    events = with_external_subscription_id(events) if filters.external_subscription_id
+    events = with_timestamp_range(events) if filters.timestamp_from || filters.timestamp_to
+
+    result.events = events
+    result
+  rescue BaseService::FailedResult
+    result
+  end
+
+  private
+
+  def with_code(scope)
+    scope.where(code: filters.code)
+  end
+
+  def with_external_subscription_id(scope)
+    scope.where(external_subscription_id: filters.external_subscription_id)
+  end
+
+  def with_timestamp_range(scope)
+    scope = scope.where(timestamp: timestamp_from..) if filters.timestamp_from
+    scope = scope.where(timestamp: ..timestamp_to) if filters.timestamp_to
+    scope
+  end
+
+  def timestamp_from
+    @timestamp_from ||= parse_datetime_filter(:timestamp_from)
+  end
+
+  def timestamp_to
+    @timestamp_to ||= parse_datetime_filter(:timestamp_to)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
         put :void, on: :member
         post :estimate, on: :collection
       end
-      resources :events, only: %i[create show] do
+      resources :events, only: %i[create show index] do
         post :estimate_fees, on: :collection
       end
       resources :applied_coupons, only: %i[create index]

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EventsQuery, type: :query do
+  subject(:events_query) { described_class.new(organization:, pagination:, filters:) }
+
+  let(:organization) { create(:organization) }
+  let(:pagination) { nil }
+  let(:filters) { {} }
+
+  let(:event) { create(:event, timestamp: 1.days.ago.to_date, organization:) }
+
+  before { event }
+
+  describe 'call' do
+    it 'returns a list of events' do
+      result = events_query.call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.events.count).to eq(1)
+        expect(result.events).to eq([event])
+      end
+    end
+
+    context 'with pagination' do
+      let(:pagination) { {page: 2, limit: 10} }
+
+      it 'applies the pagination' do
+        result = events_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.events.count).to eq(0)
+          expect(result.events.current_page).to eq(2)
+        end
+      end
+    end
+
+    context 'with code filter' do
+      let(:filters) { {code: event.code} }
+
+      it 'applies the filter' do
+        result = events_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.events.count).to eq(1)
+        end
+      end
+    end
+
+    context 'with external subscription id filter' do
+      let(:filters) { {external_customer_id: event.external_subscription_id} }
+
+      it 'applies the filter' do
+        result = events_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.events.count).to eq(1)
+        end
+      end
+    end
+
+    context 'with timestamp from filter' do
+      let(:filters) {
+        {
+          timestamp_from: 2.days.ago.iso8601.to_date.to_s,
+          timestamp_to: Date.tomorrow.iso8601.to_date.to_s
+        }
+      }
+
+      it 'applies the filter' do
+        result = events_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.events.count).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe EventsQuery, type: :query do
   let(:pagination) { nil }
   let(:filters) { {} }
 
-  let(:event) { create(:event, timestamp: 1.days.ago.to_date, organization:) }
+  let(:event) { create(:event, timestamp: 1.day.ago.to_date, organization:) }
 
   before { event }
 
@@ -39,7 +39,10 @@ RSpec.describe EventsQuery, type: :query do
     end
 
     context 'with code filter' do
+      let(:event2) { create(:event, organization:) }
       let(:filters) { {code: event.code} }
+
+      before { event2 }
 
       it 'applies the filter' do
         result = events_query.call
@@ -52,7 +55,10 @@ RSpec.describe EventsQuery, type: :query do
     end
 
     context 'with external subscription id filter' do
-      let(:filters) { {external_customer_id: event.external_subscription_id} }
+      let(:event2) { create(:event, organization:) }
+      let(:filters) { {external_subscription_id: event.external_subscription_id} }
+
+      before { event2 }
 
       it 'applies the filter' do
         result = events_query.call

--- a/spec/requests/api/v1/events_controller_spec.rb
+++ b/spec/requests/api/v1/events_controller_spec.rb
@@ -118,6 +118,10 @@ RSpec.describe Api::V1::EventsController, type: :request do
     end
 
     context 'with code' do
+      let(:event2) { create(:event, organization:) }
+
+      before { event2 }
+
       it 'returns events' do
         get_with_token(organization, "/api/v1/events?code=#{event1.code}")
 
@@ -128,6 +132,10 @@ RSpec.describe Api::V1::EventsController, type: :request do
     end
 
     context 'with external subscription id' do
+      let(:event2) { create(:event, organization:) }
+
+      before { event2 }
+
       it 'returns events' do
         get_with_token(organization, "/api/v1/events?external_subscription_id=#{event1.external_subscription_id}")
 


### PR DESCRIPTION
Hi, Ruby newbie here. This is my first Ruby and Lago contribution so, if there is any suggestion, I'd be much appreciated!

## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/retrieve-and-filter-events

## Context

Currently, REST API does not provide the endpoint to list all events (as in the Developer -> Events page). This pull request aim to expose the event list to the REST API to let the user retrieve and filter events.

## Description

This pull request add supports for:  
- Adding `GET /api/v1/events` endpoint
- Filtering events by `code`, `external_subscription_id`, `timestamp_from`, and `timestamp_to`

I'm also planning to checkout the front-end side to add these kinds of filter into the UI later as well.