### PR TITLE
feat(netsuite-taxes): Add new model attributes

### DIFF
--- a/app/models/integration_collection_mappings/netsuite_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/netsuite_collection_mapping.rb
@@ -2,6 +2,7 @@
 
 module IntegrationCollectionMappings
   class NetsuiteCollectionMapping < BaseCollectionMapping
+    settings_accessors :tax_nexus, :tax_type, :tax_code
   end
 end
 

--- a/spec/factories/integration_collection_mappings.rb
+++ b/spec/factories/integration_collection_mappings.rb
@@ -9,7 +9,10 @@ FactoryBot.define do
       {
         external_id: 'netsuite-123',
         external_account_code: 'netsuite-code-1',
-        external_name: 'Credits and Discounts'
+        external_name: 'Credits and Discounts',
+        tax_nexus: 'tax-nexus-1',
+        tax_type: 'tax-type-1',
+        tax_code: 'tax-code-1'
       }
     end
   end

--- a/spec/models/integration_collection_mappings/netsuite_collection_mapping_spec.rb
+++ b/spec/models/integration_collection_mappings/netsuite_collection_mapping_spec.rb
@@ -31,4 +31,31 @@ RSpec.describe IntegrationCollectionMappings::NetsuiteCollectionMapping, type: :
       expect(mapping.external_name).to eq(external_name)
     end
   end
+
+  describe '#tax_nexus' do
+    let(:tax_nexus) { 'tax-nexus-1' }
+
+    it 'assigns and retrieve a setting' do
+      mapping.tax_nexus = tax_nexus
+      expect(mapping.tax_nexus).to eq(tax_nexus)
+    end
+  end
+
+  describe '#tax_type' do
+    let(:tax_type) { 'tax-type-1' }
+
+    it 'assigns and retrieve a setting' do
+      mapping.tax_type = tax_type
+      expect(mapping.tax_type).to eq(tax_type)
+    end
+  end
+
+  describe '#tax_code' do
+    let(:tax_code) { 'tax-code-1' }
+
+    it 'assigns and retrieve a setting' do
+      mapping.tax_code = tax_code
+      expect(mapping.tax_code).to eq(tax_code)
+    end
+  end
 end


### PR DESCRIPTION
## Context

When Anrok is connected to NetSuite, it’s impossible for Lago to override the tax details. Thus, Lago always sends the amount excluding tax to NetSuite, creating some discrepancies.

## Description

Add new tax-related attributes to `NetsuiteCollectionMapping` model.