### PR TITLE
add migration to set parent_ids to charges

### DIFF
--- a/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
+++ b/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+#
+class AddParentToChargesFromPlanParent < ActiveRecord::Migration[7.1]
+  def change
+    now = Time.current
+    Plan.where.not(parent_id: nil).includes(:charges, parent: :charges).find_each do |plan|
+      parent = plan.parent
+      next if plan.charges.empty? || parent.charges.empty?
+
+      plan.charges.each do |child_charge|
+        parent_charges = parent.charges.where(charge_model: child_charge.charge_model, properties: child_charge.properties)
+        next if parent_charges.length != 1
+
+        child_charge.update(parent_id: parent_charges[0].id)
+      end
+    end
+    puts '=' * 80
+    puts 'Migration took: ' + (Time.current - now).to_s
+  end
+end

--- a/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
+++ b/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
@@ -26,37 +26,53 @@ class AddParentToChargesFromPlanParent < ActiveRecord::Migration[7.1]
 
   def parents_less_than_children_migration
     now = Time.current
-    # another way to solve it - load parents, for charges find full matches in children plans and update parent_id
-    # then if there are no matching charges in parent plan (with different properties) - select charges for children with
-    # similar attributes, ignoring properties
     Plan.includes(:charges, children: :charges).where(parent_id: nil).find_each(batch_size: 250) do |parent_plan|
       next if parent_plan.children.empty?
       next if parent_plan.charges.empty?
 
       parent_plan.charges.each do |parent_charge|
-        next if charge_has_copy?(parent_charge, parent_plan, :full)
-
-        # process full match children
-        full_match_ids = parent_plan.children.map(&:charges).flatten.select do |child_charge|
-          child_charge.parent_id.nil? &&
-            child_charge.charge_model == parent_charge.charge_model &&
-            child_charge.billable_metric_id == parent_charge.billable_metric_id &&
-            child_charge.properties == parent_charge.properties
-        end.map(&:id)
-        Charge.where(id: full_match_ids).update_all(parent_id: parent_charge.id)
-
-        # process matching without properties
-        next if charge_has_copy?(parent_charge, parent_plan, :without_properties)
-
-        partial_match_id = parent_plan.children.map(&:charges).flatten.select do |child_charge|
-          child_charge.parent_id.nil? &&
-            child_charge.charge_model == parent_charge.charge_model &&
-            child_charge.billable_metric_id == parent_charge.billable_metric_id
-        end.map(&:id)
-        Charge.where(id: partial_match_id).update_all(parent_id: parent_charge.id)
+        assign_children_for_parent_charge(parent_charge, children_plans)
       end
     end
     puts 'Migration took: ' + (Time.current - now).to_s + ' seconds'
+  end
+
+  def children_less_than_parents_migration
+    now = Time.current
+    Plan.where.not(parent_id: nil).order(:parent_id).includes(:charges, parent: :charges).in_batches(of: 2000).each do |plans_group|
+      plans_group.group_by(&:parent).each do |parent_plan, children_plans|
+        parent_plan.charges.each do |parent_charge|
+          assign_children_for_parent_charge(parent_charge, children_plans)
+        end
+      end
+    end
+    puts 'Migration took: ' + (Time.current - now).to_s + ' seconds'
+  end
+
+  # find full matches in children plans and update parent_id (use update_all to not have separate requests)
+  # then if there are no similar charges in parent plan (having different properties) - select charges for children with
+  # similar attributes, ignoring the properties
+  def assign_children_for_parent_charge(parent_charge, children_plans)
+    return if charge_has_copy?(parent_charge, parent_plan, :full)
+
+    # process full match children
+    full_match_ids = children_plans.map(&:charges).flatten.select do |child_charge|
+      child_charge.parent_id.nil? &&
+        child_charge.charge_model == parent_charge.charge_model &&
+        child_charge.billable_metric_id == parent_charge.billable_metric_id &&
+        child_charge.properties == parent_charge.properties
+    end.map(&:id)
+    Charge.where(id: full_match_ids).update_all(parent_id: parent_charge.id)
+
+    # process matching without properties
+    return if charge_has_copy?(parent_charge, parent_plan, :without_properties)
+
+    partial_match_id = children_plans.map(&:charges).flatten.select do |child_charge|
+      child_charge.parent_id.nil? &&
+        child_charge.charge_model == parent_charge.charge_model &&
+        child_charge.billable_metric_id == parent_charge.billable_metric_id
+    end.map(&:id)
+    Charge.where(id: partial_match_id).update_all(parent_id: parent_charge.id)
   end
 
   def charge_has_copy?(parent_charge, parent_plan, mode)
