### PR TITLE
feat(tax-integrations): Cover tax deduction case for tax integrations

### DIFF
--- a/app/graphql/types/invoices/applied_taxes/object.rb
+++ b/app/graphql/types/invoices/applied_taxes/object.rb
@@ -10,8 +10,8 @@ module Types
         field :applied_on_whole_invoice, GraphQL::Types::Boolean, null: false, method: :applied_on_whole_invoice?
         field :enumed_tax_code, Types::Invoices::AppliedTaxes::WholeInvoiceApplicableTaxCodeEnum, null: true
         field :fees_amount_cents, GraphQL::Types::BigInt, null: false
-        field :taxable_base_amount_cents, GraphQL::Types::BigInt, null: false
         field :invoice, Types::Invoices::Object, null: false
+        field :taxable_base_amount_cents, GraphQL::Types::BigInt, null: false
 
         def enumed_tax_code
           object.tax_code if object.applied_on_whole_invoice?

--- a/app/graphql/types/invoices/applied_taxes/object.rb
+++ b/app/graphql/types/invoices/applied_taxes/object.rb
@@ -10,6 +10,7 @@ module Types
         field :applied_on_whole_invoice, GraphQL::Types::Boolean, null: false, method: :applied_on_whole_invoice?
         field :enumed_tax_code, Types::Invoices::AppliedTaxes::WholeInvoiceApplicableTaxCodeEnum, null: true
         field :fees_amount_cents, GraphQL::Types::BigInt, null: false
+        field :taxable_base_amount_cents, GraphQL::Types::BigInt, null: false
         field :invoice, Types::Invoices::Object, null: false
 
         def enumed_tax_code

--- a/app/graphql/types/invoices/applied_taxes/object.rb
+++ b/app/graphql/types/invoices/applied_taxes/object.rb
@@ -11,14 +11,10 @@ module Types
         field :enumed_tax_code, Types::Invoices::AppliedTaxes::WholeInvoiceApplicableTaxCodeEnum, null: true
         field :fees_amount_cents, GraphQL::Types::BigInt, null: false
         field :invoice, Types::Invoices::Object, null: false
-        field :taxable_base_amount_cents, GraphQL::Types::BigInt, null: false
+        field :taxable_amount_cents, GraphQL::Types::BigInt, null: false
 
         def enumed_tax_code
           object.tax_code if object.applied_on_whole_invoice?
-        end
-
-        def taxable_base_amount_cents
-          object.taxable_amount_cents
         end
       end
     end

--- a/app/graphql/types/invoices/applied_taxes/object.rb
+++ b/app/graphql/types/invoices/applied_taxes/object.rb
@@ -16,6 +16,10 @@ module Types
         def enumed_tax_code
           object.tax_code if object.applied_on_whole_invoice?
         end
+
+        def taxable_base_amount_cents
+          object.taxable_amount_cents
+        end
       end
     end
   end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -194,6 +194,7 @@ end
 #  refunded_at                         :datetime
 #  succeeded_at                        :datetime
 #  taxes_amount_cents                  :bigint           not null
+#  taxes_base_rate                     :float            default(1.0), not null
 #  taxes_precise_amount_cents          :decimal(40, 15)  default(0.0), not null
 #  taxes_rate                          :float            default(0.0), not null
 #  total_aggregated_units              :decimal(, )

--- a/app/models/invoice/applied_tax.rb
+++ b/app/models/invoice/applied_tax.rb
@@ -11,6 +11,7 @@ class Invoice
 
     monetize :amount_cents,
       :fees_amount_cents,
+      :taxable_base_amount_cents,
       with_model_currency: :amount_currency
 
     validates :amount_cents, numericality: {greater_than_or_equal_to: 0}
@@ -21,6 +22,14 @@ class Invoice
     def applied_on_whole_invoice?
       TAX_CODES_APPLICABLE_ON_WHOLE_INVOICE.include?(tax_code)
     end
+
+    def taxable_base_amount_cents
+      base_amount = self[:taxable_base_amount_cents]
+
+      return fees_amount_cents if base_amount.blank? || base_amount.zero?
+
+      base_amount
+    end
   end
 end
 
@@ -28,18 +37,19 @@ end
 #
 # Table name: invoices_taxes
 #
