### PR TITLE
fix(vat-rates): Update Finnish VAT

### DIFF
--- a/lib/lago_eu_vat/lago_eu_vat/eu_vat_rates.json
+++ b/lib/lago_eu_vat/lago_eu_vat/eu_vat_rates.json
@@ -169,11 +169,11 @@
     ],
     "FI": [
       {
-        "effective_from": "0000-01-01",
+        "effective_from": "2024-09-01",
         "rates": {
           "reduced1": 10,
           "reduced2": 14,
-          "standard": 24
+          "standard": 25.5
         }
       }
     ],


### PR DESCRIPTION
## Description

Update Finnish VAT to the most recent 25.5%