### PR TITLE
feat(customer-portal): Add Subscription graphql resolver

### DIFF
--- a/app/graphql/resolvers/customer_portal/subscription_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/subscription_resolver.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module CustomerPortal
+    class SubscriptionResolver < Resolvers::BaseResolver
+      include AuthenticableCustomerPortalUser
+
+      description "Query a single subscription from the customer portal"
+
+      argument :id, ID, required: true, description: "Uniq ID of the subscription"
+
+      type Types::Subscriptions::Object, null: true
+
+      def resolve(id: nil)
+        context[:customer_portal_user].subscriptions.find(id)
+      rescue ActiveRecord::RecordNotFound
+        not_found_error(resource: "subscription")
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -26,6 +26,7 @@ module Types
     field :customer_portal_invoices, resolver: Resolvers::CustomerPortal::InvoicesResolver
     field :customer_portal_organization, resolver: Resolvers::CustomerPortal::OrganizationResolver
     field :customer_portal_overdue_balances, resolver: Resolvers::CustomerPortal::Analytics::OverdueBalancesResolver
+    field :customer_portal_subscription, resolver: Resolvers::CustomerPortal::SubscriptionResolver
     field :customer_portal_subscriptions, resolver: Resolvers::CustomerPortal::SubscriptionsResolver
     field :customer_portal_user, resolver: Resolvers::CustomerPortal::CustomerResolver
     field :customer_portal_wallets, resolver: Resolvers::CustomerPortal::WalletsResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -6097,6 +6097,16 @@ type Query {
   customerPortalOverdueBalances(expireCache: Boolean, months: Int): OverdueBalanceCollection!
 
   """
+  Query a single subscription from the customer portal
+  """
+  customerPortalSubscription(
+    """
+    Uniq ID of the subscription
+    """
+    id: ID!
+  ): Subscription
+
+  """
   Query customer portal subscriptions
   """
   customerPortalSubscriptions(limit: Int, page: Int, planCode: String, status: [StatusTypeEnum!]): SubscriptionCollection!

--- a/schema.json
+++ b/schema.json
@@ -30845,6 +30845,35 @@
               ]
             },
             {
+              "name": "customerPortalSubscription",
+              "description": "Query a single subscription from the customer portal",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Subscription",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the subscription",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "customerPortalSubscriptions",
               "description": "Query customer portal subscriptions",
               "type": {

--- a/spec/graphql/resolvers/customer_portal/subscription_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/subscription_resolver_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::CustomerPortal::SubscriptionResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($subscriptionId: ID!) {
+        customerPortalSubscription(id: $subscriptionId) {
+          id
+          name
+          startedAt
+          endingAt
+          plan {
+            id
+            code
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:) }
+
+  before do
+    customer
+  end
+
+  it_behaves_like "requires a customer portal user"
+
+  it "returns a single subscription", :aggregate_failures do
+    result = execute_graphql(
+      customer_portal_user: customer,
+      query:,
+      variables: {subscriptionId: subscription.id}
+    )
+
+    subscription_response = result["data"]["customerPortalSubscription"]
+    expect(subscription_response).to include(
+      "id" => subscription.id,
+      "name" => subscription.name,
+      "startedAt" => subscription.started_at.iso8601,
+      "endingAt" => subscription.ending_at
+    )
+
+    expect(subscription_response["plan"]).to include(
+      "id" => subscription.plan.id,
+      "code" => subscription.plan.code
+    )
+  end
+
+  context "when subscription is not found" do
+    it "returns an error" do
+      result = execute_graphql(
+        customer_portal_user: customer,
+        query:,
+        variables: {subscriptionId: "foo"}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal](https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal)

## Context

We got feedback that this portal is too limited in terms of features and information. Why?

**1st reason:** the number of information displayed is limited

**2nd reason:** the end user cannot take actions out of it (change info, add payment method)

**3rd reason:** the UI and display is not customizable

## Description

The goal of this PR is to return a specific subscription from the customer portal.