-#  id                :uuid             not null, primary key
-#  amount_cents      :bigint           default(0), not null
-#  amount_currency   :string           not null
-#  fees_amount_cents :bigint           default(0), not null
-#  tax_code          :string           not null
-#  tax_description   :string
-#  tax_name          :string           not null
-#  tax_rate          :float            default(0.0), not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  invoice_id        :uuid             not null
-#  tax_id            :uuid
+#  id                        :uuid             not null, primary key
+#  amount_cents              :bigint           default(0), not null
+#  amount_currency           :string           not null
+#  fees_amount_cents         :bigint           default(0), not null
+#  tax_code                  :string           not null
+#  tax_description           :string
+#  tax_name                  :string           not null
+#  tax_rate                  :float            default(0.0), not null
+#  taxable_base_amount_cents :bigint           default(0), not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  invoice_id                :uuid             not null
+#  tax_id                    :uuid
 #
 # Indexes
 #

--- a/app/models/invoice/applied_tax.rb
+++ b/app/models/invoice/applied_tax.rb
@@ -11,7 +11,7 @@ class Invoice
 
     monetize :amount_cents,
       :fees_amount_cents,
-      :taxable_base_amount_cents,
+      :taxable_amount_cents,
       with_model_currency: :amount_currency
 
     validates :amount_cents, numericality: {greater_than_or_equal_to: 0}
@@ -23,8 +23,8 @@ class Invoice
       TAX_CODES_APPLICABLE_ON_WHOLE_INVOICE.include?(tax_code)
     end
 
-    def taxable_base_amount_cents
-      base_amount = self[:taxable_base_amount_cents]
+    def taxable_amount_cents
+      base_amount = taxable_base_amount_cents
 
       return fees_amount_cents if base_amount.blank? || base_amount.zero?
 

--- a/app/services/credit_notes/apply_taxes_service.rb
+++ b/app/services/credit_notes/apply_taxes_service.rb
@@ -106,7 +106,7 @@ module CreditNotes
     def taxes_base_rate(applied_tax)
       return 1 if applied_tax.fees_amount_cents.blank? || applied_tax.fees_amount_cents.zero?
 
-      applied_tax.taxable_base_amount_cents.fdiv(applied_tax.fees_amount_cents)
+      applied_tax.taxable_amount_cents.fdiv(applied_tax.fees_amount_cents)
     end
   end
 end

--- a/app/services/credit_notes/apply_taxes_service.rb
+++ b/app/services/credit_notes/apply_taxes_service.rb
@@ -30,9 +30,9 @@ module CreditNotes
         result.applied_taxes << applied_tax
 
         base_amount_cents = compute_base_amount_cents(tax_code)
-        applied_tax.base_amount_cents = base_amount_cents.round
+        applied_tax.base_amount_cents = (base_amount_cents.round * taxes_base_rate(invoice_applied_tax)).round
 
-        tax_amount_cents = (base_amount_cents * invoice_applied_tax.tax_rate).fdiv(100)
+        tax_amount_cents = (applied_tax.base_amount_cents * invoice_applied_tax.tax_rate).fdiv(100)
         applied_tax.amount_cents = tax_amount_cents.round
 
         applied_taxes_amount_cents += tax_amount_cents
@@ -101,6 +101,12 @@ module CreditNotes
 
     def find_invoice_applied_tax(tax_code)
       invoice.applied_taxes.find_by(tax_code: tax_code)
+    end
+
+    def taxes_base_rate(applied_tax)
+      return 1 if applied_tax.fees_amount_cents.blank? || applied_tax.fees_amount_cents.zero?
+
+      applied_tax.taxable_base_amount_cents.fdiv(applied_tax.fees_amount_cents)
     end
   end
 end

--- a/app/services/fees/apply_provider_taxes_service.rb
+++ b/app/services/fees/apply_provider_taxes_service.rb
@@ -65,7 +65,7 @@ module Fees
       tax_amount_cents = (fee.sub_total_excluding_taxes_amount_cents * tax_rate).fdiv(100)
 
       if tax.tax_amount < tax_amount_cents
-        tax.tax_amount.fdiv(tax_amount_cents.round)
+        tax.tax_amount.fdiv(tax_amount_cents)
       else
         1
       end

--- a/app/views/templates/invoices/v4/_progressive_billing_details.slim
+++ b/app/views/templates/invoices/v4/_progressive_billing_details.slim
@@ -66,7 +66,7 @@
           - if applied_tax.applied_on_whole_invoice?
             td.body-2 = I18n.t('invoice.tax_name_only.' + applied_tax.tax_code)
           - else
-            td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_base_amount))
+            td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_amount))
             td.body-2 = MoneyHelper.format(applied_tax.amount)
     - else
       tr

