### PR TITLE
fix(intergrations): Fix fees in invoices payload

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/base_payload.rb
@@ -34,7 +34,11 @@ module Integrations
           attr_accessor :remaining_taxes_amount_cents
 
           def fees
-            @fees ||= invoice.fees.order(created_at: :asc)
+            @fees ||= if invoice.fees.where('amount_cents > ?', 0).exists?
+              invoice.fees.where('amount_cents > ?', 0).order(created_at: :asc)
+            else
+              invoice.fees.order(created_at: :asc)
+            end
           end
 
           def fee_items

--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -70,10 +70,6 @@ module Integrations
             }
           end
 
-          def fees
-            @fees ||= invoice.fees.where('amount_cents > ?', 0).order(created_at: :asc)
-          end
-
           def invoice_url
             url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
 

--- a/spec/services/integrations/aggregator/invoices/payloads/base_payload_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/base_payload_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::Invoices::Payloads::BasePayload do
+  let(:payload) { described_class.new(integration_customer:, invoice:) }
+  let(:integration_customer) { create(:xero_customer, integration:, customer:) }
+  let(:integration) { create(:xero_integration, organization:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:organization) { create(:organization) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+
+  describe '#fees' do
+    subject(:fees_call) { payload.__send__(:fees) }
+
+    context 'when there are fees with positive amount_cents' do
+      let(:fee1) { create(:fee, invoice:, amount_cents: 1000, created_at: 1.day.ago) }
+      let(:fee2) { create(:fee, invoice:, amount_cents: 2000, created_at: 2.days.ago) }
+
+      it 'returns fees with positive amount_cents ordered by created_at' do
+        expect(fees_call).to eq([fee2, fee1])
+      end
+    end
+
+    context 'when there are no fees with positive amount_cents' do
+      let(:fee1) { create(:fee, invoice:, amount_cents: 0, created_at: 1.day.ago) }
+      let(:fee2) { create(:fee, invoice:, amount_cents: -1000, created_at: 2.days.ago) }
+
+      it 'returns all fees ordered by created_at' do
+        expect(fees_call).to eq([fee2, fee1])
+      end
+    end
+
+    context 'when there are fees with positive and zero amount_cents' do
+      let(:fee1) { create(:fee, invoice:, amount_cents: 0, created_at: 1.day.ago) }
+      let(:fee2) { create(:fee, invoice:, amount_cents: 100, created_at: 2.days.ago) }
+      let(:fee3) { create(:fee, invoice:, amount_cents: 200, created_at: 3.days.ago) }
+
+      it 'returns only positive fees ordered by created_at' do
+        expect(fees_call).to eq([fee2, fee1])
+      end
+    end
+  end
+end

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
   let(:payload) { described_class.new(integration_customer:, invoice:) }
-  let(:integration_customer) { FactoryBot.create(:xero_customer, integration:, customer:) }
+  let(:integration_customer) { create(:xero_customer, integration:, customer:) }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }


### PR DESCRIPTION
## Context

Netsuite raises an error when creating an invoice with 0 lines items (fees).

## Description

This PR fixes a situation where we're about to sync an invoice with empty line items array.
