### PR TITLE
fix: Ensure DataExports::CombinePartsJob uniqueness

### DIFF
--- a/app/jobs/data_exports/combine_parts_job.rb
+++ b/app/jobs/data_exports/combine_parts_job.rb
@@ -4,6 +4,8 @@ module DataExports
   class CombinePartsJob < ApplicationJob
     queue_as :default
 
+    unique :until_executed, on_conflict: :log
+
     def perform(data_export)
       CombinePartsService.call(data_export:).raise_if_error!
     end


### PR DESCRIPTION
This should fix a race condition when multiple data export parts are finished very close in time resulting into multiple CombinePartsJob queued, hence active storage fails because of duplicated key.