### PR TITLE
feat(dunning): Add DunningCampaign and DunningCampaignThreshold

### DIFF
--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -4,6 +4,7 @@ class DunningCampaign < ApplicationRecord
   include PaperTrailTraceable
 
   belongs_to :organization
+  has_many :thresholds, class_name: "DunningCampaignThreshold", dependent: :destroy
 
   validates :name, presence: true
   validates :days_between_attempts, numericality: {greater_than: 0}

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class DunningCampaign < ApplicationRecord
+  include PaperTrailTraceable
+
+  belongs_to :organization
+
+  validates :name, presence: true
+  validates :days_between_attempts, numericality: {greater_than: 0}
+  validates :max_attempts, numericality: {greater_than: 0}
+  validates :code, uniqueness: {scope: :organization_id}
+end
+
+# == Schema Information
+#
+# Table name: dunning_campaigns
+#
+#  id                      :uuid             not null, primary key
+#  applied_to_organization :boolean          default(FALSE), not null
+#  code                    :string           not null
+#  days_between_attempts   :integer          default(1), not null
+#  description             :text
+#  max_attempts            :integer          default(1), not null
+#  name                    :string           not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  organization_id         :uuid             not null
+#
+# Indexes
+#
+#  index_dunning_campaigns_on_organization_id           (organization_id)
+#  index_dunning_campaigns_on_organization_id_and_code  (organization_id,code) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/dunning_campaign_threshold.rb
+++ b/app/models/dunning_campaign_threshold.rb
@@ -9,7 +9,6 @@ class DunningCampaignThreshold < ApplicationRecord
   validates :amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :currency, inclusion: {in: currency_list}
   validates :currency, uniqueness: {scope: :dunning_campaign_id}
-  validates :dunning_campaign_id, presence: true
 end
 
 # == Schema Information

--- a/app/models/dunning_campaign_threshold.rb
+++ b/app/models/dunning_campaign_threshold.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class DunningCampaignThreshold < ApplicationRecord
+  include Currencies
+  include PaperTrailTraceable
+
+  belongs_to :dunning_campaign
+
+  validates :amount_cents, numericality: {greater_than_or_equal_to: 0}
+  validates :currency, inclusion: {in: currency_list}
+  validates :currency, uniqueness: {scope: :dunning_campaign_id}
+  validates :dunning_campaign_id, presence: true
+end
+
+# == Schema Information
+#
+# Table name: dunning_campaign_thresholds
+#
+#  id                  :uuid             not null, primary key
+#  amount_cents        :bigint           not null
+#  currency            :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  dunning_campaign_id :uuid             not null
+#
+# Indexes
+#
+#  idx_on_dunning_campaign_id_currency_fbf233b2ae            (dunning_campaign_id,currency) UNIQUE
+#  index_dunning_campaign_thresholds_on_dunning_campaign_id  (dunning_campaign_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (dunning_campaign_id => dunning_campaigns.id)
+#

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -35,6 +35,7 @@ class Organization < ApplicationRecord
   has_many :cached_aggregations
   has_many :data_exports
   has_many :error_details
+  has_many :dunning_campaigns
 
   has_many :stripe_payment_providers, class_name: 'PaymentProviders::StripeProvider'
   has_many :gocardless_payment_providers, class_name: 'PaymentProviders::GocardlessProvider'

--- a/db/migrate/20241007083747_create_dunning_campaigns.rb
+++ b/db/migrate/20241007083747_create_dunning_campaigns.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateDunningCampaigns < ActiveRecord::Migration[7.1]
+  def change
+    create_table :dunning_campaigns, id: :uuid do |t|
+      t.references :organization, type: :uuid, null: false, foreign_key: true
+
+      t.string :name, null: false
+      t.string :code, null: false
+      t.text :description
+      t.boolean :applied_to_organization, null: false, default: false
+      t.integer :days_between_attempts, null: false, default: 1
+      t.integer :max_attempts, null: false, default: 1
+
+      t.timestamps
+
+      t.index %i[organization_id code], unique: true
+    end
+  end
+end

--- a/db/migrate/20241007092701_create_dunning_campaign_thresholds.rb
+++ b/db/migrate/20241007092701_create_dunning_campaign_thresholds.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateDunningCampaignThresholds < ActiveRecord::Migration[7.1]
+  def change
+    create_table :dunning_campaign_thresholds, id: :uuid do |t|
+      t.references :dunning_campaign, null: false, foreign_key: true, type: :uuid
+
+      t.string :currency, null: false
+      t.bigint :amount_cents, null: false
+
+      t.timestamps
+
+      t.index %i[dunning_campaign_id currency], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema[7.1].define(version: 2024_10_08_080209) do
+=======
+ActiveRecord::Schema[7.1].define(version: 2024_10_07_092701) do
+>>>>>>> d8a761eb1 (feat(dunning): Add table dunning_campaign_thresholds)
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -475,6 +479,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_08_080209) do
     t.uuid "organization_id"
     t.index ["membership_id"], name: "index_data_exports_on_membership_id"
     t.index ["organization_id"], name: "index_data_exports_on_organization_id"
+  end
+
+  create_table "dunning_campaign_thresholds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "dunning_campaign_id", null: false
+    t.string "currency", null: false
+    t.bigint "amount_cents", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dunning_campaign_id", "currency"], name: "idx_on_dunning_campaign_id_currency_fbf233b2ae", unique: true
+    t.index ["dunning_campaign_id"], name: "index_dunning_campaign_thresholds_on_dunning_campaign_id"
   end
 
   create_table "dunning_campaigns", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1251,6 +1265,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_08_080209) do
   add_foreign_key "customers_taxes", "taxes"
   add_foreign_key "data_exports", "memberships"
   add_foreign_key "data_exports", "organizations"
