### PR TITLE
feat: added translations

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -325,9 +325,12 @@ class Invoice < ApplicationRecord
   def document_invoice_name
     return I18n.t('invoice.prepaid_credit_invoice') if credit?
 
-    return I18n.t('invoice.paid_invoice') if advance_charges?
+    if %w[AU AE ID NZ].include?(organization.country)
+      return I18n.t('invoice.paid_tax_invoice') if advance_charges?
+      return I18n.t('invoice.document_tax_name')
+    end
 
-    return I18n.t('invoice.document_tax_name') if %w[AU AE ID NZ].include?(organization.country)
+    return I18n.t('invoice.paid_invoice') if advance_charges?
 
     I18n.t('invoice.document_name')
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -325,6 +325,8 @@ class Invoice < ApplicationRecord
   def document_invoice_name
     return I18n.t('invoice.prepaid_credit_invoice') if credit?
 
+    return I18n.t('invoice.paid_invoice') if advance_charges?
+
     return I18n.t('invoice.document_tax_name') if %w[AU AE ID NZ].include?(organization.country)
 
     I18n.t('invoice.document_name')

--- a/app/views/templates/invoices/v3/charge.slim
+++ b/app/views/templates/invoices/v3/charge.slim
@@ -409,7 +409,7 @@ html
 
       .mb-24
         h2.title-2.mb-4 = MoneyHelper.format(total_amount)
-        .body-1 = I18n.t('invoice.due_date', date: I18n.l(payment_due_date, format: :default))
+        .body-1 = advance_charges? ? I18n.t('invoice.already_paid') : I18n.t('invoice.due_date', date: I18n.l(payment_due_date, format: :default))
 
       .invoice-resume.mb-24.overflow-auto
         table.invoice-resume-table width="100%"
@@ -470,7 +470,7 @@ html
               td.body-2 = '-' + MoneyHelper.format(prepaid_credit_amount)
           tr
             td.body-2
-            td.body-1 = I18n.t('invoice.total_due')
+            td.body-1 = advance_charges? ? I18n.t('invoice.already_paid') : I18n.t('invoice.total_due')
             td.body-1 = MoneyHelper.format(total_amount)
 
       p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -409,7 +409,7 @@ html
 
       .mb-24
         h2.title-2.mb-4 = MoneyHelper.format(total_amount)
-        .body-1 = I18n.t('invoice.due_date', date: I18n.l(payment_due_date, format: :default))
+        .body-1 = advance_charges? ? I18n.t('invoice.already_paid') : I18n.t('invoice.due_date', date: I18n.l(payment_due_date, format: :default))
 
       .invoice-resume.mb-24.overflow-auto
         table.invoice-resume-table width="100%"
@@ -491,7 +491,7 @@ html
               td.body-2 = '-' + MoneyHelper.format(prepaid_credit_amount)
           tr
             td.body-2
-            td.body-1 = I18n.t('invoice.total_due')
+            td.body-1 = advance_charges? ? I18n.t('invoice.already_paid') : I18n.t('invoice.total_due')
             td.body-1 = MoneyHelper.format(total_amount)
 
       == SlimHelper.render('templates/invoices/v4/_eu_tax_management', self)

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -1,9 +1,9 @@
 ---
 de:
   invoice:
-    already_paid: Bereits bezahlt
     all_subscriptions: Alle Abonnements
     all_usage_based_fees: Alle nutzungsabhängigen Gebühren
+    already_paid: Bereits bezahlt
     amount: Betrag
     amount_with_tax: Betrag (inkl. Steuern)
     amount_without_tax: Betrag (ohne Steuern)

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -1,6 +1,7 @@
 ---
 de:
   invoice:
+    already_paid: Bereits bezahlt
     all_subscriptions: Alle Abonnements
     all_usage_based_fees: Alle nutzungsabhängigen Gebühren
     amount: Betrag
@@ -40,6 +41,7 @@ de:
       fee_per_package: Gebühr pro Paket
       fee_per_package_unit_price: "%{amount} pro %{package_size}"
       free_units_for_the_first: Gebühr pro Einheit für die ersten %{count}
+    paid_invoice: Bezahlte Rechnung
     payment_term: Zahlungsfrist
     payment_term_days: "%{net_payment_term} Tage"
     percentage:

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -42,6 +42,7 @@ de:
       fee_per_package_unit_price: "%{amount} pro %{package_size}"
       free_units_for_the_first: Gebühr pro Einheit für die ersten %{count}
     paid_invoice: Bezahlte Rechnung
