### PR TITLE
Don't execute RefreshDraft service when the ready_to_be_refreshed is not true

### DIFF
--- a/app/jobs/invoices/refresh_draft_job.rb
+++ b/app/jobs/invoices/refresh_draft_job.rb
@@ -4,9 +4,12 @@ module Invoices
   class RefreshDraftJob < ApplicationJob
     queue_as 'invoices'
 
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 6.hours
 
     def perform(invoice)
+      # if this has already been set to false, we can skip the job
+      return unless invoice.ready_to_be_refreshed?
+
       ::Invoices::RefreshDraftService.call(invoice:)
     end
   end


### PR DESCRIPTION
## Context

When lots of RefreshDraftJobs are enqueued, we might not be able to process them all in an hour. This code change tries to make sure that we'd not enqueue further jobs for 6 hours.