### PR TITLE
fix(wallet): Send wallet transaction webhooks outside of DB transactions

### DIFF
--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -35,7 +35,7 @@ module Credits
         invoice.prepaid_credit_amount_cents += amount_cents
       end
 
-      SendWebhookJob.perform_later('wallet_transaction.created', result.wallet_transaction)
+      after_commit { SendWebhookJob.perform_later('wallet_transaction.created', result.wallet_transaction) }
 
       result
     rescue ActiveRecord::RecordInvalid => e


### PR DESCRIPTION
## Context

Some `SendWebhookJob` for wallet transaction creation have failed lately with the following error:

```
 ActiveJob::DeserializationError 
Error while trying to deserialize arguments: Couldn't find WalletTransaction with 'id'=XXX
```
## Description

This PR makes sure that all jobs related to wallet transaction creation are performed after any database transaction.
