### PR TITLE
feat(hubspot): Sync subscriptions

### DIFF
--- a/app/services/integration_customers/hubspot_service.rb
+++ b/app/services/integration_customers/hubspot_service.rb
@@ -47,7 +47,11 @@ module IntegrationCustomers
     end
 
     def targeted_object
-      @targeted_object ||= params[:targeted_object]
+      @targeted_object ||=
+        params[:targeted_object].presence ||
+        ((customer.customer_type == 'individual') ? 'contacts' : nil) ||
+        ((customer.customer_type == 'company') ? 'companies' : nil) ||
+        integration.default_targeted_object
     end
   end
 end

--- a/app/services/integrations/aggregator/invoices/crm/create_customer_association_service.rb
+++ b/app/services/integrations/aggregator/invoices/crm/create_customer_association_service.rb
@@ -12,6 +12,8 @@ module Integrations
           def call
             return result if !integration || !integration.sync_invoices || !payload.integration_invoice
 
+            Integrations::Hubspot::Invoices::DeployObjectService.call(integration:)
+
             http_client.put_with_response(payload.customer_association_body, headers)
 
             result

--- a/app/services/integrations/aggregator/subscriptions/crm/create_customer_association_service.rb
+++ b/app/services/integrations/aggregator/subscriptions/crm/create_customer_association_service.rb
@@ -12,6 +12,8 @@ module Integrations
           def call
             return result if !integration || !integration.sync_subscriptions || !payload.integration_subscription
 
+            Integrations::Hubspot::Subscriptions::DeployObjectService.call(integration:)
+
             http_client.put_with_response(payload.customer_association_body, headers)
 
             result

--- a/app/services/integrations/hubspot/invoices/deploy_object_service.rb
+++ b/app/services/integrations/hubspot/invoices/deploy_object_service.rb
@@ -12,7 +12,9 @@ module Integrations
 
         def call
           return result unless integration.type == 'Integrations::HubspotIntegration'
-          return result if integration.invoices_properties_version == VERSION
+          if integration.invoices_properties_version == VERSION && integration.invoices_object_type_id.present?
+            return result
+          end
 
           custom_object_result = Integrations::Aggregator::CustomObjectService.call(integration:, name: 'LagoInvoices')
           if custom_object_result.success?

--- a/app/services/integrations/hubspot/subscriptions/deploy_object_service.rb
+++ b/app/services/integrations/hubspot/subscriptions/deploy_object_service.rb
@@ -12,7 +12,10 @@ module Integrations
 
         def call
           return result unless integration.type == 'Integrations::HubspotIntegration'
-          return result if integration.subscriptions_properties_version == VERSION
+          if integration.subscriptions_properties_version == VERSION &&
+              integration.subscriptions_object_type_id.present?
+            return result
+          end
 
           custom_object_result = Integrations::Aggregator::CustomObjectService.call(integration:, name: 'LagoSubscriptions')
           if custom_object_result.success?

--- a/app/services/subscriptions/billing_service.rb
+++ b/app/services/subscriptions/billing_service.rb
@@ -16,6 +16,10 @@ module Subscriptions
             # NOTE: In case of downgrade, subscription remain active until the end of the period,
             #       a next subscription is pending, the current one must be terminated
             Subscriptions::TerminateJob.perform_later(subscription, today.to_i)
+
+            if subscription.should_sync_crm_subscription?
+              Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription:)
+            end
           else
             billing_subscriptions << subscription
           end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -128,8 +128,8 @@ module Subscriptions
         after_commit { SendWebhookJob.perform_later('subscription.started', new_subscription) }
       end
 
-      if new_subscription.should_sync_crm_subscription?
-        after_commit { Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription:) }
+      if new_subscription.active? && new_subscription.should_sync_crm_subscription?
+        after_commit { Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription: new_subscription) }
       end
 
       new_subscription
