### PR TITLE
feat(daily_usage): Add clock to refresh all daily usage

### DIFF
--- a/app/jobs/clock/compute_all_daily_usages_job.rb
+++ b/app/jobs/clock/compute_all_daily_usages_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Clock
+  class ComputeAllDailyUsagesJob < ApplicationJob
+    include SentryCronConcern
+
+    queue_as 'clock'
+
+    def perform
+      DailyUsages::ComputeAllService.call
+    end
+  end
+end

--- a/app/jobs/daily_usages/compute_job.rb
+++ b/app/jobs/daily_usages/compute_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module DailyUsages
+  class ComputeJob < ApplicationJob
+
+    queue_as 'wallets'
+
+    def perform(subscription, timestamp:)
+      DailyUsages::ComputeService.call(subscription:, timestamp:).raise_if_error!
+    end
+  end
+end

--- a/app/jobs/daily_usages/compute_job.rb
+++ b/app/jobs/daily_usages/compute_job.rb
@@ -2,8 +2,7 @@
 
 module DailyUsages
   class ComputeJob < ApplicationJob
-
-    queue_as 'wallets'
+    queue_as 'low_priority'
 
     def perform(subscription, timestamp:)
       DailyUsages::ComputeService.call(subscription:, timestamp:).raise_if_error!

--- a/app/models/daily_usage.rb
+++ b/app/models/daily_usage.rb
@@ -4,6 +4,14 @@ class DailyUsage < ApplicationRecord
   belongs_to :organization
   belongs_to :customer
   belongs_to :subscription
+
+  scope :refreshed_at_in_timezone, ->(timestamp) do
+    at_time_zone = Utils::Timezone.at_time_zone_sql(customer: "cus", organization: "org")
+
+    joins("INNER JOIN customers AS cus ON daily_usages.customer_id = cus.id")
+      .joins("INNER JOIN organizations AS org ON daily_usages.organization_id = org.id")
+      .where("DATE((daily_usages.refreshed_at)#{at_time_zone}) = DATE(:timestamp#{at_time_zone})", timestamp:)
+  end
 end
 
 # == Schema Information

--- a/app/models/daily_usage.rb
+++ b/app/models/daily_usage.rb
@@ -12,6 +12,7 @@ end
 #
 #  id                       :uuid             not null, primary key
 #  from_datetime            :datetime         not null
+#  refreshed_at             :datetime         not null
 #  to_datetime              :datetime         not null
 #  usage                    :jsonb            not null
 #  created_at               :datetime         not null

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -6,8 +6,8 @@ class Organization < ApplicationRecord
   include Currencies
 
   EMAIL_SETTINGS = [
-    'invoice.finalized',
-    'credit_note.created'
+    "invoice.finalized",
+    "credit_note.created"
   ].freeze
 
   has_many :memberships
@@ -25,8 +25,8 @@ class Organization < ApplicationRecord
   has_many :add_ons
   has_many :daily_usages
   has_many :invites
-  has_many :integrations, class_name: 'Integrations::BaseIntegration'
-  has_many :payment_providers, class_name: 'PaymentProviders::BaseProvider'
+  has_many :integrations, class_name: "Integrations::BaseIntegration"
+  has_many :payment_providers, class_name: "PaymentProviders::BaseProvider"
   has_many :payment_requests
   has_many :taxes
   has_many :wallets, through: :customers
@@ -38,13 +38,13 @@ class Organization < ApplicationRecord
   has_many :error_details
   has_many :dunning_campaigns
 
-  has_many :stripe_payment_providers, class_name: 'PaymentProviders::StripeProvider'
-  has_many :gocardless_payment_providers, class_name: 'PaymentProviders::GocardlessProvider'
-  has_many :adyen_payment_providers, class_name: 'PaymentProviders::AdyenProvider'
+  has_many :stripe_payment_providers, class_name: "PaymentProviders::StripeProvider"
+  has_many :gocardless_payment_providers, class_name: "PaymentProviders::GocardlessProvider"
+  has_many :adyen_payment_providers, class_name: "PaymentProviders::AdyenProvider"
 
