### PR TITLE
feat(plan-charges-cascading): Support charge filters cascading

### DIFF
--- a/app/jobs/charges/update_job.rb
+++ b/app/jobs/charges/update_job.rb
@@ -4,8 +4,8 @@ module Charges
   class UpdateJob < ApplicationJob
     queue_as 'default'
 
-    def perform(charge:, params:, options:)
-      Charges::UpdateService.call(charge:, params:, options:).raise_if_error!
+    def perform(charge:, params:, cascade_options:)
+      Charges::UpdateService.call(charge:, params:, cascade_options:).raise_if_error!
     end
   end
 end

--- a/app/jobs/charges/update_job.rb
+++ b/app/jobs/charges/update_job.rb
@@ -4,8 +4,8 @@ module Charges
   class UpdateJob < ApplicationJob
     queue_as 'default'
 
-    def perform(charge:, params:, cascade:)
-      Charges::UpdateService.call(charge:, params:, cascade:).raise_if_error!
+    def perform(charge:, params:, options:)
+      Charges::UpdateService.call(charge:, params:, options:).raise_if_error!
     end
   end
 end

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -30,6 +30,12 @@ class ChargeFilter < ApplicationRecord
     end
   end
 
+  def to_h_with_discarded
+    @to_h_with_discarded ||= values.with_discarded.each_with_object({}) do |filter_value, result|
+      result[filter_value.billable_metric_filter.key] = filter_value.values
+    end
+  end
+
   def to_h_with_all_values
     @to_h_with_all_values ||= values.each_with_object({}) do |filter_value, result|
       values = filter_value.values

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -2,13 +2,16 @@
 
 module ChargeFilters
   class CreateOrUpdateBatchService < BaseService
-    def initialize(charge:, filters_params:, options: {})
+    def initialize(charge:, filters_params:, cascade_options: {})
       @charge = charge
       @filters_params = filters_params
-      @options = options
-      @cascade_updates = options[:cascade]
-      @parent_filters_attributes = options[:parent_filters] || []
-      @parent_filters = ChargeFilter.with_discarded.where(id: parent_filters_attributes.map { |f| f['id'] })
+      @cascade_updates = cascade_options[:cascade]
+      @parent_filters_attributes = cascade_options[:parent_filters] || []
+      @parent_filters = if parent_filters_attributes.blank?
+        ChargeFilter.none
+      else
+        ChargeFilter.with_discarded.where(id: parent_filters_attributes.map { |f| f['id'] })
+      end
 
       super
     end
@@ -87,7 +90,7 @@ module ChargeFilters
 
     private
 
-    attr_reader :charge, :filters_params, :cascade_updates, :options, :parent_filters, :parent_filters_attributes
+    attr_reader :charge, :filters_params, :cascade_updates, :parent_filters, :parent_filters_attributes
 
     def filters
       @filters ||= charge.filters.includes(values: :billable_metric_filter)

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -8,7 +8,7 @@ module ChargeFilters
       @options = options
       @cascade_updates = options[:cascade]
       @parent_filters_attributes = options[:parent_filters] || []
-      @parent_filters = ChargeFilter.with_discarded.where(id: parent_filters_attributes.map { |f| f['id']})
+      @parent_filters = ChargeFilter.with_discarded.where(id: parent_filters_attributes.map { |f| f['id'] })
 
       super
     end
@@ -40,7 +40,7 @@ module ChargeFilters
             end
 
             if parent_filter.blank? || parent_filter_properties(parent_filter) != filter.properties
-              filter.touch
+              filter.touch # rubocop:disable Rails/SkipsModelValidations
               result.filters << filter
 
               next
@@ -104,7 +104,7 @@ module ChargeFilters
     def remove_all
       ActiveRecord::Base.transaction do
         if cascade_updates
-          charge.filters.where(id: inherited_filter_ids).each { remove_filter(_1) }
+          charge.filters.where(id: inherited_filter_ids).find_each { remove_filter(_1) }
         else
           charge.filters.each { remove_filter(_1) }
         end

--- a/app/services/charges/update_service.rb
+++ b/app/services/charges/update_service.rb
@@ -2,11 +2,11 @@
 
 module Charges
   class UpdateService < BaseService
