### PR TITLE
fix(clickhouse): Fix timestamp precision

### DIFF
--- a/app/services/events/stores/clickhouse/unique_count_query.rb
+++ b/app/services/events/stores/clickhouse/unique_count_query.rb
@@ -206,7 +206,7 @@ module Events
               (#{
                 events(ordered: true)
                   .select(
-                    "toDateTime64(timestamp, 5, 'UTC') as timestamp, \
+                    "timestamp, \
                     #{sanitized_property_name} AS property, \
                     coalesce(NULLIF(events_enriched.properties['operation_type'], ''), 'add') AS operation_type"
                   )
@@ -226,7 +226,7 @@ module Events
               events(ordered: true)
                 .select(
                   "#{groups.join(", ")}, \
-                  toDateTime64(timestamp, 5, 'UTC') as timestamp, \
+                  timestamp, \
                   #{sanitized_property_name} AS property, \
                   coalesce(NULLIF(events_enriched.properties['operation_type'], ''), 'add') AS operation_type"
                 ).to_sql
@@ -287,11 +287,11 @@ module Events
                 ceil(
                   date_diff(
                     'seconds',
-                    if(timestamp < toDateTime64(:from_datetime, 5, 'UTC'), toDateTime64(:from_datetime, 5, 'UTC'), timestamp),
+                    if(timestamp < toDateTime64(:from_datetime, 3, 'UTC'), toDateTime64(:from_datetime, 3, 'UTC'), timestamp),
                     if(
-                      (leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (PARTITION BY property ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) < toDateTime64(:from_datetime, 5, 'UTC'),
-                      toDateTime64(:to_datetime, 5, 'UTC'),
-                      leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (PARTITION BY property ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+                      (leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 3, 'UTC')) OVER (PARTITION BY property ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) < toDateTime64(:from_datetime, 3, 'UTC'),
+                      toDateTime64(:to_datetime, 3, 'UTC'),
+                      leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 3, 'UTC')) OVER (PARTITION BY property ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
                     ),
                     :timezone
                   ) / 86400
@@ -317,11 +317,11 @@ module Events
                 ceil(
                   date_diff(
                     'seconds',
-                    if(timestamp < toDateTime64(:from_datetime, 5, 'UTC'), toDateTime64(:from_datetime, 5, 'UTC'), timestamp),
+                    if(timestamp < toDateTime64(:from_datetime, 3, 'UTC'), toDateTime64(:from_datetime, 3, 'UTC'), timestamp),
                     if(
-                      (leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (PARTITION BY #{group_names}, property ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) < toDateTime64(:from_datetime, 5, 'UTC'),
-                      toDateTime64(:to_datetime, 5, 'UTC'),
-                      leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (PARTITION BY #{group_names}, property ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+                      (leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 3, 'UTC')) OVER (PARTITION BY #{group_names}, property ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) < toDateTime64(:from_datetime, 3, 'UTC'),
+                      toDateTime64(:to_datetime, 3, 'UTC'),
+                      leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 3, 'UTC')) OVER (PARTITION BY #{group_names}, property ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
                     ),
                     :timezone
                   ) / 86400


### PR DESCRIPTION
This pull request focuses on optimizing timestamp precision in the `unique_count_query.rb` file by adjusting the precision level in various SQL queries. The changes include modifying the `toDateTime64` function to use a precision of 3 instead of 5 across different methods.

Timestamp precision adjustments:

* [`app/services/events/stores/clickhouse/unique_count_query.rb`](diffhunk://#diff-15e04aaa1cc9a958e117e73b27e752ce967e85a43ce0dcb7f4ded58b44b9ff78L209-R209): Changed the precision in the `events_cte_sql` method to use `timestamp` directly instead of `toDateTime64(timestamp, 5, 'UTC')`.
* [`app/services/events/stores/clickhouse/unique_count_query.rb`](diffhunk://#diff-15e04aaa1cc9a958e117e73b27e752ce967e85a43ce0dcb7f4ded58b44b9ff78L229-R229): Updated the `grouped_events_cte_sql` method to use `timestamp` directly instead of `toDateTime64(timestamp, 5, 'UTC')`.
* [`app/services/events/stores/clickhouse/unique_count_query.rb`](diffhunk://#diff-15e04aaa1cc9a958e117e73b27e752ce967e85a43ce0dcb7f4ded58b44b9ff78L290-R294): Modified the `period_ratio_sql` method to use `toDateTime64` with a precision of 3 instead of 5 for the `from_datetime` and `to_datetime` parameters.
* [`app/services/events/stores/clickhouse/unique_count_query.rb`](diffhunk://#diff-15e04aaa1cc9a958e117e73b27e752ce967e85a43ce0dcb7f4ded58b44b9ff78L320-R324): Adjusted the `grouped_period_ratio_sql` method to use `toDateTime64` with a precision of 3 instead of 5 for the `from_datetime` and `to_datetime` parameters.