-  has_many :hubspot_integrations, class_name: 'Integrations::HubspotIntegration'
-  has_many :netsuite_integrations, class_name: 'Integrations::NetsuiteIntegration'
-  has_many :xero_integrations, class_name: 'Integrations::XeroIntegration'
+  has_many :hubspot_integrations, class_name: "Integrations::HubspotIntegration"
+  has_many :netsuite_integrations, class_name: "Integrations::NetsuiteIntegration"
+  has_many :xero_integrations, class_name: "Integrations::XeroIntegration"
 
   has_one_attached :logo
 
@@ -53,7 +53,7 @@ class Organization < ApplicationRecord
     :per_organization
   ].freeze
 
-  INTEGRATIONS = %w[netsuite okta anrok xero progressive_billing hubspot auto_dunning].freeze
+  INTEGRATIONS = %w[netsuite okta anrok xero progressive_billing hubspot auto_dunning revenue_analytics].freeze
   PREMIUM_INTEGRATIONS = INTEGRATIONS - %w[anrok]
 
   enum document_numbering: DOCUMENT_NUMBERINGS
@@ -87,7 +87,7 @@ class Organization < ApplicationRecord
   def logo_url
     return if logo.blank?
 
-    Rails.application.routes.url_helpers.rails_blob_url(logo, host: ENV['LAGO_API_URL'])
+    Rails.application.routes.url_helpers.rails_blob_url(logo, host: ENV["LAGO_API_URL"])
   end
 
   def base64_logo
@@ -105,11 +105,11 @@ class Organization < ApplicationRecord
 
   def payment_provider(provider)
     case provider
-    when 'stripe'
+    when "stripe"
       stripe_payment_provider
-    when 'gocardless'
+    when "gocardless"
       gocardless_payment_provider
-    when 'adyen'
+    when "adyen"
       adyen_payment_provider
     end
   end

--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -21,7 +21,7 @@ module DailyUsages
     attr_reader :timestamp
 
     def subscriptions
-      # NOTE(DailyUsage): Filter organizations having revenue_analytics premium integrations
+      # NOTE(DailyUsage): For now the query filters organizations having revenue_analytics premium integrations
       #                   This might change in the future
       Subscription
         .with(already_refreshed_today: already_refreshed_today)
@@ -34,17 +34,7 @@ module DailyUsages
     end
 
     def already_refreshed_today
