### PR TITLE
feat(cp-improve): Customer portal update customer's customer_type

### DIFF
--- a/app/graphql/types/customer_portal/customers/object.rb
+++ b/app/graphql/types/customer_portal/customers/object.rb
@@ -32,11 +32,17 @@ module Types
 
         field :shipping_address, Types::Customers::Address, null: true
 
+        field :premium, Boolean, null: false
+
         def billing_configuration
           {
             id: "#{object&.id}-c0nf",
             document_locale: object&.document_locale
           }
+        end
+
+        def premium
+          License.premium?
         end
       end
     end

--- a/app/graphql/types/customer_portal/customers/object.rb
+++ b/app/graphql/types/customer_portal/customers/object.rb
@@ -10,6 +10,7 @@ module Types
 
         field :applicable_timezone, Types::TimezoneEnum, null: false
         field :currency, Types::CurrencyEnum, null: true
+        field :customer_type, Types::Customers::CustomerTypeEnum
         field :display_name, String, null: false
         field :email, String, null: true
         field :firstname, String

--- a/app/graphql/types/customer_portal/customers/update_input.rb
+++ b/app/graphql/types/customer_portal/customers/update_input.rb
@@ -7,6 +7,7 @@ module Types
         graphql_name "UpdateCustomerPortalCustomerInput"
         description "Customer Portal Customer Update input arguments"
 
+        argument :customer_type, Types::Customers::CustomerTypeEnum, required: false
         argument :document_locale, String, required: false
         argument :email, String, required: false
         argument :firstname, String, required: false

--- a/app/graphql/types/customer_portal/wallets/object.rb
+++ b/app/graphql/types/customer_portal/wallets/object.rb
@@ -22,6 +22,8 @@ module Types
         field :ongoing_balance_cents, GraphQL::Types::BigInt, null: false
         field :ongoing_usage_balance_cents, GraphQL::Types::BigInt, null: false
         field :rate_amount, GraphQL::Types::Float, null: false
+
+        field :last_balance_sync_at, GraphQL::Types::ISO8601DateTime, null: true
       end
     end
   end

--- a/app/services/customer_portal/customer_update_service.rb
+++ b/app/services/customer_portal/customer_update_service.rb
@@ -13,6 +13,7 @@ module CustomerPortal
       return result.not_found_failure!(resource: "customer") unless customer
 
       ActiveRecord::Base.transaction do
+        customer.customer_type = args[:customer_type] if args.key?(:customer_type)
         customer.name = args[:name] if args.key?(:name)
         customer.firstname = args[:firstname] if args.key?(:firstname)
         customer.lastname = args[:lastname] if args.key?(:lastname)

