### PR TITLE
feat: Add redis pool size

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,6 +57,7 @@ Rails.application.configure do
       ssl_params: {
         verify_mode: OpenSSL::SSL::VERIFY_NONE
       },
+      pool: {size: ENV.fetch('LAGO_REDIS_CACHE_POOL_SIZE', 5)},
       error_handler: lambda { |method:, returning:, exception:|
         Rails.logger.error(exception.message)
         Rails.logger.error(exception.backtrace.join("\n"))

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -55,6 +55,7 @@ Rails.application.configure do
       :redis_cache_store,
       {
         url: ENV['LAGO_REDIS_CACHE_URL'],
+        pool: {size: ENV.fetch('LAGO_REDIS_CACHE_POOL_SIZE', 5)},
         error_handler: lambda { |method:, returning:, exception:|
           Rails.logger.error(exception.message)
           Rails.logger.error(exception.backtrace.join("\n"))


### PR DESCRIPTION
## Context

We aim to make the Redis connection pool size for the cache configurable via an environment variable
The default Redis connection pool size is currently set to 5

## Description

This PR introduces a new environment variable `LAGO_REDIS_CACHE_POOL_SIZE` to control the Redis connection pool size for caching. If the environment variable is set, the value will be used as the pool size; if not, it will default to 5.