### PR TITLE
fix(payment-provider-code): Fix payment provider code change

### DIFF
--- a/app/models/payment_provider_customers/adyen_customer.rb
+++ b/app/models/payment_provider_customers/adyen_customer.rb
@@ -11,6 +11,7 @@ end
 # Table name: payment_provider_customers
 #
 #  id                   :uuid             not null, primary key
+#  deleted_at           :datetime
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null
@@ -21,7 +22,7 @@ end
 #
 # Indexes
 #
-#  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
+#  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE WHERE (deleted_at IS NULL)
 #  index_payment_provider_customers_on_payment_provider_id   (payment_provider_id)
 #  index_payment_provider_customers_on_provider_customer_id  (provider_customer_id)
 #

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -4,6 +4,9 @@ module PaymentProviderCustomers
   class BaseCustomer < ApplicationRecord
     include PaperTrailTraceable
     include SettingsStorable
+    include Discard::Model
+    self.discard_column = :deleted_at
+    default_scope -> { kept }
 
     self.table_name = 'payment_provider_customers'
 
@@ -13,7 +16,7 @@ module PaymentProviderCustomers
     has_many :payments
     has_many :refunds, foreign_key: :payment_provider_customer_id
 
-    validates :customer_id, uniqueness: {scope: :type}
+    validates :customer_id, uniqueness: {conditions: -> { where(deleted_at: nil) }, scope: :type}
 
     settings_accessors :provider_mandate_id, :sync_with_provider
 
@@ -28,6 +31,7 @@ end
 # Table name: payment_provider_customers
 #
 #  id                   :uuid             not null, primary key
+#  deleted_at           :datetime
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null
@@ -38,7 +42,7 @@ end
 #
 # Indexes
 #
-#  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
+#  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE WHERE (deleted_at IS NULL)
 #  index_payment_provider_customers_on_payment_provider_id   (payment_provider_id)
 #  index_payment_provider_customers_on_provider_customer_id  (provider_customer_id)
 #

--- a/app/models/payment_provider_customers/gocardless_customer.rb
+++ b/app/models/payment_provider_customers/gocardless_customer.rb
@@ -10,6 +10,7 @@ end
 # Table name: payment_provider_customers
 #
 #  id                   :uuid             not null, primary key
+#  deleted_at           :datetime
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null
@@ -20,7 +21,7 @@ end
 #
 # Indexes
 #
-#  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
+#  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE WHERE (deleted_at IS NULL)
 #  index_payment_provider_customers_on_payment_provider_id   (payment_provider_id)
 #  index_payment_provider_customers_on_provider_customer_id  (provider_customer_id)
 #

--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -39,6 +39,7 @@ end
 # Table name: payment_provider_customers
 #
 #  id                   :uuid             not null, primary key
+#  deleted_at           :datetime
 #  settings             :jsonb            not null
 #  type                 :string           not null
 #  created_at           :datetime         not null
@@ -49,7 +50,7 @@ end
 #
 # Indexes
 #
-#  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
+#  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE WHERE (deleted_at IS NULL)
 #  index_payment_provider_customers_on_payment_provider_id   (payment_provider_id)
 #  index_payment_provider_customers_on_provider_customer_id  (provider_customer_id)
 #

--- a/app/models/payment_providers/adyen_provider.rb
+++ b/app/models/payment_providers/adyen_provider.rb
@@ -26,6 +26,7 @@ end
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null
+#  deleted_at      :datetime
 #  name            :string           not null
 #  secrets         :string
 #  settings        :jsonb            not null
@@ -36,7 +37,7 @@ end
 #
 # Indexes
 #
-#  index_payment_providers_on_code_and_organization_id  (code,organization_id) UNIQUE
+#  index_payment_providers_on_code_and_organization_id  (code,organization_id) UNIQUE WHERE (deleted_at IS NULL)
 #  index_payment_providers_on_organization_id           (organization_id)
 #
 # Foreign Keys

--- a/app/models/payment_providers/base_provider.rb
+++ b/app/models/payment_providers/base_provider.rb
@@ -5,6 +5,9 @@ module PaymentProviders
     include PaperTrailTraceable
     include SecretsStorable
     include SettingsStorable
