### PR TITLE
feat(plan-cascade): add logic for cascading charge creation

### DIFF
--- a/app/jobs/charges/create_job.rb
+++ b/app/jobs/charges/create_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Charges
+  class CreateJob < ApplicationJob
+    queue_as 'default'
+
+    def perform(plan:, params:)
+      create_result = Charges::CreateService.call(plan:, params:)
+      create_result.raise_if_error!
+    end
+  end
+end

--- a/app/services/charges/create_service.rb
+++ b/app/services/charges/create_service.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Charges
+  class CreateService < BaseService
+    def initialize(plan:, params:)
+      @plan = plan
+      @params = params
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'plan') unless plan
+
+      ActiveRecord::Base.transaction do
+        charge = plan.charges.new(
+          billable_metric_id: params[:billable_metric_id],
+          invoice_display_name: params[:invoice_display_name],
+          amount_currency: params[:amount_currency],
+          charge_model: charge_model(params),
+          pay_in_advance: params[:pay_in_advance] || false,
+          prorated: params[:prorated] || false
+        )
+
+        properties = params[:properties].presence || Charges::BuildDefaultPropertiesService.call(charge.charge_model)
+        charge.properties = Charges::FilterChargeModelPropertiesService.call(
+          charge:,
+          properties:
+        ).properties
+
+        if params[:filters].present?
+          charge.save!
+          ChargeFilters::CreateOrUpdateBatchService.call(
+            charge:,
+            filters_params: params[:filters].map(&:with_indifferent_access)
+          ).raise_if_error!
+        end
+
+        if License.premium?
+          charge.invoiceable = params[:invoiceable] unless params[:invoiceable].nil?
+          charge.regroup_paid_fees = params[:regroup_paid_fees] if params.key?(:regroup_paid_fees)
+          charge.min_amount_cents = params[:min_amount_cents] || 0
+        end
+
+        charge.save!
+
+        if params[:tax_codes]
+          taxes_result = Charges::ApplyTaxesService.call(charge:, tax_codes: params[:tax_codes])
+          taxes_result.raise_if_error!
+        end
+
+        result.charge = charge
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
+    end
+
+    private
+
+    attr_reader :plan, :params
+
+    def charge_model(params)
+      model = params[:charge_model]&.to_sym
+      return if model == :graduated_percentage && !License.premium?
+
+      model
+    end
+  end
+end

--- a/spec/jobs/charges/create_job_spec.rb
+++ b/spec/jobs/charges/create_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::CreateJob, type: :job do
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:params) do
+    {
+      billable_metric_id: billable_metric.id,
+      charge_model: 'standard',
+      invoice_display_name: 'charge1',
+      min_amount_cents: 100
+    }
+  end
+
+  before do
+    allow(Charges::CreateService).to receive(:call).with(plan:, params:).and_return(BaseService::Result.new)
+  end
+
+  it 'calls the service' do
+    described_class.perform_now(plan:, params:)
+
+    expect(Charges::CreateService).to have_received(:call)
+  end
+end

--- a/spec/services/charges/create_service_spec.rb
+++ b/spec/services/charges/create_service_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::CreateService, type: :service do
+  subject(:create_service) { described_class.new(plan:, params:) }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:plan) { create(:plan, organization:) }
+
+  before { plan }
+
+  describe '#call' do
+    let(:sum_billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
+    let(:params) { {} }
+
+    context 'when plan is not found' do
+      let(:plan) { nil }
+
+      it 'returns an error' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('plan_not_found')
+        end
+      end
+    end
+
+    context 'when charge model is premium' do
+      let(:params) do
+        {
+          billable_metric_id: sum_billable_metric.id,
+          charge_model: 'graduated_percentage',
+          pay_in_advance: false,
+          invoiceable: true,
+          properties: {
+            graduated_percentage_ranges: [
+              {
+                from_value: 0,
+                to_value: 10,
+                rate: '3',
+                flat_amount: '0'
+              },
+              {
+                from_value: 11,
+                to_value: nil,
+                rate: '2',
+                flat_amount: '3'
+              }
+            ]
+          }
+        }
+      end
+
+      it 'returns an error' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:charge_model]).to eq(['value_is_mandatory'])
+        end
+      end
+
+      context 'with premium license' do
+        around { |test| lago_premium!(&test) }
+
+        it 'saves premium charge model' do
+          create_service.call
+
+          expect(plan.reload.charges.graduated_percentage.first).to have_attributes(
+            {
+              pay_in_advance: false,
+              invoiceable: true,
+              charge_model: 'graduated_percentage'
+            }
+          )
+        end
+      end
+
+      context 'when charge is successfully added' do
+        let(:billable_metric_filter) do
+          create(
+            :billable_metric_filter,
+            billable_metric: sum_billable_metric,
+            key: 'payment_method',
+            values: %w[card physical]
+          )
+        end
+
+        let(:params) do
+          {
+            billable_metric_id: sum_billable_metric.id,
+            charge_model: 'standard',
+            pay_in_advance: false,
+            prorated: true,
+            invoiceable: false,
+            min_amount_cents: 10,
+            filters: [
+              {
+                invoice_display_name: 'Card filter',
+                properties: {amount: '90'},
+                values: {billable_metric_filter.key => ['card']}
+              }
+            ]
+          }
+        end
+
+        it 'creates new charge' do
+          expect { create_service.call }.to change(Charge, :count).by(1)
+        end
+
+        it 'sets correctly attributes' do
+          create_service.call
+
+          stored_charge = plan.reload.charges.first
+
+          expect(stored_charge.reload).to have_attributes(
+            prorated: true,
+            pay_in_advance: false,
+            properties: {'amount' => '0'}
+          )
+
+          expect(stored_charge.filters.first).to have_attributes(
+            invoice_display_name: 'Card filter',
+            properties: {'amount' => '90'}
+          )
+          expect(stored_charge.filters.first.values.first).to have_attributes(
+            billable_metric_filter_id: billable_metric_filter.id,
+            values: ['card']
+          )
+        end
+
+        it 'does not update premium attributes' do
+          create_service.call
+
+          stored_charge = plan.reload.charges.first
+
+          expect(stored_charge).to have_attributes(invoiceable: true, min_amount_cents: 0)
+        end
+
+        context 'when premium' do
+          around { |test| lago_premium!(&test) }
+
+          it 'saves premium attributes' do
+            create_service.call
+
+            stored_charge = plan.reload.charges.first
+
+            expect(stored_charge).to have_attributes(invoiceable: false, min_amount_cents: 10)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently when plan is updated, these changes are not cascaded to all the children plans.

## Description

This PR handles the case for cascading charge creation
