### PR TITLE
fix(invoice) Skip ActiveRecord::RecordNotUnique for periodic invoices

### DIFF
--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -80,6 +80,10 @@ module Invoices
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::RecordNotUnique
+      return result if invoicing_reason.to_sym == :subscription_periodic
+
+      raise
     rescue BaseService::ServiceFailure => e
       raise unless e.code.to_s == 'duplicated_invoices'
       raise unless invoicing_reason.to_sym == :subscription_periodic


### PR DESCRIPTION
## Context

This PR is related to `BillSubscriptionJob` dead jobs with the following error:

```
PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_invoice_subscriptions_on_charges_from_and_to_datetime" DETAIL: Key (subscription_id, charges_from_datetime, charges_to_datetime)=(XXX, 2024-09-01 00:00:00, 2024-09-30 23:59:59.999999) already exists. 
```

This issue can appears when a lot of invoices are generated at the same time, for example on the first day of a month when a lot of calendar subscription have to be billed.
As the clock job is executed every hour and enqueues a job for all subscriptions that have to be billed on a particular day but filtering the ones that have been billed already, in some cases when the queue is full a billing job can wait for more than one hour in the queue, leading to a risk of double processing of the same subscription.
To avoid double billing, multiple mechanisms have been put in place, in particular, an index at the database level, making sure that a duplicated invoice cannot be persisted.

Today in case of duplication at DB level, an `ActiveRecord::RecordNotUnique` is raised leading to a dead job.

## Description

In case of `subscription_periodic` invoicing reason, this error can be safely ignored as it only means that the same billing job was processed twice.