### PR TITLE
feat(dunning): Permit creation of payment request without email

### DIFF
--- a/app/config/permissions/role-manager.yml
+++ b/app/config/permissions/role-manager.yml
@@ -27,7 +27,7 @@ customers:
   update: true
   delete: true
 dunning_campaigns:
-  view: false
+  view: true
   create: false
   update: false
 subscriptions:

--- a/app/mailers/payment_request_mailer.rb
+++ b/app/mailers/payment_request_mailer.rb
@@ -6,6 +6,10 @@ class PaymentRequestMailer < ApplicationMailer
   def requested
     @payment_request = params[:payment_request]
     @organization = @payment_request.organization
+
+    return if @payment_request.email.blank?
+    return if @organization.email.blank?
+
     @customer = @payment_request.customer
     @invoices = @payment_request.invoices
     @payment_url = ::PaymentRequests::Payments::GeneratePaymentUrlService.call(payable: @payment_request).payment_url

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -44,7 +44,7 @@ end
 #  id                           :uuid             not null, primary key
 #  amount_cents                 :bigint           default(0), not null
 #  amount_currency              :string           not null
-#  email                        :string           not null
+#  email                        :string
 #  payment_attempts             :integer          default(0), not null
 #  payment_status               :integer          default("pending"), not null
 #  ready_for_payment_processing :boolean          default(TRUE), not null

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -10,7 +10,6 @@ class PaymentRequest < ApplicationRecord
   belongs_to :organization
   belongs_to :customer, -> { with_discarded }
 
-  validates :email, presence: true
   validates :amount_cents, presence: true
   validates :amount_currency, presence: true
 

--- a/db/migrate/20241106104515_remove_not_null_constraint_from_email_in_payment_requests.rb
+++ b/db/migrate/20241106104515_remove_not_null_constraint_from_email_in_payment_requests.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveNotNullConstraintFromEmailInPaymentRequests < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :payment_requests, :email, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_01_151559) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_06_104515) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1015,7 +1015,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_01_151559) do
     t.uuid "customer_id", null: false
     t.bigint "amount_cents", default: 0, null: false
     t.string "amount_currency", null: false
-    t.string "email", null: false
+    t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "organization_id", null: false

--- a/spec/mailers/payment_request_mailer_spec.rb
+++ b/spec/mailers/payment_request_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PaymentRequestMailer, type: :mailer do
   let(:organization) { create(:organization, document_number_prefix: 'ORG-123B') }
   let(:first_invoice) { create(:invoice, total_amount_cents: 1000, organization:) }
   let(:second_invoice) { create(:invoice, total_amount_cents: 2000, organization:) }
-  let(:payment_request) { create(:payment_request, invoices: [first_invoice, second_invoice]) }
+  let(:payment_request) { create(:payment_request, organization:, invoices: [first_invoice, second_invoice]) }
 
   before do
     first_invoice.file.attach(
@@ -55,6 +55,24 @@ RSpec.describe PaymentRequestMailer, type: :mailer do
       expect(PaymentRequests::Payments::GeneratePaymentUrlService)
         .to have_received(:call)
         .with(payable: payment_request)
+    end
+
+    context "when payment request email is nil" do
+      before { payment_request.update(email: nil) }
+
+      it "returns a mailer with nil values" do
+        mailer = payment_request_mailer.with(payment_request:).requested
+        expect(mailer.to).to be_nil
+      end
+    end
+
+    context "when organization email is nil" do
+      before { organization.update(email: nil) }
+
+      it "returns a mailer with nil values" do
+        mailer = payment_request_mailer.with(payment_request:).requested
+        expect(mailer.to).to be_nil
+      end
     end
 
     context "when no payment url is available" do

--- a/spec/models/payment_request_spec.rb
+++ b/spec/models/payment_request_spec.rb
@@ -31,11 +31,6 @@ RSpec.describe PaymentRequest, type: :model do
       expect(payment_request).to be_valid
     end
 
-    it "is not valid without email" do
-      payment_request.email = nil
-      expect(payment_request).not_to be_valid
-    end
-
     it "is not valid without amount_cents" do
       payment_request.amount_cents = nil
       expect(payment_request).not_to be_valid


### PR DESCRIPTION
 ## Roadmap
 
👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We're first automating the overdue balance payment request, before looking at individual invoices.

 ## Description

This change removes the not null constraint on `PaymentRequest#email`.