### PR TITLE
feat(api-key-management) Add Graphql types and queries for ApiKey model

### DIFF
--- a/app/graphql/resolvers/api_key_resolver.rb
+++ b/app/graphql/resolvers/api_key_resolver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class ApiKeyResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = 'developers:keys:manage'
+
+    argument :id, ID, required: true, description: 'Uniq ID of the API key'
+
+    description 'Query the API key'
+
+    type Types::ApiKeys::Object, null: false
+
+    def resolve(id: nil)
+      current_organization.api_keys.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: 'api_key')
+    end
+  end
+end

--- a/app/graphql/resolvers/api_keys_resolver.rb
+++ b/app/graphql/resolvers/api_keys_resolver.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class ApiKeysResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = 'developers:keys:manage'
+
+    description 'Query the API keys of current organization'
+
+    argument :limit, Integer, required: false
+    argument :page, Integer, required: false
+
+    type Types::ApiKeys::SanitizedObject.collection_type, null: false
+
+    def resolve(page: nil, limit: nil)
+      current_organization.api_keys.page(page).limit(limit)
+    end
+  end
+end

--- a/app/graphql/types/api_keys/object.rb
+++ b/app/graphql/types/api_keys/object.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  module ApiKeys
+    class Object < Types::BaseObject
+      graphql_name 'ApiKey'
+
+      field :id, ID, null: false
+      field :value, String, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    end
+  end
+end

--- a/app/graphql/types/api_keys/sanitized_object.rb
+++ b/app/graphql/types/api_keys/sanitized_object.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module ApiKeys
+    class SanitizedObject < Object
+      graphql_name 'SanitizedApiKey'
+
+      def value
+        "••••••••" + object.value.last(3)
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,6 +11,8 @@ module Types
 
     field :add_on, resolver: Resolvers::AddOnResolver
     field :add_ons, resolver: Resolvers::AddOnsResolver
+    field :api_key, resolver: Resolvers::ApiKeyResolver
+    field :api_keys, resolver: Resolvers::ApiKeysResolver
     field :billable_metric, resolver: Resolvers::BillableMetricResolver
     field :billable_metrics, resolver: Resolvers::BillableMetricsResolver
     field :coupon, resolver: Resolvers::CouponResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -176,6 +176,12 @@ type AnrokIntegration {
   name: String!
 }
 
