### PR TITLE
fix(invoice-numbering): cover draft invoice number when tax error

### DIFF
--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -29,8 +29,8 @@ module Invoices
         if tax_error?(fees_result)
           invoice.fees_amount_cents = invoice.fees.sum(:amount_cents)
           invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
-          invoice.ensure_number
           invoice.failed!
+          Invoices::NumberGenerationService.call(invoice:)
 
           return result
         end

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -29,6 +29,7 @@ module Invoices
         if tax_error?(fees_result)
           invoice.fees_amount_cents = invoice.fees.sum(:amount_cents)
           invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
+          invoice.ensure_number
           invoice.failed!
 
           return result

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -31,8 +31,8 @@ module Invoices
         Credits::AppliedCouponsService.call(invoice:) if invoice.fees_amount_cents&.positive?
 
         if tax_error?(fee_result)
-          invoice.ensure_number
           invoice.failed!
+          Invoices::NumberGenerationService.call(invoice:)
           invoice.fees.each { |f| SendWebhookJob.perform_later('fee.created', f) }
           create_error_detail(fee_result.error.messages.dig(:tax_error)&.first)
 

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -31,6 +31,7 @@ module Invoices
         Credits::AppliedCouponsService.call(invoice:) if invoice.fees_amount_cents&.positive?
 
         if tax_error?(fee_result)
+          invoice.ensure_number
           invoice.failed!
           invoice.fees.each { |f| SendWebhookJob.perform_later('fee.created', f) }
           create_error_detail(fee_result.error.messages.dig(:tax_error)&.first)

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -27,8 +27,8 @@ module Invoices
 
           unless taxes_result.success?
             create_error_detail(taxes_result.error.code)
-            invoice.ensure_number
             invoice.failed!
+            Invoices::NumberGenerationService.call(invoice:)
 
             return result.service_failure!(code: 'tax_error', message: taxes_result.error.code)
           end

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -27,6 +27,7 @@ module Invoices
 
           unless taxes_result.success?
             create_error_detail(taxes_result.error.code)
+            invoice.ensure_number
             invoice.failed!
 
             return result.service_failure!(code: 'tax_error', message: taxes_result.error.code)

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -195,6 +195,7 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
           aggregate_failures do
             expect(result).to be_success
             expect(result.invoice.status).to eq('failed')
+            expect(result.invoice.number).to end_with '-DRAFT'
             expect(result.invoice.error_details.count).to eq(1)
             expect(result.invoice.error_details.first.details['tax_error']).to eq('taxDateTooFarInFuture')
           end

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -264,6 +264,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
             invoice = customer.invoices.order(created_at: :desc).first
 
             expect(invoice.status).to eq('failed')
+            expect(invoice.number).to end_with '-DRAFT'
             expect(invoice.error_details.count).to eq(1)
             expect(invoice.error_details.first.details['tax_error']).to eq('taxDateTooFarInFuture')
           end

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service do
           invoice = customer.invoices.order(created_at: :desc).first
 
           expect(invoice.status).to eq('failed')
+          expect(invoice.number).to end_with '-DRAFT'
           expect(invoice.error_details.count).to eq(1)
           expect(invoice.error_details.first.details['tax_error']).to eq('taxDateTooFarInFuture')
         end

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -214,6 +214,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
             invoice = customer.invoices.order(created_at: :desc).first
 
             expect(invoice.status).to eq('failed')
+            expect(invoice.number).to end_with '-DRAFT'
             expect(invoice.error_details.count).to eq(1)
             expect(invoice.error_details.first.details['tax_error']).to eq('taxDateTooFarInFuture')
           end


### PR DESCRIPTION
## Context

Recently one refactoring around invoice numbering was introduced.

## Description

This PR ensures that draft invoice number is attached when status is failed
