### PR TITLE
feat(dunning): Add dunning campaign to customer, database changes

### DIFF
--- a/app/models/clickhouse/events_enriched.rb
+++ b/app/models/clickhouse/events_enriched.rb
@@ -10,15 +10,15 @@ end
 #
 # Table name: events_enriched
 #
-#  code                       :string           not null, primary key
-#  decimal_value              :decimal(26, )
-#  enriched_at                :datetime         not null
-#  precise_total_amount_cents :decimal(40, 15)
-#  properties                 :string           not null
-#  sorted_properties          :string           not null
-#  timestamp                  :datetime         not null, primary key
-#  value                      :string
-#  external_subscription_id   :string           not null, primary key
-#  organization_id            :string           not null, primary key
-#  transaction_id             :string           not null
+#  aggregation_type         :string
+#  code                     :string           not null, primary key
+#  filters                  :string           not null
+#  grouped_by               :string           not null
+#  properties               :string           not null
+#  timestamp                :datetime         not null
+#  value                    :string
+#  charge_id                :string           not null, primary key
+#  external_subscription_id :string           not null, primary key
+#  organization_id          :string           not null, primary key
+#  transaction_id           :string           not null, primary key
 #

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -28,6 +28,7 @@ class Customer < ApplicationRecord
   before_save :ensure_slug
 
   belongs_to :organization
+  belongs_to :applied_dunning_campaign, optional: true, class_name: 'DunningCampaign'
 
   has_many :subscriptions
   has_many :events
@@ -192,55 +193,61 @@ end
 #
 # Table name: customers
 #
-#  id                           :uuid             not null, primary key
-#  address_line1                :string
-#  address_line2                :string
-#  city                         :string
-#  country                      :string
-#  currency                     :string
-#  customer_type                :enum
-#  deleted_at                   :datetime
-#  document_locale              :string
-#  email                        :string
-#  finalize_zero_amount_invoice :integer          default("inherit"), not null
-#  firstname                    :string
-#  invoice_grace_period         :integer
-#  lastname                     :string
-#  legal_name                   :string
-#  legal_number                 :string
-#  logo_url                     :string
-#  name                         :string
-#  net_payment_term             :integer
-#  payment_provider             :string
-#  payment_provider_code        :string
-#  phone                        :string
-#  shipping_address_line1       :string
-#  shipping_address_line2       :string
-#  shipping_city                :string
-#  shipping_country             :string
-#  shipping_state               :string
-#  shipping_zipcode             :string
-#  slug                         :string
-#  state                        :string
-#  tax_identification_number    :string
-#  timezone                     :string
-#  url                          :string
-#  vat_rate                     :float
-#  zipcode                      :string
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  external_id                  :string           not null
-#  external_salesforce_id       :string
-#  organization_id              :uuid             not null
-#  sequential_id                :bigint
+#  id                               :uuid             not null, primary key
+#  address_line1                    :string
+#  address_line2                    :string
+#  city                             :string
+#  country                          :string
+#  currency                         :string
+#  customer_type                    :enum
+#  deleted_at                       :datetime
+#  document_locale                  :string
+#  email                            :string
+#  exclude_from_dunning_campaign    :boolean          default(FALSE), not null
+#  finalize_zero_amount_invoice     :integer          default("inherit"), not null
+#  firstname                        :string
+#  invoice_grace_period             :integer
+#  last_dunning_campaign_attempt    :integer          default(0), not null
+#  last_dunning_campaign_attempt_at :datetime
+#  lastname                         :string
+#  legal_name                       :string
+#  legal_number                     :string
+#  logo_url                         :string
+#  name                             :string
+#  net_payment_term                 :integer
+#  payment_provider                 :string
+#  payment_provider_code            :string
+#  phone                            :string
+#  shipping_address_line1           :string
+#  shipping_address_line2           :string
+#  shipping_city                    :string
+#  shipping_country                 :string
+#  shipping_state                   :string
+#  shipping_zipcode                 :string
+#  slug                             :string
+#  state                            :string
+#  tax_identification_number        :string
+#  timezone                         :string
+#  url                              :string
+#  vat_rate                         :float
+#  zipcode                          :string
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  applied_dunning_campaign_id      :uuid
+#  external_id                      :string           not null
+#  external_salesforce_id           :string
+#  organization_id                  :uuid             not null
+#  sequential_id                    :bigint
 #
 # Indexes
 #
