### PR TITLE
chore(specs): Remove a warning from specs

### DIFF
--- a/spec/services/integrations/aggregator/invoices/crm/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/crm/create_service_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Crm::CreateService do
 
   before do
     allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
-    allow(invoice).to receive(:file_url).and_return(file_url)
 
     integration_customer
     integration.sync_invoices = true
@@ -54,6 +53,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Crm::CreateService do
     subject(:service_call_async) { described_class.new(invoice:).call_async }
 
     context 'when invoice exists' do
+      before { allow(invoice).to receive(:file_url).and_return(file_url) }
+
       it 'enqueues invoice create job' do
         expect { service_call_async }.to enqueue_job(Integrations::Aggregator::Invoices::Crm::CreateJob)
       end
@@ -74,6 +75,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Crm::CreateService do
   end
 
   describe '#call' do
+    before { allow(invoice).to receive(:file_url).and_return(file_url) }
+
     context 'when sync_invoices is false' do
       before { integration.update!(sync_invoices: false) }
 

--- a/spec/services/integrations/aggregator/invoices/crm/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/crm/update_service_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Crm::UpdateService do
 
   before do
     allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
-    allow(invoice).to receive(:file_url).and_return(file_url)
 
     integration_customer
     integration.sync_invoices = true
@@ -54,6 +53,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Crm::UpdateService do
     subject(:service_call_async) { described_class.new(invoice:).call_async }
 
     context 'when invoice exists' do
+      before { allow(invoice).to receive(:file_url).and_return(file_url) }
+
       it 'enqueues invoice update job' do
         expect { service_call_async }.to enqueue_job(Integrations::Aggregator::Invoices::Crm::UpdateJob)
       end
@@ -74,7 +75,10 @@ RSpec.describe Integrations::Aggregator::Invoices::Crm::UpdateService do
   end
 
   describe '#call' do
-    before { integration_invoice }
+    before do
+      allow(invoice).to receive(:file_url).and_return(file_url)
+      integration_invoice
+    end
 
     context 'when sync_invoices is false' do
       before { integration.update!(sync_invoices: false) }


### PR DESCRIPTION
## Description

This PR removes this warning from specs:

```
WARNING: An expectation of `:file_url` was set on `nil`. To allow expectations on `nil` and suppress this message, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `true`. To disallow expectations on `nil`, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `false`
```