### PR TITLE
misc: Allign env variables with documentation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,9 +27,9 @@ module LagoApi
 
     # Configuration for active record encryption
     config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1
-    config.active_record.encryption.primary_key = ENV['ENCRYPTION_PRIMARY_KEY']
-    config.active_record.encryption.deterministic_key = ENV['ENCRYPTION_DETERMINISTIC_KEY']
-    config.active_record.encryption.key_derivation_salt = ENV['ENCRYPTION_KEY_DERIVATION_SALT']
+    config.active_record.encryption.primary_key = ENV['ENCRYPTION_PRIMARY_KEY'] || ENV['LAGO_ENCRYPTION_PRIMARY_KEY']
+    config.active_record.encryption.deterministic_key = ENV['ENCRYPTION_DETERMINISTIC_KEY'] || ENV['LAGO_ENCRYPTION_DETERMINISTIC_KEY']
+    config.active_record.encryption.key_derivation_salt = ENV['ENCRYPTION_KEY_DERIVATION_SALT'] || ENV['LAGO_ENCRYPTION_KEY_DERIVATION_SALT']
 
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}')]
     config.i18n.available_locales = %i[en fr nb de it es sv]


### PR DESCRIPTION
## Context

This PR is related to https://github.com/getlago/lago-doc/pull/210

A mismatch was reported by a user between the environment variable defined on https://doc.getlago.com/guide/self-hosted/docker and the one used in the API application.

## Description

This PR makes sure that the API application is using the environment variables defined in the documentation without breaking the setup for users using the docker-compose.yml file from the main Lago repository
