### PR TITLE
feat(customer-portal): Add current billing dates to subscription object

### DIFF
--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -23,6 +23,9 @@ module Types
       field :subscription_at, GraphQL::Types::ISO8601DateTime
       field :terminated_at, GraphQL::Types::ISO8601DateTime
 
+      field :current_billing_period_ending_at, GraphQL::Types::ISO8601DateTime
+      field :current_billing_period_started_at, GraphQL::Types::ISO8601DateTime
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
@@ -50,6 +53,18 @@ module Types
         return nil unless object.plan.usage_thresholds.any?
 
         object.lifetime_usage
+      end
+
+      def current_billing_period_started_at
+        dates_service.charges_from_datetime
+      end
+
+      def current_billing_period_ending_at
+        dates_service.charges_to_datetime
+      end
+
+      def dates_service
+        @dates_service ||= ::Subscriptions::DatesService.new_instance(object, Time.current, current_usage: true)
       end
     end
   end

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -21,7 +21,9 @@ module V1
         created_at: model.created_at.iso8601,
         previous_plan_code: model.previous_subscription&.plan&.code,
         next_plan_code: model.next_subscription&.plan&.code,
-        downgrade_plan_date: model.downgrade_plan_date&.iso8601
+        downgrade_plan_date: model.downgrade_plan_date&.iso8601,
+        current_billing_period_started_at: dates_service.charges_from_datetime&.iso8601,
+        current_billing_period_ending_at: dates_service.charges_to_datetime&.iso8601
       }
 
       payload = payload.merge(customer:) if include?(:customer)
@@ -46,6 +48,10 @@ module V1
 
     def usage_threshold
       ::V1::UsageThresholdSerializer.new(options[:usage_threshold]).serialize
+    end
+
+    def dates_service
+      @dates_service ||= ::Subscriptions::DatesService.new_instance(model, Time.current, current_usage: true)
     end
   end
 end

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -47,6 +47,7 @@ module Subscriptions
 
     def from_datetime
       return @from_datetime if @from_datetime
+      return unless subscription.started_at
 
       @from_datetime = customer_timezone_shift(compute_from_date)
 
@@ -62,6 +63,7 @@ module Subscriptions
 
     def to_datetime
       return @to_datetime if @to_datetime
+      return unless subscription.started_at
 
       @to_datetime = customer_timezone_shift(compute_to_date, end_of_day: true)
       terminated_at = subscription.terminated_at&.to_time&.round
@@ -75,6 +77,8 @@ module Subscriptions
     end
 
     def charges_from_datetime
+      return unless subscription.started_at
+
       datetime = customer_timezone_shift(compute_charges_from_date)
 
       # NOTE: If customer applicable timezone changes during a billing period, there is a risk to double count events
@@ -94,6 +98,8 @@ module Subscriptions
     end
 
     def charges_to_datetime
+      return unless subscription.started_at
+
       datetime = customer_timezone_shift(compute_charges_to_date, end_of_day: true)
       datetime = subscription.terminated_at if subscription.terminated_at?(datetime)
       datetime = subscription.started_at if datetime < subscription.started_at

