### PR TITLE
feat(cascade-plan-charges): add logic for cascading charge update

### DIFF
--- a/app/jobs/charges/update_job.rb
+++ b/app/jobs/charges/update_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Charges
+  class UpdateJob < ApplicationJob
+    queue_as 'default'
+
+    def perform(charge:, params:, cascade:)
+      Charges::UpdateService.call(charge:, params:, cascade:).raise_if_error!
+    end
+  end
+end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -67,6 +67,10 @@ class Charge < ApplicationRecord
     properties.keys == ['rate']
   end
 
+  def equal_properties?(charge)
+    charge_model == charge.charge_model && properties == charge.properties
+  end
+
   private
 
   def validate_amount

--- a/app/services/charges/create_service.rb
+++ b/app/services/charges/create_service.rb
@@ -18,6 +18,7 @@ module Charges
           invoice_display_name: params[:invoice_display_name],
           amount_currency: params[:amount_currency],
           charge_model: charge_model(params),
+          parent_id: params[:parent_id],
           pay_in_advance: params[:pay_in_advance] || false,
           prorated: params[:prorated] || false
         )

--- a/app/services/charges/update_service.rb
+++ b/app/services/charges/update_service.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Charges
+  class UpdateService < BaseService
+    def initialize(charge:, params:, cascade: false)
+      @charge = charge
+      @params = params
+      @cascade = cascade
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'charge') unless charge
+      return result if cascade && charge.charge_model != params[:charge_model]
+
+      ActiveRecord::Base.transaction do
+        charge.charge_model = params[:charge_model] unless plan.attached_to_subscriptions?
+        charge.invoice_display_name = params[:invoice_display_name] unless cascade
+
+        properties = params.delete(:properties).presence || Charges::BuildDefaultPropertiesService.call(
+          params[:charge_model]
+        )
+
+        charge.update!(
+          properties: Charges::FilterChargeModelPropertiesService.call(
+            charge:,
+            properties:
+          ).properties
+        )
+
+        result.charge = charge
+
+        # In cascade mode it is allowed only to change properties
+        return result if cascade
+
+        filters = params.delete(:filters)
+        unless filters.nil?
+          ChargeFilters::CreateOrUpdateBatchService.call(
+            charge:,
+            filters_params: filters.map(&:with_indifferent_access)
+          ).raise_if_error!
+        end
+
+        tax_codes = params.delete(:tax_codes)
+        if tax_codes
+          taxes_result = Charges::ApplyTaxesService.call(charge:, tax_codes:)
+          taxes_result.raise_if_error!
+        end
+
+        # NOTE: charges cannot be edited if plan is attached to a subscription
+        unless plan.attached_to_subscriptions?
+          invoiceable = params.delete(:invoiceable)
+          min_amount_cents = params.delete(:min_amount_cents)
+
+          charge.invoiceable = invoiceable if License.premium? && !invoiceable.nil?
+          charge.min_amount_cents = min_amount_cents || 0 if License.premium?
+
+          charge.update!(params)
+        end
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
+    end
+
+    private
+
+    attr_reader :charge, :params, :cascade
+
+    delegate :plan, to: :charge
+  end
+end

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -234,7 +234,7 @@ module Plans
         create_charge_result = Charges::CreateService.call(plan:, params: payload_charge)
         create_charge_result.raise_if_error!
 
-        cascade_charge_creation(payload_charge)
+        cascade_charge_creation(payload_charge.merge(parent_id: create_charge_result.charge.id))
         created_charges_ids.push(create_charge_result.charge.id)
       end
 

--- a/spec/jobs/charges/update_job_spec.rb
+++ b/spec/jobs/charges/update_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::UpdateJob, type: :job do
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:charge) { create(:standard_charge, plan:) }
+  let(:cascade) { true }
+  let(:params) do
+    {
+      properties: {}
+    }
+  end
+
+  before do
+    allow(Charges::UpdateService).to receive(:call).with(charge:, params:, cascade:).and_return(BaseService::Result.new)
+  end
+
+  it 'calls the service' do
+    described_class.perform_now(charge:, params:, cascade:)
+
+    expect(Charges::UpdateService).to have_received(:call)
+  end
+end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -559,4 +559,32 @@ RSpec.describe Charge, type: :model do
       expect(build(:charge, charge_model: 'percentage', properties: {rate: '0.20'})).to be_basic_rate_percentage
     end
   end