-      where_clause = <<-SQL
-        DATE(
-          (daily_usages.refreshed_at)#{at_time_zone(customer: "cus", organization: "org")}
-        ) = DATE(:timestamp#{at_time_zone(customer: "cus", organization: "org")})
-      SQL
-
-      DailyUsage
-        .joins("INNER JOIN customers AS cus ON daily_usages.customer_id = cus.id")
-        .joins("INNER JOIN organizations AS org ON daily_usages.organization_id = org.id")
-        .select(:subscription_id)
-        .where(where_clause, timestamp:)
+      DailyUsage.refreshed_at_in_timezone(timestamp).select(:subscription_id)
     end
   end
 end

--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -23,7 +23,7 @@ module DailyUsages
     attr_reader :timestamp
 
     def subscriptions
-      # TODO: Filter subscriptions based on the feature availability at organization level
+      # TODO(DailyUsage): Filter subscriptions based on the feature availability at organization level - Not Decided Yet
       Subscription
         .with(already_refreshed_today: already_refreshed_today)
         .joins(customer: :organization)
@@ -36,7 +36,7 @@ module DailyUsages
     def already_refreshed_today
       where_clause = <<-SQL
         DATE(
-          (daily_usages.created_at)#{at_time_zone(customer: "cus", organization: "org")}
+          (daily_usages.refreshed_at)#{at_time_zone(customer: "cus", organization: "org")}
         ) = DATE(:timestamp#{at_time_zone(customer: "cus", organization: "org")})
       SQL
 

--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -9,13 +9,13 @@ module DailyUsages
     end
 
     def call
-      return result unless ENV['LAGO_ENABLE_REVENUE_ANALYTICS'].present?
+      return result if ENV['LAGO_ENABLE_REVENUE_ANALYTICS'].blank?
 
       subscriptions.find_each do |subscription|
         DailyUsages::ComputeJob.perform_later(subscription, timestamp:)
       end
 
-      return result
+      result
     end
 
     private

--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module DailyUsages
+  class ComputeAllService < BaseService
+    def initialize(timestamp: Time.current)
+      @timestamp = timestamp
+
+      super
+    end
+
+    def call
+      return result unless ENV['LAGO_ENABLE_REVENUE_ANALYTICS'].present?
+
+      subscriptions.find_each do |subscription|
+        DailyUsages::ComputeJob.perform_later(subscription, timestamp:)
+      end
+
+      return result
+    end
+
+    private
+
+    attr_reader :timestamp
+
+    def subscriptions
+      # TODO: Filter subscriptions based on the feature availability at organization level
+      Subscription
+        .with(already_refreshed_today: already_refreshed_today)
+        .joins(customer: :organization)
+        .joins('LEFT JOIN already_refreshed_today ON subscriptions.id = already_refreshed_today.subscription_id')
+        .active
+        .where('already_refreshed_today.subscription_id IS NULL') # Exclude subscriptions that already have a daily usage record for today in customer's timezone
+        .where("DATE_PART('hour', (:timestamp#{at_time_zone})) IN (0, 1, 2)", timestamp:) # Refresh the usage as soom as a subscription starts a new day in customer's timezone
+    end
+
+    def already_refreshed_today
+      where_clause = <<-SQL
+        DATE(
+          (daily_usages.created_at)#{at_time_zone(customer: "cus", organization: "org")}
+        ) = DATE(:timestamp#{at_time_zone(customer: "cus", organization: "org")})
+      SQL
+
+      DailyUsage
+        .joins('INNER JOIN customers AS cus ON daily_usages.customer_id = cus.id')
+        .joins('INNER JOIN organizations AS org ON daily_usages.organization_id = org.id')
+        .select(:subscription_id)
+        .where(where_clause, timestamp:)
+    end
+  end
+end

--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -9,8 +9,6 @@ module DailyUsages
     end
 
     def call
-      return result if ENV['LAGO_ENABLE_REVENUE_ANALYTICS'].blank?
-
       subscriptions.find_each do |subscription|
         DailyUsages::ComputeJob.perform_later(subscription, timestamp:)
       end
@@ -23,13 +21,15 @@ module DailyUsages
     attr_reader :timestamp
 
     def subscriptions
-      # TODO(DailyUsage): Filter subscriptions based on the feature availability at organization level - Not Decided Yet
+      # NOTE(DailyUsage): Filter organizations having revenue_analytics premium integrations
+      #                   This might change in the future
       Subscription
         .with(already_refreshed_today: already_refreshed_today)
         .joins(customer: :organization)
-        .joins('LEFT JOIN already_refreshed_today ON subscriptions.id = already_refreshed_today.subscription_id')
+        .merge(Organization.with_revenue_analytics_support)
+        .joins("LEFT JOIN already_refreshed_today ON subscriptions.id = already_refreshed_today.subscription_id")
         .active
-        .where('already_refreshed_today.subscription_id IS NULL') # Exclude subscriptions that already have a daily usage record for today in customer's timezone
+        .where("already_refreshed_today.subscription_id IS NULL") # Exclude subscriptions that already have a daily usage record for today in customer's timezone
         .where("DATE_PART('hour', (:timestamp#{at_time_zone})) IN (0, 1, 2)", timestamp:) # Refresh the usage as soom as a subscription starts a new day in customer's timezone
     end
 
@@ -41,8 +41,8 @@ module DailyUsages
       SQL
 
       DailyUsage
-        .joins('INNER JOIN customers AS cus ON daily_usages.customer_id = cus.id')
-        .joins('INNER JOIN organizations AS org ON daily_usages.organization_id = org.id')
+        .joins("INNER JOIN customers AS cus ON daily_usages.customer_id = cus.id")
+        .joins("INNER JOIN organizations AS org ON daily_usages.organization_id = org.id")
         .select(:subscription_id)
         .where(where_clause, timestamp:)
     end

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -19,9 +19,10 @@ module DailyUsages
         customer: subscription.customer,
         subscription:,
         external_subscription_id: subscription.external_id,
-        usage: ::V1::Customers::UsageSerializer.new(current_usage).serialize.to_json,
+        usage: ::V1::Customers::UsageSerializer.new(current_usage).serialize,
         from_datetime: current_usage.from_datetime,
-        to_datetime: current_usage.to_datetime # TODO: persist the timestamp
+        to_datetime: current_usage.to_datetime,
+        refreshed_at: timestamp
       )
 
       result.daily_usage = daily_usage
@@ -44,7 +45,7 @@ module DailyUsages
       @existing_daily_usage ||= DailyUsage
         .joins(customer: :organization)
         .where(subscription_id: subscription.id)
-        .where("DATE((daily_usages.created_at)#{at_time_zone}) = DATE(:timestamp#{at_time_zone})", timestamp:)
+        .where("DATE((daily_usages.refreshed_at)#{at_time_zone}) = DATE(:timestamp#{at_time_zone})", timestamp:)
         .first
     end
   end

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -44,11 +44,8 @@ module DailyUsages
     end
 
     def existing_daily_usage
-      @existing_daily_usage ||= DailyUsage
-        .joins(customer: :organization)
-        .where(subscription_id: subscription.id)
-        .where("DATE((daily_usages.refreshed_at)#{at_time_zone}) = DATE(:timestamp#{at_time_zone})", timestamp:)
-        .first
+      @existing_daily_usage ||= DailyUsage.refreshed_at_in_timezone(timestamp)
+        .find_by(subscription_id: subscription.id)
     end
   end
 end

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -27,6 +27,8 @@ module DailyUsages
 
       result.daily_usage = daily_usage
       result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
     end
 
     private

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -21,7 +21,7 @@ module DailyUsages
         external_subscription_id: subscription.external_id,
         usage: ::V1::Customers::UsageSerializer.new(current_usage).serialize.to_json,
         from_datetime: current_usage.from_datetime,
-        to_datetime: current_usage.to_datetime, # TODO: persist the timestamp
+        to_datetime: current_usage.to_datetime # TODO: persist the timestamp
       )
 
       result.daily_usage = daily_usage

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module DailyUsages
+  class ComputeService < BaseService
+    def initialize(subscription:, timestamp:)
+      @subscription = subscription
+      @timestamp = timestamp
+      super
+    end
+
+    def call
+      if existing_daily_usage.present?
+        result.daily_usage = existing_daily_usage
+        return result
+      end
+
+      daily_usage = DailyUsage.create!(
+        organization: subscription.organization,
+        customer: subscription.customer,
+        subscription:,
+        external_subscription_id: subscription.external_id,
+        usage: ::V1::Customers::UsageSerializer.new(current_usage).serialize.to_json,
+        from_datetime: current_usage.from_datetime,
+        to_datetime: current_usage.to_datetime, # TODO: persist the timestamp
+      )
+
+      result.daily_usage = daily_usage
+      result
+    end
+
+    private
+
+    attr_reader :subscription, :timestamp
+
+    def current_usage
+      @current_usage ||= Invoices::CustomerUsageService.call(
+        customer: subscription.customer,
+        subscription: subscription,
+        apply_taxes: false
+      ).raise_if_error!.usage
+    end
+
+    def existing_daily_usage
+      @existing_daily_usage ||= DailyUsage
+        .joins(customer: :organization)
+        .where(subscription_id: subscription.id)
+        .where("DATE((daily_usages.created_at)#{at_time_zone}) = DATE(:timestamp#{at_time_zone})", timestamp:)
+        .first
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -116,4 +116,10 @@ module Clockwork
       Sentry.capture_exception(e)
     end
   end
+
+  every(1.hour, 'schedule:compute_daily_usage', at: '*:15') do
+    Clock::ComputeAllDailyUsagesJob
+      .set(sentry: {"slug" => 'lago_compute_daily_usage', "cron" => '15 */1 * * *'})
+      .perform_later
+  end
 end

--- a/db/migrate/20241025081408_add_refreshed_at_to_daily_usage.rb
+++ b/db/migrate/20241025081408_add_refreshed_at_to_daily_usage.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddRefreshedAtToDailyUsage < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      add_column :daily_usages, :refreshed_at, :datetime, null: false
+    end
+  end
+end

--- a/db/migrate/20241025081408_add_refreshed_at_to_daily_usage.rb
+++ b/db/migrate/20241025081408_add_refreshed_at_to_daily_usage.rb
@@ -3,7 +3,7 @@
 class AddRefreshedAtToDailyUsage < ActiveRecord::Migration[7.1]
   def change
     safety_assured do
-      add_column :daily_usages, :refreshed_at, :datetime, null: false
+      add_column :daily_usages, :refreshed_at, :datetime, null: false # rubocop:disable Rails/NotNullColumn
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_24_082941) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_25_081408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -478,6 +478,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_24_082941) do
     t.jsonb "usage", default: "{}", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "refreshed_at", null: false
     t.index ["customer_id"], name: "index_daily_usages_on_customer_id"
     t.index ["organization_id", "external_subscription_id"], name: "idx_on_organization_id_external_subscription_id_df3a30d96d"
     t.index ["organization_id"], name: "index_daily_usages_on_organization_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -4245,6 +4245,7 @@ enum IntegrationTypeEnum {
   netsuite
   okta
   progressive_billing
