### PR TITLE
feat (cascading): add DB changes for charge cascading

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -8,7 +8,9 @@ class Charge < ApplicationRecord
 
   belongs_to :plan, -> { with_discarded }, touch: true
   belongs_to :billable_metric, -> { with_discarded }
+  belongs_to :parent, class_name: 'Charge', optional: true
 
+  has_many :children, class_name: 'Charge', foreign_key: :parent_id, dependent: :nullify
   has_many :fees
   has_many :filters, dependent: :destroy, class_name: "ChargeFilter"
   has_many :filter_values, through: :filters, class_name: "ChargeFilterValue", source: :values
@@ -170,16 +172,19 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  billable_metric_id   :uuid
+#  parent_id            :uuid
 #  plan_id              :uuid
 #
 # Indexes
 #
 #  index_charges_on_billable_metric_id  (billable_metric_id)
 #  index_charges_on_deleted_at          (deleted_at)
+#  index_charges_on_parent_id           (parent_id)
 #  index_charges_on_plan_id             (plan_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (billable_metric_id => billable_metrics.id)
+#  fk_rails_...  (parent_id => charges.id)
 #  fk_rails_...  (plan_id => plans.id)
 #

--- a/app/services/charges/override_service.rb
+++ b/app/services/charges/override_service.rb
@@ -17,6 +17,7 @@ module Charges
           c.properties = params[:properties] if params.key?(:properties)
           c.min_amount_cents = params[:min_amount_cents] if params.key?(:min_amount_cents)
           c.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
+          c.parent_id = charge.id
           c.filters = charge.filters.map do |filter|
             f = filter.dup
             f.values = filter.values.map(&:dup)

--- a/db/migrate/20241015132635_add_parent_id_to_charges.rb
+++ b/db/migrate/20241015132635_add_parent_id_to_charges.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddParentIdToCharges < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      add_reference :charges, :parent, type: :uuid, null: true, index: true, foreign_key: {to_table: :charges}
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_14_093451) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_15_132635) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -239,8 +239,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_14_093451) do
     t.boolean "prorated", default: false, null: false
     t.string "invoice_display_name"
     t.integer "regroup_paid_fees"
+    t.uuid "parent_id"
     t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id"
     t.index ["deleted_at"], name: "index_charges_on_deleted_at"
+    t.index ["parent_id"], name: "index_charges_on_parent_id"
     t.index ["plan_id"], name: "index_charges_on_plan_id"
   end
 
@@ -1240,6 +1242,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_14_093451) do
   add_foreign_key "charge_filter_values", "charge_filters"
   add_foreign_key "charge_filters", "charges"
   add_foreign_key "charges", "billable_metrics"
+  add_foreign_key "charges", "charges", column: "parent_id"
   add_foreign_key "charges", "plans"
   add_foreign_key "charges_taxes", "charges"
   add_foreign_key "charges_taxes", "taxes"

--- a/spec/services/charges/override_service_spec.rb
+++ b/spec/services/charges/override_service_spec.rb
@@ -49,21 +49,22 @@ RSpec.describe Charges::OverrideService, type: :service do
 
         expect { override_service.call }.to change(Charge, :count).by(1)
 
-        charge = Charge.order(:created_at).last
-        expect(charge).to have_attributes(
-          amount_currency: charge.amount_currency,
-          billable_metric_id: charge.billable_metric.id,
-          charge_model: charge.charge_model,
-          invoiceable: charge.invoiceable,
-          pay_in_advance: charge.pay_in_advance,
-          prorated: charge.prorated,
+        new_charge = Charge.order(:created_at).last
+        expect(new_charge).to have_attributes(
+          amount_currency: new_charge.amount_currency,
+          billable_metric_id: new_charge.billable_metric.id,
+          charge_model: new_charge.charge_model,
+          invoiceable: new_charge.invoiceable,
+          parent_id: charge.id,
+          pay_in_advance: new_charge.pay_in_advance,
+          prorated: new_charge.prorated,
           # Overriden attributes
           plan_id: plan.id,
           # invoice_display_name: 'invoice display name',
           min_amount_cents: 1000,
           properties: {'amount' => '200'}
         )
-        expect(charge.taxes).to contain_exactly(tax)
+        expect(new_charge.taxes).to contain_exactly(tax)
       end
 
       context 'with charge filters' do


### PR DESCRIPTION
## Context

Currently, plan updates are not cascaded to the children plan / charges.

## Description

This PR adds basic pre-requirement for cascading charge changes.
Later, we will write migration that would set `parent_id` on all existing charge records
