### PR TITLE
misc: move invoice numbering outside DB transaction

### DIFF
--- a/app/models/concerns/sequenced.rb
+++ b/app/models/concerns/sequenced.rb
@@ -27,7 +27,7 @@ module Sequenced
         transaction: true,
         timeout_seconds: 10.seconds
       ) do
-        sequential_id = sequence_scope.with_sequential_id.order(sequential_id: :desc).limit(1).pick(:sequential_id)
+        sequential_id = sequence_scope.with_sequential_id.where.not(id: self.id).order(sequential_id: :desc).limit(1).pick(:sequential_id)
         sequential_id ||= 0
 
         loop do

--- a/app/models/concerns/sequenced.rb
+++ b/app/models/concerns/sequenced.rb
@@ -27,7 +27,7 @@ module Sequenced
         transaction: true,
         timeout_seconds: 10.seconds
       ) do
-        sequential_id = sequence_scope.with_sequential_id.where.not(id: self.id).order(sequential_id: :desc).limit(1).pick(:sequential_id)
+        sequential_id = sequence_scope.with_sequential_id.where.not(id:).order(sequential_id: :desc).limit(1).pick(:sequential_id)
         sequential_id ||= 0
 
         loop do

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -11,9 +11,6 @@ class Invoice < ApplicationRecord
   CREDIT_NOTES_MIN_VERSION = 2
   COUPON_BEFORE_VAT_VERSION = 3
 
-  before_save :ensure_organization_sequential_id, if: -> { organization.per_organization? }
-  before_save :ensure_number
-
   belongs_to :customer, -> { with_discarded }
   belongs_to :organization
 
@@ -336,20 +333,23 @@ class Invoice < ApplicationRecord
     I18n.t('invoice.document_name')
   end
 
-  private
+  def ensure_organization_sequential_id
+    return if organization_sequential_id.present? && organization_sequential_id.positive?
+    return unless finalized?
 
-  def should_assign_sequential_id?
-    status_changed_to_finalized?
+    self.organization_sequential_id = generate_organization_sequential_id
   end
 
-  def void_invoice!
-    update!(ready_for_payment_processing: false)
+  def ensure_invoice_sequential_id
+    return if sequential_id.present?
+
+    self.sequential_id = generate_sequential_id
   end
 
   def ensure_number
-    self.number = "#{organization.document_number_prefix}-DRAFT" if number.blank? && !status_changed_to_finalized?
+    self.number = "#{organization.document_number_prefix}-DRAFT" if number.blank?  && !finalized?
 
-    return unless status_changed_to_finalized?
+    return unless finalized?
 
     if organization.per_customer?
       # NOTE: Example of expected customer slug format is ORG_PREFIX-005
@@ -365,11 +365,15 @@ class Invoice < ApplicationRecord
     end
   end
 
-  def ensure_organization_sequential_id
-    return if organization_sequential_id.present? && organization_sequential_id.positive?
-    return unless status_changed_to_finalized?
+  private
 
-    self.organization_sequential_id = generate_organization_sequential_id
+  # For invoices we want to skip callback and set sequential_id from the dedicated service
+  def should_assign_sequential_id?
+    false
+  end
+
+  def void_invoice!
+    update!(ready_for_payment_processing: false)
   end
 
   def generate_organization_sequential_id
@@ -387,11 +391,12 @@ class Invoice < ApplicationRecord
     ) do
       # If previous invoice had different numbering, base sequential id is the total number of invoices
       organization_sequential_id = if switched_from_customer_numbering?
-        organization.invoices.with_generated_number.count
+        organization.invoices.with_generated_number.where.not(id: self.id).count
       else
         organization
           .invoices
           .where.not(organization_sequential_id: 0)
+          .where.not(id: self.id)
           .order(organization_sequential_id: :desc)
           .limit(1)
           .pick(:organization_sequential_id) || 0
@@ -412,18 +417,11 @@ class Invoice < ApplicationRecord
   end
 
   def switched_from_customer_numbering?
