### PR TITLE
feat(fee): Allow filtering fees on event transaction id

### DIFF
--- a/app/controllers/api/v1/fees_controller.rb
+++ b/app/controllers/api/v1/fees_controller.rb
@@ -83,6 +83,7 @@ module Api
           :external_customer_id,
           :billable_metric_code,
           :currency,
+          :event_transaction_id,
           :created_at_from,
           :created_at_to,
           :failed_at_from,

--- a/app/queries/fees_query.rb
+++ b/app/queries/fees_query.rb
@@ -14,6 +14,8 @@ class FeesQuery < BaseQuery
     fees = with_fee_type(fees) if filters.fee_type
     fees = with_payment_status(fees) if filters.payment_status
 
+    fees = fees.where(pay_in_advance_event_transaction_id: filters.event_transaction_id) if filters.event_transaction_id
+
     fees = with_created_date_range(fees) if filters.created_at_from || filters.created_at_to
     fees = with_succeeded_date_range(fees) if filters.succeeded_at_from || filters.succeeded_at_to
     fees = with_failed_date_range(fees) if filters.failed_at_from || filters.failed_at_to

--- a/spec/queries/fees_query_spec.rb
+++ b/spec/queries/fees_query_spec.rb
@@ -189,6 +189,23 @@ RSpec.describe FeesQuery, type: :query do
       end
     end
 
+    context 'with event_transaction_id filter' do
+      let(:fee) do
+        create(:fee, subscription:, invoice: nil, pay_in_advance_event_transaction_id: 'transaction-id')
+      end
+
+      let(:filters) { {event_transaction_id: 'transaction-id'} }
+
+      it 'applies the filter' do
+        result = fees_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+        end
+      end
+    end
+
     context 'with created_at filters' do
       let(:filters) do
         {


### PR DESCRIPTION
This pull request introduces a new filter for `event_transaction_id` in the fees query functionality.

It allows users to filter fees by `pay_in_advance_event_transaction_id`.