### PR TITLE
Feat: credit note on credit invoice - estimate service

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -291,7 +291,7 @@ class Invoice < ApplicationRecord
       prepaid_credit_amount_cents
     amount = amount.negative? ? 0 : amount
 
-    return [amount, (associated_active_wallet&.balance_amount_cents || 0)].min if credit?
+    return [amount, (associated_active_wallet&.balance_cents || 0)].min if credit?
     amount
   end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -299,7 +299,7 @@ class Invoice < ApplicationRecord
     return if !credit? || customer.wallets.active.empty?
 
     wallet = fees.credit.first&.invoiceable&.wallet
-    wallet if wallet.active?
+    wallet if wallet&.active?
   end
 
   def payment_dispute_losable?

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -291,12 +291,12 @@ class Invoice < ApplicationRecord
       prepaid_credit_amount_cents
     amount = amount.negative? ? 0 : amount
 
-    return [amount, (associated_active_wallet&.balance_cents || 0)].min if credit?
+    return [amount, associated_active_wallet&.balance_cents || 0].min if credit?
     amount
   end
 
   def associated_active_wallet
-    return if !credit?  || customer.wallets.active.empty?
+    return if !credit? || customer.wallets.active.empty?
 
     wallet = fees.credit.first&.invoiceable&.wallet
     wallet if wallet.active?

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -37,7 +37,7 @@ module CreditNotes
     attr_reader :invoice, :items, :credit_note
 
     def valid_type_or_status?
-      # return false if invoice.credit?
+      return false if invoice.credit? && invoice.payment_status != 'succeeded'
 
       invoice.version_number >= Invoice::CREDIT_NOTES_MIN_VERSION
     end

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -37,7 +37,7 @@ module CreditNotes
     attr_reader :invoice, :items, :credit_note
 
     def valid_type_or_status?
-      return false if invoice.credit?
+      # return false if invoice.credit?
 
       invoice.version_number >= Invoice::CREDIT_NOTES_MIN_VERSION
     end
@@ -87,8 +87,8 @@ module CreditNotes
         taxes_result.coupons_adjustment_amount_cents +
         credit_note.precise_taxes_amount_cents
       ).round
-
       compute_refundable_amount
+      credit_note.credit_amount_cents = 0 if invoice.credit?
       credit_note.total_amount_cents = credit_note.credit_amount_cents
     end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1085,6 +1085,7 @@ RSpec.describe Invoice, type: :model do
 
       context 'when invoice v1' do
         let(:invoice) { create(:invoice, version_number: 1) }
+
         it 'returns 0' do
           expect(invoice.available_to_credit_amount_cents).to eq(0)
         end
@@ -1100,6 +1101,7 @@ RSpec.describe Invoice, type: :model do
 
       context 'when draft' do
         let(:invoice) { create(:invoice, :draft) }
+
         it 'returns 0' do
           expect(invoice.available_to_credit_amount_cents).to eq(0)
         end
@@ -1244,7 +1246,7 @@ RSpec.describe Invoice, type: :model do
 
   describe '#refundable_amount_cents' do
     let(:invoice) { create(:invoice, version_number:, status:, payment_status:, prepaid_credit_amount_cents:) }
-    let(:available_to_credit_amount_cents) { 1000}
+    let(:available_to_credit_amount_cents) { 1000 }
     let(:prepaid_credit_amount_cents) { 200 }
 
     before do
@@ -1293,7 +1295,7 @@ RSpec.describe Invoice, type: :model do
 
     context 'when invoice is a credit' do
       let(:invoice) { create(:invoice, :credit, version_number: 2, status: :finalized, payment_status: :succeeded, prepaid_credit_amount_cents: 200) }
-      let(:associated_active_wallet) { double('Wallet', balance_cents: 500) }
+      let(:associated_active_wallet) { create(:wallet, balance_cents: 500) }
 
       before do
         allow(invoice).to receive(:associated_active_wallet).and_return(associated_active_wallet)
