### PR TITLE
fix(netsuite): Fix invoice payload - add missing fields

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -39,12 +39,13 @@ module Integrations
 
           def columns
             result = {
-              'tranid' => invoice.id,
               'entity' => integration_customer.external_customer_id,
+              'taxregoverride' => true,
+              'taxdetailsoverride' => true,
               'otherrefnum' => invoice.number,
-              'custbody_lago_id' => invoice.id,
               'custbody_ava_disable_tax_calculation' => true,
               'custbody_lago_invoice_link' => invoice_url,
+              'custbody_lago_id' => invoice.id,
               'duedate' => due_date
             }
 

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -140,7 +140,8 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
       'type' => 'invoice',
       'isDynamic' => true,
       'columns' => {
-        'tranid' => invoice.id,
+        'taxregoverride' => true,
+        'taxdetailsoverride' => true,
         'entity' => integration_customer.external_customer_id,
         'otherrefnum' => invoice.number,
         'custbody_lago_id' => invoice.id,

--- a/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
@@ -136,7 +136,8 @@ RSpec.describe Integrations::Aggregator::SalesOrders::CreateService do
       'type' => 'salesorder',
       'isDynamic' => true,
       'columns' => {
-        'tranid' => invoice.id,
+        'taxregoverride' => true,
+        'taxdetailsoverride' => true,
         'entity' => integration_customer.external_customer_id,
         'otherrefnum' => invoice.number,
         'custbody_lago_id' => invoice.id,


### PR DESCRIPTION
## Context

NetSuite Sync Invoice format is wrong and failing.

## Description

Fix netsuite invoice payload by:
 - add missing fields: `taxregoverride` and `taxdetailsoverride`
 - remove: `tranid`