### PR TITLE
fix: Generate invoice for paid instant charges on subscription termination

### DIFF
--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -52,7 +52,6 @@ module Invoices
         invoice.invoice_subscriptions.each do |is|
           is.subscription.fees
             .where(invoice: nil, payment_status: :succeeded)
-            .where("CAST(fees.properties->>'timestamp' AS timestamp) <= ?", is.charges_to_datetime)
             .update_all(invoice_id: invoice.id) # rubocop:disable Rails/SkipsModelValidations
         end
 


### PR DESCRIPTION
## Context

Currently if an invoice with paid in advance charges is terminated, there are edge cases where paid fees are not invoiced because of a time boundaries issues.

## Description

This change ensure all not already invoiced paid fees are included in a new invoice when the subscription is terminating ignoring time boundaries.