@@ -1316,13 +1318,23 @@ RSpec.describe Invoice, type: :model do
 
   describe '#associated_active_wallet' do
     context 'when invoice is not a credit' do
+      let(:wallet) { create(:wallet) }
+
+      before { wallet }
 
       it 'returns nil' do
         expect(invoice.associated_active_wallet).to be_nil
       end
     end
 
-    context 'when customer has no wallet' do
+    context 'when customer has no active wallet' do
+      let(:invoice) { create :invoice, invoice_type: :credit }
+      let(:wallet) { create :wallet, status: :terminated }
+      let(:wallet_transaction) { create :wallet_transaction, wallet: wallet }
+      let(:fee) { create :fee, fee_type: :credit, invoice:, invoiceable: wallet_transaction }
+
+      before { fee }
+
       it 'returns nil' do
         expect(invoice.associated_active_wallet).to be_nil
       end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1293,7 +1293,7 @@ RSpec.describe Invoice, type: :model do
 
     context 'when invoice is a credit' do
       let(:invoice) { create(:invoice, :credit, version_number: 2, status: :finalized, payment_status: :succeeded, prepaid_credit_amount_cents: 200) }
-      let(:associated_active_wallet) { double('Wallet', balance_amount_cents: 500) }
+      let(:associated_active_wallet) { double('Wallet', balance_cents: 500) }
 
       before do
         allow(invoice).to receive(:associated_active_wallet).and_return(associated_active_wallet)

--- a/spec/scenarios/credit_note_spec.rb
+++ b/spec/scenarios/credit_note_spec.rb
@@ -920,13 +920,11 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
       )
       expect(response).to have_http_status(:method_not_allowed)
 
-
       # pay the invoice
       update_invoice(invoice, payment_status: :succeeded)
       perform_all_enqueued_jobs
       wallet.reload
       expect(wallet.balance_cents).to eq 1500
-
 
       # it allows to estimate a credit notes on credit invoices with payment status succeeded
       estimate_credit_note(
@@ -942,7 +940,6 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
       expect(estimate[:sub_total_excluding_taxes_amount_cents]).to eq(10)
       expect(estimate[:max_refundable_amount_cents]).to eq(10)
       expect(estimate[:max_creditable_amount_cents]).to eq(0)
-
 
       # when estimating a credit note with amount higher than the remaining balance, it will return the remaining balance
       wallet.update(balance_cents: 5)

--- a/spec/services/credit_notes/estimate_service_spec.rb
+++ b/spec/services/credit_notes/estimate_service_spec.rb
@@ -173,17 +173,22 @@ RSpec.describe CreditNotes::EstimateService, type: :service do
         customer:,
         currency: 'EUR',
         fees_amount_cents: 20,
-        coupons_amount_cents: 10,
-        taxes_amount_cents: 2,
         total_amount_cents: 12,
         payment_status: :succeeded,
-        taxes_rate: 20,
         version_number: 3
       )
     end
     let(:wallet) { create(:wallet, customer:, balance_cents: 3) }
     let(:wallet_transaction) { create(:wallet_transaction, wallet:) }
     let(:credit_fee) { create(:fee, fee_type: :credit, invoice:, invoiceable: wallet_transaction) }
+    let(:items) do
+      [
+        {
+          fee_id: credit_fee.id,
+          amount_cents: 10
+        }
+      ]
+    end
 
     before { credit_fee }
 
@@ -201,9 +206,9 @@ RSpec.describe CreditNotes::EstimateService, type: :service do
             currency: invoice.currency,
             credit_amount_cents: 0,
             refund_amount_cents: 3,
-            coupons_adjustment_amount_cents: 8,
-            taxes_amount_cents: 2,
-            taxes_rate: 20
+            coupons_adjustment_amount_cents: 0,
+            taxes_amount_cents: 0,
+            taxes_rate: 0
           )
         end
       end
@@ -225,9 +230,9 @@ RSpec.describe CreditNotes::EstimateService, type: :service do
             currency: invoice.currency,
             credit_amount_cents: 0,
             refund_amount_cents: 0,