-    last_invoice = organization.invoices.order(created_at: :desc).with_generated_number.first
+    last_invoice = organization.invoices.where.not(id: self.id).order(created_at: :desc).with_generated_number.first
 
     return false unless last_invoice
 
     last_invoice&.organization_sequential_id&.zero?
-  end
-
-  def status_changed_to_finalized?
-    status_changed?(from: 'draft', to: 'finalized') ||
-      status_changed?(from: 'generating', to: 'finalized') ||
-      status_changed?(from: 'open', to: 'finalized') ||
-      status_changed?(from: 'failed', to: 'finalized')
   end
 end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -347,7 +347,7 @@ class Invoice < ApplicationRecord
   end
 
   def ensure_number
-    self.number = "#{organization.document_number_prefix}-DRAFT" if number.blank?  && !finalized?
+    self.number = "#{organization.document_number_prefix}-DRAFT" if number.blank? && !finalized?
 
     return unless finalized?
 
@@ -391,12 +391,12 @@ class Invoice < ApplicationRecord
     ) do
       # If previous invoice had different numbering, base sequential id is the total number of invoices
       organization_sequential_id = if switched_from_customer_numbering?
-        organization.invoices.with_generated_number.where.not(id: self.id).count
+        organization.invoices.with_generated_number.where.not(id:).count
       else
         organization
           .invoices
           .where.not(organization_sequential_id: 0)
-          .where.not(id: self.id)
+          .where.not(id:)
           .order(organization_sequential_id: :desc)
           .limit(1)
           .pick(:organization_sequential_id) || 0
@@ -417,7 +417,7 @@ class Invoice < ApplicationRecord
   end
 
   def switched_from_customer_numbering?
-    last_invoice = organization.invoices.where.not(id: self.id).order(created_at: :desc).with_generated_number.first
+    last_invoice = organization.invoices.where.not(id:).order(created_at: :desc).with_generated_number.first
 
     return false unless last_invoice
 

--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -32,6 +32,7 @@ module Invoices
         result.invoice = invoice
       end
 
+      Invoices::NumberGenerationService.call(invoice: result.invoice)
       Utils::SegmentTrack.invoice_created(result.invoice)
       SendWebhookJob.perform_later('invoice.add_on_added', result.invoice)
       GeneratePdfAndNotifyJob.perform_later(invoice: result.invoice, email: should_deliver_email?)

--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -20,6 +20,8 @@ module Invoices
 
       invoice = create_group_invoice
 
+      Invoices::NumberGenerationService.call(invoice:) if invoice
+
       if invoice && !invoice.closed?
         SendWebhookJob.perform_later('invoice.created', invoice)
         Invoices::GeneratePdfAndNotifyJob.perform_later(invoice:, email: false)

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -40,6 +40,8 @@ module Invoices
         invoice.save!
       end
 
+      Invoices::NumberGenerationService.call(invoice:)
+
       unless invoice.closed?
         Utils::SegmentTrack.invoice_created(invoice)
         SendWebhookJob.perform_later('invoice.one_off_created', invoice)

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -47,6 +47,8 @@ module Invoices
         invoice.save!
       end
 
+      Invoices::NumberGenerationService.call(invoice:)
+
       unless invoice.closed?
         Utils::SegmentTrack.invoice_created(invoice)
         deliver_webhooks

--- a/app/services/invoices/finalize_open_credit_service.rb
+++ b/app/services/invoices/finalize_open_credit_service.rb
@@ -20,6 +20,8 @@ module Invoices
         invoice.save!
       end
 
+      Invoices::NumberGenerationService.call(invoice:)
+
       SendWebhookJob.perform_later('invoice.paid_credit_added', result.invoice)
       GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
       Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?