+  revenue_analytics
   xero
 }
 
@@ -6049,6 +6050,7 @@ enum PremiumIntegrationTypeEnum {
   netsuite
   okta
   progressive_billing
+  revenue_analytics
   xero
 }
 

--- a/schema.json
+++ b/schema.json
@@ -20644,6 +20644,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "revenue_analytics",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -30481,6 +30487,12 @@
             },
             {
               "name": "auto_dunning",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "revenue_analytics",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/clockwork_spec.rb
+++ b/spec/clockwork_spec.rb
@@ -114,4 +114,25 @@ describe Clockwork do
       end
     end
   end
+
+  describe 'schedule:' do
+    let(:job) { 'schedule:compute_daily_usage' }
+    let(:start_time) { Time.zone.parse('1 Apr 2022 00:01:00') }
+    let(:end_time) { Time.zone.parse('1 Apr 2022 01:01:00') }
+
+    it 'enqueue a activate subscriptions job' do
+      Clockwork::Test.run(
+        file: clock_file,
+        start_time:,
+        end_time:,
+        tick_speed: 1.second
+      )
+
+      expect(Clockwork::Test).to be_ran_job(job)
+      expect(Clockwork::Test.times_run(job)).to eq(1)
+
+      Clockwork::Test.block_for(job).call
+      expect(Clock::ComputeAllDailyUsagesJob).to have_been_enqueued
+    end
+  end
 end

--- a/spec/clockwork_spec.rb
+++ b/spec/clockwork_spec.rb
@@ -115,7 +115,7 @@ describe Clockwork do
     end
   end
 
-  describe 'schedule:' do
+  describe 'schedule:compute_daily_usage' do
     let(:job) { 'schedule:compute_daily_usage' }
     let(:start_time) { Time.zone.parse('1 Apr 2022 00:01:00') }
     let(:end_time) { Time.zone.parse('1 Apr 2022 01:01:00') }

--- a/spec/factories/daily_usages.rb
+++ b/spec/factories/daily_usages.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     organization { customer.organization }
     subscription { create(:subscription, customer:) }
 
-    external_subscriptin_id { subscription.external_id }
+    external_subscription_id { subscription.external_id }
     from_datetime { Time.current.beginning_of_month }
     to_datetime { Time.current.end_of_month }
     usage { {} }

--- a/spec/factories/daily_usages.rb
+++ b/spec/factories/daily_usages.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     external_subscription_id { subscription.external_id }
     from_datetime { Time.current.beginning_of_month }
     to_datetime { Time.current.end_of_month }
+    refreshed_at { Time.current }
     usage { {} }
   end
 end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -17,5 +17,9 @@ FactoryBot.define do
       started_at { 1.month.ago }
       terminated_at { Time.zone.now }
     end
+
+    trait :calendar do
+      billing_time { :calendar }
+    end
   end
 end

--- a/spec/jobs/clock/compute_all_daily_usages_job_spec.rb
+++ b/spec/jobs/clock/compute_all_daily_usages_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Clock::ComputeAllDailyUsagesJob, type: :job do
+  subject(:compute_job) { described_class }
+
+  describe '.perform' do
+    before { allow(DailyUsages::ComputeAllService).to receive(:call) }
+
+    it 'removes all old webhooks' do
+      compute_job.perform_now
+
+      expect(DailyUsages::ComputeAllService).to have_received(:call)
+    end
+  end
+end

--- a/spec/jobs/daily_usages/compute_job_spec.rb
+++ b/spec/jobs/daily_usages/compute_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DailyUsages::ComputeJob, type: :job do
+  subject(:compute_job) { described_class }
+
+  let(:subscription) { create(:subscription) }
+  let(:timestamp) { Time.current }
+
+  let(:result) { BaseService::Result.new }
+
+  describe '.perform' do
+    it 'removes all old webhooks' do
+      allow(DailyUsages::ComputeService).to receive(:call)
+        .with(subscription:, timestamp:)
+        .and_return(result)
+
+      compute_job.perform_now(subscription, timestamp:)
+
+      expect(DailyUsages::ComputeService).to have_received(:call)
+        .with(subscription:, timestamp:).once
+    end
+  end
+end

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DailyUsages::ComputeAllService, type: :service do
+  subject(:compute_service) { described_class.new(timestamp:) }
+
+  let(:timestamp) { Time.zone.parse('2024-10-22 00:05:00') }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:) }
+
+  before { subscription }
+
+  describe '#call' do
+    context 'when LAGO_ENABLE_REVENUE_ANALYTICS is not present' do
+      it 'does not enqueue any job' do
+        expect(compute_service.call).to be_success
+        expect(DailyUsages::ComputeJob).not_to have_been_enqueued
+      end
+    end
+
+    context 'when LAGO_ENABLE_REVENUE_ANALYTICS is present' do
+      before do
+        allow(ENV).to receive(:[])
+        allow(ENV).to receive(:[]).with('LAGO_ENABLE_REVENUE_ANALYTICS').and_return('true')
+      end
+
+      it 'enqueues a job to compute the daily usage' do
+        expect(compute_service.call).to be_success
+        expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
+      end
+
+      context 'when subscription usage was already computed' do
+        let!(:daily_usage) { create(:daily_usage, subscription:, created_at: timestamp + 2.minutes) }
+
+        it 'does not enqueue any job' do
+          expect(compute_service.call).to be_success
+          expect(DailyUsages::ComputeJob).not_to have_been_enqueued
+        end
+      end
+
+      context 'when the organization has a timezone' do
+        let(:organization) { create(:organization, timezone: 'America/Sao_Paulo') }
+
+        it 'takes the timezone into account' do
+          expect(compute_service.call).to be_success
+          expect(DailyUsages::ComputeJob).not_to have_been_enqueued
+        end
+
+        context 'when the day starts in the timezone' do
+          let(:timestamp) { Time.zone.parse('2024-10-22 03:05:00') }
+
+          it 'enqueues a job to compute the daily usage' do
+            expect(compute_service.call).to be_success
+            expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
+          end
+        end
+      end
+
+      context 'when the customer has a timezone' do
+        let(:customer) { create(:customer, timezone: 'America/Sao_Paulo') }
+
+        it 'takes the timezone into account' do
+          expect(compute_service.call).to be_success
+          expect(DailyUsages::ComputeJob).not_to have_been_enqueued
+        end
+
+        context 'when the day starts in the timezone' do
+          let(:timestamp) { Time.zone.parse('2024-10-22 03:05:00') }
+
+          it 'enqueues a job to compute the daily usage' do
+            expect(compute_service.call).to be_success
+            expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DailyUsages::ComputeAllService, type: :service do
       end
 
       context 'when subscription usage was already computed' do
