### PR TITLE
fix(stripe): Handle authentication errors for checkout URL

### DIFF
--- a/app/jobs/payment_provider_customers/stripe_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_checkout_url_job.rb
@@ -10,8 +10,11 @@ module PaymentProviderCustomers
     retry_on ActiveJob::DeserializationError
 
     def perform(stripe_customer)
-      result = PaymentProviderCustomers::StripeService.new(stripe_customer).generate_checkout_url
-      result.raise_if_error!
+      PaymentProviderCustomers::StripeService.new(stripe_customer)
+        .generate_checkout_url
+        .raise_if_error!
+    rescue BaseService::UnauthorizedFailure => e
+      Rails.logger.warn(e.message)
     end
   end
 end

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -137,6 +137,11 @@ module PaymentProviderCustomers
     rescue Stripe::InvalidRequestError, Stripe::PermissionError => e
       deliver_error_webhook(e)
       result
+    rescue Stripe::AuthenticationError => e
+      deliver_error_webhook(e)
+
+      message = ['Stripe authentication failed.', e.message.presence].compact.join(' ')
+      result.unauthorized_failure!(message:)
     end
 
     private


### PR DESCRIPTION
## Context

This PR fixes the handling of ` Stripe::AuthenticationError` in `PaymentProviderCustomers::StripeCheckoutUrlJob` 

Today this type of error leads to a dead job without notifications sent to the owner of the Strip account.

Since this type of Stripe error cannot be handled on Lago's side we simply have to send a webhook to the account owner and prevent the job from ending in the dead queue.

## Description

This PR reuses the logic that was introduce in the `PaymentProviderCustomers::StripeCreateJob` and inner services to notify the owner and only log the error