--- a/app/services/invoices/number_generation_service.rb
+++ b/app/services/invoices/number_generation_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Invoices
+  class NumberGenerationService < BaseService
+    def initialize(invoice:)
+      @invoice = invoice
+
+      super
+    end
+
+    def call
+      unless invoice.finalized?
+        # For invoice that is not finalized we just want to assign draft invoice number
+        invoice.ensure_number
+        invoice.save!
+
+        return result
+      end
+
+      invoice.ensure_invoice_sequential_id
+      if invoice.organization.per_organization?
+        invoice.ensure_organization_sequential_id
+      end
+
+      invoice.ensure_number
+      invoice.save!
+
+      result.invoice = invoice
+
+      result
+    end
+
+    private
+
+    attr_reader :invoice
+  end
+end

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -30,6 +30,8 @@ module Invoices
         end
       end
 
+      Invoices::NumberGenerationService.call(invoice:)
+
       if invoice.finalized?
         Utils::SegmentTrack.invoice_created(result.invoice)
         SendWebhookJob.perform_later('invoice.paid_credit_added', result.invoice)

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -45,6 +45,7 @@ module Invoices
 
       # TODO: deduct previous progressive billing invoices
 
+      Invoices::NumberGenerationService.call(invoice:)
       Utils::SegmentTrack.invoice_created(invoice)
       SendWebhookJob.perform_later('invoice.created', invoice)
       Invoices::GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)

--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -29,6 +29,8 @@ module Invoices
       end
 
       result.invoice = invoice.reload
+      Invoices::NumberGenerationService.call(invoice:)
+
       unless invoice.closed?
         SendWebhookJob.perform_later('invoice.created', invoice)
         GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -40,6 +40,7 @@ module Invoices
         result.invoice = invoice
       end
 
+      Invoices::NumberGenerationService.call(invoice:)
       SendWebhookJob.perform_later('invoice.created', invoice)
       GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
       Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -46,6 +46,9 @@ module Invoices
         flag_lifetime_usage_for_refresh
         fee_result
       end
+
+      Invoices::NumberGenerationService.call(invoice:)
+
       result.non_invoiceable_fees = fee_result.non_invoiceable_fees
 
       # non-invoiceable fees are created the first time, regardless of grace period.

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Invoice, type: :model do
     it 'assigns a sequential id and organization sequential id to a new invoice' do
       invoice.save!
       invoice.finalized!
+      invoice.ensure_invoice_sequential_id
 
       aggregate_failures do
         expect(invoice).to be_valid
@@ -71,6 +72,7 @@ RSpec.describe Invoice, type: :model do
       it 'does not replace the sequential_id and organization_sequential_id' do
         invoice.save!
         invoice.finalized!
+        invoice.ensure_invoice_sequential_id
 
         aggregate_failures do
           expect(invoice).to be_valid
@@ -89,6 +91,7 @@ RSpec.describe Invoice, type: :model do
       it 'takes the next available id' do
         invoice.save!
         invoice.finalized!
+        invoice.ensure_invoice_sequential_id
 
         aggregate_failures do
           expect(invoice).to be_valid
@@ -106,6 +109,7 @@ RSpec.describe Invoice, type: :model do
       it 'scopes the sequence to the organization' do
         invoice.save!
         invoice.finalized!
+        invoice.ensure_invoice_sequential_id
 
         aggregate_failures do
           expect(invoice).to be_valid
@@ -127,6 +131,8 @@ RSpec.describe Invoice, type: :model do
       it 'scopes the organization_sequential_id to the organization and month' do
         invoice.save!
         invoice.finalized!
+        invoice.ensure_invoice_sequential_id
+        invoice.ensure_organization_sequential_id
 
         aggregate_failures do
           expect(invoice).to be_valid
@@ -313,7 +319,7 @@ RSpec.describe Invoice, type: :model do
     end
   end
 
-  describe 'number' do
+  describe 'ensure_number' do
     let(:organization) { create(:organization, name: 'LAGO') }
     let(:customer) { create(:customer, organization:) }
     let(:subscription) { create(:subscription, organization:, customer:) }
@@ -322,6 +328,8 @@ RSpec.describe Invoice, type: :model do
     it 'generates the invoice number' do
       invoice.save!
       invoice.finalized!
+      invoice.ensure_invoice_sequential_id
+      invoice.ensure_number
       organization_id_substring = organization.id.last(4).upcase
 
       expect(invoice.number).to eq("LAG-#{organization_id_substring}-001-001")
