### PR TITLE
feat: make external-subscription-id required

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,7 +10,7 @@ class Event < EventsRecord
   belongs_to :organization
 
   validates :transaction_id, presence: true, uniqueness: {scope: %i[organization_id external_subscription_id]}
-  validates :code, :external_subscription_id, presence: true
+  validates :code, presence: true
 
   default_scope -> { kept }
   scope :from_datetime, ->(from_datetime) { where('events.timestamp >= ?', from_datetime) }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,7 +10,7 @@ class Event < EventsRecord
   belongs_to :organization
 
   validates :transaction_id, presence: true, uniqueness: {scope: %i[organization_id external_subscription_id]}
-  validates :code, presence: true
+  validates :code, :external_subscription_id, presence: true
 
   default_scope -> { kept }
   scope :from_datetime, ->(from_datetime) { where('events.timestamp >= ?', from_datetime) }

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -11,6 +11,8 @@ module Events
     end
 
     def call
+      validate_create
+
       event = Event.new
       event.organization_id = organization.id
       event.code = params[:code]
@@ -38,6 +40,16 @@ module Events
     private
 
     attr_reader :organization, :params, :timestamp, :metadata
+
+    def validate_create
+      if params[:external_subscription_id].blank?
+        missing_subscription_error
+      end
+    end
+
+    def missing_subscription_error
+      result.not_found_failure!(resource: 'subscription')
+    end
 
     def produce_kafka_event(event)
       return if ENV['LAGO_KAFKA_BOOTSTRAP_SERVERS'].blank?

--- a/app/services/events/post_process_service.rb
+++ b/app/services/events/post_process_service.rb
@@ -10,17 +10,6 @@ module Events
 
     def call
       event.external_customer_id ||= customer&.external_id
-
-      unless event.external_subscription_id
-        Deprecation.report('event_missing_external_subscription_id', organization.id)
-      end
-
-      # NOTE: prevent subscription if more than 1 subscription is active
-      #       if multiple terminated matches the timestamp, takes the most recent
-      if !event.external_subscription_id && subscriptions.count(&:active?) <= 1
-        event.external_subscription_id ||= subscriptions.first&.external_id
-      end
-
       event.save!
 
       expire_cached_charges(subscriptions)


### PR DESCRIPTION
Context
In the API references, the description of the event.external_subscription_id field incorrectly suggests that users can ingest events using the customer's external ID. However, this is not accurate, and it can cause confusion for users integrating the API.

To prevent misinterpretation, we need to mark this field as required and update the description to clearly state that the external_subscription_id is mandatory to correctly link events to customer subscriptions.