### PR TITLE
Fix: closed invoices with generated number

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -65,7 +65,7 @@ class Invoice < ApplicationRecord
   VISIBLE_STATUS = {draft: 0, finalized: 1, voided: 2, failed: 4}.freeze
   INVISIBLE_STATUS = {generating: 3, open: 5, closed: 6}.freeze
   STATUS = VISIBLE_STATUS.merge(INVISIBLE_STATUS).freeze
-  COMPLETE_INVOICE_STATUSES = %w[finalized closed].freeze
+  GENERATED_INVOICE_STATUSES = %w[finalized closed].freeze
 
   enum invoice_type: INVOICE_TYPES
   enum payment_status: PAYMENT_STATUS, _prefix: :payment

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -65,6 +65,7 @@ class Invoice < ApplicationRecord
   VISIBLE_STATUS = {draft: 0, finalized: 1, voided: 2, failed: 4}.freeze
   INVISIBLE_STATUS = {generating: 3, open: 5, closed: 6}.freeze
   STATUS = VISIBLE_STATUS.merge(INVISIBLE_STATUS).freeze
+  COMPLETE_INVOICE_STATUSES = %w[finalized closed].freeze
 
   enum invoice_type: INVOICE_TYPES
   enum payment_status: PAYMENT_STATUS, _prefix: :payment

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -324,7 +324,6 @@ module Invoices
 
     def not_in_finalizing_process?
       !finalizing_invoice?
-      # (invoice.draft? || invoice.voided?) && context != :finalize
     end
 
     def in_trial_period_not_ending_today?(subscription, timestamp)

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -361,7 +361,7 @@ module Invoices
     end
 
     def finalizing_invoice?
-      context == :finalize || Invoice::COMPLETE_INVOICE_STATUSES.include?(invoice.status)
+      context == :finalize || Invoice::GENERATED_INVOICE_STATUSES.include?(invoice.status)
     end
   end
 end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -360,7 +360,7 @@ module Invoices
     end
 
     def finalizing_invoice?
-      context == :finalize || invoice.status == 'finalized'
+      context == :finalize || Invoice::COMPLETE_INVOICE_STATUSES.include?(invoice.status)
     end
   end
 end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -323,7 +323,8 @@ module Invoices
     end
 
     def not_in_finalizing_process?
-      (invoice.draft? || invoice.voided?) && context != :finalize
+      !finalizing_invoice?
+      # (invoice.draft? || invoice.voided?) && context != :finalize
     end
 
     def in_trial_period_not_ending_today?(subscription, timestamp)

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -27,7 +27,7 @@ module Invoices
       result.invoice = invoice
 
       fee_result = ActiveRecord::Base.transaction do
-        invoice.status = invoice_status
+        set_invoice_status
         fee_result = Invoices::CalculateFeesService.call(
           invoice:,
           recurring:
@@ -119,8 +119,8 @@ module Invoices
       @grace_period ||= customer.applicable_invoice_grace_period.positive?
     end
 
-    def invoice_status
-      return :draft if grace_period?
+    def set_invoice_status
+      return invoice.assign_attributes(status: :draft) if grace_period?
 
       Invoices::TransitionToFinalStatusService.call(invoice:)
     end

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -34,7 +34,7 @@ module Invoices
           context:
         )
 
-        set_invoice_status
+        set_invoice_generated_status unless invoice.failed?
         invoice.save!
 
         # NOTE: We don't want to raise error and corrupt DB commit if there is tax error.
@@ -123,7 +123,7 @@ module Invoices
       @grace_period ||= customer.applicable_invoice_grace_period.positive?
     end
 
-    def set_invoice_status
+    def set_invoice_generated_status
       return invoice.status = :draft if grace_period?
 
       Invoices::TransitionToFinalStatusService.call(invoice:)

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -340,6 +340,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
         it 'creates an invoice in :finalized status' do
           result = invoice_service.call
           expect(result.invoice.status).to eq('finalized')
+          expect(result.invoice.number).not_to include('DRAFT')
         end
       end
 
@@ -353,6 +354,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
         it 'creates an invoice in :closed status' do
           result = invoice_service.call
           expect(result.invoice.status).to eq('closed')
+          expect(result.invoice.number).to include('DRAFT')
         end
 
         context 'when organization gas grace period' do


### PR DESCRIPTION
 **context** 
Before we were setting invoice status to `finalized` or `draft` before calculating fees (because before calculating fees we don't know if it will be 0-invoice or no, and as result we don't know if it will be `:finalized` or `:closed`)

but inside calculate_fees_service we save the invoice, so if it's in `finalized` status we would generate number for this invoice, which is not needed for `closed` invoices

as result we should set invoice to `finalized` or to `closed` after we calculated fees.

so the definition if the process is finalization or  drafting of the invoice should be done not only by status, but also by the context.

 **what was done** 

- instead of setting invoice status before calculating fees, set up context
- define if the process is finalization for applying credit notes the same way we define it for tax reporting
