### PR TITLE
Fix: change default value for WalletTransaction metadata

### DIFF
--- a/db/migrate/20240920084727_change_wallet_transactions_metadata_default.rb
+++ b/db/migrate/20240920084727_change_wallet_transactions_metadata_default.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class ChangeWalletTransactionsMetadataDefault < ActiveRecord::Migration[7.1]
+  def up
+    change_column_default :wallet_transactions, :metadata, []
+    safety_assured do
+      execute <<-SQL
+        UPDATE wallet_transactions
+        SET metadata = '[]'::jsonb
+        WHERE metadata = '{}'::jsonb;
+      SQL
+    end
+  end
+
+  def down
+    change_column_default :wallet_transactions, :metadata, {}
+    safety_assured do
+      execute <<-SQL
+        UPDATE wallet_transactions
+        SET metadata = '{}'::jsonb
+        WHERE metadata = '[]'::jsonb;
+      SQL
+    end
+  end
+end

--- a/db/migrate/20240920084727_change_wallet_transactions_metadata_default.rb
+++ b/db/migrate/20240920084727_change_wallet_transactions_metadata_default.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ChangeWalletTransactionsMetadataDefault < ActiveRecord::Migration[7.1]
   def up
     change_column_default :wallet_transactions, :metadata, []

--- a/db/migrate/20240920091133_change_recurring_transaction_rules_transaction_metadata_default.rb
+++ b/db/migrate/20240920091133_change_recurring_transaction_rules_transaction_metadata_default.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class ChangeRecurringTransactionRulesTransactionMetadataDefault < ActiveRecord::Migration[7.1]
+  def up
+    change_column_default :recurring_transaction_rules, :transaction_metadata, []
+    safety_assured do
+      execute <<-SQL
+        UPDATE recurring_transaction_rules
+        SET transaction_metadata = '[]'::jsonb
+        WHERE transaction_metadata = '{}'::jsonb;
+      SQL
+    end
+  end
+
+  def down
+    change_column_default :recurring_transaction_rules, :transaction_metadata, {}
+    safety_assured do
+      execute <<-SQL
+        UPDATE recurring_transaction_rules
+        SET transaction_metadata = '{}'::jsonb
+        WHERE transaction_metadata = '[]'::jsonb;
+      SQL
+    end
+  end
+end

--- a/db/migrate/20240920091133_change_recurring_transaction_rules_transaction_metadata_default.rb
+++ b/db/migrate/20240920091133_change_recurring_transaction_rules_transaction_metadata_default.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ChangeRecurringTransactionRulesTransactionMetadataDefault < ActiveRecord::Migration[7.1]
   def up
     change_column_default :recurring_transaction_rules, :transaction_metadata, []

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_17_145042) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_20_084727) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1128,7 +1128,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_17_145042) do
     t.integer "source", default: 0, null: false
     t.integer "transaction_status", default: 0, null: false
     t.boolean "invoice_requires_successful_payment", default: false, null: false
-    t.jsonb "metadata", default: {}
+    t.jsonb "metadata", default: []
     t.index ["invoice_id"], name: "index_wallet_transactions_on_invoice_id"
     t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_20_084727) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_20_091133) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1022,7 +1022,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_084727) do
     t.decimal "target_ongoing_balance", precision: 30, scale: 5
     t.datetime "started_at"
     t.boolean "invoice_requires_successful_payment", default: false, null: false
-    t.jsonb "transaction_metadata", default: {}
+    t.jsonb "transaction_metadata", default: []
     t.index ["started_at"], name: "index_recurring_transaction_rules_on_started_at"
     t.index ["wallet_id"], name: "index_recurring_transaction_rules_on_wallet_id"
   end

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
                 invoice_requires_successful_payment: false,
-                metadata: {}
+                metadata: []
               }
             )
         end
@@ -80,7 +80,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
                   source: :interval,
                   invoice_requires_successful_payment: false,
-                  metadata: {}
+                  metadata: []
                 }
               )
           end
@@ -111,7 +111,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   granted_credits: "0.0",
                   source: :interval,
                   invoice_requires_successful_payment: false,
-                  metadata: {}
+                  metadata: []
                 }
               )
           end
@@ -136,7 +136,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
                 invoice_requires_successful_payment: false,
-                metadata: {}
+                metadata: []
               }
             )
         end
@@ -165,7 +165,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
                   source: :interval,
                   invoice_requires_successful_payment: false,
-                  metadata: {}
+                  metadata: []
                 }
               )
           end
@@ -199,7 +199,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
                   source: :interval,
                   invoice_requires_successful_payment: false,
-                  metadata: {}
+                  metadata: []
                 }
               )
           end
@@ -224,7 +224,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
                 invoice_requires_successful_payment: false,
-                metadata: {}
+                metadata: []
               }
             )
         end
@@ -253,7 +253,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
                   source: :interval,
                   invoice_requires_successful_payment: false,
-                  metadata: {}
+                  metadata: []
                 }
               )
           end
@@ -277,7 +277,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
                   source: :interval,
                   invoice_requires_successful_payment: false,
-                  metadata: {}
+                  metadata: []
                 }
               )
           end
@@ -302,7 +302,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
                 invoice_requires_successful_payment: false,
-                metadata: {}
+                metadata: []
               }
             )
         end
@@ -331,7 +331,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
                   source: :interval,
                   invoice_requires_successful_payment: false,
-                  metadata: {}
+                  metadata: []
                 }
               )
           end
@@ -426,7 +426,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
                 invoice_requires_successful_payment: true,
-                metadata: {}
+                metadata: []
               }
             )
         end

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Wallets::ThresholdTopUpService, type: :service do
             granted_credits: "3.0",
             source: :threshold,
             invoice_requires_successful_payment: false,
-            metadata: {}
+            metadata: []
           }
         )
     end
@@ -132,7 +132,7 @@ RSpec.describe Wallets::ThresholdTopUpService, type: :service do
               granted_credits: "0.0",
               source: :threshold,
               invoice_requires_successful_payment: false,
-              metadata: {}
+              metadata: []
             }
           )
       end


### PR DESCRIPTION
All api clients expect metadata to be returned as array (and when records are created, it's also an array), but if we create WalletTransaction without metadata, it takes default value of `{}` which then breaks api-clients