### PR TITLE
feat(DataExport) Parallelize data export by splitting it into parts

### DIFF
--- a/app/jobs/data_exports/combine_parts_job.rb
+++ b/app/jobs/data_exports/combine_parts_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DataExports
+  class CombinePartsJob < ApplicationJob
+    queue_as :default
+
+    def perform(data_export)
+      CombinePartsService.call(data_export:).raise_if_error!
+    end
+  end
+end

--- a/app/jobs/data_exports/export_resources_job.rb
+++ b/app/jobs/data_exports/export_resources_job.rb
@@ -4,8 +4,10 @@ module DataExports
   class ExportResourcesJob < ApplicationJob
     queue_as :default
 
-    def perform(data_export)
-      ExportResourcesService.call(data_export:).raise_if_error!
+    DEFAULT_BATCH_SIZE = 100
+
+    def perform(data_export, batch_size: DEFAULT_BATCH_SIZE)
+      ExportResourcesService.call(data_export:, batch_size:).raise_if_error!
     end
   end
 end

--- a/app/jobs/data_exports/process_part_job.rb
+++ b/app/jobs/data_exports/process_part_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DataExports
+  class ProcessPartJob < ApplicationJob
+    queue_as :low_priority
+
+    def perform(data_export_part)
+      ProcessPartService.call(data_export_part:).raise_if_error!
+    end
+  end
+end

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -10,6 +10,8 @@ class DataExport < ApplicationRecord
 
   has_one_attached :file
 
+  has_many :data_export_parts
+
   validates :resource_type, presence: true
   validates :format, presence: true, inclusion: {in: EXPORT_FORMATS}
   validates :status, presence: true, inclusion: {in: STATUSES}

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -40,8 +40,6 @@ class DataExport < ApplicationRecord
   end
 
   def filename
-    return if file.blank?
-
     "#{created_at.strftime("%Y%m%d%H%M%S")}_#{resource_type}.#{format}"
   end
 
@@ -55,6 +53,13 @@ class DataExport < ApplicationRecord
     )
 
     File.join(ENV['LAGO_API_URL'], blob_path)
+  end
+
+  def export_class
+    case resource_type
+    when "invoices" then DataExports::Csv::Invoices
+    when "invoice_fees" then DataExports::Csv::InvoiceFees
+    end
   end
 end
 

--- a/app/models/data_export_part.rb
+++ b/app/models/data_export_part.rb
@@ -1,0 +1,24 @@
+class DataExportPart < ApplicationRecord
+end
+
+# == Schema Information
+#
+# Table name: data_export_parts
+#
+#  id             :uuid             not null, primary key
+#  completed      :boolean          default(FALSE), not null
+#  csv_lines      :text
+#  index          :integer
+#  object_ids     :uuid             not null, is an Array
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  data_export_id :uuid             not null
+#
+# Indexes
+#
+#  index_data_export_parts_on_data_export_id  (data_export_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (data_export_id => data_exports.id)
+#

--- a/app/models/data_export_part.rb
+++ b/app/models/data_export_part.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DataExportPart < ApplicationRecord
+  belongs_to :data_export
+
   scope :completed, -> { where(completed: true) }
 end
 

--- a/app/models/data_export_part.rb
+++ b/app/models/data_export_part.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 class DataExportPart < ApplicationRecord
+  scope :completed, -> { where(completed: true) }
 end
 
 # == Schema Information

--- a/app/services/data_exports/combine_parts_service.rb
+++ b/app/services/data_exports/combine_parts_service.rb
@@ -16,7 +16,12 @@ module DataExports
         tempfile.write("\n")
 
         # Note the order here, this is crucial to make sure the data is in the expected order
-        data_export.data_export_parts.order(:index).find_each { |part| tempfile.write(part.csv_lines) }
+        ids = data_export.data_export_parts.order(index: :asc).ids
+        # This is not the most optimal and will do N+1 queries, but the whole point is to not load the entire CSV in memory
+        # we're trading speed for reliability here.
+        ids.each do |id|
+          tempfile.write(data_export.data_export_parts.find(id).csv_lines)
+        end
 
         tempfile.rewind
 

