### PR TITLE
feat(hubspot): Modify models for syncing subscriptions

### DIFF
--- a/app/models/integration_resource.rb
+++ b/app/models/integration_resource.rb
@@ -4,7 +4,7 @@ class IntegrationResource < ApplicationRecord
   belongs_to :syncable, polymorphic: true
   belongs_to :integration, class_name: 'Integrations::BaseIntegration'
 
-  RESOURCE_TYPES = %i[invoice sales_order payment credit_note].freeze
+  RESOURCE_TYPES = %i[invoice sales_order payment credit_note subscription].freeze
 
   enum resource_type: RESOURCE_TYPES
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -12,6 +12,7 @@ class Subscription < ApplicationRecord
   has_many :events
   has_many :invoice_subscriptions
   has_many :invoices, through: :invoice_subscriptions
+  has_many :integration_resources, as: :syncable
   has_many :fees
   has_many :daily_usages
   has_one :lifetime_usage, autosave: true
@@ -164,6 +165,10 @@ class Subscription < ApplicationRecord
     number_od_days -= 1
 
     number_od_days.negative? ? 0 : number_od_days
+  end
+
+  def should_sync_crm_subscription?
+    customer.integration_customers.crm_kind.any? { |c| c.integration.sync_subscriptions }
   end
 
   def terminated_at?(timestamp)

--- a/spec/models/integration_resource_spec.rb
+++ b/spec/models/integration_resource_spec.rb
@@ -5,8 +5,12 @@ require 'rails_helper'
 RSpec.describe IntegrationResource, type: :model do
   subject(:integration_resource) { create(:integration_resource) }
 
+  let(:resource_types) do
+    %i[invoice sales_order payment credit_note subscription]
+  end
+
   it { is_expected.to belong_to(:syncable) }
   it { is_expected.to belong_to(:integration) }
 
-  it { is_expected.to define_enum_for(:resource_type).with_values(%i[invoice sales_order payment credit_note]) }
+  it { is_expected.to define_enum_for(:resource_type).with_values(resource_types) }
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Subscription, type: :model do
   it_behaves_like 'paper_trail traceable'
 
   it { is_expected.to have_many(:daily_usages) }
+  it { is_expected.to have_many(:integration_resources) }
   it { is_expected.to have_one(:lifetime_usage) }
 
   describe '#upgraded?' do
@@ -415,6 +416,43 @@ RSpec.describe Subscription, type: :model do
 
         it 'returns subscription name' do
           expect(subscription_invoice_name).to eq(subscription.name)
+        end
+      end
+    end
+  end
+
+  describe '#should_sync_crm_subscription?' do
+    subject(:method_call) { subscription.should_sync_crm_subscription? }
+
+    let(:subscription) { create(:subscription, customer:) }
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+
+    context 'without integration crm customer' do
+      it 'returns false' do
+        expect(method_call).to eq(false)
+      end
+    end
+
+    context 'with integration crm customer' do
+      let(:integration_customer) { create(:hubspot_customer, integration:, customer:) }
+      let(:integration) { create(:hubspot_integration, organization:, sync_subscriptions:) }
+
+      before { integration_customer }
+
+      context 'when sync subscriptions is true' do
+        let(:sync_subscriptions) { true }
+
+        it 'returns true' do
+          expect(method_call).to eq(true)
+        end
+      end
+
+      context 'when sync subscriptions is false' do
+        let(:sync_subscriptions) { false }
+
+        it 'returns false' do
+          expect(method_call).to eq(false)
         end
       end
     end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-hubspot

## Context

When creating or updating subscriptions in Lago, we must sync them to Hubspot.

## Description

This PR adds model attributes, methods for subscriptions to be syncable to Hubspot.
