### PR TITLE
misc: Update cache format version

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,6 @@ module LagoApi
       g.orm(:active_record, primary_key_type: :uuid)
     end
 
-    # TODO: turn this value to 7.1 after upgrading to Rails 7.1
-    config.active_support.cache_format_version = 7.0
+    config.active_support.cache_format_version = 7.1
   end
 end


### PR DESCRIPTION
## Context

Rails version was bumped few month ago to `7.1.X`, but to make migration possible, the cache format version was kept to `7.0`. This was a requirement of the standard rails upgrade process. It will also be required to upgrade to rails `7.2` and `7.3`

## Description

Since rails 7.1 is in production for few month now it safe to change the cache version.