--- a/app/views/templates/invoices/v4/_progressive_billing_details.slim
+++ b/app/views/templates/invoices/v4/_progressive_billing_details.slim
@@ -66,7 +66,7 @@
           - if applied_tax.applied_on_whole_invoice?
             td.body-2 = I18n.t('invoice.tax_name_only.' + applied_tax.tax_code)
           - else
-            td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.fees_amount))
+            td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_base_amount))
             td.body-2 = MoneyHelper.format(applied_tax.amount)
     - else
       tr

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -160,7 +160,7 @@
                   td.body-2 = I18n.t('invoice.tax_name_only.' + applied_tax.tax_code)
                   td.body-2
                 - else
-                  td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.fees_amount))
+                  td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_base_amount))
                   td.body-2 = MoneyHelper.format(applied_tax.amount)
           - else
             tr

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -160,7 +160,7 @@
                   td.body-2 = I18n.t('invoice.tax_name_only.' + applied_tax.tax_code)
                   td.body-2
                 - else
-                  td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_base_amount))
+                  td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_amount))
                   td.body-2 = MoneyHelper.format(applied_tax.amount)
           - else
             tr

--- a/app/views/templates/invoices/v4/_subscriptions_summary.slim
+++ b/app/views/templates/invoices/v4/_subscriptions_summary.slim
@@ -39,7 +39,7 @@ table.total-table width="100%"
           td.body-2
         - else
           td.body-2
-          td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_base_amount))
+          td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_amount))
           td.body-2 = MoneyHelper.format(applied_tax.amount)
   - else
     tr

--- a/app/views/templates/invoices/v4/_subscriptions_summary.slim
+++ b/app/views/templates/invoices/v4/_subscriptions_summary.slim
@@ -39,7 +39,7 @@ table.total-table width="100%"
           td.body-2
         - else
           td.body-2
-          td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.fees_amount))
+          td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_base_amount))
           td.body-2 = MoneyHelper.format(applied_tax.amount)
   - else
     tr

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -468,7 +468,7 @@ html
                   td.body-2
                 - else
                   td.body-2
-                  td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_base_amount))
+                  td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_amount))
                   td.body-2 = MoneyHelper.format(applied_tax.amount)
           - else
             tr

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -468,7 +468,7 @@ html
                   td.body-2
                 - else
                   td.body-2
-                  td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.fees_amount))
+                  td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_base_amount))
                   td.body-2 = MoneyHelper.format(applied_tax.amount)
           - else
             tr

--- a/app/views/templates/invoices/v4/one_off.slim
+++ b/app/views/templates/invoices/v4/one_off.slim
@@ -447,7 +447,7 @@ html
                     td.body-2
                   - else
                     td.body-2
-                    td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.fees_amount))
+                    td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_base_amount))
                     td.body-2 = MoneyHelper.format(applied_tax.amount)
             - else
               tr

--- a/app/views/templates/invoices/v4/one_off.slim
+++ b/app/views/templates/invoices/v4/one_off.slim
@@ -447,7 +447,7 @@ html
                     td.body-2
                   - else
                     td.body-2
-                    td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_base_amount))
+                    td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.taxable_amount))
                     td.body-2 = MoneyHelper.format(applied_tax.amount)
             - else
               tr

--- a/db/migrate/20240924114730_add_taxes_deduction_rate_fields_to_fees_and_applied_taxes.rb
+++ b/db/migrate/20240924114730_add_taxes_deduction_rate_fields_to_fees_and_applied_taxes.rb
@@ -2,14 +2,7 @@
 
 class AddTaxesDeductionRateFieldsToFeesAndAppliedTaxes < ActiveRecord::Migration[7.1]
   def change
-    safety_assured do
-      change_table :fees do |t|
-        t.float :taxes_base_rate, default: 1.0, null: false
-      end
-
-      change_table :invoices_taxes do |t|
-        t.bigint :taxable_base_amount_cents, default: 0, null: false
-      end
-    end
+    add_column :fees, :taxes_base_rate, :float, default: 1.0, null: false
+    add_column :invoices_taxes, :taxable_base_amount_cents, :bigint, default: 0, null: false
   end
 end

