### PR TITLE
feat(dunning): Add DunningCampaignsResolver

### DIFF
--- a/app/config/permissions/definition.yml
+++ b/app/config/permissions/definition.yml
@@ -31,6 +31,7 @@ customers:
   update:
   delete:
 dunning_campaigns:
+  view:
   create:
 subscriptions:
   view: true

--- a/app/config/permissions/role-finance.yml
+++ b/app/config/permissions/role-finance.yml
@@ -27,6 +27,7 @@ customers:
   update: false
   delete: false
 dunning_campaigns:
+  view: true
   create: true
 subscriptions:
   create: false

--- a/app/config/permissions/role-manager.yml
+++ b/app/config/permissions/role-manager.yml
@@ -27,6 +27,7 @@ customers:
   update: true
   delete: true
 dunning_campaigns:
+  view: false
   create: false
 subscriptions:
   create: true

--- a/app/graphql/resolvers/dunning_campaigns_resolver.rb
+++ b/app/graphql/resolvers/dunning_campaigns_resolver.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class DunningCampaignsResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description "Query dunning campaigns of an organization"
+
+    argument :applied_to_organization, Boolean, required: false
+    argument :limit, Integer, required: false
+    argument :order, String, required: false
+    argument :page, Integer, required: false
+    argument :search_term, String, required: false
+
+    type Types::DunningCampaigns::Object.collection_type, null: false
+
+    def resolve( # rubocop:disable Metrics/ParameterLists
+      applied_to_organization: nil,
+      order: nil,
+      page: nil,
+      limit: nil,
+      search_term: nil
+    )
+      result = ::DunningCampaignsQuery.call(
+        organization: current_organization,
+        search_term:,
+        order:,
+        pagination: {page:, limit:},
+        filters: {applied_to_organization:}
+      )
+
+      result.dunning_campaigns
+    end
+  end
+end

--- a/app/graphql/resolvers/dunning_campaigns_resolver.rb
+++ b/app/graphql/resolvers/dunning_campaigns_resolver.rb
@@ -7,6 +7,8 @@ module Resolvers
 
     description "Query dunning campaigns of an organization"
 
+    REQUIRED_PERMISSION = "dunning_campaigns:view"
+
     argument :applied_to_organization, Boolean, required: false
     argument :limit, Integer, required: false
     argument :order, String, required: false

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -32,6 +32,7 @@ module Types
     field :customer_portal_wallets, resolver: Resolvers::CustomerPortal::WalletsResolver
     field :customer_usage, resolver: Resolvers::Customers::UsageResolver
     field :customers, resolver: Resolvers::CustomersResolver
+    field :dunning_campaigns, resolver: Resolvers::DunningCampaignsResolver
     field :events, resolver: Resolvers::EventsResolver
     field :google_auth_url, resolver: Resolvers::Auth::Google::AuthUrlResolver
     field :gross_revenues, resolver: Resolvers::Analytics::GrossRevenuesResolver

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -3,6 +3,8 @@
 class DunningCampaign < ApplicationRecord
   include PaperTrailTraceable
 
+  ORDERS = %w[name code].freeze
+
   belongs_to :organization
   has_many :thresholds, class_name: "DunningCampaignThreshold", dependent: :destroy
   accepts_nested_attributes_for :thresholds
@@ -11,6 +13,10 @@ class DunningCampaign < ApplicationRecord
   validates :days_between_attempts, numericality: {greater_than: 0}
   validates :max_attempts, numericality: {greater_than: 0}
   validates :code, uniqueness: {scope: :organization_id}
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name code]
+  end
 end
 
 # == Schema Information

--- a/app/queries/dunning_campaigns_query.rb
+++ b/app/queries/dunning_campaigns_query.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class DunningCampaignsQuery < BaseQuery
+  DEFAULT_ORDER = "name"
+
+  def call
+    dunning_campaigns = base_scope.result
+    dunning_campaigns = paginate(dunning_campaigns)
+    dunning_campaigns = dunning_campaigns.order(order)
+
+    dunning_campaigns = with_applied_to_organization(dunning_campaigns) unless filters.applied_to_organization.nil?
+
+    result.dunning_campaigns = dunning_campaigns
+    result
+  end
+
+  private
+
+  def base_scope
+    DunningCampaign.where(organization:).ransack(search_params)
+  end
+
+  def search_params
+    return if search_term.blank?
+
+    {
+      m: "or",
+      name_cont: search_term,
+      code_cont: search_term
+    }
+  end
+
+  def order
+    DunningCampaign::ORDERS.include?(@order) ? @order : DEFAULT_ORDER
+  end
+
+  def with_applied_to_organization(scope)
+    scope.where(applied_to_organization: filters.applied_to_organization)
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3726,6 +3726,21 @@ type DunningCampaign {
   updatedAt: ISO8601DateTime!
 }
 
