### PR TITLE
Fix invoice status when choosing final status for the invoice

### DIFF
--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -37,7 +37,7 @@ module Invoices
         else
           invoice.status = :draft
         end
-        invoice.save
+        invoice.save!
 
         # NOTE: We don't want to raise error and corrupt DB commit if there is tax error.
         #       In that case we want fees to stay attached to the invoice. There is retry action that will enable users

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -28,16 +28,16 @@ module Invoices
 
       fee_result = ActiveRecord::Base.transaction do
         invoice.status = invoice_status
+        fee_result = Invoices::CalculateFeesService.call(
+          invoice:,
+          recurring:
+        )
         if invoice_status == :finalized
           Invoices::TransitionToFinalStatusService.call(invoice:)
         else
           invoice.status = :draft
         end
-
-        fee_result = Invoices::CalculateFeesService.call(
-          invoice:,
-          recurring:
-        )
+        invoice.save
 
         # NOTE: We don't want to raise error and corrupt DB commit if there is tax error.
         #       In that case we want fees to stay attached to the invoice. There is retry action that will enable users

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -32,10 +32,8 @@ module Invoices
           invoice:,
           recurring:
         )
-        if invoice_status == :finalized
+        if invoice.status == :finalized
           Invoices::TransitionToFinalStatusService.call(invoice:)
-        else
-          invoice.status = :draft
         end
         invoice.save!
 

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -32,7 +32,7 @@ module Invoices
           invoice:,
           recurring:
         )
-        if invoice.status == :finalized
+        if invoice.status == "finalized"
           Invoices::TransitionToFinalStatusService.call(invoice:)
         end
         invoice.save!

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -335,6 +335,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
       before do
         customer.update(finalize_zero_amount_invoice: :skip)
       end
+
       context 'when invoice total amount is not 0' do
         it 'creates an invoice in :finalized status' do
           result = invoice_service.call
@@ -344,6 +345,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
 
       context 'when invoice total amount is 0' do
         let(:plan) { create(:plan, interval: 'monthly', pay_in_advance:, amount_cents: 0) }
+
         before do
           plan
         end
@@ -361,7 +363,6 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
             result = invoice_service.call
             expect(result.invoice.status).to eq('draft')
           end
-
         end
       end
     end

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -359,6 +359,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
           before do
             organization.update!(invoice_grace_period: 30)
           end
+
           it 'creates an invoice in :draft status' do
             result = invoice_service.call
             expect(result.invoice.status).to eq('draft')


### PR DESCRIPTION
**context**

when assigning status before calculating fees, the total of the invoice is always 0, so the `TransitionToFinalStatusService` was always returning `:closed`
