### PR TITLE
feat(customer-portal): Add applicable timezone to customer portal customer

### DIFF
--- a/app/graphql/types/customer_portal/customers/object.rb
+++ b/app/graphql/types/customer_portal/customers/object.rb
@@ -8,6 +8,7 @@ module Types
 
         field :id, ID, null: false
 
+        field :applicable_timezone, Types::TimezoneEnum, null: false
         field :currency, Types::CurrencyEnum, null: true
         field :display_name, String, null: false
         field :email, String, null: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -3240,6 +3240,7 @@ input CustomerMetadataInput {
 type CustomerPortalCustomer {
   addressLine1: String
   addressLine2: String
+  applicableTimezone: TimezoneEnum!
   billingConfiguration: CustomerBillingConfiguration
   city: String
   country: CountryCode

--- a/schema.json
+++ b/schema.json
@@ -13684,6 +13684,24 @@
               ]
             },
             {
+              "name": "applicableTimezone",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "TimezoneEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "billingConfiguration",
               "description": null,
               "type": {

--- a/spec/graphql/types/customer_portal/customers/object_spec.rb
+++ b/spec/graphql/types/customer_portal/customers/object_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Types::CustomerPortal::Customers::Object do
 
   it { is_expected.to have_field(:id).of_type("ID!") }
 
+  it { is_expected.to have_field(:applicable_timezone).of_type("TimezoneEnum!") }
   it { is_expected.to have_field(:display_name).of_type("String!") }
   it { is_expected.to have_field(:firstname).of_type("String") }
   it { is_expected.to have_field(:lastname).of_type("String") }


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal](https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal)

## Context

We got feedback that this portal is too limited in terms of features and information. Why?

**1st reason:** the number of information displayed is limited

**2nd reason:** the end user cannot take actions out of it (change info, add payment method)

**3rd reason:** the UI and display is not customizable

## Description

The goal of this PR is to add applicable timezone to the customer's customer portal graphql type.
