### PR TITLE
feat(dunning): only one dunning campaign applied to organization on creation

### DIFF
--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -46,8 +46,9 @@ end
 #
 # Indexes
 #
-#  index_dunning_campaigns_on_organization_id           (organization_id)
-#  index_dunning_campaigns_on_organization_id_and_code  (organization_id,code) UNIQUE
+#  index_dunning_campaigns_on_organization_id             (organization_id)
+#  index_dunning_campaigns_on_organization_id_and_code    (organization_id,code) UNIQUE
+#  index_unique_applied_to_organization_per_organization  (organization_id) UNIQUE WHERE (applied_to_organization = true)
 #
 # Foreign Keys
 #

--- a/app/services/dunning_campaigns/create_service.rb
+++ b/app/services/dunning_campaigns/create_service.rb
@@ -14,6 +14,13 @@ module DunningCampaigns
       # TODO: At least one threshold currency/amount pair is needed
 
       ActiveRecord::Base.transaction do
+        if params[:applied_to_organization]
+          organization
+            .dunning_campaigns
+            .applied_to_organization
+            .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
+        end
+
         dunning_campaign = organization.dunning_campaigns.create!(
           applied_to_organization: params[:applied_to_organization],
           code: params[:code],
@@ -23,8 +30,6 @@ module DunningCampaigns
           description: params[:description],
           thresholds_attributes: params[:thresholds].map(&:to_h)
         )
-
-        # TODO: If the dunning campaign is applied to the organization, we need to remove the flag from all other dunning campaigns.
 
         result.dunning_campaign = dunning_campaign
       end

--- a/db/migrate/20241031123415_add_applied_to_organization_unique_index_to_dunning_campaigns.rb
+++ b/db/migrate/20241031123415_add_applied_to_organization_unique_index_to_dunning_campaigns.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddAppliedToOrganizationUniqueIndexToDunningCampaigns < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :dunning_campaigns, [:organization_id],
+      unique: true,
+      algorithm: :concurrently,
+      where: "applied_to_organization = true",
+      name: "index_unique_applied_to_organization_per_organization"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_31_102231) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_31_123415) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -548,6 +548,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_31_102231) do
     t.datetime "updated_at", null: false
     t.index ["organization_id", "code"], name: "index_dunning_campaigns_on_organization_id_and_code", unique: true
     t.index ["organization_id"], name: "index_dunning_campaigns_on_organization_id"
+    t.index ["organization_id"], name: "index_unique_applied_to_organization_per_organization", unique: true, where: "(applied_to_organization = true)"
   end
 
   create_table "error_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic
👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We're first automating the overdue balance payment request, before looking at individual invoices.

 ## Description

This change ensures only one campaign can be applied to organization on creation (per organization). Adds a database unique index to ensure data consistency.