-        before { create(:daily_usage, subscription:, created_at: timestamp + 2.minutes) }
+        before { create(:daily_usage, subscription:, refreshed_at: timestamp + 2.minutes) }
 
         it 'does not enqueue any job' do
           expect(compute_service.call).to be_success

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DailyUsages::ComputeAllService, type: :service do
       end
 
       context 'when subscription usage was already computed' do
-        let!(:daily_usage) { create(:daily_usage, subscription:, created_at: timestamp + 2.minutes) }
+        before { create(:daily_usage, subscription:, created_at: timestamp + 2.minutes) }
 
         it 'does not enqueue any job' do
           expect(compute_service.call).to be_success

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -1,80 +1,79 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe DailyUsages::ComputeAllService, type: :service do
   subject(:compute_service) { described_class.new(timestamp:) }
 
-  let(:timestamp) { Time.zone.parse('2024-10-22 00:05:00') }
+  let(:timestamp) { Time.zone.parse("2024-10-22 00:05:00") }
 
-  let(:organization) { create(:organization) }
+  let(:organization) { create(:organization, premium_integrations:) }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
 
+  let(:premium_integrations) do
+    ["revenue_analytics"]
+  end
+
   before { subscription }
 
-  describe '#call' do
-    context 'when LAGO_ENABLE_REVENUE_ANALYTICS is not present' do
-      it 'does not enqueue any job' do
+  describe "#call" do
+    it "enqueues a job to compute the daily usage" do
+      expect(compute_service.call).to be_success
+      expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
+    end
+
+    context "when subscription usage was already computed" do
+      before { create(:daily_usage, subscription:, refreshed_at: timestamp + 2.minutes) }
+
+      it "does not enqueue any job" do
         expect(compute_service.call).to be_success
         expect(DailyUsages::ComputeJob).not_to have_been_enqueued
       end
     end
 
