### PR TITLE
Bug(DataExport) - update DEFAULT_BATCH_SIZE of ExportResourcesJob

### DIFF
--- a/app/jobs/data_exports/export_resources_job.rb
+++ b/app/jobs/data_exports/export_resources_job.rb
@@ -4,7 +4,7 @@ module DataExports
   class ExportResourcesJob < ApplicationJob
     queue_as :default
 
-    DEFAULT_BATCH_SIZE = 100
+    DEFAULT_BATCH_SIZE = 20
 
     def perform(data_export, batch_size: DEFAULT_BATCH_SIZE)
       ExportResourcesService.call(data_export:, batch_size:).raise_if_error!

--- a/spec/jobs/data_exports/export_resources_job_spec.rb
+++ b/spec/jobs/data_exports/export_resources_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DataExports::ExportResourcesJob, type: :job do
   before do
     allow(DataExports::ExportResourcesService)
       .to receive(:call)
-      .with(data_export:, batch_size: 100)
+      .with(data_export:, batch_size: 20)
       .and_return(result)
   end
 
@@ -18,6 +18,6 @@ RSpec.describe DataExports::ExportResourcesJob, type: :job do
 
     expect(DataExports::ExportResourcesService)
       .to have_received(:call)
-      .with(data_export:, batch_size: 100)
+      .with(data_export:, batch_size: 20)
   end
 end


### PR DESCRIPTION
## Description

We have multiple batch size constants and I had forgotten this one.