### PR TITLE
feat(tax-invoices): add required invoice title for some countries

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -325,7 +325,7 @@ class Invoice < ApplicationRecord
   def document_invoice_name
     return I18n.t('invoice.prepaid_credit_invoice') if credit?
 
-    return I18n.t('invoice.document_tax_name') if %w[AU AE ID].include?(organization.country)
+    return I18n.t('invoice.document_tax_name') if %w[AU AE ID NZ].include?(organization.country)
 
     I18n.t('invoice.document_name')
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -322,6 +322,14 @@ class Invoice < ApplicationRecord
       end
   end
 
+  def document_invoice_name
+    return I18n.t('invoice.prepaid_credit_invoice') if credit?
+
+    return I18n.t('invoice.document_tax_name') if %w[AU AE ID].include?(organization.country)
+
+    I18n.t('invoice.document_name')
+  end
+
   private
 
   def should_assign_sequential_id?

--- a/app/views/templates/invoices/v1.slim
+++ b/app/views/templates/invoices/v1.slim
@@ -366,7 +366,7 @@ html
 
     .wrapper
       .mb-24
-        h1.invoice-title = I18n.t('invoice.document_name')
+        h1.invoice-title = document_invoice_name
         - if organization.logo.present?
           img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
 

--- a/app/views/templates/invoices/v2.slim
+++ b/app/views/templates/invoices/v2.slim
@@ -366,7 +366,7 @@ html
 
     .wrapper
       .mb-24
-        h1.invoice-title = I18n.t('invoice.document_name')
+        h1.invoice-title = document_invoice_name
         - if organization.logo.present?
           img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
 

--- a/app/views/templates/invoices/v3.slim
+++ b/app/views/templates/invoices/v3.slim
@@ -342,7 +342,7 @@ html
 
     .wrapper
       .mb-24
-        h1.invoice-title = I18n.t('invoice.document_name')
+        h1.invoice-title = document_invoice_name
         - if organization.logo.present?
           img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
 

--- a/app/views/templates/invoices/v3/charge.slim
+++ b/app/views/templates/invoices/v3/charge.slim
@@ -336,7 +336,7 @@ html
 
     .wrapper
       .mb-24
-        h1.invoice-title = I18n.t('invoice.document_name')
+        h1.invoice-title = document_invoice_name
         - if organization.logo.present?
           img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
 

--- a/app/views/templates/invoices/v3/one_off.slim
+++ b/app/views/templates/invoices/v3/one_off.slim
@@ -337,7 +337,7 @@ html
 
     .wrapper
       .mb-24
-        h1.invoice-title = I18n.t('invoice.document_name')
+        h1.invoice-title = document_invoice_name
         - if organization.logo.present?
           img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
 

--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -371,7 +371,7 @@ html
 
     .wrapper
       .mb-24
-        h1.invoice-title = credit? ? I18n.t('invoice.prepaid_credit_invoice') : I18n.t('invoice.document_name')
+        h1.invoice-title = document_invoice_name
         - if organization.logo.present?
           img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
 

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -336,7 +336,7 @@ html
 
     .wrapper
       .mb-24
-        h1.invoice-title = I18n.t('invoice.document_name')
+        h1.invoice-title = document_invoice_name
         - if organization.logo.present?
           img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
 

--- a/app/views/templates/invoices/v4/one_off.slim
+++ b/app/views/templates/invoices/v4/one_off.slim
@@ -339,7 +339,7 @@ html
 
     .wrapper
       .mb-24
-        h1.invoice-title = I18n.t('invoice.document_name')
+        h1.invoice-title = document_invoice_name
         - if organization.logo.present?
           img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
 

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -17,6 +17,7 @@ de:
     date_to: Bis
     details: "%{resource} Details"
     document_name: Rechnung
+    document_tax_name: Steuerrechnung
     due_date: Fälligkeit %{date}
     fee_prorated: Die Gebühr wird anteilig nach Nutzungstagen berechnet, der angezeigte Stückpreis ist ein Durchschnitt
     fees_from_to_date: Gebühren vom %{from_date} bis %{to_date}

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -17,6 +17,7 @@ en:
     date_to: to
     details: "%{resource} details"
     document_name: Invoice
+    document_tax_name: Tax invoice
     due_date: Due %{date}
     fee_prorated: The fee is prorated on days of usage, the displayed unit price is an average
     fees_from_to_date: Fees from %{from_date} to %{to_date}

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -16,6 +16,7 @@ es:
     date_to: hasta
     details: Detalles de %{resource}
     document_name: Factura
