### PR TITLE
feat(dunning): Update dunning campaign config for customers

### DIFF
--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -59,6 +59,11 @@ module Types
 
       field :credit_notes, [Types::CreditNotes::Object], null: true
 
+      field :applied_dunning_campaign, Types::DunningCampaigns::Object, null: true
+      field :exclude_from_dunning_campaign, Boolean, null: false
+      field :last_dunning_campaign_attempt, Integer, null: false
+      field :last_dunning_campaign_attempt_at, GraphQL::Types::ISO8601DateTime, null: true
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -46,6 +46,9 @@ module Types
 
       argument :billing_configuration, Types::Customers::BillingConfigurationInput, required: false
       argument :finalize_zero_amount_invoice, Types::Customers::FinalizeZeroAmountInvoiceEnum, required: false
+
+      argument :applied_dunning_campaign_id, ID, required: false
+      argument :exclude_from_dunning_campaign, Boolean, required: false
     end
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -117,6 +117,10 @@ class Organization < ApplicationRecord
     super(value&.upcase)
   end
 
+  def auto_dunning_enabled?
+    License.premium? && premium_integrations.include?("auto_dunning")
+  end
+
   private
 
   def generate_api_key

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -11,7 +11,7 @@ module DunningCampaigns
     end
 
     def call
-      return result.forbidden_failure! unless auto_dunning_enabled?
+      return result.forbidden_failure! unless organization.auto_dunning_enabled?
       return result.not_found_failure!(resource: "dunning_campaign") unless dunning_campaign
 
       ActiveRecord::Base.transaction do
@@ -36,9 +36,5 @@ module DunningCampaigns
     private
 
     attr_reader :dunning_campaign, :organization, :params
-
-    def auto_dunning_enabled?
-      License.premium? && organization.premium_integrations.include?("auto_dunning")
-    end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3116,6 +3116,7 @@ type Customer {
   applicableTimezone: TimezoneEnum!
   appliedAddOns: [AppliedAddOn!]
   appliedCoupons: [AppliedCoupon!]
+  appliedDunningCampaign: DunningCampaign
   billingConfiguration: CustomerBillingConfiguration
 
   """
@@ -3141,6 +3142,7 @@ type Customer {
   deletedAt: ISO8601DateTime
   displayName: String!
   email: String
+  excludeFromDunningCampaign: Boolean!
   externalId: String!
   externalSalesforceId: String
 
@@ -3167,6 +3169,8 @@ type Customer {
   id: ID!
   invoiceGracePeriod: Int
   invoices: [Invoice!]
+  lastDunningCampaignAttempt: Int!
+  lastDunningCampaignAttemptAt: ISO8601DateTime
   lastname: String
   legalName: String
   legalNumber: String
@@ -7772,6 +7776,7 @@ Update Customer input arguments
 input UpdateCustomerInput {
   addressLine1: String
   addressLine2: String
+  appliedDunningCampaignId: ID
   billingConfiguration: CustomerBillingConfigurationInput
   city: String
 
@@ -7783,6 +7788,7 @@ input UpdateCustomerInput {
   currency: CurrencyEnum
   customerType: CustomerTypeEnum
   email: String
+  excludeFromDunningCampaign: Boolean
   externalId: String!
   externalSalesforceId: String
   finalizeZeroAmountInvoice: FinalizeZeroAmountInvoiceEnum

--- a/schema.json
+++ b/schema.json
@@ -12555,6 +12555,20 @@
               ]
             },
             {
+              "name": "appliedDunningCampaign",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "DunningCampaign",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "billingConfiguration",
               "description": null,
               "type": {
@@ -12765,6 +12779,24 @@
               ]
             },
             {
+              "name": "excludeFromDunningCampaign",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "externalId",
               "description": null,
               "type": {
@@ -12925,6 +12957,38 @@
                     "ofType": null
                   }
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "lastDunningCampaignAttempt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "lastDunningCampaignAttemptAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -38392,6 +38456,30 @@
               "type": {
                 "kind": "ENUM",
                 "name": "FinalizeZeroAmountInvoiceEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "appliedDunningCampaignId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "excludeFromDunningCampaign",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -72,4 +72,9 @@ RSpec.describe Types::Customers::Object do
 
   it { is_expected.to have_field(:can_edit_attributes).of_type('Boolean!') }
   it { is_expected.to have_field(:finalize_zero_amount_invoice).of_type('FinalizeZeroAmountInvoiceEnum') }
+
+  it { is_expected.to have_field(:applied_dunning_campaign).of_type("DunningCampaign") }
+  it { is_expected.to have_field(:exclude_from_dunning_campaign).of_type("Boolean!") }
+  it { is_expected.to have_field(:last_dunning_campaign_attempt).of_type("Int!") }
+  it { is_expected.to have_field(:last_dunning_campaign_attempt_at).of_type("ISO8601DateTime") }
 end

--- a/spec/graphql/types/customers/update_customer_input_spec.rb
+++ b/spec/graphql/types/customers/update_customer_input_spec.rb
@@ -38,4 +38,7 @@ RSpec.describe Types::Customers::UpdateCustomerInput do
   it { is_expected.to accept_argument(:provider_customer).of_type('ProviderCustomerInput') }
   it { is_expected.to accept_argument(:integration_customers).of_type('[IntegrationCustomerInput!]') }
   it { is_expected.to accept_argument(:billing_configuration).of_type('CustomerBillingConfigurationInput') }
+
+  it { is_expected.to accept_argument(:applied_dunning_campaign_id).of_type("ID") }
+  it { is_expected.to accept_argument(:exclude_from_dunning_campaign).of_type("Boolean") }
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -161,4 +161,24 @@ RSpec.describe Organization, type: :model do
       expect(described_class.with_progressive_billing_support).to eq([organization])
     end
   end
+
+  describe "#auto_dunning_enabled?" do
+    subject(:auto_dunning_enabled?) { organization.auto_dunning_enabled? }
+
+    it { is_expected.to eq(false) }
+
+    context "when premium features are enabled" do
+      around { |test| lago_premium!(&test) }
+
+      it { is_expected.to eq(false) }
+
+      context "with auto_dunning integration is enabled" do
+        let(:organization) do
+          described_class.new(premium_integrations: ["auto_dunning"])
+        end
+
+        it { is_expected.to eq(true) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic
👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We're first automating the overdue balance payment request, before looking at individual invoices.

 ## Description

Add auto dunning campaign fields to customers object type.

Update customers auto dunning campaign config through customers update mutation.

`exclude_from_dunning_campaign` has higher priority than the applied campaign and if both config arguments are provided at update, exclusion true overwrites the applied campaign.