### PR TITLE
feat(InvoiceError) - Add InvoiceError

### DIFF
--- a/app/jobs/clock/retry_generating_subscription_invoices_job.rb
+++ b/app/jobs/clock/retry_generating_subscription_invoices_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Clock
+  class RetryGeneratingSubscriptionInvoicesJob < ApplicationJob
+    include SentryCronConcern
+
+    queue_as 'clock'
+
+    THRESHOLD = -> { 1.day.ago }
+
+    def perform
+      Invoice.subscription.generating.where.not(id: InvoiceError.select(:id)).where('created_at < ?', THRESHOLD.call).find_each do |invoice|
+        next unless invoice.invoice_subscriptions.any?
+        invoicing_reasons = invoice.invoice_subscriptions.pluck(:invoicing_reason).uniq
+        invoicing_reason = (invoicing_reasons.size == 1) ? invoicing_reasons.first : :upgrading
+        BillSubscriptionJob.perform_later(
+          subscriptions: invoice.subscriptions.to_a,
+          timestamp: invoice.invoice_subscriptions.first.timestamp,
+          invoicing_reason:,
+          invoice:,
+          skip_charges: invoice.skip_charges
+        )
+      end
+    end
+  end
+end

--- a/app/models/clickhouse/events_raw.rb
+++ b/app/models/clickhouse/events_raw.rb
@@ -50,13 +50,12 @@ end
 #
 # Table name: events_raw
 #
-#  code                       :string           not null, primary key
-#  ingested_at                :datetime         not null
+#  code                       :string           not null
 #  precise_total_amount_cents :decimal(40, 15)
 #  properties                 :string           not null
-#  timestamp                  :datetime         not null, primary key
+#  timestamp                  :datetime         not null
 #  external_customer_id       :string           not null
-#  external_subscription_id   :string           not null, primary key
-#  organization_id            :string           not null, primary key
-#  transaction_id             :string           not null, primary key
+#  external_subscription_id   :string           not null
+#  organization_id            :string           not null
+#  transaction_id             :string           not null
 #

--- a/app/models/invoice_error.rb
+++ b/app/models/invoice_error.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class InvoiceError < ApplicationRecord
+  # NOTE! Invoice errors will have the same id as the invoice they belong to.
+  def self.create_for(invoice:, error:)
+    return unless invoice
+
+    create(id: invoice.id,
+      backtrace: error.backtrace,
+      error: error.inspect.to_json,
+      invoice: invoice.to_json(except: :file),
+      subscriptions: invoice.subscriptions.to_json)
+  end
+end
+
+# == Schema Information
+#
+# Table name: invoice_errors
+#
+#  id            :uuid             not null, primary key
+#  backtrace     :text
+#  error         :json
+#  invoice       :json
+#  subscriptions :json
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#

--- a/clock.rb
+++ b/clock.rb
@@ -58,6 +58,11 @@ module Clockwork
       .set(sentry: {"slug" => 'lago_bill_customers', "cron" => '10 */1 * * *'})
       .perform_later
   end
+  every(1.hour, 'schedule:retry_generating_subscription_invoices', at: '*:30') do
+    Clock::RetryGeneratingSubscriptionInvoicesJob
+      .set(sentry: {"slug" => 'lago_retry_invoices', "cron" => '30 */1 * * *'})
+      .perform_later
+  end
 
   every(1.hour, 'schedule:finalize_invoices', at: '*:20') do
     Clock::FinalizeInvoicesJob

--- a/db/migrate/20241031102231_create_invoice_errors.rb
+++ b/db/migrate/20241031102231_create_invoice_errors.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateInvoiceErrors < ActiveRecord::Migration[7.1]
+  def change
+    create_table :invoice_errors, id: :uuid do |t|
+      t.text :backtrace
+      t.json :invoice
+      t.json :subscriptions
+      t.json :error
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_25_081408) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_31_102231) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -777,6 +777,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_25_081408) do
     t.index ["membership_id"], name: "index_invites_on_membership_id"
     t.index ["organization_id"], name: "index_invites_on_organization_id"
     t.index ["token"], name: "index_invites_on_token", unique: true
+  end
+
+  create_table "invoice_errors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "backtrace"
+    t.json "invoice"
+    t.json "subscriptions"
+    t.json "error"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "invoice_metadata", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/clockwork_spec.rb
+++ b/spec/clockwork_spec.rb
@@ -115,6 +115,27 @@ describe Clockwork do
     end
   end
 