-    def initialize(charge:, params:, options: {})
+    def initialize(charge:, params:, cascade_options: {})
       @charge = charge
       @params = params
-      @options = options
-      @cascade = options[:cascade]
+      @cascade_options = cascade_options
+      @cascade = cascade_options[:cascade]
 
       super
     end
@@ -19,7 +19,7 @@ module Charges
         charge.charge_model = params[:charge_model] unless plan.attached_to_subscriptions?
         charge.invoice_display_name = params[:invoice_display_name] unless cascade
 
-        if !cascade || options[:equal_properties]
+        if !cascade || cascade_options[:equal_properties]
           properties = params.delete(:properties).presence || Charges::BuildDefaultPropertiesService.call(
             params[:charge_model]
           )
@@ -33,7 +33,7 @@ module Charges
           ChargeFilters::CreateOrUpdateBatchService.call(
             charge:,
             filters_params: filters.map(&:with_indifferent_access),
-            options:
+            cascade_options:
           ).raise_if_error!
         end
 
@@ -69,7 +69,7 @@ module Charges
 
     private
 
-    attr_reader :charge, :params, :options, :cascade
+    attr_reader :charge, :params, :cascade_options, :cascade
 
     delegate :plan, to: :charge
   end

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -130,7 +130,7 @@ module Plans
           Charges::UpdateJob.perform_later(
             charge: child_charge,
             params: payload_charge,
-            options: {
+            cascade_options: {
               cascade: true,
               parent_filters: charge.filters.map(&:attributes),
               equal_properties: charge.equal_properties?(child_charge)

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -126,8 +126,16 @@ module Plans
       plan.children.includes(:charges).find_each do |p|
         child_charge = p.charges.find { |c| c.parent_id == charge.id }
 
-        if child_charge && charge.equal_properties?(child_charge)
-          Charges::UpdateJob.perform_later(charge: child_charge, params: payload_charge, cascade: true)
+        if child_charge
+          Charges::UpdateJob.perform_later(
+            charge: child_charge,
+            params: payload_charge,
+            options: {
+              cascade: true,
+              parent_filters: charge.filters.map(&:attributes),
+              equal_properties: charge.equal_properties?(child_charge)
+            }
+          )
         end
       end
     end

--- a/spec/jobs/charges/update_job_spec.rb
+++ b/spec/jobs/charges/update_job_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Charges::UpdateJob, type: :job do
   end
 
   before do
-    allow(Charges::UpdateService).to receive(:call).with(charge:, params:, options:).and_return(BaseService::Result.new)
+    allow(Charges::UpdateService).to receive(:call).with(charge:, params:, cascade_options:).and_return(BaseService::Result.new)
   end
 
   it 'calls the service' do
-    described_class.perform_now(charge:, params:, options:)
+    described_class.perform_now(charge:, params:, cascade_options:)
 
     expect(Charges::UpdateService).to have_received(:call)
   end

--- a/spec/jobs/charges/update_job_spec.rb
+++ b/spec/jobs/charges/update_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Charges::UpdateJob, type: :job do
   let(:organization) { create(:organization) }
   let(:plan) { create(:plan, organization:) }
   let(:charge) { create(:standard_charge, plan:) }
-  let(:options) { {} }
+  let(:cascade_options) { {} }
   let(:params) do
     {
       properties: {}

--- a/spec/jobs/charges/update_job_spec.rb
+++ b/spec/jobs/charges/update_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Charges::UpdateJob, type: :job do
   let(:organization) { create(:organization) }
   let(:plan) { create(:plan, organization:) }
   let(:charge) { create(:standard_charge, plan:) }
-  let(:cascade) { true }
+  let(:options) { {} }
   let(:params) do
     {
       properties: {}
@@ -14,11 +14,11 @@ RSpec.describe Charges::UpdateJob, type: :job do
   end
 
   before do
-    allow(Charges::UpdateService).to receive(:call).with(charge:, params:, cascade:).and_return(BaseService::Result.new)
+    allow(Charges::UpdateService).to receive(:call).with(charge:, params:, options:).and_return(BaseService::Result.new)
   end
 
   it 'calls the service' do
-    described_class.perform_now(charge:, params:, cascade:)
+    described_class.perform_now(charge:, params:, options:)
 
     expect(Charges::UpdateService).to have_received(:call)
   end

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -375,6 +375,30 @@ RSpec.describe ChargeFilter, type: :model do
     end
   end
 
+  describe '#to_h_with_discarded' do
+    subject(:charge_filter) { create(:charge_filter) }
+
+    let(:card) { create(:billable_metric_filter, key: 'card', values: %w[credit debit]) }
+    let(:scheme) { create(:billable_metric_filter, key: 'scheme', values: %w[visa mastercard]) }
+    let(:values) do
+      [
+        create(:charge_filter_value, charge_filter:, values: ['credit'], billable_metric_filter: card).discard,
+        create(:charge_filter_value, charge_filter:, values: ['visa'], billable_metric_filter: scheme).discard
+      ]
+    end
+
+    before { values }
+
+    it 'returns the values as a hash' do
+      expect(charge_filter.to_h_with_discarded).to eq(
+        {
+          'card' => ['credit'],
+          'scheme' => ['visa']
+        }
+      )
+    end
+  end
+
   describe '#to_h_with_all_values' do
     subject(:charge_filter) { build(:charge_filter, values:) }
 

--- a/spec/services/charge_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/charge_filters/create_or_update_batch_service_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
-  subject(:service) { described_class.call(charge:, filters_params:, options:) }
+  subject(:service) { described_class.call(charge:, filters_params:, cascade_options:) }
 
   let(:charge) { create(:standard_charge) }
   let(:filters_params) { {} }
-  let(:options) { {} }
+  let(:cascade_options) { {} }
 
   let(:card_location_filter) do
     create(
@@ -80,7 +80,7 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
             values: [card_location_filter.values.first]
           )
         end
-        let(:options) do
+        let(:cascade_options) do
           {
             cascade: true,
             parent_filters: charge_parent.filters.map(&:attributes)
@@ -275,7 +275,7 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
           )
         ]
       end
-      let(:options) do
+      let(:cascade_options) do
         {
           cascade: true,
           parent_filters: charge_parent.filters.map(&:attributes)

--- a/spec/services/charge_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/charge_filters/create_or_update_batch_service_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
-  subject(:service) { described_class.call(charge:, filters_params:) }
+  subject(:service) { described_class.call(charge:, filters_params:, options:) }
 
   let(:charge) { create(:standard_charge) }
   let(:filters_params) { {} }
+  let(:options) { {} }
 
   let(:card_location_filter) do
     create(
@@ -57,6 +58,51 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
       it 'discards all filters and the related values' do
         expect { service }.to change { filter.reload.discarded? }.to(true)
           .and change { filter_value.reload.discarded? }.to(true)
+      end
+
+      context 'with cascade_updates set to true and existing filters' do
+        let(:charge_parent) { create(:standard_charge) }
+        let(:filter_extra) { create(:charge_filter, charge:) }
+        let(:filter_parent) { create(:charge_filter, charge: charge_parent) }
+        let(:filter_value_extra) do
+          create(
+            :charge_filter_value,
+            charge_filter: filter_extra,
+            billable_metric_filter: card_location_filter,
+            values: [card_location_filter.values.second]
+          )
+        end
+        let(:filter_value_parent) do
+          create(
+            :charge_filter_value,
+            charge_filter: filter_parent,
+            billable_metric_filter: card_location_filter,
+            values: [card_location_filter.values.first]
+          )
+        end
+        let(:options) do
+          {
+            cascade: true,
+            parent_filters: charge_parent.filters.map(&:attributes),
+          }
+        end
+
+        before do
+          filter_value_extra
+          filter_value_parent
+        end
+
+        it 'discards all filters and the related values that are inherited from parent' do
+          expect { service }.to change { filter.reload.discarded? }.to(true)
+            .and change { filter_value.reload.discarded? }.to(true)
+        end
+
+        it 'does not discard filters and the related values that are defined on child' do
+          service
+
+          expect(filter_extra.reload.discarded?).to eq(false)
+          expect(filter_value_extra.reload.discarded?).to eq(false)
+        end
       end
     end
   end
@@ -198,6 +244,128 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
         new_filter = result.filters.first
         expect(new_filter.values.count).to eq(2)
         expect(new_filter.values.pluck(:values).flatten).to match_array(%w[domestic visa mastercard])
+      end
+    end
+
+    context 'with cascading option' do
+      let(:charge_parent) { create(:standard_charge) }
+      let(:filter_extra) { create(:charge_filter, charge:) }
+      let(:filter_parent) { create(:charge_filter, properties: filter.properties, charge: charge_parent) }
+      let(:filter_value_extra) do
+        create(
+          :charge_filter_value,
+          charge_filter: filter_extra,
+          billable_metric_filter: card_location_filter,
+          values: [card_location_filter.values.second]
+        )
+      end
+      let(:filter_values_parent) do
+        [
+          create(
+            :charge_filter_value,
+            charge_filter: filter_parent,
+            billable_metric_filter: card_location_filter,
+            values: ['domestic']
+          ),
+          create(
+            :charge_filter_value,
+            charge_filter: filter_parent,
+            billable_metric_filter: scheme_filter,
+            values: ['visa']
+          )
+        ]
+      end
+      let(:options) do
+        {
+          cascade: true,
+          parent_filters: charge_parent.filters.map(&:attributes),
+        }
+      end
+
+      before do
+        filter_values_parent
+        filter_value_extra
+      end
+
+      it 'updates the filter if child and parent properties are the same' do
+        expect { service }.not_to change(ChargeFilter, :count)
+
+        expect(filter.reload).to have_attributes(
+          invoice_display_name: 'New display name',
+          properties: {'amount' => '20'}
+        )
+        expect(filter.values.count).to eq(2)
+        expect(filter.values.pluck(:values).flatten).to match_array(%w[domestic visa])
+      end
+
+      context 'when properties are already overridden' do
+        let(:properties) { {amount: '755'} }
+        let(:filter_parent) { create(:charge_filter, properties:, charge: charge_parent) }
+
+        it 'does not update the filter' do
+          expect { service }.not_to change(ChargeFilter, :count)
+
+          expect(filter.reload).to have_attributes(
+            invoice_display_name: nil,
+            properties: charge.properties
+          )
+          expect(filter.values.count).to eq(2)
+          expect(filter.values.pluck(:values).flatten).to match_array(%w[domestic visa])
+        end
+      end
+
+      context 'when changing filter values' do
+        let(:filters_params) do
+          [
+            {
+              values: {
+                card_location_filter.key => ['international'],
+                scheme_filter.key => ['mastercard']
+              },
+              invoice_display_name: 'New display name',
+              properties: {amount: '20'}
+            }
+          ]
+        end
+
+        it 'creates a new filter and removes only the one that matches with parent' do
+          result = service
+
+          expect(result.filters.count).to eq(1)
+          expect(filter.reload).to be_discarded
+          expect(filter_value_extra.reload).not_to be_discarded
+
+          new_filter = result.filters.first
+          expect(new_filter.values.count).to eq(2)
+          expect(new_filter.values.pluck(:values).flatten).to match_array(%w[international mastercard])
+        end
+      end
+
+      context 'when adding a value into filter values' do
+        let(:filters_params) do
+          [
+            {
+              values: {
+                card_location_filter.key => ['domestic'],
+                scheme_filter.key => %w[visa mastercard]
+              },
+              invoice_display_name: 'New display name',
+              properties: {amount: '20'}
+            }
+          ]
+        end
+
+        it 'creates a new filter and removes only the one that matches with parent' do
+          result = service
+
+          expect(result.filters.count).to eq(1)
+          expect(filter.reload).to be_discarded
+          expect(filter_value_extra.reload).not_to be_discarded
+
+          new_filter = result.filters.first
+          expect(new_filter.values.count).to eq(2)
+          expect(new_filter.values.pluck(:values).flatten).to match_array(%w[domestic visa mastercard])
+        end
       end
     end
   end

--- a/spec/services/charge_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/charge_filters/create_or_update_batch_service_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
         let(:options) do
           {
             cascade: true,
-            parent_filters: charge_parent.filters.map(&:attributes),
+            parent_filters: charge_parent.filters.map(&:attributes)
           }
         end
 
@@ -278,7 +278,7 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
       let(:options) do
         {
           cascade: true,
-          parent_filters: charge_parent.filters.map(&:attributes),
+          parent_filters: charge_parent.filters.map(&:attributes)
         }
       end
 

--- a/spec/services/charges/update_service_spec.rb
+++ b/spec/services/charges/update_service_spec.rb
@@ -3,12 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe Charges::UpdateService, type: :service do
-  subject(:update_service) { described_class.new(charge:, params:, cascade:) }
+  subject(:update_service) { described_class.new(charge:, params:, options:) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:plan) { create(:plan, organization:) }
-  let(:cascade) { false }
+  let(:options) do
+    {
+      cascade: false
+    }
+  end
 
   describe '#call' do
     let(:sum_billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
@@ -99,16 +103,60 @@ RSpec.describe Charges::UpdateService, type: :service do
     end
 
     context 'when cascade is true' do
-      let(:cascade) { true }
+      let(:options) do
+        {
+          cascade: true,
+          parent_filters: [],
+          equal_properties: true
+        }
+      end
 
-      it 'updates only charge properties' do
+      it 'updates charge properties and filters' do
         update_service.call
 
         expect(charge.reload).to have_attributes(
           properties: {'amount' => '0'}
         )
 
-        expect(charge.filters.count).to eq(0)
+        expect(charge.filters.first).to have_attributes(
+          invoice_display_name: 'Card filter',
+          properties: {'amount' => '90'}
+        )
+        expect(charge.filters.first.values.first).to have_attributes(
+          billable_metric_filter_id: billable_metric_filter.id,
+          values: ['card']
+        )
+      end
+
+      context 'with charge properties already overridden' do
+        let(:options) do
+          {
+            cascade: true,
+            parent_filters: [],
+            equal_properties: false
+          }
+        end
+        let(:params) do
+          {
+            id: charge&.id,
+            billable_metric_id: sum_billable_metric.id,
+            charge_model: 'standard',
+            pay_in_advance: true,
+            prorated: true,
+            invoiceable: false,
+            properties: {
+              amount: '400'
+            }
+          }
+        end
+
+        it 'does not update charge properties' do
+          update_service.call
+
+          expect(charge.reload).to have_attributes(
+            properties: {'amount' => '300'}
+          )
+        end
       end
     end
   end

--- a/spec/services/charges/update_service_spec.rb
+++ b/spec/services/charges/update_service_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Charges::UpdateService, type: :service do
-  subject(:update_service) { described_class.new(charge:, params:, options:) }
+  subject(:update_service) { described_class.new(charge:, params:, cascade_options:) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:plan) { create(:plan, organization:) }
-  let(:options) do
+  let(:cascade_options) do
     {
       cascade: false
     }
@@ -103,7 +103,7 @@ RSpec.describe Charges::UpdateService, type: :service do
     end
 
     context 'when cascade is true' do
-      let(:options) do
+      let(:cascade_options) do
         {
           cascade: true,
           parent_filters: [],
@@ -129,7 +129,7 @@ RSpec.describe Charges::UpdateService, type: :service do
       end
 
       context 'with charge properties already overridden' do
-        let(:options) do
+        let(:cascade_options) do
           {
             cascade: true,
             parent_filters: [],


### PR DESCRIPTION
## Context

Currently when plan is updated, these changes are not cascaded to all the children plans.

## Description

This PR supports cascading of charge filters. There are several rules:

- If main attribute that supports cascading is not true -> cascading is disabled
- Charge filter properties are cascaded only if the same properties are not already overridden in the child filter
- We need to ensure that all filters that are specific to the child are not changed in any way (extra filters that don't exist on parent)
- When performing cascading, we are basically at the same time updating parent filters and children filters. However, we need to ensure that logic which handles cascading on children filter uses parent filter attributes **before** update for comparison. That's why we pass parent filter attributes before any update to the children logic.