-    context 'when LAGO_ENABLE_REVENUE_ANALYTICS is present' do
-      before do
-        allow(ENV).to receive(:[])
-        allow(ENV).to receive(:[]).with('LAGO_ENABLE_REVENUE_ANALYTICS').and_return('true')
-      end
+    context "when the organization has a timezone" do
+      let(:organization) { create(:organization, timezone: "America/Sao_Paulo", premium_integrations:) }
 
-      it 'enqueues a job to compute the daily usage' do
+      it "takes the timezone into account" do
         expect(compute_service.call).to be_success
-        expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
+        expect(DailyUsages::ComputeJob).not_to have_been_enqueued
       end
 
-      context 'when subscription usage was already computed' do
-        before { create(:daily_usage, subscription:, refreshed_at: timestamp + 2.minutes) }
+      context "when the day starts in the timezone" do
+        let(:timestamp) { Time.zone.parse("2024-10-22 03:05:00") }
 
-        it 'does not enqueue any job' do
+        it "enqueues a job to compute the daily usage" do
           expect(compute_service.call).to be_success
-          expect(DailyUsages::ComputeJob).not_to have_been_enqueued
+          expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
         end
       end
+    end
 
-      context 'when the organization has a timezone' do
-        let(:organization) { create(:organization, timezone: 'America/Sao_Paulo') }
+    context "when the customer has a timezone" do
+      let(:customer) { create(:customer, organization:, timezone: "America/Sao_Paulo") }
 
