### PR TITLE
feat(dunning): update customer to fallback to organization dunning

### DIFF
--- a/app/graphql/types/organizations/current_organization_type.rb
+++ b/app/graphql/types/organizations/current_organization_type.rb
@@ -49,6 +49,8 @@ module Types
       field :gocardless_payment_providers, [Types::PaymentProviders::Gocardless], permission: 'organization:integrations:view'
       field :stripe_payment_providers, [Types::PaymentProviders::Stripe], permission: 'organization:integrations:view'
 
+      field :applied_dunning_campaign, Types::DunningCampaigns::Object
+
       def webhook_url
         object.webhook_endpoints.map(&:webhook_url).first
       end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -46,6 +46,8 @@ class Organization < ApplicationRecord
   has_many :netsuite_integrations, class_name: 'Integrations::NetsuiteIntegration'
   has_many :xero_integrations, class_name: 'Integrations::XeroIntegration'
 
+  has_one :applied_dunning_campaign, -> { where(applied_to_organization: true) }, class_name: "DunningCampaign"
+
   has_one_attached :logo
 
   DOCUMENT_NUMBERINGS = [

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -96,7 +96,7 @@ module Customers
 
       if customer.organization.auto_dunning_enabled?
         if args.key?(:applied_dunning_campaign_id)
-          dunning_campaign = DunningCampaign.find(args[:applied_dunning_campaign_id])
+          dunning_campaign = DunningCampaign.find_by(id: args[:applied_dunning_campaign_id])
           customer.applied_dunning_campaign = dunning_campaign
           customer.exclude_from_dunning_campaign = false
         end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3066,6 +3066,7 @@ type CurrentOrganization {
   addressLine2: String
   adyenPaymentProviders: [AdyenProvider!]
   apiKey: String
+  appliedDunningCampaign: DunningCampaign
   billingConfiguration: OrganizationBillingConfiguration
   city: String
   country: CountryCode

--- a/schema.json
+++ b/schema.json
@@ -11822,6 +11822,20 @@
               ]
             },
             {
+              "name": "appliedDunningCampaign",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "DunningCampaign",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "billingConfiguration",
               "description": null,
               "type": {

--- a/spec/graphql/types/organizations/current_organization_type_spec.rb
+++ b/spec/graphql/types/organizations/current_organization_type_spec.rb
@@ -40,4 +40,6 @@ RSpec.describe Types::Organizations::CurrentOrganizationType do
   it { is_expected.to have_field(:adyen_payment_providers).of_type('[AdyenProvider!]').with_permission('organization:integrations:view') }
   it { is_expected.to have_field(:gocardless_payment_providers).of_type('[GocardlessProvider!]').with_permission('organization:integrations:view') }
   it { is_expected.to have_field(:stripe_payment_providers).of_type('[StripeProvider!]').with_permission('organization:integrations:view') }
+
+  it { is_expected.to have_field(:applied_dunning_campaign).of_type("DunningCampaign") }
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:dunning_campaigns) }
   it { is_expected.to have_many(:daily_usages) }
 
-  it { is_expected.to have_one(:applied_dunning_campaign).conditions("applied_to_organization = true") }
+  it { is_expected.to have_one(:applied_dunning_campaign).conditions(applied_to_organization: true) }
 
   it { is_expected.to validate_inclusion_of(:default_currency).in_array(described_class.currency_list) }
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:dunning_campaigns) }
   it { is_expected.to have_many(:daily_usages) }
 
+  it { is_expected.to have_one(:applied_dunning_campaign).conditions("applied_to_organization = true") }
+
   it { is_expected.to validate_inclusion_of(:default_currency).in_array(described_class.currency_list) }
 
   it 'sets the default value to true' do

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -418,6 +418,31 @@ RSpec.describe Customers::UpdateService, type: :service do
             expect(customers_service.call).to be_success
           end
         end
+
+        context "with applied_dunning_campaign_id nil" do
+          let(:customer) do
+            create(
+              :customer,
+              organization:,
+              applied_dunning_campaign: dunning_campaign,
+              exclude_from_dunning_campaign: false,
+              last_dunning_campaign_attempt: 3,
+              last_dunning_campaign_attempt_at: 2.days.ago
+            )
+          end
+
+          let(:update_args) { {applied_dunning_campaign_id: nil} }
+
+          it "updates auto dunning config", :aggregate_failures do
+            expect { customers_service.call }
+              .to change(customer, :applied_dunning_campaign_id).to(nil)
+              .and not_change(customer, :exclude_from_dunning_campaign)
+              .and change(customer, :last_dunning_campaign_attempt).to(0)
+              .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
+
+            expect(customers_service.call).to be_success
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic
👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We're first automating the overdue balance payment request, before looking at individual invoices.

 ## Description

Customer update service accepts `applied_dunning_campaign_id` as nil to unset its applied campaign and fallback to organization's default dunning campaign.