### PR TITLE
Fix: adjust tax precise amount when issuing credit notes

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -129,6 +129,18 @@ class CreditNote < ApplicationRecord
   end
   alias_method :sub_total_excluding_taxes_amount_currency, :currency
 
+  def precise_total
+    items.sum(&:precise_amount_cents) + precise_taxes_amount_cents
+  end
+
+  def taxes_rounding_adjustment
+    taxes_amount_cents - precise_taxes_amount_cents
+  end
+
+  def rounding_adjustment
+    total_amount_cents - precise_total
+  end
+
   private
 
   def ensure_number

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -130,7 +130,7 @@ class CreditNote < ApplicationRecord
   alias_method :sub_total_excluding_taxes_amount_currency, :currency
 
   def precise_total
-    items.sum(&:precise_amount_cents) + precise_taxes_amount_cents
+    items.sum(&:precise_amount_cents) - precise_coupons_adjustment_amount_cents + precise_taxes_amount_cents
   end
 
   def taxes_rounding_adjustment

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -272,8 +272,8 @@ class Invoice < ApplicationRecord
       fee_rate = fee.creditable_amount_cents.fdiv(fees_total_creditable)
       prorated_credit_amount = credit_adjustement * fee_rate
       (fee.creditable_amount_cents - prorated_credit_amount) * (fee.taxes_rate || 0)
-    end.fdiv(100)
-    # end.fdiv(100).round
+    end.fdiv(100).round
+    # end.fdiv(100)
     # BECAUE OF THIS ROUND the returned value is not precise
 
     fees_total_creditable - credit_adjustement + vat

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -274,7 +274,7 @@ class Invoice < ApplicationRecord
       (fee.creditable_amount_cents - prorated_credit_amount) * (fee.taxes_rate || 0)
     end.fdiv(100).round
     # end.fdiv(100)
-    # BECAUE OF THIS ROUND the returned value is not precise
+    # BECAUSE OF THIS ROUND the returned value is not precise
 
     fees_total_creditable - credit_adjustement + vat
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -272,9 +272,7 @@ class Invoice < ApplicationRecord
       fee_rate = fee.creditable_amount_cents.fdiv(fees_total_creditable)
       prorated_credit_amount = credit_adjustement * fee_rate
       (fee.creditable_amount_cents - prorated_credit_amount) * (fee.taxes_rate || 0)
-    end.fdiv(100).round
-    # end.fdiv(100)
-    # BECAUSE OF THIS ROUND the returned value is not precise
+    end.fdiv(100).round # BECAUSE OF THIS ROUND the returned value is not precise
 
     fees_total_creditable - credit_adjustement + vat
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -272,7 +272,9 @@ class Invoice < ApplicationRecord
       fee_rate = fee.creditable_amount_cents.fdiv(fees_total_creditable)
       prorated_credit_amount = credit_adjustement * fee_rate
       (fee.creditable_amount_cents - prorated_credit_amount) * (fee.taxes_rate || 0)
-    end.fdiv(100).round
+    end.fdiv(100)
+    # end.fdiv(100).round
+    # BECAUE OF THIS ROUND the returned value is wrong...
 
     fees_total_creditable - credit_adjustement + vat
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -274,7 +274,7 @@ class Invoice < ApplicationRecord
       (fee.creditable_amount_cents - prorated_credit_amount) * (fee.taxes_rate || 0)
     end.fdiv(100)
     # end.fdiv(100).round
-    # BECAUE OF THIS ROUND the returned value is wrong...
+    # BECAUE OF THIS ROUND the returned value is not precise
 
     fees_total_creditable - credit_adjustement + vat
   end

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -204,10 +204,25 @@ module CreditNotes
       credit_note.precise_coupons_adjustment_amount_cents = taxes_result.coupons_adjustment_amount_cents
       credit_note.coupons_adjustment_amount_cents = taxes_result.coupons_adjustment_amount_cents.round
       credit_note.precise_taxes_amount_cents = taxes_result.taxes_amount_cents
+      adjust_credit_note_tax_rounding if credit_note_for_all_remaining_amount?
+
       credit_note.taxes_amount_cents = taxes_result.taxes_amount_cents.round
       credit_note.taxes_rate = taxes_result.taxes_rate
 
       taxes_result.applied_taxes.each { |applied_tax| credit_note.applied_taxes << applied_tax }
+    end
+
+    def credit_note_for_all_remaining_amount?
+      credit_note.items.sum(&:precise_amount_cents) == credit_note.invoice.fees.sum(&:creditable_amount_cents)
+    end
+
+    def adjust_credit_note_tax_rounding
+      credit_note.precise_taxes_amount_cents -= all_rounding_tax_adjustments
+      credit_note.taxes_amount_cents = taxes_result.taxes_amount_cents.round
+    end
+
+    def all_rounding_tax_adjustments
+      credit_note.invoice.credit_notes.sum(&:taxes_rounding_adjustment)
     end
   end
 end

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -206,19 +206,18 @@ module CreditNotes
       credit_note.precise_taxes_amount_cents = taxes_result.taxes_amount_cents
       adjust_credit_note_tax_rounding if credit_note_for_all_remaining_amount?
 