--- a/app/services/data_exports/combine_parts_service.rb
+++ b/app/services/data_exports/combine_parts_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module DataExports
+  class CombinePartsService < BaseService
+    def initialize(data_export:)
+      @data_export = data_export
+
+      super
+    end
+
+    def call
+      result.data_export = data_export
+      data_export.transaction do
+        data_export.completed!
+
+        Tempfile.create([data_export.resource_type, ".#{data_export.format}"]) do |tempfile|
+          tempfile.write(data_export.export_class.headers.join(';'))
+
+          # Note the order here, this is crucial to make sure the data is in the expected order
+          data_export.data_export_parts.order(:index).find_each { |part| tempfile.write(part.csv_lines) }
+
+          tempfile.rewind
+
+          data_export.file.attach(
+            io: tempfile,
+            filename: data_export.filename,
+            key: "data_exports/#{data_export.id}.#{format}",
+            content_type: "text/csv"
+          )
+
+          data_export.completed!
+        end
+      end
+      DataExportMailer.with(data_export:).completed.deliver_later
+
+      result
+    end
+  end
+end

--- a/app/services/data_exports/create_part_service.rb
+++ b/app/services/data_exports/create_part_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module DataExports
+  class CreatePartService < BaseService
+    def initialize(data_export:, object_ids:, index:)
+      @data_export = data_export
+      @object_ids = object_ids
+      @index = index
+
+      super
+    end
+
+    def call
+      result.data_export_part = data_export.data_export_parts.create!(object_ids:, index:)
+      after_commit { DataExports::ProcessPartJob.perform_later(result.data_export_part) }
+      result
+    rescue => e
+      result.service_failure!(code: 'data_export_part_creation_failed', message: e.full_message)
+    end
+
+    private
+
+    attr_reader :data_export, :object_ids, :index
+  end
+end

--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -22,7 +22,7 @@ module DataExports
       end
 
       def call
-        ::CSV.open(output, 'wb', headers: false) do |csv|
+        result.csv_lines = ::CSV.generate(headers: false) do |csv|
           invoices.each do |invoice|
             serialized_invoice = serializer_klass.new(invoice).serialize
 
@@ -69,8 +69,7 @@ module DataExports
             end
           end
         end
-
-        output.rewind
+        result
       end
 
       def self.headers

--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -12,10 +12,9 @@ module DataExports
         data_export_part:,
         invoice_serializer_klass: V1::InvoiceSerializer,
         fee_serializer_klass: V1::FeeSerializer,
-        subscription_serializer_klass: V1::SubscriptionSerializer,
-        output: Tempfile.create
+        subscription_serializer_klass: V1::SubscriptionSerializer
       )
-        super(data_export_part:, serializer_klass: invoice_serializer_klass, output:)
+        super(data_export_part:, serializer_klass: invoice_serializer_klass)
 
         @fee_serializer_klass = fee_serializer_klass
         @subscription_serializer_klass = subscription_serializer_klass

--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -6,32 +6,25 @@ require 'forwardable'
 module DataExports
   module Csv
     class InvoiceFees < Invoices
-      DEFAULT_BATCH_SIZE = 50
-
       extend Forwardable
 
       def initialize(
-        data_export:,
+        data_export_part:,
         invoice_serializer_klass: V1::InvoiceSerializer,
         fee_serializer_klass: V1::FeeSerializer,
         subscription_serializer_klass: V1::SubscriptionSerializer,
         output: Tempfile.create
       )
+        super(data_export_part:, serializer_klass: invoice_serializer_klass, output:)
 
-        @data_export = data_export
-        @invoice_serializer_klass = invoice_serializer_klass
         @fee_serializer_klass = fee_serializer_klass
         @subscription_serializer_klass = subscription_serializer_klass
-        @output = output
-        @batch_size = DEFAULT_BATCH_SIZE
       end
 
       def call
-        ::CSV.open(output, 'wb', headers: true) do |csv|
-          csv << headers
-
-          invoices.find_each(batch_size:).lazy.each do |invoice|
-            serialized_invoice = invoice_serializer_klass.new(invoice).serialize
+        ::CSV.open(output, 'wb', headers: false) do |csv|
+          invoices.each do |invoice|
+            serialized_invoice = serializer_klass.new(invoice).serialize
 
             invoice
               .fees