@@ -333,6 +341,9 @@ RSpec.describe Invoice, type: :model do
       it 'scopes the organization_sequential_id to the organization and month' do
         invoice.save!
         invoice.finalized!
+        invoice.ensure_invoice_sequential_id
+        invoice.ensure_organization_sequential_id
+        invoice.ensure_number
         organization_id_substring = organization.id.last(4).upcase
 
         expect(invoice.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime("%Y%m")}-001")
@@ -349,6 +360,9 @@ RSpec.describe Invoice, type: :model do
         it 'scopes the organization_sequential_id to the organization and month' do
           invoice.save!
           invoice.finalized!
+          invoice.ensure_invoice_sequential_id
+          invoice.ensure_organization_sequential_id
+          invoice.ensure_number
 
           organization_id_substring = organization.id.last(4).upcase
 
@@ -367,6 +381,9 @@ RSpec.describe Invoice, type: :model do
         it 'scopes the organization_sequential_id to the organization and month' do
           invoice.save!
           invoice.finalized!
+          invoice.ensure_invoice_sequential_id
+          invoice.ensure_organization_sequential_id
+          invoice.ensure_number
 
           organization_id_substring = organization.id.last(4).upcase
 
@@ -409,6 +426,9 @@ RSpec.describe Invoice, type: :model do
         it 'scopes the organization_sequential_id to the organization and month' do
           invoice.save!
           invoice.finalized!
+          invoice.ensure_invoice_sequential_id
+          invoice.ensure_organization_sequential_id
+          invoice.ensure_number
 
           organization_id_substring = organization.id.last(4).upcase
 
@@ -420,7 +440,8 @@ RSpec.describe Invoice, type: :model do
           expect(invoice1.reload.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime("%Y%m")}-014")
           expect(invoice2.reload.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime("%Y%m")}-015")
 
-          invoice1.finalized!
+          invoice.finalized!
+          Invoices::RefreshDraftAndFinalizeService.call(invoice: invoice1)
 
           expect(invoice1.reload.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime("%Y%m")}-014")
         end
@@ -461,6 +482,9 @@ RSpec.describe Invoice, type: :model do
         it 'scopes the organization_sequential_id to the organization and month' do
           invoice.save!
           invoice.finalized!
+          invoice.ensure_invoice_sequential_id
+          invoice.ensure_organization_sequential_id
+          invoice.ensure_number
 
           organization_id_substring = organization.id.last(4).upcase
 
@@ -472,7 +496,8 @@ RSpec.describe Invoice, type: :model do
           expect(invoice1.reload.number).to eq("LAG-#{organization_id_substring}-DRAFT")
           expect(invoice2.reload.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime("%Y%m")}-014")
 
-          invoice1.finalized!
+          invoice.finalized!
+          Invoices::RefreshDraftAndFinalizeService.call(invoice: invoice1)
 
           expect(invoice1.reload.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime("%Y%m")}-016")
         end

