### PR TITLE
feat(dunning): schedule process dunning campaigns jobs every hour at 45'

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -127,4 +127,10 @@ module Clockwork
       .set(sentry: {"slug" => 'lago_compute_daily_usage', "cron" => '15 */1 * * *'})
       .perform_later
   end
+
+  every(1.hour, "schedule:process_dunning_campaigns", at: "*:45") do
+    Clock::ProcessDunningCampaignsJob
+      .set(sentry: {"slug" => "lago_process_dunning_campaigns", "cron" => "45 */1 * * *"})
+      .perform_later
+  end
 end

--- a/spec/clockwork_spec.rb
+++ b/spec/clockwork_spec.rb
@@ -156,4 +156,25 @@ describe Clockwork do
       expect(Clock::ComputeAllDailyUsagesJob).to have_been_enqueued
     end
   end
+
+  describe "schedule:process_dunning_campaigns" do
+    let(:job) { "schedule:process_dunning_campaigns" }
+    let(:start_time) { Time.zone.parse("1 Apr 2022 00:01:00") }
+    let(:end_time) { Time.zone.parse("1 Apr 2022 01:01:00") }
+
+    it "enqueue a process dunning campaigns job" do
+      Clockwork::Test.run(
+        file: clock_file,
+        start_time:,
+        end_time:,
+        tick_speed: 1.second
+      )
+
+      expect(Clockwork::Test).to be_ran_job(job)
+      expect(Clockwork::Test.times_run(job)).to eq(1)
+
+      Clockwork::Test.block_for(job).call
+      expect(Clock::ProcessDunningCampaignsJob).to have_been_enqueued
+    end
+  end
 end


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We're first automating the overdue balance payment request, before looking at individual invoices.

 ## Description

This change adds the scheduler to run the ProcessDunningCampaigns job every hour at 45 minute.