-      credit_note.taxes_amount_cents = taxes_result.taxes_amount_cents.round
+      credit_note.taxes_amount_cents = credit_note.precise_taxes_amount_cents.round
       credit_note.taxes_rate = taxes_result.taxes_rate
 
       taxes_result.applied_taxes.each { |applied_tax| credit_note.applied_taxes << applied_tax }
     end
 
     def credit_note_for_all_remaining_amount?
-      credit_note.items.sum(&:precise_amount_cents) == credit_note.invoice.fees.sum(&:creditable_amount_cents)
+      credit_note.invoice.creditable_amount_cents == 0
     end
 
     def adjust_credit_note_tax_rounding
       credit_note.precise_taxes_amount_cents -= all_rounding_tax_adjustments
-      credit_note.taxes_amount_cents = taxes_result.taxes_amount_cents.round
     end
 
     def all_rounding_tax_adjustments

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -23,14 +23,10 @@ module CreditNotes
         balance_amount_currency: invoice.currency
       )
 
-      # byebug
       validate_items
       return result unless result.success?
 
       compute_amounts_and_taxes
-      valid_credit_note?
-      # byebug
-      return result unless result.success?
 
       result.credit_note = credit_note
       result

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -107,7 +107,6 @@ module CreditNotes
     def compute_refundable_amount
       credit_note.refund_amount_cents = credit_note.credit_amount_cents
 
-      # invoice.refundable_amount_cents is incorrect - in our case it returns 8200, but it should be 8199...
       refundable_amount_cents = invoice.refundable_amount_cents
       return unless credit_note.credit_amount_cents > refundable_amount_cents
 

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -67,7 +67,6 @@ module CreditNotes
     end
 
     def valid_item?(item)
-      # byebug
       CreditNotes::ValidateItemService.new(result, item:).valid?
     end
 
@@ -80,7 +79,7 @@ module CreditNotes
       credit_note.precise_coupons_adjustment_amount_cents = taxes_result.coupons_adjustment_amount_cents
       credit_note.coupons_adjustment_amount_cents = taxes_result.coupons_adjustment_amount_cents.round
       credit_note.precise_taxes_amount_cents = taxes_result.taxes_amount_cents
-      # adjust_credit_note_tax_precise_rounding(taxes_result) if credit_note_for_all_remaining_amount?
+      adjust_credit_note_tax_precise_rounding if credit_note_for_all_remaining_amount?
 
       credit_note.taxes_amount_cents = credit_note.precise_taxes_amount_cents.round
       credit_note.taxes_rate = taxes_result.taxes_rate
@@ -101,9 +100,8 @@ module CreditNotes
       credit_note.items.sum(&:precise_amount_cents) == credit_note.invoice.fees.sum(&:creditable_amount_cents)
     end
 
-    def adjust_credit_note_tax_precise_rounding(taxes_result)
+    def adjust_credit_note_tax_precise_rounding
       credit_note.precise_taxes_amount_cents -= all_rounding_tax_adjustments
-      credit_note.taxes_amount_cents = taxes_result.taxes_amount_cents.round
     end
 
     def all_rounding_tax_adjustments
@@ -113,8 +111,7 @@ module CreditNotes
     def compute_refundable_amount
       credit_note.refund_amount_cents = credit_note.credit_amount_cents
 
-      # byebug
-      # invoice.refundable_amount_cents is incorrect - in our case it returns 82.00
+      # invoice.refundable_amount_cents is incorrect - in our case it returns 8200, but it should be 8199...
       refundable_amount_cents = invoice.refundable_amount_cents
       return unless credit_note.credit_amount_cents > refundable_amount_cents
 

--- a/app/services/credit_notes/validate_item_service.rb
+++ b/app/services/credit_notes/validate_item_service.rb
@@ -7,6 +7,8 @@ module CreditNotes
 
       valid_item_amount?
       valid_individual_amount?
+      # we don't save taxes on the credit_note item and we'll adjust them when creating credit notes, so it makes sense
+      # to check taxes on credit note level, where taxes are calculated and stored.
       # valid_global_amount?
 
       if errors?
@@ -42,13 +44,9 @@ module CreditNotes
       credited_invoice_amount_cents + refunded_invoice_amount_cents
     end
 
-    # QUESTION HERE:
-    # we don't save taxes on the credit_note item. does it make sense then to check taxes on credit note level rather
-    # than on item level?
-    #
-    # def total_item_amount_cents
-    #   (item.amount_cents + (item.amount_cents * fee.taxes_rate).fdiv(100)).round
-    # end
+    def total_item_amount_cents
+      (item.amount_cents + (item.amount_cents * fee.taxes_rate).fdiv(100)).round
+    end
 
     def valid_fee?
       return true if item.fee.present?

--- a/app/services/credit_notes/validate_item_service.rb
+++ b/app/services/credit_notes/validate_item_service.rb
@@ -7,7 +7,7 @@ module CreditNotes
 
       valid_item_amount?
       valid_individual_amount?