-        it 'takes the timezone into account' do
-          expect(compute_service.call).to be_success
-          expect(DailyUsages::ComputeJob).not_to have_been_enqueued
-        end
-
-        context 'when the day starts in the timezone' do
-          let(:timestamp) { Time.zone.parse('2024-10-22 03:05:00') }
-
-          it 'enqueues a job to compute the daily usage' do
-            expect(compute_service.call).to be_success
-            expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
-          end
-        end
+      it "takes the timezone into account" do
+        expect(compute_service.call).to be_success
+        expect(DailyUsages::ComputeJob).not_to have_been_enqueued
       end
 
-      context 'when the customer has a timezone' do
-        let(:customer) { create(:customer, timezone: 'America/Sao_Paulo') }
+      context "when the day starts in the timezone" do
+        let(:timestamp) { Time.zone.parse("2024-10-22 03:05:00") }
 
-        it 'takes the timezone into account' do
+        it "enqueues a job to compute the daily usage" do
           expect(compute_service.call).to be_success
-          expect(DailyUsages::ComputeJob).not_to have_been_enqueued
+          expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
         end
+      end
+    end
 
-        context 'when the day starts in the timezone' do
-          let(:timestamp) { Time.zone.parse('2024-10-22 03:05:00') }
+    context "when revenue_analytics premium integration flag is not present" do
+      let(:premium_integrations) { [] }
 
