### PR TITLE
fix(wallet): Save wallet transaction using floor for credits

### DIFF
--- a/app/services/wallet_transactions/void_service.rb
+++ b/app/services/wallet_transactions/void_service.rb
@@ -2,9 +2,9 @@
 
 module WalletTransactions
   class VoidService < BaseService
-    def initialize(wallet:, credits:, from_source: :manual, metadata: {})
+    def initialize(wallet:, credits_amount:, from_source: :manual, metadata: {})
       @wallet = wallet
-      @credits = credits
+      @credits_amount = credits_amount
       @from_source = from_source
       @metadata = metadata
 
@@ -34,10 +34,6 @@ module WalletTransactions
 
     private
 
-    attr_reader :wallet, :credits, :from_source, :metadata
-
-    def credits_amount
-      @credits_amount ||= BigDecimal(credits)
-    end
+    attr_reader :wallet, :credits_amount, :from_source, :metadata
   end
 end

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -112,5 +112,14 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
         expect(result.error.messages[:paid_credits]).to eq(['invalid_paid_credits'])
       end
     end
+
+    context 'with decimal value' do
+      let(:paid_credits) { '4.399999' }
+
+      it 'creates wallet transaction with floored value' do
+        result = create_service
+        expect(result.wallet_transactions.first.credit_amount).to eq(4.39999)
+      end
+    end
   end
 end

--- a/spec/services/wallet_transactions/void_service_spec.rb
+++ b/spec/services/wallet_transactions/void_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe WalletTransactions::VoidService, type: :service do
-  subject(:void_service) { described_class.call(wallet:, credits:) }
+  subject(:void_service) { described_class.call(wallet:, credits_amount:) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
@@ -19,7 +19,7 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
       credits_ongoing_balance: 10.0
     )
   end
-  let(:credits) { '10.00' }
+  let(:credits_amount) { BigDecimal('10.00') }
 
   before do
     subscription
@@ -27,7 +27,7 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
 
   describe '#call' do
     context 'when credits amount is zero' do
-      let(:credits) { '0.00' }
+      let(:credits_amount) { BigDecimal('0.00') }
 
       it 'does not create a wallet transaction' do
         expect { void_service }.not_to change(WalletTransaction, :count)
@@ -35,7 +35,7 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
     end
 
     context 'when transaction have metadata' do
-      subject(:void_service) { described_class.call(wallet:, credits:, metadata:) }
+      subject(:void_service) { described_class.call(wallet:, credits_amount:, metadata:) }
 
       let(:metadata) { [{'key' => 'valid_value', 'value' => 'also_valid'}] }
 


### PR DESCRIPTION
This pull request includes several changes to the `wallet_transactions` services to standardize the handling of credit amounts and improve precision by using `BigDecimal` and flooring the values to five decimal places. 

### Standardizing credit amounts:

* [`app/services/wallet_transactions/create_service.rb`](diffhunk://#diff-982c298415227695373911c5d4f1807aa1efe9ba65e962ab7f0065ac1edea794L27-R27): Modified `handle_paid_credits`, `handle_granted_credits`, and `handle_voided_credits` to use `BigDecimal` for credit amounts, flooring them to five decimal places. [[1]](diffhunk://#diff-982c298415227695373911c5d4f1807aa1efe9ba65e962ab7f0065ac1edea794L27-R27) [[2]](diffhunk://#diff-982c298415227695373911c5d4f1807aa1efe9ba65e962ab7f0065ac1edea794L36-R36) [[3]](diffhunk://#diff-982c298415227695373911c5d4f1807aa1efe9ba65e962ab7f0065ac1edea794L46-R46)
* [`app/services/wallet_transactions/void_service.rb`](diffhunk://#diff-786f18b52b028d25817ec8b3d7a1d230b546fe5a0d3a799b8f3d008ac96e482cL5-R7): Updated the `initialize` method and removed the `credits_amount` method to directly use the `credits_amount` parameter. [[1]](diffhunk://#diff-786f18b52b028d25817ec8b3d7a1d230b546fe5a0d3a799b8f3d008ac96e482cL5-R7) [[2]](diffhunk://#diff-786f18b52b028d25817ec8b3d7a1d230b546fe5a0d3a799b8f3d008ac96e482cL37-R37)