--- a/schema.graphql
+++ b/schema.graphql
@@ -6502,6 +6502,8 @@ type Subscription {
   billingTime: BillingTimeEnum
   canceledAt: ISO8601DateTime
   createdAt: ISO8601DateTime!
+  currentBillingPeriodEndingAt: ISO8601DateTime
+  currentBillingPeriodStartedAt: ISO8601DateTime
   customer: Customer!
   endingAt: ISO8601DateTime
   externalId: String!

--- a/schema.json
+++ b/schema.json
@@ -33071,6 +33071,34 @@
               ]
             },
             {
+              "name": "currentBillingPeriodEndingAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "currentBillingPeriodStartedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "customer",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/customer_portal/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/subscriptions_resolver_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Resolvers::CustomerPortal::SubscriptionsResolver, type: :graphql 
     <<~GQL
       query {
         customerPortalSubscriptions(limit: 5, planCode: "#{plan.code}", status: [active]) {
-            collection { id externalId plan { code } }
+            collection { id externalId currentBillingPeriodStartedAt currentBillingPeriodEndingAt plan { code } }
             metadata { currentPage, totalCount }
         }
       }

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -23,6 +23,9 @@ RSpec.describe Types::Subscriptions::Object do
   it { is_expected.to have_field(:subscription_at).of_type('ISO8601DateTime') }
   it { is_expected.to have_field(:terminated_at).of_type('ISO8601DateTime') }
 
+  it { is_expected.to have_field(:current_billing_period_started_at).of_type('ISO8601DateTime') }
+  it { is_expected.to have_field(:current_billing_period_ending_at).of_type('ISO8601DateTime') }
+
   it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
   it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
 

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -5,7 +5,11 @@ require 'rails_helper'
 RSpec.describe ::V1::SubscriptionSerializer do
   subject(:serializer) { described_class.new(subscription, root_name: 'subscription', includes: %i[customer plan]) }
 
-  let!(:subscription) { create(:subscription, ending_at: Time.current + 1.month) }
+  let(:started_at) { Time.zone.parse('2024-04-23 10:00') }
+  let(:ending_at) { Time.zone.parse('2024-06-30') }
+  let!(:subscription) do
+    create(:subscription, created_at: started_at, started_at:, ending_at:)
+  end
 
   context 'when plan has one minimium commitment' do
     let(:commitment) { create(:commitment, plan: subscription.plan) }
@@ -13,63 +17,72 @@ RSpec.describe ::V1::SubscriptionSerializer do
     before { commitment }
 
     it 'serializes the object' do
-      result = JSON.parse(serializer.to_json)
+      travel_to(Time.zone.parse('2024-05-28')) do
+        result = JSON.parse(serializer.to_json)
 
-      aggregate_failures do
-        expect(result['subscription']).to include(
-          'lago_id' => subscription.id,
-          'external_id' => subscription.external_id,
-          'lago_customer_id' => subscription.customer_id,
-          'external_customer_id' => subscription.customer.external_id,
-          'name' => subscription.name,
-          'plan_code' => subscription.plan.code,
-          'status' => subscription.status,
-          'billing_time' => subscription.billing_time,
-          'created_at' => subscription.created_at.iso8601,
-          'ending_at' => subscription.ending_at.iso8601,
-          'trial_ended_at' => nil
-        )
+        aggregate_failures do
+          expect(result['subscription']).to include(
+            'lago_id' => subscription.id,
+            'external_id' => subscription.external_id,
+            'lago_customer_id' => subscription.customer_id,
+            'external_customer_id' => subscription.customer.external_id,
+            'name' => subscription.name,
+            'plan_code' => subscription.plan.code,
+            'status' => subscription.status,
+            'billing_time' => subscription.billing_time,
+            'created_at' => started_at.iso8601,
+            'ending_at' => ending_at.iso8601,
+            'trial_ended_at' => nil,
+            'current_billing_period_started_at' => '2024-05-01T00:00:00Z',
+            'current_billing_period_ending_at' => '2024-05-31T23:59:59Z'
+          )
 
-        expect(result['subscription']['customer']['lago_id']).to be_present
-        expect(result['subscription']['plan']['lago_id']).to be_present
+          expect(result['subscription']['customer']['lago_id']).to be_present
+          expect(result['subscription']['plan']['lago_id']).to be_present
 
-        expect(result['subscription']['plan']['minimum_commitment']).to include(
-          'lago_id' => commitment.id,
-          'plan_code' => commitment.plan.code,
-          'invoice_display_name' => commitment.invoice_display_name,
-          'amount_cents' => commitment.amount_cents,
-          'interval' => commitment.plan.interval,
-          'created_at' => commitment.created_at.iso8601,
-          'updated_at' => commitment.updated_at.iso8601,
-          'taxes' => []
-        )
-        expect(result['subscription']['plan']['minimum_commitment']).not_to include(
-          'commitment_type' => 'minimum_commitment'
-        )
+          expect(result['subscription']['plan']['minimum_commitment']).to include(
+            'lago_id' => commitment.id,
+            'plan_code' => commitment.plan.code,
+            'invoice_display_name' => commitment.invoice_display_name,
+            'amount_cents' => commitment.amount_cents,
+            'interval' => commitment.plan.interval,
+            'created_at' => commitment.created_at.iso8601,
+            'updated_at' => commitment.updated_at.iso8601,
+            'taxes' => []
+          )
+          expect(result['subscription']['plan']['minimum_commitment']).not_to include(
+            'commitment_type' => 'minimum_commitment'
+          )
+        end
       end
     end
   end
 
   context 'when plan has no minimium commitment' do
     it 'serializes the object' do
-      result = JSON.parse(serializer.to_json)
+      travel_to(Time.zone.parse('2024-05-28')) do
+        result = JSON.parse(serializer.to_json)
 
-      aggregate_failures do
-        expect(result['subscription']).to include(
-          'lago_id' => subscription.id,
-          'external_id' => subscription.external_id,
-          'lago_customer_id' => subscription.customer_id,
-          'external_customer_id' => subscription.customer.external_id,
-          'name' => subscription.name,
-          'plan_code' => subscription.plan.code,
-          'status' => subscription.status,
-          'billing_time' => subscription.billing_time,
-          'created_at' => subscription.created_at.iso8601,
-          'ending_at' => subscription.ending_at.iso8601
-        )
+        aggregate_failures do
+          expect(result['subscription']).to include(
+            'lago_id' => subscription.id,
+            'external_id' => subscription.external_id,
+            'lago_customer_id' => subscription.customer_id,
+            'external_customer_id' => subscription.customer.external_id,
+            'name' => subscription.name,
+            'plan_code' => subscription.plan.code,
+            'status' => subscription.status,
+            'billing_time' => subscription.billing_time,
+            'created_at' => started_at.iso8601,
+            'ending_at' => ending_at.iso8601,
+            'trial_ended_at' => nil,
+            'current_billing_period_started_at' => '2024-05-01T00:00:00Z',
+            'current_billing_period_ending_at' => '2024-05-31T23:59:59Z'
+          )
 
-        expect(result['subscription']['customer']['lago_id']).to be_present
-        expect(result['subscription']['plan']['minimum_commitment']).to be_nil
+          expect(result['subscription']['customer']['lago_id']).to be_present
+          expect(result['subscription']['plan']['minimum_commitment']).to be_nil
+        end
       end
     end
   end

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         expect(result).to eq('2022-02-01 00:00:00 UTC')
       end
 
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.from_datetime).to be_nil
+        end
+      end
+
       context 'with customer timezone' do
         let(:timezone) { 'America/New_York' }
 
