### PR TITLE
misc(clickhouse): Use official clickhouse-activerecord gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,134 +1,134 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.3.4'
+ruby "3.3.4"
 
 # Core
-gem 'aasm'
-gem 'activejob-uniqueness', require: 'active_job/uniqueness/sidekiq_patch'
-gem 'bootsnap', require: false
-gem 'clockwork', require: false
-gem 'parallel'
-gem 'puma', '~> 6.4'
-gem 'rails', '~> 7.1.3.4'
-gem 'redis'
-gem 'sidekiq'
+gem "aasm"
+gem "activejob-uniqueness", require: "active_job/uniqueness/sidekiq_patch"
+gem "bootsnap", require: false
+gem "clockwork", require: false
+gem "parallel"
+gem "puma", "~> 6.4"
+gem "rails", "~> 7.1.3.4"
+gem "redis"
+gem "sidekiq"
 
 # Security
-gem 'bcrypt'
-gem 'googleauth', '~> 1.11.0'
-gem 'jwt'
-gem 'oauth2'
-gem 'rack-cors'
+gem "bcrypt"
+gem "googleauth", "~> 1.11.0"
+gem "jwt"
+gem "oauth2"
+gem "rack-cors"
 
 # Database
-gem 'after_commit_everywhere'
-gem 'clickhouse-activerecord', git: 'https://github.com/getlago/clickhouse-activerecord.git'
-gem 'discard', '~> 1.2'
-gem 'kaminari-activerecord'
-gem 'paper_trail', '~> 15.1'
-gem 'pg'
-gem 'ransack', '~> 4.1.0'
-gem 'scenic'
-gem 'with_advisory_lock'
-gem 'strong_migrations'
+gem "after_commit_everywhere"
+gem "clickhouse-activerecord", "~> 1.2.0"
+gem "discard", "~> 1.2"
+gem "kaminari-activerecord"
+gem "paper_trail", "~> 15.1"
+gem "pg"
+gem "ransack", "~> 4.1.0"
+gem "scenic"
+gem "with_advisory_lock"
+gem "strong_migrations"
 
 # Currencies, Countries, Timezones...
-gem 'bigdecimal'
-gem 'countries'
-gem 'money-rails'
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem "bigdecimal"
+gem "countries"
+gem "money-rails"
+gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 # GraphQL
-gem 'graphql'
-gem 'graphql-pagination'
+gem "graphql"
+gem "graphql-pagination"
 
 # Payment processing
-gem 'adyen-ruby-api-library'
-gem 'gocardless_pro', '~> 2.34'
-gem 'stripe'
+gem "adyen-ruby-api-library"
+gem "gocardless_pro", "~> 2.34"
+gem "stripe"
 
 # Analytics
-gem 'activejob-traceable'
-gem 'analytics-ruby', '~> 2.4.0', require: 'segment/analytics'
+gem "activejob-traceable"
+gem "analytics-ruby", "~> 2.4.0", require: "segment/analytics"
 
 # Logging
-gem 'lograge'
-gem 'logstash-event'
+gem "lograge"
+gem "logstash-event"
 
 # HTTP and Multipart support
-gem 'multipart-post'
-gem 'mutex_m'
+gem "multipart-post"
+gem "mutex_m"
 
 # Monitoring
-gem 'newrelic_rpm'
-gem 'opentelemetry-exporter-otlp'
-gem 'opentelemetry-instrumentation-all'
-gem 'opentelemetry-sdk'
-gem 'sentry-rails', '~> 5.18.0'
-gem 'sentry-ruby', '~> 5.18.0'
-gem 'sentry-sidekiq', '~> 5.18.0'
+gem "newrelic_rpm"
+gem "opentelemetry-exporter-otlp"
+gem "opentelemetry-instrumentation-all"
+gem "opentelemetry-sdk"
+gem "sentry-rails", "~> 5.18.0"
+gem "sentry-ruby", "~> 5.18.0"
+gem "sentry-sidekiq", "~> 5.18.0"
 
 # Storage
-gem 'aws-sdk-s3', require: false
-gem 'google-cloud-storage', require: false
+gem "aws-sdk-s3", require: false
+gem "google-cloud-storage", require: false
 
 # Templating
-gem 'slim'
-gem 'slim-rails'
+gem "slim"
+gem "slim-rails"
 
 # Kafka
