### PR TITLE
fix(credit-notes): submit credit note to tax provider after transaction ends

### DIFF
--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -193,7 +193,7 @@ module CreditNotes
     end
 
     def report_to_tax_provider
-      CreditNotes::ProviderTaxes::ReportJob.perform_later(credit_note:)
+      after_commit { CreditNotes::ProviderTaxes::ReportJob.perform_later(credit_note:) }
     end
 
     def compute_amounts_and_taxes


### PR DESCRIPTION
## Context

Job for submitting credit note in tax provider should be called once DB transaction ends