+    include Discard::Model
+    self.discard_column = :deleted_at
+    default_scope -> { kept }
 
     self.table_name = 'payment_providers'
 
@@ -32,6 +35,7 @@ end
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null
+#  deleted_at      :datetime
 #  name            :string           not null
 #  secrets         :string
 #  settings        :jsonb            not null
@@ -42,7 +46,7 @@ end
 #
 # Indexes
 #
-#  index_payment_providers_on_code_and_organization_id  (code,organization_id) UNIQUE
+#  index_payment_providers_on_code_and_organization_id  (code,organization_id) UNIQUE WHERE (deleted_at IS NULL)
 #  index_payment_providers_on_organization_id           (organization_id)
 #
 # Foreign Keys

--- a/app/models/payment_providers/base_provider.rb
+++ b/app/models/payment_providers/base_provider.rb
@@ -15,6 +15,7 @@ module PaymentProviders
       class_name: 'PaymentProviderCustomers::BaseCustomer',
       foreign_key: :payment_provider_id
 
+    has_many :customers, through: :payment_provider_customers
     has_many :payments, dependent: :nullify, foreign_key: :payment_provider_id
     has_many :refunds, dependent: :nullify, foreign_key: :payment_provider_id
 

--- a/app/models/payment_providers/gocardless_provider.rb
+++ b/app/models/payment_providers/gocardless_provider.rb
@@ -33,6 +33,7 @@ end
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null
+#  deleted_at      :datetime
 #  name            :string           not null
 #  secrets         :string
 #  settings        :jsonb            not null
@@ -43,7 +44,7 @@ end
 #
 # Indexes
 #
-#  index_payment_providers_on_code_and_organization_id  (code,organization_id) UNIQUE
+#  index_payment_providers_on_code_and_organization_id  (code,organization_id) UNIQUE WHERE (deleted_at IS NULL)
 #  index_payment_providers_on_organization_id           (organization_id)
 #
 # Foreign Keys

--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -30,6 +30,7 @@ end
 #
 #  id              :uuid             not null, primary key
 #  code            :string           not null
+#  deleted_at      :datetime
 #  name            :string           not null
 #  secrets         :string
 #  settings        :jsonb            not null
@@ -40,7 +41,7 @@ end
 #
 # Indexes
 #
-#  index_payment_providers_on_code_and_organization_id  (code,organization_id) UNIQUE
+#  index_payment_providers_on_code_and_organization_id  (code,organization_id) UNIQUE WHERE (deleted_at IS NULL)
 #  index_payment_providers_on_organization_id           (organization_id)
 #
 # Foreign Keys

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -96,7 +96,7 @@ module Customers
 
       ActiveRecord::Base.transaction do
         if old_provider_customer && args[:payment_provider].nil? && args[:payment_provider_code].present?
-          old_provider_customer.destroy!
+          old_provider_customer.discard!
           customer.payment_provider_code = nil
         end
 

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -29,7 +29,7 @@ module PaymentProviderCustomers
     end
 
     def update
-      return result unless stripe_payment_provider
+      return result if !stripe_payment_provider || stripe_customer.provider_customer_id.blank?
 
       Stripe::Customer.update(stripe_customer.provider_customer_id, stripe_update_payload, {api_key:})
       result
@@ -176,7 +176,7 @@ module PaymentProviderCustomers
         stripe_create_payload,
         {
           api_key:,
-          idempotency_key: customer.id
+          idempotency_key: [customer.id, customer.updated_at.to_i].join('-')
         }
       )
     rescue Stripe::InvalidRequestError, Stripe::PermissionError => e

--- a/app/services/payment_providers/adyen_service.rb
+++ b/app/services/payment_providers/adyen_service.rb
@@ -38,15 +38,6 @@ module PaymentProviders
       adyen_provider.success_redirect_url = args[:success_redirect_url] if args.key?(:success_redirect_url)
       adyen_provider.save!
 
-      # if api_key != adyen_provider.api_key
-      #   # NOTE: ensure existing payment_provider_customers are
-      #   #       attached to the provider
-      #   reattach_provider_customers(
-      #     organization_id: args[:organization_id],
-      #     adyen_provider:
-      #   )
-      # end
-
       if payment_provider_code_changed?(adyen_provider, old_code, args)
         adyen_provider.customers.update_all(payment_provider_code: args[:code]) # rubocop:disable Rails/SkipsModelValidations
       end
