### PR TITLE
feat(netsuite-taxes): Add new tax attributes to collection mapping services

### DIFF
--- a/app/graphql/mutations/integration_collection_mappings/create.rb
+++ b/app/graphql/mutations/integration_collection_mappings/create.rb
@@ -17,8 +17,7 @@ module Mutations
 
       def resolve(**args)
         result = ::IntegrationCollectionMappings::CreateService
-          .new(context[:current_user])
-          .call(**args.merge(organization_id: current_organization.id))
+          .call(params: args.merge(organization_id: current_organization.id))
 
         result.success? ? result.integration_collection_mapping : result_error(result)
       end

--- a/app/graphql/mutations/integrations/hubspot/create.rb
+++ b/app/graphql/mutations/integrations/hubspot/create.rb
@@ -18,8 +18,7 @@ module Mutations
 
         def resolve(**args)
           result = ::Integrations::Hubspot::CreateService
-            .new(params: args.merge(organization_id: current_organization.id))
-            .call
+            .call(params: args.merge(organization_id: current_organization.id))
 
           result.success? ? result.integration : result_error(result)
         end

--- a/app/services/integration_collection_mappings/create_service.rb
+++ b/app/services/integration_collection_mappings/create_service.rb
@@ -2,21 +2,32 @@
 
 module IntegrationCollectionMappings
   class CreateService < BaseService
-    def call(**args)
-      integration = Integrations::BaseIntegration.find_by(id: args[:integration_id])
+    attr_reader :params
+
+    def initialize(params:)
+      @params = params
+
+      super
+    end
+
+    def call
+      integration = Integrations::BaseIntegration.find_by(id: params[:integration_id])
 
       return result.not_found_failure!(resource: 'integration') unless integration
 
       integration_collection_mapping = IntegrationCollectionMappings::Factory.new_instance(integration:).new(
-        integration_id: args[:integration_id],
-        mapping_type: args[:mapping_type]
+        integration_id: params[:integration_id],
+        mapping_type: params[:mapping_type]
       )
 
-      integration_collection_mapping.external_id = args[:external_id] if args.key?(:external_id)
-      if args.key?(:external_account_code)
-        integration_collection_mapping.external_account_code = args[:external_account_code]
+      integration_collection_mapping.external_id = params[:external_id] if params.key?(:external_id)
+      if params.key?(:external_account_code)
+        integration_collection_mapping.external_account_code = params[:external_account_code]
       end
-      integration_collection_mapping.external_name = args[:external_name] if args.key?(:external_name)
+      integration_collection_mapping.external_name = params[:external_name] if params.key?(:external_name)
+      integration_collection_mapping.tax_nexus = params[:tax_nexus] if params.key?(:tax_nexus)
+      integration_collection_mapping.tax_code = params[:tax_code] if params.key?(:tax_code)
+      integration_collection_mapping.tax_type = params[:tax_type] if params.key?(:tax_type)
 
       integration_collection_mapping.save!
 

--- a/app/services/integration_collection_mappings/update_service.rb
+++ b/app/services/integration_collection_mappings/update_service.rb
@@ -19,6 +19,9 @@ module IntegrationCollectionMappings
         integration_collection_mapping.external_account_code = params[:external_account_code]
       end
       integration_collection_mapping.external_name = params[:external_name] if params.key?(:external_name)
+      integration_collection_mapping.tax_nexus = params[:tax_nexus] if params.key?(:tax_nexus)
+      integration_collection_mapping.tax_code = params[:tax_code] if params.key?(:tax_code)
+      integration_collection_mapping.tax_type = params[:tax_type] if params.key?(:tax_type)
 
       integration_collection_mapping.save!
 

--- a/spec/services/integration_collection_mappings/create_service_spec.rb
+++ b/spec/services/integration_collection_mappings/create_service_spec.rb
@@ -3,20 +3,21 @@
 require 'rails_helper'
 
 RSpec.describe IntegrationCollectionMappings::CreateService, type: :service do
-  let(:service) { described_class.new(membership.user) }
-
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }
   let(:add_on) { create(:add_on, organization:) }
 
   describe '#call' do
-    subject(:service_call) { service.call(**create_args) }
+    subject(:service_call) { described_class.call(params: create_args) }
 
     let(:create_args) do
       {
         mapping_type: :fallback_item,
-        integration_id: integration.id
+        integration_id: integration.id,
+        tax_nexus: '123',
+        tax_code: '456',
+        tax_type: 'tax-type-1'
       }
     end
 
@@ -30,6 +31,9 @@ RSpec.describe IntegrationCollectionMappings::CreateService, type: :service do
         aggregate_failures do
           expect(integration_collection_mapping.mapping_type).to eq('fallback_item')
           expect(integration_collection_mapping.integration_id).to eq(integration.id)
+          expect(integration_collection_mapping.tax_nexus).to eq(create_args[:tax_nexus])
+          expect(integration_collection_mapping.tax_code).to eq(create_args[:tax_code])
+          expect(integration_collection_mapping.tax_type).to eq(create_args[:tax_type])
         end
       end
 

--- a/spec/services/integration_collection_mappings/update_service_spec.rb
+++ b/spec/services/integration_collection_mappings/update_service_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe IntegrationCollectionMappings::UpdateService, type: :service do
       {
         external_id: '456',
         external_name: 'Name1',
-        external_account_code: 'code-2'
+        external_account_code: 'code-2',
+        tax_nexus: 'updated-123',
+        tax_code: 'updated-456',
+        tax_type: 'updated-tax-type-1'
       }
     end
 
@@ -32,6 +35,9 @@ RSpec.describe IntegrationCollectionMappings::UpdateService, type: :service do
           expect(integration_collection_mapping.external_id).to eq('456')
           expect(integration_collection_mapping.external_name).to eq('Name1')
           expect(integration_collection_mapping.external_account_code).to eq('code-2')
+          expect(integration_collection_mapping.tax_nexus).to eq(update_args[:tax_nexus])
+          expect(integration_collection_mapping.tax_code).to eq(update_args[:tax_code])
+          expect(integration_collection_mapping.tax_type).to eq(update_args[:tax_type])
         end
       end
 


### PR DESCRIPTION
## Context

When Anrok is connected to NetSuite, it’s impossible for Lago to override the tax details. Thus, Lago always sends the amount excluding tax to NetSuite, creating some discrepancies.

## Description

Add new tax-related attributes to collection mapping services.