### PR TITLE
Feat: credit note on credit - create service

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -150,7 +150,10 @@ class Fee < ApplicationRecord
   alias_method :precise_total_amount_currency, :currency
 
   def creditable_amount_cents
-    amount_cents - credit_note_items.sum(:amount_cents)
+    remaining_amount = amount_cents - credit_note_items.sum(:amount_cents)
+
+    return [remaining_amount, invoice.associated_active_wallet&.balance_cents || 0].min if credit?
+    remaining_amount
   end
 
   # There are add_on type and one_off type so in order not to mix those two types with associations,

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -55,7 +55,7 @@ module CreditNotes
         )
         if invoice.credit?
           WalletTransactions::VoidService.call(wallet: associated_wallet,
-            credits: voiding_credits, credit_note_id: credit_note.id)
+            credits_amount: voiding_credits, credit_note_id: credit_note.id)
         end
       end
 
@@ -240,7 +240,9 @@ module CreditNotes
 
       # wallet transactions don't have cents amount, so we have to convert value into full amount
       # and then convert money into amount of credits
-      credit_note.refund_amount_cents / credit_note.refund_amount.currency.subunit_to_unit / associated_wallet.rate_amount
+      amount_cents = credit_note.refund_amount_cents
+      amount = amount_cents.fdiv(credit_note.refund_amount.currency.subunit_to_unit)
+      amount.fdiv(associated_wallet.rate_amount)
     end
   end
 end

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -102,7 +102,7 @@ module CreditNotes
 
     def valid_type_or_status?
       return true if automatic
-      return false if invoice.credit?
+      return false if invoice.credit? && invoice.payment_status != 'succeeded'
 
       invoice.version_number >= Invoice::CREDIT_NOTES_MIN_VERSION
     end

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -106,7 +106,7 @@ module CreditNotes
 
     def valid_type_or_status?
       return true if automatic
-      return false if invoice.credit? && invoice.payment_status != 'succeeded'
+      return false if invoice.credit? && (invoice.payment_status != 'succeeded' || invoice.associated_active_wallet.nil?)
 
       invoice.version_number >= Invoice::CREDIT_NOTES_MIN_VERSION
     end

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -240,7 +240,7 @@ module CreditNotes
 
       # wallet transactions don't have cents amount, so we have to convert value into full amount
       # and then convert money into amount of credits
-      credit_note.refund_amount_cents / 100 / associated_wallet.rate_amount
+      credit_note.refund_amount_cents / credit_note.refund_amount.currency.subunit_to_unit / associated_wallet.rate_amount
     end
   end
 end

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -106,7 +106,7 @@ module CreditNotes
 
     def valid_type_or_status?
       return true if automatic
-      return false if invoice.credit? && (invoice.payment_status != 'succeeded' || invoice.associated_active_wallet.nil?)
+      return false if invoice.credit? && (invoice.payment_status != 'succeeded' || associated_wallet.nil?)
 
       invoice.version_number >= Invoice::CREDIT_NOTES_MIN_VERSION
     end

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -37,7 +37,7 @@ module CreditNotes
     attr_reader :invoice, :items, :credit_note
 
     def valid_type_or_status?
-      return false if invoice.credit? && invoice.payment_status != 'succeeded'
+      return false if invoice.credit? && (invoice.payment_status != 'succeeded' || invoice.associated_active_wallet.nil?)
 
       invoice.version_number >= Invoice::CREDIT_NOTES_MIN_VERSION
     end

--- a/app/services/credit_notes/validate_item_service.rb
+++ b/app/services/credit_notes/validate_item_service.rb
@@ -64,7 +64,11 @@ module CreditNotes
     def valid_individual_amount?
       return true if item.amount_cents <= fee.creditable_amount_cents
 
-      add_error(field: :amount_cents, error_code: 'higher_than_remaining_fee_amount')
+      if invoice.credit? && item.amount_cents > invoice.associated_active_wallet&.balance_cents
+        add_error(field: :amount_cents, error_code: 'higher_than_wallet_balance')
+      else
+        add_error(field: :amount_cents, error_code: 'higher_than_remaining_fee_amount')
+      end
     end
 
     # NOTE: Check if item amount is less than or equal to invoice remaining creditable amount

--- a/app/services/credit_notes/validate_service.rb
+++ b/app/services/credit_notes/validate_service.rb
@@ -83,6 +83,10 @@ module CreditNotes
 
     # NOTE: Check if credited amount is less than or equal to invoice fee amount
     def valid_credit_amount?
+      if invoice.credit? && credit_note.credit_amount_cents > 0
+        add_error(field: :credit_amount_cents, error_code: 'cannot_credit_invoice')
+      end
+
       return true if credit_note.credit_amount_cents <= invoice.fee_total_amount_cents - credited_invoice_amount_cents
 
       add_error(field: :credit_amount_cents, error_code: 'higher_than_remaining_invoice_amount')

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -402,4 +402,55 @@ RSpec.describe Fee, type: :model do
       end
     end
   end
