### PR TITLE
feat(dunning): Stop and reset counters for customers

### DIFF
--- a/app/services/dunning_campaigns/bulk_process_service.rb
+++ b/app/services/dunning_campaigns/bulk_process_service.rb
@@ -34,10 +34,7 @@ module DunningCampaigns
         return result if max_attempts_reached?
         return result unless days_between_attempts_satisfied?
 
-        DunningCampaigns::ProcessAttemptJob.perform_later(
-          customer: customer,
-          dunning_campaign_threshold: threshold
-        )
+        DunningCampaigns::ProcessAttemptJob.perform_later(customer:, dunning_campaign_threshold: threshold)
 
         result
       end

--- a/app/services/dunning_campaigns/create_service.rb
+++ b/app/services/dunning_campaigns/create_service.rb
@@ -19,6 +19,15 @@ module DunningCampaigns
             .dunning_campaigns
             .applied_to_organization
             .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
+
+          # NOTE: Stop and reset existing campaigns.
+          organization.customers.where(
+            applied_dunning_campaign_id: nil,
+            exclude_from_dunning_campaign: false
+          ).update_all( # rubocop:disable Rails/SkipsModelValidations
+            last_dunning_campaign_attempt: 0,
+            last_dunning_campaign_attempt_at: nil
+          )
         end
 
         dunning_campaign = organization.dunning_campaigns.create!(

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -21,6 +21,15 @@ module DunningCampaigns
             .applied_to_organization
             .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
 
+          # NOTE: Stop and reset existing campaigns.
+          organization.customers.where(
+            applied_dunning_campaign_id: nil,
+            exclude_from_dunning_campaign: false
+          ).update_all( # rubocop:disable Rails/SkipsModelValidations
+            last_dunning_campaign_attempt: 0,
+            last_dunning_campaign_attempt_at: nil
+          )
+
           dunning_campaign.applied_to_organization = params[:applied_to_organization]
         end
 

--- a/spec/services/dunning_campaigns/create_service_spec.rb
+++ b/spec/services/dunning_campaigns/create_service_spec.rb
@@ -106,6 +106,13 @@ RSpec.describe DunningCampaigns::CreateService, type: :service, aggregate_failur
                 .to(false)
             end
           end
+
+          it "stops and resets counters on customers" do
+            customer = create(:customer, organization:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at: Time.current)
+
+            expect { create_service.call }.to change { customer.reload.last_dunning_campaign_attempt }.from(1).to(0)
+              .and change { customer.last_dunning_campaign_attempt_at }.from(a_value).to(nil)
+          end
         end
 
         context "with validation error" do

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -87,6 +87,13 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
                 .to(false)
             end
           end
+
+          it "stops and resets counters on customers" do
+            customer = create(:customer, organization:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at: Time.current)
+
+            expect { result }.to change { customer.reload.last_dunning_campaign_attempt }.from(1).to(0)
+              .and change { customer.last_dunning_campaign_attempt_at }.from(a_value).to(nil)
+          end
         end
 
         context "with no dunning campaign record" do


### PR DESCRIPTION
 ## Roadmap
 
👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We're first automating the overdue balance payment request, before looking at individual invoices.

 ## Description

This change resets counter at customer level when set as default a new campaign.