### PR TITLE
Fix: credit notes sorting

### DIFF
--- a/app/queries/credit_notes_query.rb
+++ b/app/queries/credit_notes_query.rb
@@ -4,7 +4,7 @@ class CreditNotesQuery < BaseQuery
   def call
     credit_notes = base_scope.result
     credit_notes = paginate(credit_notes)
-    credit_notes = credit_notes.order(issuing_date: :desc)
+    credit_notes = credit_notes.order(created_at: :desc)
 
     credit_notes = with_customer_id(credit_notes) if filters.customer_id.present?
 


### PR DESCRIPTION
## Context

we show credit notes on invoice page and on all credit notes page
at invoice page we sort them by `created_at` of type `date_time`
at the all credit notes page we sort them by `issuing_date` of type `date`

As result they are sorted slightly differently and they are not sorted accurately on the all credit notes page

## Description

Unified ways we sort credit notes, using `:created_at` for sorting