@@ -131,14 +122,6 @@ module PaymentProviders
         result.raise_if_error!
       end
     end
-
-    # def reattach_provider_customers(organization_id:, adyen_provider:)
-    #   PaymentProviderCustomers::AdyenCustomer
-    #     .joins(:customer)
-    #     .where(payment_provider_id: nil, customers: {organization_id:}).find_each do |c|
-    #       c.update(payment_provider_id: adyen_provider.id)
-    #     end
-    # end
 
     private
 

--- a/app/services/payment_providers/adyen_service.rb
+++ b/app/services/payment_providers/adyen_service.rb
@@ -26,7 +26,7 @@ module PaymentProviders
         )
       end
 
-      api_key = adyen_provider.api_key
+      # api_key = adyen_provider.api_key
       old_code = adyen_provider.code
 
       adyen_provider.api_key = args[:api_key] if args.key?(:api_key)
@@ -38,14 +38,14 @@ module PaymentProviders
       adyen_provider.success_redirect_url = args[:success_redirect_url] if args.key?(:success_redirect_url)
       adyen_provider.save!
 
-      if api_key != adyen_provider.api_key
-        # NOTE: ensure existing payment_provider_customers are
-        #       attached to the provider
-        reattach_provider_customers(
-          organization_id: args[:organization_id],
-          adyen_provider:
-        )
-      end
+      # if api_key != adyen_provider.api_key
+      #   # NOTE: ensure existing payment_provider_customers are
+      #   #       attached to the provider
+      #   reattach_provider_customers(
+      #     organization_id: args[:organization_id],
+      #     adyen_provider:
+      #   )
+      # end
 
       if payment_provider_code_changed?(adyen_provider, old_code, args)
         adyen_provider.customers.update_all(payment_provider_code: args[:code]) # rubocop:disable Rails/SkipsModelValidations
@@ -132,13 +132,13 @@ module PaymentProviders
       end
     end
 
-    def reattach_provider_customers(organization_id:, adyen_provider:)
-      PaymentProviderCustomers::AdyenCustomer
-        .joins(:customer)
-        .where(payment_provider_id: nil, customers: {organization_id:}).find_each do |c|
-          c.update(payment_provider_id: adyen_provider.id)
-        end
-    end
+    # def reattach_provider_customers(organization_id:, adyen_provider:)
+    #   PaymentProviderCustomers::AdyenCustomer
+    #     .joins(:customer)
+    #     .where(payment_provider_id: nil, customers: {organization_id:}).find_each do |c|
+    #       c.update(payment_provider_id: adyen_provider.id)
+    #     end
+    # end
 
     private
 

--- a/app/services/payment_providers/adyen_service.rb
+++ b/app/services/payment_providers/adyen_service.rb
@@ -27,6 +27,7 @@ module PaymentProviders
       end
 
       api_key = adyen_provider.api_key
+      old_code = adyen_provider.code
 
       adyen_provider.api_key = args[:api_key] if args.key?(:api_key)
       adyen_provider.code = args[:code] if args.key?(:code)
@@ -44,6 +45,10 @@ module PaymentProviders
           organization_id: args[:organization_id],
           adyen_provider:
         )
+      end
+
+      if payment_provider_code_changed?(adyen_provider, old_code, args)
+        adyen_provider.customers.update_all(payment_provider_code: args[:code]) # rubocop:disable Rails/SkipsModelValidations
       end
 
       result.adyen_provider = adyen_provider

--- a/app/services/payment_providers/base_service.rb
+++ b/app/services/payment_providers/base_service.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  class BaseService < BaseService
+    private
+
+    def payment_provider_code_changed?(payment_provider, old_code, args)
+      payment_provider.persisted? && args.key?(:code) && old_code != args[:code]
+    end
+  end
+end

--- a/app/services/payment_providers/destroy_service.rb
+++ b/app/services/payment_providers/destroy_service.rb
@@ -9,7 +9,12 @@ module PaymentProviders
       )
       return result.not_found_failure!(resource: 'payment_provider') unless payment_provider
 
