### PR TITLE
feat(Salesforce): Add ability to create salesforce customer 

### DIFF
--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -34,6 +34,8 @@ module IntegrationCustomers
         'IntegrationCustomers::XeroCustomer'
       when 'hubspot'
         'IntegrationCustomers::HubspotCustomer'
+      when 'salesforce'
+        'IntegrationCustomers::SalesforceCustomer'
       else
         raise(NotImplementedError)
       end

--- a/app/models/integration_customers/salesforce_customer.rb
+++ b/app/models/integration_customers/salesforce_customer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class SalesforceCustomer < BaseCustomer
+  end
+end
+
+# == Schema Information
+#
+# Table name: integration_customers
+#
+#  id                   :uuid             not null, primary key
+#  settings             :jsonb            not null
+#  type                 :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  customer_id          :uuid             not null
+#  external_customer_id :string
+#  integration_id       :uuid             not null
+#
+# Indexes
+#
+#  index_integration_customers_on_customer_id           (customer_id)
+#  index_integration_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
+#  index_integration_customers_on_external_customer_id  (external_customer_id)
+#  index_integration_customers_on_integration_id        (integration_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (integration_id => integrations.id)
+#

--- a/spec/factories/integration_customers.rb
+++ b/spec/factories/integration_customers.rb
@@ -57,7 +57,7 @@ FactoryBot.define do
 
     settings do
       {
-        sync_with_provider: false,
+        sync_with_provider: false
       }
     end
   end

--- a/spec/factories/integration_customers.rb
+++ b/spec/factories/integration_customers.rb
@@ -48,4 +48,17 @@ FactoryBot.define do
       }
     end
   end
+
+  factory :hubspot_customer, class: 'IntegrationCustomers::SalesforceCustomer' do
+    association :integration, factory: :salesforce_integration
+    customer
+    type { 'IntegrationCustomers::HubspotCustomer' }
+    external_customer_id { SecureRandom.uuid }
+
+    settings do
+      {
+        sync_with_provider: false,
+      }
+    end
+  end
 end

--- a/spec/factories/integration_customers.rb
+++ b/spec/factories/integration_customers.rb
@@ -52,7 +52,7 @@ FactoryBot.define do
   factory :salesforce_customer, class: 'IntegrationCustomers::SalesforceCustomer' do
     association :integration, factory: :salesforce_integration
     customer
-    type { 'IntegrationCustomers::HubspotCustomer' }
+    type { 'IntegrationCustomers::SalesforceCustomer' }
     external_customer_id { SecureRandom.uuid }
 
     settings do

--- a/spec/factories/integration_customers.rb
+++ b/spec/factories/integration_customers.rb
@@ -49,7 +49,7 @@ FactoryBot.define do
     end
   end
 
-  factory :hubspot_customer, class: 'IntegrationCustomers::SalesforceCustomer' do
+  factory :salesforce_customer, class: 'IntegrationCustomers::SalesforceCustomer' do
     association :integration, factory: :salesforce_integration
     customer
     type { 'IntegrationCustomers::HubspotCustomer' }

--- a/spec/models/integration_customers/base_customer_spec.rb
+++ b/spec/models/integration_customers/base_customer_spec.rb
@@ -97,6 +97,15 @@ RSpec.describe IntegrationCustomers::BaseCustomer, type: :model do
       end
     end
 
+    context 'when type is salesforce' do
+      let(:type) { 'salesforce' }
+      let(:customer_type) { 'IntegrationCustomers::SalesforceCustomer' }
+
+      it 'returns customer type' do
+        expect(subject).to eq(customer_type)
+      end
+    end
+
     context 'when type is not supported' do
       let(:type) { 'n/a' }
 


### PR DESCRIPTION
## Context
This PR enables Salesforce integration by allowing synchronization of external_customer_id from Salesforce to our system.

Example JSON

```
{
    "customer": {
        "external_id": "external_id",
        "name": "name_test",
        "firstname": "first name",
        "lastname": "last name",
        "customer_type": "individual",
        "metadata": [],
        "taxes": [],
        "integration_customers": [
            {
                "integration_type": "salesforce",
                "integration_code": "salesforce",
                "external_customer_id": 333333
            }
        ]
    }
}

```