### PR TITLE
fix: Ensure correct integration customer is used when syncing netsuite payments

### DIFF
--- a/app/services/integrations/aggregator/payments/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/payments/payloads/base_payload.rb
@@ -35,7 +35,7 @@ module Integrations
           end
 
           def integration_customer
-            @integration_customer ||= invoice.customer&.integration_customers&.first
+            @integration_customer ||= invoice.customer&.integration_customers&.accounting_kind&.first
           end
         end
       end

--- a/spec/services/integrations/aggregator/payments/payloads/base_payload_spec.rb
+++ b/spec/services/integrations/aggregator/payments/payloads/base_payload_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::Payments::Payloads::BasePayload, type: :service do
+  let(:payload) { described_class.new(integration:, payment:) }
+  let(:payment) { create(:payment, payable: invoice) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:organization) { create(:organization) }
+
+  describe '#initialize' do
+    it 'assigns the payment' do
+      expect(payload.instance_variable_get(:@payment)).to eq(payment)
+    end
+  end
+
+  describe '#integration_customer' do
+    subject(:method_call) { payload.__send__(:integration_customer) }
+
+    before do
+      integration_customer
+      create(:hubspot_customer, customer:)
+    end
+
+    it 'returns the first accounting kind integration customer' do
+      expect(subject).to eq(integration_customer)
+    end
+
+    it 'memoizes the integration customer' do
+      subject
+      expect(payload.instance_variable_get(:@integration_customer)).to eq(integration_customer)
+    end
+  end
+
+  describe '#body' do
+    it 'returns correct body' do
+      expect(payload.body).to eq(
+        [
+          {
+            'invoice_id' => nil,
+            'account_code' => nil,
+            'date' => payment.created_at.utc.iso8601,
+            'amount_cents' => payment.amount_cents
+          }
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

When syncing netsuite payments we need to ensure that correct `integration_customer` object is used in the payload since there can be attached integration_customers of other kinds as well 