### PR TITLE
Feat: Add price breakdown for pay in advance percentage charge

### DIFF
--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -12,21 +12,23 @@ module Invoices
       puts '-' * 100
       puts 'charge id: ' + charge.id.to_s
       puts 'event id: ' + event["id"].to_s
-      # result = Invoices::CreatePayInAdvanceChargeService.call(charge:, event:, timestamp:, invoice:)
-      # return if result.success?
+      # when running it from rails console, everything works fine;
+      # when running from sideqik = min/max is not applied :think:
+      result = Invoices::CreatePayInAdvanceChargeService.call(charge:, event:, timestamp:, invoice:)
+      return if result.success?
       # NOTE: We don't want a dead job for failed invoice due to the tax reason.
       #       This invoice should be in failed status and can be retried.
-      # return if tax_error?(result)
-      #
-      # result.raise_if_error! if invoice || result.invoice.nil? || !result.invoice.generating?
-      #
-      # # NOTE: retry the job with the already created invoice in a previous failed attempt
-      # self.class.set(wait: 3.seconds).perform_later(
-      #   charge:,
-      #   event:,
-      #   timestamp:,
-      #   invoice: result.invoice
-      # )
+      return if tax_error?(result)
+
+      result.raise_if_error! if invoice || result.invoice.nil? || !result.invoice.generating?
+
+      # NOTE: retry the job with the already created invoice in a previous failed attempt
+      self.class.set(wait: 3.seconds).perform_later(
+        charge:,
+        event:,
+        timestamp:,
+        invoice: result.invoice
+      )
     end
 
     private

--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -9,21 +9,24 @@ module Invoices
     unique :until_executed, on_conflict: :log
 
     def perform(charge:, event:, timestamp:, invoice: nil)
-      result = Invoices::CreatePayInAdvanceChargeService.call(charge:, event:, timestamp:, invoice:)
-      return if result.success?
+      puts '-' * 100
+      puts 'charge id: ' + charge.id.to_s
+      puts 'event id: ' + event["id"].to_s
+      # result = Invoices::CreatePayInAdvanceChargeService.call(charge:, event:, timestamp:, invoice:)
+      # return if result.success?
       # NOTE: We don't want a dead job for failed invoice due to the tax reason.
       #       This invoice should be in failed status and can be retried.
-      return if tax_error?(result)
-
-      result.raise_if_error! if invoice || result.invoice.nil? || !result.invoice.generating?
-
-      # NOTE: retry the job with the already created invoice in a previous failed attempt
-      self.class.set(wait: 3.seconds).perform_later(
-        charge:,
-        event:,
-        timestamp:,
-        invoice: result.invoice
-      )
+      # return if tax_error?(result)
+      #
+      # result.raise_if_error! if invoice || result.invoice.nil? || !result.invoice.generating?
+      #
+      # # NOTE: retry the job with the already created invoice in a previous failed attempt
+      # self.class.set(wait: 3.seconds).perform_later(
+      #   charge:,
+      #   event:,
+      #   timestamp:,
+      #   invoice: result.invoice
+      # )
     end
 
     private

--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -9,11 +9,6 @@ module Invoices
     unique :until_executed, on_conflict: :log
 
     def perform(charge:, event:, timestamp:, invoice: nil)
-      puts '-' * 100
-      puts 'charge id: ' + charge.id.to_s
-      puts 'event id: ' + event["id"].to_s
-      # when running it from rails console, everything works fine;
-      # when running from sideqik = min/max is not applied :think:
       result = Invoices::CreatePayInAdvanceChargeService.call(charge:, event:, timestamp:, invoice:)
       return if result.success?
       # NOTE: We don't want a dead job for failed invoice due to the tax reason.

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -62,7 +62,7 @@ class Charge < ApplicationRecord
   def simple_percentage?
     return false unless percentage?
 
-    properties.keys == ['charge']
+    properties.keys == ['rate']
   end
 
   private

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -59,7 +59,7 @@ class Charge < ApplicationRecord
     standard? || dynamic?
   end
 
-  def simple_percentage?
+  def basic_rate_percentage?
     return false unless percentage?
 
     properties.keys == ['rate']

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -59,6 +59,12 @@ class Charge < ApplicationRecord
     standard? || dynamic?
   end
 
+  def simple_percentage?
+    return false unless percentage?
+
+    properties.keys == ['charge']
+  end
+
   private
 
   def validate_amount

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -2,6 +2,8 @@
 
 module Charges
   class ApplyPayInAdvanceChargeModelService < BaseService
+    CHARDE_AMOUNT_DETAILS_KEYS = %i[units free_units free_events paid_units per_unit_total_amount paid_events
+                                    fixed_fee_unit_amount fixed_fee_total_amount min_max_adjustment_total_amount]
     def initialize(charge:, aggregation_result:, properties:)
       @charge = charge
       @aggregation_result = aggregation_result
@@ -27,6 +29,7 @@ module Charges
       result.amount = amount_cents
       result.precise_amount = amount * currency.subunit_to_unit.to_d
       result.unit_amount = rounded_amount.zero? ? BigDecimal("0") : rounded_amount / compute_units
+      result.amount_details = calculated_amount_details
       result
     end
 
@@ -55,15 +58,17 @@ module Charges
       end
     end
 
-    # Compute aggregation and apply charge for all events including the current one
-    def amount_including_event
-      @amount_including_event ||= charge_model.apply(charge:, aggregation_result:, properties:).amount
+    def applied_charge_model
+      @applied_charge_model ||= charge_model.apply(charge:, aggregation_result:, properties:)
     end
 
-    # Compute aggregation and apply charge for all events excluding the current one
-    def amount_excluding_event
-      return @amount_excluding_event if defined?(@amount_excluding_event)
+    # Compute aggregation and apply charge for all events including the current one
+    def amount_including_event
+      @amount_including_event ||= applied_charge_model.amount
+    end
 