-      valid_global_amount?
+      # valid_global_amount?
 
       if errors?
         result.validation_failure!(errors:)
@@ -42,9 +42,13 @@ module CreditNotes
       credited_invoice_amount_cents + refunded_invoice_amount_cents
     end
 
-    def total_item_amount_cents
-      (item.amount_cents + (item.amount_cents * fee.taxes_rate).fdiv(100)).round
-    end
+    # QUESTION HERE:
+    # we don't save taxes on the credit_note item. does it make sense then to check taxes on credit note level rather
+    # than on item level?
+    #
+    # def total_item_amount_cents
+    #   (item.amount_cents + (item.amount_cents * fee.taxes_rate).fdiv(100)).round
+    # end
 
     def valid_fee?
       return true if item.fee.present?

--- a/app/services/credit_notes/validate_item_service.rb
+++ b/app/services/credit_notes/validate_item_service.rb
@@ -7,9 +7,6 @@ module CreditNotes
 
       valid_item_amount?
       valid_individual_amount?
-      # we don't save taxes on the credit_note item and we'll adjust them when creating credit notes, so it makes sense
-      # to check taxes on credit note level, where taxes are calculated and stored.
-      # valid_global_amount?
 
       if errors?
         result.validation_failure!(errors:)

--- a/app/services/credit_notes/validate_service.rb
+++ b/app/services/credit_notes/validate_service.rb
@@ -3,17 +3,11 @@
 module CreditNotes
   class ValidateService < BaseValidator
     def valid?
-      # byebug
       valid_invoice_status?
-#       byebug
       valid_items_amount?
-#       byebug
       valid_refund_amount?
-#       byebug
       valid_credit_amount?
-#       byebug
       valid_global_amount?
-#       byebug
 
       if errors?
         result.validation_failure!(errors:)

--- a/app/services/credit_notes/validate_service.rb
+++ b/app/services/credit_notes/validate_service.rb
@@ -3,11 +3,17 @@
 module CreditNotes
   class ValidateService < BaseValidator
     def valid?
+      # byebug
       valid_invoice_status?
+#       byebug
       valid_items_amount?
+#       byebug
       valid_refund_amount?
+#       byebug
       valid_credit_amount?
+#       byebug
       valid_global_amount?
+#       byebug
 
       if errors?
         result.validation_failure!(errors:)

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -3,7 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe CreditNote, type: :model do
-  subject(:credit_note) { create(:credit_note) }
+  subject(:credit_note) do
+    create :credit_note, credit_amount_cents: 11000, total_amount_cents: 11000, taxes_amount_cents: 1000,
+           taxes_rate: 10.0, precise_taxes_amount_cents: 1000
+  end
+
+  let(:item) { create(:credit_note_item, credit_note:, precise_amount_cents: 10000, amount_cents: 1000) }
+
+  before do
+    item
+    credit_note.reload
+  end
 
   it_behaves_like 'paper_trail traceable'
 
@@ -243,10 +253,28 @@ RSpec.describe CreditNote, type: :model do
     end
   end
 
-  describe ' #sub_total_excluding_taxes_amount_cents' do
+  describe '#sub_total_excluding_taxes_amount_cents' do
     it 'returs the total amount without the taxes' do
       expect(credit_note.sub_total_excluding_taxes_amount_cents)
         .to eq(credit_note.items.sum(&:precise_amount_cents) - credit_note.precise_coupons_adjustment_amount_cents)
+    end
+  end
+
+  describe '#precise_total' do
+    it 'returns the total precise amount including precise taxes' do
+      expect(credit_note.precise_total).to eq(11000)
+    end
+  end
+
+  describe '#taxes_rounding_adjustment' do
+    it 'returns the difference between taxes and precise taxes' do
+      expect(credit_note.taxes_rounding_adjustment).to eq(0)
+    end
+  end
+
+  describe '#rounding_adjustment' do
+    it 'returns the difference between credit note total and credit note precise total' do
+      expect(credit_note.taxes_rounding_adjustment).to eq(0)
     end
   end
 
@@ -328,4 +356,38 @@ RSpec.describe CreditNote, type: :model do
       end
     end
   end
+
+
+  context 'when taxes are not precise' do
+    subject(:credit_note) do
+      create :credit_note, credit_amount_cents: 8200, total_amount_cents: 8200, taxes_amount_cents: 1367,
+        taxes_rate: 20.0, precise_taxes_amount_cents: 1366.6
+    end
+
+    let(:item) { create(:credit_note_item, credit_note:, precise_amount_cents: 6833, amount_cents: 6833) }
+
+    before do
+      item
+    end
+
+    describe '#precise_total' do
+      it 'returns the total precise amount including precise taxes' do
+        expect(credit_note.precise_total).to eq(8199.6)
+      end
+    end
+
+    describe '#taxes_rounding_adjustment' do
+      it 'returns the difference between taxes and precise taxes' do
+        expect(credit_note.taxes_rounding_adjustment).to eq(0.4)
+      end
+    end
+
+    describe '#rounding_adjustment' do
+      it 'returns the difference between credit note total and credit note precise total' do
+        expect(credit_note.taxes_rounding_adjustment).to eq(0.4)
+      end
+    end
+  end
 end