+
+  describe '#equal_properties?' do
+    let(:charge1) { build(:standard_charge, properties: {amount: 100}) }
+
+    context 'when charge model is not the same' do
+      let(:charge2) { build(:percentage_charge) }
+
+      it 'returns false' do
+        expect(charge1.equal_properties?(charge2)).to eq(false)
+      end
+    end
+
+    context 'when charge model is the same and properties are different' do
+      let(:charge2) { build(:standard_charge, properties: {amount: 200}) }
+
+      it 'returns false if properties are not the same' do
+        expect(charge1.equal_properties?(charge2)).to eq(false)
+      end
+    end
+
+    context 'when charge model and properties are the same' do
+      let(:charge2) { build(:standard_charge, properties: {amount: 100}) }
+
+      it 'returns true if both charge model and properties are the same' do
+        expect(charge1.equal_properties?(charge2)).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/services/charges/create_service_spec.rb
+++ b/spec/services/charges/create_service_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe Charges::CreateService, type: :service do
       end
 
       context 'when charge is successfully added' do
+        let(:parent_charge) { build(:standard_charge) }
         let(:billable_metric_filter) do
           create(
             :billable_metric_filter,
@@ -97,6 +98,7 @@ RSpec.describe Charges::CreateService, type: :service do
             pay_in_advance: false,
             prorated: true,
             invoiceable: false,
+            parent_id: parent_charge.id,
             min_amount_cents: 10,
             filters: [
               {
@@ -120,6 +122,7 @@ RSpec.describe Charges::CreateService, type: :service do
           expect(stored_charge.reload).to have_attributes(
             prorated: true,
             pay_in_advance: false,
+            parent_id: parent_charge.id,
             properties: {'amount' => '0'}
           )
 

--- a/spec/services/charges/update_service_spec.rb
+++ b/spec/services/charges/update_service_spec.rb
@@ -3,11 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Charges::UpdateService, type: :service do
-  subject(:update_service) { described_class.new(charge:, params:) }
+  subject(:update_service) { described_class.new(charge:, params:, cascade:) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:plan) { create(:plan, organization:) }
+  let(:cascade) { false }
 
   describe '#call' do
     let(:sum_billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
@@ -94,6 +95,20 @@ RSpec.describe Charges::UpdateService, type: :service do
         update_service.call
 
         expect(charge.reload).to have_attributes(pay_in_advance: true, invoiceable: false)
+      end
+    end
+
+    context 'when cascade is true' do
+      let(:cascade) { true }
+
+      it 'updates only charge properties' do
+        update_service.call
+
+        expect(charge.reload).to have_attributes(
+          properties: {'amount' => '0'}
+        )
+
+        expect(charge.filters.count).to eq(0)
       end
     end
   end

--- a/spec/services/charges/update_service_spec.rb
+++ b/spec/services/charges/update_service_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::UpdateService, type: :service do
+  subject(:update_service) { described_class.new(charge:, params:) }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:plan) { create(:plan, organization:) }
+
+  describe '#call' do
+    let(:sum_billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
+    let(:charge) do
+      create(
+        :standard_charge,
+        plan_id: plan.id,
+        billable_metric_id: sum_billable_metric.id,
+        amount_currency: 'USD',
+        properties: {
+          amount: '300'
+        }
+      )
+    end
+    let(:billable_metric_filter) do
+      create(
+        :billable_metric_filter,
+        billable_metric: sum_billable_metric,
+        key: 'payment_method',
+        values: %w[card physical]
+      )
+    end
+    let(:params) do
+      {
+        id: charge&.id,
+        billable_metric_id: sum_billable_metric.id,
+        charge_model: 'standard',
+        pay_in_advance: true,
+        prorated: true,
+        invoiceable: false,
+        filters: [
+          {
+            invoice_display_name: 'Card filter',
+            properties: {amount: '90'},
+            values: {billable_metric_filter.key => ['card']}
+          }
+        ]
+      }
+    end
+
+    before { charge }
+
+    context 'when charge is not found' do
+      let(:charge) { nil }
+
+      it 'returns an error' do
+        result = update_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('charge_not_found')
+        end
+      end
+    end
+
+    it 'updates existing charge' do
+      update_service.call
+
+      expect(charge.reload).to have_attributes(
+        prorated: true,
+        properties: {'amount' => '0'}
+      )
+
+      expect(charge.filters.first).to have_attributes(
+        invoice_display_name: 'Card filter',
+        properties: {'amount' => '90'}
+      )
+      expect(charge.filters.first.values.first).to have_attributes(
+        billable_metric_filter_id: billable_metric_filter.id,
+        values: ['card']
+      )
+    end
+
+    it 'does not update premium attributes' do
+      update_service.call
+
+      expect(charge.reload).to have_attributes(pay_in_advance: true, invoiceable: true)
+    end
+
+    context 'when premium' do
+      around { |test| lago_premium!(&test) }
+
+      it 'saves premium attributes' do
+        update_service.call
+
+        expect(charge.reload).to have_attributes(pay_in_advance: true, invoiceable: false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently when plan is updated, these changes are not cascaded to all the children plans.

## Description

This PR handles the case for cascading charge update case
