### PR TITLE
Feat salesforce services

### DIFF
--- a/app/services/integrations/salesforce/create_service.rb
+++ b/app/services/integrations/salesforce/create_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Salesforce
+    class CreateService < BaseService
+      attr_reader :params
+
+      def initialize(params:)
+        @params = params
+
+        super
+      end
+
+      def call
+        organization = Organization.find_by(id: params[:organization_id])
+
+        unless organization.premium_integrations.include?('salesforce')
+          return result.not_allowed_failure!(code: 'premium_integration_missing')
+        end
+
+        integration = Integrations::SalesforceIntegration.new(
+          organization:,
+          name: params[:name],
+          code: params[:code],
+          instance_id: params[:instance_id]
+        )
+
+        integration.save!
+
+        result.integration = integration
+        result
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
+      end
+    end
+  end
+end

--- a/app/services/integrations/salesforce/update_service.rb
+++ b/app/services/integrations/salesforce/update_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Salesforce
+    class UpdateService < BaseService
+      def initialize(integration:, params:)
+        @integration = integration
+        @params = params
+
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: 'integration') unless integration
+
+        unless integration.organization.premium_integrations.include?('salesforce')
+          return result.not_allowed_failure!(code: 'premium_integration_missing')
+        end
+
+        integration.name = params[:name] if params.key?(:name)
+        integration.code = params[:code] if params.key?(:code)
+        integration.instance_id = params[:instance_id] if params.key?(:instance_id)
+
+        integration.save!
+
+        result.integration = integration
+        result
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
+      end
+
+      private
+
+      attr_reader :integration, :params
+    end
+  end
+end

--- a/spec/services/integrations/salesforce/create_service_spec.rb
+++ b/spec/services/integrations/salesforce/create_service_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Salesforce::CreateService, type: :service do
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+
+  describe '#call' do
+    subject(:service_call) { described_class.call(params: create_args) }
+
+    let(:name) { 'Salesforce 1' }
+
+    let(:create_args) do
+      {
+        name:,
+        code: 'salesforce',
+        organization_id: organization.id,
+        instance_id: 'Instance1'
+      }
+    end
+
+    context 'without premium license' do
+      it 'does not create an integration' do
+        expect { service_call }.not_to change(Integrations::SalesforceIntegration, :count)
+      end
+
+      it 'returns an error' do
+        result = service_call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        end
+      end
+    end
+
+    context 'with premium license' do
+      context 'with salesforce premium integration not present' do
+        it 'returns an error' do
+          result = service_call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          end
+        end
+      end
+
+      context 'with salesforce premium integration present' do
+        before { organization.update!(premium_integrations: ['salesforce']) }
+
+        context 'without validation errors' do
+          it 'creates an integration' do
+            expect { service_call }.to change(Integrations::SalesforceIntegration, :count).by(1)
+
+            integration = Integrations::SalesforceIntegration.order(:created_at).last
+            expect(integration.instance_id).to eq('Instance1')
+          end
+        end
+
+        context 'with validation error' do
+          let(:instance_id) { nil }
+
+          it 'returns an error' do
+            result = service_call
+
+            aggregate_failures do
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::ValidationFailure)
+              expect(result.error.messages[:instance_id]).to eq(['value_is_mandatory'])
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/sync-lago-customers-with-salesforce

## Context

We need to be able to create a Salesforce integration in Lago and sync Lago customers to Salesforce using this integration details.

## Description

This PR adds `create` and `update` services to store the integration. They will be used by the GraphQL mutations.