+"""
+DunningCampaignCollection type
+"""
+type DunningCampaignCollection {
+  """
+  A collection of paginated DunningCampaignCollection
+  """
+  collection: [DunningCampaign!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
 type DunningCampaignThreshold {
   amountCents: BigInt!
   currency: CurrencyEnum!
@@ -6199,6 +6214,11 @@ type Query {
   Query customers of an organization
   """
   customers(limit: Int, page: Int, searchTerm: String): CustomerCollection!
+
+  """
+  Query dunning campaigns of an organization
+  """
+  dunningCampaigns(appliedToOrganization: Boolean, limit: Int, order: String, page: Int, searchTerm: String): DunningCampaignCollection!
 
   """
   Query events of an organization

--- a/schema.graphql
+++ b/schema.graphql
@@ -5888,6 +5888,7 @@ type Permissions {
   developersManage: Boolean!
   draftInvoicesUpdate: Boolean!
   dunningCampaignsCreate: Boolean!
+  dunningCampaignsView: Boolean!
   invoicesCreate: Boolean!
   invoicesExport: Boolean!
   invoicesSend: Boolean!

--- a/schema.json
+++ b/schema.json
@@ -16581,6 +16581,63 @@
         },
         {
           "kind": "OBJECT",
+          "name": "DunningCampaignCollection",
+          "description": "DunningCampaignCollection type",
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated DunningCampaignCollection",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DunningCampaign",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "DunningCampaignThreshold",
           "description": null,
           "interfaces": [
@@ -31741,6 +31798,83 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "searchTerm",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "dunningCampaigns",
+              "description": "Query dunning campaigns of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "DunningCampaignCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "appliedToOrganization",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "order",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -28761,6 +28761,24 @@
               ]
             },
             {
+              "name": "dunningCampaignsView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "invoicesCreate",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/dunning_campaigns_resolver_spec.rb
+++ b/spec/graphql/resolvers/dunning_campaigns_resolver_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DunningCampaignsResolver, type: :graphql do
+  let(:required_permission) { "dunning_campaigns:view" }
   let(:query) do
     <<~GQL
       query {
@@ -20,10 +21,15 @@ RSpec.describe Resolvers::DunningCampaignsResolver, type: :graphql do
 
   before { dunning_campaign }
 
-  it "returns a list of dunning campaigns" do
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "dunning_campaigns:view"
+
+  it "returns a list of dunning campaigns", :aggregate_failures do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:
     )
 
@@ -55,6 +61,7 @@ RSpec.describe Resolvers::DunningCampaignsResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: create(:organization),
+        permissions: required_permission,
         query:
       )
 

--- a/spec/graphql/resolvers/dunning_campaigns_resolver_spec.rb
+++ b/spec/graphql/resolvers/dunning_campaigns_resolver_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::DunningCampaignsResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query {
+        dunningCampaigns(limit: 5) {
+          collection { id name }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:dunning_campaign) { create(:dunning_campaign, organization:) }
+
+  before { dunning_campaign }
+
+  it "returns a list of dunning campaigns" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:
+    )
+
+    dunning_campaigns_response = result["data"]["dunningCampaigns"]
+
+    aggregate_failures do
+      expect(dunning_campaigns_response["collection"].first).to include(
+        "id" => dunning_campaign.id,
+        "name" => dunning_campaign.name
+      )
+
+      expect(dunning_campaigns_response["metadata"]).to include(
+        "currentPage" => 1,
+        "totalCount" => 1
+      )
+    end
+  end
+
+  context "without current organization" do
+    it "returns an error" do
+      result = execute_graphql(current_user: membership.user, query:)
+
+      expect_graphql_error(result:, message: "Missing organization id")
+    end
+  end
+
+  context "when not member of the organization" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: create(:organization),
+        query:
+      )
+
+      expect_graphql_error(result:, message: "Not in organization")
+    end
+  end
+end

--- a/spec/queries/dunning_campaigns_query_spec.rb
+++ b/spec/queries/dunning_campaigns_query_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DunningCampaignsQuery, type: :query do
     create(:dunning_campaign, organization:, name: "defgh", code: "11", applied_to_organization: true)
   end
   let(:dunning_campaign_second) do
-    create(:dunning_campaign, organization:, name: "abcde", code: "22", applied_to_organization: true)
+    create(:dunning_campaign, organization:, name: "abcde", code: "22", applied_to_organization: false)
   end
 
   let(:dunning_campaign_third) do
@@ -45,7 +45,7 @@ RSpec.describe DunningCampaignsQuery, type: :query do
   context "with pagination" do
     let(:pagination) { {page: 2, limit: 2} }
 
-    it "applies the pagination" do
+    it "applies the pagination", :aggregate_failures do
       aggregate_failures do
         expect(result).to be_success
         expect(result.dunning_campaigns.count).to eq(1)
@@ -66,11 +66,19 @@ RSpec.describe DunningCampaignsQuery, type: :query do
     end
   end
 
-  context "with a filter on applied by default" do
+  context "with applied_to_organization is false" do
     let(:filters) { {applied_to_organization: false} }
 
-    it "returns only one dunning campaign" do
-      expect(result.dunning_campaigns).to eq([dunning_campaign_third])
+    it "returns second and third campaigns" do
+      expect(result.dunning_campaigns).to eq([dunning_campaign_second, dunning_campaign_third])
+    end
+  end
+
+  context "with applied_to_organization is true" do
+    let(:filters) { {applied_to_organization: true} }
+
+    it "returns only the first dunning campaign" do
+      expect(result.dunning_campaigns).to eq([dunning_campaign_first])
     end
   end
 

--- a/spec/queries/dunning_campaigns_query_spec.rb
+++ b/spec/queries/dunning_campaigns_query_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DunningCampaignsQuery, type: :query do
+  subject(:result) do
+    described_class.call(organization:, pagination:, search_term:, filters:, order:)
+  end
+
+  let(:pagination) { nil }
+  let(:search_term) { nil }
+  let(:filters) { nil }
+  let(:order) { nil }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:dunning_campaign_first) do
+    create(:dunning_campaign, organization:, name: "defgh", code: "11", applied_to_organization: true)
+  end
+  let(:dunning_campaign_second) do
+    create(:dunning_campaign, organization:, name: "abcde", code: "22", applied_to_organization: true)
+  end
+
+  let(:dunning_campaign_third) do
+    create(
+      :dunning_campaign,
+      organization:,
+      name: "presuv",
+      code: "33",
+      applied_to_organization: false
+    )
+  end
+
+  before do
+    dunning_campaign_first
+    dunning_campaign_second
+    dunning_campaign_third
+  end
+
+  it "returns all dunning campaigns ordered by name asc" do
+    expect(result.dunning_campaigns).to eq(
+      [dunning_campaign_second, dunning_campaign_first, dunning_campaign_third]
+    )
+  end
+
+  context "with pagination" do
+    let(:pagination) { {page: 2, limit: 2} }
+
+    it "applies the pagination" do
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.dunning_campaigns.count).to eq(1)
+        expect(result.dunning_campaigns.current_page).to eq(2)
+        expect(result.dunning_campaigns.prev_page).to eq(1)
+        expect(result.dunning_campaigns.next_page).to be_nil
+        expect(result.dunning_campaigns.total_pages).to eq(2)
+        expect(result.dunning_campaigns.total_count).to eq(3)
+      end
+    end
+  end
+
+  context "when searching for /de/ term" do
+    let(:search_term) { "de" }
+
+    it "returns only two dunning campaigns" do
+      expect(result.dunning_campaigns).to eq([dunning_campaign_second, dunning_campaign_first])
+    end
+  end
+
+  context "with a filter on applied by default" do
+    let(:filters) { {applied_to_organization: false} }
+
+    it "returns only one dunning campaign" do
+      expect(result.dunning_campaigns).to eq([dunning_campaign_third])
+    end
+  end
+
+  context "with order on code" do
+    let(:order) { "code" }
+
+    it "returns the dunning campaigns ordered by code" do
+      expect(result.dunning_campaigns).to eq(
+        [dunning_campaign_first, dunning_campaign_second, dunning_campaign_third]
+      )
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a new feature to manage and query dunning campaigns within an organization. The most important changes include adding new permissions, creating a resolver and query for dunning campaigns, and updating the GraphQL schema to support these queries.

### GraphQL Resolvers and Types:

* [`app/graphql/resolvers/dunning_campaigns_resolver.rb`](diffhunk://#diff-d45ebb2f5c75cc98d69a0d641723cff50a2a7034d18de7561d16ff45c71680c3R1-R38): Created a new resolver for querying dunning campaigns with appropriate permissions and arguments.
* [`app/graphql/types/query_type.rb`](diffhunk://#diff-f091357fe3bc9b42153dde4873030274dd9aa16c9cf86f689fee229ca9558b8cR35): Added `dunning_campaigns` field to the `QueryType` to use the new resolver.

### Model and Query Enhancements:

* [`app/models/dunning_campaign.rb`](diffhunk://#diff-3b7eb2d6a06a5b47d979ac5e42118e603975d556bac67a32d1372160bd29c7cdR6-R7): Added `ORDERS` constant and `ransackable_attributes` method for sorting and searching. [[1]](diffhunk://#diff-3b7eb2d6a06a5b47d979ac5e42118e603975d556bac67a32d1372160bd29c7cdR6-R7) [[2]](diffhunk://#diff-3b7eb2d6a06a5b47d979ac5e42118e603975d556bac67a32d1372160bd29c7cdR16-R19)
* [`app/queries/dunning_campaigns_query.rb`](diffhunk://#diff-0d6920857152058222fe3b254236d3b9f001691a8101247633146b92cbabec9cR1-R40): Created a new query class to handle filtering, sorting, and pagination of dunning campaigns.