### PR TITLE
fix(wallet): Send wallet transaction webhooks outside of DB transactions

### DIFF
--- a/app/services/wallet_transactions/settle_service.rb
+++ b/app/services/wallet_transactions/settle_service.rb
@@ -10,7 +10,7 @@ module WalletTransactions
 
     def call
       wallet_transaction.update!(status: :settled, settled_at: Time.current)
-      SendWebhookJob.perform_later('wallet_transaction.updated', wallet_transaction)
+      after_commit { SendWebhookJob.perform_later('wallet_transaction.updated', wallet_transaction) }
 
       result.wallet_transaction = wallet_transaction
       result


### PR DESCRIPTION
This pull request includes an important change to the `SettleService` class in the `wallet_transactions` service. The change ensures that the webhook job is performed after the database transaction is committed.

Changes to `SettleService`:

* [`app/services/wallet_transactions/settle_service.rb`](diffhunk://#diff-1ed6ac3fbaced38ad306980aed9b8d706fcee5ec604b15a53ca681c756357fffL13-R13): Modified the `call` method to use the `after_commit` callback for performing the `SendWebhookJob` to ensure it runs only after the transaction is successfully committed.