+  describe 'schedule:retry_generating_subscription_invoices' do
+    let(:job) { 'schedule:retry_generating_subscription_invoices' }
+    let(:start_time) { Time.zone.parse('1 Apr 2022 00:01:00') }
+    let(:end_time) { Time.zone.parse('1 Apr 2022 01:01:00') }
+
+    it 'enqueues a Clock::RetryGeneratingSubscriptionInvoiceJob' do
+      Clockwork::Test.run(
+        file: clock_file,
+        start_time:,
+        end_time:,
+        tick_speed: 1.second
+      )
+
+      expect(Clockwork::Test).to be_ran_job(job)
+      expect(Clockwork::Test.times_run(job)).to eq(1)
+
+      Clockwork::Test.block_for(job).call
+      expect(Clock::RetryGeneratingSubscriptionInvoicesJob).to have_been_enqueued
+    end
+  end
+
   describe 'schedule:compute_daily_usage' do
     let(:job) { 'schedule:compute_daily_usage' }
     let(:start_time) { Time.zone.parse('1 Apr 2022 00:01:00') }

--- a/spec/jobs/clock/retry_generating_subscription_invoices_job_spec.rb
+++ b/spec/jobs/clock/retry_generating_subscription_invoices_job_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Clock::RetryGeneratingSubscriptionInvoicesJob, job: true do
+  subject { described_class }
+
+  describe '.perform' do
+    let(:old_generating_invoice) { create(:invoice, :generating, created_at: 5.days.ago) }
+
+    before do
+      old_generating_invoice
+    end
+
+    it "does not enqueue a BillSubscriptionJob for this invoice (missing subscriptions)" do
+      expect do
+        described_class.perform_now
+      end.not_to have_enqueued_job(BillSubscriptionJob)
+    end
+
+    context "with an actual invoice that should be retried" do
+      let(:old_generating_invoice) { create(:invoice, :subscription, created_at: 5.days.ago) }
+
+      before do
+        old_generating_invoice.update(status: :generating)
+      end
+
+      it "does enqueue a BillSubscriptionJob for this invoice " do
+        expect do
+          described_class.perform_now
+        end.to have_enqueued_job(BillSubscriptionJob)
+      end
+
+      context "with an existing invoice error" do
+        let(:invoice_error) { InvoiceError.create(id: old_generating_invoice.id) }
+
+        before do
+          invoice_error
+        end
+
+        it "does not enqueue a BillSubscriptionJob for this invoice" do
+          expect do
+            described_class.perform_now
+          end.not_to have_enqueued_job(BillSubscriptionJob)
+        end
+      end
+    end
+
+    context "with an addon" do
+      let(:old_generating_invoice) { create(:invoice, :add_on, created_at: 5.days.ago) }
+
+      before do
+        old_generating_invoice.update(status: :generating)
+      end
+
+      it "does not enqueue a BillSubscriptionJob for this invoice" do
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(BillSubscriptionJob)
+      end
+    end
+  end
+end

--- a/spec/models/invoice_error_spec.rb
+++ b/spec/models/invoice_error_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InvoiceError, type: :model do
+  let(:invoice) { create(:invoice, :generating) }
+  let(:result) { BaseService::Result.new }
+  let(:error) { BaseService::ValidationFailure.new(result, messages: messages) }
+  let(:messages) { ["message1", "message2"] }
+
+  let(:error_with_backtrace) do
+    error = OpenStruct.new
+    error.backtrace = "backtrace"
+    error
+  end
+
+  describe ".create_for" do
+    it "does nothing if the invoice is nil" do
+      expect(described_class.create_for(invoice: nil, error:)).to eq(nil)
+    end
+
+    it "creates an invoice error with the same id as the invoice" do
+      invoice_error = described_class.create_for(invoice:, error:)
+      expect(invoice_error.id).to eq(invoice.id)
+    end
+
+    it "stores the error in the error field" do
+      invoice_error = described_class.create_for(invoice:, error:)
+      expect(invoice_error.error).to eq(error.inspect.to_json)
+    end
+
+    it "stores the backtrace in the backtrace field" do
+      invoice_error = described_class.create_for(invoice:, error: error_with_backtrace)
+      expect(invoice_error.backtrace).to eq("backtrace")
+    end
+
+    it "stores the subscriptions in the subscriptions field" do
+      invoice_error = described_class.create_for(invoice:, error:)
+      expect(invoice_error.subscriptions).to eq("[]")
+    end
+  end
+end


### PR DESCRIPTION
## Description

When invoices fails to generate it's hard to understand what's going wrong.
We're now automatically retrying invoices that are stuck in generating state. We will also create InvoiceError objects for invoices that fail to generate and finalize.