-          it 'enqueues a job to compute the daily usage' do
-            expect(compute_service.call).to be_success
-            expect(DailyUsages::ComputeJob).to have_been_enqueued.with(subscription, timestamp:)
-          end
-        end
+      it "does not enqueue any job" do
+        expect(compute_service.call).to be_success
+        expect(DailyUsages::ComputeJob).not_to have_been_enqueued
       end
     end
   end

--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
         organization_id: organization.id,
         customer_id: customer.id,
         subscription_id: subscription.id,
-        external_subscription_id: subscription.external_id,
+        external_subscription_id: subscription.external_id
         # TODO
       )
     end

--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DailyUsages::ComputeService, type: :service do
+  subject(:compute_service) { described_class.new(subscription:, timestamp:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:) }
+
+  let(:timestamp) { Time.zone.parse('2024-10-22 00:05:00') }
+
+  describe '#call' do
+    it 'creates a daily usage', aggregate_failures: true do
+      expect { compute_service.call }.to change(DailyUsage, :count).by(1)
+
+      daily_usage = DailyUsage.order(created_at: :asc).last
+      expect(daily_usage).to have_attributes(
+        organization_id: organization.id,
+        customer_id: customer.id,
+        subscription_id: subscription.id,
+        external_subscription_id: subscription.external_id,
+        # TODO
+      )
+    end
+
+    context 'when a daily usage already exists' do
+      let(:existing_daily_usage) do
+        create(:daily_usage, subscription:, organization:, customer:, created_at: timestamp)
+      end
+
+      before { existing_daily_usage }
+
+      it 'returns the existing daily usage', aggregate_failure: true do
+        result = compute_service.call
+
+        expect(result).to be_success
+        expect(result.daily_usage).to eq(existing_daily_usage)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR is part of the Usage Revenue and unit. It follows https://github.com/getlago/lago-api/pull/2718

Today, Lago does not offer a way to retrieve customer usage with a granularity lower than the billing period (via invoices and fees). On the other end, it is possible to get the current usage for a customer/subscription, but this usage is just a “snapshot” of the usage a the current time. 

## Description

This PR adds the base logic to compute the daily usage for every active subscription.

For now the feature is enabled by checking the presence of the `LAGO_ENABLE_REVENUE_ANALYTICS` environment variable.