### PR TITLE
feat(DailyUsage): Add daily_usages:fill_history task

### DIFF
--- a/app/models/clickhouse/events_raw.rb
+++ b/app/models/clickhouse/events_raw.rb
@@ -51,6 +51,7 @@ end
 # Table name: events_raw
 #
 #  code                       :string           not null
+#  ingested_at                :datetime         not null
 #  precise_total_amount_cents :decimal(40, 15)
 #  properties                 :string           not null
 #  timestamp                  :datetime         not null

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -19,7 +19,7 @@ module DailyUsages
         customer: subscription.customer,
         subscription:,
         external_subscription_id: subscription.external_id,
-        usage: ::V1::Customers::UsageSerializer.new(current_usage).serialize,
+        usage: ::V1::Customers::UsageSerializer.new(current_usage, includes: %i[charges_usage]).serialize,
         from_datetime: current_usage.from_datetime,
         to_datetime: current_usage.to_datetime,
         refreshed_at: timestamp

--- a/lib/tasks/daily_usages.rake
+++ b/lib/tasks/daily_usages.rake
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'timecop'
+
+namespace :daily_usages do
+  desc "Fill past daily usage"
+  task :fill_history, [:organization_id] => :environment do |_task, args|
+    abort "Missing organization_id\n\n" unless args[:organization_id]
+
+    organization = Organization.find(args[:organization_id])
+
+    subscriptions = organization.subscriptions
+      .where(status: [:active, :terminated])
+      .where.not(started_at: nil)
+      .where('terminated_at IS NULL OR terminated_at >= ?', 4.months.ago)
+      .includes(:customer)
+
+    subscriptions.find_each do |subscription|
+      from = subscription.started_at.to_date
+      if from < 4.months.ago
+        from = 4.months.ago.to_date
+      end
+
+      to = (subscription.terminated_at || Time.current).to_date
+
+      (from..to).each do |date|
+        datetime = date + 5.minutes
+
+        Timecop.freeze(datetime) do
+          usage = Invoices::CustomerUsageService.call(
+            customer: subscription.customer,
+            subscription: subscription,
+            apply_taxes: false,
+            with_cache: false,
+            max_to_datetime: date.beginning_of_day
+          ).raise_if_error!.usage
+
+          DailyUsage.create!(
+            organization:,
+            customer: subscription.customer,
+            subscription:,
+            external_subscription_id: subscription.external_id,
+            usage: ::V1::Customers::UsageSerializer.new(usage, includes: %i[charges_usage]).serialize,
+            from_datetime: usage.from_datetime,
+            to_datetime: usage.to_datetime,
+            refreshed_at: date
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/daily_usages.rake
+++ b/lib/tasks/daily_usages.rake
@@ -4,35 +4,41 @@ require 'timecop'
 
 namespace :daily_usages do
   desc "Fill past daily usage"
-  task :fill_history, [:organization_id] => :environment do |_task, args|
+  task :fill_history, [:organization_id, :days_ago] => :environment do |_task, args|
     abort "Missing organization_id\n\n" unless args[:organization_id]
 
+    Rails.logger.level = Logger::INFO
+
+    days_ago = (args[:days_ago] || 120).to_i.days.ago
     organization = Organization.find(args[:organization_id])
 
     subscriptions = organization.subscriptions
       .where(status: [:active, :terminated])
       .where.not(started_at: nil)
-      .where('terminated_at IS NULL OR terminated_at >= ?', 4.months.ago)
-      .includes(:customer)
+      .where('terminated_at IS NULL OR terminated_at >= ?', days_ago)
+      .includes(customer: :organization)
 
     subscriptions.find_each do |subscription|
       from = subscription.started_at.to_date
-      if from < 4.months.ago
-        from = 4.months.ago.to_date
+      if from < days_ago
+        from = days_ago.to_date
       end
 
       to = (subscription.terminated_at || Time.current).to_date
 
       (from..to).each do |date|
-        datetime = date + 5.minutes
+        datetime = date.in_time_zone(subscription.customer.applicable_timezone).beginning_of_day.utc
 
-        Timecop.freeze(datetime) do
+        next if date == Date.today &&
+          DailyUsage.refreshed_at_in_timezone(datetime).where(subscription_id: subscription.id).exists?
+
+        Timecop.freeze(datetime + 5.minutes) do
           usage = Invoices::CustomerUsageService.call(
             customer: subscription.customer,
             subscription: subscription,
             apply_taxes: false,
             with_cache: false,
-            max_to_datetime: date.beginning_of_day
+            max_to_datetime: datetime
           ).raise_if_error!.usage
 
           DailyUsage.create!(
@@ -43,7 +49,7 @@ namespace :daily_usages do
             usage: ::V1::Customers::UsageSerializer.new(usage, includes: %i[charges_usage]).serialize,
             from_datetime: usage.from_datetime,
             to_datetime: usage.to_datetime,
-            refreshed_at: date
+            refreshed_at: datetime
           )
         end
       end


### PR DESCRIPTION
## Context

This PR is part of the Usage Revenue and unit.

Today, Lago does not offer a way to retrieve customer usage with a granularity lower than the billing period (via invoices and fees). On the other end, it is possible to get the current usage for a customer/subscription, but this usage is just a “snapshot” of the usage a the current time. 

## Description

This PR adds a rake task to fill the daily usage history for a specific organization