### PR TITLE
feat(DynamicPricing): Accept precise_total_amount_cents when creating an event

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -90,6 +90,7 @@ module Api
             :code,
             :timestamp,
             :external_subscription_id,
+            :precise_total_amount_cents,
             properties: {}
           )
       end
@@ -102,6 +103,7 @@ module Api
               :code,
               :timestamp,
               :external_subscription_id,
+              :precise_total_amount_cents,
               properties: {} # rubocop:disable Style/HashAsLastArrayItem
             ]
           ).to_h.deep_symbolize_keys

--- a/app/serializers/v1/event_serializer.rb
+++ b/app/serializers/v1/event_serializer.rb
@@ -9,6 +9,7 @@ module V1
         lago_customer_id: model.customer_id,
         code: model.code,
         timestamp: model.timestamp.iso8601(3),
+        precise_total_amount_cents: model.precise_total_amount_cents&.to_s,
         properties: model.properties,
         lago_subscription_id: model.subscription_id,
         external_subscription_id: model.external_subscription_id,

--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -48,6 +48,7 @@ module Events
         event.properties = event_params[:properties] || {}
         event.metadata = metadata || {}
         event.timestamp = Time.zone.at(event_params[:timestamp] ? event_params[:timestamp].to_f : timestamp)
+        event.precise_total_amount_cents = event_params[:precise_total_amount_cents]
 
         result.events.push(event)
         result.errors = result.errors.merge({index => event.errors.messages}) unless event.valid?
@@ -80,7 +81,8 @@ module Events
           timestamp: event.timestamp.to_f,
           code: event.code,
           properties: event.properties,
-          ingested_at: Time.zone.now.iso8601[...-1]
+          ingested_at: Time.zone.now.iso8601[...-1],
+          precise_total_amount_cents: event.precise_total_amount_cents
         }.to_json
       )
     end

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -19,6 +19,7 @@ module Events
       event.properties = params[:properties] || {}
       event.metadata = metadata || {}
       event.timestamp = Time.zone.at(params[:timestamp] ? params[:timestamp].to_f : timestamp)
+      event.precise_total_amount_cents = params[:precise_total_amount_cents]
 
       event.save! unless organization.clickhouse_aggregation?
 
@@ -52,6 +53,7 @@ module Events
           transaction_id: event.transaction_id,
           timestamp: event.timestamp.iso8601[...-1], # NOTE: Removes trailing 'Z' to allow clickhouse parsing
           code: event.code,
+          precise_total_amount_cents: event.precise_total_amount_cents,
           properties: event.properties,
           ingested_at: Time.zone.now.iso8601[...-1]
         }.to_json

--- a/spec/requests/api/v1/events_controller_spec.rb
+++ b/spec/requests/api/v1/events_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
             transaction_id: SecureRandom.uuid,
             external_subscription_id: subscription.external_id,
             timestamp: Time.current.to_i,
+            precise_total_amount_cents: '123.45',
             properties: {
               foo: 'bar'
             }
@@ -48,6 +49,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
               transaction_id: event.transaction_id,
               external_subscription_id: subscription.external_id,
               timestamp: Time.current.to_i,
+              precise_total_amount_cents: '123.45',
               properties: {
                 foo: 'bar'
               }
@@ -72,6 +74,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
               transaction_id: SecureRandom.uuid,
               external_subscription_id: subscription.external_id,
               timestamp: Time.current.to_i,
+              precise_total_amount_cents: '123.45',
               properties: {
                 foo: 'bar'
               }
@@ -136,6 +139,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
           code: metric.code,
           external_subscription_id: subscription.external_id,
           transaction_id: SecureRandom.uuid,
+          precise_total_amount_cents: '123.45',
           properties: {
             foo: 'bar'
           }

--- a/spec/serializers/v1/event_serializer_spec.rb
+++ b/spec/serializers/v1/event_serializer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ::V1::EventSerializer do
       :event,
       customer_id: nil,
       subscription_id: nil,
+      precise_total_amount_cents: '123.6',
       properties: {
         item_value: '12'
       }
@@ -26,6 +27,7 @@ RSpec.describe ::V1::EventSerializer do
         'lago_customer_id' => event.customer_id,
         'code' => event.code,
         'timestamp' => event.timestamp.iso8601(3),
+        'precise_total_amount_cents' => '123.6',
         'properties' => event.properties,
         'lago_subscription_id' => event.subscription_id,
         'external_subscription_id' => event.external_subscription_id,

--- a/spec/services/events/create_batch_service_spec.rb
+++ b/spec/services/events/create_batch_service_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Events::CreateBatchService, type: :service do
   let(:code) { 'sum_agg' }
   let(:metadata) { {} }
   let(:creation_timestamp) { Time.current.to_f }
+  let(:precise_total_amount_cents) { '123.34' }
 
   let(:events_params) do
     events = []
@@ -26,6 +27,7 @@ RSpec.describe Events::CreateBatchService, type: :service do
         external_subscription_id: SecureRandom.uuid,
         code:,
         transaction_id: SecureRandom.uuid,
+        precise_total_amount_cents:,
         properties: {foo: 'bar'},
         timestamp:
       }
@@ -178,6 +180,7 @@ RSpec.describe Events::CreateBatchService, type: :service do
               external_subscription_id: SecureRandom.uuid,
               code:,
               transaction_id: SecureRandom.uuid,
+              precise_total_amount_cents:,
               properties: {foo: 'bar'},
               timestamp:
             }
@@ -204,6 +207,7 @@ RSpec.describe Events::CreateBatchService, type: :service do
               external_subscription_id: SecureRandom.uuid,
               code:,
               transaction_id: SecureRandom.uuid,
+              precise_total_amount_cents:,
               properties: {foo: 'bar'},
               timestamp:
             }


### PR DESCRIPTION
## Context

AI, CPaaS and Fintech customers can apply a price to a unit that fluctuates over time. Currently Lago does not support this usecase.

## Description

This PR updates `POST /api/v1/events` and `POST /api/v1/batch_events` to accept the new `precise_total_amount_cents` field on event model.