-      payment_provider.destroy!
+      customer_ids = payment_provider.customer_ids
+
+      payment_provider.payment_provider_customers.update_all(payment_provider_id: nil) # rubocop:disable Rails/SkipsModelValidations
+      payment_provider.discard!
+
+      Customer.where(id: customer_ids).update_all(payment_provider: nil, payment_provider_code: nil) # rubocop:disable Rails/SkipsModelValidations
 
       result.payment_provider = payment_provider
       result

--- a/app/services/payment_providers/destroy_service.rb
+++ b/app/services/payment_providers/destroy_service.rb
@@ -11,10 +11,12 @@ module PaymentProviders
 
       customer_ids = payment_provider.customer_ids
 
-      payment_provider.payment_provider_customers.update_all(payment_provider_id: nil) # rubocop:disable Rails/SkipsModelValidations
-      payment_provider.discard!
+      ActiveRecord::Base.transaction do
+        payment_provider.payment_provider_customers.update_all(payment_provider_id: nil) # rubocop:disable Rails/SkipsModelValidations
+        payment_provider.discard!
 
-      Customer.where(id: customer_ids).update_all(payment_provider: nil, payment_provider_code: nil) # rubocop:disable Rails/SkipsModelValidations
+        Customer.where(id: customer_ids).update_all(payment_provider: nil, payment_provider_code: nil) # rubocop:disable Rails/SkipsModelValidations
+      end
 
       result.payment_provider = payment_provider
       result

--- a/app/services/payment_providers/gocardless_service.rb
+++ b/app/services/payment_providers/gocardless_service.rb
@@ -32,12 +32,18 @@ module PaymentProviders
         )
       end
 
+      old_code = gocardless_provider.code
+
       gocardless_provider.access_token = access_token if access_token
       gocardless_provider.webhook_secret = SecureRandom.alphanumeric(50) if gocardless_provider.webhook_secret.blank?
       gocardless_provider.success_redirect_url = args[:success_redirect_url] if args.key?(:success_redirect_url)
       gocardless_provider.code = args[:code] if args.key?(:code)
       gocardless_provider.name = args[:name] if args.key?(:name)
       gocardless_provider.save!
+
+      if payment_provider_code_changed?(gocardless_provider, old_code, args)
+        gocardless_provider.customers.update_all(payment_provider_code: args[:code]) # rubocop:disable Rails/SkipsModelValidations
+      end
 
       result.gocardless_provider = gocardless_provider
       result

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -37,13 +37,6 @@ module PaymentProviders
         unregister_webhook(stripe_provider, secret_key)
 
         PaymentProviders::Stripe::RegisterWebhookJob.perform_later(stripe_provider)
-
-        # NOTE: ensure existing payment_provider_customers are
-        #       attached to the provider
-        # reattach_provider_customers(
-        #   organization_id: args[:organization_id],
-        #   stripe_provider:
-        # )
       end
 
       if payment_provider_code_changed?(stripe_provider, old_code, args)
@@ -193,13 +186,6 @@ module PaymentProviders
 
       Sentry.capture_exception(e)
     end
-
-    # def reattach_provider_customers(organization_id:, stripe_provider:)
-    #   PaymentProviderCustomers::StripeCustomer
-    #     .joins(:customer)
-    #     .where(payment_provider_id: nil, customers: {organization_id:})
-    #     .update_all(payment_provider_id: stripe_provider.id) # rubocop:disable Rails/SkipsModelValidations
-    # end
 
     def payment_service_klass(event)
       payable_type = event.data.object.metadata.to_h[:lago_payable_type] || "Invoice"

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -25,6 +25,7 @@ module PaymentProviders
       end
 
       secret_key = stripe_provider.secret_key
+      old_code = stripe_provider.code
 
       stripe_provider.secret_key = args[:secret_key] if args.key?(:secret_key)
       stripe_provider.code = args[:code] if args.key?(:code)
@@ -43,6 +44,10 @@ module PaymentProviders
           organization_id: args[:organization_id],
           stripe_provider:
         )
+      end
+
+      if payment_provider_code_changed?(stripe_provider, old_code, args)
+        stripe_provider.customers.update_all(payment_provider_code: args[:code]) # rubocop:disable Rails/SkipsModelValidations
       end
 
       result.stripe_provider = stripe_provider

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -40,10 +40,10 @@ module PaymentProviders
 
         # NOTE: ensure existing payment_provider_customers are
         #       attached to the provider
