### PR TITLE
Feat(anrok): call report credit note job when creating a credit note

### DIFF
--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -11,6 +11,16 @@ class CreditNoteItem < ApplicationRecord
   def applied_taxes
     credit_note.applied_taxes.where(tax_code: fee.applied_taxes.select('fees_taxes.tax_code'))
   end
+
+  # This method returns item amount with coupons applied
+  # coupons are applied proportionally to the way they're applied on corresponding fee
+  # so knowing the item total proportion to fee total we can calculate item amount with coupons
+  def sub_total_excluding_taxes_amount_cents
+    return 0 if amount_cents.zero? || fee.amount_cents.zero?
+
+    item_proportion_to_fee = amount_cents.to_f / fee.amount_cents
+    item_proportion_to_fee * fee.sub_total_excluding_taxes_amount_cents
+  end
 end
 
 # == Schema Information

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -60,6 +60,7 @@ module CreditNotes
         deliver_webhook
         deliver_email
         handle_refund if should_handle_refund?
+        report_to_tax_provider if should_report_to_tax_provider?
 
         if credit_note.should_sync_credit_note?
           Integrations::Aggregator::CreditNotes::CreateJob.perform_later(credit_note:)
@@ -175,6 +176,12 @@ module CreditNotes
       invoice_payment.present?
     end
 
+    def should_report_to_tax_provider?
+      return false unless credit_note.finalized?
+
+      credit_note.customer.anrok_customer.present?
+    end
+
     def invoice_payment
       @invoice_payment ||= credit_note.invoice.payments.order(created_at: :desc).first
     end
@@ -188,6 +195,10 @@ module CreditNotes
       when PaymentProviders::AdyenProvider
         CreditNotes::Refunds::AdyenCreateJob.perform_later(credit_note)
       end
+    end
+
+    def report_to_tax_provider
+      CreditNotes::ProviderTaxes::ReportJob.perform_later(credit_note:)
     end
 
     def compute_amounts_and_taxes

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -60,7 +60,7 @@ module CreditNotes
         deliver_webhook
         deliver_email
         handle_refund if should_handle_refund?
-        report_to_tax_provider if should_report_to_tax_provider?
+        report_to_tax_provider
 
         if credit_note.should_sync_credit_note?
           Integrations::Aggregator::CreditNotes::CreateJob.perform_later(credit_note:)
@@ -174,12 +174,6 @@ module CreditNotes
       return false unless credit_note.invoice.payment_succeeded?
 
       invoice_payment.present?
-    end
-
-    def should_report_to_tax_provider?
-      return false unless credit_note.finalized?
-
-      credit_note.customer.anrok_customer.present?
     end
 
     def invoice_payment

--- a/app/services/integrations/aggregator/taxes/credit_notes/payload.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/payload.rb
@@ -51,7 +51,7 @@ module Integrations
             {
               'item_id' => fee.item_id,
               'item_code' => mapped_item.external_id,
-              'amount_cents' => (fee.sub_total_excluding_taxes_amount_cents&.to_i || 0) * -1
+              'amount_cents' => (item.amount_cents&.to_i || 0) * -1
             }
           end
 

--- a/app/services/integrations/aggregator/taxes/credit_notes/payload.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/payload.rb
@@ -51,14 +51,13 @@ module Integrations
             {
               'item_id' => fee.item_id,
               'item_code' => mapped_item.external_id,
-              'amount_cents' => item.sub_total_excluding_taxes_amount_cents * -1
+              'amount_cents' => item.sub_total_excluding_taxes_amount_cents.to_i * -1
             }
           end
 
           private
 
           attr_reader :customer, :integration_customer, :credit_note
-
         end
       end
     end

--- a/app/services/integrations/aggregator/taxes/credit_notes/payload.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/payload.rb
@@ -51,7 +51,7 @@ module Integrations
             {
               'item_id' => fee.item_id,
               'item_code' => mapped_item.external_id,
-              'amount_cents' => calculate_amount_with_coupons(item, fee)(item.amount_cents&.to_i || 0) * -1
+              'amount_cents' => item.sub_total_excluding_taxes_amount_cents * -1
             }
           end
 
@@ -59,10 +59,6 @@ module Integrations
 
           attr_reader :customer, :integration_customer, :credit_note
 
-          def calculate_amount_with_coupons(item, fee)
-            item_proportion_to_fee = fee.amount_cents / item.amount_cents.to_f
-            item_proportion_to_fee * fee.sub_total_excluding_taxes_amount_cents
-          end
         end
       end
     end

--- a/app/services/integrations/aggregator/taxes/credit_notes/payload.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/payload.rb
@@ -51,13 +51,18 @@ module Integrations
             {
               'item_id' => fee.item_id,
               'item_code' => mapped_item.external_id,
-              'amount_cents' => (item.amount_cents&.to_i || 0) * -1
+              'amount_cents' => calculate_amount_with_coupons(item, fee)(item.amount_cents&.to_i || 0) * -1
             }
           end
 
           private
 
           attr_reader :customer, :integration_customer, :credit_note
+
+          def calculate_amount_with_coupons(item, fee)
+            item_proportion_to_fee = fee.amount_cents / item.amount_cents.to_f
+            item_proportion_to_fee * fee.sub_total_excluding_taxes_amount_cents
+          end
         end
       end
     end

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -39,5 +39,11 @@ FactoryBot.define do
       shipping_state { state }
       shipping_country { country }
     end
+
+    trait :with_tax_integration do
+      after :create do |customer|
+        create(:anrok_customer, customer:)
+      end
+    end
   end
 end

