### PR TITLE
fix(pdf): Fix credit note generating pdf and webhook

### DIFF
--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -58,6 +58,7 @@ module CreditNotes
       if credit_note.finalized?
         track_credit_note_created
         deliver_webhook
+        CreditNotes::GeneratePdfJob.perform_later(credit_note)
         deliver_email
         handle_refund if should_handle_refund?
         report_to_tax_provider

--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -41,6 +41,7 @@ module Invoices
       invoice.credit_notes.each do |credit_note|
         track_credit_note_created(credit_note)
         SendWebhookJob.perform_later('credit_note.created', credit_note)
+        CreditNotes::GeneratePdfJob.perform_later(credit_note)
       end
 
       result

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -121,8 +121,11 @@ RSpec.describe CreditNotes::CreateService, type: :service do
     it 'delivers a webhook' do
       create_service.call
 
-      expect(SendWebhookJob).to have_been_enqueued
-        .with('credit_note.created', CreditNote)
+      aggregate_failures do
+        expect(SendWebhookJob).to have_been_enqueued.with('credit_note.created', CreditNote)
+
+        expect(CreditNotes::GeneratePdfJob).to have_been_enqueued
+      end
     end
 
     it 'delivers an email' do

--- a/spec/services/credit_notes/generate_service_spec.rb
+++ b/spec/services/credit_notes/generate_service_spec.rb
@@ -97,5 +97,15 @@ RSpec.describe CreditNotes::GenerateService, type: :service do
         end.to have_enqueued_job(SendWebhookJob)
       end
     end
+
+    context 'when context is admin' do
+      let(:context) { 'admin' }
+
+      it 'calls the SendWebhook job' do
+        expect do
+          credit_note_generate_service.call
+        end.to have_enqueued_job(SendWebhookJob)
+      end
+    end
   end
 end

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -197,6 +197,12 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
           finalize_service.call
         end.to have_enqueued_job(SendWebhookJob).with('credit_note.created', CreditNote)
       end
+
+      it 'enqueues CreditNotes::GeneratePdfJob' do
+        expect do
+          finalize_service.call
+        end.to have_enqueued_job(CreditNotes::GeneratePdfJob)
+      end
     end
 
     context 'when tax integration is set up' do


### PR DESCRIPTION
## Context

For credit notes, Lago does not automatically generate PDF files. The webhook `credit_note.generated` is only sent when an API request is made.

Expected behaviour: the credit note logic should be the same as the invoice logic.

## Description

This PR changes logic for generating credit notes and their webhook so that it's the same as invoices.