### PR TITLE
feat(cascade-plan-changes): add api and GQL support for cascade feature

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -17,7 +17,13 @@ module Api
 
       def update
         plan = current_organization.plans.parents.find_by(code: params[:code])
-        result = ::Plans::UpdateService.call(plan:, params: input_params.to_h.deep_symbolize_keys)
+
+        update_params = input_params.to_h.deep_symbolize_keys
+        if params[:plan].key?(:cascade_updates)
+          update_params[:cascade_updates] = params.require(:plan).permit(:cascade_updates)[:cascade_updates]
+        end
+
+        result = ::Plans::UpdateService.call(plan:, params: update_params)
 
         if result.success?
           render_plan(result.plan)

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -17,13 +17,7 @@ module Api
 
       def update
         plan = current_organization.plans.parents.find_by(code: params[:code])
-
-        update_params = input_params.to_h.deep_symbolize_keys
-        if params[:plan].key?(:cascade_updates)
-          update_params[:cascade_updates] = params.require(:plan).permit(:cascade_updates)[:cascade_updates]
-        end
-
-        result = ::Plans::UpdateService.call(plan:, params: update_params)
+        result = ::Plans::UpdateService.call(plan:, params: input_params.to_h.deep_symbolize_keys)
 
         if result.success?
           render_plan(result.plan)
@@ -83,6 +77,7 @@ module Api
           :trial_period,
           :pay_in_advance,
           :bill_charges_monthly,
+          :cascade_updates,
           tax_codes: [],
           minimum_commitment: [
             :id,

--- a/app/graphql/mutations/plans/update.rb
+++ b/app/graphql/mutations/plans/update.rb
@@ -13,6 +13,7 @@ module Mutations
       argument :amount_cents, GraphQL::Types::BigInt, required: true
       argument :amount_currency, Types::CurrencyEnum, required: true
       argument :bill_charges_monthly, Boolean, required: false
+      argument :cascade_updates, Boolean, required: false
       argument :code, String, required: true
       argument :description, String, required: false
       argument :id, String, required: true

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -25,6 +25,8 @@ module Types
       field :charges, [Types::Charges::Object]
       field :taxes, [Types::Taxes::Object]
 
+      field :has_overridden_plans, Boolean
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
@@ -44,6 +46,10 @@ module Types
 
       def charges_count
         object.charges.count
+      end
+
+      def has_overridden_plans
+        object.children.any?
       end
 
       def subscriptions_count

--- a/schema.graphql
+++ b/schema.graphql
@@ -5993,6 +5993,7 @@ type Plan {
   customersCount: Int!
   description: String
   draftInvoicesCount: Int!
+  hasOverriddenPlans: Boolean
   id: ID!
   interval: PlanInterval!
   invoiceDisplayName: String
@@ -8114,6 +8115,7 @@ input UpdatePlanInput {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   billChargesMonthly: Boolean
+  cascadeUpdates: Boolean
   charges: [ChargeInput!]!
 
   """

--- a/schema.json
+++ b/schema.json
@@ -29968,6 +29968,20 @@
               ]
             },
             {
+              "name": "hasOverriddenPlans",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -40437,6 +40451,18 @@
             },
             {
               "name": "billChargesMonthly",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cascadeUpdates",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/spec/graphql/types/plans/object_spec.rb
+++ b/spec/graphql/types/plans/object_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Types::Plans::Object do
   it { is_expected.to have_field(:bill_charges_monthly).of_type('Boolean') }
   it { is_expected.to have_field(:code).of_type('String!') }
   it { is_expected.to have_field(:description).of_type('String') }
+  it { is_expected.to have_field(:has_overridden_plans).of_type('Boolean') }
   it { is_expected.to have_field(:interval).of_type('PlanInterval!') }
   it { is_expected.to have_field(:invoice_display_name).of_type('String') }
   it { is_expected.to have_field(:minimum_commitment).of_type('Commitment') }


### PR DESCRIPTION
## Context

Currently when plan is updated, these changes are not cascaded to all the children plans.

## Description

This PR adds `cascade_updates` attribute that allows user to skip cascade action.

Also, this PR includes `has_overridden_plans` attribute on GQL plan object.
