### PR TITLE
feat(rounding): Apply rounding to billable metric aggregation results

### DIFF
--- a/app/services/billable_metrics/aggregations/apply_rounding_service.rb
+++ b/app/services/billable_metrics/aggregations/apply_rounding_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module BillableMetrics
+  module Aggregations
+    class ApplyRoundingService < ::BaseService
+      def initialize(billable_metric:, units:)
+        @billable_metric = billable_metric
+        @units = units
+
+        super
+      end
+
+      def call
+        precision = billable_metric.rounding_precision || 0
+
+        result.units = case billable_metric.rounding_function&.to_sym
+        when :ceil
+          units.ceil(precision)
+        when :floor
+          units.floor(precision)
+        when :round
+          units.round(precision)
+        else
+          units
+        end
+
+        result
+      end
+
+      private
+
+      attr_reader :billable_metric, :units
+    end
+  end
+end

--- a/spec/services/billable_metrics/aggregations/apply_rounding_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/apply_rounding_service_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BillableMetrics::Aggregations::ApplyRoundingService, type: :service do
+  subject(:rounding_service) { described_class.new(billable_metric:, units:) }
+
+  let(:rounding_function) { 'round' }
+  let(:rounding_precision) { 2 }
+
+  let(:billable_metric) do
+    create(:billable_metric, rounding_precision:, rounding_function:)
+  end
+
+  let(:units) { 123.456 }
+
+  describe '#call' do
+    let(:result) { rounding_service.call }
+
+    context 'with round function' do
+      it 'returns the rounded units' do
+        expect(result.units).to eq(123.46)
+      end
+
+      context 'without precision' do
+        let(:rounding_precision) { nil }
+
+        it 'applies the rounding to the integer value' do
+          expect(result.units).to eq(123)
+        end
+      end
+
+      context 'with negative precision' do
+        let(:rounding_precision) { -2 }
+
+        it 'applies the rounding' do
+          expect(result.units).to eq(100)
+        end
+      end
+    end
+
+    context 'with ceil function' do
+      let(:rounding_function) { 'ceil' }
+
+      it 'returns the rounded units' do
+        expect(result.units).to eq(123.46)
+      end
+
+      context 'without precision' do
+        let(:rounding_precision) { nil }
+
+        it 'applies the rounding to the integer value' do
+          expect(result.units).to eq(124)
+        end
+      end
+
+      context 'with negative precision' do
+        let(:rounding_precision) { -2 }
+
+        it 'applies the rounding' do
+          expect(result.units).to eq(200)
+        end
+      end
+    end
+
+    context 'with floor function' do
+      let(:rounding_function) { 'floor' }
+
+      it 'returns the rounded units' do
+        expect(result.units).to eq(123.45)
+      end
+
+      context 'without precision' do
+        let(:rounding_precision) { nil }
+
+        it 'applies the rounding to the integer value' do
+          expect(result.units).to eq(123)
+        end
+      end
+
+      context 'with negative precision' do
+        let(:rounding_precision) { -2 }
+
+        it 'applies the rounding' do
+          expect(result.units).to eq(100)
+        end
+      end
+    end
+
+    context 'without rounding function' do
+      let(:rounding_function) { nil }
+
+      it 'returns the units' do
+        expect(result.units).to eq(units)
+      end
+    end
+  end
+end

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -199,6 +199,31 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       expect(result.aggregation).to eq(9.64517)
       expect(result.current_usage_units).to eq(29)
     end
+
+    context 'when rounding is configured' do
+      let(:billable_metric) do
+        create(
+          :billable_metric,
+          organization:,
+          aggregation_type: 'sum_agg',
+          field_name: 'total_count',
+          recurring: true,
+          rounding_function: 'ceil',
+          rounding_precision: 2
+        )
+      end
+
+      before do
+        latest_events.last.update!(properties: {total_count: 12.434})
+      end
+
+      it 'aggregates the events' do
+        result = sum_service.aggregate(options:)
+
+        expect(result.aggregation).to eq(9.73)
+        expect(result.current_usage_units).to eq(29.44)
+      end
+    end
   end
 
   context 'when current usage context and charge is pay in advance' do


### PR DESCRIPTION
## Context

In addition to the [flexible aggregation](https://github.com/119ef63110d2803db639f0db37a3b135?pvs=25), some customers wants to round the output of the aggregation.

## Description

This PR applies the rounding logic to the billable metric aggregation result.