--- a/schema.graphql
+++ b/schema.graphql
@@ -3245,6 +3245,7 @@ type CustomerPortalCustomer {
   city: String
   country: CountryCode
   currency: CurrencyEnum
+  customerType: CustomerTypeEnum
   displayName: String!
   email: String
   firstname: String
@@ -3284,6 +3285,7 @@ type CustomerPortalWallet {
   currency: CurrencyEnum!
   expirationAt: ISO8601DateTime
   id: ID!
+  lastBalanceSyncAt: ISO8601DateTime
   name: String
   ongoingBalanceCents: BigInt!
   ongoingUsageBalanceCents: BigInt!
@@ -7746,6 +7748,7 @@ input UpdateCustomerPortalCustomerInput {
   """
   clientMutationId: String
   country: CountryCode
+  customerType: CustomerTypeEnum
   documentLocale: String
   email: String
   firstname: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -3254,6 +3254,7 @@ type CustomerPortalCustomer {
   legalName: String
   legalNumber: String
   name: String
+  premium: Boolean!
   shippingAddress: CustomerAddress
   state: String
   taxIdentificationNumber: String

--- a/schema.json
+++ b/schema.json
@@ -13892,6 +13892,24 @@
               ]
             },
             {
+              "name": "premium",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "shippingAddress",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -13758,6 +13758,20 @@
               ]
             },
             {
+              "name": "customerType",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "CustomerTypeEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "displayName",
               "description": null,
               "type": {
@@ -14214,6 +14228,20 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "lastBalanceSyncAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -37740,6 +37768,18 @@
           "possibleTypes": null,
           "fields": null,
           "inputFields": [
+            {
+              "name": "customerType",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "CustomerTypeEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "documentLocale",
               "description": null,

--- a/spec/graphql/mutations/customer_portal/update_customer_spec.rb
+++ b/spec/graphql/mutations/customer_portal/update_customer_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Mutations::CustomerPortal::UpdateCustomer, type: :graphql do
     <<~GQL
       mutation($input: UpdateCustomerPortalCustomerInput!) {
         updateCustomerPortalCustomer(input: $input) {
+          customerType
           name
           firstname
           lastname
@@ -49,6 +50,7 @@ RSpec.describe Mutations::CustomerPortal::UpdateCustomer, type: :graphql do
 
   let(:input) do
     {
+      customerType: "company",
       name: "Updated customer name",
       firstname: "Updated customer firstname",
       lastname: "Updated customer lastname",
@@ -78,6 +80,7 @@ RSpec.describe Mutations::CustomerPortal::UpdateCustomer, type: :graphql do
   it "updates a customer", :aggregate_failures do
     result_data = result["data"]["updateCustomerPortalCustomer"]
 
+    expect(result_data["customerType"]).to eq(input[:customerType])
     expect(result_data["name"]).to eq(input[:name])
     expect(result_data["firstname"]).to eq(input[:firstname])
     expect(result_data["lastname"]).to eq(input[:lastname])

--- a/spec/graphql/types/customer_portal/customers/object_spec.rb
+++ b/spec/graphql/types/customer_portal/customers/object_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Types::CustomerPortal::Customers::Object do
   it { is_expected.to have_field(:id).of_type("ID!") }
 
   it { is_expected.to have_field(:applicable_timezone).of_type("TimezoneEnum!") }
+  it { is_expected.to have_field(:currency).of_type("CurrencyEnum") }
+  it { is_expected.to have_field(:customer_type).of_type("CustomerTypeEnum") }
   it { is_expected.to have_field(:display_name).of_type("String!") }
   it { is_expected.to have_field(:firstname).of_type("String") }
   it { is_expected.to have_field(:lastname).of_type("String") }

--- a/spec/graphql/types/customer_portal/customers/object_spec.rb
+++ b/spec/graphql/types/customer_portal/customers/object_spec.rb
@@ -29,4 +29,6 @@ RSpec.describe Types::CustomerPortal::Customers::Object do
   it { is_expected.to have_field(:shipping_address).of_type("CustomerAddress") }
 
   it { is_expected.to have_field(:billing_configuration).of_type('CustomerBillingConfiguration') }
+
+  it { is_expected.to have_field(:premium).of_type("Boolean!") }
 end

--- a/spec/graphql/types/customer_portal/customers/update_input_spec.rb
+++ b/spec/graphql/types/customer_portal/customers/update_input_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe Types::CustomerPortal::Customers::UpdateInput do
   subject { described_class }
 
+  it { is_expected.to accept_argument(:customer_type).of_type("CustomerTypeEnum") }
   it { is_expected.to accept_argument(:document_locale).of_type("String") }
   it { is_expected.to accept_argument(:email).of_type("String") }
   it { is_expected.to accept_argument(:firstname).of_type("String") }

--- a/spec/graphql/types/customer_portal/wallets/object_spec.rb
+++ b/spec/graphql/types/customer_portal/wallets/object_spec.rb
@@ -20,4 +20,5 @@ RSpec.describe Types::CustomerPortal::Wallets::Object do
   it { is_expected.to have_field(:ongoing_balance_cents).of_type("BigInt!") }
   it { is_expected.to have_field(:ongoing_usage_balance_cents).of_type("BigInt!") }
   it { is_expected.to have_field(:rate_amount).of_type("Float!") }
+  it { is_expected.to have_field(:last_balance_sync_at).of_type('ISO8601DateTime') }
 end

--- a/spec/services/customer_portal/customer_update_service_spec.rb
+++ b/spec/services/customer_portal/customer_update_service_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe CustomerPortal::CustomerUpdateService, type: :service do
 
   let(:update_args) do
     {
+      customer_type: "individual",
       document_locale: "es",
       name: "Updated customer name",
       firstname: "Updated customer firstname",
@@ -38,6 +39,7 @@ RSpec.describe CustomerPortal::CustomerUpdateService, type: :service do
 
     updated_customer = result.customer
 
+    expect(updated_customer.customer_type).to eq(update_args[:customer_type])
     expect(updated_customer.name).to eq(update_args[:name])
     expect(updated_customer.firstname).to eq(update_args[:firstname])
     expect(updated_customer.lastname).to eq(update_args[:lastname])


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/add-features-to-the-customer-portal

 ## Context

The current customer portal already exposes some customer information. However, it is missing some important pieces of customer information. Also, we want to allow customer to edit their own billing information.

 ## Description

This change enable customers to update their customer type (individual/company) through the customer portal.

Also, adds `last_balance_sync_at` to CustomerPortal::Wallet:Object in order to render the last time wallet balance was synced in a tooltip.

And expose a `premium` field in `CustomerPortalCustomer` type.