### PR TITLE
bug(caching) - Add cache key version to Subscriptions::ChargeCacheService

### DIFF
--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -2,6 +2,8 @@
 
 module Subscriptions
   class ChargeCacheService
+    CACHE_KEY_VERSION = '1'
+
     def self.expire_for_subscription(subscription)
       subscription.plan.charges.includes(:filters)
         .find_each { expire_for_subscription_charge(subscription:, charge: _1) }
@@ -21,9 +23,12 @@ module Subscriptions
       @charge_filter = charge_filter
     end
 
+    # IMPORTANT
+    # when making changes here, please make sure to bump the cache key so old values are immediately invalidated!
     def cache_key
       [
         'charge-usage',
+        CACHE_KEY_VERSION,
         charge.id,
         subscription.id,
         charge.updated_at.iso8601,

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
     it 'uses the Rails cache' do
       key = [
         'charge-usage',
+        Subscriptions::ChargeCacheService::CACHE_KEY_VERSION,
         charge.id,
         subscription.id,
         charge.updated_at.iso8601

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Subscriptions::ChargeCacheService, type: :service do
   describe '#cache_key' do
     it 'returns the cache key' do
       expect(cache_service.cache_key)
-        .to eq("charge-usage/#{charge.id}/#{subscription.id}/#{charge.updated_at.iso8601}")
+        .to eq("charge-usage/#{described_class::CACHE_KEY_VERSION}/#{charge.id}/#{subscription.id}/#{charge.updated_at.iso8601}")
     end
 
     context 'with a charge filter' do
@@ -20,7 +20,7 @@ RSpec.describe Subscriptions::ChargeCacheService, type: :service do
 
       it 'returns the cache key with the charge filter' do
         expect(cache_service.cache_key)
-          .to eq("charge-usage/#{charge.id}/#{subscription.id}/#{charge.updated_at.iso8601}/#{charge_filter.id}/#{charge_filter.updated_at.iso8601}")
+          .to eq("charge-usage/#{described_class::CACHE_KEY_VERSION}/#{charge.id}/#{subscription.id}/#{charge.updated_at.iso8601}/#{charge_filter.id}/#{charge_filter.updated_at.iso8601}")
       end
     end
   end


### PR DESCRIPTION
## Description

If fees were present in the cache they would be duplicated when moving to the new caching scheme.
this PR adds a key that we can bump when making changes to the caching.