@@ -72,37 +88,5 @@ class AddParentToChargesFromPlanParent < ActiveRecord::Migration[7.1]
           charge.billable_metric_id == parent_charge.billable_metric_id
       end.length > 1
     end
-  end
-
-  def children_less_than_parents_migration
-    now = Time.current
-    Plan.where.not(parent_id: nil).includes(:charges, parent: :charges).find_each do |plan|
-      parent = plan.parent
-      next if plan.charges.empty? || parent.charges.empty?
-
-      plan.charges.each do |child_charge|
-        next if child_charge.parent_id.present?
-
-        matches_without_properties = parent.charges.select do |charge|
-          charge.charge_model == child_charge.charge_model &&
-            charge.billable_metric_id == child_charge.billable_metric_id
-        end
-        full_matches = parent.charges.select do |charge|
-          charge.charge_model == child_charge.charge_model &&
-            charge.billable_metric_id == child_charge.billable_metric_id &&
-            charge.properties == child_charge.properties
-        end
-        if full_matches.length == 1
-          child_charge.update_columns(parent_id: full_matches[0].id) # rubocop:disable Rails/SkipsModelValidations
-        elsif matches_without_properties.length == 1
-          child_charge.update_columns(parent_id: matches_without_properties[0].id) # rubocop:disable Rails/SkipsModelValidations
-        end
-      end
-    end
-    Rails.logger.info('=' * 80)
-    Rails.logger.info('Migration took: ' + (Time.current - now).to_s + ' seconds')
-  end
-
-  def down
   end
 end

--- a/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
+++ b/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
@@ -12,6 +12,69 @@ class AddParentToChargesFromPlanParent < ActiveRecord::Migration[7.1]
   end
 
   def up
+    parents_count = Plan.where(parent_id: nil).count
+    children_count = Plan.where.not(parent_id: nil).count
+    if parents_count < children_count
+      parents_less_than_children_migration
+    else
+      children_less_than_parents_migration
+    end
+  end
+
+  def down
+  end
+
+  def parents_less_than_children_migration
+    now = Time.current
+    # another way to solve it - load parents, for charges find full matches in children plans and update parent_id
+    # then if there are no matching charges in parent plan (with different properties) - select charges for children with
+    # similar attributes, ignoring properties
+    Plan.includes(:charges, children: :charges).where(parent_id: nil).find_each(batch_size: 250) do |parent_plan|
+      next if parent_plan.children.empty?
+      next if parent_plan.charges.empty?
+
+      parent_plan.charges.each do |parent_charge|
+        next if charge_has_copy?(parent_charge, parent_plan, :full)
+
+        # process full match children
+        full_match_ids = parent_plan.children.map(&:charges).flatten.select do |child_charge|
+          child_charge.parent_id.nil? &&
+            child_charge.charge_model == parent_charge.charge_model &&
+            child_charge.billable_metric_id == parent_charge.billable_metric_id &&
+            child_charge.properties == parent_charge.properties
+        end.map(&:id)
+        Charge.where(id: full_match_ids).update_all(parent_id: parent_charge.id)
+
+        # process matching without properties
+        next if charge_has_copy?(parent_charge, parent_plan, :without_properties)
+
+        partial_match_id = parent_plan.children.map(&:charges).flatten.select do |child_charge|
+          child_charge.parent_id.nil? &&
+            child_charge.charge_model == parent_charge.charge_model &&
+            child_charge.billable_metric_id == parent_charge.billable_metric_id
+        end.map(&:id)
+        Charge.where(id: partial_match_id).update_all(parent_id: parent_charge.id)
+      end
+    end
+    puts 'Migration took: ' + (Time.current - now).to_s + ' seconds'
+  end
+
+  def charge_has_copy?(parent_charge, parent_plan, mode)
+    if mode == :full
+      parent_plan.charges.select do |charge|
+        charge.charge_model == parent_charge.charge_model &&
+          charge.billable_metric_id == parent_charge.billable_metric_id &&
+          charge.properties == parent_charge.properties
+      end.length > 1
+    elsif mode == :without_properties
+      parent_plan.charges.select do |charge|
+        charge.charge_model == parent_charge.charge_model &&
+          charge.billable_metric_id == parent_charge.billable_metric_id
+      end.length > 1
+    end
+  end
+
+  def children_less_than_parents_migration
     now = Time.current
     Plan.where.not(parent_id: nil).includes(:charges, parent: :charges).find_each do |plan|
       parent = plan.parent
