### PR TITLE
misc(nango): Increase the number of job retries in case of RequestLimitError

### DIFF
--- a/app/jobs/integrations/aggregator/credit_notes/create_job.rb
+++ b/app/jobs/integrations/aggregator/credit_notes/create_job.rb
@@ -7,7 +7,7 @@ module Integrations
         queue_as 'integrations'
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-        retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+        retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
         def perform(credit_note:)
           result = Integrations::Aggregator::CreditNotes::CreateService.call(credit_note:)

--- a/app/jobs/integrations/aggregator/fetch_items_job.rb
+++ b/app/jobs/integrations/aggregator/fetch_items_job.rb
@@ -6,7 +6,7 @@ module Integrations
       queue_as 'integrations'
 
       retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-      retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+      retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
       def perform(integration:)
         result = Integrations::Aggregator::ItemsService.call(integration:)

--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -7,7 +7,7 @@ module Integrations
         queue_as 'integrations'
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-        retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+        retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
         def perform(invoice:)
           result = Integrations::Aggregator::Invoices::CreateService.call(invoice:)

--- a/app/jobs/integrations/aggregator/invoices/crm/create_customer_association_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/create_customer_association_job.rb
@@ -8,7 +8,7 @@ module Integrations
           queue_as 'integrations'
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
-          retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+          retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
           def perform(invoice:)
             result = Integrations::Aggregator::Invoices::Crm::CreateCustomerAssociationService.call(invoice:)

--- a/app/jobs/integrations/aggregator/invoices/crm/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/create_job.rb
@@ -9,7 +9,7 @@ module Integrations
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
-          retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+          retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
           def perform(invoice:)
             result = Integrations::Aggregator::Invoices::Crm::CreateService.call(invoice:)

--- a/app/jobs/integrations/aggregator/invoices/crm/update_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/update_job.rb
@@ -9,7 +9,7 @@ module Integrations
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
-          retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+          retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
           def perform(invoice:)
             result = Integrations::Aggregator::Invoices::Crm::UpdateService.call(invoice:)

--- a/app/jobs/integrations/aggregator/payments/create_job.rb
+++ b/app/jobs/integrations/aggregator/payments/create_job.rb
@@ -7,7 +7,7 @@ module Integrations
         queue_as 'integrations'
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 5
-        retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+        retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
         def perform(payment:)
           result = Integrations::Aggregator::Payments::CreateService.call(payment:)

--- a/app/jobs/integrations/aggregator/perform_sync_job.rb
+++ b/app/jobs/integrations/aggregator/perform_sync_job.rb
@@ -6,7 +6,7 @@ module Integrations
       queue_as 'integrations'
 
       retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-      retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+      retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
       def perform(integration:, sync_items: true)
         sync_result = Integrations::Aggregator::SyncService.call(integration:)

--- a/app/jobs/integrations/aggregator/sales_orders/create_job.rb
+++ b/app/jobs/integrations/aggregator/sales_orders/create_job.rb
@@ -7,7 +7,7 @@ module Integrations
         queue_as 'integrations'
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-        retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+        retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
         def perform(invoice:)
           result = Integrations::Aggregator::SalesOrders::CreateService.call(invoice:)

--- a/app/jobs/integrations/aggregator/send_restlet_endpoint_job.rb
+++ b/app/jobs/integrations/aggregator/send_restlet_endpoint_job.rb
@@ -6,7 +6,7 @@ module Integrations
       queue_as 'integrations'
 
       retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-      retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+      retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
       def perform(integration:)
         result = Integrations::Aggregator::SendRestletEndpointService.call(integration:)

--- a/app/jobs/integrations/aggregator/subscriptions/crm/create_customer_association_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/create_customer_association_job.rb
@@ -8,7 +8,7 @@ module Integrations
           queue_as 'integrations'
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
-          retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+          retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
           def perform(subscription:)
             result = Integrations::Aggregator::Subscriptions::Crm::CreateCustomerAssociationService.call(subscription:)

--- a/app/jobs/integrations/aggregator/subscriptions/crm/create_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/create_job.rb
@@ -9,7 +9,7 @@ module Integrations
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
-          retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+          retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
           def perform(subscription:)
             result = Integrations::Aggregator::Subscriptions::Crm::CreateService.call(subscription:)

--- a/app/jobs/integrations/aggregator/subscriptions/crm/update_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/update_job.rb
@@ -9,7 +9,7 @@ module Integrations
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
-          retry_on RequestLimitError, wait: :polynomially_longer, attempts: 10
+          retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
           def perform(subscription:)
             result = Integrations::Aggregator::Subscriptions::Crm::UpdateService.call(subscription:)

--- a/app/jobs/integrations/hubspot/companies/deploy_properties_job.rb
+++ b/app/jobs/integrations/hubspot/companies/deploy_properties_job.rb
@@ -7,7 +7,7 @@ module Integrations
         queue_as 'integrations'
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-        retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 10
+        retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
 
         def perform(integration:)
           result = Integrations::Hubspot::Companies::DeployPropertiesService.call(integration:)

--- a/app/jobs/integrations/hubspot/contacts/deploy_properties_job.rb
+++ b/app/jobs/integrations/hubspot/contacts/deploy_properties_job.rb
@@ -7,7 +7,7 @@ module Integrations
         queue_as 'integrations'
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-        retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 10
+        retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
 
         def perform(integration:)
           result = Integrations::Hubspot::Contacts::DeployPropertiesService.call(integration:)

--- a/app/jobs/integrations/hubspot/invoices/deploy_object_job.rb
+++ b/app/jobs/integrations/hubspot/invoices/deploy_object_job.rb
@@ -7,7 +7,7 @@ module Integrations
         queue_as 'integrations'
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-        retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 10
+        retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
 
         def perform(integration:)
           result = Integrations::Hubspot::Invoices::DeployObjectService.call(integration:)

--- a/app/jobs/integrations/hubspot/save_portal_id_job.rb
+++ b/app/jobs/integrations/hubspot/save_portal_id_job.rb
@@ -6,6 +6,7 @@ module Integrations
       queue_as 'integrations'
 
       retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
+      retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
 
       def perform(integration:)
         result = Integrations::Hubspot::SavePortalIdService.call(integration:)

--- a/app/jobs/integrations/hubspot/subscriptions/deploy_object_job.rb
+++ b/app/jobs/integrations/hubspot/subscriptions/deploy_object_job.rb
@@ -7,7 +7,7 @@ module Integrations
         queue_as 'integrations'
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-        retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 10
+        retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
 
         def perform(integration:)
           result = Integrations::Hubspot::Subscriptions::DeployObjectService.call(integration:)


### PR DESCRIPTION
## Context

When generating a lot of invoices at once, Nango starts failing with `Request Limit Exceeded ` error

## Description

This PR increases the number of attempts it makes to retry the failed jobs. We're changing it from 10 to 100 attempts with `wait: :polynomially_longer`.