### PR TITLE
feat(hubspot): Add new attributes to hubspot integration model

### DIFF
--- a/app/jobs/integrations/aggregator/sync_custom_objects_and_properties_job.rb
+++ b/app/jobs/integrations/aggregator/sync_custom_objects_and_properties_job.rb
@@ -6,10 +6,10 @@ module Integrations
       queue_as 'integrations'
 
       def perform(integration:)
-        Integrations::Hubspot::Objects::DeploySubscriptionsJob.perform_later(integration: integration)
-        Integrations::Hubspot::Objects::DeployInvoicesJob.perform_later(integration: integration)
-        Integrations::Hubspot::Properties::DeployCompaniesJob.perform_later(integration: integration)
-        Integrations::Hubspot::Properties::DeployContactsJob.perform_later(integration: integration)
+        Integrations::Hubspot::Objects::DeploySubscriptionsJob.perform_later(integration:)
+        Integrations::Hubspot::Objects::DeployInvoicesJob.perform_later(integration:)
+        Integrations::Hubspot::Properties::DeployCompaniesJob.perform_later(integration:)
+        Integrations::Hubspot::Properties::DeployContactsJob.perform_later(integration:)
       end
     end
   end

--- a/app/jobs/integrations/aggregator/sync_custom_objects_and_properties_job.rb
+++ b/app/jobs/integrations/aggregator/sync_custom_objects_and_properties_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class SyncCustomObjectsAndPropertiesJob < ApplicationJob
+      queue_as 'integrations'
+
+      def perform(integration:)
+        Integrations::Hubspot::Objects::DeploySubscriptionsJob.perform_later(integration: integration)
+        Integrations::Hubspot::Objects::DeployInvoicesJob.perform_later(integration: integration)
+        Integrations::Hubspot::Properties::DeployCompaniesJob.perform_later(integration: integration)
+        Integrations::Hubspot::Properties::DeployContactsJob.perform_later(integration: integration)
+      end
+    end
+  end
+end

--- a/app/jobs/integrations/hubspot/objects/deploy_invoices_job.rb
+++ b/app/jobs/integrations/hubspot/objects/deploy_invoices_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Hubspot
+    module Objects
+      class DeployInvoicesJob < ApplicationJob
+        queue_as 'integrations'
+
+        retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
+        retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 10
+
+        def perform(integration:)
+          result = Integrations::Hubspot::Objects::DeployInvoicesService.call(integration:)
+          result.raise_if_error!
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/integrations/hubspot/objects/deploy_subscriptions_job.rb
+++ b/app/jobs/integrations/hubspot/objects/deploy_subscriptions_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Hubspot
+    module Objects
+      class DeploySubscriptionsJob < ApplicationJob
+        queue_as 'integrations'
+
+        retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
+        retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 10
+
+        def perform(integration:)
+          result = Integrations::Hubspot::Objects::DeploySubscriptionsService.call(integration:)
+          result.raise_if_error!
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/integrations/hubspot/properties/deploy_companies_job.rb
+++ b/app/jobs/integrations/hubspot/properties/deploy_companies_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Hubspot
+    module Properties
+      class DeployCompaniesJob < ApplicationJob
+        queue_as 'integrations'
+
+        retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
+        retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 10
+
+        def perform(integration:)
+          result = Integrations::Hubspot::Properties::DeployCompaniesService.call(integration:)
+          result.raise_if_error!
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/integrations/hubspot/properties/deploy_contacts_job.rb
+++ b/app/jobs/integrations/hubspot/properties/deploy_contacts_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Hubspot
+    module Properties
+      class DeployContactsJob < ApplicationJob
+        queue_as 'integrations'
+
+        retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
+        retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 10
+
+        def perform(integration:)
+          result = Integrations::Hubspot::Properties::DeployContactsService.call(integration:)
+          result.raise_if_error!
+        end
+      end
+    end
+  end
+end

--- a/app/models/integrations/hubspot_integration.rb
+++ b/app/models/integrations/hubspot_integration.rb
@@ -4,10 +4,20 @@ module Integrations
   class HubspotIntegration < BaseIntegration
     validates :connection_id, :private_app_token, :default_targeted_object, presence: true
 
-    settings_accessors :default_targeted_object, :sync_subscriptions, :sync_invoices
+    settings_accessors :default_targeted_object, :sync_subscriptions, :sync_invoices, :subscriptions_object_type_id,
+      :invoices_object_type_id, :companies_properties_version, :contacts_properties_version,
+      :subscriptions_properties_version, :invoices_properties_version
     secrets_accessors :connection_id, :private_app_token
 
-    TARGETED_OBJECTS = %w[Companies Contacts]
+    TARGETED_OBJECTS = %w[companies contacts].freeze
+
+    def companies_object_type_id
+      '0-2'
+    end
+
+    def contacts_object_type_id
+      '0-1'
+    end
   end
 end
 

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -65,6 +65,19 @@ module Integrations
         }
       end
 
+      def deliver_error_webhook(code:, message:)
+        SendWebhookJob.perform_later(
+          'customer.accounting_provider_error',
+          Customer.last,
+          provider:,
+          provider_code: integration.code,
+          provider_error: {
+            message:,
+            error_code: code
+          }
+        )
+      end
+
       def deliver_error_webhook(customer:, code:, message:)
         SendWebhookJob.perform_later(
           'customer.accounting_provider_error',

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -65,7 +65,7 @@ module Integrations
         }
       end
 