+
+

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe CreditNote, type: :model do
   subject(:credit_note) do
     create :credit_note, credit_amount_cents: 11000, total_amount_cents: 11000, taxes_amount_cents: 1000,
-           taxes_rate: 10.0, precise_taxes_amount_cents: 1000
+      taxes_rate: 10.0, precise_taxes_amount_cents: 1000
   end
 
   let(:item) { create(:credit_note_item, credit_note:, precise_amount_cents: 10000, amount_cents: 1000) }
@@ -357,7 +357,6 @@ RSpec.describe CreditNote, type: :model do
     end
   end
 
-
   context 'when taxes are not precise' do
     subject(:credit_note) do
       create :credit_note, credit_amount_cents: 8200, total_amount_cents: 8200, taxes_amount_cents: 1367,
@@ -389,5 +388,3 @@ RSpec.describe CreditNote, type: :model do
     end
   end
 end
-
-

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -10,11 +10,6 @@ RSpec.describe CreditNote, type: :model do
 
   let(:item) { create(:credit_note_item, credit_note:, precise_amount_cents: 10000, amount_cents: 1000) }
 
-  before do
-    item
-    credit_note.reload
-  end
-
   it_behaves_like 'paper_trail traceable'
 
   it { is_expected.to have_many(:integration_resources) }
@@ -253,16 +248,23 @@ RSpec.describe CreditNote, type: :model do
     end
   end
 
-  describe '#sub_total_excluding_taxes_amount_cents' do
-    it 'returs the total amount without the taxes' do
-      expect(credit_note.sub_total_excluding_taxes_amount_cents)
-        .to eq(credit_note.items.sum(&:precise_amount_cents) - credit_note.precise_coupons_adjustment_amount_cents)
+  context 'when calculating depends on related items' do
+    before do
+      item
+      credit_note.reload
     end
-  end
 
-  describe '#precise_total' do
-    it 'returns the total precise amount including precise taxes' do
-      expect(credit_note.precise_total).to eq(11000)
+    describe '#sub_total_excluding_taxes_amount_cents' do
+      it 'returs the total amount without the taxes' do
+        expect(credit_note.sub_total_excluding_taxes_amount_cents)
+          .to eq(credit_note.items.sum(&:precise_amount_cents) - credit_note.precise_coupons_adjustment_amount_cents)
+      end
+    end
+
+    describe '#precise_total' do
+      it 'returns the total precise amount including precise taxes' do
+        expect(credit_note.precise_total).to eq(11000)
+      end
     end
   end
 
@@ -367,6 +369,7 @@ RSpec.describe CreditNote, type: :model do
 
     before do
       item
+      credit_note.reload
     end
 
     describe '#precise_total' do

--- a/spec/scenarios/credit_note_spec.rb
+++ b/spec/scenarios/credit_note_spec.rb
@@ -445,42 +445,93 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
           expect(credit_note.precise_total).to eq(8199.2)
           expect(credit_note.taxes_rounding_adjustment).to eq(-0.2)
         end
-
       end
 
       context 'when four items are refunded separately, some whole, some in parts' do
-      let(:add_ons) { create_list(:add_on, 4, organization:, amount_cents: 68_33) }
+        let(:add_ons) { create_list(:add_on, 4, organization:, amount_cents: 68_33) }
 
-      it 'solves the rounding issue' do
-        #  create a one off invoice with two addons and small amounts as feed
-        create_one_off_invoice(customer, add_ons)
-        # invoice amount should be with taxes calculated on items sum:
-        invoice = customer.invoices.order(:created_at).last
-        expect(invoice.total_amount_cents).to eq(327_98)
-        expect(invoice.taxes_amount_cents).to eq(54_66)
-        fees = invoice.fees
-        invoice.update(payment_status: 'succeeded')
+        it 'solves the rounding issue' do
+          #  create a one off invoice with two addons and small amounts as feed
+          create_one_off_invoice(customer, add_ons)
+          # invoice amount should be with taxes calculated on items sum:
+          invoice = customer.invoices.order(:created_at).last
+          expect(invoice.total_amount_cents).to eq(327_98)
+          expect(invoice.taxes_amount_cents).to eq(54_66)
+          fees = invoice.fees
+          invoice.update(payment_status: 'succeeded')
 