-            coupons_adjustment_amount_cents: 8,
-            taxes_amount_cents: 2,
-            taxes_rate: 20
+            coupons_adjustment_amount_cents: 0,
+            taxes_amount_cents: 0,
+            taxes_rate: 0
           )
         end
       end

--- a/spec/services/credit_notes/estimate_service_spec.rb
+++ b/spec/services/credit_notes/estimate_service_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe CreditNotes::EstimateService, type: :service do
       )
     end
     let(:wallet) { create(:wallet, customer:, balance_cents: 3) }
-    let(:wallet_transaction) { create(:wallet_transaction, wallet:)}
+    let(:wallet_transaction) { create(:wallet_transaction, wallet:) }
     let(:credit_fee) { create(:fee, fee_type: :credit, invoice:, invoiceable: wallet_transaction) }
 
     before { credit_fee }
@@ -211,6 +211,7 @@ RSpec.describe CreditNotes::EstimateService, type: :service do
 
     context 'when wallet for the credits is not active' do
       let(:wallet) { create(:wallet, customer:, balance_cents: 3, status: :terminated) }
+
       it 'estimates the credit and refund amount hot higher than wallet.balance_amount_cents' do
         result = estimate_service.call
 

--- a/spec/services/credit_notes/estimate_service_spec.rb
+++ b/spec/services/credit_notes/estimate_service_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe CreditNotes::EstimateService, type: :service do
         customer:,
         currency: invoice.currency,
         credit_amount_cents: 9,
+        refund_amount_cents: 9,
         coupons_adjustment_amount_cents: 8,
         taxes_amount_cents: 2,
         taxes_rate: 20
@@ -183,6 +184,75 @@ RSpec.describe CreditNotes::EstimateService, type: :service do
 
         expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
         expect(result.error.code).to eq('invalid_type_or_status')
+      end
+    end
+  end
+
+  context 'when invoice is a credit invoice' do
+    let(:invoice) do
+      create(
+        :invoice,
+        type: :credit,
+        organization:,
+        customer:,
+        currency: 'EUR',
+        fees_amount_cents: 20,
+        coupons_amount_cents: 10,
+        taxes_amount_cents: 2,
+        total_amount_cents: 12,
+        payment_status: :succeeded,
+        taxes_rate: 20,
+        version_number: 3
+      )
+    end
+    let(:wallet) { create(:wallet, customer:, balance_amount_cents: 3) }
+    let(:wallet_transaction) { create(:wallet_transaction, wallet:)}
+    let(:credit_fee) { create(:fee, fee_type: :credit, invoice:, invoiceable: wallet_transaction) }
+
+    before { credit_fee }
+
+    context 'when wallet for the credits is active' do
+      it 'estimates the credit and refund amount hot higher than wallet.balance_amount_cents' do
+        result = estimate_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          credit_note = result.credit_note
+          expect(credit_note).to have_attributes(
+            invoice:,
+            customer:,
+            currency: invoice.currency,
+            credit_amount_cents: 0,
+            refund_amount_cents: 3,
+            coupons_adjustment_amount_cents: 8,
+            taxes_amount_cents: 2,
+            taxes_rate: 20
+          )
+        end
+      end
+    end
+
+    context 'when wallet for the credits is not active' do
+      let(:wallet) { create(:wallet, customer:, balance_amount_cents: 3, status: :terminated) }
+      it 'estimates the credit and refund amount hot higher than wallet.balance_amount_cents' do
+        result = estimate_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          credit_note = result.credit_note
+          expect(credit_note).to have_attributes(
+            invoice:,
+            customer:,
+            currency: invoice.currency,
+            credit_amount_cents: 0,
+            refund_amount_cents: 0,
+            coupons_adjustment_amount_cents: 8,
+            taxes_amount_cents: 2,
+            taxes_rate: 20
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
Adding a possibility to estimate credit note on prepaid credit invoice:
- allow credit note for credit invoices
- credited amount for credit invoices is 0
- refund amount for credit invoices is not bigger than available wallet balance