+    paid_tax_invoice: Bezahlte Steuerrechnung
     payment_term: Zahlungsfrist
     payment_term_days: "%{net_payment_term} Tage"
     percentage:

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -1,6 +1,7 @@
 ---
 en:
   invoice:
+    already_paid: Already paid
     all_subscriptions: All Subscriptions
     all_usage_based_fees: All usage based fees
     amount: Amount
@@ -40,6 +41,7 @@ en:
       fee_per_package: Fee per package
       fee_per_package_unit_price: "%{amount} per %{package_size}"
       free_units_for_the_first: Free units for the first %{count}
+    paid_invoice: Paid invoice
     payment_term: Payment term
     payment_term_days: "%{net_payment_term} days"
     percentage:

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -1,9 +1,9 @@
 ---
 en:
   invoice:
-    already_paid: Already paid
     all_subscriptions: All Subscriptions
     all_usage_based_fees: All usage based fees
+    already_paid: Already paid
     amount: Amount
     amount_with_tax: Amount (incl. tax)
     amount_without_tax: Amount (excl. tax)

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -42,6 +42,7 @@ en:
       fee_per_package_unit_price: "%{amount} per %{package_size}"
       free_units_for_the_first: Free units for the first %{count}
     paid_invoice: Paid invoice
+    paid_tax_invoice: Paid tax invoice
     payment_term: Payment term
     payment_term_days: "%{net_payment_term} days"
     percentage:

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -1,9 +1,9 @@
 ---
 es:
   invoice:
-    already_paid: Ya pagado
     all_subscriptions: Todos los suscripciones
     all_usage_based_fees: Todos los cargos basados en el uso
+    already_paid: Ya pagado
     amount: Total (excl. impuestos)
     amount_with_tax: Total (impuestos incl.)
     amount_without_tax: Total (impuestos excl.)

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -1,6 +1,7 @@
 ---
 es:
   invoice:
+    already_paid: Ya pagado
     all_subscriptions: Todos los suscripciones
     all_usage_based_fees: Todos los cargos basados en el uso
     amount: Total (excl. impuestos)
@@ -39,6 +40,7 @@ es:
       fee_per_package: Tarifa por paquete
       fee_per_package_unit_price: "%{amount} por %{package_size}"
       free_units_for_the_first: Unidades gratuitas para las %{count} primeras
+    paid_invoice: Factura pagada
     payment_term: Plazo de pago neto
     payment_term_days: "%{net_payment_term} días"
     percentage:

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -41,6 +41,7 @@ es:
       fee_per_package_unit_price: "%{amount} por %{package_size}"
       free_units_for_the_first: Unidades gratuitas para las %{count} primeras
     paid_invoice: Factura pagada
+    paid_tax_invoice: Factura fiscal pagada
     payment_term: Plazo de pago neto
     payment_term_days: "%{net_payment_term} días"
     percentage:

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -42,6 +42,7 @@ fr:
       fee_per_package_unit_price: "%{amount} par tranche de %{package_size}"
       free_units_for_the_first: Unités gratuites pour les premiers %{count}
     paid_invoice: Facture payée
+    paid_tax_invoice: Facture fiscale payée
     payment_term: Délai de paiement
     payment_term_days: "%{net_payment_term} jours"
     percentage:

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -1,6 +1,7 @@
 ---
 fr:
   invoice:
+    already_paid: Déjà payé
     all_subscriptions: Tous les abonnements
     all_usage_based_fees: Tous les frais de consommation
     amount: Montant
@@ -40,6 +41,7 @@ fr:
       fee_per_package: Frais par tranche
       fee_per_package_unit_price: "%{amount} par tranche de %{package_size}"
       free_units_for_the_first: Unités gratuites pour les premiers %{count}
+    paid_invoice: Facture payée
     payment_term: Délai de paiement
     payment_term_days: "%{net_payment_term} jours"
     percentage:

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -1,9 +1,9 @@
 ---
 fr:
   invoice:
-    already_paid: Déjà payé
     all_subscriptions: Tous les abonnements
     all_usage_based_fees: Tous les frais de consommation
+    already_paid: Déjà payé
     amount: Montant
     amount_with_tax: Montant (TTC)
     amount_without_tax: Montant (HT)

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -42,6 +42,7 @@ it:
       fee_per_package_unit_price: "%{amount} per %{package_size}"
       free_units_for_the_first: Unità gratuite per il primo %{count}
     paid_invoice: Fattura pagata
+    paid_tax_invoice: Fattura fiscale pagata
     payment_term: Termine di pagamento
     payment_term_days: "%{net_payment_term} giorni"
     percentage:

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -1,6 +1,7 @@
 ---
 it:
   invoice:
