### PR TITLE
feat(dunning): Filter dunning campaigns by threshold currency

### DIFF
--- a/app/graphql/resolvers/dunning_campaigns_resolver.rb
+++ b/app/graphql/resolvers/dunning_campaigns_resolver.rb
@@ -10,6 +10,7 @@ module Resolvers
     REQUIRED_PERMISSION = "dunning_campaigns:view"
 
     argument :applied_to_organization, Boolean, required: false
+    argument :currency, [Types::CurrencyEnum], required: false
     argument :limit, Integer, required: false
     argument :order, String, required: false
     argument :page, Integer, required: false
@@ -19,6 +20,7 @@ module Resolvers
 
     def resolve( # rubocop:disable Metrics/ParameterLists
       applied_to_organization: nil,
+      currency: nil,
       order: nil,
       page: nil,
       limit: nil,
@@ -29,7 +31,10 @@ module Resolvers
         search_term:,
         order:,
         pagination: {page:, limit:},
-        filters: {applied_to_organization:}
+        filters: {
+          applied_to_organization:,
+          currency:
+        }
       )
 
       result.dunning_campaigns

--- a/app/queries/dunning_campaigns_query.rb
+++ b/app/queries/dunning_campaigns_query.rb
@@ -9,6 +9,7 @@ class DunningCampaignsQuery < BaseQuery
     dunning_campaigns = dunning_campaigns.order(order)
 
     dunning_campaigns = with_applied_to_organization(dunning_campaigns) unless filters.applied_to_organization.nil?
+    dunning_campaigns = with_currency_threshold(dunning_campaigns) if filters.currency.present?
 
     result.dunning_campaigns = dunning_campaigns
     result
@@ -36,5 +37,12 @@ class DunningCampaignsQuery < BaseQuery
 
   def with_applied_to_organization(scope)
     scope.where(applied_to_organization: filters.applied_to_organization)
+  end
+
+  def with_currency_threshold(scope)
+    scope
+      .joins(:thresholds)
+      .where(dunning_campaign_thresholds: {currency: filters.currency})
+      .distinct
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -6232,7 +6232,7 @@ type Query {
   """
   Query dunning campaigns of an organization
   """
-  dunningCampaigns(appliedToOrganization: Boolean, limit: Int, order: String, page: Int, searchTerm: String): DunningCampaignCollection!
+  dunningCampaigns(appliedToOrganization: Boolean, currency: [CurrencyEnum!], limit: Int, order: String, page: Int, searchTerm: String): DunningCampaignCollection!
 
   """
   Query events of an organization

--- a/schema.json
+++ b/schema.json
@@ -31935,6 +31935,26 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CurrencyEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic
👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We're first automating the overdue balance payment request, before looking at individual invoices.

 ## Description

Add filter to dunning campaigns resolver to request campaigns in a give set of currencies. This will allow to display only relevant campaigns matching customer currency.