### PR TITLE
feat(dunning): validate dunning campaign has at least one threshold

### DIFF
--- a/app/services/dunning_campaigns/create_service.rb
+++ b/app/services/dunning_campaigns/create_service.rb
@@ -11,7 +11,7 @@ module DunningCampaigns
 
     def call
       return result.forbidden_failure! unless organization.auto_dunning_enabled?
-      # TODO: At least one threshold currency/amount pair is needed
+      return result.validation_failure!(errors: {thresholds: ["can't be blank"]}) if params[:thresholds].blank?
 
       ActiveRecord::Base.transaction do
         if params[:applied_to_organization]

--- a/spec/services/dunning_campaigns/bulk_process_service_spec.rb
+++ b/spec/services/dunning_campaigns/bulk_process_service_spec.rb
@@ -390,7 +390,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
       end
     end
 
-    context "when neither organizaiton nor customer has an applied dunning campaign" do
+    context "when neither organization nor customer has an applied dunning campaign" do
       let(:dunning_campaign) { create :dunning_campaign, organization:, applied_to_organization: false }
 
       let(:dunning_campaign_threshold) do
@@ -403,7 +403,6 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
       end
 
       before do
-        dunning_campaign
         dunning_campaign_threshold
         invoice_1
       end

--- a/spec/services/dunning_campaigns/create_service_spec.rb
+++ b/spec/services/dunning_campaigns/create_service_spec.rb
@@ -121,6 +121,20 @@ RSpec.describe DunningCampaigns::CreateService, type: :service, aggregate_failur
             expect(result.error.messages[:code]).to eq(["value_already_exist"])
           end
         end
+
+        context "without thresholds" do
+          let(:thresholds) { [] }
+
+          it "returns an error" do
+            result = create_service.call
+
+            aggregate_failures do
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::ValidationFailure)
+              expect(result.error.messages[:thresholds]).to eq(["can't be blank"])
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
 ## Roadmap
 
👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We're first automating the overdue balance payment request, before looking at individual invoices.

 ## Description

This change introduces validation to ensure dunning campaign at least has one threshold.