### PR TITLE
feat(hubspot): Add associations, attributes to customer models to support hubspot integration

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -58,6 +58,7 @@ class Customer < ApplicationRecord
   has_one :netsuite_customer, class_name: 'IntegrationCustomers::NetsuiteCustomer'
   has_one :anrok_customer, class_name: 'IntegrationCustomers::AnrokCustomer'
   has_one :xero_customer, class_name: 'IntegrationCustomers::XeroCustomer'
+  has_one :hubspot_customer, class_name: 'IntegrationCustomers::HubspotCustomer'
 
   PAYMENT_PROVIDERS = %w[stripe gocardless adyen].freeze
 

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -16,6 +16,10 @@ module IntegrationCustomers
       where(type: %w[IntegrationCustomers::NetsuiteCustomer IntegrationCustomers::XeroCustomer])
     end
 
+    scope :crm_kind, -> do
+      where(type: %w[IntegrationCustomers::HubspotCustomer])
+    end
+
     settings_accessors :sync_with_provider
 
     def self.customer_type(type)
@@ -28,6 +32,8 @@ module IntegrationCustomers
         'IntegrationCustomers::AnrokCustomer'
       when 'xero'
         'IntegrationCustomers::XeroCustomer'
+      when 'hubspot'
+        'IntegrationCustomers::HubspotCustomer'
       else
         raise(NotImplementedError)
       end

--- a/app/models/integration_customers/hubspot_customer.rb
+++ b/app/models/integration_customers/hubspot_customer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class HubspotCustomer < BaseCustomer
+    settings_accessors :targeted_object, :email
+  end
+end
+
+# == Schema Information
+#
+# Table name: integration_customers
+#
+#  id                   :uuid             not null, primary key
+#  settings             :jsonb            not null
+#  type                 :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  customer_id          :uuid             not null
+#  external_customer_id :string
+#  integration_id       :uuid             not null
+#
+# Indexes
+#
+#  index_integration_customers_on_customer_id           (customer_id)
+#  index_integration_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
+#  index_integration_customers_on_external_customer_id  (external_customer_id)
+#  index_integration_customers_on_integration_id        (integration_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (integration_id => integrations.id)
+#

--- a/app/serializers/v1/integration_customer_serializer.rb
+++ b/app/serializers/v1/integration_customer_serializer.rb
@@ -23,6 +23,8 @@ module V1
         'anrok'
       when 'IntegrationCustomers::XeroCustomer'
         'xero'
+      when 'IntegrationCustomers::HubspotCustomer'
+        'hubspot'
       end
     end
   end

--- a/spec/factories/integration_customers.rb
+++ b/spec/factories/integration_customers.rb
@@ -33,4 +33,19 @@ FactoryBot.define do
       {sync_with_provider: true}
     end
   end
+
+  factory :hubspot_customer, class: 'IntegrationCustomers::HubspotCustomer' do
+    association :integration, factory: :hubspot_integration
+    customer
+    type { 'IntegrationCustomers::HubspotCustomer' }
+    external_customer_id { SecureRandom.uuid }
+
+    settings do
+      {
+        sync_with_provider: true,
+        email: Faker::Internet.email,
+        targeted_object: Integrations::HubspotIntegration::TARGETED_OBJECTS.sample
+      }
+    end
+  end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Customer, type: :model do
   it { is_expected.to have_one(:netsuite_customer) }
   it { is_expected.to have_one(:anrok_customer) }
   it { is_expected.to have_one(:xero_customer) }
+  it { is_expected.to have_one(:hubspot_customer) }
 
   it 'sets the default value to inherit' do
     expect(customer.finalize_zero_amount_invoice).to eq "inherit"

--- a/spec/models/integration_customers/base_customer_spec.rb
+++ b/spec/models/integration_customers/base_customer_spec.rb
@@ -13,6 +13,42 @@ RSpec.describe IntegrationCustomers::BaseCustomer, type: :model do
   it { is_expected.to belong_to(:integration) }
   it { is_expected.to belong_to(:customer) }
 
+  describe '.accounting_kind' do
+    let(:netsuite_customer) { create(:netsuite_customer) }
+    let(:xero_customer) { create(:xero_customer) }
+    let(:anrok_customer) { create(:anrok_customer) }
+    let(:hubspot_customer) { create(:hubspot_customer) }
+
+    before do
+      netsuite_customer
+      xero_customer
+      anrok_customer
+      hubspot_customer
+    end
+
+    it 'returns only accounting kind customers' do
+      expect(described_class.accounting_kind).to contain_exactly(netsuite_customer, xero_customer)
+    end
+  end
+
+  describe '.crm_kind' do
+    let(:netsuite_customer) { create(:netsuite_customer) }
+    let(:xero_customer) { create(:xero_customer) }
+    let(:anrok_customer) { create(:anrok_customer) }
+    let(:hubspot_customer) { create(:hubspot_customer) }
+
+    before do
+      netsuite_customer
+      xero_customer
+      anrok_customer
+      hubspot_customer
+    end
+
+    it 'returns only crm kind customers' do
+      expect(described_class.crm_kind).to contain_exactly(hubspot_customer)
+    end
+  end
+
   describe '.customer_type' do
     subject(:customer_type_call) { described_class.customer_type(type) }
 
@@ -46,6 +82,15 @@ RSpec.describe IntegrationCustomers::BaseCustomer, type: :model do
     context 'when type is xero' do
       let(:type) { 'xero' }
       let(:customer_type) { 'IntegrationCustomers::XeroCustomer' }
+
+      it 'returns customer type' do
+        expect(subject).to eq(customer_type)
+      end
+    end
+
+    context 'when type is hubspot' do
+      let(:type) { 'hubspot' }
+      let(:customer_type) { 'IntegrationCustomers::HubspotCustomer' }
 
       it 'returns customer type' do
         expect(subject).to eq(customer_type)

--- a/spec/models/integration_customers/hubspot_customer_spec.rb
+++ b/spec/models/integration_customers/hubspot_customer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntegrationCustomers::HubspotCustomer, type: :model do
+  subject(:hubspot_customer) { build(:hubspot_customer) }
+
+  describe '#targeted_object' do
+    let(:targeted_object) { Integrations::HubspotIntegration::TARGETED_OBJECTS.sample }
+
+    it 'assigns and retrieve a setting' do
+      hubspot_customer.targeted_object = targeted_object
+      expect(hubspot_customer.targeted_object).to eq(targeted_object)
+    end
+  end
+
+  describe '#email' do
+    let(:email) { Faker::Internet.email }
+
+    it 'assigns and retrieve a setting' do
+      hubspot_customer.email = email
+      expect(hubspot_customer.email).to eq(email)
+    end
+  end
+end

--- a/spec/serializers/v1/integration_customer_serializer_spec.rb
+++ b/spec/serializers/v1/integration_customer_serializer_spec.rb
@@ -45,5 +45,13 @@ RSpec.describe ::V1::IntegrationCustomerSerializer do
         expect(subject).to eq('xero')
       end
     end
+
+    context 'when customer is a hubspot customer' do
+      let(:integration_customer) { create(:hubspot_customer) }
+
+      it 'returns hubspot' do
+        expect(subject).to eq('hubspot')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-hubspot

## Description

This PR adds models, associations and attributes needed for hubspot customers.
It also adds logic to the custoemr serializer so that it can return correct customer type.