### PR TITLE
feat(dunning): Add subscriptions resolver to customer portal

### DIFF
--- a/app/graphql/resolvers/customer_portal/subscriptions_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/subscriptions_resolver.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module CustomerPortal
+    class SubscriptionsResolver < Resolvers::BaseResolver
+      include AuthenticableCustomerPortalUser
+
+      description "Query customer portal subscriptions"
+
+      argument :limit, Integer, required: false
+      argument :page, Integer, required: false
+      argument :plan_code, String, required: false
+      argument :status, [Types::Subscriptions::StatusTypeEnum], required: false
+
+      type Types::Subscriptions::Object.collection_type, null: false
+
+      def resolve(page: nil, limit: nil, plan_code: nil, status: nil)
+        result = SubscriptionsQuery.call(
+          organization: context[:customer_portal_user],
+          pagination: {page:, limit:},
+          filters: {
+            external_customer_id: context[:customer_portal_user].external_id,
+            plan_code:,
+            status:
+          }
+        )
+
+        result.subscriptions
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -25,6 +25,7 @@ module Types
     field :customer_portal_invoices, resolver: Resolvers::CustomerPortal::InvoicesResolver
     field :customer_portal_organization, resolver: Resolvers::CustomerPortal::OrganizationResolver
     field :customer_portal_overdue_balances, resolver: Resolvers::CustomerPortal::Analytics::OverdueBalancesResolver
+    field :customer_portal_subscriptions, resolver: Resolvers::CustomerPortal::SubscriptionsResolver
     field :customer_portal_user, resolver: Resolvers::CustomerPortal::CustomerResolver
     field :customer_usage, resolver: Resolvers::Customers::UsageResolver
     field :customers, resolver: Resolvers::CustomersResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -5969,6 +5969,11 @@ type Query {
   customerPortalOverdueBalances(expireCache: Boolean, months: Int): OverdueBalanceCollection!
 
   """
+  Query customer portal subscriptions
+  """
+  customerPortalSubscriptions(limit: Int, page: Int, planCode: String, status: [StatusTypeEnum!]): SubscriptionCollection!
+
+  """
   Query a customer portal user
   """
   customerPortalUser: Customer

--- a/schema.json
+++ b/schema.json
@@ -29790,6 +29790,79 @@
               ]
             },
             {
+              "name": "customerPortalSubscriptions",
+              "description": "Query customer portal subscriptions",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SubscriptionCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "planCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "status",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "StatusTypeEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "customerPortalUser",
               "description": "Query a customer portal user",
               "type": {

--- a/spec/graphql/resolvers/customer_portal/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/subscriptions_resolver_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::CustomerPortal::SubscriptionsResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query {
+        customerPortalSubscriptions(limit: 5, planCode: "#{plan.code}", status: [active]) {
+            collection { id externalId plan { code } }
+            metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:active_subscription) { create(:subscription, customer:, plan:) }
+  let(:terminated_subscription) { create(:subscription, :terminated, customer:, plan:) }
+
+  before do
+    active_subscription
+    terminated_subscription
+  end
+
+  it_behaves_like "requires a customer portal user"
+
+  it "returns a list of subscriptions" do
+    result = execute_graphql(customer_portal_user: customer, query:)
+
+    subscriptions_response = result["data"]["customerPortalSubscriptions"]
+
+    aggregate_failures do
+      expect(subscriptions_response["collection"].pluck("id")).to contain_exactly(active_subscription.id)
+      expect(subscriptions_response["metadata"]["currentPage"]).to eq(1)
+      expect(subscriptions_response["metadata"]["totalCount"]).to eq(1)
+    end
+  end
+
+  context "with filter on status" do
+    let(:query) do
+      <<~GQL
+        query($status: [StatusTypeEnum!]) {
+          customerPortalSubscriptions(status: $status) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    it "only returns draft invoice" do
+      result = execute_graphql(
+        customer_portal_user: customer,
+        query:,
+        variables: {status: ["terminated"]}
+      )
+
+      subscriptions_response = result["data"]["customerPortalSubscriptions"]
+
+      aggregate_failures do
+        expect(subscriptions_response["collection"].first["id"]).to eq(terminated_subscription.id)
+        expect(subscriptions_response["metadata"]["totalCount"]).to eq(1)
+      end
+    end
+  end
+
+  context "without customer portal user" do
+    it "returns an error" do
+      result = execute_graphql(query:)
+      expect_unauthorized_error(result)
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal](https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal)

## Context

We got feedback that this portal is too limited in terms of features and information. Why?

**1st reason:** the number of information displayed is limited

**2nd reason:** the end user cannot take actions out of it (change info, add payment method)

**3rd reason:** the UI and display is not customizable

## Description

The goal of this PR is to return subscriptions from the customer portal.