+    document_tax_name: Factura fiscal
     due_date: Vence el %{date}
     fee_prorated: La tarifa se prorratea según los días de uso, el precio unitario mostrado es un promedio
     fees_from_to_date: Cargos desde %{from_date} hasta %{to_date}

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -17,6 +17,7 @@ fr:
     date_to: au
     details: Détails de %{resource}
     document_name: Facture
+    document_tax_name: Facture fiscale
     due_date: Date d'échéance le %{date}
     fee_prorated: Les frais sont calculés au prorata des jours d'utilisation, le prix unitaire affiché est une moyenne
     fees_from_to_date: Frais de conso. du %{from_date} au %{to_date}

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -17,6 +17,7 @@ it:
     date_to: al
     details: Dettagli %{resource}
     document_name: Fattura
+    document_tax_name: Fattura fiscale
     due_date: Scadenza %{date}
     fee_prorated: La tariffa è calcolata in base ai giorni di utilizzo, il prezzo unitario visualizzato è una media
     fees_from_to_date: Tariffe dal %{from_date} al %{to_date}

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -17,6 +17,7 @@ nb:
     date_to: til
     details: "%{resource} detaljer"
     document_name: Faktura
+    document_tax_name: Skattefaktura
     due_date: Forfallsdato %{date}
     fee_prorated: Avgiften beregnes forholdsmessig etter brukerdager, den viste enhetsprisen er et gjennomsnitt
     fees_from_to_date: Gebyrer fra %{from_date} til %{to_date}

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -16,6 +16,7 @@ sv:
     date_to: till och med
     details: "%{resource} specifikation”"
     document_name: Faktura
+    document_tax_name: Skattefaktura
     due_date: Förfaller %{date}
     fee_prorated: Avgiften är proraterad för användningsdagar, det visade enhetspriset är ett genomsnitt
     fees_from_to_date: Avgifter från %{from_date} till %{to_date}

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -632,6 +632,32 @@ RSpec.describe Invoice, type: :model do
     end
   end
 
+  describe '#document_invoice_name' do
+    let(:organization) { create(:organization, name: 'LAGO', country: 'FR') }
+    let(:customer) { create(:customer, organization:) }
+    let(:invoice) { create(:invoice, customer:, organization:) }
+
+    it 'returns the correct name for EU country' do
+      expect(invoice.document_name).to eq('Invoice')
+    end
+
+    context 'when organization country is Australia' do
+      let(:organization) { create(:organization, name: 'LAGO', country: 'AU') }
+
+      it 'returns the correct name that includes keyword tax' do
+        expect(invoice.document_name).to eq('Tax invoice')
+      end
+    end
+
+    context 'when it is credit invoice' do
+      let(:invoice) { create(:invoice, customer:, organization:, invoice_type: :credit) }
+
+      it 'returns the correct name for EU country' do
+        expect(invoice.document_name).to eq('Advance invoice')
+      end
+    end
+  end
+
   describe '#charge_pay_in_advance_proration_range' do
     let(:invoice_subscription) { create(:invoice_subscription, subscription:) }
     let(:invoice) { invoice_subscription.invoice }

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -638,14 +638,14 @@ RSpec.describe Invoice, type: :model do
     let(:invoice) { create(:invoice, customer:, organization:) }
 
     it 'returns the correct name for EU country' do
-      expect(invoice.document_name).to eq('Invoice')
+      expect(invoice.document_invoice_name).to eq('Invoice')
     end
 
     context 'when organization country is Australia' do
       let(:organization) { create(:organization, name: 'LAGO', country: 'AU') }
 
       it 'returns the correct name that includes keyword tax' do
-        expect(invoice.document_name).to eq('Tax invoice')
+        expect(invoice.document_invoice_name).to eq('Tax invoice')
       end
     end
 
@@ -653,7 +653,7 @@ RSpec.describe Invoice, type: :model do
       let(:invoice) { create(:invoice, customer:, organization:, invoice_type: :credit) }
 
       it 'returns the correct name for EU country' do
-        expect(invoice.document_name).to eq('Advance invoice')
+        expect(invoice.document_invoice_name).to eq('Advance invoice')
       end
     end
   end


### PR DESCRIPTION
## Context

In some countries, invoices must include specific information when taxes are included. One of these obligations is to display `Tax invoice` in the header of the document, instead of `Invoice`.

## Description

This PR handles described use-case. Currently we are handling only following country codes: `AU`, `AE`, `NZ` and `ID`.