### PR TITLE
feat(customer_portal): Add usage resolver to customer portal

### DIFF
--- a/app/graphql/resolvers/customer_portal/customers/usage_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/customers/usage_resolver.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module CustomerPortal
+    module Customers
+      class UsageResolver < Resolvers::BaseResolver
+        include AuthenticableCustomerPortalUser
+
+        description "Query the usage of the customer on the current billing period"
+
+        argument :subscription_id, type: ID, required: true
+
+        type Types::Customers::Usage::Current, null: false
+
+        def resolve(subscription_id:)
+          result = Invoices::CustomerUsageService.with_ids(
+            current_user: nil,
+            organization_id: context[:customer_portal_user].organization_id,
+            customer_id: context[:customer_portal_user].id,
+            subscription_id:,
+            apply_taxes: false
+          ).call
+
+          result.success? ? result.usage : result_error(result)
+        rescue ActiveRecord::RecordNotFound
+          not_found_error(resource: "customer")
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/customers/usage_resolver.rb
+++ b/app/graphql/resolvers/customers/usage_resolver.rb
@@ -16,7 +16,8 @@ module Resolvers
 
       def resolve(customer_id:, subscription_id:)
         result = Invoices::CustomerUsageService.with_ids(
-          context[:current_user],
+          current_user: context[:current_user],
+          organization_id: context[:current_user].organization_ids,
           customer_id:,
           subscription_id:,
           apply_taxes: false

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -21,6 +21,7 @@ module Types
     field :current_version, resolver: Resolvers::VersionResolver
     field :customer, resolver: Resolvers::CustomerResolver
     field :customer_invoices, resolver: Resolvers::Customers::InvoicesResolver
+    field :customer_portal_customer_usage, resolver: Resolvers::CustomerPortal::Customers::UsageResolver
     field :customer_portal_invoice_collections, resolver: Resolvers::CustomerPortal::Analytics::InvoiceCollectionsResolver
     field :customer_portal_invoices, resolver: Resolvers::CustomerPortal::InvoicesResolver
     field :customer_portal_organization, resolver: Resolvers::CustomerPortal::OrganizationResolver

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -18,8 +18,8 @@ module Invoices
       result.not_found_failure!(resource: 'customer')
     end
 
-    def self.with_ids(current_user, customer_id:, subscription_id:, apply_taxes: true)
-      customer = Customer.find_by(id: customer_id, organization_id: current_user.organization_ids)
+    def self.with_ids(current_user:, organization_id:, customer_id:, subscription_id:, apply_taxes: true)
+      customer = Customer.find_by(id: customer_id, organization_id:)
       subscription = customer&.active_subscriptions&.find_by(id: subscription_id)
       new(current_user, customer:, subscription:, apply_taxes:)
     rescue ActiveRecord::RecordNotFound

--- a/schema.graphql
+++ b/schema.graphql
@@ -6070,6 +6070,11 @@ type Query {
   customerInvoices(customerId: ID!, limit: Int, page: Int, searchTerm: String, status: [InvoiceStatusTypeEnum!]): InvoiceCollection!
 
   """
+  Query the usage of the customer on the current billing period
+  """
+  customerPortalCustomerUsage(subscriptionId: ID!): CustomerUsage!
+
+  """
   Query invoice collections of a customer portal user
   """
   customerPortalInvoiceCollections(expireCache: Boolean, months: Int): FinalizedInvoiceCollectionCollection!

--- a/schema.json
+++ b/schema.json
@@ -30619,6 +30619,39 @@
               ]
             },
             {
+              "name": "customerPortalCustomerUsage",
+              "description": "Query the usage of the customer on the current billing period",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CustomerUsage",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "subscriptionId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "customerPortalInvoiceCollections",
               "description": "Query invoice collections of a customer portal user",
               "type": {

--- a/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
@@ -1,0 +1,277 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($subscriptionId: ID!) {
+        customerPortalCustomerUsage(subscriptionId: $subscriptionId) {
+          fromDatetime
+          toDatetime
+          currency
+          issuingDate
+          amountCents
+          totalAmountCents
+          taxesAmountCents
+          chargesUsage {
+            billableMetric { name code aggregationType }
+            charge { chargeModel }
+            filters { id units amountCents invoiceDisplayName values eventsCount }
+            units
+            amountCents
+            groupedUsage {
+              amountCents
+              units
+              eventsCount
+              groupedBy
+              filters { id units amountCents invoiceDisplayName values eventsCount }
+            }
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:tax) { create(:tax, organization:, rate: 20) }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) do
+    create(
+      :subscription,
+      plan:,
+      customer:,
+      started_at: Time.zone.now - 2.years
+    )
+  end
+  let(:plan) { create(:plan, interval: "monthly") }
+
+  let(:metric) { create(:billable_metric, aggregation_type: "count_agg") }
+  let(:sum_metric) { create(:sum_billable_metric, organization:) }
+  let(:charge) do
+    create(
+      :graduated_charge,
+      plan: subscription.plan,
+      charge_model: "graduated",
+      billable_metric: metric,
+      properties: {
+        graduated_ranges: [
+          {
+            from_value: 0,
+            to_value: nil,
+            per_unit_amount: "0.01",
+            flat_amount: "0.01"
+          }
+        ]
+      }
+    )
+  end
+  let(:standard_charge) do
+    create(
+      :standard_charge,
+      plan: subscription.plan,
+      billable_metric: sum_metric,
+      properties: {
+        amount: 1.to_s,
+        grouped_by: ["agent_name"]
+      }
+    )
+  end
+
+  let(:billable_metric_filter) do
+    create(:billable_metric_filter, billable_metric: metric, key: "cloud", values: %w[aws gcp])
+  end
+
+  let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }
+  let(:charge_filter_value) do
+    create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ["aws"])
+  end
+
+  before do
+    subscription
+    charge
+    tax
+    charge_filter_value
+
+    create_list(
+      :event,
+      4,
+      organization:,
+      customer:,
+      subscription:,
+      code: metric.code,
+      timestamp: Time.zone.now
+    )
+
+    create_list(
+      :event,
+      4,
+      organization:,
+      customer:,
+      subscription:,
+      code: sum_metric.code,
+      timestamp: Time.zone.now,
+      properties: {
+        agent_name: "frodo",
+        cloud: "aws",
+        item_id: 1
+      }
+    )
+  end
+
+  it_behaves_like "requires a customer portal user"
+
+  it "returns the usage for the customer" do
+    result = execute_graphql(
+      customer_portal_user: customer,
+      query:,
+      variables: {
+        subscriptionId: subscription.id
+      }
+    )
+
+    usage_response = result["data"]["customerPortalCustomerUsage"]
+
+    aggregate_failures do
+      expect(usage_response["fromDatetime"]).to eq(Time.current.beginning_of_month.iso8601)
+      expect(usage_response["toDatetime"]).to eq(Time.current.end_of_month.iso8601)
+      expect(usage_response["currency"]).to eq("EUR")
+      expect(usage_response["issuingDate"]).to eq(Time.zone.today.end_of_month.iso8601)
+      expect(usage_response["amountCents"]).to eq("405")
+      expect(usage_response["totalAmountCents"]).to eq("405")
+      expect(usage_response["taxesAmountCents"]).to eq("0")
+
+      charge_usage = usage_response["chargesUsage"].first
+      expect(charge_usage["billableMetric"]["name"]).to eq(metric.name)
+      expect(charge_usage["billableMetric"]["code"]).to eq(metric.code)
+      expect(charge_usage["billableMetric"]["aggregationType"]).to eq("count_agg")
+      expect(charge_usage["charge"]["chargeModel"]).to eq("graduated")
+      expect(charge_usage["units"]).to eq(4.0)
+      expect(charge_usage["amountCents"]).to eq("5")
+
+      charge_usage = usage_response["chargesUsage"].last
+      expect(charge_usage["billableMetric"]["name"]).to eq(sum_metric.name)
+      expect(charge_usage["billableMetric"]["code"]).to eq(sum_metric.code)
+      expect(charge_usage["billableMetric"]["aggregationType"]).to eq("sum_agg")
+      expect(charge_usage["charge"]["chargeModel"]).to eq("standard")
+      expect(charge_usage["units"]).to eq(4.0)
+      expect(charge_usage["amountCents"]).to eq("400")
+
+      grouped_usage = charge_usage["groupedUsage"].first
+      expect(grouped_usage["amountCents"]).to eq("400")
+      expect(grouped_usage["units"]).to eq(4.0)
+      expect(grouped_usage["eventsCount"]).to eq(4)
+      expect(grouped_usage["groupedBy"]).to eq({"agent_name" => "frodo"})
+    end
+  end
+
+  context "with filters" do
+    let(:cloud_bm_filter) do
+      create(:billable_metric_filter, billable_metric: metric, key: "cloud", values: %w[aws google])
+    end
+
+    let(:aws_filter) do
+      create(:charge_filter, charge:, properties: {amount: "10"})
+    end
+    let(:aws_filter_value) do
+      create(:charge_filter_value, charge_filter: aws_filter, billable_metric_filter: cloud_bm_filter, values: ["aws"])
+    end
+
+    let(:google_filter) do
+      create(:charge_filter, charge:, properties: {amount: "20"})
+    end
+    let(:google_filter_value) do
+      create(
+        :charge_filter_value,
+        charge_filter: google_filter,
+        billable_metric_filter: cloud_bm_filter,
+        values: ["google"]
+      )
+    end
+
+    let(:charge) do
+      create(
+        :standard_charge,
+        plan: subscription.plan,
+        billable_metric: metric,
+        properties: {amount: "0"}
+      )
+    end
+
+    before do
+      aws_filter_value
+      google_filter_value
+
+      create_list(
+        :event,
+        3,
+        organization:,
+        customer:,
+        subscription:,
+        code: metric.code,
+        timestamp: Time.zone.now,
+        properties: {cloud: "aws"}
+      )
+
+      create(
+        :event,
+        organization:,
+        customer:,
+        subscription:,
+        code: metric.code,
+        timestamp: Time.zone.now,
+        properties: {cloud: "google"}
+      )
+    end
+
+    it "returns the filter usage for the customer" do
+      result = execute_graphql(
+        customer_portal_user: customer,
+        query:,
+        variables: {
+          subscriptionId: subscription.id
+        }
+      )
+
+      charge_usage = result["data"]["customerPortalCustomerUsage"]["chargesUsage"][0]
+      filters_usage = charge_usage["filters"]
+
+      aggregate_failures do
+        expect(charge_usage["units"]).to eq(8)
+        expect(charge_usage["amountCents"]).to eq("5000")
+        expect(filters_usage).to contain_exactly(
+          {
+            "id" => nil,
+            "units" => 4,
+            "amountCents" => "0",
+            "invoiceDisplayName" => nil,
+            "values" => {},
+            "eventsCount" => 4
+          },
+          {
+            "id" => aws_filter.id,
+            "units" => 3,
+            "amountCents" => "3000",
+            "invoiceDisplayName" => nil,
+            "values" => {
+              "cloud" => ["aws"]
+            },
+            "eventsCount" => 3
+          },
+          {
+            "id" => google_filter.id,
+            "units" => 1,
+            "amountCents" => "2000",
+            "invoiceDisplayName" => nil,
+            "values" => {
+              "cloud" => ["google"]
+            },
+            "eventsCount" => 1
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -4,7 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
   subject(:usage_service) do
-    described_class.with_ids(membership.user, customer_id:, subscription_id:, apply_taxes:)
+    described_class.with_ids(
+      current_user: membership.user,
+      organization_id: membership.organization_id,
+      customer_id:,
+      subscription_id:,
+      apply_taxes:
+    )
   end
 
   let(:membership) { create(:membership) }


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal](https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal)

## Context

We got feedback that this portal is too limited in terms of features and information. Why?

**1st reason:** the number of information displayed is limited

**2nd reason:** the end user cannot take actions out of it (change info, add payment method)

**3rd reason:** the UI and display is not customizable

## Description

The goal of this PR is to return customer usage from the customer portal.
