### PR TITLE
fix(bug): invoicing reason nil when calling from RetryGeneratingSubscriptionInvoicesJob

### DIFF
--- a/app/jobs/clock/retry_generating_subscription_invoices_job.rb
+++ b/app/jobs/clock/retry_generating_subscription_invoices_job.rb
@@ -11,7 +11,7 @@ module Clock
     def perform
       Invoice.subscription.generating.where.not(id: InvoiceError.select(:id)).where('created_at < ?', THRESHOLD.call).find_each do |invoice|
         next unless invoice.invoice_subscriptions.any?
-        invoicing_reasons = invoice.invoice_subscriptions.pluck(:invoicing_reason).uniq
+        invoicing_reasons = invoice.invoice_subscriptions.pluck(:invoicing_reason).uniq.compact
         invoicing_reason = (invoicing_reasons.size == 1) ? invoicing_reasons.first : :upgrading
         BillSubscriptionJob.perform_later(
           invoice.subscriptions.to_a,


### PR DESCRIPTION
## Context

InvoiceSubscriptions can have `invoicing_reason == nil`, so before picking the reason we have to remove nils from the array of invoicing reasons as inside BillSubscriptionJob we're trying to transform invoicing_reason to_sym, and if nil is sent, it crashes

https://lago.sentry.io/issues/6033978013/?referrer=slack&notification_uuid=0479c7e7-eb80-429f-a0a3-486cac9a9b77&environment=production&alert_rule_id=11137413&alert_type=issue


<img width="976" alt="image" src="https://github.com/user-attachments/assets/add307fb-e8a7-4fcf-adfe-8dd200c3904b">
