### PR TITLE
add a field to invoice graphql object

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -42,6 +42,7 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      field :available_to_credit_amount_cents, GraphQL::Types::BigInt, null: false
       field :associated_active_wallet_present, Boolean, null: false
       field :creditable_amount_cents, GraphQL::Types::BigInt, null: false
       field :refundable_amount_cents, GraphQL::Types::BigInt, null: false

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -42,8 +42,8 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
-      field :available_to_credit_amount_cents, GraphQL::Types::BigInt, null: false
       field :associated_active_wallet_present, Boolean, null: false
+      field :available_to_credit_amount_cents, GraphQL::Types::BigInt, null: false
       field :creditable_amount_cents, GraphQL::Types::BigInt, null: false
       field :refundable_amount_cents, GraphQL::Types::BigInt, null: false
 

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -42,6 +42,7 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      field :associated_active_wallet_present: Boolean, null: false
       field :creditable_amount_cents, GraphQL::Types::BigInt, null: false
       field :refundable_amount_cents, GraphQL::Types::BigInt, null: false
 
@@ -85,6 +86,10 @@ module Types
           syncable_type: 'Invoice',
           resource_type: :invoice
         )&.external_id
+      end
+
+      def associated_active_wallet_present
+        object.associated_active_wallet.present?
       end
     end
   end

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -42,7 +42,7 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
-      field :associated_active_wallet_present: Boolean, null: false
+      field :associated_active_wallet_present, Boolean, null: false
       field :creditable_amount_cents, GraphQL::Types::BigInt, null: false
       field :refundable_amount_cents, GraphQL::Types::BigInt, null: false
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -4264,6 +4264,7 @@ Invoice
 type Invoice {
   appliedTaxes: [InvoiceAppliedTax!]
   associatedActiveWalletPresent: Boolean!
+  availableToCreditAmountCents: BigInt!
   chargeAmountCents: BigInt!
   couponsAmountCents: BigInt!
   createdAt: ISO8601DateTime!

--- a/schema.graphql
+++ b/schema.graphql
@@ -4263,6 +4263,7 @@ Invoice
 """
 type Invoice {
   appliedTaxes: [InvoiceAppliedTax!]
+  associatedActiveWalletPresent: Boolean!
   chargeAmountCents: BigInt!
   couponsAmountCents: BigInt!
   createdAt: ISO8601DateTime!

--- a/schema.json
+++ b/schema.json
@@ -20722,6 +20722,24 @@
               ]
             },
             {
+              "name": "availableToCreditAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "chargeAmountCents",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -20704,6 +20704,24 @@
               ]
             },
             {
+              "name": "associatedActiveWalletPresent",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "chargeAmountCents",
               "description": null,
               "type": {


### PR DESCRIPTION
## Context

To help FE to show the correct reason of disabling button to create credit note, we need to show them when a credit invoice is not associated with an active wallet

## Description

added associated_active_wallet_present field to invoice graphql object