@@ -251,7 +251,7 @@ module Subscriptions
       current_subscription.save!
 
       if current_subscription.should_sync_crm_subscription?
-        Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription:)
+        Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription: current_subscription)
       end
     end
 

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -128,7 +128,7 @@ module Subscriptions
         after_commit { SendWebhookJob.perform_later('subscription.started', new_subscription) }
       end
 
-      if new_subscription.active? && new_subscription.should_sync_crm_subscription?
+      if new_subscription.should_sync_crm_subscription?
         after_commit { Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription: new_subscription) }
       end
 

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -129,7 +129,7 @@ module Subscriptions
       end
 
       if new_subscription.should_sync_crm_subscription?
-        after_commit { Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription: new_subscription) }
+        after_commit { Integrations::Aggregator::Subscriptions::Crm::CreateJob.perform_later(subscription: new_subscription) }
       end
 
       new_subscription

--- a/app/services/subscriptions/free_trial_billing_service.rb
+++ b/app/services/subscriptions/free_trial_billing_service.rb
@@ -24,6 +24,10 @@ module Subscriptions
         subscription.update!(trial_ended_at: subscription.trial_end_utc_date_from_query)
 
         SendWebhookJob.perform_later('subscription.trial_ended', subscription)
+
+        if subscription.should_sync_crm_subscription?
+          Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription:)
+        end
       end
     end
 

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -18,6 +18,10 @@ module Subscriptions
       elsif !subscription.terminated?
         subscription.mark_as_terminated!
 
+        if subscription.should_sync_crm_subscription?
+          Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription:)
+        end
+
         if subscription.plan.pay_in_advance? && pay_in_advance_invoice_issued?
           # NOTE: As subscription was payed in advance and terminated before the end of the period,
           #       we have to create a credit note for the days that were not consumed
@@ -36,7 +40,12 @@ module Subscriptions
       end
 
       # NOTE: Pending next subscription should be canceled as well
-      subscription.next_subscription&.mark_as_canceled!
+      next_subscription = subscription.next_subscription
+      next_subscription&.mark_as_canceled!
+
+      if next_subscription&.should_sync_crm_subscription?
+        Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(next_subscription)
+      end
 
       # NOTE: Wait to ensure job is performed at the end of the database transaction.
       # See https://github.com/getlago/lago-api/blob/main/app/services/subscriptions/create_service.rb#L46.
@@ -56,7 +65,15 @@ module Subscriptions
 
       ActiveRecord::Base.transaction do
         subscription.mark_as_terminated!(rotation_date)
+
+        if subscription.should_sync_crm_subscription?
+          Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription:)
+        end
+
         next_subscription.mark_as_active!(rotation_date)
+        if next_subscription.should_sync_crm_subscription?
+          Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(next_subscription)
+        end
       end
 
       # NOTE: Create an invoice for the terminated subscription

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -44,7 +44,7 @@ module Subscriptions
       next_subscription&.mark_as_canceled!
 
       if next_subscription&.should_sync_crm_subscription?
-        Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(next_subscription)
+        Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription: next_subscription)
       end
 
       # NOTE: Wait to ensure job is performed at the end of the database transaction.

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -36,6 +36,10 @@ module Subscriptions
         process_subscription_at_change(subscription)
       else
         subscription.save!
+
+        if subscription.should_sync_crm_subscription?
+          Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription:)
+        end
       end
 
       result.subscription = subscription

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -45,5 +45,11 @@ FactoryBot.define do
         create(:anrok_customer, customer:)
       end
     end
+
+    trait :with_hubspot_integration do
+      after :create do |customer|
+        create(:hubspot_customer, customer:)
+      end
+    end
   end
 end

