### PR TITLE
bug(PayInAdvance) - Add dedicated lock_key_arguments for pay in advance jobs

### DIFF
--- a/app/jobs/fees/create_pay_in_advance_job.rb
+++ b/app/jobs/fees/create_pay_in_advance_job.rb
@@ -14,6 +14,12 @@ module Fees
       result.raise_if_error!
     end
 
+    def lock_key_arguments
+      args = arguments.first
+      event = Events::CommonFactory.new_instance(source: args[:event])
+      [args[:charge], event.organization_id, event.external_subscription_id, event.transaction_id]
+    end
+
     private
 
     def tax_error?(result)

--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -26,6 +26,12 @@ module Invoices
       )
     end
 
+    def lock_key_arguments
+      args = arguments.first
+      event = Events::CommonFactory.new_instance(source: args[:event])
+      [args[:charge], event.organization_id, event.external_subscription_id, event.transaction_id]
+    end
+
     private
 
     def tax_error?(result)


### PR DESCRIPTION
After adding the `PreciseTotalAmountCents` to Clickhouse, we now have discrepancies between event json. The one coming from Kafka always has "0.0" set for precise total amount cents while the ruby one has nil. 

This causes 2 duplicate invoice jobs to be enqueued for the same event. The uniqueness key compared all arguments to the job. 

The fix is to limit what is used as lock_key via the `lock_key_arguments` method.