@@ -44,7 +37,7 @@ module DataExports
                 :billable_metric,
                 {charge_filter: {values: :billable_metric_filter}}
               )
-              .find_each(batch_size:)
+              .find_each
               .lazy
               .each do |fee|
               serialized_fee = fee_serializer_klass.new(fee).serialize
@@ -80,11 +73,7 @@ module DataExports
         output.rewind
       end
 
-      private
-
-      attr_reader :invoice_serializer_klass, :fee_serializer_klass, :subscription_serializer_klass
-
-      def headers
+      def self.headers
         %w[
           invoice_lago_id
           invoice_number
@@ -108,6 +97,10 @@ module DataExports
           fee_total_amount_cents
         ]
       end
+
+      private
+
+      attr_reader :invoice_serializer_klass, :fee_serializer_klass, :subscription_serializer_klass
     end
   end
 end

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -8,20 +8,19 @@ module DataExports
     class Invoices < BaseService
       extend Forwardable
 
-      def initialize(data_export_part:, serializer_klass: V1::InvoiceSerializer, output: Tempfile.create)
+      def initialize(data_export_part:, serializer_klass: V1::InvoiceSerializer)
         @data_export_part = data_export_part
         @serializer_klass = serializer_klass
-        @output = output
+        super
       end
 
       def call
-        ::CSV.open(output, 'wb', headers: false) do |csv|
+        result.csv_lines = ::CSV.generate(headers: false) do |csv|
           invoices.each do |invoice|
             csv << serialized_invoice(invoice)
           end
         end
-
-        output.rewind
+        result
       end
 
       def self.headers

--- a/app/services/data_exports/process_part_service.rb
+++ b/app/services/data_exports/process_part_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module DataExports
+  class ProcessPartService
+    def initialize(data_export_part:)
+      super(nil)
+
+      @data_export_part = data_export_part
+      @data_export = data_export_part.data_export
+    end
+
+    def call
+      result.data_export_part = data_export_part
+
+      data_export_part.transaction do
+        # produce CSV lines into StringIO
+        output = StringIO.new
+        data_export.export_class.call(data_export_part:, output:).raise_if_error!
+
+        data_export_part.update!(csv_lines: output, completed: true)
+      end
+
+      # check if we are the last one to finish
+      if last_completed
+        DataExports::CombinePartsJob.perform_later(data_export_part.data_export)
+      end
+    end
+
+    private
+
+    attr_reader :data_export_part, :data_export
+
+    def last_completed
+      data_export.data_export_parts.completed.count == data_export.data_export_parts.count
+    end
+  end
+end

--- a/app/services/data_exports/process_part_service.rb
+++ b/app/services/data_exports/process_part_service.rb
@@ -3,10 +3,9 @@
 module DataExports
   class ProcessPartService < BaseService
     def initialize(data_export_part:)
-      super(nil)
-
       @data_export_part = data_export_part
       @data_export = data_export_part.data_export
+      super(nil)
     end
 
     def call

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -11,6 +11,7 @@ queues:
   - invoices
   - wallets
   - integrations
+  - low_priority
 
 production:
   concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 10) %>

--- a/db/migrate/20241024082941_create_data_export_parts.rb
+++ b/db/migrate/20241024082941_create_data_export_parts.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateDataExportParts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :data_export_parts, id: :uuid do |t|
+      t.integer :index
+      t.references :data_export, type: :uuid, foreign_key: true, null: false, index: true
+      t.uuid :object_ids, null: false, array: true
+      t.boolean :completed, null: false, default: false
+      t.text :csv_lines
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_21_095706) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_24_082941) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -482,6 +482,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_21_095706) do
     t.index ["organization_id", "external_subscription_id"], name: "idx_on_organization_id_external_subscription_id_df3a30d96d"
     t.index ["organization_id"], name: "index_daily_usages_on_organization_id"
     t.index ["subscription_id"], name: "index_daily_usages_on_subscription_id"
+  end
+
+  create_table "data_export_parts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "index"
+    t.uuid "data_export_id", null: false
+    t.uuid "object_ids", null: false, array: true
+    t.boolean "completed", default: false, null: false
+    t.text "csv_lines"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["data_export_id"], name: "index_data_export_parts_on_data_export_id"
   end
 
   create_table "data_exports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1293,6 +1304,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_21_095706) do
   add_foreign_key "daily_usages", "customers"
   add_foreign_key "daily_usages", "organizations"
   add_foreign_key "daily_usages", "subscriptions"
