### PR TITLE
fix(clickhouse): Uniq count should count uniq values...

### DIFF
--- a/app/models/clickhouse/events_enriched.rb
+++ b/app/models/clickhouse/events_enriched.rb
@@ -11,7 +11,7 @@ end
 # Table name: events_enriched
 #
 #  code                       :string           not null, primary key
-#  decimal_value              :decimal(26, )
+#  decimal_value              :decimal(38, 26)
 #  enriched_at                :datetime         not null
 #  precise_total_amount_cents :decimal(40, 15)
 #  properties                 :string           not null

--- a/db/clickhouse_migrate/20240705080709_create_events_enriched.rb
+++ b/db/clickhouse_migrate/20240705080709_create_events_enriched.rb
@@ -29,7 +29,7 @@ class CreateEventsEnriched < ActiveRecord::Migration[7.1]
       t.string :properties, map: true, null: false
       t.string :sorted_properties, map: true, null: false, default: -> { 'mapSort(properties)' }
       t.string :value
-      t.decimal :decimal_value, precision: 26
+      t.decimal :decimal_value, precision: 38, scale: 26, default: -> { 'toDecimal128OrZero(value, 26)' }
       t.datetime :enriched_at, null: false, precision: 3, default: -> { 'now()' }
       t.decimal :precise_total_amount_cents, precision: 40, scale: 15
     end


### PR DESCRIPTION
## Context

This PR fixes the unique count aggregation for clickhouse event store

## Description

The unique count implementation uses window function to avoid double counting multiple addition or removals of the same unique property. The clickhouse implementation was a rewriting of the one implemented in clickhouse but it was not working as expected.