+    def applied_charge_model_excluding_event
+      return @applied_charge_model_excluding_event if defined?(@applied_charge_model_excluding_event)
       previous_result = BaseService::Result.new
       previous_result.aggregation = aggregation_result.aggregation - aggregation_result.pay_in_advance_aggregation
       previous_result.count = aggregation_result.count - 1
@@ -76,11 +81,16 @@ module Charges
         )
       end
 
-      @amount_excluding_event ||= charge_model.apply(
+      @applied_charge_model_excluding_event ||= charge_model.apply(
         charge:,
         aggregation_result: previous_result,
         properties: (properties || {}).merge(exclude_event: true)
-      ).amount
+      )
+    end
+
+    # Compute aggregation and apply charge for all events excluding the current one
+    def amount_excluding_event
+      @amount_excluding_event ||= applied_charge_model_excluding_event.amount
     end
 
     def currency
@@ -103,6 +113,15 @@ module Charges
         aggregation_result.max_aggregation &&
         aggregation_result.units_applied &&
         aggregation_result.current_aggregation <= aggregation_result.max_aggregation
+    end
+
+    def calculated_amount_details
+      all_charges_details = applied_charge_model.amount_details
+      charges_details_without_last_event = applied_charge_model_excluding_event.amount_details
+
+      CHARDE_AMOUNT_DETAILS_KEYS.each_with_object({rate: all_charges_details[:rate]}) do |key, result|
+        result[key] = (all_charges_details[key].to_f - charges_details_without_last_event[key].to_f).to_s
+      end
     end
   end
 end

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -117,6 +117,8 @@ module Charges
     end
 
     def calculated_amount_details
+      return {} unless charge.percentage?
+
       all_charges_details = applied_charge_model.amount_details
       charges_details_without_last_event = applied_charge_model_excluding_event.amount_details
       return {} if all_charges_details.blank? || charges_details_without_last_event.blank?

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -119,8 +119,9 @@ module Charges
     def calculated_amount_details
       all_charges_details = applied_charge_model.amount_details
       charges_details_without_last_event = applied_charge_model_excluding_event.amount_details
+      return {} if all_charges_details.blank? || charges_details_without_last_event.blank?
 
-      CHARGE_AMOUNT_DETAILS_KEYS.each_with_object({ rate: all_charges_details[:rate] }) do |key, result|
+      CHARGE_AMOUNT_DETAILS_KEYS.each_with_object({rate: all_charges_details[:rate]}) do |key, result|
         result[key] = (all_charges_details[key].to_f - charges_details_without_last_event[key].to_f).to_s
       end
     end

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -2,8 +2,8 @@
 
 module Charges
   class ApplyPayInAdvanceChargeModelService < BaseService
-    CHARDE_AMOUNT_DETAILS_KEYS = %i[units free_units free_events paid_units per_unit_total_amount paid_events
-      fixed_fee_unit_amount fixed_fee_total_amount min_max_adjustment_total_amount]
+    CHARGE_AMOUNT_DETAILS_KEYS = %i[units free_events paid_units paid_events fixed_fee_total_amount min_max_adjustment_total_amount]
+
     def initialize(charge:, aggregation_result:, properties:)
       @charge = charge
       @aggregation_result = aggregation_result
@@ -118,10 +118,19 @@ module Charges
     def calculated_amount_details
       all_charges_details = applied_charge_model.amount_details
       charges_details_without_last_event = applied_charge_model_excluding_event.amount_details
+      base_details = {
+        rate: all_charges_details[:rate],
+        per_unit_total_amount: all_charges_details[:per_unit_total_amount]
+      }
 
-      CHARDE_AMOUNT_DETAILS_KEYS.each_with_object({rate: all_charges_details[:rate]}) do |key, result|
+      puts 'all_charges_details'
+      puts all_charges_details
+      puts 'charges_details_without_last_event'
+      puts charges_details_without_last_event
+      result = CHARGE_AMOUNT_DETAILS_KEYS.each_with_object(base_details) do |key, result|
         result[key] = (all_charges_details[key].to_f - charges_details_without_last_event[key].to_f).to_s
       end
+      result.merge({free_units: (result[:units].to_f - result[:paid_units].to_f).to_s})
     end
   end
 end

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -2,7 +2,8 @@
 
 module Charges
   class ApplyPayInAdvanceChargeModelService < BaseService
-    CHARGE_AMOUNT_DETAILS_KEYS = %i[units free_events paid_units paid_events fixed_fee_total_amount min_max_adjustment_total_amount per_unit_total_amount]
+    CHARGE_AMOUNT_DETAILS_KEYS = %i[units free_units paid_units free_events paid_events fixed_fee_total_amount
+      min_max_adjustment_total_amount per_unit_total_amount]
 
     def initialize(charge:, aggregation_result:, properties:)
       @charge = charge
@@ -118,18 +119,10 @@ module Charges
     def calculated_amount_details
       all_charges_details = applied_charge_model.amount_details
       charges_details_without_last_event = applied_charge_model_excluding_event.amount_details
-      base_details = {
-        rate: all_charges_details[:rate]
-      }
 
-      puts 'all_charges_details'
-      puts all_charges_details
-      puts 'charges_details_without_last_event'
-      puts charges_details_without_last_event
-      result = CHARGE_AMOUNT_DETAILS_KEYS.each_with_object(base_details) do |key, result|
+      CHARGE_AMOUNT_DETAILS_KEYS.each_with_object({ rate: all_charges_details[:rate] }) do |key, result|
         result[key] = (all_charges_details[key].to_f - charges_details_without_last_event[key].to_f).to_s
       end
-      result.merge({free_units: (result[:units].to_f - result[:paid_units].to_f).to_s})
     end
   end
 end

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -122,7 +122,6 @@ module Charges
       return {} if all_charges_details.blank? || charges_details_without_last_event.blank?
 
       fixed_values  = { rate: all_charges_details[:rate], fixed_fee_unit_amount: all_charges_details[:fixed_fee_unit_amount] }