--- a/db/migrate/20240924114730_add_taxes_deduction_rate_fields_to_fees_and_applied_taxes.rb
+++ b/db/migrate/20240924114730_add_taxes_deduction_rate_fields_to_fees_and_applied_taxes.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddTaxesDeductionRateFieldsToFeesAndAppliedTaxes < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      change_table :fees do |t|
+        t.float :taxes_base_rate, default: 1.0, null: false
+      end
+
+      change_table :invoices_taxes do |t|
+        t.bigint :taxable_base_amount_cents, default: 0, null: false
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -780,8 +780,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_24_114730) do
     t.bigint "progressive_billing_credit_amount_cents", default: 0, null: false
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
+    t.index ["number"], name: "index_invoices_on_number"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
     t.index ["payment_overdue"], name: "index_invoices_on_payment_overdue"
+    t.index ["sequential_id"], name: "index_invoices_on_sequential_id"
     t.index ["status"], name: "index_invoices_on_status"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"
   end
@@ -1021,7 +1023,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_24_114730) do
     t.integer "method", default: 0, null: false
     t.decimal "target_ongoing_balance", precision: 30, scale: 5
     t.datetime "started_at"
-    t.boolean "invoice_require_successful_payment", default: false, null: false
+    t.boolean "invoice_requires_successful_payment", default: false, null: false
     t.jsonb "transaction_metadata", default: []
     t.index ["started_at"], name: "index_recurring_transaction_rules_on_started_at"
     t.index ["wallet_id"], name: "index_recurring_transaction_rules_on_wallet_id"
@@ -1127,7 +1129,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_24_114730) do
     t.uuid "invoice_id"
     t.integer "source", default: 0, null: false
     t.integer "transaction_status", default: 0, null: false
-    t.boolean "invoice_require_successful_payment", default: false, null: false
+    t.boolean "invoice_requires_successful_payment", default: false, null: false
     t.jsonb "metadata", default: []
     t.index ["invoice_id"], name: "index_wallet_transactions_on_invoice_id"
     t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"
@@ -1155,7 +1157,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_24_114730) do
     t.decimal "credits_ongoing_balance", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "credits_ongoing_usage_balance", precision: 30, scale: 5, default: "0.0", null: false
     t.boolean "depleted_ongoing_balance", default: false, null: false
-    t.boolean "invoice_require_successful_payment", default: false, null: false
+    t.boolean "invoice_requires_successful_payment", default: false, null: false
     t.index ["customer_id"], name: "index_wallets_on_customer_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_20_091133) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_24_114730) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -561,6 +561,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_091133) do
     t.datetime "deleted_at"
     t.decimal "precise_amount_cents", precision: 40, scale: 15, default: "0.0", null: false
     t.decimal "taxes_precise_amount_cents", precision: 40, scale: 15, default: "0.0", null: false
+    t.float "taxes_base_rate", default: 1.0, null: false
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_filter_id"], name: "index_fees_on_charge_filter_id"
@@ -779,10 +780,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_091133) do
     t.bigint "progressive_billing_credit_amount_cents", default: 0, null: false
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
-    t.index ["number"], name: "index_invoices_on_number"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
     t.index ["payment_overdue"], name: "index_invoices_on_payment_overdue"
-    t.index ["sequential_id"], name: "index_invoices_on_sequential_id"
     t.index ["status"], name: "index_invoices_on_status"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"
   end
@@ -809,6 +808,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_091133) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "fees_amount_cents", default: 0, null: false
+    t.bigint "taxable_base_amount_cents", default: 0, null: false
     t.index ["invoice_id", "tax_id"], name: "index_invoices_taxes_on_invoice_id_and_tax_id", unique: true, where: "((tax_id IS NOT NULL) AND (created_at >= '2023-09-12 00:00:00'::timestamp without time zone))"
     t.index ["invoice_id"], name: "index_invoices_taxes_on_invoice_id"
     t.index ["tax_id"], name: "index_invoices_taxes_on_tax_id"
@@ -1021,7 +1021,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_091133) do
     t.integer "method", default: 0, null: false
     t.decimal "target_ongoing_balance", precision: 30, scale: 5
     t.datetime "started_at"
-    t.boolean "invoice_requires_successful_payment", default: false, null: false
+    t.boolean "invoice_require_successful_payment", default: false, null: false
     t.jsonb "transaction_metadata", default: []
     t.index ["started_at"], name: "index_recurring_transaction_rules_on_started_at"
     t.index ["wallet_id"], name: "index_recurring_transaction_rules_on_wallet_id"
@@ -1127,7 +1127,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_091133) do
     t.uuid "invoice_id"
     t.integer "source", default: 0, null: false
     t.integer "transaction_status", default: 0, null: false