@@ -187,6 +195,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         expect(result).to eq('2022-02-28 23:59:59 UTC')
       end
 
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.to_datetime).to be_nil
+        end
+      end
+
       context 'with customer timezone' do
         let(:timezone) { 'America/New_York' }
 
@@ -326,6 +342,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         expect(result).to eq(date_service.from_datetime.to_s)
       end
 
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.charges_from_datetime).to be_nil
+        end
+      end
+
       context 'with customer timezone' do
         let(:timezone) { 'America/New_York' }
 
@@ -436,6 +460,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_datetime.to_s)
+      end
+
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.charges_to_datetime).to be_nil
+        end
       end
 
       context 'with customer timezone' do

--- a/spec/services/subscriptions/dates/quarterly_service_spec.rb
+++ b/spec/services/subscriptions/dates/quarterly_service_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
         expect(result).to eq('2022-04-01 00:00:00 UTC')
       end
 
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.from_datetime).to be_nil
+        end
+      end
+
       context 'with customer timezone' do
         let(:timezone) { 'America/New_York' }
 
@@ -195,6 +203,14 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
         expect(result).to eq('2022-06-30 23:59:59 UTC')
       end
 
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.to_datetime).to be_nil
+        end
+      end
+
       context 'with customer timezone' do
         let(:timezone) { 'America/New_York' }
 
@@ -312,6 +328,14 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
         expect(result).to eq(date_service.from_datetime.to_s)
       end
 
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.charges_from_datetime).to be_nil
+        end
+      end
+
       context 'with customer timezone' do
         let(:timezone) { 'America/New_York' }
 
@@ -395,6 +419,14 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_datetime.to_s)
+      end
+
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.charges_to_datetime).to be_nil
+        end
       end
 
       context 'with customer timezone' do

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         expect(Time.zone.parse(result).wday).to eq(1)
       end
 
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.from_datetime).to be_nil
+        end
+      end
+
       context 'with customer timezone' do
         let(:timezone) { 'America/New_York' }
 
@@ -130,6 +138,14 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         expect(result).to eq('2022-03-06 23:59:59 UTC')
       end
 
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.to_datetime).to be_nil
+        end
+      end
+
       context 'with customer timezone' do
         let(:timezone) { 'America/New_York' }
 
@@ -213,6 +229,14 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         expect(result).to eq(date_service.from_datetime.to_s)
       end
 
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.charges_from_datetime).to be_nil
+        end
+      end
+
       context 'with customer timezone' do
         let(:timezone) { 'America/New_York' }
 
@@ -293,6 +317,14 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_datetime.to_s)
+      end
+
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.charges_to_datetime).to be_nil
+        end
       end
 
       context 'with customer timezone' do

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         expect(result).to eq('2021-01-01 00:00:00 UTC')
       end
 
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.charges_to_datetime).to be_nil
+        end
+      end
+
       context 'with customer timezone' do
         let(:timezone) { 'America/New_York' }
 
@@ -154,6 +162,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         expect(result).to eq('2021-12-31 23:59:59 UTC')
       end
 
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.to_datetime).to be_nil
+        end
+      end
+
       context 'with customer timezone' do
         let(:timezone) { 'America/New_York' }
 
@@ -262,6 +278,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       it 'returns from_date' do
         expect(result).to eq(date_service.from_datetime.to_s)
+      end
+
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.charges_from_datetime).to be_nil
+        end
       end
 
       context 'with customer timezone' do
@@ -379,6 +403,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_datetime.to_s)
+      end
+
+      context 'when subscription is not yet started' do
+        let(:started_at) { nil }
+
+        it 'returns nil' do
+          expect(date_service.charges_to_datetime).to be_nil
+        end
       end
 
       context 'with customer timezone' do


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal](https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal)

## Context

We got feedback that this portal is too limited in terms of features and information. Why?

**1st reason:** the number of information displayed is limited

**2nd reason:** the end user cannot take actions out of it (change info, add payment method)

**3rd reason:** the UI and display is not customizable

## Description

The goal of this PR is to add current billing dates to subscription object.
