### PR TITLE
fix(integration): Fix rate limit handling

### DIFF
--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -123,9 +123,7 @@ module Integrations
       def request_limit_error?(http_error)
         return false unless http_error.error_code.to_i == 500
 
-        http_error.json_message.dig('error', 'payload', 'error', 'code') == REQUEST_LIMIT_ERROR_CODE
-      rescue JSON::ParserError
-        false
+        http_error.error_body.include?(REQUEST_LIMIT_ERROR_CODE)
       end
     end
   end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/2570

## Description

It updates the way we check for the presence of the rate error limit code in the payload to avoid parsing the JSON body and be independent from the format of the response.