--- a/spec/models/credit_note_item_spec.rb
+++ b/spec/models/credit_note_item_spec.rb
@@ -27,4 +27,3 @@ RSpec.describe CreditNoteItem, type: :model do
     end
   end
 end
-

--- a/spec/models/credit_note_item_spec.rb
+++ b/spec/models/credit_note_item_spec.rb
@@ -1,3 +1,30 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+
+RSpec.describe CreditNoteItem, type: :model do
+  subject(:credit_note_item) { create(:credit_note_item) }
+
+  it { is_expected.to belong_to(:credit_note) }
+  it { is_expected.to belong_to(:fee) }
+
+  describe '#sub_total_excluding_taxes_amount_cents' do
+    let(:credit_note_item) { build(:credit_note_item, amount_cents: 100, fee: fee) }
+    let(:fee) { build(:fee, amount_cents: 1000, precise_amount_cents: 1000, precise_coupons_amount_cents: 0) }
+
+    context 'when there are no coupons applied' do
+      it 'returns item amount with coupons applied' do
+        expect(credit_note_item.sub_total_excluding_taxes_amount_cents).to eq(100)
+      end
+    end
+
+    context 'when there are coupons applied' do
+      let(:fee) { build(:fee, amount_cents: 1000, precise_amount_cents: 1000, precise_coupons_amount_cents: 20) }
+
+      it 'returns item amount with coupons applied' do
+        expect(credit_note_item.sub_total_excluding_taxes_amount_cents).to eq(98)
+      end
+    end
+  end
+end
+

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -147,7 +147,6 @@ RSpec.describe CreditNotes::CreateService, type: :service do
 
         expect(CreditNotes::ProviderTaxes::ReportJob).to have_received(:perform_later).once
       end
-
     end
 
     context 'when organization does not have right email settings' do

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -138,14 +138,10 @@ RSpec.describe CreditNotes::CreateService, type: :service do
     context 'when customer has tax_provider set up' do
       let(:customer) { create(:customer, :with_tax_integration, organization:) }
 
-      before do
-        allow(CreditNotes::ProviderTaxes::ReportJob).to receive(:perform_later)
-      end
-
-      it 'enqueues a tax sync job' do
-        create_service.call
-
-        expect(CreditNotes::ProviderTaxes::ReportJob).to have_received(:perform_later).once
+      it 'sync with tax provider' do
+        expect do
+          create_service.call
+        end.to have_enqueued_job(CreditNotes::ProviderTaxes::ReportJob)
       end
     end
 

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -135,6 +135,21 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       let(:service_call) { create_service.call }
     end
 
+    context 'when customer has tax_provider set up' do
+      let(:customer) { create(:customer, :with_tax_integration, organization:) }
+
+      before do
+        allow(CreditNotes::ProviderTaxes::ReportJob).to receive(:perform_later)
+      end
+
+      it 'enqueues a tax sync job' do
+        create_service.call
+
+        expect(CreditNotes::ProviderTaxes::ReportJob).to have_received(:perform_later).once
+      end
+
+    end
+
     context 'when organization does not have right email settings' do
       before { invoice.organization.update!(email_settings: []) }
 

--- a/spec/services/integrations/aggregator/taxes/credit_notes/payload_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/payload_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payload do
       :fee,
       invoice:,
       add_on:,
-      created_at: current_time - 3.seconds
+      created_at: current_time - 3.seconds,
+      amount_cents: 200
     )
   end
   let(:fee_add_on_two) do
@@ -52,7 +53,8 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payload do
       :fee,
       invoice:,
       add_on: add_on_two,
-      created_at: current_time - 2.seconds
+      created_at: current_time - 2.seconds,
+      amount_cents: 200
     )
   end
   let(:credit_note) do
@@ -66,10 +68,10 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payload do
   end
 
   let(:credit_note_item1) do
-    create(:credit_note_item, credit_note:, fee: fee_add_on, amount_cents: fee_add_on.amount_cents)
+    create(:credit_note_item, credit_note:, fee: fee_add_on, amount_cents: 190)
   end
   let(:credit_note_item2) do
-    create(:credit_note_item, credit_note:, fee: fee_add_on_two, amount_cents: fee_add_on_two.amount_cents)
+    create(:credit_note_item, credit_note:, fee: fee_add_on_two, amount_cents: 180)
   end
 
   let(:body) do
@@ -92,12 +94,12 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payload do
           {
             'item_id' => fee_add_on.item_id,
             'item_code' => 'm1',
-            'amount_cents' => -200
+            'amount_cents' => -190
           },
           {
             'item_id' => fee_add_on_two.item_id,
             'item_code' => '1',
-            'amount_cents' => -200
+            'amount_cents' => -180
           }
         ]
       }

--- a/spec/services/integrations/aggregator/taxes/credit_notes/payload_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/payload_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payload do
       invoice:,
       add_on:,
       created_at: current_time - 3.seconds,
-      amount_cents: 200
+      amount_cents: 200,
+      precise_amount_cents: 200
     )
   end
   let(:fee_add_on_two) do
@@ -54,7 +55,9 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payload do
       invoice:,
       add_on: add_on_two,
       created_at: current_time - 2.seconds,
-      amount_cents: 200
+      amount_cents: 200,
+      precise_amount_cents: 200,
+      precise_coupons_amount_cents: 20
     )
   end
   let(:credit_note) do
@@ -99,7 +102,7 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payload do
           {
             'item_id' => fee_add_on_two.item_id,
             'item_code' => '1',
-            'amount_cents' => -180
+            'amount_cents' => -162
           }
         ]
       }


### PR DESCRIPTION
When creating a credit note we should schedule a job to report credit note creation to tax provider is customer has tax_provider set up;

When reporting credit note, the reported amount should be taken from the items amounts