### PR TITLE
feat(dunning): campaign creation requires organization premium add-on

### DIFF
--- a/app/services/dunning_campaigns/create_service.rb
+++ b/app/services/dunning_campaigns/create_service.rb
@@ -10,7 +10,7 @@ module DunningCampaigns
     end
 
     def call
-      # TODO: Restrict to dunning premium add-on
+      return result.forbidden_failure! unless organization.auto_dunning_enabled?
       # TODO: At least one threshold currency/amount pair is needed
 
       ActiveRecord::Base.transaction do

--- a/spec/graphql/mutations/dunning_campaigns/create_spec.rb
+++ b/spec/graphql/mutations/dunning_campaigns/create_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::DunningCampaigns::Create, type: :graphql do
   let(:required_permission) { "dunning_campaigns:create" }
-  let(:membership) { create(:membership) }
+  let(:organization) { create(:organization, premium_integrations: ["auto_dunning"]) }
+  let(:membership) { create(:membership, organization:) }
   let(:input) do
     {
       name: "Dunning campaign name",
@@ -42,6 +43,8 @@ RSpec.describe Mutations::DunningCampaigns::Create, type: :graphql do
     GQL
   end
 
+  around { |test| lago_premium!(&test) }
+
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "dunning_campaigns:create"
@@ -49,7 +52,7 @@ RSpec.describe Mutations::DunningCampaigns::Create, type: :graphql do
   it "creates a dunning campaign" do
     result = execute_graphql(
       current_user: membership.user,
-      current_organization: membership.organization,
+      current_organization: organization,
       permissions: required_permission,
       query: mutation,
       variables: {input:}

--- a/spec/services/dunning_campaigns/create_service_spec.rb
+++ b/spec/services/dunning_campaigns/create_service_spec.rb
@@ -2,11 +2,10 @@
 
 require "rails_helper"
 
-RSpec.describe DunningCampaigns::CreateService, type: :service do
+RSpec.describe DunningCampaigns::CreateService, type: :service, aggregate_failures: true do
   subject(:create_service) { described_class.new(organization:, params:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let(:organization) { create :organization }
   let(:params) do
     {
       name: "Dunning Campaign",
@@ -27,27 +26,59 @@ RSpec.describe DunningCampaigns::CreateService, type: :service do
   end
 
   describe "#call" do
-    it "creates a dunning campaign" do
-      expect { create_service.call }.to change(DunningCampaign, :count).by(1)
-        .and change(DunningCampaignThreshold, :count).by(2)
-    end
-
-    it "returns dunning campaign in the result" do
-      result = create_service.call
-      expect(result.dunning_campaign).to be_a(DunningCampaign)
-      expect(result.dunning_campaign.thresholds.first).to be_a(DunningCampaignThreshold)
-    end
-
-    context "with validation error" do
-      before { create(:dunning_campaign, organization: organization, code: "dunning-campaign") }
-
+    context "when lago freemium" do
       it "returns an error" do
         result = create_service.call
 
-        aggregate_failures do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+      end
+
+      it "does not update the dunning campaign" do
+        expect { create_service.call }.not_to change(DunningCampaign, :count)
+      end
+    end
+
+    context "when lago premium" do
+      around { |test| lago_premium!(&test) }
+
+      context "when no auto_dunning premium integration" do
+        it "returns an error" do
+          result = create_service.call
+
           expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:code]).to eq(["value_already_exist"])
+          expect(result.error).to be_a(BaseService::ForbiddenFailure)
+        end
+      end
+
+      context "when auto_dunning premium integration" do
+        let(:organization) do
+          create(:organization, premium_integrations: ["auto_dunning"])
+        end
+
+        it "creates a dunning campaign" do
+          expect { create_service.call }.to change(DunningCampaign, :count).by(1)
+            .and change(DunningCampaignThreshold, :count).by(2)
+        end
+
+        it "returns dunning campaign in the result" do
+          result = create_service.call
+          expect(result.dunning_campaign).to be_a(DunningCampaign)
+          expect(result.dunning_campaign.thresholds.first).to be_a(DunningCampaignThreshold)
+        end
+
+        context "with validation error" do
+          before do
+            create(:dunning_campaign, organization:, code: "dunning-campaign")
+          end
+
+          it "returns an error" do
+            result = create_service.call
+
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:code]).to eq(["value_already_exist"])
+          end
         end
       end
     end


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic
👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We're first automating the overdue balance payment request, before looking at individual invoices.

 ## Description

This change adds the requirement of premium license and premium addon enabled at organization to create dunning campaigns