### PR TITLE
misc: Retry RefreshOngoingBalanceJob if stale object

### DIFF
--- a/app/jobs/wallets/refresh_ongoing_balance_job.rb
+++ b/app/jobs/wallets/refresh_ongoing_balance_job.rb
@@ -6,6 +6,8 @@ module Wallets
 
     unique :until_executed, on_conflict: :log
 
+    retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6
+
     def perform(wallet)
       return unless wallet.ready_to_be_refreshed?
 


### PR DESCRIPTION
This pull request includes a small change to the `app/jobs/wallets/refresh_ongoing_balance_job.rb` file. The change adds a retry mechanism for the `RefreshOngoingBalanceJob` class to handle `ActiveRecord::StaleObjectError` with a polynomial backoff strategy.

* [`app/jobs/wallets/refresh_ongoing_balance_job.rb`](diffhunk://#diff-b9d74143d00aee0ddc9a3ae9d05b87e50bb09e2a1395eaf34ee96740bcc73724R9-R10): Added `retry_on ActiveRecord::StaleObjectError` with a polynomial backoff strategy and 3 attempts.