-        # estimate and create credit notes for first three items - full refund; the taxes are rounded to higher number
-        3.times do |i|
+          # estimate and create credit notes for first three items - full refund; the taxes are rounded to higher number
+          3.times do |i|
+            estimate_credit_note(
+              invoice_id: invoice.id,
+              items: [
+                {
+                  fee_id: fees[i].id,
+                  amount_cents: 68_33
+                }
+              ]
+            )
+
+            # Estimate the credit notes amount on one fee rounds the taxes to higher number
+            estimate = json[:estimated_credit_note]
+            expect(estimate).to include(
+              taxes_amount_cents: 13_67,
+              precise_taxes_amount_cents: "1366.6",
+              sub_total_excluding_taxes_amount_cents: 6833,
+              max_creditable_amount_cents: 8200,
+              max_refundable_amount_cents: 8200,
+              taxes_rate: 20.0
+            )
+
+            # Emit a credit note on only one fee
+            create_credit_note(
+              invoice_id: invoice.id,
+              reason: :other,
+              credit_amount_cents: 0,
+              refund_amount_cents: 82_00,
+              items: [
+                {
+                  fee_id: fees[i].id,
+                  amount_cents: 68_33
+                }
+              ]
+            )
+
+            credit_note = invoice.credit_notes.order(:created_at).last
+            expect(credit_note).to have_attributes(
+              refund_amount_cents: 82_00,
+              total_amount_cents: 82_00,
+              taxes_amount_cents: 13_67,
+              precise_taxes_amount_cents: 1366.6
+            )
+            expect(credit_note.precise_total).to eq(8199.6)
+            expect(credit_note.taxes_rounding_adjustment).to eq(0.4)
+          end
+          # this value is wrong because of all rounding because if we subtract issued credit notes from the invoice, it
+          # will result in 327_98 - 82_00 * 3 = 81_98
+          expect(invoice.creditable_amount_cents).to eq(8200)
+
+          # split last refundable item into three chunks, first's taxes are rounded to lower number
+          # next two are rounded to higher number
+          # cn_1 => 13.67, cn2 => 22.33, cn3 => 32.33
+          # CN1
           estimate_credit_note(
             invoice_id: invoice.id,
             items: [
               {
-                fee_id: fees[i].id,
-                amount_cents: 68_33
+                fee_id: fees[3].id,
+                amount_cents: 13_67
               }
             ]
           )
 
-          # Estimate the credit notes amount on one fee rounds the taxes to higher number
           estimate = json[:estimated_credit_note]
           expect(estimate).to include(
-            taxes_amount_cents: 13_67,
-            precise_taxes_amount_cents: "1366.6",
-            sub_total_excluding_taxes_amount_cents: 6833,
-            max_creditable_amount_cents: 8200,
-            max_refundable_amount_cents: 8200,
+            taxes_amount_cents: 273,
+            precise_taxes_amount_cents: "273.4",
+            sub_total_excluding_taxes_amount_cents: 1367,
+            max_creditable_amount_cents: 1640,
+            max_refundable_amount_cents: 1640,
             taxes_rate: 20.0
           )
 
@@ -489,175 +540,123 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
             invoice_id: invoice.id,
             reason: :other,
             credit_amount_cents: 0,
-            refund_amount_cents: 82_00,
+            refund_amount_cents: 1640,
             items: [
               {
-                fee_id: fees[i].id,
-                amount_cents: 68_33
+                fee_id: fees[3].id,
+                amount_cents: 1367
               }
             ]
           )
 
           credit_note = invoice.credit_notes.order(:created_at).last
           expect(credit_note).to have_attributes(
-            refund_amount_cents: 82_00,
-            total_amount_cents: 82_00,
-            taxes_amount_cents: 13_67,
-            precise_taxes_amount_cents: 1366.6
+            refund_amount_cents: 1640,
+            total_amount_cents: 1640,
+            taxes_amount_cents: 273,
+            precise_taxes_amount_cents: 273.4
           )
-          expect(credit_note.precise_total).to eq(8199.6)
+          expect(credit_note.precise_total).to eq(1640.4)
+          expect(credit_note.taxes_rounding_adjustment).to eq(-0.4)
+          # real remaining: 81_98 - 16_40 = 65_58
+          expect(invoice.creditable_amount_cents).to eq(6559)
+
+          # cn_1 => 13.67, cn2 => 22.33, cn3 => 32.33
+          # CN2
+          estimate_credit_note(
+            invoice_id: invoice.id,
+            items: [
+              {
+                fee_id: fees[3].id,
+                amount_cents: 22_33
+              }
+            ]
+          )
+
+          estimate = json[:estimated_credit_note]
+          expect(estimate).to include(
+            taxes_amount_cents: 447,
+            precise_taxes_amount_cents: "446.6",
+            sub_total_excluding_taxes_amount_cents: 2233,
+            max_creditable_amount_cents: 2680,
+            max_refundable_amount_cents: 2680,
+            taxes_rate: 20.0
+          )
+
+          # Emit a credit note on only one fee
+          create_credit_note(
+            invoice_id: invoice.id,
+            reason: :other,
+            credit_amount_cents: 0,
+            refund_amount_cents: 2680,
+            items: [
+              {
+                fee_id: fees[3].id,
+                amount_cents: 2233
+              }
+            ]
+          )
+
+          credit_note = invoice.credit_notes.order(:created_at).last
+          expect(credit_note).to have_attributes(
+            refund_amount_cents: 2680,
+            total_amount_cents: 2680,
+            taxes_amount_cents: 447,
+            precise_taxes_amount_cents: 446.6
+          )
+          expect(credit_note.precise_total).to eq(2679.6)
           expect(credit_note.taxes_rounding_adjustment).to eq(0.4)