+
+  describe '#creditable_amount_cents' do
+    let(:fee) { create(:fee, fee_type:, amount_cents:,  invoice:) }
+    let(:invoice) { create(:invoice, invoice_type: :credit) }
+    let(:amount_cents) { 1000 }
+
+    context 'when fee_type is subscription' do
+      let(:fee_type) { 'subscription' }
+
+      it 'returns the correct creditable amount' do
+        expect(fee.creditable_amount_cents).to eq(1000)
+      end
+    end
+
+    context 'when fee_type is credit' do
+      let(:fee_type) { 'credit' }
+      let(:wallet_transaction) { create(:wallet_transaction, wallet:) }
+
+      it 'returns the correct creditable amount when no associated wallet is found' do
+        expect(fee.creditable_amount_cents).to eq(0)
+      end
+
+      context 'when associated walled exists' do
+        before { fee.update(invoiceable: wallet_transaction, fee_type: :credit) }
+
+        context 'when associated wallet have lower amount than remaining items sum' do
+          let(:wallet) { create(:wallet, balance_cents: 500, customer: invoice.customer) }
+
+          it 'returns the wallet balance' do
+            expect(fee.creditable_amount_cents).to eq(500)
+          end
+        end
+
+        context 'when associated wallet have higher amount than remaining items sum' do
+          let(:wallet) { create(:wallet, balance_cents: 1500, customer: invoice.customer) }
+
+          it 'returns the wallet balance' do
+            expect(fee.creditable_amount_cents).to eq(1000)
+          end
+        end
+
+        context 'when associated wallet is terminated' do
+          let(:wallet) { create(:wallet, balance_cents: 1500, status: :terminated, customer: invoice.customer) }
+
+          it 'returns the wallet balance' do
+            expect(fee.creditable_amount_cents).to eq(0)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -404,7 +404,7 @@ RSpec.describe Fee, type: :model do
   end
 
   describe '#creditable_amount_cents' do
-    let(:fee) { create(:fee, fee_type:, amount_cents:,  invoice:) }
+    let(:fee) { create(:fee, fee_type:, amount_cents:, invoice:) }
     let(:invoice) { create(:invoice, invoice_type: :credit) }
     let(:amount_cents) { 1000 }
 

--- a/spec/scenarios/credit_note_spec.rb
+++ b/spec/scenarios/credit_note_spec.rb
@@ -1039,7 +1039,6 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
       )
       expect(response).to have_http_status(:method_not_allowed)
       expect(response.body).to include('invalid_type_or_status')
-
     end
   end
 end

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -439,7 +439,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
           currency: 'EUR',
           fees_amount_cents: 1000,
           total_amount_cents: 1000,
-          payment_status: :succeeded,
+          payment_status: :succeeded
         )
       end
       let(:wallet) { create :wallet, customer:, balance_cents: 1000, rate_amount: }
@@ -478,8 +478,8 @@ RSpec.describe CreditNotes::CreateService, type: :service do
           # in the transaction is 1, while the "money" amount is 10
           expect(wallet_transaction.credit_amount).to eq(1)
           expect(wallet_transaction.amount).to eq(10)
-          expect(wallet_transaction. transaction_status).to eq("voided")
-          expect(wallet_transaction. transaction_type).to eq("outbound")
+          expect(wallet_transaction.transaction_status).to eq("voided")
+          expect(wallet_transaction.transaction_type).to eq("outbound")
           expect(wallet.reload.balance_cents).to eq(0)
         end
       end
@@ -487,7 +487,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       context 'with different rate amount' do
         let(:rate_amount) { 20 }
 
-        it 'it calculates correct credits amount' do
+        it 'calculates correct credits amount' do
           result = create_service.call
 
           aggregate_failures do
@@ -502,10 +502,10 @@ RSpec.describe CreditNotes::CreateService, type: :service do
         end
       end
 
-      context 'When wallet is terminated' do
+      context 'when wallet is terminated' do
         let(:wallet) { create :wallet, customer:, balance_cents: 1000, rate_amount:, status: :terminated }
 
-        it 'it returns error' do
+        it 'returns error' do
           result = create_service.call
 
           aggregate_failures do
@@ -520,7 +520,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       context 'when associated wallet balance is less than requested sum' do
         let(:wallet) { create :wallet, customer:, balance_cents: 500, rate_amount: }
 
-        it 'it returns error' do
+        it 'returns error' do
           result = create_service.call
 
           aggregate_failures do
@@ -535,7 +535,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       context 'when creating credit_note with credit amount' do
         let(:credit_amount_cents) { 10 }
 
-        it 'it returns error' do
+        it 'returns error' do
           result = create_service.call
 
           aggregate_failures do


### PR DESCRIPTION
## Context

Last part of issuing credit notes on credit invoices - creation of a credit note and voiding credits

## Description

- updated service to create credit note
- added validation to create and estimate credit notes to return error if requested amount is higher than available
- added validation to have association with active wallet
- added validation to not allow create credited credit_notes for credit invoices