+type ApiKey {
+  createdAt: ISO8601DateTime!
+  id: ID!
+  value: String!
+}
+
 type AppliedAddOn {
   addOn: AddOn!
   amountCents: BigInt!
@@ -6133,6 +6139,21 @@ type Query {
   addOns(limit: Int, page: Int, searchTerm: String): AddOnCollection!
 
   """
+  Query the API key
+  """
+  apiKey(
+    """
+    Uniq ID of the API key
+    """
+    id: ID!
+  ): ApiKey!
+
+  """
+  Query the API keys of current organization
+  """
+  apiKeys(limit: Int, page: Int): SanitizedApiKeyCollection!
+
+  """
   Query a single billable metric of an organization
   """
   billableMetric(
@@ -6759,6 +6780,27 @@ input RevokeMembershipInput {
   """
   clientMutationId: String
   id: ID!
+}
+
+type SanitizedApiKey {
+  createdAt: ISO8601DateTime!
+  id: ID!
+  value: String!
+}
+
+"""
+SanitizedApiKeyCollection type
+"""
+type SanitizedApiKeyCollection {
+  """
+  A collection of paginated SanitizedApiKeyCollection
+  """
+  collection: [SanitizedApiKey!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
 }
 
 enum StatusTypeEnum {

--- a/schema.json
+++ b/schema.json
@@ -1392,6 +1392,73 @@
         },
         {
           "kind": "OBJECT",
+          "name": "ApiKey",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "value",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "AppliedAddOn",
           "description": null,
           "interfaces": [
@@ -31263,6 +31330,80 @@
               ]
             },
             {
+              "name": "apiKey",
+              "description": "Query the API key",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ApiKey",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the API key",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "apiKeys",
+              "description": "Query the API keys of current organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SanitizedApiKeyCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "billableMetric",
               "description": "Query a single billable metric of an organization",
               "type": {
@@ -35150,6 +35291,130 @@
               "deprecationReason": null
             }
           ],
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SanitizedApiKey",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "value",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SanitizedApiKeyCollection",
+          "description": "SanitizedApiKeyCollection type",
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated SanitizedApiKeyCollection",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SanitizedApiKey",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
           "enumValues": null
         },
         {

--- a/spec/graphql/resolvers/api_key_resolver_spec.rb
+++ b/spec/graphql/resolvers/api_key_resolver_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::ApiKeyResolver, type: :graphql do
+  subject(:result) do
+    execute_graphql(
+      current_user: membership.user,
+      current_organization: membership.organization,
+      permissions: required_permission,
+      query:,
+      variables: {apiKeyId: api_key_id}
+    )
+  end
+
+  let(:query) do
+    <<~GQL
+      query($apiKeyId: ID!) {
+        apiKey(id: $apiKeyId) {
+          id value createdAt
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:required_permission) { 'developers:keys:manage' }
+  let(:api_key) { membership.organization.api_keys.first }
+
+  before { create(:api_key) }
+
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'developers:keys:manage'
+
+  context 'when api key with such ID exists in the current organization' do
+    let(:api_key_id) { api_key.id }
+
+    it 'returns an api key' do
+      api_key_response = result['data']['apiKey']
+
+      aggregate_failures do
+        expect(api_key_response['id']).to eq(api_key.id)
+        expect(api_key_response['value']).to eq(api_key.value)
+        expect(api_key_response['createdAt']).to eq(api_key.created_at.iso8601)
+      end
+    end
+  end
+
+  context 'when api key with such ID does not exist in the current organization' do
+    let(:api_key_id) { SecureRandom.uuid }
+
+    it 'returns an error' do
+      expect_graphql_error(result:, message: 'Resource not found')
+    end
+  end
+end

--- a/spec/graphql/resolvers/api_keys_resolver_spec.rb
+++ b/spec/graphql/resolvers/api_keys_resolver_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::ApiKeysResolver, type: :graphql do
+  subject(:result) do
+    execute_graphql(
+      current_user: membership.user,
+      current_organization: membership.organization,
+      permissions: required_permission,
+      query:
+    )
+  end
+
+  let(:query) do
+    <<~GQL
+      query {
+        apiKeys(limit: 5) {
+          collection { id value createdAt }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:required_permission) { 'developers:keys:manage' }
+  let(:api_key) { membership.organization.api_keys.first }
+
+  before { create(:api_key) }
+
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'developers:keys:manage'
+
+  it 'returns a list of api keys' do
+    api_key_response = result['data']['apiKeys']
+
+    aggregate_failures do
+      expect(api_key_response['collection'].first['id']).to eq(api_key.id)
+      expect(api_key_response['collection'].first['value']).to eq("••••••••" + api_key.value.last(3))
+      expect(api_key_response['collection'].first['createdAt']).to eq(api_key.created_at.iso8601)
+
+      expect(api_key_response['metadata']['currentPage']).to eq(1)
+      expect(api_key_response['metadata']['totalCount']).to eq(1)
+    end
+  end
+end

--- a/spec/graphql/types/api_keys/object_spec.rb
+++ b/spec/graphql/types/api_keys/object_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::ApiKeys::Object do
+  subject { described_class }
+
+  it { is_expected.to have_field(:id).of_type('ID!') }
+  it { is_expected.to have_field(:value).of_type('String!') }
+  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
+end

--- a/spec/graphql/types/api_keys/sanitized_object_spec.rb
+++ b/spec/graphql/types/api_keys/sanitized_object_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::ApiKeys::SanitizedObject do
+  subject { described_class }
+
+  it { is_expected.to have_field(:id).of_type('ID!') }
+  it { is_expected.to have_field(:value).of_type('String!') }
+  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
+end


### PR DESCRIPTION
## Context

Adding GraphQl types and queries to the newly added ApiKey model. Those would be used to implement hide and reveal feature on FE side later.

## Description

Added new types, queries for ApiKey model.