-
       CHARGE_AMOUNT_DETAILS_KEYS.each_with_object(fixed_values) do |key, result|
         result[key] = (all_charges_details[key].to_f - charges_details_without_last_event[key].to_f).to_s
       end

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -123,7 +123,7 @@ module Charges
       charges_details_without_last_event = applied_charge_model_excluding_event.amount_details
       return {} if all_charges_details.blank? || charges_details_without_last_event.blank?
 
-      fixed_values  = { rate: all_charges_details[:rate], fixed_fee_unit_amount: all_charges_details[:fixed_fee_unit_amount] }
+      fixed_values = {rate: all_charges_details[:rate], fixed_fee_unit_amount: all_charges_details[:fixed_fee_unit_amount]}
       details = CHARGE_AMOUNT_DETAILS_KEYS.each_with_object(fixed_values) do |key, result|
         result[key] = (all_charges_details[key].to_f - charges_details_without_last_event[key].to_f).to_s
       end

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -122,9 +122,12 @@ module Charges
       return {} if all_charges_details.blank? || charges_details_without_last_event.blank?
 
       fixed_values  = { rate: all_charges_details[:rate], fixed_fee_unit_amount: all_charges_details[:fixed_fee_unit_amount] }
-      CHARGE_AMOUNT_DETAILS_KEYS.each_with_object(fixed_values) do |key, result|
+      details = CHARGE_AMOUNT_DETAILS_KEYS.each_with_object(fixed_values) do |key, result|
         result[key] = (all_charges_details[key].to_f - charges_details_without_last_event[key].to_f).to_s
       end
+      # TODO: remove this when Charges::ChargeModels::PercentageService#free_units_value respects :exclude_event flag
+      details[:free_units] = (details[:units].to_f - details[:paid_units].to_f).to_s
+      details
     end
   end
 end

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -2,7 +2,7 @@
 
 module Charges
   class ApplyPayInAdvanceChargeModelService < BaseService
-    CHARGE_AMOUNT_DETAILS_KEYS = %i[units free_events paid_units paid_events fixed_fee_total_amount min_max_adjustment_total_amount]
+    CHARGE_AMOUNT_DETAILS_KEYS = %i[units free_events paid_units paid_events fixed_fee_total_amount min_max_adjustment_total_amount per_unit_total_amount]
 
     def initialize(charge:, aggregation_result:, properties:)
       @charge = charge
@@ -119,8 +119,7 @@ module Charges
       all_charges_details = applied_charge_model.amount_details
       charges_details_without_last_event = applied_charge_model_excluding_event.amount_details
       base_details = {
-        rate: all_charges_details[:rate],
-        per_unit_total_amount: all_charges_details[:per_unit_total_amount]
+        rate: all_charges_details[:rate]
       }
 
       puts 'all_charges_details'

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -121,7 +121,9 @@ module Charges
       charges_details_without_last_event = applied_charge_model_excluding_event.amount_details
       return {} if all_charges_details.blank? || charges_details_without_last_event.blank?
 
-      CHARGE_AMOUNT_DETAILS_KEYS.each_with_object({rate: all_charges_details[:rate]}) do |key, result|
+      fixed_values  = { rate: all_charges_details[:rate], fixed_fee_unit_amount: all_charges_details[:fixed_fee_unit_amount] }
+
+      CHARGE_AMOUNT_DETAILS_KEYS.each_with_object(fixed_values) do |key, result|
         result[key] = (all_charges_details[key].to_f - charges_details_without_last_event[key].to_f).to_s
       end
     end

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -3,7 +3,7 @@
 module Charges
   class ApplyPayInAdvanceChargeModelService < BaseService
     CHARDE_AMOUNT_DETAILS_KEYS = %i[units free_units free_events paid_units per_unit_total_amount paid_events
-                                    fixed_fee_unit_amount fixed_fee_total_amount min_max_adjustment_total_amount]
+      fixed_fee_unit_amount fixed_fee_total_amount min_max_adjustment_total_amount]
     def initialize(charge:, aggregation_result:, properties:)
       @charge = charge
       @aggregation_result = aggregation_result

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -20,7 +20,20 @@ module Charges
         free_events = if aggregation_result.count >= free_units_count
           free_units_count
         else
-          [aggregation_result.count - free_units_count, 0].max
+          # [aggregation_result.count - free_units_count, 0].max
+          # if we have 1 event, but we accept 3 free events, this event should be recorded as free.
+          # with current logic it is:
+          # 1 - 3 = -2
+          # [-2, 0].max => 0. and we have stored 0 free events, but 1 paid event
+          # but
+          # as result if our charge allows 3 free transactions, when we calculate 3rd values, we're getting this:
+          # all_charges_details
+          # {:units=>"4500.0", :free_units=>"4500.0", :free_events=>3, :paid_units=>"0.0", :rate=>0.2e2, :per_unit_total_amount=>0.0, :paid_events=>0, :fixed_fee_unit_amount=>0.0, :fixed_fee_total_amount=>"0.0", :min_max_adjustment_total_amount=>"0.0"}
+          # charges_details_without_last_event
+          # {:units=>"3000.0", :free_units=>"4500.0", :free_events=>0, :paid_units=>"0.0", :rate=>0.2e2, :per_unit_total_amount=>0, :paid_events=>2, :fixed_fee_unit_amount=>0.1e2, :fixed_fee_total_amount=>"0.0", :min_max_adjustment_total_amount=>"0.0"}
+          # so all events charge returns us {free_events: 3, paid_events: 0}
+          # all without last returns us {free_events: 0, paid_events: 2}
+          [aggregation_result.count, 0].max
         end
         paid_events = aggregation_result.count - free_events
 

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -82,7 +82,7 @@ module Fees
           unit_amount_cents:,
           precise_unit_amount: result.unit_amount,
           grouped_by: format_grouped_by,
-          amount_details: result.amount_details
+          amount_details: result.amount_details || {}
         )
 
         unless customer_provider_taxation?

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -85,7 +85,6 @@ module Fees
           amount_details: result.amount_details
         )
 
-#         byebug
         unless customer_provider_taxation?
           taxes_result = Fees::ApplyTaxesService.call(fee:)
           taxes_result.raise_if_error!

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -136,7 +136,6 @@ module Fees
       puts '=' * 80
       puts 'aggregation_result: ' + aggregation_result.to_s
       puts 'properties: ' + properties.to_s