-gem 'karafka', '~> 2.4.0'
-gem 'karafka-web', '~> 0.9.0'
+gem "karafka", "~> 2.4.0"
+gem "karafka-web", "~> 0.9.0"
 
 # Taxes
-gem 'valvat', require: false
+gem "valvat", require: false
 
 # Data Export
-gem 'csv', '~> 3.0'
+gem "csv", "~> 3.0"
 
 group :development, :test, :staging do
-  gem 'factory_bot_rails'
-  gem 'faker'
-  gem 'timecop'
+  gem "factory_bot_rails"
+  gem "faker"
+  gem "timecop"
 end
 
 group :development, :test do
-  gem 'byebug'
-  gem 'clockwork-test'
-  gem 'debug', platforms: %i[mri mingw x64_mingw], require: false
-  gem 'dotenv'
-  gem 'i18n-tasks', git: 'https://github.com/glebm/i18n-tasks.git'
-  gem 'rspec-rails'
-  gem 'simplecov', require: false
-  gem 'webmock'
-  gem 'rubocop-rails'
-  gem 'rubocop-graphql', require: false
-  gem 'rubocop-performance', require: false
-  gem 'rubocop-rspec', require: false
-  gem 'rubocop-thread_safety', require: false
-  gem 'awesome_print'
+  gem "byebug"
+  gem "clockwork-test"
+  gem "debug", platforms: %i[mri mingw x64_mingw], require: false
+  gem "dotenv"
+  gem "i18n-tasks", git: "https://github.com/glebm/i18n-tasks.git"
+  gem "rspec-rails"
+  gem "simplecov", require: false
+  gem "webmock"
+  gem "rubocop-rails"
+  gem "rubocop-graphql", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rspec", require: false
+  gem "rubocop-thread_safety", require: false
+  gem "awesome_print"
 end
 
 group :test do
-  gem 'database_cleaner-active_record'
-  gem 'guard-rspec', require: false
-  gem 'rspec-graphql_matchers'
-  gem 'shoulda-matchers'
+  gem "database_cleaner-active_record"
+  gem "guard-rspec", require: false
+  gem "rspec-graphql_matchers"
+  gem "shoulda-matchers"
 end
 
 group :development do
-  gem 'bullet'
-  gem 'coffee-rails'
-  gem 'graphiql-rails', git: 'https://github.com/rmosolgo/graphiql-rails.git'
+  gem "bullet"
+  gem "coffee-rails"
+  gem "graphiql-rails", git: "https://github.com/rmosolgo/graphiql-rails.git"
 
   gem "standard", require: false
-  gem 'annotate'
+  gem "annotate"
 
-  gem 'sass-rails'
-  gem 'uglifier'
+  gem "sass-rails"
+  gem "uglifier"
 
-  gem 'ruby-lsp-rails', require: false
+  gem "ruby-lsp-rails", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/getlago/clickhouse-activerecord.git
-  revision: 7c61304f5b70cd0c890972282ea2a5b458e45a31
-  specs:
-    clickhouse-activerecord (1.1.3)
-      activerecord (~> 7.1)
-      bundler (>= 1.13.4)
-
-GIT
   remote: https://github.com/glebm/i18n-tasks.git
   revision: 2cba1093e3c555b6664f62604a2e2f2dfe6f1a6e
   specs:
@@ -152,6 +144,9 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
+    clickhouse-activerecord (1.2.0)
+      activerecord (~> 7.1)
+      bundler (>= 1.13.4)
     clockwork (3.0.2)
       activesupport
       tzinfo
@@ -879,7 +874,7 @@ DEPENDENCIES
   bootsnap
   bullet
   byebug
-  clickhouse-activerecord!
+  clickhouse-activerecord (~> 1.2.0)
   clockwork
   clockwork-test
   coffee-rails


### PR DESCRIPTION
## Context

Two pull requests opened on the `clickhouse-active` records repository were merged lately.
- https://github.com/PNixx/clickhouse-activerecord/pull/158
- https://github.com/PNixx/clickhouse-activerecord/pull/169

Since now all mandatory pieces that we require to use it in production are here, we can use the official gem rather than the fork.

## Description

This PR replaces `gem 'clickhouse-activerecord', git: 'https://github.com/getlago/clickhouse-activerecord.git'` with `gem "clickhouse-activerecord", "~> 1.2.0"`