### PR TITLE
fix(netsuite): Add tranid to netsuite create invoice payload

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -39,6 +39,7 @@ module Integrations
 
           def columns
             result = {
+              'tranid' => invoice.id,
               'entity' => integration_customer.external_customer_id,
               'taxregoverride' => true,
               'taxdetailsoverride' => true,

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
       'type' => 'invoice',
       'isDynamic' => true,
       'columns' => {
+        'tranid' => invoice.id,
         'taxregoverride' => true,
         'taxdetailsoverride' => true,
         'entity' => integration_customer.external_customer_id,

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -237,6 +237,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
       context 'when tax nexus is not present' do
         let(:columns) do
           {
+            'tranid' => invoice.id,
             'entity' => integration_customer.external_customer_id,
             'taxregoverride' => true,
             'taxdetailsoverride' => true,
@@ -324,6 +325,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
 
           let(:columns) do
             {
+              'tranid' => invoice.id,
               'entity' => integration_customer.external_customer_id,
               'taxregoverride' => true,
               'taxdetailsoverride' => true,
@@ -346,6 +348,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
 
           let(:columns) do
             {
+              'tranid' => invoice.id,
               'entity' => integration_customer.external_customer_id,
               'taxregoverride' => true,
               'taxdetailsoverride' => true,
@@ -368,6 +371,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
     context 'when tax item is not mapped' do
       let(:columns) do
         {
+          'tranid' => invoice.id,
           'entity' => integration_customer.external_customer_id,
           'taxregoverride' => true,
           'taxdetailsoverride' => true,

--- a/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe Integrations::Aggregator::SalesOrders::CreateService do
       'type' => 'salesorder',
       'isDynamic' => true,
       'columns' => {
+        'tranid' => invoice.id,
         'taxregoverride' => true,
         'taxdetailsoverride' => true,
         'entity' => integration_customer.external_customer_id,


### PR DESCRIPTION
## Context

NetSuite Sync Invoice format is wrong and failing.

## Description

Fix netsuite invoice payload by:
 - re-add: `tranid`