### PR TITLE
Feat: issue credit note on credit invoice - db change

### DIFF
--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -68,6 +68,7 @@ end
 #
 # Foreign Keys
 #
+#  fk_rails_...  (credit_note_id => credit_notes.id)
 #  fk_rails_...  (invoice_id => invoices.id)
 #  fk_rails_...  (wallet_id => wallets.id)
 #

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -53,13 +53,15 @@ end
 #  transaction_type                    :integer          not null
 #  created_at                          :datetime         not null
 #  updated_at                          :datetime         not null
+#  credit_note_id                      :uuid
 #  invoice_id                          :uuid
 #  wallet_id                           :uuid             not null
 #
 # Indexes
 #
-#  index_wallet_transactions_on_invoice_id  (invoice_id)
-#  index_wallet_transactions_on_wallet_id   (wallet_id)
+#  index_wallet_transactions_on_credit_note_id  (credit_note_id)
+#  index_wallet_transactions_on_invoice_id      (invoice_id)
+#  index_wallet_transactions_on_wallet_id       (wallet_id)
 #
 # Foreign Keys
 #

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -5,6 +5,7 @@ class WalletTransaction < ApplicationRecord
 
   belongs_to :wallet
   belongs_to :invoice, optional: true
+  belongs_to :credit_note, optional: true
 
   STATUSES = [
     :pending,

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -4,7 +4,7 @@ class WalletTransaction < ApplicationRecord
   include PaperTrailTraceable
 
   belongs_to :wallet
-  
+
   # these two relationships are populated only for outbound transactions
   belongs_to :invoice, optional: true
   belongs_to :credit_note, optional: true

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -4,6 +4,8 @@ class WalletTransaction < ApplicationRecord
   include PaperTrailTraceable
 
   belongs_to :wallet
+  
+  # these two relationships are populated only for outbound transactions
   belongs_to :invoice, optional: true
   belongs_to :credit_note, optional: true
 

--- a/db/migrate/20241010055733_add_reference_to_credit_note_from_wallet_transaction.rb
+++ b/db/migrate/20241010055733_add_reference_to_credit_note_from_wallet_transaction.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddReferenceToCreditNoteFromWalletTransaction < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 

--- a/db/migrate/20241010055733_add_reference_to_credit_note_from_wallet_transaction.rb
+++ b/db/migrate/20241010055733_add_reference_to_credit_note_from_wallet_transaction.rb
@@ -4,6 +4,6 @@ class AddReferenceToCreditNoteFromWalletTransaction < ActiveRecord::Migration[7.
   disable_ddl_transaction!
 
   def change
-    add_reference :wallet_transactions, :credit_note, type: :uuid, null: true, index: { algorithm: :concurrently }
+    add_reference :wallet_transactions, :credit_note, type: :uuid, null: true, index: {algorithm: :concurrently}
   end
 end

--- a/db/migrate/20241010055733_add_reference_to_credit_note_from_wallet_transaction.rb
+++ b/db/migrate/20241010055733_add_reference_to_credit_note_from_wallet_transaction.rb
@@ -1,0 +1,7 @@
+class AddReferenceToCreditNoteFromWalletTransaction < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :wallet_transactions, :credit_note, type: :uuid, null: true, index: { algorithm: :concurrently }
+  end
+end

--- a/db/migrate/20241011123148_add_foreign_key_constraint_to_credit_note_id_at_wallet_transaction.rb
+++ b/db/migrate/20241011123148_add_foreign_key_constraint_to_credit_note_id_at_wallet_transaction.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddForeignKeyConstraintToCreditNoteIdAtWalletTransaction < ActiveRecord::Migration[7.1]
+  def change
+    add_foreign_key :wallet_transactions, :credit_notes, validate: false
+  end
+end

--- a/db/migrate/20241011123621_change_validate_on_foreign_key_from_wallet_transaction_to_credit_note.rb
+++ b/db/migrate/20241011123621_change_validate_on_foreign_key_from_wallet_transaction_to_credit_note.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeValidateOnForeignKeyFromWalletTransactionToCreditNote < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :wallet_transactions, :credit_notes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_10_055733) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_11_123621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1298,6 +1298,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_10_055733) do
   add_foreign_key "subscriptions", "plans"
   add_foreign_key "taxes", "organizations"
   add_foreign_key "usage_thresholds", "plans"
+  add_foreign_key "wallet_transactions", "credit_notes"
   add_foreign_key "wallet_transactions", "invoices"
   add_foreign_key "wallet_transactions", "wallets"
   add_foreign_key "wallets", "customers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_08_080209) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_10_055733) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1133,6 +1133,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_08_080209) do
     t.integer "transaction_status", default: 0, null: false
     t.boolean "invoice_requires_successful_payment", default: false, null: false
     t.jsonb "metadata", default: []
+    t.uuid "credit_note_id"
+    t.index ["credit_note_id"], name: "index_wallet_transactions_on_credit_note_id"
     t.index ["invoice_id"], name: "index_wallet_transactions_on_invoice_id"
     t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"
   end


### PR DESCRIPTION
## Context

Now we don't allow creation of credit notes on prepaid credits. We want to implement this possibility. 
When credits will be issued, we'll be creating a voiding outbound wallet_transaction. Currently we're tracking the outbound wallet transactions. To support this behaviour we'll need to add credit_note_id to the wallet transaction

## Description

Added credit_note_id to wallet_transaction
