### PR TITLE
feat(rounding): Expose rounding attributes to APIs

### DIFF
--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -122,6 +122,8 @@ module Api
           :recurring,
           :field_name,
           :expression,
+          :rounding_function,
+          :rounding_precision,
           filters: [:key, {values: []}]
         )
       end

--- a/app/graphql/types/billable_metrics/create_input.rb
+++ b/app/graphql/types/billable_metrics/create_input.rb
@@ -12,6 +12,8 @@ module Types
       argument :field_name, String, required: false
       argument :name, String, required: true
       argument :recurring, Boolean, required: false
+      argument :rounding_function, Types::BillableMetrics::RoundingFunctionEnum, required: false
+      argument :rounding_precision, Integer, required: false
       argument :weighted_interval, Types::BillableMetrics::WeightedIntervalEnum, required: false
 
       argument :filters, [Types::BillableMetricFilters::Input], required: false

--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -27,6 +27,9 @@ module Types
       field :recurring, Boolean, null: false
       field :subscriptions_count, Integer, null: false
 
+      field :rounding_function, Types::BillableMetrics::RoundingFunctionEnum, null: true
+      field :rounding_precision, Integer, null: true
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/billable_metrics/rounding_function_enum.rb
+++ b/app/graphql/types/billable_metrics/rounding_function_enum.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module BillableMetrics
+    class RoundingFunctionEnum < Types::BaseEnum
+      BillableMetric::ROUNDING_FUNCTIONS.values.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/billable_metrics/update_input.rb
+++ b/app/graphql/types/billable_metrics/update_input.rb
@@ -14,6 +14,8 @@ module Types
       argument :field_name, String, required: false
       argument :name, String, required: true
       argument :recurring, Boolean, required: false
+      argument :rounding_function, Types::BillableMetrics::RoundingFunctionEnum, required: false
+      argument :rounding_precision, Integer, required: false
       argument :weighted_interval, Types::BillableMetrics::WeightedIntervalEnum, required: false
 
       argument :filters, [Types::BillableMetricFilters::Input], required: false

--- a/app/serializers/v1/billable_metric_serializer.rb
+++ b/app/serializers/v1/billable_metric_serializer.rb
@@ -11,6 +11,8 @@ module V1
         aggregation_type: model.aggregation_type,
         weighted_interval: model.weighted_interval,
         recurring: model.recurring,
+        rounding_function: model.rounding_function,
+        rounding_precision: model.rounding_precision,
         created_at: model.created_at.iso8601,
         field_name: model.field_name,
         expression: model.expression,

--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -23,6 +23,8 @@ module BillableMetrics
           recurring: args[:recurring] || false,
           aggregation_type: args[:aggregation_type]&.to_sym,
           field_name: args[:field_name],
+          rounding_function: args[:rounding_function]&.to_sym,
+          rounding_precision: args[:rounding_precision],
           weighted_interval: args[:weighted_interval]&.to_sym,
           expression: args[:expression]
         )

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -38,6 +38,8 @@ module BillableMetrics
         billable_metric.weighted_interval = params[:weighted_interval]&.to_sym if params.key?(:weighted_interval)
         billable_metric.field_name = params[:field_name] if params.key?(:field_name)
         billable_metric.recurring = params[:recurring] if params.key?(:recurring)
