### PR TITLE
bug(PastUsage) - Filter fees by external subscription id

### DIFF
--- a/app/queries/past_usage_query.rb
+++ b/app/queries/past_usage_query.rb
@@ -41,7 +41,7 @@ class PastUsageQuery < BaseQuery
   end
 
   def fees_query(invoice)
-    query = invoice.fees.charge.includes(:charge_filter)
+    query = invoice.fees.joins(:subscription).where(subscription: {external_id: filters.external_subscription_id}).charge.includes(:charge_filter)
     return query unless filters.billable_metric_code
 
     query.joins(:charge).where(charges: {billable_metric_id: billable_metric.id})

--- a/spec/queries/past_usage_query_spec.rb
+++ b/spec/queries/past_usage_query_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe PastUsageQuery, type: :query do
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
+  let(:subscription2) { create(:subscription, customer:, plan:) }
 
   let(:invoice_subscription1) do
     create(
@@ -33,6 +34,15 @@ RSpec.describe PastUsageQuery, type: :query do
       charges_from_datetime: DateTime.parse('2023-07-17T00:00:00'),
       charges_to_datetime: DateTime.parse('2023-08-16T23:59:59'),
       subscription:
+    )
+  end
+
+  let(:invoice_subscription3) do
+    create(
+      :invoice_subscription,
+      charges_from_datetime: DateTime.parse('2023-07-17T00:00:00'),
+      charges_to_datetime: DateTime.parse('2023-08-16T23:59:59'),
+      subscription: subscription2
     )
   end
 
@@ -107,6 +117,43 @@ RSpec.describe PastUsageQuery, type: :query do
       end
     end
 
+    context 'with fees belonging to multiple subscriptions' do
+      let(:billable_metric1) { create(:billable_metric, organization:) }
+      let(:billable_metric_code) { billable_metric1&.code }
+
+      let(:billable_metric2) { create(:billable_metric, organization:) }
+
+      let(:charge1) { create(:standard_charge, plan:, billable_metric: billable_metric1) }
+      let(:charge2) { create(:standard_charge, plan:, billable_metric: billable_metric2) }
+
+      let(:fee1) { create(:charge_fee, charge: charge1, subscription:, invoice: invoice_subscription1.invoice) }
+      let(:fee2) { create(:charge_fee, charge: charge2, subscription: subscription2, invoice: invoice_subscription1.invoice) }
+
+      let(:filters) do
+        {
+          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id
+        }
+      end
+
+      before do
+        invoice_subscription3
+        fee1
+        fee2
+      end
+
+      it 'filters the fees accordingly' do
+        result = usage_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.usage_periods.count).to eq(2)
+          expect(result.usage_periods.first.fees.count).to eq(1)
+          expect(result.usage_periods.first.fees.first.subscription).to eq(subscription)
+        end
+      end
+    end
+
     context 'with billable_metric_code' do
       let(:billable_metric1) { create(:billable_metric, organization:) }
       let(:billable_metric_code) { billable_metric1&.code }
@@ -116,8 +163,8 @@ RSpec.describe PastUsageQuery, type: :query do
       let(:charge1) { create(:standard_charge, plan:, billable_metric: billable_metric1) }
       let(:charge2) { create(:standard_charge, plan:, billable_metric: billable_metric2) }
 
-      let(:fee1) { create(:charge_fee, charge: charge1, invoice: invoice_subscription1.invoice) }
-      let(:fee2) { create(:charge_fee, charge: charge2, invoice: invoice_subscription1.invoice) }
+      let(:fee1) { create(:charge_fee, charge: charge1, subscription:, invoice: invoice_subscription1.invoice) }
+      let(:fee2) { create(:charge_fee, charge: charge2, subscription:, invoice: invoice_subscription1.invoice) }
 
       let(:filters) do
         {

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -351,8 +351,8 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
 
     let(:invoice) { invoice_subscription.invoice }
 
-    let(:fee1) { create(:charge_fee, charge: charge1, invoice:) }
-    let(:fee2) { create(:charge_fee, charge: charge2, invoice:) }
+    let(:fee1) { create(:charge_fee, charge: charge1, subscription:, invoice:) }
+    let(:fee2) { create(:charge_fee, charge: charge2, subscription:, invoice:) }
 
     let(:path) do
       [


### PR DESCRIPTION
## Context

Past usage endpoint allows you to retrieve past usage, an external subscription id parameter is required. 
However, we incorrectly send all fees belonging to the found invoice, we should filter these by the subscription id as well.