-      byebug
       charge_model_result = Charges::ApplyPayInAdvanceChargeModelService.call(
         charge:, aggregation_result:, properties:
       )

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -133,6 +133,10 @@ module Fees
     end
 
     def apply_charge_model(aggregation_result:, properties:)
+      puts '=' * 80
+      puts 'aggregation_result: ' + aggregation_result.to_s
+      puts 'properties: ' + properties.to_s
+      byebug
       charge_model_result = Charges::ApplyPayInAdvanceChargeModelService.call(
         charge:, aggregation_result:, properties:
       )

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -133,9 +133,6 @@ module Fees
     end
 
     def apply_charge_model(aggregation_result:, properties:)
-      puts '=' * 80
-      puts 'aggregation_result: ' + aggregation_result.to_s
-      puts 'properties: ' + properties.to_s
       charge_model_result = Charges::ApplyPayInAdvanceChargeModelService.call(
         charge:, aggregation_result:, properties:
       )

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -81,9 +81,11 @@ module Fees
           taxes_precise_amount_cents: 0.to_d,
           unit_amount_cents:,
           precise_unit_amount: result.unit_amount,
-          grouped_by: format_grouped_by
+          grouped_by: format_grouped_by,
+          amount_details: result.amount_details
         )
 
+#         byebug
         unless customer_provider_taxation?
           taxes_result = Fees::ApplyTaxesService.call(fee:)
           taxes_result.raise_if_error!

--- a/app/views/templates/invoices/v4/_charge_percentage.slim
+++ b/app/views/templates/invoices/v4/_charge_percentage.slim
@@ -1,0 +1,40 @@
+
+- if amount_details['free_units'].to_f.positive?
+  / Free units per transaction
+  | free units per transaction
+  tr.details
+    td.body-2 = I18n.t('invoice.percentage.free_units_per_transaction', count: amount_details['free_events'])
+    td.body-2 = amount_details['free_units']
+    td.body-2 = MoneyHelper.format(0.to_money(amount_currency))
+    td.body-2 == TaxHelper.applied_taxes(self)
+    td.body-2 = MoneyHelper.format(0.to_money(amount_currency))
+/ Percentage rate on amount
+tr.details
+  td.body-2 = I18n.t('invoice.percentage.percentage_rate_on_amount')
+  td.body-2 = amount_details['paid_units']
+  td.body-2 = amount_details['rate'] + '%'
+  td.body-2 == TaxHelper.applied_taxes(self)
+  td.body-2 = MoneyHelper.format(amount_details['per_unit_total_amount'].to_money(amount_currency))
+- if amount_details['fixed_fee_total_amount'].to_f.positive?
+  / Fixed fee per transaction
+  tr.details
+    td.body-2 = I18n.t('invoice.percentage.fee_per_transaction')
+    td.body-2 = amount_details['paid_events']
+    td.body-2 = MoneyHelper.format(amount_details['fixed_fee_total_amount'].to_money(amount_currency))
+    td.body-2 == TaxHelper.applied_taxes(self)
+    td.body-2 = MoneyHelper.format(amount_details['fixed_fee_total_amount'].to_money(amount_currency))
+- unless amount_details['min_max_adjustment_total_amount'].to_f.zero?
+  / Adjustment for min/max per transaction
+  tr.details
+    td.body-2 = I18n.t('invoice.percentage.adjustment_per_transaction')
+    td.body-2 = 1
+    td.body-2 = MoneyHelper.format(amount_details['min_max_adjustment_total_amount'].to_money(amount_currency))
+    td.body-2 == TaxHelper.applied_taxes(self)
+    td.body-2 = MoneyHelper.format(amount_details['min_max_adjustment_total_amount'].to_money(amount_currency))
+/ Sub total
+tr.details.subtotal
+  td.body-2 = I18n.t('invoice.sub_total')
+  td.body-2
+  td.body-2
+  td.body-2
+  td.body-2 = MoneyHelper.format(amount)

--- a/app/views/templates/invoices/v4/_charge_percentage.slim
+++ b/app/views/templates/invoices/v4/_charge_percentage.slim
@@ -1,7 +1,6 @@
 
 - if amount_details['free_units'].to_f.positive? || amount_details['free_events'].to_f.positive?
   / Free units per transaction
-  | free units per transaction
   tr.details
     td.body-2 = I18n.t('invoice.percentage.free_units_per_transaction', count: 1)
     td.body-2 = amount_details['free_units']

--- a/app/views/templates/invoices/v4/_charge_percentage.slim
+++ b/app/views/templates/invoices/v4/_charge_percentage.slim
@@ -1,20 +1,21 @@
 
-- if amount_details['free_units'].to_f.positive?
+- if amount_details['free_units'].to_f.positive? || amount_details['free_events'].to_f.positive?
   / Free units per transaction
   | free units per transaction
   tr.details
-    td.body-2 = I18n.t('invoice.percentage.free_units_per_transaction', count: amount_details['free_events'])
+    td.body-2 = I18n.t('invoice.percentage.free_units_per_transaction', count: 1)
     td.body-2 = amount_details['free_units']
     td.body-2 = MoneyHelper.format(0.to_money(amount_currency))
     td.body-2 == TaxHelper.applied_taxes(self)
     td.body-2 = MoneyHelper.format(0.to_money(amount_currency))
 / Percentage rate on amount