+          # real remaining: 65_58 - 26_80 = 38_78
+          expect(invoice.creditable_amount_cents).to eq(3880)
+
+          # cn_1 => 13.67, cn2 => 22.33, cn3 => 32.33
+          # CN3
+          estimate_credit_note(
+            invoice_id: invoice.id,
+            items: [
+              {
+                fee_id: fees[3].id,
+                amount_cents: 32_33
+              }
+            ]
+          )
+
+          estimate = json[:estimated_credit_note]
+          expect(estimate).to include(
+            taxes_amount_cents: 645,
+            precise_taxes_amount_cents: "645.4",
+            sub_total_excluding_taxes_amount_cents: 3233,
+            max_creditable_amount_cents: 3878,
+            max_refundable_amount_cents: 3878,
+            taxes_rate: 20.0
+          )
+
+          # Emit a credit note on only one fee
+          create_credit_note(
+            invoice_id: invoice.id,
+            reason: :other,
+            credit_amount_cents: 0,
+            refund_amount_cents: 3878,
+            items: [
+              {
+                fee_id: fees[3].id,
+                amount_cents: 3233
+              }
+            ]
+          )
+
+          credit_note = invoice.credit_notes.order(:created_at).last
+          expect(credit_note).to have_attributes(
+            refund_amount_cents: 3878,
+            total_amount_cents: 3878,
+            taxes_amount_cents: 645,
+            precise_taxes_amount_cents: 645.4
+          )
+          expect(credit_note.precise_total).to eq(3878.4)
+          expect(credit_note.taxes_rounding_adjustment).to eq(-0.4)
+          expect(invoice.creditable_amount_cents).to eq(0)
         end
-        # this value is wrong because of all rounding because if we subtract issued credit notes from the invoice, it
-        # will result in 327_98 - 82_00 * 3 = 81_98
-        expect(invoice.creditable_amount_cents).to eq(8200)
-
-        # split last refundable item into three chunks, first's taxes are rounded to lower number
-        # next two are rounded to higher number
-        # cn_1 => 13.67, cn2 => 22.33, cn3 => 32.33
-        # CN1
-        estimate_credit_note(
-          invoice_id: invoice.id,
-          items: [
-            {
-              fee_id: fees[3].id,
-              amount_cents: 13_67
-            }
-          ]
-        )
-
-        estimate = json[:estimated_credit_note]
-        expect(estimate).to include(
-          taxes_amount_cents: 273,
-          precise_taxes_amount_cents: "273.4",
-          sub_total_excluding_taxes_amount_cents: 1367,
-          max_creditable_amount_cents: 1640,
-          max_refundable_amount_cents: 1640,
-          taxes_rate: 20.0
-        )
-
-        # Emit a credit note on only one fee
-        create_credit_note(
-          invoice_id: invoice.id,
-          reason: :other,
-          credit_amount_cents: 0,
-          refund_amount_cents: 1640,
-          items: [
-            {
-              fee_id: fees[3].id,
-              amount_cents: 1367
-            }
-          ]
-        )
-
-        credit_note = invoice.credit_notes.order(:created_at).last
-        expect(credit_note).to have_attributes(
-          refund_amount_cents: 1640,
-          total_amount_cents: 1640,
-          taxes_amount_cents: 273,
-          precise_taxes_amount_cents: 273.4
-        )
-        expect(credit_note.precise_total).to eq(1640.4)
-        expect(credit_note.taxes_rounding_adjustment).to eq(-0.4)
-        # real remaining: 81_98 - 16_40 = 65_58
-        expect(invoice.creditable_amount_cents).to eq(6559)
-
-        # cn_1 => 13.67, cn2 => 22.33, cn3 => 32.33
-        # CN2
-        estimate_credit_note(
-          invoice_id: invoice.id,
-          items: [
-            {
-              fee_id: fees[3].id,
-              amount_cents: 22_33
-            }
-          ]
-        )
-
-        estimate = json[:estimated_credit_note]
-        expect(estimate).to include(
-          taxes_amount_cents: 447,
-          precise_taxes_amount_cents: "446.6",
-          sub_total_excluding_taxes_amount_cents: 2233,
-          max_creditable_amount_cents: 2680,
-          max_refundable_amount_cents: 2680,
-          taxes_rate: 20.0
-        )
-
-        # Emit a credit note on only one fee
-        create_credit_note(
-          invoice_id: invoice.id,
-          reason: :other,
-          credit_amount_cents: 0,
-          refund_amount_cents: 2680,
-          items: [
-            {
-              fee_id: fees[3].id,
-              amount_cents: 2233
-            }
-          ]
-        )
-
-        credit_note = invoice.credit_notes.order(:created_at).last
-        expect(credit_note).to have_attributes(
-          refund_amount_cents: 2680,
-          total_amount_cents: 2680,
-          taxes_amount_cents: 447,
-          precise_taxes_amount_cents: 446.6
-        )
-        expect(credit_note.precise_total).to eq(2679.6)
-        expect(credit_note.taxes_rounding_adjustment).to eq(0.4)
-        # real remaining: 65_58 - 26_80 = 38_78
-        expect(invoice.creditable_amount_cents).to eq(3880)
-
-        # cn_1 => 13.67, cn2 => 22.33, cn3 => 32.33
-        # CN3
-        estimate_credit_note(
-          invoice_id: invoice.id,
-          items: [
-            {
-              fee_id: fees[3].id,
-              amount_cents: 32_33
-            }
-          ]
-        )
-
-        estimate = json[:estimated_credit_note]
-        expect(estimate).to include(
-          taxes_amount_cents: 645,
-          precise_taxes_amount_cents: "645.4",
-          sub_total_excluding_taxes_amount_cents: 3233,
-          max_creditable_amount_cents: 3878,
-          max_refundable_amount_cents: 3878,
-          taxes_rate: 20.0
-        )
-
-        # Emit a credit note on only one fee
-        create_credit_note(
-          invoice_id: invoice.id,
-          reason: :other,
-          credit_amount_cents: 0,
-          refund_amount_cents: 3878,
-          items: [
-            {
-              fee_id: fees[3].id,
-              amount_cents: 3233
-            }
-          ]
-        )
-
-        credit_note = invoice.credit_notes.order(:created_at).last
-        expect(credit_note).to have_attributes(
-          refund_amount_cents: 3878,
-          total_amount_cents: 3878,
-          taxes_amount_cents: 645,
-          precise_taxes_amount_cents: 645.4
-        )
-        expect(credit_note.precise_total).to eq(3878.4)
-        expect(credit_note.taxes_rounding_adjustment).to eq(-0.4)
-        expect(invoice.creditable_amount_cents).to eq(0)
       end
