### PR TITLE
fix(gocarless): Refund metadata can contains 3 keys at max

### DIFF
--- a/app/services/credit_notes/refunds/gocardless_service.rb
+++ b/app/services/credit_notes/refunds/gocardless_service.rb
@@ -90,13 +90,15 @@ module CreditNotes
       end
 
       def create_gocardless_refund
+        # NOTE: Gocarless API accepts only 3 keys at max in metadata
+        #       See https://developer.gocardless.com/api-reference#refunds-create-a-refund
+        #       for reference
         client.refunds.create(
           params: {
             amount: credit_note.refund_amount_cents,
             total_amount_confirmation: credit_note.refund_amount_cents,
             links: {payment: payment.provider_payment_id},
             metadata: {
-              lago_customer_id: customer.id,
               lago_credit_note_id: credit_note.id,
               lago_invoice_id: invoice.id,
               reason: credit_note.reason.to_s


### PR DESCRIPTION
## Context

This PR is a fix for `CreditNotes::Refunds::GocardlessCreateJob` failing with `GoCardlessPro::InvalidApiUsageError, One of your parameters was incorrectly typed`

In the [Gocardless API reference](https://developer.gocardless.com/api-reference#refunds-create-a-refund) the metadata field is defined like this:
> Key-value store of custom data. Up to 3 keys are permitted, with key names up to 50 characters and values up to 500 characters.

Today, we are sending `lago_customer_id`, `lago_credit_note_id`, `lago_invoice_id` and `reason` wich is more than 3...

## Description

Since the `lago_customer_id` is not used when receiving related webhooks this PR removes it from the metadatas so that we only send 3 keys.