-tr.details
-  td.body-2 = I18n.t('invoice.percentage.percentage_rate_on_amount')
-  td.body-2 = amount_details['paid_units']
-  td.body-2 = amount_details['rate'] + '%'
-  td.body-2 == TaxHelper.applied_taxes(self)
-  td.body-2 = MoneyHelper.format(amount_details['per_unit_total_amount'].to_money(amount_currency))
+- if amount_details['paid_units'].to_f.positive?
+  tr.details
+    td.body-2 = I18n.t('invoice.percentage.percentage_rate_on_amount')
+    td.body-2 = amount_details['paid_units']
+    td.body-2 = amount_details['rate'] + '%'
+    td.body-2 == TaxHelper.applied_taxes(self)
+    td.body-2 = MoneyHelper.format(amount_details['per_unit_total_amount'].to_money(amount_currency))
 - if amount_details['fixed_fee_total_amount'].to_f.positive?
   / Fixed fee per transaction
   tr.details

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -457,7 +457,7 @@ html
             tr
               - if fee.charge.percentage?
                 - if fee.charge.simple_percentage?
-                  tr.charge-name
+                  tr
                     td.body-1
                       = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
                     td.body-2 = fee.amount_details['paid_units']

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -243,29 +243,29 @@ html
       }
 
       .invoice-resume-table tr td {
-          padding-top: 8px;
-          padding-bottom: 8px;
-          text-align: right;
-          word-wrap: break-word;
+        padding-top: 8px;
+        padding-bottom: 8px;
+        text-align: right;
+        word-wrap: break-word;
       }
       .invoice-resume-table td:first-child {
-          width: 50%;
-          text-align: left;
+        width: 50%;
+        text-align: left;
       }
       .invoice-resume-table td:nth-child(2) {
-          width: 12.5%;
-          max-width: 10vw;
+        width: 12.5%;
+        max-width: 10vw;
       }
       .invoice-resume-table td:nth-child(3) {
-          width: 12.5%;
-          max-width: 10vw;
+        width: 12.5%;
+        max-width: 10vw;
       }
       .invoice-resume-table td:nth-child(4) {
-          width: 12.5%;
+        width: 12.5%;
       }
       .invoice-resume-table td:nth-child(5) {
-          width: 12.5%;
-          max-width: 10vw;
+        width: 12.5%;
+        max-width: 10vw;
       }
 
       .invoice-resume-table tr {
@@ -276,28 +276,28 @@ html
       }
 
       .invoice-resume-table tr.details, .invoice-resume-table tr.charge-name {
-          border: none;
+        border: none;
       }
 
       .invoice-resume-table tr.charge-name td {
-          padding-bottom: 0;
-          color: #19212e;
+        padding-bottom: 0;
+        color: #19212e;
       }
 
       .invoice-resume-table tr.details td {
-          color: #66758F;
-          padding-top: 4px;
-          padding-bottom: 4px;
+        color: #66758F;
+        padding-top: 4px;
+        padding-bottom: 4px;
       }
 
       .invoice-resume-table tr.details td:first-child {
-          padding-left: 8px;
+        padding-left: 8px;
       }
 
       .invoice-resume-table tr.details.subtotal td {
-          padding-bottom: 8px;
-          border-bottom: 1px solid #d9dee7;
-          color: #19212e;
+        padding-bottom: 8px;
+        border-bottom: 1px solid #d9dee7;
+        color: #19212e;
       }
 
       .invoice-resume .total-table tr td {

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -266,6 +266,32 @@ html
       .invoice-resume table {
         border-collapse: collapse;
       }
+
+      .invoice-resume-table tr.details, .invoice-resume-table tr.charge-name {
+          border: none;
+      }
+
+      .invoice-resume-table tr.charge-name td {
+          padding-bottom: 0;
+          color: #19212e;
+      }
+
+      .invoice-resume-table tr.details td {
+          color: #66758F;
+          padding-top: 4px;
+          padding-bottom: 4px;
+      }
+
+      .invoice-resume-table tr.details td:first-child {
+          padding-left: 8px;
+      }
+
+      .invoice-resume-table tr.details.subtotal td {
+          padding-bottom: 8px;
+          border-bottom: 1px solid #d9dee7;
+          color: #19212e;
+      }
+
       .invoice-resume .total-table tr td {
         padding-top: 8px;
         padding-bottom: 8px;
@@ -421,32 +447,51 @@ html
             td.body-2 = I18n.t('invoice.amount')
           - fees.order(:succeeded_at, :created_at).each do |fee|
             tr
-              - if !fee.charge.invoiceable? # TODO: edit with `invoicing_strategy`
-                td
-                  .body-1
+              - if fee.charge.charge_model.to_sym == :percentage
+                tr.charge-name
+                  td.body-1
                     = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
                     - if fee.charge_filter_id?
                       = ' • ' + fee.filter_display_name(separator: ' • ')
-                  - succeeded_at_date = fee.succeeded_at&.in_time_zone(customer.applicable_timezone)&.to_date
-                  - if succeeded_at_date
-                    .body-3 = I18n.l(succeeded_at_date, format: :default)
-              - elsif fee.charge.prorated?
-                - pay_in_advance_range = charge_pay_in_advance_proration_range(fee, invoice_subscription(fee.subscription.id).timestamp)
-                td
-                  .body-1
-                    = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
-                    - if fee.charge_filter_id?
-                      = ' • ' + fee.filter_display_name(separator: ' • ')
-                  .body-3 = I18n.t('invoice.breakdown_for_days', breakdown_duration: pay_in_advance_range[:number_of_days], breakdown_total_duration: pay_in_advance_range[:period_duration])
+                    - if fee.billable_metric.weighted_sum_agg?
+                      .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(fee.subscription.plan.interval))
+                    - if fee.charge.percentage?
+                      .body-3 = I18n.t('invoice.total_events', count: fee.events_count)
+                    - if fee.charge.prorated?
+                      .body-3 = I18n.t('invoice.fee_prorated')
+                  td.body-2
+                  td.body-2
+                  td.body-2
+                  td.body-2
+                == SlimHelper.render('templates/invoices/v4/_charge_percentage', fee)
               - else
-                td.body-1
-                  = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
-                  - if fee.charge_filter_id?
-                    = ' • ' + fee.filter_display_name(separator: ' • ')
-              td.body-2 = fee.units
-              td.body-2 = MoneyHelper.format(fee.unit_amount)
-              td.body-2 == TaxHelper.applied_taxes(fee)
-              td.body-2 = MoneyHelper.format(fee.amount)
+                - if !fee.charge.invoiceable? # TODO: edit with `invoicing_strategy`
+                  td
+                    .body-1
+                      = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
+                      - if fee.charge_filter_id?
+                        = ' • ' + fee.filter_display_name(separator: ' • ')
+                    - succeeded_at_date = fee.succeeded_at&.in_time_zone(customer.applicable_timezone)&.to_date
+                    - if succeeded_at_date
+                      .body-3 = I18n.l(succeeded_at_date, format: :default)
+                - elsif fee.charge.prorated?
+                  - pay_in_advance_range = charge_pay_in_advance_proration_range(fee, invoice_subscription(fee.subscription.id).timestamp)
+                  td
+                    .body-1
+                      = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
+                      - if fee.charge_filter_id?
+                        = ' • ' + fee.filter_display_name(separator: ' • ')
+                    .body-3 = I18n.t('invoice.breakdown_for_days', breakdown_duration: pay_in_advance_range[:number_of_days], breakdown_total_duration: pay_in_advance_range[:period_duration])
+                - else
+                  td.body-1
+                    = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
+                    - if fee.charge_filter_id?
+                      = ' • ' + fee.filter_display_name(separator: ' • ')
+                td.body-2 = fee.units
+                td.body-2 = MoneyHelper.format(fee.unit_amount)
+                td.body-2 == TaxHelper.applied_taxes(fee)
+                td.body-2 = MoneyHelper.format(fee.amount)
+
 
         table.total-table width="100%"
           - if coupons_amount_cents.positive?

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -241,25 +241,33 @@ html
       .invoice-resume-table tr:first-child td {
         color: #66758F;
       }
-      .invoice-resume-table td {
-        padding-top: 8px;
-        padding-bottom: 8px;
+
+      .invoice-resume-table tr td {
+          padding-top: 8px;
+          padding-bottom: 8px;
+          text-align: right;
+          word-wrap: break-word;
       }
       .invoice-resume-table td:first-child {
-        width: 50%;
+          width: 50%;
+          text-align: left;
       }
       .invoice-resume-table td:nth-child(2) {
-        width: 14%;
+          width: 12.5%;
+          max-width: 10vw;
       }
       .invoice-resume-table td:nth-child(3) {
-        width: 18%;
+          width: 12.5%;
+          max-width: 10vw;
       }
       .invoice-resume-table td:nth-child(4) {
-        width: 18%;
+          width: 12.5%;
       }
-      .invoice-resume-table tr td:last-child {
-        text-align: right;
+      .invoice-resume-table td:nth-child(5) {
+          width: 12.5%;
+          max-width: 10vw;
       }
+
       .invoice-resume-table tr {
         border-bottom: 1px solid #D9DEE7;
       }
@@ -447,23 +455,31 @@ html
             td.body-2 = I18n.t('invoice.amount')
           - fees.order(:succeeded_at, :created_at).each do |fee|
             tr
-              - if fee.charge.charge_model.to_sym == :percentage
-                tr.charge-name
-                  td.body-1
-                    = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
-                    - if fee.charge_filter_id?
-                      = ' • ' + fee.filter_display_name(separator: ' • ')
-                    - if fee.billable_metric.weighted_sum_agg?
-                      .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(fee.subscription.plan.interval))
-                    - if fee.charge.percentage?
+              - if fee.charge.percentage?
+                - if fee.charge.simple_percentage?
+                  tr.charge-name
+                    td.body-1
+                      = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
+                    td.body-2 = fee.amount_details['paid_units']
+                    td.body-2 = fee.amount_details['rate'] + '%'
+                    td.body-2 == TaxHelper.applied_taxes(fee)
+                    td.body-2 = MoneyHelper.format(fee.amount_details['per_unit_total_amount'].to_money(fee.amount_currency))
+                - else
+                  tr.charge-name
+                    td.body-1
+                      = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
+                      - if fee.charge_filter_id?
+                        = ' • ' + fee.filter_display_name(separator: ' • ')
+                      - if fee.billable_metric.weighted_sum_agg?
+                        .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(fee.subscription.plan.interval))
                       .body-3 = I18n.t('invoice.total_events', count: fee.events_count)
-                    - if fee.charge.prorated?
-                      .body-3 = I18n.t('invoice.fee_prorated')
-                  td.body-2
-                  td.body-2
-                  td.body-2
-                  td.body-2
-                == SlimHelper.render('templates/invoices/v4/_charge_percentage', fee)
+                      - if fee.charge.prorated?
+                        .body-3 = I18n.t('invoice.fee_prorated')
+                    td.body-2
+                    td.body-2
+                    td.body-2
+                    td.body-2
+                  == SlimHelper.render('templates/invoices/v4/_charge_percentage', fee)
               - else
                 - if !fee.charge.invoiceable? # TODO: edit with `invoicing_strategy`
                   td

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -455,8 +455,8 @@ html
             td.body-2 = I18n.t('invoice.amount')
           - fees.order(:succeeded_at, :created_at).each do |fee|
             tr
-              - if fee.charge.percentage?
-                - if fee.charge.simple_percentage?
+              - if fee.charge.percentage? && fee.amount_details.present?
+                - if fee.charge.basic_rate_percentage?
                   tr
                     td.body-1
                       = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -545,4 +545,18 @@ RSpec.describe Charge, type: :model do
       end
     end
   end
+
+  describe '#simple_percentage?' do
+    it 'returns false if charge model is not percentage' do
+      expect(build(:standard_charge).simple_percentage?).to be_falsey
+    end
+
+    it 'returns false if charge model is percentage but has other properties except rate' do
+      expect(build(:charge, charge_model: 'percentage', properties: {fixed_amount: '20'}).simple_percentage?).to be_falsey
+    end
+
+    it 'returns true only if properties of percentage charge contain only rate' do
+      expect(build(:charge, charge_model: 'percentage', properties: {rate: '0.20'}).simple_percentage?).to be_truthy
+    end
+  end
 end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -548,15 +548,15 @@ RSpec.describe Charge, type: :model do
 
   describe '#basic_rate_percentage?' do
     it 'returns false if charge model is not percentage' do
-      expect(build(:standard_charge)).not_to basic_rate_percentage
+      expect(build(:standard_charge)).not_to be_basic_rate_percentage
     end
 
     it 'returns false if charge model is percentage but has other properties except rate' do
-      expect(build(:charge, charge_model: 'percentage', properties: {fixed_amount: '20'})).not_to basic_rate_percentage
+      expect(build(:charge, charge_model: 'percentage', properties: {fixed_amount: '20'})).not_to be_basic_rate_percentage
     end
 
     it 'returns true only if properties of percentage charge contain only rate' do
-      expect(build(:charge, charge_model: 'percentage', properties: {rate: '0.20'})).to basic_rate_percentage
+      expect(build(:charge, charge_model: 'percentage', properties: {rate: '0.20'})).to be_basic_rate_percentage
     end
   end
 end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -546,17 +546,17 @@ RSpec.describe Charge, type: :model do
     end
   end
 
-  describe '#simple_percentage?' do
+  describe '#basic_rate_percentage?' do
     it 'returns false if charge model is not percentage' do
-      expect(build(:standard_charge)).not_to be_simple_percentage
+      expect(build(:standard_charge)).not_to basic_rate_percentage
     end
 
     it 'returns false if charge model is percentage but has other properties except rate' do
-      expect(build(:charge, charge_model: 'percentage', properties: {fixed_amount: '20'})).not_to be_simple_percentage
+      expect(build(:charge, charge_model: 'percentage', properties: {fixed_amount: '20'})).not_to basic_rate_percentage
     end
 
     it 'returns true only if properties of percentage charge contain only rate' do
-      expect(build(:charge, charge_model: 'percentage', properties: {rate: '0.20'})).to be_simple_percentage
+      expect(build(:charge, charge_model: 'percentage', properties: {rate: '0.20'})).to basic_rate_percentage
     end
   end
 end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -548,15 +548,15 @@ RSpec.describe Charge, type: :model do
 
   describe '#simple_percentage?' do
     it 'returns false if charge model is not percentage' do
-      expect(build(:standard_charge).simple_percentage?).to be_falsey
+      expect(build(:standard_charge)).not_to be_simple_percentage
     end
 
     it 'returns false if charge model is percentage but has other properties except rate' do
-      expect(build(:charge, charge_model: 'percentage', properties: {fixed_amount: '20'}).simple_percentage?).to be_falsey
+      expect(build(:charge, charge_model: 'percentage', properties: {fixed_amount: '20'})).not_to be_simple_percentage
     end
 
     it 'returns true only if properties of percentage charge contain only rate' do
-      expect(build(:charge, charge_model: 'percentage', properties: {rate: '0.20'}).simple_percentage?).to be_truthy
+      expect(build(:charge, charge_model: 'percentage', properties: {rate: '0.20'})).to be_simple_percentage
     end
   end
 end

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -772,10 +772,10 @@ describe "Pay in advance charges Scenarios", :scenarios, type: :request, transac
             events_count: 1,
             amount_cents: 0,
             amount_details: {
-              "rate"=>"5.0", "units"=>"8.0", "free_units"=>"8.0", "paid_units"=>"0.0",
-              "free_events"=>"1.0", "paid_events"=>"0.0", "fixed_fee_unit_amount"=>"0.0",
-              "per_unit_total_amount"=>"0.0", "fixed_fee_total_amount"=>"0.0",
-              "min_max_adjustment_total_amount"=>"0.0"
+              "rate" => "5.0", "units" => "8.0", "free_units" => "8.0", "paid_units" => "0.0",
+              "free_events" => "1.0", "paid_events" => "0.0", "fixed_fee_unit_amount" => "0.0",
+              "per_unit_total_amount" => "0.0", "fixed_fee_total_amount" => "0.0",
+              "min_max_adjustment_total_amount" => "0.0"
             }
           )
         end
