### PR TITLE
feat(daily_usage): Add DailyUsage model

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -39,6 +39,7 @@ class Customer < ApplicationRecord
   has_many :credit_notes
   has_many :applied_add_ons
   has_many :add_ons, through: :applied_add_ons
+  has_many :daily_usages
   has_many :wallets
   has_many :wallet_transactions, through: :wallets
   has_many :payment_provider_customers,

--- a/app/models/daily_usage.rb
+++ b/app/models/daily_usage.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class DailyUsage < ApplicationRecord
+  belongs_to :organization
+  belongs_to :customer
+  belongs_to :subscription
+end
+
+# == Schema Information
+#
+# Table name: daily_usages
+#
+#  id                       :uuid             not null, primary key
+#  from_datetime            :datetime         not null
+#  to_datetime              :datetime         not null
+#  usage                    :jsonb            not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  customer_id              :uuid             not null
+#  external_subscription_id :string           not null
+#  organization_id          :uuid             not null
+#  subscription_id          :uuid             not null
+#
+# Indexes
+#
+#  idx_on_organization_id_external_subscription_id_df3a30d96d  (organization_id,external_subscription_id)
+#  index_daily_usages_on_customer_id                           (customer_id)
+#  index_daily_usages_on_organization_id                       (organization_id)
+#  index_daily_usages_on_subscription_id                       (subscription_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (subscription_id => subscriptions.id)
+#

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -23,6 +23,7 @@ class Organization < ApplicationRecord
   has_many :coupons
   has_many :applied_coupons, through: :coupons
   has_many :add_ons
+  has_many :daily_usages
   has_many :invites
   has_many :integrations, class_name: 'Integrations::BaseIntegration'
   has_many :payment_providers, class_name: 'PaymentProviders::BaseProvider'

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -13,6 +13,7 @@ class Subscription < ApplicationRecord
   has_many :invoice_subscriptions
   has_many :invoices, through: :invoice_subscriptions
   has_many :fees
+  has_many :daily_usages
   has_one :lifetime_usage, autosave: true
 
   validates :external_id, :billing_time, presence: true

--- a/db/migrate/20241021095706_create_daily_usages.rb
+++ b/db/migrate/20241021095706_create_daily_usages.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateDailyUsages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :daily_usages, id: :uuid do |t|
+      t.references :organization, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :customer, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :subscription, type: :uuid, null: false, foreign_key: true, index: true
+      t.string :external_subscription_id, null: false
+      t.datetime :from_datetime, null: false
+      t.datetime :to_datetime, null: false
+      t.jsonb :usage, null: false, default: '{}'
+      t.timestamps
+
+      t.index %i[organization_id external_subscription_id]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_16_133129) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_21_095706) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -466,6 +466,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_133129) do
     t.index ["customer_id", "tax_id"], name: "index_customers_taxes_on_customer_id_and_tax_id", unique: true
     t.index ["customer_id"], name: "index_customers_taxes_on_customer_id"
     t.index ["tax_id"], name: "index_customers_taxes_on_tax_id"
+  end
+
+  create_table "daily_usages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "organization_id", null: false
+    t.uuid "customer_id", null: false
+    t.uuid "subscription_id", null: false
+    t.string "external_subscription_id", null: false
+    t.datetime "from_datetime", null: false
+    t.datetime "to_datetime", null: false
+    t.jsonb "usage", default: "{}", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_daily_usages_on_customer_id"
+    t.index ["organization_id", "external_subscription_id"], name: "idx_on_organization_id_external_subscription_id_df3a30d96d"
+    t.index ["organization_id"], name: "index_daily_usages_on_organization_id"
+    t.index ["subscription_id"], name: "index_daily_usages_on_subscription_id"
   end
 
   create_table "data_exports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1274,6 +1290,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_133129) do
   add_foreign_key "customers", "organizations"
   add_foreign_key "customers_taxes", "customers"
   add_foreign_key "customers_taxes", "taxes"
+  add_foreign_key "daily_usages", "customers"
+  add_foreign_key "daily_usages", "organizations"
+  add_foreign_key "daily_usages", "subscriptions"
   add_foreign_key "data_exports", "memberships"
   add_foreign_key "data_exports", "organizations"
   add_foreign_key "dunning_campaign_thresholds", "dunning_campaigns"

--- a/spec/factories/daily_usages.rb
+++ b/spec/factories/daily_usages.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :daily_usage do
+    customer
+    organization { customer.organization }
+    subscription { create(:subscription, customer:) }
+
+    external_subscriptin_id { subscription.external_id }
+    from_datetime { Time.current.beginning_of_month }
+    to_datetime { Time.current.end_of_month }
+    usage { {} }
+  end
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Customer, type: :model do
   it_behaves_like 'paper_trail traceable'
 
   it { is_expected.to belong_to(:applied_dunning_campaign).optional }
+  it { is_expected.to have_many(:daily_usages) }
 
   it { is_expected.to have_many(:integration_customers).dependent(:destroy) }
   it { is_expected.to have_many(:payment_requests) }

--- a/spec/models/daily_usage_spec.rb
+++ b/spec/models/daily_usage_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DailyUsage, type: :model do
+  it { is_expected.to belong_to(:organization) }
+  it { is_expected.to belong_to(:customer) }
+  it { is_expected.to belong_to(:subscription) }
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:xero_integrations) }
   it { is_expected.to have_many(:data_exports) }
   it { is_expected.to have_many(:dunning_campaigns) }
+  it { is_expected.to have_many(:daily_usages) }
 
   it { is_expected.to validate_inclusion_of(:default_currency).in_array(described_class.currency_list) }
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Subscription, type: :model do
   let(:plan) { create(:plan) }
 
   it_behaves_like 'paper_trail traceable'
+
+  it { is_expected.to have_many(:daily_usages) }
   it { is_expected.to have_one(:lifetime_usage) }
 
   describe '#upgraded?' do


### PR DESCRIPTION
## Context

This PR is part of the Usage Revenue and unit.

Today, Lago does not offer a way to retrieve customer usage with a granularity lower than the billing period (via invoices and fees). On the other end, it is possible to get the current usage for a customer/subscription, but this usage is just a “snapshot” of the usage a the current time. 

## Description

This PR is the first part of a feature implementing a daily usage monitoring. Is simply introduce a new `DailyUsage` model to store the computed daily usage.