+  add_foreign_key "data_export_parts", "data_exports"
   add_foreign_key "data_exports", "memberships"
   add_foreign_key "data_exports", "organizations"
   add_foreign_key "dunning_campaign_thresholds", "dunning_campaigns"

--- a/spec/factories/data_export_parts.rb
+++ b/spec/factories/data_export_parts.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :data_export_part do
+    data_export
+
+    index { 0 }
+    object_ids { [] }
+  end
+end

--- a/spec/jobs/data_exports/combine_parts_job_spec.rb
+++ b/spec/jobs/data_exports/combine_parts_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataExports::CombinePartsJob, type: :job do
+  let(:data_export) { create(:data_export) }
+  let(:result) { BaseService::Result.new }
+
+  before do
+    allow(DataExports::CombinePartsService)
+      .to receive(:call)
+      .with(data_export:)
+      .and_return(result)
+  end
+
+  it "calls ProcessPart service" do
+    described_class.perform_now(data_export)
+
+    expect(DataExports::CombinePartsService)
+      .to have_received(:call)
+      .with(data_export:)
+  end
+end

--- a/spec/jobs/data_exports/export_resources_job_spec.rb
+++ b/spec/jobs/data_exports/export_resources_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DataExports::ExportResourcesJob, type: :job do
   before do
     allow(DataExports::ExportResourcesService)
       .to receive(:call)
-      .with(data_export:)
+      .with(data_export:, batch_size: 100)
       .and_return(result)
   end
 
@@ -18,6 +18,6 @@ RSpec.describe DataExports::ExportResourcesJob, type: :job do
 
     expect(DataExports::ExportResourcesService)
       .to have_received(:call)
-      .with(data_export:)
+      .with(data_export:, batch_size: 100)
   end
 end

--- a/spec/jobs/data_exports/process_part_job_spec.rb
+++ b/spec/jobs/data_exports/process_part_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataExports::ProcessPartJob, type: :job do
+  let(:data_export_part) { create(:data_export_part) }
+  let(:result) { BaseService::Result.new }
+
+  before do
+    allow(DataExports::ProcessPartService)
+      .to receive(:call)
+      .with(data_export_part:)
+      .and_return(result)
+  end
+
+  it "calls ProcessPart service" do
+    described_class.perform_now(data_export_part)
+
+    expect(DataExports::ProcessPartService)
+      .to have_received(:call)
+      .with(data_export_part:)
+  end
+end

--- a/spec/models/data_export_part_spec.rb
+++ b/spec/models/data_export_part_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataExportPart, type: :model do
+  it { is_expected.to belong_to(:data_export) }
+end

--- a/spec/models/data_export_spec.rb
+++ b/spec/models/data_export_spec.rb
@@ -60,6 +60,34 @@ RSpec.describe DataExport, type: :model do
     end
   end
 
+  describe "#export_class" do
+    let(:data_export) { create :data_export, resource_type: }
+
+    context "when resource_type is invoices" do
+      let(:resource_type) { "invoices" }
+
+      it "returns DataExports::Csv::Invoices" do
+        expect(data_export.export_class).to eq(DataExports::Csv::Invoices)
+      end
+    end
+
+    context "when resource_type is invoice_fees" do
+      let(:resource_type) { "invoice_fees" }
+
+      it "returns DataExports::Csv::InvoiceFees" do
+        expect(data_export.export_class).to eq(DataExports::Csv::InvoiceFees)
+      end
+    end
+
+    context "when resource_type is an unsupported value" do
+      let(:resource_type) { "unsupported" }
+
+      it "returns nil" do
+        expect(data_export.export_class).to eq(nil)
+      end
+    end
+  end
+
   describe '.filename' do
     subject(:filename) { data_export.filename }
 
@@ -75,7 +103,12 @@ RSpec.describe DataExport, type: :model do
     context 'when data export does not have a file' do
       let(:data_export) { create :data_export }
 
-      it { is_expected.to be_nil }
+      it 'returns the file name' do
+        freeze_time do
+          timestamp = Time.zone.now.strftime('%Y%m%d%H%M%S')
+          expect(filename).to eq("#{timestamp}_invoices.csv")
+        end
+      end
     end
   end
 