@@ -805,10 +805,10 @@ describe "Pay in advance charges Scenarios", :scenarios, type: :request, transac
             events_count: 1,
             amount_cents: 0,
             amount_details: {
-              "rate"=>"5.0", "units"=>"5.0", "free_units"=>"5.0", "paid_units"=>"0.0",
-              "free_events"=>"1.0", "paid_events"=>"0.0", "fixed_fee_unit_amount"=>"0.0",
-              "per_unit_total_amount"=>"0.0", "fixed_fee_total_amount"=>"0.0",
-              "min_max_adjustment_total_amount"=>"0.0"
+              "rate" => "5.0", "units" => "5.0", "free_units" => "5.0", "paid_units" => "0.0",
+              "free_events" => "1.0", "paid_events" => "0.0", "fixed_fee_unit_amount" => "0.0",
+              "per_unit_total_amount" => "0.0", "fixed_fee_total_amount" => "0.0",
+              "min_max_adjustment_total_amount" => "0.0"
             }
           )
         end
@@ -833,10 +833,10 @@ describe "Pay in advance charges Scenarios", :scenarios, type: :request, transac
             events_count: 1,
             amount_cents: 100 + 15,
             amount_details: {
-              "rate"=>"5.0", "units"=>"3.0", "free_units"=>"0.0", "paid_units"=>"3.0",
-              "free_events"=>"0.0", "paid_events"=>"1.0", "fixed_fee_unit_amount"=>"1.0",
-              "per_unit_total_amount"=>"0.15", "fixed_fee_total_amount"=>"1.0",
-              "min_max_adjustment_total_amount"=>"0.0"
+              "rate" => "5.0", "units" => "3.0", "free_units" => "0.0", "paid_units" => "3.0",
+              "free_events" => "0.0", "paid_events" => "1.0", "fixed_fee_unit_amount" => "1.0",
+              "per_unit_total_amount" => "0.15", "fixed_fee_total_amount" => "1.0",
+              "min_max_adjustment_total_amount" => "0.0"
             }
           )
         end