-      def deliver_error_webhook(code:, message:)
+      def deliver_integration_error_webhook(code:, message:)
         SendWebhookJob.perform_later(
           'customer.accounting_provider_error',
           Customer.last,

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -66,7 +66,7 @@ module Integrations
       end
 
       def deliver_integration_error_webhook(code:, message:)
-        SendWebhookJob.perform_later(
+        SendWebhookJob.perform_now(
           'customer.accounting_provider_error',
           Customer.last,
           provider:,

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -65,19 +65,6 @@ module Integrations
         }
       end
 
-      def deliver_integration_error_webhook(code:, message:)
-        SendWebhookJob.perform_now(
-          'customer.accounting_provider_error',
-          Customer.last,
-          provider:,
-          provider_code: integration.code,
-          provider_error: {
-            message:,
-            error_code: code
-          }
-        )
-      end
-
       def deliver_error_webhook(customer:, code:, message:)
         SendWebhookJob.perform_later(
           'customer.accounting_provider_error',

--- a/app/services/integrations/hubspot/create_service.rb
+++ b/app/services/integrations/hubspot/create_service.rb
@@ -32,6 +32,7 @@ module Integrations
 
         if integration.type == 'Integrations::HubspotIntegration'
           Integrations::Aggregator::SendPrivateAppTokenJob.perform_later(integration:)
+          Integrations::Aggregator::SyncCustomObjectsAndPropertiesJob.perform_later(integration:)
         end
 
         result.integration = integration

--- a/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
@@ -12,7 +12,7 @@ module Integrations
 
         def call
           return unless integration.type == 'Integrations::HubspotIntegration'
-          return result if integration.invoices_properties_version == VERSION
+          #return result if integration.invoices_properties_version == VERSION
           response = nil
           ActiveRecord::Base.transaction do
             response = http_client.post_with_response(payload, headers)
@@ -24,9 +24,8 @@ module Integrations
         rescue LagoHttpClient::HttpError => e
           code = code(e)
           message = message(e)
+          pp "deu bue erros aqui"
           deliver_integration_error_webhook(code:, message:)
-          return result if e.error_code.to_i < 500
-          raise e
         end
 
         private

--- a/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
@@ -24,7 +24,7 @@ module Integrations
         rescue LagoHttpClient::HttpError => e
           code = code(e)
           message = message(e)
-          deliver_error_webhook(customer:, code:, message:)
+          deliver_error_webhook(code:, message:)
           return result if e.error_code.to_i < 500
           raise e
         end

--- a/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
@@ -24,7 +24,7 @@ module Integrations
         rescue LagoHttpClient::HttpError => e
           code = code(e)
           message = message(e)
-          deliver_error_webhook(code:, message:)
+          deliver_integration_error_webhook(code:, message:)
           return result if e.error_code.to_i < 500
           raise e
         end

--- a/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
@@ -24,7 +24,7 @@ module Integrations
         rescue LagoHttpClient::HttpError => e
           # code = code(e)
           # message = message(e)
-          # deliver_error_webhook(customer:, code:, message:)
+          # deliver_error_webhook(customer: nil, code:, message:)
         end
 
         private

--- a/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
@@ -28,7 +28,7 @@ module Integrations
           return result if e.error_code.to_i < 500
           raise e
         rescue Integrations::Aggregator::BasePayload::Failure => e
-          deliver_error_webhook(customer:, code:, message:)
+          deliver_error_webhook(code: e.code, message: e.code.humanize)
         end
 
         private

--- a/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
@@ -19,6 +19,14 @@ module Integrations
           integration.save!
           result.response = response
           result
+        rescue LagoHttpClient::HttpError => e
+          code = code(e)
+          message = message(e)
+          deliver_error_webhook(customer:, code:, message:)
+          return result if e.error_code.to_i < 500
+          raise e
+        rescue Integrations::Aggregator::BasePayload::Failure => e
+          deliver_error_webhook(customer:, code: e.code, message: e.code.humanize)
         end
 
         private

--- a/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
@@ -28,7 +28,8 @@ module Integrations
         def headers
           {
             'Provider-Config-Key' => 'hubspot',
-            'Authorization' => "Bearer #{secret_key}"
+            'Authorization' => "Bearer #{secret_key}",
+            'Connection-Id' => integration.connection_id
           }
         end
 

--- a/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Hubspot
+    module Objects
+      class DeployInvoicesService < Integrations::Aggregator::BaseService
+        VERSION = 1
+
+        def action_path
+          "v1/hubspot/object"
+        end
+
+        def call
+          return unless integration.type == 'Integrations::HubspotIntegration'
+          return result if integration.invoices_properties_version == VERSION
+
+          response = http_client.post_with_response(payload, headers)
+          if response.success?
+            integration.invoices_properties_version = VERSION
+            integration.save!
+          end
+          result.response = response
+          result
+        end
+
+        private
+
+        def headers
+          {
+            'Provider-Config-Key' => 'hubspot',
+            'Authorization' => "Bearer #{secret_key}"
+          }
+        end
+
+        def payload
+          {
+            name: "LagoInvoices",
+            description: "Invoices issued by Lago billing engine",
+            requiredProperties: [
+              "lago_invoice_id"
+            ],
+            labels: {
+              singular: "LagoInvoice",
+              plural: "LagoInvoices"
+            },
+            primaryDisplayProperty: "lago_invoice_number",
+            secondaryDisplayProperties: %w[lago_invoice_status lago_invoice_id],
+            searchableProperties: %w[lago_invoice_number lago_invoice_id],
+            properties: [
+              {
+                name: "lago_invoice_id",
+                label: "Lago Invoice Id",
+                type: "string",
+                fieldType: "text",
+                hasUniqueValue: true,
+                searchableInGlobalSearch: true
+              },
+              {
+                name: "lago_invoice_number",
+                label: "Lago Invoice Number",
+                type: "string",
+                fieldType: "text",
+                searchableInGlobalSearch: true
+              },
+              {
+                name: "lago_invoice_issuing_date",
+                label: "Lago Invoice Issuing Date",
+                type: "date",
+                fieldType: "date"
+              },
+              {
+                name: "lago_invoice_payment_due_date",
+                label: "Lago Invoice Payment Due Date",
+                type: "date",
+                fieldType: "date"
+              },
+              {
+                name: "lago_invoice_payment_overdue",
+                label: "Lago Invoice Payment Overdue",
+                groupName: "LagoInvoices",
+                type: "bool",
+                fieldType: "booleancheckbox",
+                options: [
+                  {
+                    label: "True",
+                    value: "true"
+                  },
+                  {
+                    label: "False",
+                    value: "false"
+                  }
+                ]
+              },
+              {
+                name: "lago_invoice_type",
+                label: "Lago Invoice Type",
+                type: "string",
+                fieldType: "text"
+              },
+              {
+                name: "lago_invoice_status",
+                label: "Lago Invoice Status",
+                type: "string",
+                fieldType: "text"
+              },
+              {
+                name: "lago_invoice_payment_status",
+                label: "Lago Invoice Payment Status",
+                type: "string",
+                fieldType: "text"
+              },
+              {
+                name: "lago_invoice_currency",
+                label: "Lago Invoice Currency",
+                type: "string",
+                fieldType: "text"
+              },
+              {
+                name: "lago_invoice_total_amount",
+                label: "Lago Invoice Total Amount",
+                type: "number",
+                fieldType: "number"
+              },
+              {
+                name: "lago_invoice_subtotal_excluding_taxes",
+                label: "Lago Invoice Subtotal Excluding Taxes",
+                type: "number",
+                fieldType: "number"
+              },
+              {
+                name: "lago_invoice_file_url",
+                label: "Lago Invoice File URL",
+                type: "string",
+                fieldType: "file"
+              }
+            ],
+            associatedObjects: %w[COMPANY CONTACT]
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
@@ -27,8 +27,6 @@ module Integrations
           deliver_error_webhook(customer:, code:, message:)
           return result if e.error_code.to_i < 500
           raise e
-        rescue Integrations::Aggregator::BasePayload::Failure => e
-          deliver_error_webhook(code: e.code, message: e.code.humanize)
         end
 
         private

--- a/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
@@ -15,10 +15,8 @@ module Integrations
           return result if integration.invoices_properties_version == VERSION
 
           response = http_client.post_with_response(payload, headers)
-          if response.success?
-            integration.invoices_properties_version = VERSION
-            integration.save!
-          end
+          integration.invoices_properties_version = VERSION
+          integration.save!
           result.response = response
           result
         end

--- a/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_invoices_service.rb
@@ -12,7 +12,7 @@ module Integrations
 
         def call
           return unless integration.type == 'Integrations::HubspotIntegration'
-          #return result if integration.invoices_properties_version == VERSION
+          return result if integration.invoices_properties_version == VERSION
           response = nil
           ActiveRecord::Base.transaction do
             response = http_client.post_with_response(payload, headers)
@@ -22,10 +22,9 @@ module Integrations
           result.response = response
           result
         rescue LagoHttpClient::HttpError => e
-          code = code(e)
-          message = message(e)
-          pp "deu bue erros aqui"
-          deliver_integration_error_webhook(code:, message:)
+          # code = code(e)
+          # message = message(e)
+          # deliver_error_webhook(customer:, code:, message:)
         end
 
         private

--- a/app/services/integrations/hubspot/objects/deploy_subscriptions_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_subscriptions_service.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Hubspot
+    module Objects
+      class DeploySubscriptionsService < Integrations::Aggregator::BaseService
+        VERSION = 1
+
+        def action_path
+          "v1/hubspot/object"
+        end
+
+        def call
+          return unless integration.type == 'Integrations::HubspotIntegration'
+          return result if integration.subscriptions_properties_version == VERSION
+
+          response = http_client.post_with_response(payload, headers)
+          if response.success?
+            integration.subscriptions_properties_version = VERSION
+            integration.save!
+          end
+          result.response = response
+          result
+        end
+
+        private
+
+        def headers
+          {
+            'Provider-Config-Key' => 'hubspot',
+            'Authorization' => "Bearer #{secret_key}"
+          }
+        end
+
+        def payload
+          {
+            secondaryDisplayProperties: [
+              "lago_external_subscription_id"
+            ],
+            requiredProperties: [
+              "lago_subscription_id"
+            ],
+            searchableProperties: %w[lago_subscription_id lago_external_subscription_id],
+            name: "LagoSubscriptions",
+            associatedObjects: %w[COMPANY CONTACT],
+            properties: [
+              {
+                name: "lago_subscription_id",
+                label: "Lago Subscription Id",
+                type: "string",
+                fieldType: "text",
+                hasUniqueValue: true,
+                searchableInGlobalSearch: true
+              },
+              {
+                name: "lago_external_subscription_id",
+                label: "Lago External Subscription Id",
+                type: "string",
+                fieldType: "text",
+                searchableInGlobalSearch: true
+              },
+              {
+                name: "lago_subscription_name",
+                label: "Lago Subscription Name",
+                type: "string",
+                fieldType: "text"
+              },
+              {
+                name: "lago_subscription_plan_code",
+                label: "Lago Subscription Plan Code",
+                type: "string",
+                fieldType: "text"
+              },
+              {
+                name: "lago_subscription_status",
+                label: "Lago Subscription Status",
+                type: "string",
+                fieldType: "text"
+              },
+              {
+                name: "lago_subscription_created_at",
+                label: "Lago Subscription Created At",
+                type: "date",
+                fieldType: "date"
+              },
+              {
+                name: "lago_subscription_started_at",
+                label: "Lago Subscription Started At",
+                type: "date",
+                fieldType: "date"
+              },
+              {
+                name: "lago_subscription_ending_at",
+                label: "Lago Subscription Ending At",
+                type: "date",
+                fieldType: "date"
+              },
+              {
+                name: "lago_subscription_at",
+                label: "Lago Subscription At",
+                type: "date",
+                fieldType: "date"
+              },
+              {
+                name: "lago_subscription_terminated_at",
+                label: "Lago Subscription Terminated At",
+                type: "date",
+                fieldType: "date"
+              },
+              {
+                name: "lago_subscription_trial_ended_at",
+                label: "Lago Subscription Trial Ended At",
+                type: "date",
+                fieldType: "date"
+              },
+              {
+                name: "lago_billing_time",
+                label: "Lago Billing Time",
+                type: "enumeration",
+                fieldType: "radio",
+                displayOrder: -1,
+                hasUniqueValue: false,
+                searchableInGlobalSearch: true,
+                formField: true,
+                options: [
+                  {
+                    label: "Calendar",
+                    value: "calendar",
+                    displayOrder: 1
+                  },
+                  {
+                    label: "Anniversary",
+                    value: "anniversary",
+                    displayOrder: 2
+                  }
+                ]
+              }
+            ],
+            labels: {
+              singular: "LagoSubscription",
+              plural: "LagoSubscriptions"
+            },
+            primaryDisplayProperty: "lago_subscription_id",
+            description: "string"
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/integrations/hubspot/objects/deploy_subscriptions_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_subscriptions_service.rb
@@ -28,7 +28,8 @@ module Integrations
         def headers
           {
             'Provider-Config-Key' => 'hubspot',
-            'Authorization' => "Bearer #{secret_key}"
+            'Authorization' => "Bearer #{secret_key}",
+            'Connection-Id' => integration.connection_id
           }
         end
 

--- a/app/services/integrations/hubspot/objects/deploy_subscriptions_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_subscriptions_service.rb
@@ -18,6 +18,8 @@ module Integrations
           if response.success?
             integration.subscriptions_properties_version = VERSION
             integration.save!
+          else
+
           end
           result.response = response
           result

--- a/app/services/integrations/hubspot/objects/deploy_subscriptions_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_subscriptions_service.rb
@@ -18,8 +18,6 @@ module Integrations
           if response.success?
             integration.subscriptions_properties_version = VERSION
             integration.save!
-          else
-
           end
           result.response = response
           result

--- a/app/services/integrations/hubspot/objects/deploy_subscriptions_service.rb
+++ b/app/services/integrations/hubspot/objects/deploy_subscriptions_service.rb
@@ -15,10 +15,8 @@ module Integrations
           return result if integration.subscriptions_properties_version == VERSION
 
           response = http_client.post_with_response(payload, headers)
-          if response.success?
-            integration.subscriptions_properties_version = VERSION
-            integration.save!
-          end
+          integration.subscriptions_properties_version = VERSION
+          integration.save!
           result.response = response
           result
         end

--- a/app/services/integrations/hubspot/properties/deploy_companies_service.rb
+++ b/app/services/integrations/hubspot/properties/deploy_companies_service.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Hubspot
+    module Properties
+      class DeployCompaniesService < Integrations::Aggregator::BaseService
+        VERSION = 1
+
+        def action_path
+          "v1/hubspot/properties"
+        end
+
+        def call
+          return unless integration.type == 'Integrations::HubspotIntegration'
+          return result if integration.companies_properties_version == VERSION
+
+          response = http_client.post_with_response(payload, headers)
+          if response.success?
+            integration.companies_properties_version = VERSION
+            integration.save!
+          end
+          result.response = response
+          result
+        end
+
+        private
+
+        def headers
+          {
+            'Provider-Config-Key' => 'hubspot',
+            'Authorization' => "Bearer #{secret_key}"
+          }
+        end
+
+        def payload
+          {
+            objectType: "companies",
+            inputs: [
+              {
+                groupName: "companyinformation",
+                name: "lago_customer_id",
+                label: "Lago Customer Id",
+                type: "string",
+                fieldType: "text",
+                displayOrder: -1,
+                hasUniqueValue: true,
+                searchableInGlobalSearch: true,
+                formField: true
+              },
+              {
+                groupName: "companyinformation",
+                name: "lago_customer_external_id",
+                label: "Lago Customer External Id",
+                type: "string",
+                fieldType: "text",
+                displayOrder: -1,
+                searchableInGlobalSearch: true,
+                formField: true
+              },
+              {
+                groupName: "companyinformation",
+                name: "lago_billing_email",
+                label: "Lago Billing Email",
+                type: "string",
+                fieldType: "text",
+                searchableInGlobalSearch: true,
+                formField: true
+              },
+              {
+                groupName: "companyinformation",
+                name: "lago_tax_identification_number",
+                label: "Lago Tax Identification Number",
+                type: "string",
+                fieldType: "text",
+                searchableInGlobalSearch: true,
+                formField: true
+              }
+            ]
+          }.freeze
+        end
+      end
+    end
+  end
+end

--- a/app/services/integrations/hubspot/properties/deploy_companies_service.rb
+++ b/app/services/integrations/hubspot/properties/deploy_companies_service.rb
@@ -28,7 +28,8 @@ module Integrations
         def headers
           {
             'Provider-Config-Key' => 'hubspot',
-            'Authorization' => "Bearer #{secret_key}"
+            'Authorization' => "Bearer #{secret_key}",
+            'Connection-Id' => integration.connection_id
           }
         end
 

--- a/app/services/integrations/hubspot/properties/deploy_companies_service.rb
+++ b/app/services/integrations/hubspot/properties/deploy_companies_service.rb
@@ -15,10 +15,8 @@ module Integrations
           return result if integration.companies_properties_version == VERSION
 
           response = http_client.post_with_response(payload, headers)
-          if response.success?
-            integration.companies_properties_version = VERSION
-            integration.save!
-          end
+          integration.companies_properties_version = VERSION
+          integration.save!
           result.response = response
           result
         end

--- a/app/services/integrations/hubspot/properties/deploy_companies_service.rb
+++ b/app/services/integrations/hubspot/properties/deploy_companies_service.rb
@@ -13,12 +13,18 @@ module Integrations
         def call
           return unless integration.type == 'Integrations::HubspotIntegration'
           return result if integration.companies_properties_version == VERSION
-
-          response = http_client.post_with_response(payload, headers)
-          integration.companies_properties_version = VERSION
-          integration.save!
+          response = nil
+          ActiveRecord::Base.transaction do
+            response = http_client.post_with_response(payload, headers)
+            integration.companies_properties_version = VERSION
+            integration.save!
+          end
           result.response = response
           result
+        rescue LagoHttpClient::HttpError => e
+          # code = code(e)
+          # message = message(e)
+          # deliver_error_webhook(customer:, code:, message:)
         end
 
         private

--- a/app/services/integrations/hubspot/properties/deploy_contacts_service.rb
+++ b/app/services/integrations/hubspot/properties/deploy_contacts_service.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Hubspot
+    module Properties
+      class DeployContactsService < Integrations::Aggregator::BaseService
+        VERSION = 1
+
+        def action_path
+          "v1/hubspot/properties"
+        end
+
+        def call
+          return unless integration.type == 'Integrations::HubspotIntegration'
+          return result if integration.contacts_properties_version == VERSION
+
+          response = http_client.post_with_response(payload, headers)
+          if response.success?
+            integration.contacts_properties_version = VERSION
+            integration.save!
+          end
+          result.response = response
+          result
+        end
+
+        private
+
+        def headers
+          {
+            'Provider-Config-Key' => 'hubspot',
+            'Authorization' => "Bearer #{secret_key}"
+          }
+        end
+
+        def payload
+          {
+            objectType: "contacts",
+            inputs: [
+              {
+                groupName: "contactinformation",
+                name: "lago_customer_id",
+                label: "Lago Customer Id",
+                type: "string",
+                fieldType: "text",
+                displayOrder: -1,
+                hasUniqueValue: true,
+                searchableInGlobalSearch: true,
+                formField: true
+              },
+              {
+                groupName: "contactinformation",
+                name: "lago_customer_external_id",
+                label: "Lago Customer External Id",
+                type: "string",
+                fieldType: "text",
+                displayOrder: -1,
+                hasUniqueValue: true,
+                searchableInGlobalSearch: true,
+                formField: true
+              },
+              {
+                groupName: "contactinformation",
+                name: "lago_billing_email",
+                label: "Lago Billing Email",
+                type: "string",
+                fieldType: "text",
+                searchableInGlobalSearch: true,
+                formField: true
+              }
+            ]
+          }.freeze
+        end
+      end
+    end
+  end
+end

--- a/app/services/integrations/hubspot/properties/deploy_contacts_service.rb
+++ b/app/services/integrations/hubspot/properties/deploy_contacts_service.rb
@@ -28,7 +28,8 @@ module Integrations
         def headers
           {
             'Provider-Config-Key' => 'hubspot',
-            'Authorization' => "Bearer #{secret_key}"
+            'Authorization' => "Bearer #{secret_key}",
+            'Connection-Id' => integration.connection_id
           }
         end
 

--- a/app/services/integrations/hubspot/properties/deploy_contacts_service.rb
+++ b/app/services/integrations/hubspot/properties/deploy_contacts_service.rb
@@ -15,10 +15,8 @@ module Integrations
           return result if integration.contacts_properties_version == VERSION
 
           response = http_client.post_with_response(payload, headers)
-          if response.success?
-            integration.contacts_properties_version = VERSION
-            integration.save!
-          end
+          integration.contacts_properties_version = VERSION
+          integration.save!
           result.response = response
           result
         end

--- a/app/services/integrations/hubspot/properties/deploy_contacts_service.rb
+++ b/app/services/integrations/hubspot/properties/deploy_contacts_service.rb
@@ -13,12 +13,18 @@ module Integrations
         def call
           return unless integration.type == 'Integrations::HubspotIntegration'
           return result if integration.contacts_properties_version == VERSION
-
-          response = http_client.post_with_response(payload, headers)
-          integration.contacts_properties_version = VERSION
-          integration.save!
+          response = nil
+          ActiveRecord::Base.transaction do
+            response = http_client.post_with_response(payload, headers)
+            integration.contacts_properties_version = VERSION
+            integration.save!
+          end
           result.response = response
           result
+        rescue LagoHttpClient::HttpError => e
+          # code = code(e)
+          # message = message(e)
+          # deliver_error_webhook(customer:, code:, message:)
         end
 
         private

--- a/app/services/integrations/hubspot/properties/deploy_invoices_service.rb
+++ b/app/services/integrations/hubspot/properties/deploy_invoices_service.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Hubspot
+    module Properties
+      class DeployInvoicesService < Integrations::Aggregator::BaseService
+        VERSION = 1
+
+        def action_path
+          "v1/hubspot/properties"
+        end
+
+        def call
+          return unless integration.type == 'Integrations::HubspotIntegration'
+          return result if integration.invoices_properties_version == VERSION
+          response = nil
+          ActiveRecord::Base.transaction do
+            response = http_client.post_with_response(payload, headers)
+            integration.invoices_properties_version = VERSION
+            integration.save!
+          end
+          result.response = response
+          result
+        rescue LagoHttpClient::HttpError => e
+          # code = code(e)
+          # message = message(e)
+          # deliver_error_webhook(customer:, code:, message:)
+        end
+
+        private
+
+        def headers
+          {
+            'Provider-Config-Key' => 'hubspot',
+            'Authorization' => "Bearer #{secret_key}",
+            'Connection-Id' => integration.connection_id
+          }
+        end
+
+        def payload
+          {
+            objectType: "LagoInvoices",
+            inputs: [
+              {
+                groupName: "lagoinvoices_information",
+                name: "example",
+                label: "example label",
+                type: "string",
+                fieldType: "text"
+              }
+            ]
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/integrations/hubspot/properties/deploy_subscriptions_service.rb
+++ b/app/services/integrations/hubspot/properties/deploy_subscriptions_service.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Hubspot
+    module Properties
+      class DeploySubscriptionsService < Integrations::Aggregator::BaseService
+        VERSION = 1
+
+        def action_path
+          "v1/hubspot/properties"
+        end
+
+        def call
+          return unless integration.type == 'Integrations::HubspotIntegration'
+          return result if integration.subscriptions_properties_version == VERSION
+          response = nil
+          ActiveRecord::Base.transaction do
+            response = http_client.post_with_response(payload, headers)
+            integration.subscriptions_properties_version = VERSION
+            integration.save!
+          end
+          result.response = response
+          result
+        rescue LagoHttpClient::HttpError => e
+          # code = code(e)
+          # message = message(e)
+          # deliver_error_webhook(customer:, code:, message:)
+        end
+
+        private
+
+        def headers
+          {
+            'Provider-Config-Key' => 'hubspot',
+            'Authorization' => "Bearer #{secret_key}",
+            'Connection-Id' => integration.connection_id
+          }
+        end
+
+        def payload
+          {
+            objectType: "LagoSubscriptions",
+            inputs: [
+              {
+                groupName: "lagosubscriptions_information",
+                name: "example",
+                label: "example label",
+                type: "string",
+                fieldType: "text"
+              }
+            ]
+          }
+        end
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -6763,8 +6763,8 @@ type SyncIntegrationInvoicePayload {
 }
 
 enum TargetedObjectsEnum {
-  Companies
-  Contacts
+  companies
+  contacts
 }
 
 type Tax {

--- a/schema.json
+++ b/schema.json
@@ -35002,13 +35002,13 @@
           "inputFields": null,
           "enumValues": [
             {
-              "name": "Companies",
+              "name": "companies",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "Contacts",
+              "name": "contacts",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/factories/integrations.rb
+++ b/spec/factories/integrations.rb
@@ -60,7 +60,17 @@ FactoryBot.define do
     name { 'Hubspot Integration' }
 
     settings do
-      {default_targeted_object: 'Companies', sync_subscriptions: true, sync_invoices: true}
+      {
+        default_targeted_object: 'companies',
+        sync_subscriptions: true,
+        sync_invoices: true,
+        subscriptions_object_type_id: Faker::Number.number(digits: 2),
+        invoices_object_type_id: Faker::Number.number(digits: 2),
+        companies_properties_version: 1,
+        contacts_properties_version: 1,
+        subscriptions_properties_version: 1,
+        invoices_properties_version: 1
+      }
     end
 
     secrets do

--- a/spec/graphql/mutations/integrations/hubspot/create_spec.rb
+++ b/spec/graphql/mutations/integrations/hubspot/create_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Mutations::Integrations::Hubspot::Create, type: :graphql do
           code:,
           name:,
           connectionId: 'this-is-random-uuid',
-          defaultTargetedObject: 'Companies',
+          defaultTargetedObject: 'companies',
           privateAppToken: 'some-private-app-token'
         }
       }

--- a/spec/graphql/types/integrations/hubspot/targeted_objects_enum_spec.rb
+++ b/spec/graphql/types/integrations/hubspot/targeted_objects_enum_spec.rb
@@ -4,6 +4,6 @@ require 'rails_helper'
 
 RSpec.describe Types::Integrations::Hubspot::TargetedObjectsEnum do
   it 'enumerizes the correct values' do
-    expect(described_class.values.keys).to match_array(%w[Companies Contacts])
+    expect(described_class.values.keys).to match_array(%w[companies contacts])
   end
 end

--- a/spec/jobs/integrations/aggregator/sync_custom_objects_and_properties_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/sync_custom_objects_and_properties_job_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe Integrations::Aggregator::SyncCustomObjectsAndPropertiesJob, type
       allow(Integrations::Hubspot::Properties::DeployContactsJob).to receive(:perform_later)
     end
 
-    it 'calls all jobs with the correct integration' do
+    it 'schedules all jobs needed with the current integration' do
       described_class.perform_now(integration: integration)
 
-      expect(Integrations::Hubspot::Objects::DeploySubscriptionsJob).to have_received(:perform_later).with(integration: integration)
-      expect(Integrations::Hubspot::Objects::DeployInvoicesJob).to have_received(:perform_later).with(integration: integration)
-      expect(Integrations::Hubspot::Properties::DeployCompaniesJob).to have_received(:perform_later).with(integration: integration)
-      expect(Integrations::Hubspot::Properties::DeployContactsJob).to have_received(:perform_later).with(integration: integration)
+      expect(Integrations::Hubspot::Objects::DeploySubscriptionsJob).to have_received(:perform_later).with(integration:)
+      expect(Integrations::Hubspot::Objects::DeployInvoicesJob).to have_received(:perform_later).with(integration:)
+      expect(Integrations::Hubspot::Properties::DeployCompaniesJob).to have_received(:perform_later).with(integration:)
+      expect(Integrations::Hubspot::Properties::DeployContactsJob).to have_received(:perform_later).with(integration:)
     end
   end
 end

--- a/spec/jobs/integrations/aggregator/sync_custom_objects_and_properties_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/sync_custom_objects_and_properties_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Integrations::Aggregator::SyncCustomObjectsAndPropertiesJob, type
     end
 
     it 'schedules all jobs needed with the current integration' do
-      described_class.perform_now(integration: integration)
+      sync_job.perform_now(integration: integration)
 
       expect(Integrations::Hubspot::Objects::DeploySubscriptionsJob).to have_received(:perform_later).with(integration:)
       expect(Integrations::Hubspot::Objects::DeployInvoicesJob).to have_received(:perform_later).with(integration:)

--- a/spec/jobs/integrations/aggregator/sync_custom_objects_and_properties_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/sync_custom_objects_and_properties_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::SyncCustomObjectsAndPropertiesJob, type: :job do
+  describe '#perform' do
+    subject(:sync_job) { described_class }
+
+    let(:integration) { create(:hubspot_integration) }
+
+    before do
+      allow(Integrations::Hubspot::Objects::DeploySubscriptionsJob).to receive(:perform_later)
+      allow(Integrations::Hubspot::Objects::DeployInvoicesJob).to receive(:perform_later)
+      allow(Integrations::Hubspot::Properties::DeployCompaniesJob).to receive(:perform_later)
+      allow(Integrations::Hubspot::Properties::DeployContactsJob).to receive(:perform_later)
+    end
+
+    it 'calls all jobs with the correct integration' do
+      described_class.perform_now(integration: integration)
+
+      expect(Integrations::Hubspot::Objects::DeploySubscriptionsJob).to have_received(:perform_later).with(integration: integration)
+      expect(Integrations::Hubspot::Objects::DeployInvoicesJob).to have_received(:perform_later).with(integration: integration)
+      expect(Integrations::Hubspot::Properties::DeployCompaniesJob).to have_received(:perform_later).with(integration: integration)
+      expect(Integrations::Hubspot::Properties::DeployContactsJob).to have_received(:perform_later).with(integration: integration)
+    end
+  end
+end

--- a/spec/jobs/integrations/hubspot/objects/deploy_invoices_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/objects/deploy_invoices_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Hubspot::Objects::DeployInvoicesJob, type: :job do
+  describe '#perform' do
+    subject(:deploy_invoices_job) { described_class }
+
+    let(:deploy_invoices_service) { instance_double(Integrations::Hubspot::Objects::DeployInvoicesService) }
+    let(:integration) { create(:hubspot_integration) }
+    let(:result) { BaseService::Result.new }
+
+    before do
+      allow(Integrations::Hubspot::Objects::DeployInvoicesService).to receive(:new).and_return(deploy_invoices_service)
+      allow(deploy_invoices_service).to receive(:call).and_return(result)
+    end
+
+    it 'calls the DeployInvoicesService to deploy invoices' do
+      described_class.perform_now(integration:)
+
+      expect(Integrations::Hubspot::Objects::DeployInvoicesService).to have_received(:new)
+      expect(deploy_invoices_service).to have_received(:call)
+    end
+  end
+end

--- a/spec/jobs/integrations/hubspot/objects/deploy_invoices_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/objects/deploy_invoices_job_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Integrations::Hubspot::Objects::DeployInvoicesJob, type: :job do
       allow(deploy_invoices_service).to receive(:call).and_return(result)
     end
 
-    it 'calls the DeployInvoicesService to deploy invoices' do
-      described_class.perform_now(integration:)
+    it 'calls the DeployInvoicesService to deploy invoice custom object' do
+      deploy_invoices_job.perform_now(integration:)
 
       expect(Integrations::Hubspot::Objects::DeployInvoicesService).to have_received(:new)
       expect(deploy_invoices_service).to have_received(:call)

--- a/spec/jobs/integrations/hubspot/objects/deploy_subscriptions_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/objects/deploy_subscriptions_job_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Integrations::Hubspot::Objects::DeploySubscriptionsJob, type: :jo
       allow(deploy_subscriptions_service).to receive(:call).and_return(result)
     end
 
-    it 'calls the DeploySubscriptionsService to deploy subscriptions' do
-      described_class.perform_now(integration:)
+    it 'calls the DeploySubscriptionsService to deploy subscription custom object' do
+      deploy_subscriptions_job.perform_now(integration:)
 
       expect(Integrations::Hubspot::Objects::DeploySubscriptionsService).to have_received(:new)
       expect(deploy_subscriptions_service).to have_received(:call)

--- a/spec/jobs/integrations/hubspot/objects/deploy_subscriptions_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/objects/deploy_subscriptions_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Hubspot::Objects::DeploySubscriptionsJob, type: :job do
+  describe '#perform' do
+    subject(:deploy_subscriptions_job) { described_class }
+
+    let(:deploy_subscriptions_service) { instance_double(Integrations::Hubspot::Objects::DeploySubscriptionsService) }
+    let(:integration) { create(:hubspot_integration) }
+    let(:result) { BaseService::Result.new }
+
+    before do
+      allow(Integrations::Hubspot::Objects::DeploySubscriptionsService).to receive(:new).and_return(deploy_subscriptions_service)
+      allow(deploy_subscriptions_service).to receive(:call).and_return(result)
+    end
+
+    it 'calls the DeploySubscriptionsService to deploy subscriptions' do
+      described_class.perform_now(integration:)
+
+      expect(Integrations::Hubspot::Objects::DeploySubscriptionsService).to have_received(:new)
+      expect(deploy_subscriptions_service).to have_received(:call)
+    end
+  end
+end

--- a/spec/jobs/integrations/hubspot/properties/deploy_companies_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/properties/deploy_companies_job_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Integrations::Hubspot::Properties::DeployCompaniesJob, type: :job
       allow(deploy_companies_service).to receive(:call).and_return(result)
     end
 
-    it 'calls the DeployCompaniesService to sync the properties' do
-      described_class.perform_now(integration:)
+    it 'calls the DeployCompaniesService to sync companies custom properties' do
+      deploy_companies_job.perform_now(integration:)
 
       expect(Integrations::Hubspot::Properties::DeployCompaniesService).to have_received(:new)
       expect(deploy_companies_service).to have_received(:call)

--- a/spec/jobs/integrations/hubspot/properties/deploy_companies_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/properties/deploy_companies_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Hubspot::Properties::DeployCompaniesJob, type: :job do
+  describe '#perform' do
+    subject(:deploy_companies_job) { described_class }
+
+    let(:deploy_companies_service) { instance_double(Integrations::Hubspot::Properties::DeployCompaniesService) }
+    let(:integration) { create(:hubspot_integration) }
+    let(:result) { BaseService::Result.new }
+
+    before do
+      allow(Integrations::Hubspot::Properties::DeployCompaniesService).to receive(:new).and_return(deploy_companies_service)
+      allow(deploy_companies_service).to receive(:call).and_return(result)
+    end
+
+    it 'calls the DeployCompaniesService to sync the properties' do
+      described_class.perform_now(integration:)
+
+      expect(Integrations::Hubspot::Properties::DeployCompaniesService).to have_received(:new)
+      expect(deploy_companies_service).to have_received(:call)
+    end
+  end
+end

--- a/spec/jobs/integrations/hubspot/properties/deploy_contacts_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/properties/deploy_contacts_job_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Integrations::Hubspot::Properties::DeployContactsJob, type: :job 
       allow(deploy_contact_service).to receive(:call).and_return(result)
     end
 
-    it 'calls the DeployContactsService to deploy contacts' do
-      described_class.perform_now(integration:)
+    it 'calls the DeployContactsService to sync contacts custom properties' do
+      deploy_contact_job.perform_now(integration:)
 
       expect(Integrations::Hubspot::Properties::DeployContactsService).to have_received(:new)
       expect(deploy_contact_service).to have_received(:call)

--- a/spec/jobs/integrations/hubspot/properties/deploy_contacts_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/properties/deploy_contacts_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Hubspot::Properties::DeployContactsJob, type: :job do
+  describe '#perform' do
+    subject(:deploy_contact_job) { described_class }
+
+    let(:deploy_contact_service) { instance_double(Integrations::Hubspot::Properties::DeployContactsService) }
+    let(:integration) { create(:hubspot_integration) }
+    let(:result) { BaseService::Result.new }
+
+    before do
+      allow(Integrations::Hubspot::Properties::DeployContactsService).to receive(:new).and_return(deploy_contact_service)
+      allow(deploy_contact_service).to receive(:call).and_return(result)
+    end
+
+    it 'calls the DeployContactsService to deploy contacts' do
+      described_class.perform_now(integration:)
+
+      expect(Integrations::Hubspot::Properties::DeployContactsService).to have_received(:new)
+      expect(deploy_contact_service).to have_received(:call)
+    end
+  end
+end

--- a/spec/models/integrations/hubspot_integration_spec.rb
+++ b/spec/models/integrations/hubspot_integration_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Integrations::HubspotIntegration, type: :model do
 
   describe '#default_targeted_object' do
     it 'assigns and retrieve a setting' do
-      hubspot_integration.default_targeted_object = 'Companies'
-      expect(hubspot_integration.default_targeted_object).to eq('Companies')
+      hubspot_integration.default_targeted_object = 'companies'
+      expect(hubspot_integration.default_targeted_object).to eq('companies')
     end
   end
 
@@ -48,6 +48,60 @@ RSpec.describe Integrations::HubspotIntegration, type: :model do
     it 'assigns and retrieve a setting' do
       hubspot_integration.sync_subscriptions = true
       expect(hubspot_integration.sync_subscriptions).to eq(true)
+    end
+  end
+
+  describe '#subscriptions_object_type_id' do
+    it 'assigns and retrieve a setting' do
+      hubspot_integration.subscriptions_object_type_id = '123'
+      expect(hubspot_integration.subscriptions_object_type_id).to eq('123')
+    end
+  end
+
+  describe '#invoices_object_type_id' do
+    it 'assigns and retrieve a setting' do
+      hubspot_integration.invoices_object_type_id = '123'
+      expect(hubspot_integration.invoices_object_type_id).to eq('123')
+    end
+  end
+
+  describe '#companies_properties_version' do
+    it 'assigns and retrieve a setting' do
+      hubspot_integration.companies_properties_version = 5
+      expect(hubspot_integration.companies_properties_version).to eq(5)
+    end
+  end
+
+  describe '#contacts_properties_version' do
+    it 'assigns and retrieve a setting' do
+      hubspot_integration.contacts_properties_version = 6
+      expect(hubspot_integration.contacts_properties_version).to eq(6)
+    end
+  end
+
+  describe '#subscriptions_properties_version' do
+    it 'assigns and retrieve a setting' do
+      hubspot_integration.subscriptions_properties_version = 7
+      expect(hubspot_integration.subscriptions_properties_version).to eq(7)
+    end
+  end
+
+  describe '#invoices_properties_version' do
+    it 'assigns and retrieve a setting' do
+      hubspot_integration.invoices_properties_version = 8
+      expect(hubspot_integration.invoices_properties_version).to eq(8)
+    end
+  end
+
+  describe '#companies_object_type_id' do
+    it 'returns the correct object type id for companies' do
+      expect(hubspot_integration.companies_object_type_id).to eq('0-2')
+    end
+  end
+
+  describe '#contacts_object_type_id' do
+    it 'returns the correct object type id for contacts' do
+      expect(hubspot_integration.contacts_object_type_id).to eq('0-1')
     end
   end
 end

--- a/spec/services/integrations/hubspot/objects/deploy_invoices_service_spec.rb
+++ b/spec/services/integrations/hubspot/objects/deploy_invoices_service_spec.rb
@@ -51,18 +51,5 @@ RSpec.describe Integrations::Hubspot::Objects::DeployInvoicesService do
         end
       end
     end
-
-    context 'when the API call fails' do
-      let(:response) { instance_double('Response', success?: false) }
-
-      it 'does not update the invoices_properties_version' do
-        deploy_invoices_service.call
-
-        aggregate_failures do
-          expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
-          expect(integration.reload.invoices_properties_version).to be_nil
-        end
-      end
-    end
   end
 end

--- a/spec/services/integrations/hubspot/objects/deploy_invoices_service_spec.rb
+++ b/spec/services/integrations/hubspot/objects/deploy_invoices_service_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Hubspot::Objects::DeployInvoicesService do
+  subject(:deploy_invoices_service) { described_class.new(integration:) }
+
+  let(:integration) { create(:hubspot_integration) }
+
+  describe '.call' do
+    let(:http_client) { instance_double(LagoHttpClient::Client) }
+    let(:endpoint) { "https://api.nango.dev/v1/hubspot/object" }
+    let(:response) { instance_double('Response', success?: true) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(endpoint)
+        .and_return(http_client)
+      allow(http_client).to receive(:post_with_response).and_return(response)
+
+      integration.invoices_properties_version = nil
+      integration.save!
+    end
+
+    it 'successfully deploys invoices and updates the invoices_properties_version' do
+      deploy_invoices_service.call
+
+      aggregate_failures do
+        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        expect(http_client).to have_received(:post_with_response) do |payload, headers|
+          expect(payload[:name]).to eq('LagoInvoices')
+          expect(headers['Authorization']).to include('Bearer')
+        end
+        expect(integration.reload.invoices_properties_version).to eq(described_class::VERSION)
+      end
+    end
+
+    context 'when invoices_properties_version is already up-to-date' do
+      before do
+        integration.invoices_properties_version = described_class::VERSION
+        integration.save!
+      end
+
+      it 'does not make an API call and keeps the version unchanged' do
+        deploy_invoices_service.call
+
+        aggregate_failures do
+          expect(LagoHttpClient::Client).not_to have_received(:new)
+          expect(http_client).not_to have_received(:post_with_response)
+          expect(integration.reload.invoices_properties_version).to eq(described_class::VERSION)
+        end
+      end
+    end
+
+    context 'when the API call fails' do
+      let(:response) { instance_double('Response', success?: false) }
+
+      it 'does not update the invoices_properties_version' do
+        deploy_invoices_service.call
+
+        aggregate_failures do
+          expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+          expect(integration.reload.invoices_properties_version).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/integrations/hubspot/objects/deploy_invoices_service_spec.rb
+++ b/spec/services/integrations/hubspot/objects/deploy_invoices_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Integrations::Hubspot::Objects::DeployInvoicesService do
       integration.save!
     end
 
-    it 'successfully deploys invoices and updates the invoices_properties_version' do
+    it 'successfully deploys invoice custom object and updates the invoices_properties_version' do
       deploy_invoices_service.call
 
       aggregate_failures do

--- a/spec/services/integrations/hubspot/objects/deploy_subscriptions_service_spec.rb
+++ b/spec/services/integrations/hubspot/objects/deploy_subscriptions_service_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Hubspot::Objects::DeploySubscriptionsService do
+  subject(:deploy_subscriptions_service) { described_class.new(integration:) }
+
+  let(:integration) { create(:hubspot_integration) }
+
+  describe '.call' do
+    let(:http_client) { instance_double(LagoHttpClient::Client) }
+    let(:endpoint) { "https://api.nango.dev/v1/hubspot/object" }
+    let(:response) { instance_double('Response', success?: true) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(endpoint)
+        .and_return(http_client)
+      allow(http_client).to receive(:post_with_response).and_return(response)
+
+      integration.subscriptions_properties_version = nil
+      integration.save!
+    end
+
+    it 'successfully deploys subscriptions and updates the subscriptions_properties_version' do
+      deploy_subscriptions_service.call
+
+      aggregate_failures do
+        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        expect(http_client).to have_received(:post_with_response) do |payload, headers|
+          expect(payload[:name]).to eq('LagoSubscriptions')
+          expect(headers['Authorization']).to include('Bearer')
+        end
+        expect(integration.reload.subscriptions_properties_version).to eq(described_class::VERSION)
+      end
+    end
+
+    context 'when subscriptions_properties_version is already up-to-date' do
+      before do
+        integration.subscriptions_properties_version = described_class::VERSION
+        integration.save!
+      end
+
+      it 'does not make an API call and keeps the version unchanged' do
+        deploy_subscriptions_service.call
+
+        aggregate_failures do
+          expect(LagoHttpClient::Client).not_to have_received(:new)
+          expect(http_client).not_to have_received(:post_with_response)
+          expect(integration.reload.subscriptions_properties_version).to eq(described_class::VERSION)
+        end
+      end
+    end
+
+    context 'when the API call fails' do
+      let(:response) { instance_double('Response', success?: false) }
+
+      it 'does not update the subscriptions_properties_version' do
+        deploy_subscriptions_service.call
+
+        aggregate_failures do
+          expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+          expect(integration.reload.subscriptions_properties_version).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/integrations/hubspot/objects/deploy_subscriptions_service_spec.rb
+++ b/spec/services/integrations/hubspot/objects/deploy_subscriptions_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Integrations::Hubspot::Objects::DeploySubscriptionsService do
       integration.save!
     end
 
-    it 'successfully deploys subscriptions and updates the subscriptions_properties_version' do
+    it 'successfully deploys subscription custom object and updates the subscriptions_properties_version' do
       deploy_subscriptions_service.call
 
       aggregate_failures do

--- a/spec/services/integrations/hubspot/properties/deploy_companies_service_spec.rb
+++ b/spec/services/integrations/hubspot/properties/deploy_companies_service_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Hubspot::Properties::DeployCompaniesService do
+  subject(:deploy_companies_service) { described_class.new(integration:) }
+
+  let(:integration) { create(:hubspot_integration) }
+
+  describe '.call' do
+    let(:http_client) { instance_double(LagoHttpClient::Client) }
+    let(:endpoint) { "https://api.nango.dev/v1/hubspot/properties" }
+    let(:response) { instance_double('Response', success?: true) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(endpoint)
+        .and_return(http_client)
+      allow(http_client).to receive(:post_with_response).and_return(response)
+
+      integration.companies_properties_version = nil
+      integration.save!
+    end
+
+    it 'successfully deploys companies and updates the companies_properties_version' do
+      deploy_companies_service.call
+
+      aggregate_failures do
+        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        expect(http_client).to have_received(:post_with_response) do |payload, headers|
+          expect(payload[:objectType]).to eq('companies')
+          expect(headers['Authorization']).to include('Bearer')
+        end
+        expect(integration.reload.companies_properties_version).to eq(described_class::VERSION)
+      end
+    end
+
+    context 'when companies_properties_version is already up-to-date' do
+      before do
+        integration.companies_properties_version = described_class::VERSION
+        integration.save!
+      end
+
+      it 'does not make an API call and keeps the version unchanged' do
+        deploy_companies_service.call
+
+        aggregate_failures do
+          expect(LagoHttpClient::Client).not_to have_received(:new)
+          expect(http_client).not_to have_received(:post_with_response)
+          expect(integration.reload.companies_properties_version).to eq(described_class::VERSION)
+        end
+      end
+    end
+
+    context 'when the API call fails' do
+      let(:response) { instance_double('Response', success?: false) }
+
+      it 'does not update the contacts_properties_version' do
+        deploy_companies_service.call
+
+        aggregate_failures do
+          expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+          expect(integration.reload.companies_properties_version).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/integrations/hubspot/properties/deploy_companies_service_spec.rb
+++ b/spec/services/integrations/hubspot/properties/deploy_companies_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Integrations::Hubspot::Properties::DeployCompaniesService do
       integration.save!
     end
 
-    it 'successfully deploys companies and updates the companies_properties_version' do
+    it 'successfully deploys companies properties and updates the companies_properties_version' do
       deploy_companies_service.call
 
       aggregate_failures do
@@ -55,7 +55,7 @@ RSpec.describe Integrations::Hubspot::Properties::DeployCompaniesService do
     context 'when the API call fails' do
       let(:response) { instance_double('Response', success?: false) }
 
-      it 'does not update the contacts_properties_version' do
+      it 'does not update the companies_properties_version' do
         deploy_companies_service.call
 
         aggregate_failures do

--- a/spec/services/integrations/hubspot/properties/deploy_contacts_service_spec.rb
+++ b/spec/services/integrations/hubspot/properties/deploy_contacts_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Integrations::Hubspot::Properties::DeployContactsService do
       integration.save!
     end
 
-    it 'successfully deploys contacts and updates the contacts_properties_version' do
+    it 'successfully deploys contacts properties and updates the contacts_properties_version' do
       deploy_contacts_service.call
 
       aggregate_failures do

--- a/spec/services/integrations/hubspot/properties/deploy_contacts_service_spec.rb
+++ b/spec/services/integrations/hubspot/properties/deploy_contacts_service_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Hubspot::Properties::DeployContactsService do
+  subject(:deploy_contacts_service) { described_class.new(integration:) }
+
+  let(:integration) { create(:hubspot_integration) }
+
+  describe '.call' do
+    let(:http_client) { instance_double(LagoHttpClient::Client) }
+    let(:endpoint) { "https://api.nango.dev/v1/hubspot/properties" }
+    let(:response) { instance_double('Response', success?: true) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(endpoint)
+        .and_return(http_client)
+      allow(http_client).to receive(:post_with_response).and_return(response)
+
+      integration.contacts_properties_version = nil
+      integration.save!
+    end
+
+    it 'successfully deploys contacts and updates the contacts_properties_version' do
+      deploy_contacts_service.call
+
+      aggregate_failures do
+        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        expect(http_client).to have_received(:post_with_response) do |payload, headers|
+          expect(payload[:objectType]).to eq('contacts')
+          expect(headers['Authorization']).to include('Bearer')
+        end
+        expect(integration.reload.contacts_properties_version).to eq(described_class::VERSION)
+      end
+    end
+
+    context 'when contacts_properties_version is already up-to-date' do
+      before do
+        integration.contacts_properties_version = described_class::VERSION
+        integration.save!
+      end
+
+      it 'does not make an API call and keeps the version unchanged' do
+        deploy_contacts_service.call
+
+        aggregate_failures do
+          expect(LagoHttpClient::Client).not_to have_received(:new)
+          expect(http_client).not_to have_received(:post_with_response)
+          expect(integration.reload.contacts_properties_version).to eq(described_class::VERSION)
+        end
+      end
+    end
+
+    context 'when the API call fails' do
+      let(:response) { instance_double('Response', success?: false) }
+
+      it 'does not update the contacts_properties_version' do
+        deploy_contacts_service.call
+
+        aggregate_failures do
+          expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+          expect(integration.reload.contacts_properties_version).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

The goal of this change is the deployment of custom properties and objects in HubSpot when a new integration is created via Lago. Specifically, we need to create the necessary fields for both native HubSpot objects (`Companies` and `Contacts`) and create custom objects (`Subscriptions` and `Invoices`)  in the user's HubSpot account. 

## Description

This PR introduces a new job, `SyncCustomObjectsAndPropertiesJob`, which orchestrates the setup of custom objects and property synchronization in HubSpot when a new integration is created via Lago. The job does not handle sending the actual records, and this will be addressed in a future PR.

version control has been implemented to track the deployment state of these objects and properties. This allows us to know what has been deployed and to trigger a sync when sending new records if the schema has been updated.