### PR TITLE
fix(membership): Ensure membership is in current organization when revoking

### DIFF
--- a/app/graphql/mutations/memberships/revoke.rb
+++ b/app/graphql/mutations/memberships/revoke.rb
@@ -4,6 +4,7 @@ module Mutations
   module Memberships
     class Revoke < BaseMutation
       include AuthenticableApiUser
+      include RequiredOrganization
 
       REQUIRED_PERMISSION = 'organization:members:update'
 
@@ -15,7 +16,8 @@ module Mutations
       type Types::MembershipType
 
       def resolve(id:)
-        result = ::Memberships::RevokeService.new(context[:current_user]).call(id)
+        membership = current_organization.memberships.find_by(id: id)
+        result = ::Memberships::RevokeService.call(user: context[:current_user], membership:)
 
         result.success? ? result.membership : result_error(result)
       end

--- a/app/services/memberships/revoke_service.rb
+++ b/app/services/memberships/revoke_service.rb
@@ -2,10 +2,16 @@
 
 module Memberships
   class RevokeService < BaseService
-    def call(id)
-      membership = Membership.find_by(id:)
+    def initialize(user:, membership:)
+      @user = user
+      @membership = membership
+
+      super
+    end
+
+    def call
       return result.not_found_failure!(resource: 'membership') unless membership
-      return result.not_allowed_failure!(code: 'cannot_revoke_own_membership') if result.user.id == membership.user.id
+      return result.not_allowed_failure!(code: 'cannot_revoke_own_membership') if user.id == membership.user.id
       return result.not_allowed_failure!(code: 'last_admin') if membership.organization.memberships.admin.count == 1 && membership.admin?
 
       membership.mark_as_revoked!
@@ -13,5 +19,9 @@ module Memberships
       result.membership = membership
       result
     end
+
+    private
+
+    attr_reader :user, :membership
   end
 end

--- a/spec/graphql/mutations/memberships/revoke_spec.rb
+++ b/spec/graphql/mutations/memberships/revoke_spec.rb
@@ -19,13 +19,15 @@ RSpec.describe Mutations::Memberships::Revoke, type: :graphql do
   end
 
   it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:members:update'
 
   it 'Revokes a membership' do
     user = create(:user)
-    create(:membership, organization: organization, role: :admin)
+    create(:membership, organization:, role: :admin, user:)
 
     result = execute_graphql(
+      current_organization: organization,
       current_user: user,
       permissions: required_permission,
       query: mutation,
@@ -42,6 +44,7 @@ RSpec.describe Mutations::Memberships::Revoke, type: :graphql do
 
   it 'Cannot Revoke my own membership' do
     result = execute_graphql(
+      current_organization: organization,
       current_user: membership.user,
       permissions: required_permission,
       query: mutation,
@@ -63,6 +66,7 @@ RSpec.describe Mutations::Memberships::Revoke, type: :graphql do
     other_user = create(:membership, organization: organization, role: :finance)
 
     result = execute_graphql(
+      current_organization: organization,
       current_user: other_user.user,
       permissions: required_permission,
       query: mutation,


### PR DESCRIPTION
## Context

Today it is possible the revoke a membership from any organization as long as you know the ID.
The `Mutations::Memberships::Revoke` is delegating the logic to `Memberships::RevokeService`, but this service is not checking that the membership is part of any organization (`Membership.find_by`)

## Description

This PR refactors the service to use the common `call` pattern.
It also update the mutation to require an Organization and lookup for the membership with a scope to the current organization.