+    already_paid: Già pagato
     all_subscriptions: Tutti gli abbonamenti
     all_usage_based_fees: Tutte le tariffe basate sull'utilizzo
     amount: Importo
@@ -40,6 +41,7 @@ it:
       fee_per_package: Tassa per pacchetto
       fee_per_package_unit_price: "%{amount} per %{package_size}"
       free_units_for_the_first: Unità gratuite per il primo %{count}
+    paid_invoice: Fattura pagata
     payment_term: Termine di pagamento
     payment_term_days: "%{net_payment_term} giorni"
     percentage:

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -1,9 +1,9 @@
 ---
 it:
   invoice:
-    already_paid: Già pagato
     all_subscriptions: Tutti gli abbonamenti
     all_usage_based_fees: Tutte le tariffe basate sull'utilizzo
+    already_paid: Già pagato
     amount: Importo
     amount_with_tax: Importo (incl. tasse)
     amount_without_tax: Importo (escl. tasse)

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -1,9 +1,9 @@
 ---
 nb:
   invoice:
-    already_paid: Allerede betalt
     all_subscriptions: Alle Abonnement
     all_usage_based_fees: Alle bruksbaserte kostnader
+    already_paid: Allerede betalt
     amount: Beløp
     amount_with_tax: Beløp (inkl. MVA)
     amount_without_tax: Beløp (ekskl. MVA)

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -1,6 +1,7 @@
 ---
 nb:
   invoice:
+    already_paid: Allerede betalt
     all_subscriptions: Alle Abonnement
     all_usage_based_fees: Alle bruksbaserte kostnader
     amount: Beløp
@@ -40,6 +41,7 @@ nb:
       fee_per_package: Gebyr per pakke
       fee_per_package_unit_price: "%{amount} per %{package_size}"
       free_units_for_the_first: Gratis enheter for de første %{count}
+    paid_invoice: Betalt faktura
     payment_term: Betalingsperiode
     payment_term_days: "%{net_payment_term} dager"
     percentage:

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -42,6 +42,7 @@ nb:
       fee_per_package_unit_price: "%{amount} per %{package_size}"
       free_units_for_the_first: Gratis enheter for de første %{count}
     paid_invoice: Betalt faktura
+    paid_tax_invoice: Betalt skattefaktura
     payment_term: Betalingsperiode
     payment_term_days: "%{net_payment_term} dager"
     percentage:

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -41,6 +41,7 @@ sv:
       fee_per_package_unit_price: "%{amount} per %{package_size}"
       free_units_for_the_first: Gratis enheter för de första %{count}
     paid_invoice: Betald faktura
+    paid_tax_invoice: Betald skattefaktura
     payment_term: Betalningsvillkor
     payment_term_days: "%{net_payment_term} dagar"
     percentage:

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -1,6 +1,7 @@
 ---
 sv:
   invoice:
+    already_paid: Redan betalt
     all_subscriptions: Alla prenumerationer
     all_usage_based_fees: Alla avgifter baserade på användning
     amount: Belopp (exkl. moms)
@@ -39,6 +40,7 @@ sv:
       fee_per_package: Avgift per paket
       fee_per_package_unit_price: "%{amount} per %{package_size}"
       free_units_for_the_first: Gratis enheter för de första %{count}
+    paid_invoice: Betald faktura
     payment_term: Betalningsvillkor
     payment_term_days: "%{net_payment_term} dagar"
     percentage:

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -1,9 +1,9 @@
 ---
 sv:
   invoice:
-    already_paid: Redan betalt
     all_subscriptions: Alla prenumerationer
     all_usage_based_fees: Alla avgifter baserade på användning
+    already_paid: Redan betalt
     amount: Belopp (exkl. moms)
     amount_with_tax: Belopp (inkl. moms)
     amount_without_tax: Belopp (exkl. moms)


### PR DESCRIPTION
## Context

When an invoice is generated for **paid_in_advance fees** (invoice_type: `advance_charges`), the title of the invoice currently displays "Invoice" and the last line of the PDF shows "Total due." However, since this invoice is already paid, this is misleading for the users.

The goal is to provide more accurate labeling in the invoice title and the total section.

## Description

### Changes:
   - For invoices of type `advance_charges`, the title should now display "Paid invoice" instead of "Invoice."   
   - For these invoices, instead of displaying "Total due," we now show "Already paid."
   - on the due date -> now appears already paid without date 

### Changes made in the PDF:
- Conditional logic has been added to check if the invoice type is `advance_charges` and select the correct label

![image](https://github.com/user-attachments/assets/47c7b742-d65f-4713-a865-8a65d4cf5cad)