+        billable_metric.rounding_function = params[:rounding_function] if params.key?(:rounding_function)
+        billable_metric.rounding_precision = params[:rounding_precision] if params.key?(:rounding_precision)
         billable_metric.weighted_interval = params[:weighted_interval]&.to_sym if params.key?(:weighted_interval)
         billable_metric.expression = params[:expression] if params.key?(:expression)
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -251,6 +251,8 @@ type BillableMetric {
   organization: Organization
   plansCount: Int!
   recurring: Boolean!
+  roundingFunction: RoundingFunctionEnum
+  roundingPrecision: Int
   subscriptionsCount: Int!
   updatedAt: ISO8601DateTime!
   weightedInterval: WeightedIntervalEnum
@@ -1859,6 +1861,8 @@ input CreateBillableMetricInput {
   filters: [BillableMetricFiltersInput!]
   name: String!
   recurring: Boolean
+  roundingFunction: RoundingFunctionEnum
+  roundingPrecision: Int
   weightedInterval: WeightedIntervalEnum
 }
 
@@ -6790,6 +6794,12 @@ input RevokeMembershipInput {
   id: ID!
 }
 
+enum RoundingFunctionEnum {
+  ceil
+  floor
+  round
+}
+
 type SanitizedApiKey {
   createdAt: ISO8601DateTime!
   id: ID!
@@ -7832,6 +7842,8 @@ input UpdateBillableMetricInput {
   id: String!
   name: String!
   recurring: Boolean
+  roundingFunction: RoundingFunctionEnum
+  roundingPrecision: Int
   weightedInterval: WeightedIntervalEnum
 }
 

--- a/schema.json
+++ b/schema.json
@@ -2317,6 +2317,34 @@
               ]
             },
             {
+              "name": "roundingFunction",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "RoundingFunctionEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "roundingPrecision",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "subscriptionsCount",
               "description": null,
               "type": {
@@ -6779,6 +6807,30 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "roundingFunction",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "RoundingFunctionEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "roundingPrecision",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "defaultValue": null,
@@ -35340,6 +35392,35 @@
           "enumValues": null
         },
         {
+          "kind": "ENUM",
+          "name": "RoundingFunctionEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "round",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ceil",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "floor",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
           "kind": "OBJECT",
           "name": "SanitizedApiKey",
           "description": null,
@@ -38368,6 +38449,30 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "roundingFunction",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "RoundingFunctionEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "roundingPrecision",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/types/billable_metrics/create_input_spec.rb
+++ b/spec/graphql/types/billable_metrics/create_input_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Types::BillableMetrics::CreateInput do
   it { is_expected.to accept_argument(:field_name).of_type('String') }
   it { is_expected.to accept_argument(:name).of_type('String!') }
   it { is_expected.to accept_argument(:recurring).of_type('Boolean') }
+  it { is_expected.to accept_argument(:rounding_function).of_type('RoundingFunctionEnum') }
+  it { is_expected.to accept_argument(:rounding_precision).of_type('Int') }
   it { is_expected.to accept_argument(:weighted_interval).of_type('WeightedIntervalEnum') }
   it { is_expected.to accept_argument(:filters).of_type('[BillableMetricFiltersInput!]') }
 end

--- a/spec/graphql/types/billable_metrics/object_spec.rb
+++ b/spec/graphql/types/billable_metrics/object_spec.rb
@@ -24,4 +24,6 @@ RSpec.describe Types::BillableMetrics::Object do
   it { is_expected.to have_field(:deleted_at).of_type('ISO8601DateTime') }
   it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
   it { is_expected.to have_field(:integration_mappings).of_type('[Mapping!]') }
+  it { is_expected.to have_field(:rounding_function).of_type('RoundingFunctionEnum') }
+  it { is_expected.to have_field(:rounding_precision).of_type('Int') }
 end

--- a/spec/graphql/types/billable_metrics/update_input_spec.rb
+++ b/spec/graphql/types/billable_metrics/update_input_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Types::BillableMetrics::UpdateInput do
   it { is_expected.to accept_argument(:field_name).of_type('String') }
   it { is_expected.to accept_argument(:name).of_type('String!') }
   it { is_expected.to accept_argument(:recurring).of_type('Boolean') }
+  it { is_expected.to accept_argument(:rounding_function).of_type('RoundingFunctionEnum') }
+  it { is_expected.to accept_argument(:rounding_precision).of_type('Int') }
   it { is_expected.to accept_argument(:weighted_interval).of_type('WeightedIntervalEnum') }
   it { is_expected.to accept_argument(:filters).of_type('[BillableMetricFiltersInput!]') }
 end

--- a/spec/requests/api/v1/billable_metrics_controller_spec.rb
+++ b/spec/requests/api/v1/billable_metrics_controller_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
         aggregation_type: 'sum_agg',
         field_name: 'amount_sum',
         expression: '1 + 2',
-        recurring: true
+        recurring: true,
+        rounding_function: 'round',
+        rounding_precision: 2
       }
     end
 
@@ -28,6 +30,8 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
       expect(json[:billable_metric][:created_at]).to be_present
       expect(json[:billable_metric][:recurring]).to eq(create_params[:recurring])
       expect(json[:billable_metric][:expression]).to eq(create_params[:expression])
+      expect(json[:billable_metric][:rounding_function]).to eq(create_params[:rounding_function])
+      expect(json[:billable_metric][:rounding_precision]).to eq(create_params[:rounding_precision])
       expect(json[:billable_metric][:filters]).to eq([])
     end
 
@@ -49,10 +53,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
 
         expect(response).to have_http_status(:success)
         expect(json[:billable_metric][:lago_id]).to be_present
-        expect(json[:billable_metric][:recurring]).to eq(
-          create_params[:recurring
-                    ]
-        )
+        expect(json[:billable_metric][:recurring]).to eq(create_params[:recurring])
         expect(json[:billable_metric][:aggregation_type]).to eq('weighted_sum_agg')
         expect(json[:billable_metric][:weighted_interval]).to eq('seconds')
       end

--- a/spec/serializers/v1/billable_metric_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_serializer_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe ::V1::BillableMetricSerializer do
       expect(result['billable_metric']['aggregation_type']).to eq(billable_metric.aggregation_type)
       expect(result['billable_metric']['field_name']).to eq(billable_metric.field_name)
       expect(result['billable_metric']['created_at']).to eq(billable_metric.created_at.iso8601)
+      expect(result['billable_metric']['rounding_function']).to eq(billable_metric.rounding_function)
+      expect(result['billable_metric']['rounding_precision']).to eq(billable_metric.rounding_precision)
       expect(result['billable_metric']['weighted_interval']).to eq(billable_metric.weighted_interval)
       expect(result['billable_metric']['expression']).to eq(billable_metric.expression)
       expect(result['billable_metric']['active_subscriptions_count']).to eq(0)

--- a/spec/services/billable_metrics/create_service_spec.rb
+++ b/spec/services/billable_metrics/create_service_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe BillableMetrics::CreateService, type: :service do
         organization_id: organization.id,
         aggregation_type: "count_agg",
         expression: "1 + 2",
+        rounding_function: "ceil",
+        rounding_precision: 2,
         recurring: false
       }
     end


### PR DESCRIPTION
## Context

In addition to the [flexible aggregation](https://github.com/119ef63110d2803db639f0db37a3b135?pvs=25), some customers wants to round the output of the aggregation.

## Description

This PR exposes `rounding_function` and `rounding_precision` fields to REST and GraphQL APIs. It also update `BillableMetrics#CreateService` and `BillableMetrics#UpdateService`