-    end
     end
 
     context 'when creating credit note with small items and applied coupons' do
@@ -787,7 +786,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
         expect(invoice.creditable_amount_cents).to eq(31122.253421098216)
 
         # issue a CN for the full first charge - 68_33 before taxes and coupons
-        first_charge = invoice.fees.find{|fee| fee.amount_cents == 68_33}
+        first_charge = invoice.fees.find { |fee| fee.amount_cents == 68_33 }
         estimate_credit_note(
           invoice_id: invoice.id,
           items: [
@@ -800,13 +799,13 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
 
         estimate = json[:estimated_credit_note]
         expect(estimate).to include(
-                              taxes_amount_cents: 1319,
-                              precise_taxes_amount_cents: "1319.2",
-                              sub_total_excluding_taxes_amount_cents: 6596,
-                              max_creditable_amount_cents: 7915,
-                              coupons_adjustment_amount_cents: 237,
-                              taxes_rate: 20.0
-                            )
+          taxes_amount_cents: 1319,
+          precise_taxes_amount_cents: "1319.2",
+          sub_total_excluding_taxes_amount_cents: 6596,
+          max_creditable_amount_cents: 7915,
+          coupons_adjustment_amount_cents: 237,
+          taxes_rate: 20.0
+        )
         create_credit_note(
           invoice_id: invoice.id,
           reason: :other,
@@ -821,19 +820,19 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
 
         credit_note = invoice.credit_notes.order(:created_at).last
         expect(credit_note).to have_attributes(
-                                 credit_amount_cents: 7915,
-                                 total_amount_cents: 7915,
-                                 taxes_amount_cents: 1319,
-                                 precise_taxes_amount_cents: 1319.2,
-                                 precise_coupons_adjustment_amount_cents: 236.72267
-                               )
+          credit_amount_cents: 7915,
+          total_amount_cents: 7915,
+          taxes_amount_cents: 1319,
+          precise_taxes_amount_cents: 1319.2,
+          precise_coupons_adjustment_amount_cents: 236.72267
+        )
         expect(credit_note.precise_total).to eq(7915.47733)
         expect(credit_note.taxes_rounding_adjustment).to eq(-0.2)
         # real remaining: 311_22 - 79_15 = 232_07
         expect(invoice.creditable_amount_cents).to eq(23206.97609561753)
 
         # issue a CN for the full last charge - 200_33 before taxes and coupons
-        last_charge = invoice.fees.find{|fee| fee.amount_cents == 200_33}
+        last_charge = invoice.fees.find { |fee| fee.amount_cents == 200_33 }
         estimate_credit_note(
           invoice_id: invoice.id,
           items: [

--- a/spec/services/credit_notes/validate_item_service_spec.rb
+++ b/spec/services/credit_notes/validate_item_service_spec.rb
@@ -95,21 +95,5 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
         end
       end
     end
-
-    # this check should not be on the item level, as taxes are applied and saved on the credit note level
-    # context 'when reaching invoice creditable amount' do
-    #   before do
-    #     create(:credit_note, invoice:, total_amount_cents: 99)
-    #   end
-    #
-    #   it 'fails the validation' do
-    #     aggregate_failures do
-    #       expect(validator).not_to be_valid
-    #
-    #       expect(result.error).to be_a(BaseService::ValidationFailure)
-    #       expect(result.error.messages[:amount_cents]).to eq(['higher_than_remaining_invoice_amount'])
-    #     end
-    #   end
-    # end
   end
 end

--- a/spec/services/credit_notes/validate_item_service_spec.rb
+++ b/spec/services/credit_notes/validate_item_service_spec.rb
@@ -96,19 +96,20 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
       end
     end
 
-    context 'when reaching invoice creditable amount' do
-      before do
-        create(:credit_note, invoice:, total_amount_cents: 99)
-      end
-
-      it 'fails the validation' do
-        aggregate_failures do
-          expect(validator).not_to be_valid
-
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:amount_cents]).to eq(['higher_than_remaining_invoice_amount'])
-        end
-      end
-    end
+    # this check should not be on the item level, as taxes are applied and saved on the credit note level
+    # context 'when reaching invoice creditable amount' do
+    #   before do
+    #     create(:credit_note, invoice:, total_amount_cents: 99)
+    #   end
+    #
+    #   it 'fails the validation' do
+    #     aggregate_failures do
+    #       expect(validator).not_to be_valid
+    #
+    #       expect(result.error).to be_a(BaseService::ValidationFailure)
+    #       expect(result.error.messages[:amount_cents]).to eq(['higher_than_remaining_invoice_amount'])
+    #     end
+    #   end
+    # end
   end
 end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -69,7 +69,7 @@ module ScenariosHelper
     put_with_token(organization, "/api/v1/invoices/#{invoice.id}", {invoice: params})
   end
 
-  def create_one_off_invoice(customer,addons)
+  def create_one_off_invoice(customer, addons)
     create_invoice_params = {
       customer: customer,
       currency: "EUR",
@@ -78,11 +78,12 @@ module ScenariosHelper
     }
     addons.each do |fee|
       fee_addon_params = {
-        "add_on_id": fee.id,
-        "name": fee.name,
-        "units": 1,
-        "unit_amount_cents": fee.amount_cents,
-        "tax_codes": [
+        add_on_id: fee.id,
+        add_on_code: fee.code,
+        name: fee.name,
+        units: 1,
+        unit_amount_cents: fee.amount_cents,
+        tax_codes: [
           tax.code
         ]
       }

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -71,7 +71,7 @@ module ScenariosHelper
 
   def create_one_off_invoice(customer, addons)
     create_invoice_params = {
-      customer: customer,
+      external_customer_id: customer.external_id,
       currency: "EUR",
       fees: [],
       timestamp: Time.zone.now.to_i
@@ -89,7 +89,7 @@ module ScenariosHelper
       }
       create_invoice_params[:fees].push(fee_addon_params)
     end
-    Invoices::CreateOneOffService.call(**create_invoice_params)
+    post_with_token(organization, "/api/v1/invoices", {invoice: create_invoice_params})
   end
 
   ### Coupons

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -69,6 +69,28 @@ module ScenariosHelper
     put_with_token(organization, "/api/v1/invoices/#{invoice.id}", {invoice: params})
   end
 
+  def create_one_off_invoice(customer,addons)
+    create_invoice_params = {
+      customer: customer,
+      currency: "EUR",
+      fees: [],
+      timestamp: Time.zone.now.to_i
+    }
+    addons.each do |fee|
+      fee_addon_params = {
+        "add_on_id": fee.id,
+        "name": fee.name,
+        "units": 1,
+        "unit_amount_cents": fee.amount_cents,
+        "tax_codes": [
+          tax.code
+        ]
+      }
+      create_invoice_params[:fees].push(fee_addon_params)
+    end
+    Invoices::CreateOneOffService.call(**create_invoice_params)
+  end
+
   ### Coupons
 
   def create_coupon(params)


### PR DESCRIPTION
## Context

We have this issue that when we issue Invoice, we apply tax on sum of items,
but when we issue a credit note, we apply tax on each item separately.
as result, some values can be rounded in deffirent direction which result in not matching sum.

Example that our client had (all values are amount_cents):
```
Invoice 001
charge01 = 68_33
charge 02 = 68_33
charge03 = 57_50
charge04 = 85_00
```

if we apply 20% taxes on the sum of charges, we get:
```
(68_33 + 68_33 + 57_50 + 85_00) * 1.2 = 334_99,2
```
but because it is in cents, when issuing the invoice, the value is rounded to `334_99`

Next, when we create credit notes for this invoice, and we create a separate CN per each item:
```
CN01 = 68_33 * 1.2 = 8199.6 => 82_00
CN02 = 57_50 * 1.2 = 69_00
CN03 = 85_00 * 1.2 = 102_00
CN04 = 68_33 * 1.2 = 8199.6 = 82_00
```
Sum of these credit notes is `335_00` which is more than the invoice total, and we fail vthe validation, despite the fees amount is correct

## Description

To help this situation, we can operate adjustments that were made when credit notes are issued.
So when we're creating CN1-3, we simply create credit notes.
when we create CN4, we are subtracting  all rounding adjustments that were made for all credit notes for this invoice. in our case, we will need to subtract `0.4` cents from precise taxes amount, and then for the last credit note
`CN04 = 68_33 * 1.2 = 8199.6 -0.4 = 8199.2 => 8199`
and the values are matching

also removed validation on credit_note_item total amount, as it tries to predict taxes, but they are adjusted further in the credit note creation service