--- a/spec/services/integration_customers/hubspot_service_spec.rb
+++ b/spec/services/integration_customers/hubspot_service_spec.rb
@@ -3,13 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe IntegrationCustomers::HubspotService, type: :service do
-  let(:integration) { create(:xero_integration, organization:) }
+  let(:integration) { create(:hubspot_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }
   let(:customer) { create(:customer, organization:, customer_type: 'individual') }
+  let(:targeted_object) { 'contacts' }
 
   describe '#create' do
-    subject(:service_call) { described_class.new(integration:, customer:, subsidiary_id: nil, targeted_object: 'contacts').create }
+    subject(:service_call) { described_class.new(integration:, customer:, subsidiary_id: nil, targeted_object:).create }
 
     let(:contact_id) { SecureRandom.uuid }
     let(:create_result) do
@@ -45,6 +46,53 @@ RSpec.describe IntegrationCustomers::HubspotService, type: :service do
 
     it 'creates integration customer' do
       expect { service_call }.to change(IntegrationCustomers::HubspotCustomer, :count).by(1)
+    end
+
+    context "with targeted_object" do
+      let(:customer) { create(:customer, organization:, customer_type:) }
+      let(:customer_type) { "individual" }
+
+      context 'when params[:targeted_object] is specified as "contacts"' do
+        let(:targeted_object) { 'contacts' }
+
+        it 'uses Integrations::Aggregator::Contacts::CreateService' do
+          allow(Integrations::Aggregator::Contacts::CreateService).to receive(:call).and_return(create_result)
+          service_call
+          expect(Integrations::Aggregator::Contacts::CreateService).to have_received(:call)
+        end
+      end
+
+      context 'when params[:targeted_object] is specified as "companies"' do
+        let(:targeted_object) { 'companies' }
+
+        it 'uses Integrations::Aggregator::Companies::CreateService' do
+          allow(Integrations::Aggregator::Companies::CreateService).to receive(:call).and_return(create_result)
+          service_call
+          expect(Integrations::Aggregator::Companies::CreateService).to have_received(:call)
+        end
+      end
+
+      context 'when params[:targeted_object] is not specified and customer is an individual' do
+        let(:targeted_object) { nil }
+        let(:customer) { create(:customer, organization:, customer_type: 'individual') }
+
+        it 'defaults to Integrations::Aggregator::Contacts::CreateService' do
+          allow(Integrations::Aggregator::Contacts::CreateService).to receive(:call).and_return(create_result)
+          service_call
+          expect(Integrations::Aggregator::Contacts::CreateService).to have_received(:call)
+        end
+      end
+
+      context 'when params[:targeted_object] is not specified and customer is a company' do
+        let(:targeted_object) { nil }
+        let(:customer) { create(:customer, organization:, customer_type: 'company') }
+
+        it 'defaults to Integrations::Aggregator::Companies::CreateService' do
+          allow(Integrations::Aggregator::Companies::CreateService).to receive(:call).and_return(create_result)
+          service_call
+          expect(Integrations::Aggregator::Companies::CreateService).to have_received(:call)
+        end
+      end
     end
   end
 end

--- a/spec/services/integrations/aggregator/invoices/crm/create_customer_association_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/crm/create_customer_association_service_spec.rb
@@ -65,7 +65,14 @@ RSpec.describe Integrations::Aggregator::Invoices::Crm::CreateCustomerAssociatio
       context 'when request is successful' do
         before do
           allow(service).to receive(:http_client).and_return(lago_client)
+          allow(Integrations::Hubspot::Invoices::DeployObjectService).to receive(:call)
         end
+
+        it 'calls the DeployObjectService' do
+          service_call
+          expect(Integrations::Hubspot::Invoices::DeployObjectService).to have_received(:call).with(integration: integration)
+        end
+
 
         it 'returns result' do
           expect(service_call).to be_a(BaseService::Result)

--- a/spec/services/integrations/aggregator/invoices/crm/create_customer_association_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/crm/create_customer_association_service_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Crm::CreateCustomerAssociatio
           expect(Integrations::Hubspot::Invoices::DeployObjectService).to have_received(:call).with(integration: integration)
         end
 
-
         it 'returns result' do
           expect(service_call).to be_a(BaseService::Result)
         end

--- a/spec/services/integrations/aggregator/subscriptions/crm/create_customer_association_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/crm/create_customer_association_service_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Crm::CreateCustomerAssoc
       context 'when request is successful' do
         before do
           allow(service).to receive(:http_client).and_return(lago_client)
+          allow(Integrations::Hubspot::Subscriptions::DeployObjectService).to receive(:call)
+        end
+
+        it 'calls the DeployObjectService' do
+          service_call
+          expect(Integrations::Hubspot::Subscriptions::DeployObjectService).to have_received(:call).with(integration: integration)
         end
 
         it 'returns result' do

--- a/spec/services/subscriptions/billing_service_spec.rb
+++ b/spec/services/subscriptions/billing_service_spec.rb
@@ -518,5 +518,30 @@ RSpec.describe Subscriptions::BillingService, type: :service do
         end
       end
     end
+
+    context 'when a subscription should sync CRM subscription' do
+      let(:interval) { :weekly }
+
+      let(:subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan:,
+          subscription_at:,
+          started_at: Time.zone.now
+        )
+      end
+
+      before do
+        allow(subscription).to receive(:should_sync_crm_subscription?).and_return(true)
+        allow(Integrations::Aggregator::Subscriptions::Crm::UpdateJob).to receive(:perform_later)
+      end
+
+      it 'enqueues Integrations::Aggregator::Subscriptions::Crm::UpdateJob' do
+        expect(Integrations::Aggregator::Subscriptions::Crm::UpdateJob)
+          .to have_received(:perform_later).with(subscription:)
+        billing_service.call
+      end
+    end
   end
 end

--- a/spec/services/subscriptions/billing_service_spec.rb
+++ b/spec/services/subscriptions/billing_service_spec.rb
@@ -457,7 +457,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
         travel_to(current_date) do
           billing_service.call
           expect(Integrations::Aggregator::Subscriptions::Crm::UpdateJob)
-            .to have_received(:perform_later).with(subscription:)
+            .to have_received(:perform_later).with(subscription: previous_subscription)
         end
       end
     end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -77,12 +77,12 @@ RSpec.describe Subscriptions::CreateService, type: :service do
       let(:customer) { create(:customer, :with_hubspot_integration, organization:, currency: 'EUR') }
 
       before do
-        allow(Integrations::Aggregator::Subscriptions::Crm::UpdateJob).to receive(:perform_later)
+        allow(Integrations::Aggregator::Subscriptions::Crm::CreateJob).to receive(:perform_later)
       end
 
       it 'enqueues the CRM update job for a new subscription' do
         create_service.call
-        expect(Integrations::Aggregator::Subscriptions::Crm::UpdateJob).to have_received(:perform_later)
+        expect(Integrations::Aggregator::Subscriptions::Crm::CreateJob).to have_received(:perform_later)
       end
     end
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         allow(Integrations::Aggregator::Subscriptions::Crm::CreateJob).to receive(:perform_later)
       end
 
-      it 'enqueues the CRM update job for a new subscription' do
+      it 'enqueues the CRM create job for a new subscription' do
         create_service.call
         expect(Integrations::Aggregator::Subscriptions::Crm::CreateJob).to have_received(:perform_later)
       end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -450,13 +450,13 @@ RSpec.describe Subscriptions::CreateService, type: :service do
       context 'when plan is not the same' do
         context 'when we upgrade the plan' do
           let(:customer) { create(:customer, :with_hubspot_integration, organization:, currency: 'EUR') }
-          before do
-            subscription.mark_as_active!
-          end
-
           let(:plan) { create(:plan, amount_cents: 200, organization:) }
           let(:old_plan) { create(:plan, amount_cents: 100, organization:) }
           let(:name) { 'invoice display name new' }
+
+          before do
+            subscription.mark_as_active!
+          end
 
           it 'terminates the existing subscription' do
             expect { create_service.call }.to change { subscription.reload.status }.from('active').to('terminated')

--- a/spec/services/subscriptions/free_trial_billing_service_spec.rb
+++ b/spec/services/subscriptions/free_trial_billing_service_spec.rb
@@ -66,12 +66,13 @@ RSpec.describe Subscriptions::FreeTrialBillingService, type: :service do
       it 'calls the CRM update job' do
         customer = create(:customer)
         plan = create(:plan, trial_period: 10, pay_in_advance: true)
-        subscription = create(:subscription, customer:, plan:, started_at: 10.days.ago)
-        allow(subscription).to receive(:should_sync_crm_subscription?).and_return(true)
+        subscription = create(:subscription, customer:, plan:, started_at: 15.days.ago)
+        allow_any_instance_of(Subscription).to receive(:should_sync_crm_subscription?).and_return(true)
+        allow(Integrations::Aggregator::Subscriptions::Crm::UpdateJob).to receive(:perform_later)
 
-        expect(Integrations::Aggregator::Subscriptions::Crm::UpdateJob)
-          .to have_received(:perform_later).with(subscription:)
         service.call
+        expect(Integrations::Aggregator::Subscriptions::Crm::UpdateJob)
+          .to have_received(:perform_later).with(subscription: subscription)
       end
     end
   end

--- a/spec/services/subscriptions/free_trial_billing_service_spec.rb
+++ b/spec/services/subscriptions/free_trial_billing_service_spec.rb
@@ -64,12 +64,10 @@ RSpec.describe Subscriptions::FreeTrialBillingService, type: :service do
 
     context 'when the subscription should sync with CRM' do
       it 'calls the CRM update job' do
-        customer = create(:customer)
+        customer = create(:customer, :with_hubspot_integration)
         plan = create(:plan, trial_period: 10, pay_in_advance: true)
         subscription = create(:subscription, customer:, plan:, started_at: 15.days.ago)
-        allow_any_instance_of(Subscription).to receive(:should_sync_crm_subscription?).and_return(true)
         allow(Integrations::Aggregator::Subscriptions::Crm::UpdateJob).to receive(:perform_later)
-
         service.call
         expect(Integrations::Aggregator::Subscriptions::Crm::UpdateJob)
           .to have_received(:perform_later).with(subscription: subscription)

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -18,6 +18,19 @@ RSpec.describe Subscriptions::TerminateService do
       end
     end
 
+    context 'when the subscription should sync with CRM' do
+      before do
+        allow(subscription).to receive(:should_sync_crm_subscription?).and_return(true)
+        allow(Integrations::Aggregator::Subscriptions::Crm::UpdateJob).to receive(:perform_later)
+      end
+
+      it 'calls the CRM update job' do
+        terminate_service.call
+        expect(Integrations::Aggregator::Subscriptions::Crm::UpdateJob)
+          .to have_received(:perform_later).with(subscription:)
+      end
+    end
+
     it 'enqueues a BillSubscriptionJob' do
       expect do
         terminate_service.call

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -34,6 +34,22 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
       end
     end
 
+    context 'when subscription should sync CRM subscription' do
+      let(:params) { {name: 'new name'} }
+
+      before do
+        allow(subscription).to receive(:should_sync_crm_subscription?).and_return(true)
+        allow(Integrations::Aggregator::Subscriptions::Crm::UpdateJob).to receive(:perform_later)
+      end
+
+      it 'enqueues a job to update CRM subscription' do
+        update_service.call
+
+        expect(Integrations::Aggregator::Subscriptions::Crm::UpdateJob)
+          .to have_received(:perform_later).with(subscription: subscription)
+      end
+    end
+
     context 'when subscription_at is not passed at all' do
       let(:params) do
         {


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-hubspot

## Context

When creating or updating subscriptions in Lago, we must sync them to Hubspot.

## Description

This PR calls the services that handle syncing subscriptions to Hubspot via Nango.
