### PR TITLE
misc(event): Remove ordering of event queries when not required

### DIFF
--- a/app/services/billable_metrics/aggregations/custom_service.rb
+++ b/app/services/billable_metrics/aggregations/custom_service.rb
@@ -128,7 +128,7 @@ module BillableMetrics
 
         # NOTE: Loop over events by batch
         (1..total_batches).each do |batch|
-          events_properties = store.events.page(batch).per(BATCH_SIZE)
+          events_properties = store.events(ordered: true).page(batch).per(BATCH_SIZE)
             .map { |event| {timestamp: event.timestamp, properties: event.properties} }
 
           state = sandboxed_aggregation(events_properties, state)

--- a/app/services/events/stores/clickhouse/unique_count_query.rb
+++ b/app/services/events/stores/clickhouse/unique_count_query.rb
@@ -204,7 +204,7 @@ module Events
           <<-SQL
             WITH events_data AS (
               (#{
-                events
+                events(ordered: true)
                   .select(
                     "toDateTime64(timestamp, 5, 'UTC') as timestamp, \
                     #{sanitized_property_name} AS property, \
@@ -224,7 +224,7 @@ module Events
 
           <<-SQL
             WITH events_data AS (#{
-              events
+              events(ordered: true)
                 .select(
                   "#{groups.join(", ")}, \
                   toDateTime64(timestamp, 5, 'UTC') as timestamp, \
@@ -340,7 +340,7 @@ module Events
         end
 
         def group_names
-          @group_names ||= store.grouped_by.map.with_index { |_, index| "g_#{index}" }.join(', ')
+          @group_names ||= store.grouped_by.map.with_index { |_, index| "g_#{index}" }.join(", ")
         end
       end
     end

--- a/app/services/events/stores/clickhouse/weighted_sum_query.rb
+++ b/app/services/events/stores/clickhouse/weighted_sum_query.rb
@@ -65,7 +65,7 @@ module Events
               (#{initial_value_sql})
               UNION ALL
               (#{
-                events
+                events(ordered: true)
                   .select("timestamp, #{sanitized_numeric_property} AS difference")
                   .group(Events::Stores::ClickhouseStore::DEDUPLICATION_GROUP)
                   .to_sql
@@ -124,7 +124,7 @@ module Events
               (#{grouped_initial_value_sql(initial_values)})
               UNION ALL
               (#{
-                events
+                events(ordered: true)
                   .select("#{groups.join(", ")}, timestamp, #{sanitized_numeric_property} AS difference")
                   .group(Events::Stores::ClickhouseStore::DEDUPLICATION_GROUP)
                   .to_sql
@@ -143,9 +143,9 @@ module Events
 
             [
               groups,
-              'toDateTime64(:from_datetime, 5, \'UTC\') AS timestamp',
+              "toDateTime64(:from_datetime, 5, 'UTC') AS timestamp",
               "toDecimal128(#{initial_value[:value]}, :decimal_scale) AS difference"
-            ].flatten.join(', ')
+            ].flatten.join(", ")
           end
 
           <<-SQL
@@ -166,8 +166,8 @@ module Events
             [
               groups,
               "toDateTime64(:to_datetime, 5, 'UTC') AS timestamp",
-              'toDecimal128(0, :decimal_scale) AS difference'
-            ].flatten.join(', ')
+              "toDecimal128(0, :decimal_scale) AS difference"
+            ].flatten.join(", ")
           end
 
           <<-SQL
@@ -202,7 +202,7 @@ module Events
         end
 
         def group_names
-          @group_names ||= store.grouped_by.map.with_index { |_, index| "g_#{index}" }.join(', ')
+          @group_names ||= store.grouped_by.map.with_index { |_, index| "g_#{index}" }.join(", ")
         end
       end
     end

--- a/app/services/events/stores/postgres/unique_count_query.rb
+++ b/app/services/events/stores/postgres/unique_count_query.rb
@@ -203,7 +203,7 @@ module Events
           # NOTE: Common table expression returning event's timestamp, property name and operation type.
           <<-SQL
             WITH events_data AS (#{
-              events
+              events(ordered: true)
                 .select(
                   "timestamp, \
                   #{sanitized_property_name} AS property, \
@@ -220,7 +220,7 @@ module Events
 
           <<-SQL
             WITH events_data AS (#{
-              events
+              events(ordered: true)
                 .select(
                   "#{groups.join(", ")}, \
                   timestamp, \
@@ -331,7 +331,7 @@ module Events
         end
 
         def group_names
-          @group_names ||= store.grouped_by.map.with_index { |_, index| "g_#{index}" }.join(', ')
+          @group_names ||= store.grouped_by.map.with_index { |_, index| "g_#{index}" }.join(", ")
         end
       end
     end

--- a/app/services/events/stores/postgres/weighted_sum_query.rb
+++ b/app/services/events/stores/postgres/weighted_sum_query.rb
@@ -65,7 +65,7 @@ module Events
               (#{initial_value_sql})
               UNION
               (#{
-                events
+                events(ordered: true)
                   .select("timestamp, (#{sanitized_property_name})::numeric AS difference, events.created_at")
                   .to_sql
               })
@@ -122,7 +122,7 @@ module Events
               (#{grouped_initial_value_sql(initial_values)})
               UNION
               (#{
-                events
+                events(ordered: true)
                   .select("#{groups.join(", ")}, timestamp, (#{sanitized_property_name})::numeric AS difference, events.created_at")
                   .to_sql
               })
@@ -138,16 +138,16 @@ module Events
               if initial_value[:groups][g]
                 "'#{ActiveRecord::Base.sanitize_sql_for_conditions(initial_value[:groups][g])}'"
               else
-                'NULL'
+                "NULL"
               end
             end
 
             [
               groups,
-              'timestamp without time zone :from_datetime',
+              "timestamp without time zone :from_datetime",
               initial_value[:value],
-              'timestamp without time zone :from_datetime'
-            ].flatten.join(', ')
+              "timestamp without time zone :from_datetime"
+            ].flatten.join(", ")
           end
 
           <<-SQL
@@ -164,16 +164,16 @@ module Events
               if initial_value[:groups][g]
                 "'#{ActiveRecord::Base.sanitize_sql_for_conditions(initial_value[:groups][g])}'"
               else
-                'NULL'
+                "NULL"
               end
             end
 
             [
               groups,
-              'timestamp without time zone :from_datetime',
+              "timestamp without time zone :from_datetime",
               0,
-              'timestamp without time zone :from_datetime'
-            ].flatten.join(', ')
+              "timestamp without time zone :from_datetime"
+            ].flatten.join(", ")
           end
 
           <<-SQL
@@ -204,7 +204,7 @@ module Events
         end
 
         def group_names
-          @group_names ||= store.grouped_by.map.with_index { |_, index| "g_#{index}" }.join(', ')
+          @group_names ||= store.grouped_by.map.with_index { |_, index| "g_#{index}" }.join(", ")
         end
       end
     end


### PR DESCRIPTION
## Context

When running aggregation for billable metrics we are (almost) always ordering events by the `timestamp` property.
In most cases this order is not necessary since the end-result will not be dependent of the event order (sum, count, max...) and the order clause might slow down the queries.

## Description

This PR updates all events-related aggregation queries to get rid of the order and keep it only when required. This should allow for a small gain in aggregation performances.