+#  index_customers_on_applied_dunning_campaign_id      (applied_dunning_campaign_id)
 #  index_customers_on_deleted_at                       (deleted_at)
 #  index_customers_on_external_id_and_organization_id  (external_id,organization_id) UNIQUE WHERE (deleted_at IS NULL)
 #  index_customers_on_organization_id                  (organization_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (applied_dunning_campaign_id => dunning_campaigns.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -6,7 +6,10 @@ class DunningCampaign < ApplicationRecord
   ORDERS = %w[name code].freeze
 
   belongs_to :organization
+
   has_many :thresholds, class_name: "DunningCampaignThreshold", dependent: :destroy
+  has_many :customers, foreign_key: :applied_dunning_campaign_id, dependent: :nullify
+
   accepts_nested_attributes_for :thresholds
 
   validates :name, presence: true

--- a/db/migrate/20241016104211_add_dunning_campaign_to_customers.rb
+++ b/db/migrate/20241016104211_add_dunning_campaign_to_customers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddDunningCampaignToCustomers < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      change_table :customers, bulk: true do |t|
+        t.references :applied_dunning_campaign, type: :uuid, null: true, foreign_key: {to_table: :dunning_campaigns}, index: true
+        t.boolean :exclude_from_dunning_campaign, default: false, null: false
+        t.integer :last_dunning_campaign_attempt, default: 0, null: false
+        t.timestamp :last_dunning_campaign_attempt_at
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -446,6 +446,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_133129) do
     t.string "firstname"
     t.string "lastname"
     t.enum "customer_type", enum_type: "customer_type"
+    t.uuid "applied_dunning_campaign_id"
+    t.boolean "exclude_from_dunning_campaign", default: false, null: false
+    t.integer "last_dunning_campaign_attempt", default: 0, null: false
+    t.datetime "last_dunning_campaign_attempt_at", precision: nil
+    t.index ["applied_dunning_campaign_id"], name: "index_customers_on_applied_dunning_campaign_id"
     t.index ["deleted_at"], name: "index_customers_on_deleted_at"
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_customers_on_organization_id"
@@ -1265,6 +1270,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_133129) do
   add_foreign_key "credits", "invoices"
   add_foreign_key "credits", "invoices", column: "progressive_billing_invoice_id"
   add_foreign_key "customer_metadata", "customers"
+  add_foreign_key "customers", "dunning_campaigns", column: "applied_dunning_campaign_id"
   add_foreign_key "customers", "organizations"
   add_foreign_key "customers_taxes", "customers"
   add_foreign_key "customers_taxes", "taxes"

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Customer, type: :model do
 
   it_behaves_like 'paper_trail traceable'
 
+  it { is_expected.to belong_to(:applied_dunning_campaign).optional }
+
   it { is_expected.to have_many(:integration_customers).dependent(:destroy) }
   it { is_expected.to have_many(:payment_requests) }
 

--- a/spec/models/dunning_campaign_spec.rb
+++ b/spec/models/dunning_campaign_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe DunningCampaign, type: :model do
 
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to have_many(:thresholds).dependent(:destroy) }
+  it { is_expected.to have_many(:customers).dependent(:nullify) }
 
   it { is_expected.to validate_presence_of(:name) }
 


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic
👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We're first automating the overdue balance payment request, before looking at individual invoices.

 ## Description

The goal of this change is to create set the relationship between customers and dunning campaigns.

A customer could have one dunning campaign applied, or, inherit its organization default campaign (none applied) or, be excluded from dunning at all (with a boolean flag).

Also, when deleting a dunning campaign, all customers with the campaign assigned must be reset.