-    t.boolean "invoice_requires_successful_payment", default: false, null: false
+    t.boolean "invoice_require_successful_payment", default: false, null: false
     t.jsonb "metadata", default: []
     t.index ["invoice_id"], name: "index_wallet_transactions_on_invoice_id"
     t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"
@@ -1155,7 +1155,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_091133) do
     t.decimal "credits_ongoing_balance", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "credits_ongoing_usage_balance", precision: 30, scale: 5, default: "0.0", null: false
     t.boolean "depleted_ongoing_balance", default: false, null: false
-    t.boolean "invoice_requires_successful_payment", default: false, null: false
+    t.boolean "invoice_require_successful_payment", default: false, null: false
     t.index ["customer_id"], name: "index_wallets_on_customer_id"
   end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -4246,7 +4246,7 @@ type InvoiceAppliedTax implements AppliedTax {
   taxDescription: String
   taxName: String!
   taxRate: Float!
-  taxableBaseAmountCents: BigInt!
+  taxableAmountCents: BigInt!
   updatedAt: ISO8601DateTime!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -4246,6 +4246,7 @@ type InvoiceAppliedTax implements AppliedTax {
   taxDescription: String
   taxName: String!
   taxRate: Float!
+  taxableBaseAmountCents: BigInt!
   updatedAt: ISO8601DateTime!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -21009,7 +21009,7 @@
               ]
             },
             {
-              "name": "taxableBaseAmountCents",
+              "name": "taxableAmountCents",
               "description": null,
               "type": {
                 "kind": "NON_NULL",

--- a/schema.json
+++ b/schema.json
@@ -21009,6 +21009,24 @@
               ]
             },
             {
+              "name": "taxableBaseAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "updatedAt",
               "description": null,
               "type": {

--- a/spec/models/invoice/applied_tax_spec.rb
+++ b/spec/models/invoice/applied_tax_spec.rb
@@ -24,4 +24,26 @@ RSpec.describe Invoice::AppliedTax, type: :model do
       end
     end
   end
+
+  describe '#taxable_amount_cents' do
+    before do
+      applied_tax.fees_amount_cents = 150
+    end
+
+    context 'when taxable_base_amount_cents is zero' do
+      it 'returns fees_amount_cents' do
+        applied_tax.taxable_base_amount_cents = 0
+
+        expect(applied_tax.taxable_amount_cents).to eq(150)
+      end
+    end
+
+    context 'when taxable_base_amount_cents is NOT zero' do
+      it 'returns taxable_base_amount_cents' do
+        applied_tax.taxable_base_amount_cents = 100
+
+        expect(applied_tax.taxable_amount_cents).to eq(100)
+      end
+    end
+  end
 end

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -123,7 +123,9 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
         # setting item_id based on the test example
         response = JSON.parse(json)
         response['succeededInvoices'].first['fees'].first['item_id'] = add_on_first.id
+        response['succeededInvoices'].first['fees'].first['tax_breakdown'].first['tax_amount'] = 240
         response['succeededInvoices'].first['fees'].last['item_id'] = add_on_second.id
+        response['succeededInvoices'].first['fees'].last['tax_breakdown'].first['tax_amount'] = 60
 
         response.to_json
       end

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Invoices::RetryService, type: :service do
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
 
           expect(result.invoice.currency).to eq('EUR')
-          expect(result.invoice.fees_amount_cents).to eq(3_000)
+          expect(result.invoice.fees_amount_cents).to eq(3_000) # 2000 + 1000
 
           expect(result.invoice.taxes_amount_cents).to eq(350)
           expect(result.invoice.taxes_rate.round(2)).to eq(11.67) # (0.667 * 10) + (0.333 * 15)

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Invoices::RetryService, type: :service do
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
 
           expect(result.invoice.currency).to eq('EUR')
-          expect(result.invoice.fees_amount_cents).to eq(3_000) # 2000 + 1000
+          expect(result.invoice.fees_amount_cents).to eq(3_000)
 
           expect(result.invoice.taxes_amount_cents).to eq(350)
           expect(result.invoice.taxes_rate.round(2)).to eq(11.67) # (0.667 * 10) + (0.333 * 15)


### PR DESCRIPTION
## Context

Lago recently launched integration with tax provider Anrok.

## Description

In some scenarios tax is not applied on the sum of all fees (with coupon applied).

Instead, there are scenarios where tax base is less than the sum of the fees (with coupon applied) and it depends mostly on the country (e.g. Texas in the USA).

This PR is covering described case. `tax_base_rate` is included in tax logic and also used to display correct base in the UI/PDF.
