### PR TITLE
Feat: credit note on credit - update void credits service

### DIFF
--- a/app/services/wallet_transactions/void_service.rb
+++ b/app/services/wallet_transactions/void_service.rb
@@ -2,11 +2,12 @@
 
 module WalletTransactions
   class VoidService < BaseService
-    def initialize(wallet:, credits_amount:, from_source: :manual, metadata: {})
+    def initialize(wallet:, credits_amount:, from_source: :manual, metadata: {}, credit_note_id: nil)
       @wallet = wallet
       @credits_amount = credits_amount
       @from_source = from_source
       @metadata = metadata
+      @credit_note_id = credit_note_id
 
       super
     end
@@ -23,7 +24,8 @@ module WalletTransactions
           settled_at: Time.current,
           source: from_source,
           transaction_status: :voided,
-          metadata:
+          metadata:,
+          credit_note_id:
         )
         Wallets::Balance::DecreaseService.new(wallet:, credits_amount:).call
         result.wallet_transaction = wallet_transaction
@@ -34,6 +36,6 @@ module WalletTransactions
 
     private
 
-    attr_reader :wallet, :credits_amount, :from_source, :metadata
+    attr_reader :wallet, :credits_amount, :from_source, :metadata, :credit_note_id
   end
 end

--- a/spec/services/wallet_transactions/void_service_spec.rb
+++ b/spec/services/wallet_transactions/void_service_spec.rb
@@ -80,8 +80,9 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
     end
 
     context 'when credit_note_id is passed' do
-      let(:credit_note_id) { create(:credit_note, organization: organization).id }
       subject(:void_service) { described_class.call(wallet:, credits:, credit_note_id:) }
+
+      let(:credit_note_id) { create(:credit_note, organization: organization).id }
 
       it 'saves credit_note_id in wallet_transaction' do
         result = void_service

--- a/spec/services/wallet_transactions/void_service_spec.rb
+++ b/spec/services/wallet_transactions/void_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
     end
 
     context 'when credit_note_id is passed' do
-      subject(:void_service) { described_class.call(wallet:, credits:, credit_note_id:) }
+      subject(:void_service) { described_class.call(wallet:, credits_amount:, credit_note_id:) }
 
       let(:credit_note_id) { create(:credit_note, organization: organization).id }
 

--- a/spec/services/wallet_transactions/void_service_spec.rb
+++ b/spec/services/wallet_transactions/void_service_spec.rb
@@ -78,5 +78,17 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
       expect(wallet.balance_cents).to eq(0)
       expect(wallet.credits_balance).to eq(0.0)
     end
+
+    context 'when credit_note_id is passed' do
+      let(:credit_note_id) { create(:credit_note, organization: organization).id }
+      subject(:void_service) { described_class.call(wallet:, credits:, credit_note_id:) }
+
+      it 'saves credit_note_id in wallet_transaction' do
+        result = void_service
+        wallet_transaction = result.wallet_transaction
+
+        expect(wallet_transaction.credit_note_id).to eq(credit_note_id)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

In order keep consistency of outbound transactions from the wallet, we want to save a credit_note_id into wallet_transaction when woiding credits and when credit_note_id is sent