+  add_foreign_key "dunning_campaign_thresholds", "dunning_campaigns"
   add_foreign_key "dunning_campaigns", "organizations"
   add_foreign_key "error_details", "organizations"
   add_foreign_key "fees", "add_ons"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
 ActiveRecord::Schema[7.1].define(version: 2024_10_08_080209) do
-=======
-ActiveRecord::Schema[7.1].define(version: 2024_10_07_092701) do
->>>>>>> d8a761eb1 (feat(dunning): Add table dunning_campaign_thresholds)
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -477,6 +477,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_08_080209) do
     t.index ["organization_id"], name: "index_data_exports_on_organization_id"
   end
 
+  create_table "dunning_campaigns", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "organization_id", null: false
+    t.string "name", null: false
+    t.string "code", null: false
+    t.text "description"
+    t.boolean "applied_to_organization", default: false, null: false
+    t.integer "days_between_attempts", default: 1, null: false
+    t.integer "max_attempts", default: 1, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id", "code"], name: "index_dunning_campaigns_on_organization_id_and_code", unique: true
+    t.index ["organization_id"], name: "index_dunning_campaigns_on_organization_id"
+  end
+
   create_table "error_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "owner_type", null: false
     t.uuid "owner_id", null: false
@@ -1237,6 +1251,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_08_080209) do
   add_foreign_key "customers_taxes", "taxes"
   add_foreign_key "data_exports", "memberships"
   add_foreign_key "data_exports", "organizations"
+  add_foreign_key "dunning_campaigns", "organizations"
   add_foreign_key "error_details", "organizations"
   add_foreign_key "fees", "add_ons"
   add_foreign_key "fees", "applied_add_ons"

--- a/spec/factories/dunning_campaign_thresholds.rb
+++ b/spec/factories/dunning_campaign_thresholds.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :dunning_campaign_threshold do
+    dunning_campaign
+    currency { "USD" }
+    amount_cents { 1000 }
+  end
+end

--- a/spec/factories/dunning_campaigns.rb
+++ b/spec/factories/dunning_campaigns.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :dunning_campaign do
+    organization
+    name { Faker::Name.name }
+    code { SecureRandom.uuid }
+    days_between_attempts { Faker::Number.number(digits: 2) }
+    max_attempts { Faker::Number.number(digits: 2) }
+    applied_to_organization { false }
+  end
+end

--- a/spec/models/dunning_campaign_spec.rb
+++ b/spec/models/dunning_campaign_spec.rb
@@ -8,11 +8,12 @@ RSpec.describe DunningCampaign, type: :model do
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:organization) }
+  it { is_expected.to have_many(:thresholds).dependent(:destroy) }
 
   it { is_expected.to validate_presence_of(:name) }
 
-  it { is_expected.to validate_numericality_of(:days_between_attempts).is_greater_than(0)}
-  it { is_expected.to validate_numericality_of(:max_attempts).is_greater_than(0)}
+  it { is_expected.to validate_numericality_of(:days_between_attempts).is_greater_than(0) }
+  it { is_expected.to validate_numericality_of(:max_attempts).is_greater_than(0) }
 
   it { is_expected.to validate_uniqueness_of(:code).scoped_to(:organization_id) }
 end

--- a/spec/models/dunning_campaign_spec.rb
+++ b/spec/models/dunning_campaign_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DunningCampaign, type: :model do
+  subject(:dunning_campaign) { create(:dunning_campaign) }
+
+  it_behaves_like "paper_trail traceable"
+
+  it { is_expected.to belong_to(:organization) }
+
+  it { is_expected.to validate_presence_of(:name) }
+
+  it { is_expected.to validate_numericality_of(:days_between_attempts).is_greater_than(0)}
+  it { is_expected.to validate_numericality_of(:max_attempts).is_greater_than(0)}
+
+  it { is_expected.to validate_uniqueness_of(:code).scoped_to(:organization_id) }
+end

--- a/spec/models/dunning_campaign_threshold_spec.rb
+++ b/spec/models/dunning_campaign_threshold_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DunningCampaignThreshold, type: :model do
+  subject(:dunning_campaign_threshold) { create(:dunning_campaign_threshold) }
+
+  it_behaves_like "paper_trail traceable"
+
+  it { is_expected.to belong_to(:dunning_campaign) }
+
+  it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than_or_equal_to(0) }
+  it { is_expected.to validate_inclusion_of(:currency).in_array(described_class.currency_list) }
+  it { is_expected.to validate_uniqueness_of(:currency).scoped_to(:dunning_campaign_id) }
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:netsuite_integrations) }
   it { is_expected.to have_many(:xero_integrations) }
   it { is_expected.to have_many(:data_exports) }
+  it { is_expected.to have_many(:dunning_campaigns) }
 
   it { is_expected.to validate_inclusion_of(:default_currency).in_array(described_class.currency_list) }
 


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices](https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices)

## Context

As a user, as part of the dunning process, I want to send email reminders to my customers when they have overdue invoices.

## Description

The goal of this PR is to setup the basic dunning entities:
- `DunningCampaign` 
- `DunningCampaignThreshold`

<img width="809" alt="Screenshot 2024-10-11 at 09 21 51" src="https://github.com/user-attachments/assets/555f6261-bb77-4a7b-ad0d-33b83b1ba228">

