### PR TITLE
fix(customer): Fix create/update via API when finalize_zero_amount_invoice is nil

### DIFF
--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -52,7 +52,7 @@ module Customers
         customer.legal_number = params[:legal_number] if params.key?(:legal_number)
         customer.net_payment_term = params[:net_payment_term] if params.key?(:net_payment_term)
         customer.external_salesforce_id = params[:external_salesforce_id] if params.key?(:external_salesforce_id)
-        customer.finalize_zero_amount_invoice = params[:finalize_zero_amount_invoice] if params.key?(:finalize_zero_amount_invoice)
+        customer.finalize_zero_amount_invoice = params[:finalize_zero_amount_invoice] || 'inherit' if params.key?(:finalize_zero_amount_invoice)
         customer.firstname = params[:firstname] if params.key?(:firstname)
         customer.lastname = params[:lastname] if params.key?(:lastname)
         customer.customer_type = params[:customer_type] if params.key?(:customer_type)

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -246,6 +246,29 @@ RSpec.describe Customers::CreateService, type: :service do
         end
       end
 
+      context 'with nil value for finalize_zero_amount_invoice' do
+        let(:create_args) do
+          {
+            external_id:,
+            finalize_zero_amount_invoice: nil
+          }
+        end
+
+        it 'creates customer with finalize_zero_amount_invoice set to the default value' do
+          result = customers_service.create_from_api(
+            organization:,
+            params: create_args
+          )
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            customer = result.customer
+            expect(customer.finalize_zero_amount_invoice).to eq("inherit")
+          end
+        end
+      end
+
       context 'with incorrect value of finalize_zero_amount_invoice' do
         let(:create_args) do
           {


### PR DESCRIPTION
## Context

Creation of customer via the REST API is failing if a nil value is provided for the `finalize_zero_amount_invoice` field (when called via the Ruby client for example)

The raised error is a `ActiveRecord::NotNullViolation`

## Description

This PR defaults to the default value (`inherit`) when it's the case