-        reattach_provider_customers(
-          organization_id: args[:organization_id],
-          stripe_provider:
-        )
+        # reattach_provider_customers(
+        #   organization_id: args[:organization_id],
+        #   stripe_provider:
+        # )
       end
 
       if payment_provider_code_changed?(stripe_provider, old_code, args)
@@ -194,12 +194,12 @@ module PaymentProviders
       Sentry.capture_exception(e)
     end
 
-    def reattach_provider_customers(organization_id:, stripe_provider:)
-      PaymentProviderCustomers::StripeCustomer
-        .joins(:customer)
-        .where(payment_provider_id: nil, customers: {organization_id:})
-        .update_all(payment_provider_id: stripe_provider.id) # rubocop:disable Rails/SkipsModelValidations
-    end
+    # def reattach_provider_customers(organization_id:, stripe_provider:)
+    #   PaymentProviderCustomers::StripeCustomer
+    #     .joins(:customer)
+    #     .where(payment_provider_id: nil, customers: {organization_id:})
+    #     .update_all(payment_provider_id: stripe_provider.id) # rubocop:disable Rails/SkipsModelValidations
+    # end
 
     def payment_service_klass(event)
       payable_type = event.data.object.metadata.to_h[:lago_payable_type] || "Invoice"

--- a/db/migrate/20230202110407_add_index_to_payment_provider_customers.rb
+++ b/db/migrate/20230202110407_add_index_to_payment_provider_customers.rb
@@ -5,12 +5,12 @@ class AddIndexToPaymentProviderCustomers < ActiveRecord::Migration[7.0]
     reversible do |dir|
       dir.up do
         # Remove duplicated customers before adding new index
-        payment_customers = PaymentProviderCustomers::BaseCustomer.group(:customer_id, :type)
+        payment_customers = PaymentProviderCustomers::BaseCustomer.unscoped.group(:customer_id, :type)
           .having('COUNT(id) > 1')
           .select('COUNT(id) AS customer_count, customer_id, type')
 
         payment_customers.each do |payment_customer|
-          customers = PaymentProviderCustomers::BaseCustomer.where(
+          customers = PaymentProviderCustomers::BaseCustomer.unscoped.where(
             customer_id: payment_customer.customer_id,
             type: payment_customer.type
           ).order('payment_provider_id ASC NULLS LAST, updated_at desc')

--- a/db/migrate/20241001105523_add_deleted_at_to_payment_providers.rb
+++ b/db/migrate/20241001105523_add_deleted_at_to_payment_providers.rb
@@ -4,19 +4,14 @@ class AddDeletedAtToPaymentProviders < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def up
-    safety_assured do
-      add_column :payment_providers, :deleted_at, :datetime
-
-      remove_index :payment_providers, %i[code organization_id]
-      add_index :payment_providers, %i[code organization_id], unique: true, where: 'deleted_at IS NULL'
-    end
+    add_column :payment_providers, :deleted_at, :datetime
+    remove_index :payment_providers, %i[code organization_id]
+    add_index :payment_providers, %i[code organization_id], unique: true, where: 'deleted_at IS NULL', algorithm: :concurrently
   end
 
   def down
-    safety_assured do
-      remove_column :payment_providers, :deleted_at
-      remove_index :payment_providers, %i[code organization_id]
-      add_index :payment_providers, %i[code organization_id], unique: true
-    end
+    remove_column :payment_providers, :deleted_at
+    remove_index :payment_providers, %i[code organization_id]
+    add_index :payment_providers, %i[code organization_id], unique: true, algorithm: :concurrently
   end
 end

--- a/db/migrate/20241001105523_add_deleted_at_to_payment_providers.rb
+++ b/db/migrate/20241001105523_add_deleted_at_to_payment_providers.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToPaymentProviders < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      add_column :payment_providers, :deleted_at, :datetime
+
+      remove_index :payment_providers, %i[code organization_id]
+      add_index :payment_providers, %i[code organization_id], unique: true, where: 'deleted_at IS NULL'
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_column :payment_providers, :deleted_at
+      remove_index :payment_providers, %i[code organization_id]
+      add_index :payment_providers, %i[code organization_id], unique: true
+    end
+  end
+end

--- a/db/migrate/20241001112117_add_deleted_at_to_payment_provider_customers.rb
+++ b/db/migrate/20241001112117_add_deleted_at_to_payment_provider_customers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToPaymentProviderCustomers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      add_column :payment_provider_customers, :deleted_at, :datetime
+
+      remove_index :payment_provider_customers, %i[customer_id type]
+      add_index :payment_provider_customers, %i[customer_id type], unique: true, where: 'deleted_at IS NULL'
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_column :payment_provider_customers, :deleted_at
+      add_index :payment_provider_customers, %i[customer_id type], unique: true
+    end
+  end
+end

--- a/db/migrate/20241001112117_add_deleted_at_to_payment_provider_customers.rb
+++ b/db/migrate/20241001112117_add_deleted_at_to_payment_provider_customers.rb
@@ -4,18 +4,13 @@ class AddDeletedAtToPaymentProviderCustomers < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def up
-    safety_assured do
-      add_column :payment_provider_customers, :deleted_at, :datetime
-
-      remove_index :payment_provider_customers, %i[customer_id type]
-      add_index :payment_provider_customers, %i[customer_id type], unique: true, where: 'deleted_at IS NULL'
-    end
+    add_column :payment_provider_customers, :deleted_at, :datetime
+    remove_index :payment_provider_customers, %i[customer_id type]
+    add_index :payment_provider_customers, %i[customer_id type], unique: true, where: 'deleted_at IS NULL', algorithm: :concurrently
   end
 
   def down
-    safety_assured do
-      remove_column :payment_provider_customers, :deleted_at
-      add_index :payment_provider_customers, %i[customer_id type], unique: true
-    end
+    remove_column :payment_provider_customers, :deleted_at
+    add_index :payment_provider_customers, %i[customer_id type], unique: true, algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_24_114730) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_01_112117) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -903,7 +903,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_24_114730) do
     t.jsonb "settings", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["customer_id", "type"], name: "index_payment_provider_customers_on_customer_id_and_type", unique: true