--- a/spec/models/data_export_spec.rb
+++ b/spec/models/data_export_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe DataExport, type: :model do
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:membership) }
+  it { is_expected.to have_many(:data_export_parts) }
 
   it { is_expected.to validate_presence_of(:format) }
   it { is_expected.to validate_presence_of(:resource_type) }

--- a/spec/services/data_exports/combine_parts_service_spec.rb
+++ b/spec/services/data_exports/combine_parts_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DataExports::CombinePartsService, type: :service do
   subject(:result) { described_class.call(data_export:) }
 
   let(:data_export) { create :data_export, :processing, resource_type: 'invoice_fees' }
-  let(:data_export_part) { create :data_export_part, data_export:, csv_lines: }
+  let(:data_export_part) { create :data_export_part, data_export:, csv_lines:, index: 1 }
   let(:csv_lines) do
     <<~CSV
       292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
@@ -26,7 +26,23 @@ RSpec.describe DataExports::CombinePartsService, type: :service do
         CSV
 
         expect(result).to be_success
-        expect(data_export.file.download).to eq(expected_csv)
+
+        # deal with encoding (using download would use 8-bit ASCII)
+        content = nil
+        data_export.file.open do |file|
+          content = File.read file
+        end
+        expect(content).to eq(expected_csv)
+      end
+
+      it "marks the export as complete" do
+        expect(result.data_export).to be_completed
+      end
+
+      it "sends an email" do
+        expect { result }
+          .to have_enqueued_mail(DataExportMailer, :completed)
+          .with(params: {data_export:}, args: [])
       end
     end
 
@@ -40,7 +56,7 @@ RSpec.describe DataExports::CombinePartsService, type: :service do
 
       before { data_export_part2 }
 
-      it "combines the parts into 1 file on the data export" do
+      it "combines the parts into 1 file in the right order" do
         expected_csv = <<~CSV
           invoice_lago_id,invoice_number,invoice_issuing_date,fee_lago_id,fee_item_type,fee_item_code,fee_item_name,fee_item_description,fee_item_invoice_display_name,fee_item_filter_invoice_display_name,fee_item_grouped_by,subscription_external_id,subscription_plan_code,fee_from_date_utc,fee_to_date_utc,fee_amount_currency,fee_units,fee_precise_unit_amount,fee_taxes_amount_cents,fee_total_amount_cents
           292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
@@ -48,7 +64,12 @@ RSpec.describe DataExports::CombinePartsService, type: :service do
         CSV
 
         expect(result).to be_success
-        expect(data_export.file.download).to eq(expected_csv)
+
+        content = nil
+        data_export.file.open do |file|
+          content = File.read file
+        end
+        expect(content).to eq(expected_csv)
       end
     end
   end

--- a/spec/services/data_exports/combine_parts_service_spec.rb
+++ b/spec/services/data_exports/combine_parts_service_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataExports::CombinePartsService, type: :service do
+  subject(:result) { described_class.call(data_export:) }
+
+  let(:data_export) { create :data_export, :processing, resource_type: 'invoice_fees' }
+  let(:data_export_part) { create :data_export_part, data_export:, csv_lines: }
+  let(:csv_lines) do
+    <<~CSV
+      292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
+    CSV
+  end
+
+  before do
+    data_export_part
+  end
+
+  describe "#call" do
+    context "when there is only 1 part" do
+      it "adds the correct headers" do
+        expected_csv = <<~CSV
+          invoice_lago_id,invoice_number,invoice_issuing_date,fee_lago_id,fee_item_type,fee_item_code,fee_item_name,fee_item_description,fee_item_invoice_display_name,fee_item_filter_invoice_display_name,fee_item_grouped_by,subscription_external_id,subscription_plan_code,fee_from_date_utc,fee_to_date_utc,fee_amount_currency,fee_units,fee_precise_unit_amount,fee_taxes_amount_cents,fee_total_amount_cents
+          292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
+        CSV
+
+        expect(result).to be_success
+        expect(data_export.file.download).to eq(expected_csv)
+      end
+    end
+
+    context "when there are multiple parts" do
+      let(:data_export_part2) { create :data_export_part, data_export:, csv_lines: csv_lines2, index: 2 }
+      let(:csv_lines2) do
+        <<~CSV
+          392ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
+        CSV
+      end
+
+      before { data_export_part2 }
+
+      it "combines the parts into 1 file on the data export" do
+        expected_csv = <<~CSV
+          invoice_lago_id,invoice_number,invoice_issuing_date,fee_lago_id,fee_item_type,fee_item_code,fee_item_name,fee_item_description,fee_item_invoice_display_name,fee_item_filter_invoice_display_name,fee_item_grouped_by,subscription_external_id,subscription_plan_code,fee_from_date_utc,fee_to_date_utc,fee_amount_currency,fee_units,fee_precise_unit_amount,fee_taxes_amount_cents,fee_total_amount_cents
+          292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
+          392ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
+        CSV
+
+        expect(result).to be_success
+        expect(data_export.file.download).to eq(expected_csv)
+      end
+    end
+  end
+end

