### PR TITLE
misc: Refactor more pre-call era services

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -4,8 +4,7 @@ module Api
   module V1
     class PlansController < Api::BaseController
       def create
-        service = ::Plans::CreateService.new
-        result = service.create(
+        result = ::Plans::CreateService.call(
           input_params.merge(organization_id: current_organization.id).to_h.deep_symbolize_keys
         )
 

--- a/app/graphql/mutations/invites/create.rb
+++ b/app/graphql/mutations/invites/create.rb
@@ -17,9 +17,7 @@ module Mutations
       type Types::Invites::Object
 
       def resolve(**args)
-        result = ::Invites::CreateService
-          .new(context[:current_user])
-          .call(**args.merge(current_organization:))
+        result = ::Invites::CreateService.call(args.merge(current_organization:))
 
         result.success? ? result.invite : result_error(result)
       end

--- a/app/graphql/mutations/invites/revoke.rb
+++ b/app/graphql/mutations/invites/revoke.rb
@@ -15,10 +15,9 @@ module Mutations
 
       type Types::Invites::Object
 
-      def resolve(**args)
-        result = ::Invites::RevokeService
-          .new(context[:current_user])
-          .call(**args.merge(current_organization:))
+      def resolve(id:)
+        invite = current_organization.invites.pending.find_by(id:, status: :pending)
+        result = ::Invites::RevokeService.call(invite)
 
         result.success? ? result.invite : result_error(result)
       end

--- a/app/graphql/mutations/plans/create.rb
+++ b/app/graphql/mutations/plans/create.rb
@@ -32,9 +32,7 @@ module Mutations
       def resolve(**args)
         args[:charges].map!(&:to_h)
 
-        result = ::Plans::CreateService
-          .new(context[:current_user])
-          .create(**args.merge(organization_id: current_organization.id))
+        result = ::Plans::CreateService.call(args.merge(organization_id: current_organization.id))
 
         result.success? ? result.plan : result_error(result)
       end

--- a/app/graphql/resolvers/customer_portal/customers/usage_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/customers/usage_resolver.rb
@@ -14,7 +14,6 @@ module Resolvers
 
         def resolve(subscription_id:)
           result = Invoices::CustomerUsageService.with_ids(
-            current_user: nil,
             organization_id: context[:customer_portal_user].organization_id,
             customer_id: context[:customer_portal_user].id,
             subscription_id:,

--- a/app/graphql/resolvers/customers/usage_resolver.rb
+++ b/app/graphql/resolvers/customers/usage_resolver.rb
@@ -16,7 +16,6 @@ module Resolvers
 
       def resolve(customer_id:, subscription_id:)
         result = Invoices::CustomerUsageService.with_ids(
-          current_user: context[:current_user],
           organization_id: context[:current_user].organization_ids,
           customer_id:,
           subscription_id:,

--- a/app/services/invites/create_service.rb
+++ b/app/services/invites/create_service.rb
@@ -2,8 +2,13 @@
 
 module Invites
   class CreateService < BaseService
-    def call(**args)
-      return result unless valid?(**args)
+    def initialize(args)
+      @args = args
+      super
+    end
+
+    def call
+      return result unless valid?(args)
 
       result.invite = Invite.create!(
         organization_id: args[:current_organization].id,
@@ -19,6 +24,8 @@ module Invites
 
     private
 
+    attr_reader :args
+
     def generate_token
       token = SecureRandom.hex(20)
 
@@ -27,7 +34,7 @@ module Invites
       token
     end
 
-    def valid?(**args)
+    def valid?(args)
       Invites::ValidateService.new(result, **args).valid?
     end
   end

--- a/app/services/invites/revoke_service.rb
+++ b/app/services/invites/revoke_service.rb
@@ -2,14 +2,23 @@
 
 module Invites
   class RevokeService < BaseService
-    def call(**args)
-      invite = args[:current_organization].invites.pending.find_by(id: args[:id], status: :pending)
+    def initialize(invite)
+      @invite = invite
+      super
+    end
+
+    def call
       return result.not_found_failure!(resource: 'invite') unless invite
+      return result.not_found_failure!(resource: 'invite') unless invite.pending?
 
       invite.mark_as_revoked!
 
       result.invite = invite
       result
     end
+
+    private
+
+    attr_reader :invite
   end
 end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -2,8 +2,8 @@
 
 module Invoices
   class CustomerUsageService < BaseService
-    def initialize(current_user, customer:, subscription:, apply_taxes: true)
-      super(current_user)
+    def initialize(customer:, subscription:, apply_taxes: true)
+      super
 
       @apply_taxes = apply_taxes
       @customer = customer
@@ -13,15 +13,15 @@ module Invoices
     def self.with_external_ids(customer_external_id:, external_subscription_id:, organization_id:, apply_taxes: true)
       customer = Customer.find_by!(external_id: customer_external_id, organization_id:)
       subscription = customer&.active_subscriptions&.find_by(external_id: external_subscription_id)
-      new(nil, customer:, subscription:, apply_taxes:)
+      new(customer:, subscription:, apply_taxes:)
     rescue ActiveRecord::RecordNotFound
       result.not_found_failure!(resource: 'customer')
     end
 
-    def self.with_ids(current_user:, organization_id:, customer_id:, subscription_id:, apply_taxes: true)
+    def self.with_ids(organization_id:, customer_id:, subscription_id:, apply_taxes: true)
       customer = Customer.find_by(id: customer_id, organization_id:)
       subscription = customer&.active_subscriptions&.find_by(id: subscription_id)
-      new(current_user, customer:, subscription:, apply_taxes:)
+      new(customer:, subscription:, apply_taxes:)
     rescue ActiveRecord::RecordNotFound
       result.not_found_failure!(resource: 'customer')
     end

--- a/app/services/lifetime_usages/calculate_service.rb
+++ b/app/services/lifetime_usages/calculate_service.rb
@@ -50,7 +50,6 @@ module LifetimeUsages
 
     def calculate_current_usage_amount_cents
       result = Invoices::CustomerUsageService.call(
-        nil, # current_user
         customer: subscription.customer,
         subscription: subscription,
         apply_taxes: false

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -2,7 +2,12 @@
 
 module Plans
   class CreateService < BaseService
-    def create(args)
+    def initialize(args)
+      @args = args
+      super
+    end
+
+    def call
       plan = Plan.new(
         organization_id: args[:organization_id],
         name: args[:name],
@@ -75,6 +80,8 @@ module Plans
     end
 
     private
+
+    attr_reader :args
 
     def create_commitment(plan, args, commitment_type)
       Commitment.create!(

--- a/app/services/wallets/balance/refresh_ongoing_service.rb
+++ b/app/services/wallets/balance/refresh_ongoing_service.rb
@@ -10,7 +10,7 @@ module Wallets
 
       def call
         usage_amount_cents = customer.active_subscriptions.map do |subscription|
-          invoice = ::Invoices::CustomerUsageService.call(nil, customer:, subscription:).invoice
+          invoice = ::Invoices::CustomerUsageService.call(customer:, subscription:).invoice
 
           {
             total_usage_amount_cents: invoice.total_amount.to_f * wallet.ongoing_balance.currency.subunit_to_unit,

--- a/spec/services/invites/revoke_service_spec.rb
+++ b/spec/services/invites/revoke_service_spec.rb
@@ -3,23 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe Invites::RevokeService, type: :service do
-  subject(:revoke_service) { described_class.new(membership.user) }
+  subject(:revoke_service) { described_class.new(invite) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:invite) { create(:invite, organization:) }
 
   describe '#call' do
-    context 'when invite is not found' do
-      let(:revoke_args) do
-        {
-          id: nil,
-          current_organization: organization
-        }
+    it 'revokes the invite' do
+      freeze_time do
+        result = revoke_service.call
+
+        expect(result).to be_success
+        expect(result.invite.id).to eq(invite.id)
+        expect(result.invite).to be_revoked
+        expect(result.invite.revoked_at).to eq(Time.current)
       end
+    end
+
+    context 'when invite is not found' do
+      let(:invite) { nil }
 
       it 'returns an error' do
-        result = revoke_service.call(**revoke_args)
+        result = revoke_service.call
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('invite_not_found')
@@ -27,16 +33,10 @@ RSpec.describe Invites::RevokeService, type: :service do
     end
 
     context 'when invite is revoked' do
-      let(:revoked_invite) { create(:invite, organization:, status: 'revoked') }
-      let(:revoke_args) do
-        {
-          id: revoked_invite.id,
-          current_organization: organization
-        }
-      end
+      let(:invite) { create(:invite, organization:, status: 'revoked') }
 
       it 'returns an error' do
-        result = revoke_service.call(**revoke_args)
+        result = revoke_service.call
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('invite_not_found')
@@ -44,39 +44,13 @@ RSpec.describe Invites::RevokeService, type: :service do
     end
 
     context 'when invite is accepted' do
-      let(:accepted_invite) { create(:invite, organization:, status: 'accepted') }
-      let(:revoke_args) do
-        {
-          id: accepted_invite.id,
-          current_organization: organization
-        }
-      end
+      let(:invite) { create(:invite, organization:, status: 'accepted') }
 
       it 'returns an error' do
-        result = revoke_service.call(**revoke_args)
+        result = revoke_service.call
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('invite_not_found')
-      end
-    end
-
-    context 'when revoking invite' do
-      let(:revoke_args) do
-        {
-          id: invite.id,
-          current_organization: organization
-        }
-      end
-
-      it 'revokes the invite' do
-        freeze_time do
-          result = revoke_service.call(**revoke_args)
-
-          expect(result).to be_success
-          expect(result.invite.id).to eq(invite.id)
-          expect(result.invite).to be_revoked
-          expect(result.invite.revoked_at).to eq(Time.current)
-        end
       end
     end
   end

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
   subject(:usage_service) do
     described_class.with_ids(
-      current_user: membership.user,
       organization_id: membership.organization_id,
       customer_id:,
       subscription_id:,


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/2641 and https://github.com/getlago/lago-api/pull/2645 and keeps refactoring some old service to take advantage of the `call` pattern and to remove the `user` arguments used in `BaseService#initialize`. 

## Description

This PR:
- Turn the `Plans::CreateService#create` method into a proper `Plans::CreateService#call` one
- Remove the need for the `current_user` argument in `Invites::CreateService` and move the arguments for the `call` method to the `initializer`
- Refact `Invites::RevokeService` to take the `invite` as an argument instead if the `id` and `current_organization` and move the argument for the `call` method to the `initializer`
- Remove the `current_user` argument for the `Invoices::CustomerUsageService`