+    t.datetime "deleted_at"
+    t.index ["customer_id", "type"], name: "index_payment_provider_customers_on_customer_id_and_type", unique: true, where: "(deleted_at IS NULL)"
     t.index ["payment_provider_id"], name: "index_payment_provider_customers_on_payment_provider_id"
     t.index ["provider_customer_id"], name: "index_payment_provider_customers_on_provider_customer_id"
   end
@@ -917,7 +918,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_24_114730) do
     t.datetime "updated_at", null: false
     t.string "code", null: false
     t.string "name", null: false
-    t.index ["code", "organization_id"], name: "index_payment_providers_on_code_and_organization_id", unique: true
+    t.datetime "deleted_at"
+    t.index ["code", "organization_id"], name: "index_payment_providers_on_code_and_organization_id", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_payment_providers_on_organization_id"
   end
 

--- a/lib/tasks/stripe.rake
+++ b/lib/tasks/stripe.rake
@@ -3,7 +3,7 @@
 namespace :stripe do
   desc 'Refresh stripe webhooks to add or remove an event type'
   task refresh_registered_webhooks: :environment do
-    PaymentProviders::StripeProvider.find_each do |stripe_provider|
+    PaymentProviders::StripeProvider.unscoped.find_each do |stripe_provider|
       next unless stripe_provider.secret_key
 
       PaymentProviders::Stripe::RefreshWebhookJob.perform_later(stripe_provider)

--- a/spec/models/payment_providers/base_provider_spec.rb
+++ b/spec/models/payment_providers/base_provider_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe PaymentProviders::BaseProvider, type: :model do
     {secrets: secrets.to_json}
   end
 
+  it { is_expected.to have_many(:payment_provider_customers).dependent(:nullify) }
+  it { is_expected.to have_many(:customers).through(:payment_provider_customers) }
+  it { is_expected.to have_many(:payments).dependent(:nullify) }
+  it { is_expected.to have_many(:refunds).dependent(:nullify) }
+
   describe '.json_secrets' do
     it { expect(provider.secrets_json).to eq(secrets) }
   end