@@ -24,8 +87,10 @@ class AddParentToChargesFromPlanParent < ActiveRecord::Migration[7.1]
           charge.charge_model == child_charge.charge_model &&
             charge.billable_metric_id == child_charge.billable_metric_id
         end
-        full_matches = matches_without_properties.select do |charge|
-          charge.properties == child_charge.properties
+        full_matches = parent.charges.select do |charge|
+          charge.charge_model == child_charge.charge_model &&
+            charge.billable_metric_id == child_charge.billable_metric_id &&
+            charge.properties == child_charge.properties
         end
         if full_matches.length == 1
           child_charge.update_columns(parent_id: full_matches[0].id) # rubocop:disable Rails/SkipsModelValidations

--- a/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
+++ b/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
@@ -1,20 +1,25 @@
 # frozen_string_literal: true
 #
 class AddParentToChargesFromPlanParent < ActiveRecord::Migration[7.1]
-  def change
+  def up
     now = Time.current
     Plan.where.not(parent_id: nil).includes(:charges, parent: :charges).find_each do |plan|
       parent = plan.parent
       next if plan.charges.empty? || parent.charges.empty?
 
       plan.charges.each do |child_charge|
-        parent_charges = parent.charges.where(charge_model: child_charge.charge_model, properties: child_charge.properties)
+        parent_charges = parent.charges.select do |charge|
+          charge.charge_model == child_charge.charge_model && charge.properties == child_charge.properties
+        end
         next if parent_charges.length != 1
 
-        child_charge.update(parent_id: parent_charges[0].id)
+        child_charge.update_columns(parent_id: parent_charges[0].id)
       end
     end
     puts '=' * 80
-    puts 'Migration took: ' + (Time.current - now).to_s
+    puts 'Migration took: ' + (Time.current - now).to_s + ' seconds'
+  end
+
+  def down
   end
 end

--- a/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
+++ b/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 class AddParentToChargesFromPlanParent < ActiveRecord::Migration[7.1]
+  class Plan < ApplicationRecord
+    has_many :charges, dependent: :destroy
+    belongs_to :parent, class_name: 'Plan', optional: true
+  end
+
+  class Charge < ApplicationRecord
+    belongs_to :plan
+    belongs_to :parent, class_name: 'Charge', optional: true
+  end
+
   def up
     now = Time.current
     Plan.where.not(parent_id: nil).includes(:charges, parent: :charges).find_each do |plan|

--- a/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
+++ b/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AddParentToChargesFromPlanParent < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
   class Plan < ApplicationRecord
     has_many :charges, dependent: :destroy
     belongs_to :parent, class_name: 'Plan', optional: true

--- a/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
+++ b/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 class AddParentToChargesFromPlanParent < ActiveRecord::Migration[7.1]
   def up
     now = Time.current
@@ -8,16 +8,18 @@ class AddParentToChargesFromPlanParent < ActiveRecord::Migration[7.1]
       next if plan.charges.empty? || parent.charges.empty?
 
       plan.charges.each do |child_charge|
+        next if child_charge.parent_id.present?
+
         parent_charges = parent.charges.select do |charge|
           charge.charge_model == child_charge.charge_model && charge.properties == child_charge.properties
         end
         next if parent_charges.length != 1
 
-        child_charge.update_columns(parent_id: parent_charges[0].id)
+        child_charge.update_columns(parent_id: parent_charges[0].id) # rubocop:disable Rails/SkipsModelValidations
       end
     end
-    puts '=' * 80
-    puts 'Migration took: ' + (Time.current - now).to_s + ' seconds'
+    Rails.logger.info('=' * 80)
+    Rails.logger.info('Migration took: ' + (Time.current - now).to_s + ' seconds')
   end
 
   def down

--- a/lib/tasks/tests/seed_plans.rake
+++ b/lib/tasks/tests/seed_plans.rake
@@ -13,7 +13,7 @@ namespace :tests do
     create_plans = args[:num_plans].to_i || 10
     create_plans.times do |i|
       args = build_plan_args(organization, all_metrics, i)