@@ -893,10 +893,10 @@ describe "Pay in advance charges Scenarios", :scenarios, type: :request, transac
             events_count: 1,
             amount_cents: 0,
             amount_details: {
-              "rate"=>"5.0", "units"=>"100.0", "free_units"=>"100.0", "paid_units"=>"0.0",
-              "free_events"=>"1.0", "paid_events"=>"0.0", "fixed_fee_unit_amount"=>"0.0",
-              "per_unit_total_amount"=>"0.0", "fixed_fee_total_amount"=>"0.0",
-              "min_max_adjustment_total_amount"=>"0.0"
+              "rate" => "5.0", "units" => "100.0", "free_units" => "100.0", "paid_units" => "0.0",
+              "free_events" => "1.0", "paid_events" => "0.0", "fixed_fee_unit_amount" => "0.0",
+              "per_unit_total_amount" => "0.0", "fixed_fee_total_amount" => "0.0",
+              "min_max_adjustment_total_amount" => "0.0"
             }
           )
         end
@@ -926,10 +926,10 @@ describe "Pay in advance charges Scenarios", :scenarios, type: :request, transac
             events_count: 1,
             amount_cents: 0,
             amount_details: {
-              "rate"=>"5.0", "units"=>"10.0", "free_units"=>"10.0", "paid_units"=>"0.0",
-              "free_events"=>"1.0", "paid_events"=>"0.0", "fixed_fee_unit_amount"=>"0.0",
-              "per_unit_total_amount"=>"0.0", "fixed_fee_total_amount"=>"0.0",
-              "min_max_adjustment_total_amount"=>"0.0"
+              "rate" => "5.0", "units" => "10.0", "free_units" => "10.0", "paid_units" => "0.0",
+              "free_events" => "1.0", "paid_events" => "0.0", "fixed_fee_unit_amount" => "0.0",
+              "per_unit_total_amount" => "0.0", "fixed_fee_total_amount" => "0.0",
+              "min_max_adjustment_total_amount" => "0.0"
             }
           )
         end