--- a/spec/services/invoices/number_generation_service_spec.rb
+++ b/spec/services/invoices/number_generation_service_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::NumberGenerationService, type: :service do
+  subject(:generation_service) { described_class.new(invoice:) }
+
+  describe '#call' do
+    let(:organization) { create(:organization, document_numbering:) }
+    let(:customer) { create(:customer, organization:, sequential_id: 1) }
+    let(:document_numbering) { 'per_customer' }
+    let(:status) { 'finalized' }
+    let(:invoice) do
+      create(:invoice, status:, organization:, customer:, sequential_id: nil, organization_sequential_id: 0)
+    end
+
+    context 'when invoice is draft' do
+      let(:status) { 'draft' }
+
+      it 'returns invoice with draft invoice number' do
+        result = generation_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(invoice.reload.number).to eq("#{organization.document_number_prefix}-DRAFT")
+          expect(invoice.reload.sequential_id).to eq(nil)
+          expect(invoice.reload.organization_sequential_id).to eq(0)
+        end
+      end
+    end
+
+    context 'when invoice is finalized and numbering is per_customer' do
+      it 'generates sequential ID and invoice number' do
+        result = generation_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(invoice.reload.number).to eq("#{organization.document_number_prefix}-001-001")
+          expect(invoice.reload.sequential_id).to eq(1)
+          expect(invoice.reload.organization_sequential_id).to eq(0)
+        end
+      end
+
+      context 'when sequential_id and organization_sequential_id are present' do
+        before do
+          invoice.sequential_id = 3
+          invoice.organization_sequential_id = 5
+        end
+
+        it 'does not replace the sequential_id and organization_sequential_id' do
+          result = generation_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(invoice.reload.number).to eq("#{organization.document_number_prefix}-001-003")
+            expect(invoice.reload.sequential_id).to eq(3)
+            expect(invoice.reload.organization_sequential_id).to eq(5)
+          end
+        end
+      end
+
+      context 'when invoices already exist' do
+        before do
+          create(:invoice, customer:, organization:, sequential_id: 4, organization_sequential_id: 14)
+          create(:invoice, customer:, organization:, sequential_id: 5, organization_sequential_id: 15)
+        end
+
+        it 'takes the next available id' do
+          result = generation_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(invoice.reload.number).to eq("#{organization.document_number_prefix}-001-006")
+            expect(invoice.reload.sequential_id).to eq(6)
+            expect(invoice.reload.organization_sequential_id).to eq(0)
+          end
+        end
+      end
+
+      context 'with invoices on other organization' do
+        before do
+          create(:invoice, sequential_id: 1, organization_sequential_id: 1)
+        end
+
+        it 'scopes the sequence to the organization' do
+          result = generation_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(invoice.reload.number).to eq("#{organization.document_number_prefix}-001-001")
+            expect(invoice.reload.sequential_id).to eq(1)
+            expect(invoice.reload.organization_sequential_id).to eq(0)
+          end
+        end
+      end
+    end
+
+    context 'when invoice is finalized and numbering is per_organization' do
+      let(:document_numbering) { 'per_organization' }
+
+      it 'generates both sequential IDs and invoice number' do
+        result = generation_service.call
+
+        formatted_year_and_month = Time.now.in_time_zone(organization.timezone || 'UTC').strftime('%Y%m')
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(invoice.reload.number).to eq("#{organization.document_number_prefix}-#{formatted_year_and_month}-001")
+          expect(invoice.reload.sequential_id).to eq(1)
+          expect(invoice.reload.organization_sequential_id).to eq(1)
+        end
+      end
+
+      context 'with organization numbering and invoices in another month' do
+        let(:organization) { create(:organization, document_numbering: 'per_organization') }
+        let(:created_at) { Time.now.utc - 1.month }
+
+        before do
+          create(:invoice, customer:, organization:, sequential_id: 4, organization_sequential_id: 14, created_at:)
+          create(:invoice, customer:, organization:, sequential_id: 5, organization_sequential_id: 15, created_at:)
+        end
+
+        it 'scopes the organization_sequential_id to the organization' do
+          result = generation_service.call
+
+          formatted_year_and_month = Time.now.in_time_zone(organization.timezone || 'UTC').strftime('%Y%m')
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(invoice.reload.number).to eq("#{organization.document_number_prefix}-#{formatted_year_and_month}-016")
+            expect(invoice.reload.sequential_id).to eq(6)
+            expect(invoice.reload.organization_sequential_id).to eq(16)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Invoices::RetryService, type: :service do
         organization:,
         subscriptions: [subscription],
         currency: 'EUR',
+        number: "#{organization.document_number_prefix}-DRAFT",
         issuing_date: Time.zone.at(timestamp).to_date
       )
     end


### PR DESCRIPTION
## Context

Currently invoice numbering requires locking scope on invoices table.

## Description

This PR moves invoice numbering logic to the very end of the invoice generation process (outside DB transaction). With this approach, lock duration is decreased and it it less likely to face `SequenceError`
