### PR TITLE
misc: Remove the need for BaseService current user argument

### DIFF
--- a/app/graphql/mutations/payment_providers/destroy.rb
+++ b/app/graphql/mutations/payment_providers/destroy.rb
@@ -15,9 +15,11 @@ module Mutations
       field :id, ID, null: true
 
       def resolve(id:)
-        result = ::PaymentProviders::DestroyService
-          .new(context[:current_user])
-          .destroy(id:)
+        payment_provider = ::PaymentProviders::BaseProvider.find_by(
+          id:,
+          organization_id: context[:current_user].organization_ids
+        )
+        result = ::PaymentProviders::DestroyService.call(payment_provider)
 
         result.success? ? result.payment_provider : result_error(result)
       end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -156,10 +156,9 @@ class BaseService
     end
   end
 
-  def initialize(current_user = nil)
+  def initialize(args = nil)
     @result = Result.new
     @source = CurrentContext&.source
-    result.user = current_user.is_a?(User) ? current_user : nil
   end
 
   def call(**args, &block)

--- a/app/services/payment_providers/destroy_service.rb
+++ b/app/services/payment_providers/destroy_service.rb
@@ -2,11 +2,13 @@
 
 module PaymentProviders
   class DestroyService < BaseService
-    def destroy(id:)
-      payment_provider = PaymentProviders::BaseProvider.find_by(
-        id:,
-        organization_id: result.user.organization_ids
-      )
+    def initialize(payment_provider)
+      @payment_provider = payment_provider
+
+      super
+    end
+
+    def call
       return result.not_found_failure!(resource: 'payment_provider') unless payment_provider
 
       customer_ids = payment_provider.customer_ids
@@ -21,5 +23,9 @@ module PaymentProviders
       result.payment_provider = payment_provider
       result
     end
+
+    private
+
+    attr_reader :payment_provider
   end
 end

--- a/spec/services/base_service_spec.rb
+++ b/spec/services/base_service_spec.rb
@@ -11,10 +11,9 @@ RSpec.describe ::BaseService, type: :service do
 
   context 'with current_user' do
     it 'assigns the current_user to the result' do
-      user = create(:user)
-      result = described_class.new(user).send :result
+      result = described_class.new.send :result
 
-      expect(result.user).to eq(user)
+      expect(result).to be_a(::BaseService::Result)
     end
 
     it 'does not assign the current_user to the result if it isn\'t a User' do

--- a/spec/services/payment_providers/destroy_service_spec.rb
+++ b/spec/services/payment_providers/destroy_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe PaymentProviders::DestroyService, type: :service do
-  subject(:destroy_service) { described_class.new(membership.user) }
+  subject(:destroy_service) { described_class.new(payment_provider) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
@@ -14,24 +14,15 @@ RSpec.describe PaymentProviders::DestroyService, type: :service do
     before { payment_provider }
 
     it 'destroys the payment_provider' do
-      expect { destroy_service.destroy(id: payment_provider.id) }
+      expect { destroy_service.call }
         .to change(PaymentProviders::BaseProvider, :count).by(-1)
     end
 
     context 'when payment provider is not found' do
-      it 'returns an error' do
-        result = destroy_service.destroy(id: nil)
-
-        expect(result).not_to be_success
-        expect(result.error.error_code).to eq('payment_provider_not_found')
-      end
-    end
-
-    context 'when payment provider is not attached to the organization' do
-      let(:payment_provider) { create(:stripe_provider) }
+      let(:payment_provider) { nil }
 
       it 'returns an error' do
-        result = destroy_service.destroy(id: payment_provider.id)
+        result = destroy_service.call
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('payment_provider_not_found')


### PR DESCRIPTION
## Context

The `BaseService#initialize` method is expecting a first argument of type `User` that is then assigned to the created `result`. This argument is not used in any places (last references were removed in previous PRs) 

## Description

This PR simply removes this reference, and refactors the `::PaymentProviders::DestroyService` that was the last remaining service relying on it.