### PR TITLE
feat(fee): Expose charge_id in REST API

### DIFF
--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -7,6 +7,7 @@ module V1
 
       payload = {
         lago_id: model.id,
+        lago_charge_id: model.charge_id,
         lago_charge_filter_id: model.charge_filter_id,
         lago_invoice_id: model.invoice_id,
         lago_true_up_fee_id: model.true_up_fee&.id,

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ::V1::FeeSerializer do
     aggregate_failures do
       expect(result['fee']).to include(
         'lago_id' => fee.id,
+        'lago_charge_id' => fee.charge_id,
         'lago_charge_filter_id' => fee.charge_filter_id,
         'lago_invoice_id' => fee.invoice_id,
         'lago_true_up_fee_id' => fee.true_up_fee&.id,


### PR DESCRIPTION
## Description

This PR exposes a new `lago_charge_id` field for the `Fee` resource in the REST API.
It will help users to find the billed resource.