### PR TITLE
misc(usage): Scope usage caching to the charge filter level

### DIFF
--- a/app/services/events/post_process_service.rb
+++ b/app/services/events/post_process_service.rb
@@ -84,10 +84,13 @@ module Events
       charges = billable_metric.charges
         .joins(:plan)
         .where(plans: {id: active_subscription.map(&:plan_id)})
+        .includes(filters: {values: :billable_metric_filter})
 
       charges.each do |charge|
+        charge_filter = ChargeFilters::EventMatchingService.call(charge:, event:).charge_filter
+
         active_subscription.each do |subscription|
-          Subscriptions::ChargeCacheService.new(subscription:, charge:).expire_cache
+          Subscriptions::ChargeCacheService.new(subscription:, charge:, charge_filter:).expire_cache
         end
       end
     end

--- a/app/services/subscriptions/charge_cache_middleware.rb
+++ b/app/services/subscriptions/charge_cache_middleware.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class ChargeCacheMiddleware
+    def initialize(subscription:, charge:, to_datetime:, cache: true)
+      @subscription = subscription
+      @charge = charge
+      @to_datetime = to_datetime
+      @cache = cache
+    end
+
+    def call(charge_filter:)
+      return yield unless cache
+
+      json = Rails.cache.fetch(cache_key(charge_filter), expires_in: cache_expiration) do
+        yield.to_json
+      end
+
+      JSON.parse(json).map { |j| Fee.new(j.slice(*Fee.column_names)) }
+    end
+
+    private
+
+    attr_reader :subscription, :charge, :to_datetime, :cache
+
+    def cache_key(charge_filter)
+      Subscriptions::ChargeCacheService.new(subscription:, charge:, charge_filter:).cache_key
+    end
+
+    def cache_expiration
+      (to_datetime - Time.current).to_i.seconds
+    end
+  end
+end

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -7,7 +7,7 @@ namespace :cache do
 
     Charge.where(id: charge_id).includes(plan: :subscriptions).find_each do |charge|
       charge.plan.subscriptions.find_each do |subscription|
-        Subscriptions::ChargeCacheService.new(subscription:, charge:).expire_cache
+        Subscriptions::ChargeCacheService.expire_for_subscription_charge(subscription:, charge:)
       end
     end
   end

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Subscriptions::ChargeCacheService, type: :service do
+  subject(:cache_service) { described_class.new(subscription:, charge:, charge_filter:) }
+
+  let(:subscription) { create(:subscription) }
+  let(:charge) { create(:standard_charge, plan: subscription.plan) }
+  let(:charge_filter) { nil }
+
+  describe '#cache_key' do
+    it 'returns the cache key' do
+      expect(cache_service.cache_key)
+        .to eq("charge-usage/#{charge.id}/#{subscription.id}/#{charge.updated_at.iso8601}")
+    end
+
+    context 'with a charge filter' do
+      let(:charge_filter) { create(:charge_filter) }
+
+      it 'returns the cache key with the charge filter' do
+        expect(cache_service.cache_key)
+          .to eq("charge-usage/#{charge.id}/#{subscription.id}/#{charge.updated_at.iso8601}/#{charge_filter.id}/#{charge_filter.updated_at.iso8601}")
+      end
+    end
+  end
+
+  describe '#expire_cache' do
+    it 'deletes the cached value' do
+      allow(Rails.cache).to receive(:delete).with(cache_service.cache_key)
+
+      cache_service.expire_cache
+
+      expect(Rails.cache).to have_received(:delete).with(cache_service.cache_key)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Today caching for usage data is scope to the charge.
When an event is received for a specific billable metric code will invalidate the cache for all charges attached to it for the customer's plan. The cache will leave until the end of the billing period or until a new event is received for the same billable metric code and subscription.
This logic avoid recomputing the complete charge aggregation every time the customer usage is requested.

This logic was fine until the introduction of charge filters.
Aggregation for filters are done one by one for every filter, and stored in cache using the same charge cache key (ie: all filtered aggregations are grouped inside the same charge cached bucket). When an event matching a filter is received it invalidate the cache for all filters, meaning that when fetching the usage we have to resegregate it for every single filter even if nothing new was received for the majority of them.

## Description

This PR refactors some parts of the usage computation and adds a new caching logic to scope the caching up to the charge filter when applicable and keeping the actual caching when no filters are attached to the charge.