@@ -959,10 +959,10 @@ describe "Pay in advance charges Scenarios", :scenarios, type: :request, transac
             events_count: 1,
             amount_cents: 150,
             amount_details: {
-              "rate"=>"5.0", "units"=>"20.0", "free_units"=>"10.0", "paid_units"=>"10.0",
-              "free_events"=>"0.0", "paid_events"=>"1.0", "fixed_fee_unit_amount"=>"1.0",
-              "per_unit_total_amount"=>"0.5", "fixed_fee_total_amount"=>"1.0",
-              "min_max_adjustment_total_amount"=>"0.0"
+              "rate" => "5.0", "units" => "20.0", "free_units" => "10.0", "paid_units" => "10.0",
+              "free_events" => "0.0", "paid_events" => "1.0", "fixed_fee_unit_amount" => "1.0",
+              "per_unit_total_amount" => "0.5", "fixed_fee_total_amount" => "1.0",
+              "min_max_adjustment_total_amount" => "0.0"
             }
           )
         end
@@ -992,12 +992,12 @@ describe "Pay in advance charges Scenarios", :scenarios, type: :request, transac
             events_count: 1,
             amount_cents: 200,
             amount_details: {
-              "rate"=>"5.0", "units"=>"20.0", "free_units"=>"0.0", "paid_units"=>"20.0",
-              "free_events"=>"0.0", "paid_events"=>"1.0", "fixed_fee_unit_amount"=>"1.0",
-              "per_unit_total_amount"=>"1.0", "fixed_fee_total_amount"=>"1.0",
-              "min_max_adjustment_total_amount"=>"0.0"
+              "rate" => "5.0", "units" => "20.0", "free_units" => "0.0", "paid_units" => "20.0",
+              "free_events" => "0.0", "paid_events" => "1.0", "fixed_fee_unit_amount" => "1.0",
+              "per_unit_total_amount" => "1.0", "fixed_fee_total_amount" => "1.0",
+              "min_max_adjustment_total_amount" => "0.0"
             }
-         )
+          )
         end
       end
     end

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -59,6 +59,7 @@ describe "Pay in advance charges Scenarios", :scenarios, type: :request, transac
         expect(fee.units).to eq(1)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(1000)
+        expect(fee.amount_details).to eq({})
       end
 
       ### 17 february: Send an other event.
@@ -139,6 +140,7 @@ describe "Pay in advance charges Scenarios", :scenarios, type: :request, transac
         expect(fee.units).to eq(1)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(1200)
+        expect(fee.amount_details).to eq({})
       end
 
       ### 16 february: Send an event.
@@ -344,6 +346,7 @@ describe "Pay in advance charges Scenarios", :scenarios, type: :request, transac
         expect(fee.units).to eq(10)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(1000)
+        expect(fee.amount_details).to eq({})
       end
 
       travel_to(DateTime.new(2023, 2, 17)) do
@@ -566,6 +569,7 @@ describe "Pay in advance charges Scenarios", :scenarios, type: :request, transac
         expect(fee.units).to eq(3)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(0) # free units
+        expect(fee.amount_details).to eq({})
       end
 
       travel_to(DateTime.new(2023, 2, 17)) do
@@ -673,6 +677,7 @@ describe "Pay in advance charges Scenarios", :scenarios, type: :request, transac
         expect(fee.units).to eq(3)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(2 * 3 + 1)
+        expect(fee.amount_details).to eq({})
       end
 
       travel_to(DateTime.new(2023, 2, 17)) do

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
         result.unit_amount = 0.01111111111
         result.count = 1
         result.units = 9
+        result.amount_details = {}
       end
     end
 


### PR DESCRIPTION
## Context

We needed to enhance representation of price for percentage pay in advance charge. Initial request was to simply show only percentage if only percentage is set, but then the request grew up to show the whole amount breakdown as we have in subscription invoices

## Description

- added amount_details calculation for fee as we have for fee aggregation (subscription invoices)
- amount_detail is calculated only for percentage invoices
- added fix for free_events calculation: before if we had a plan that allows 3 free events, we received two and generate the invoice, in the invoice it will say that there are 0 free events. Now it will say 2 free_events
