### PR TITLE
feat(customer-portal): Extract organization type and add premium integrations

### DIFF
--- a/app/graphql/resolvers/customer_portal/organization_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/organization_resolver.rb
@@ -5,9 +5,9 @@ module Resolvers
     class OrganizationResolver < Resolvers::BaseResolver
       include AuthenticableCustomerPortalUser
 
-      description 'Query customer portal organization'
+      description "Query customer portal organization"
 
-      type Types::Organizations::OrganizationType, null: true
+      type Types::CustomerPortal::Organizations::Object, null: true
 
       def resolve
         context[:customer_portal_user].organization

--- a/app/graphql/types/customer_portal/organizations/object.rb
+++ b/app/graphql/types/customer_portal/organizations/object.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  module CustomerPortal
+    module Organizations
+      class Object < Types::Organizations::BaseOrganizationType
+        graphql_name "CustomerPortalOrganization"
+        description "CustomerPortalOrganization"
+
+        field :id, ID, null: false
+
+        field :billing_configuration, Types::Organizations::BillingConfiguration, null: true
+        field :default_currency, Types::CurrencyEnum, null: false
+        field :logo_url, String
+        field :name, String, null: false
+        field :premium_integrations, [Types::Integrations::PremiumIntegrationTypeEnum], null: false
+        field :timezone, Types::TimezoneEnum, null: true
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3259,6 +3259,19 @@ type CustomerPortalCustomer {
 }
 
 """
+CustomerPortalOrganization
+"""
+type CustomerPortalOrganization {
+  billingConfiguration: OrganizationBillingConfiguration
+  defaultCurrency: CurrencyEnum!
+  id: ID!
+  logoUrl: String
+  name: String!
+  premiumIntegrations: [PremiumIntegrationTypeEnum!]!
+  timezone: TimezoneEnum
+}
+
+"""
 CustomerPortalWallet
 """
 type CustomerPortalWallet {
@@ -6089,7 +6102,7 @@ type Query {
   """
   Query customer portal organization
   """
-  customerPortalOrganization: Organization
+  customerPortalOrganization: CustomerPortalOrganization
 
   """
   Query overdue balances of a customer portal user

--- a/schema.json
+++ b/schema.json
@@ -13921,6 +13921,141 @@
         },
         {
           "kind": "OBJECT",
+          "name": "CustomerPortalOrganization",
+          "description": "CustomerPortalOrganization",
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "billingConfiguration",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "OrganizationBillingConfiguration",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "defaultCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "logoUrl",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "premiumIntegrations",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "PremiumIntegrationTypeEnum",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "timezone",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "TimezoneEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "CustomerPortalWallet",
           "description": "CustomerPortalWallet",
           "interfaces": [
@@ -30794,7 +30929,7 @@
               "description": "Query customer portal organization",
               "type": {
                 "kind": "OBJECT",
-                "name": "Organization",
+                "name": "CustomerPortalOrganization",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/graphql/resolvers/customer_portal/organization_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/organization_resolver_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Resolvers::CustomerPortal::OrganizationResolver, type: :graphql d
             id
             documentLocale
           }
+          premiumIntegrations
         }
       }
     GQL
@@ -37,6 +38,7 @@ RSpec.describe Resolvers::CustomerPortal::OrganizationResolver, type: :graphql d
       expect(data['name']).to eq(organization.name)
       expect(data['billingConfiguration']['id']).to eq("#{organization.id}-c0nf")
       expect(data['billingConfiguration']['documentLocale']).to eq('en')
+      expect(data['premiumIntegrations']).to eq([])
     end
   end
 end

--- a/spec/graphql/types/customer_portal/organizations/object_spec.rb
+++ b/spec/graphql/types/customer_portal/organizations/object_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::CustomerPortal::Organizations::Object do
+  subject { described_class }
+
+  it { is_expected.to be < ::Types::Organizations::BaseOrganizationType }
+
+  it { is_expected.to have_field(:id).of_type("ID!") }
+  it { is_expected.to have_field(:billing_configuration).of_type("OrganizationBillingConfiguration") }
+  it { is_expected.to have_field(:default_currency).of_type("CurrencyEnum!") }
+  it { is_expected.to have_field(:logo_url).of_type("String") }
+  it { is_expected.to have_field(:name).of_type("String!") }
+  it { is_expected.to have_field(:premium_integrations).of_type("[PremiumIntegrationTypeEnum!]!") }
+  it { is_expected.to have_field(:timezone).of_type("TimezoneEnum") }
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal](https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal)

## Context

We got feedback that this portal is too limited in terms of features and information. Why?

**1st reason:** the number of information displayed is limited

**2nd reason:** the end user cannot take actions out of it (change info, add payment method)

**3rd reason:** the UI and display is not customizable

## Description

The goal of this PR is to add premium integrations to the organization's customer portal graphql type.