-      result = Plans::CreateService.call(args: args)
+      result = Plans::CreateService.call(args)
       plan = result.plan
       generate_children_plans(plan, all_metrics, delete_charge_parents)
     end

--- a/lib/tasks/tests/seed_plans.rake
+++ b/lib/tasks/tests/seed_plans.rake
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require 'faker'
+require 'factory_bot_rails'
+
+namespace :tests do
+  desc 'creates plans with children plans - creates [<num_plans>] of parents plans and 15 children for each plan; <delete_charge_parents> decides if charges of children plans will be unlinked from parent charges'
+  task :seed_plans, [:num_plans, :delete_charge_parents] => :environment do |_task, args|
+    organization = Organization.find_or_create_by!(name: 'Hooli')
+    all_metrics = find_or_create_metrics(organization)
+
+    delete_charge_parents = args[:delete_charge_parents] == 'true'
+    create_plans = args[:num_plans].to_i || 10
+    create_plans.times do |i|
+      args = build_plan_args(organization, all_metrics, i)
+      result = Plans::CreateService.call(args: args)
+      plan = result.plan
+      generate_children_plans(plan, all_metrics, delete_charge_parents)
+    end
+  end
+end
+
+def find_or_create_metrics(organization)
+  metered_metrics_params = [
+    { name: 'metered_count', agg_type: :count_agg},
+    { name: 'metered_count_uniq', agg_type: :unique_count_agg },
+    { name: 'metered_latest', agg_type: :latest_agg},
+    { name: 'metered_max', agg_type: :max_agg },
+    { name: 'metered_sum', agg_type: :sum_agg },
+    { name: 'metered_weighted_sum', agg_type: :weighted_sum_agg }
+  ]
+  metered_metrics = metered_metrics_params.map do |params|
+    organization.billable_metrics.find_or_create_by!(name: params[:name],
+                                                     code: params[:name],
+                                                     recurring: false,
+                                                     aggregation_type: params[:agg_type],
+                                                     field_name: 'test',
+                                                     weighted_interval: "seconds")
+  end
+
+  recurring_metrics_params = [
+    {name: 'recurring_sum', agg_type: :sum_agg},
+    {name: 'recurring_weighted_sum', agg_type: :weighted_sum_agg}
+  ]
+  recurring_metrics = recurring_metrics_params.map do |params|
+    organization.billable_metrics.find_or_create_by!(name: params[:name],
+                                                     code: params[:name],
+                                                     recurring: true,
+                                                     aggregation_type: params[:agg_type],
+                                                     field_name: 'test',
+                                                     weighted_interval: "seconds")
+  end
+
+  all_metrics = metered_metrics + recurring_metrics
+end
+
+def build_plan_args(organization, all_metrics, i)
+  charges_params = []
+  charge_models = Charge::CHARGE_MODELS.dup
+  charge_models.delete(:custom)
+  rand(2..25).times do
+    metric = all_metrics.sample
+    if metric.latest_agg?
+      charge_models.delete(:graduated_percentage)
+      charge_models.delete(:percentage)
+    end
+    unless metric.sum_agg?
+      charge_models.delete(:dynamic)
+    end
+    charge_model = charge_models.sample
+    pay_in_advance = (metric.payable_in_advance? && charge_model != :volume) ? [true, false].sample : false
+    charge_params = {
+      billable_metric_id: metric.id,
+      charge_model: charge_model,
+      pay_in_advance: pay_in_advance,
+      prorated: can_be_prorated?(charge_model, metric, pay_in_advance) ? [true, false].sample : false
+    }
+    charges_params << charge_params
+  end
+
+  args = {
+    organization_id: organization.id,
+    name: "Plan parent #{i+1}",
+    code: "plan_parent_#{i+1}-#{SecureRandom.hex(5)}",
+    pay_in_advance: [true, false].sample,
+    amount_cents: Faker::Number.number(digits: 4),
+    amount_currency: 'USD',
+    interval: %i[monthly yearly].sample,
+    trial_period: [0, 10].sample,
+    charges: charges_params
+  }
+end
+
+def can_be_prorated?(charge_model, billable_metric, pay_in_advance)
+  unless billable_metric.weighted_sum_agg?
+    return true if billable_metric.recurring? && pay_in_advance && charge_model == :standard
+    return true if billable_metric.recurring? && !pay_in_advance && (charge_model == :standard || charge_model == :volume || charge_model == :graduated)
+  end
+
+  false
+end
+
+
+def generate_children_plans(plan, all_metrics, delete_charge_parents)
+  5.times do
+    # change plan, do not change charges
+    res = Plans::OverrideService.call(plan: plan, params: {name: "Plan '#{plan.code}' child"})
+    pl = res.plan
+    pl.charges.update_all(parent_id: nil) if delete_charge_parents
+
+    # change charges, not properties do not change plan
+    res = Plans::OverrideService.call(plan: plan, params: {charges: override_charges(plan, all_metrics)})
+    pl = res.plan
+    pl.charges.update_all(parent_id: nil) if delete_charge_parents
+
+    # change charges models and properties (randomly)
+    res = Plans::OverrideService.call(plan: plan, params: {charges: override_charges_rand(plan, all_metrics)})
+    pl = res.plan
+    pl.charges.update_all(parent_id: nil) if delete_charge_parents
+  end
+end
+
+def override_charges(plan, all_metrics)
+  plan.charges.map do |charge|
+    {
+      id: charge.id,
+      billable_metric_id: charge.billable_metric_id,
+      charge_model: charge.charge_model,
+      pay_in_advance: charge.pay_in_advance,
+      prorated: charge.prorated,
+      properties: charge.properties
+    }
+  end
+end
+
+def override_charges_rand(plan, all_metrics)
+  plan.charges.map do |charge|
+    charge_model = charge.charge_model
+    metric = nil
+    loop do
+      metric = all_metrics.sample
+      if metric.latest_agg?
+        next if charge_model == :graduated_percentage
+        next if charge_model == :percentage
+      end
+      unless metric.sum_agg?
+        next if charge_model == :dynamic
+      end
+      break
+    end
+
+    pay_in_advance = (metric.payable_in_advance? && charge_model != :volume) ? [true, false].sample : false
+    puts 'before charge_mode: ' + charge.charge_model.to_s
+    puts 'after charge_mode: ' + charge_model.to_s
+    {
+      id: charge.id,
+      billable_metric_id: metric.id,
+      charge_model: charge_model,
+      pay_in_advance: pay_in_advance,
+      prorated: can_be_prorated?(charge_model, metric, pay_in_advance) ? [true, false].sample : false,
+      properties: new_properties_for(charge_model)
+    }
+  end
+end
+
+def new_properties_for(charge_model)
+  case charge_model&.to_sym
+  when :standard then default_standard_properties
+  when :graduated then default_graduated_properties
+  when :package then default_package_properties
+  when :percentage then default_percentage_properties
+  when :volume then default_volume_properties
+  when :graduated_percentage then default_graduated_percentage_properties
+  when :dynamic then default_dynamic_properties
+  end
+end
+
+def default_standard_properties
+  {amount: '10'}
+end
+
+def default_graduated_properties
+  {
+    'graduated_ranges' => [
+      {
+        from_value: 0,
+        to_value: nil,
+        per_unit_amount: '10',
+        flat_amount: '5'
+      }
+    ]
+  }
+end
+
+def default_package_properties
+  {
+    package_size: 1,
+    amount: '5',
+    free_units: 10
+  }
+end
+
+def default_percentage_properties
+  {rate: '20'}
+end
+
+def default_volume_properties
+  {
+    'volume_ranges' => [
+      {
+        from_value: 0,
+        to_value: nil,
+        per_unit_amount: '20',
+        flat_amount: '10'
+      }
+    ]
+  }
+end
+
+def default_graduated_percentage_properties
+  {
+    'graduated_percentage_ranges' => [
+      {
+        from_value: 0,
+        to_value: nil,
+        rate: '20',
+        fixed_amount: '20',
+        flat_amount: '20'
+      }
+    ]
+  }
+end
+
+def default_dynamic_properties
+  {}
+end


### PR DESCRIPTION
## Context

We want to populate parent_ids for charges. To define a parent for a charge, we're looking into plan's parent plan and trying to find a charge with matching charge_model and properties. If parent plan has more than one matching charge, we claim that we're not able to define a parent charge

## Description

added a migration that:
- goes through children plans and loads their charges and parents with their charges
- for each charge of children plan it tries to select charge from parent plan with matching charge model and charge properties
- if only one matching charge is found, update child charge with parent charge (without callbacks)

added a rake task to seed test data, so we can deploy it onto staging, create any number of plans with children, select to not save parent_ids for their charges, run the migration code and check the result