--- a/spec/services/data_exports/create_part_service_spec.rb
+++ b/spec/services/data_exports/create_part_service_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataExports::CreatePartService, type: :service do
+  subject(:result) { described_class.call(data_export:, object_ids:, index:) }
+
+  let(:data_export) { create :data_export, resource_type: 'invoices', format: 'csv' }
+
+  let(:index) { 1 }
+  let(:object_ids) { [uuid] }
+  let(:uuid) { SecureRandom.uuid }
+
+  it "creates 1 part" do
+    expect { result }.to change(DataExportPart, :count).by(1)
+    expect(result).to be_success
+    expect(result.data_export_part.index).to eq(index)
+    expect(result.data_export_part.object_ids).to eq(object_ids)
+    expect(data_export.reload.data_export_parts.sole).to eq(result.data_export_part)
+  end
+
+  it "enqueues a job for this part" do
+    expect { result }.to have_enqueued_job(DataExports::ProcessPartJob).on_queue('low_priority')
+  end
+end

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe DataExports::Csv::InvoiceFees do
     create :data_export, :processing, resource_type: 'invoice_fees', resource_query:
   end
 
+  let(:data_export_part) do
+    data_export.data_export_parts.create(index: 1, object_ids: [invoice.id])
+  end
+
   let(:resource_query) do
     {
       currency:,
@@ -144,7 +148,7 @@ RSpec.describe DataExports::Csv::InvoiceFees do
   describe '#call' do
     subject(:call) do
       described_class.new(
-        data_export:,
+        data_export_part:,
         invoice_serializer_klass:,
         fee_serializer_klass:,
         subscription_serializer_klass:,
@@ -154,7 +158,6 @@ RSpec.describe DataExports::Csv::InvoiceFees do
 
     it 'generates the correct CSV output' do
       expected_csv = <<~CSV
-        invoice_lago_id,invoice_number,invoice_issuing_date,fee_lago_id,fee_item_type,fee_item_code,fee_item_name,fee_item_description,fee_item_invoice_display_name,fee_item_filter_invoice_display_name,fee_item_grouped_by,subscription_external_id,subscription_plan_code,fee_from_date_utc,fee_to_date_utc,fee_amount_currency,fee_units,fee_precise_unit_amount,fee_taxes_amount_cents,fee_total_amount_cents
         292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
       CSV
 

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -39,22 +39,6 @@ RSpec.describe DataExports::Csv::InvoiceFees do
   let(:search_term) { 'service ABC' }
   let(:status) { 'finalized' }
 
-  let(:filters) do
-    {
-      "currency" => currency,
-      "customer_external_id" => customer_external_id,
-      "customer_id" => customer_id,
-      "invoice_type" => invoice_type,
-      "issuing_date_from" => issuing_date_from,
-      "issuing_date_to" => issuing_date_to,
-      "payment_dispute_lost" => payment_dispute_lost,
-      "payment_overdue" => payment_overdue,
-      "payment_status" => payment_status,
-      "status" => status
-    }
-  end
-
-  let(:tempfile) { Tempfile.create("test_export") }
   let(:invoice_serializer_klass) { class_double('V1::InvoiceSerializer') }
   let(:fee_serializer_klass) { class_double('V1::FeeSerializer') }
   let(:subscription_serializer_klass) { class_double('V1::SubscriptionSerializer') }
@@ -69,12 +53,6 @@ RSpec.describe DataExports::Csv::InvoiceFees do
 
   let(:subscription_serializer) do
     instance_double('V1::SubscriptionSerializer', serialize: serialized_subscription)
-  end
-
-  let(:invoices_query_results) do
-    BaseService::Result.new.tap do |result|
-      result.invoices = Invoice.all
-    end
   end
 
   let(:invoice) { create :invoice }
@@ -133,26 +111,15 @@ RSpec.describe DataExports::Csv::InvoiceFees do
     allow(subscription_serializer_klass)
       .to receive(:new)
       .and_return(subscription_serializer)
-
-    allow(InvoicesQuery)
-      .to receive(:call)
-      .with(
-        organization: data_export.organization,
-        pagination: nil,
-        search_term:,
-        filters:
-      )
-      .and_return(invoices_query_results)
   end
 
   describe '#call' do
-    subject(:call) do
+    subject(:result) do
       described_class.new(
         data_export_part:,
         invoice_serializer_klass:,
         fee_serializer_klass:,
-        subscription_serializer_klass:,
-        output: tempfile
+        subscription_serializer_klass:
       ).call
     end
 
@@ -161,9 +128,9 @@ RSpec.describe DataExports::Csv::InvoiceFees do
         292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
       CSV
 
-      call
-      tempfile.rewind
-      generated_csv = tempfile.read
+      expect(result).to be_success
+
+      generated_csv = result.csv_lines
 
       expect(generated_csv).to eq(expected_csv)
     end

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe DataExports::Csv::Invoices do
   let(:data_export) { create :data_export, :processing, resource_query: }
 
+  let(:data_export_part) { data_export.data_export_parts.create(object_ids: [invoice.id], index: 1) }
+
   let(:resource_query) do
     {
       currency:,
@@ -111,12 +113,11 @@ RSpec.describe DataExports::Csv::Invoices do
 
   describe '#call' do
     subject(:call) do
-      described_class.new(data_export:, serializer_klass:, output: tempfile).call
+      described_class.new(data_export_part:, serializer_klass:, output: tempfile).call
     end
 
     it 'generates the correct CSV output' do
       expected_csv = <<~CSV
-        lago_id,sequential_id,issuing_date,customer_lago_id,customer_external_id,customer_name,customer_country,customer_tax_identification_number,invoice_number,invoice_type,payment_status,status,file_url,currency,fees_amount_cents,coupons_amount_cents,taxes_amount_cents,credit_notes_amount_cents,prepaid_credit_amount_cents,total_amount_cents,payment_due_date,payment_dispute_lost_at,payment_overdue
         invoice-lago-id-123,SEQ123,2023-01-01,customer-lago-id-456,CUST123,customer name,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false
       CSV
 

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -35,31 +35,9 @@ RSpec.describe DataExports::Csv::Invoices do
   let(:search_term) { 'service ABC' }
   let(:status) { 'finalized' }
 
-  let(:filters) do
-    {
-      "currency" => currency,
-      "customer_external_id" => customer_external_id,
-      "customer_id" => customer_id,
-      "invoice_type" => invoice_type,
-      "issuing_date_from" => issuing_date_from,
-      "issuing_date_to" => issuing_date_to,
-      "payment_dispute_lost" => payment_dispute_lost,
-      "payment_overdue" => payment_overdue,
-      "payment_status" => payment_status,
-      "status" => status
-    }
-  end
-
-  let(:tempfile) { Tempfile.create("test_export") }
   let(:serializer_klass) { class_double('V1::InvoiceSerializer') }
   let(:invoice_serializer) do
     instance_double('V1::InvoiceSerializer', serialize: serialized_invoice)
-  end
-
-  let(:invoices_query_results) do
-    BaseService::Result.new.tap do |result|
-      result.invoices = Invoice.all
-    end
   end
 
   let(:invoice) { create :invoice }
@@ -99,21 +77,11 @@ RSpec.describe DataExports::Csv::Invoices do
     allow(serializer_klass)
       .to receive(:new)
       .and_return(invoice_serializer)
-
-    allow(InvoicesQuery)
-      .to receive(:call)
-      .with(
-        organization: data_export.organization,
-        pagination: nil,
-        search_term:,
-        filters:
-      )
-      .and_return(invoices_query_results)
   end
 
   describe '#call' do
-    subject(:call) do
-      described_class.new(data_export_part:, serializer_klass:, output: tempfile).call
+    subject(:result) do
+      described_class.new(data_export_part:, serializer_klass:).call
     end
 
     it 'generates the correct CSV output' do
@@ -121,9 +89,8 @@ RSpec.describe DataExports::Csv::Invoices do
         invoice-lago-id-123,SEQ123,2023-01-01,customer-lago-id-456,CUST123,customer name,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false
       CSV
 
-      call
-      tempfile.rewind
-      generated_csv = tempfile.read
+      expect(result).to be_success
+      generated_csv = result.csv_lines
 
       expect(generated_csv).to eq(expected_csv)
     end

--- a/spec/services/data_exports/process_part_service_spec.rb
+++ b/spec/services/data_exports/process_part_service_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataExports::ProcessPartService, type: :service do
+  subject(:result) { described_class.call(data_export_part:) }
+
+  let(:data_export) { create :data_export, resource_type: 'invoices', format: 'csv' }
+  let(:data_export_part) { create :data_export_part, data_export:, object_ids: [invoice.id] }
+  let(:invoice) { create :invoice }
+  let(:serialized_invoice) do
+    {
+      lago_id: 'invoice-lago-id-123',
+      sequential_id: 'SEQ123',
+      issuing_date: '2023-01-01',
+      customer: {
+        name: 'customer name',
+        lago_id: 'customer-lago-id-456',
+        external_id: 'CUST123',
+        country: 'US',
+        tax_identification_number: '123456789'
+      },
+      number: 'INV123',
+      invoice_type: 'credit',
+      payment_status: 'pending',
+      status: 'finalized',
+      file_url: 'http://api.lago.com/invoice.pdf',
+      currency: 'USD',
+      fees_amount_cents: 70000,
+      coupons_amount_cents: 1655,
+      taxes_amount_cents: 10500,
+      credit_notes_amount_cents: 334,
+      prepaid_credit_amount_cents: 1000,
+      total_amount_cents: 77511,
+      payment_due_date: '2023-02-01',
+      payment_dispute_lost_at: '2023-12-22',
+      payment_overdue: false
+    }
+  end
+  let(:invoice_serializer) do
+    instance_double('V1::InvoiceSerializer', serialize: serialized_invoice)
+  end
+
+  before do
+    allow(V1::InvoiceSerializer)
+      .to receive(:new)
+      .and_return(invoice_serializer)
+  end
+
+  describe "#call" do
+    it "processes the part" do
+      expected_csv = <<~CSV
+        invoice-lago-id-123,SEQ123,2023-01-01,customer-lago-id-456,CUST123,customer name,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false
+      CSV
+      expect(result).to be_success
+      expect(result.data_export_part.csv_lines).to eq(expected_csv)
+    end
+
+    it "enqueues a job when the last part is completed" do
+      expect { result }.to have_enqueued_job(DataExports::CombinePartsJob).with(data_export_part.data_export)
+    end
+  end
+end

--- a/spec/services/data_exports/process_part_service_spec.rb
+++ b/spec/services/data_exports/process_part_service_spec.rb
@@ -60,4 +60,14 @@ RSpec.describe DataExports::ProcessPartService, type: :service do
       expect { result }.to have_enqueued_job(DataExports::CombinePartsJob).with(data_export_part.data_export)
     end
   end
+
+  context 'when other parts have not been complete' do
+    let(:other_part) { create :data_export_part, data_export:, object_ids: [invoice.id], index: 2 }
+
+    before { other_part }
+
+    it "does not enqueue a job" do
+      expect { result }.not_to have_enqueued_job(DataExports::CombinePartsJob).with(data_export_part.data_export)
+    end
+  end
 end


### PR DESCRIPTION
## Context

When exporting lots of invoices, we're bumping into the limits of how fast we can export data.

## Description

This PR introduces the concept of `DataExportPart`. It's a way for data exports to be split into many parts. These parts can then be handled by a single Sidekiq job. This allows a trivial way to split up the data export. 

once the parts are done, they will be combined into the final export.