### PR TITLE
fix(webhook): Handle Errno::EHOSTUNREACH

### DIFF
--- a/app/services/webhooks/send_http_service.rb
+++ b/app/services/webhooks/send_http_service.rb
@@ -22,6 +22,7 @@ module Webhooks
       Errno::ECONNRESET,
       Errno::ECONNREFUSED,
       Errno::EPIPE,
+      Errno::EHOSTUNREACH,
       OpenSSL::SSL::SSLError,
       SocketError,
       EOFError => e


### PR DESCRIPTION
## Description

This PR makes sure that webhook deliveries failing with an `Errno::EHOSTUNREACH` does not end-up in the dead job queue but are marked as `failed` and automatically reprocessed.