### PR TITLE
misc: Avoid reloading charge filter if already loaded

### DIFF
--- a/app/services/charge_filters/event_matching_service.rb
+++ b/app/services/charge_filters/event_matching_service.rb
@@ -33,6 +33,10 @@ module ChargeFilters
     end
 
     def filters
+      # NOTE: when called from the cache invalidator, filters are already pre-loaded,
+      #       we just return the preloaded list to avoid N+1 queries
+      return charge.filters if charge.association_cached?(:filters)
+
       charge.filters.includes(values: :billable_metric_filter)
     end
   end


### PR DESCRIPTION
## Context

This PR is related to https://github.com/getlago/lago-api/pull/2678.
The charge filter lookup that was added in the `Events::PostProcessService` lead to some performance regression. The reason behind this is that the `ChargeFilters::EventMatchingService` is reloading systematically the charge filters and associated values even if they were already pre-loaded in the `Events::PostProcessService`

## Description

The PR is checking the cached status of the `filters` association to avoid the reload.