--- a/spec/services/payment_providers/adyen_service_spec.rb
+++ b/spec/services/payment_providers/adyen_service_spec.rb
@@ -20,6 +20,39 @@ RSpec.describe PaymentProviders::AdyenService, type: :service do
       end.to change(PaymentProviders::AdyenProvider, :count).by(1)
     end
 
+    context 'when code was changed' do
+      let(:new_code) { 'updated_code_1' }
+      let(:adyen_customer) { create(:adyen_customer, payment_provider:, customer:) }
+      let(:customer) { create(:customer, organization:) }
+
+      let(:payment_provider) do
+        create(
+          :adyen_provider,
+          organization:,
+          code:,
+          name:,
+          api_key: 'secret'
+        )
+      end
+
+      before { adyen_customer }
+
+      it 'updates payment provider codes of all customers' do
+        result = adyen_service.create_or_update(
+          id: payment_provider.id,
+          organization:,
+          code: new_code,
+          name:,
+          api_key: 'secret'
+        )
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.adyen_provider.customers.first.payment_provider_code).to eq(new_code)
+        end
+      end
+    end
+
     context 'when organization already has an adyen provider' do
       let(:adyen_provider) do
         create(:adyen_provider, organization:, api_key: 'api_key_789', code:)

--- a/spec/services/payment_providers/gocardless_service_spec.rb
+++ b/spec/services/payment_providers/gocardless_service_spec.rb
@@ -40,6 +40,39 @@ RSpec.describe PaymentProviders::GocardlessService, type: :service do
       end.to change(PaymentProviders::GocardlessProvider, :count).by(1)
     end
 
+    context 'when code was changed' do
+      let(:new_code) { 'updated_code_3' }
+      let(:gocardless_customer) { create(:gocardless_customer, payment_provider:, customer:) }
+      let(:customer) { create(:customer, organization:) }
+
+      let(:payment_provider) do
+        create(
+          :gocardless_provider,
+          organization:,
+          code:,
+          name:,
+          access_token: 'secret'
+        )
+      end
+
+      before { gocardless_customer }
+
+      it 'updates payment provider codes of all customers' do
+        result = gocardless_service.create_or_update(
+          id: payment_provider.id,
+          organization:,
+          code: new_code,
+          name:,
+          access_token: 'secret'
+        )
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.gocardless_provider.customers.first.payment_provider_code).to eq(new_code)
+        end
+      end
+    end
+
     context 'when organization already have a gocardless provider' do
       let(:gocardless_provider) do
         create(:gocardless_provider, organization:, access_token: 'access_token_123', code:)

--- a/spec/services/payment_providers/stripe_service_spec.rb
+++ b/spec/services/payment_providers/stripe_service_spec.rb
@@ -30,6 +30,39 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
       end.to change(PaymentProviders::StripeProvider, :count).by(1)
     end
 
+    context 'when code was changed' do
+      let(:new_code) { 'updated_code_2' }
+      let(:stripe_customer) { create(:stripe_customer, payment_provider:, customer:) }
+      let(:customer) { create(:customer, organization:) }
+
+      let(:payment_provider) do
+        create(
+          :stripe_provider,
+          organization:,
+          code:,
+          name:,
+          secret_key: 'secret'
+        )
+      end
+
+      before { stripe_customer }
+
+      it 'updates payment provider codes of all customers' do
+        result = stripe_service.create_or_update(
+          id: payment_provider.id,
+          organization_id: organization.id,
+          code: new_code,
+          name:,
+          secret_key: 'secret'
+        )
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.stripe_provider.customers.first.payment_provider_code).to eq(new_code)
+        end
+      end
+    end
+
     context 'when organization already have a stripe provider' do
       let(:stripe_provider) do
         create(


### PR DESCRIPTION
## Context

### Payment provider integration code update does not reflect on assigned customers

**How to reproduce issue?**

1. Create a payment provider integration (tested with stripe but probably happens with all of them)

2. Assign it to a customer

3. Update the integration code in the settings OR delete the integration

**Expected behaviour**

The payment provider value attached to my customer should wither be updated, if integration's code is updated,  or removed if integration's code have been removed.

## Description

This PR fixes all payment provider services that handle the code update.

It also adds soft-deleting of:
- payment providers
- payment provider customers

So there are also 2 new migrations that add `deleted_at` column and drop and re-create indices because of that.