### PR TITLE
bug(DataExport) - Decrease batch size for data export & use tempfile

### DIFF
--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -21,7 +21,7 @@ module DataExports
       end
 
       def call
-        result.csv_lines = ::CSV.generate(headers: false) do |csv|
+        result.csv_file = with_csv do |csv|
           invoices.each do |invoice|
             serialized_invoice = serializer_klass.new(invoice).serialize
 

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -15,7 +15,7 @@ module DataExports
       end
 
       def call
-        result.csv_lines = ::CSV.generate(headers: false) do |csv|
+        result.csv_file = with_csv do |csv|
           invoices.each do |invoice|
             csv << serialized_invoice(invoice)
           end
@@ -52,6 +52,14 @@ module DataExports
       end
 
       private
+
+      def with_csv
+        tempfile = Tempfile.create([data_export_part.id, ".csv"])
+        yield CSV.new(tempfile, headers: false)
+
+        tempfile.rewind
+        tempfile
+      end
 
       attr_reader :data_export_part, :serializer_klass, :output, :batch_size
 

--- a/app/services/data_exports/export_resources_service.rb
+++ b/app/services/data_exports/export_resources_service.rb
@@ -4,7 +4,7 @@ module DataExports
   class ExportResourcesService < BaseService
     EXPIRED_FAILURE_MESSAGE = 'Data Export already expired'
     PROCESSED_FAILURE_MESSAGE = 'Data Export already processed'
-    DEFAULT_BATCH_SIZE = 100
+    DEFAULT_BATCH_SIZE = 20
 
     ResourceTypeNotSupportedError = Class.new(StandardError)
 

--- a/app/services/data_exports/process_part_service.rb
+++ b/app/services/data_exports/process_part_service.rb
@@ -10,6 +10,7 @@ module DataExports
 
     def call
       result.data_export_part = data_export_part
+      return result if data_export_part.completed
 
       # produce CSV lines into StringIO
       export_result = data_export.export_class.call(data_export_part:).raise_if_error!

--- a/app/services/data_exports/process_part_service.rb
+++ b/app/services/data_exports/process_part_service.rb
@@ -14,7 +14,11 @@ module DataExports
 
       # produce CSV lines into StringIO
       export_result = data_export.export_class.call(data_export_part:).raise_if_error!
-      data_export_part.update!(csv_lines: export_result.csv_lines, completed: true)
+      file = export_result.csv_file
+      data_export_part.update!(csv_lines: file.read, completed: true)
+      # Explicitely close and unlink the file
+      file.close
+      File.unlink(file.path)
 
       # check if we are the last one to finish
       if last_completed

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -130,7 +130,11 @@ RSpec.describe DataExports::Csv::InvoiceFees do
 
       expect(result).to be_success
 
-      generated_csv = result.csv_lines
+      file = result.csv_file
+      generated_csv = file.read
+
+      file.close
+      File.unlink(file.path)
 
       expect(generated_csv).to eq(expected_csv)
     end

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -90,8 +90,11 @@ RSpec.describe DataExports::Csv::Invoices do
       CSV
 
       expect(result).to be_success
-      generated_csv = result.csv_lines
+      file = result.csv_file
+      generated_csv = file.read
 
+      file.close
+      File.unlink(file.path)
       expect(generated_csv).to eq(expected_csv)
     end
   end


### PR DESCRIPTION
## Description

when running sidekiq with high amount of concurrency, the default batch size could result in large amounts of longer running jobs. These could make a worker consume too much memory. 

This PR aims to fine-tune the batch size by reducing it by a factor 5 (so jobs will be faster and consume less memory individually). It will also not keep the entire CSV in memory, but rather use a tempfile.