### PR TITLE
bug(Clock::SubscriptionsToBeTerminatedJob) - Make sure we only send the webhook once per subscription

### DIFF
--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -17,6 +17,7 @@ module Clock
           sent_at_dates
         )
         .where('webhooks.id IS NULL OR webhooks.created_at::date != ?', Time.current.to_date)
+        .distinct
         .find_each do |subscription|
           SendWebhookJob.perform_later('subscription.termination_alert', subscription)
         end


### PR DESCRIPTION
## Description

The `left join` in this query causes the same subscription to be returned multiple times. Adding the `distinct` makes sure we're dealing with a list of unique subscriptions.

The reason we can have multiple already existing webhooks is that organizations can have multiple webhook endpoints.