### PR TITLE
feat(netsuite-taxes): Add new tax attributes to GraphQL types and inputs

### DIFF
--- a/app/graphql/types/integration_collection_mappings/create_input.rb
+++ b/app/graphql/types/integration_collection_mappings/create_input.rb
@@ -10,6 +10,9 @@ module Types
       argument :external_name, String, required: false
       argument :integration_id, ID, required: true
       argument :mapping_type, Types::IntegrationCollectionMappings::MappingTypeEnum, required: true
+      argument :tax_code, String, required: false
+      argument :tax_nexus, String, required: false
+      argument :tax_type, String, required: false
     end
   end
 end

--- a/app/graphql/types/integration_collection_mappings/object.rb
+++ b/app/graphql/types/integration_collection_mappings/object.rb
@@ -11,6 +11,9 @@ module Types
       field :id, ID, null: false
       field :integration_id, ID, null: false
       field :mapping_type, Types::IntegrationCollectionMappings::MappingTypeEnum, null: false
+      field :tax_code, String, null: true
+      field :tax_nexus, String, null: true
+      field :tax_type, String, null: true
     end
   end
 end

--- a/app/graphql/types/integration_collection_mappings/update_input.rb
+++ b/app/graphql/types/integration_collection_mappings/update_input.rb
@@ -12,6 +12,9 @@ module Types
       argument :external_name, String, required: false
       argument :integration_id, ID, required: false
       argument :mapping_type, Types::IntegrationCollectionMappings::MappingTypeEnum, required: false
+      argument :tax_code, String, required: false
+      argument :tax_nexus, String, required: false
+      argument :tax_type, String, required: false
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -387,6 +387,9 @@ type CollectionMapping {
   id: ID!
   integrationId: ID!
   mappingType: MappingTypeEnum!
+  taxCode: String
+  taxNexus: String
+  taxType: String
 }
 
 """
@@ -2010,6 +2013,9 @@ input CreateIntegrationCollectionMappingInput {
   externalName: String
   integrationId: ID!
   mappingType: MappingTypeEnum!
+  taxCode: String
+  taxNexus: String
+  taxType: String
 }
 
 """
@@ -7630,6 +7636,9 @@ input UpdateIntegrationCollectionMappingInput {
   id: ID!
   integrationId: ID
   mappingType: MappingTypeEnum
+  taxCode: String
+  taxNexus: String
+  taxType: String
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -3663,6 +3663,48 @@
               "args": [
 
               ]
+            },
+            {
+              "name": "taxCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxNexus",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxType",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
             }
           ],
           "inputFields": null,
@@ -7955,6 +7997,42 @@
                   "name": "MappingTypeEnum",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxNexus",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxType",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -36720,6 +36798,42 @@
               "type": {
                 "kind": "ENUM",
                 "name": "MappingTypeEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxNexus",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxType",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/types/integration_collection_mappings/create_input_spec.rb
+++ b/spec/graphql/types/integration_collection_mappings/create_input_spec.rb
@@ -10,4 +10,7 @@ RSpec.describe Types::IntegrationCollectionMappings::CreateInput do
   it { is_expected.to accept_argument(:external_account_code).of_type('String') }
   it { is_expected.to accept_argument(:external_id).of_type('String!') }
   it { is_expected.to accept_argument(:external_name).of_type('String') }
+  it { is_expected.to accept_argument(:tax_code).of_type('String') }
+  it { is_expected.to accept_argument(:tax_nexus).of_type('String') }
+  it { is_expected.to accept_argument(:tax_type).of_type('String') }
 end

--- a/spec/graphql/types/integration_collection_mappings/object_spec.rb
+++ b/spec/graphql/types/integration_collection_mappings/object_spec.rb
@@ -11,4 +11,7 @@ RSpec.describe Types::IntegrationCollectionMappings::Object do
   it { is_expected.to have_field(:external_account_code).of_type('String') }
   it { is_expected.to have_field(:external_id).of_type('String!') }
   it { is_expected.to have_field(:external_name).of_type('String') }
+  it { is_expected.to have_field(:tax_code).of_type('String') }
+  it { is_expected.to have_field(:tax_nexus).of_type('String') }
+  it { is_expected.to have_field(:tax_type).of_type('String') }
 end

--- a/spec/graphql/types/integration_collection_mappings/update_input_spec.rb
+++ b/spec/graphql/types/integration_collection_mappings/update_input_spec.rb
@@ -11,4 +11,7 @@ RSpec.describe Types::IntegrationCollectionMappings::UpdateInput do
   it { is_expected.to accept_argument(:external_account_code).of_type('String') }
   it { is_expected.to accept_argument(:external_id).of_type('String') }
   it { is_expected.to accept_argument(:external_name).of_type('String') }
+  it { is_expected.to accept_argument(:tax_code).of_type('String') }
+  it { is_expected.to accept_argument(:tax_nexus).of_type('String') }
+  it { is_expected.to accept_argument(:tax_type).of_type('String') }
 end


### PR DESCRIPTION
## Context

When Anrok is connected to NetSuite, it’s impossible for Lago to override the tax details. Thus, Lago always sends the amount excluding tax to NetSuite, creating some discrepancies.

## Description

Add new tax-related attributes to GraphQL types and inputs.