### PR TITLE
feat(daily_usage): Compute and store usage_diff

### DIFF
--- a/app/models/daily_usage.rb
+++ b/app/models/daily_usage.rb
@@ -23,6 +23,7 @@ end
 #  refreshed_at             :datetime         not null
 #  to_datetime              :datetime         not null
 #  usage                    :jsonb            not null
+#  usage_diff               :jsonb            not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  customer_id              :uuid             not null

--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -24,31 +24,12 @@ module V1
               aggregation_type: fee.billable_metric.aggregation_type
             },
             filters: filters(fees),
-            groups: groups(fees),
             grouped_usage: grouped_usage(fees)
           }
         end
       end
 
       private
-
-      # TODO: Remove after migration to filters and refresh of cache
-      def groups(fees)
-        fees.sort_by { |f| f.charge_filter&.display_name.to_s }.map do |f|
-          next unless f.charge_filter
-
-          values = f.charge_filter.to_h || {}
-
-          {
-            lago_id: "charge-filter-#{f.charge_filter_id}",
-            key: values.keys.join(', '),
-            value: values.values.flatten.join(', '),
-            units: f.units,
-            amount_cents: f.amount_cents,
-            events_count: f.events_count
-          }
-        end.compact
-      end
 
       def filters(fees)
         return [] unless fees.first.charge&.filters&.any?
@@ -73,8 +54,7 @@ module V1
             events_count: grouped_fees.sum(&:events_count),
             units: grouped_fees.map { |f| BigDecimal(f.units) }.sum.to_s,
             grouped_by: grouped_fees.first.grouped_by,
-            filters: filters(grouped_fees),
-            groups: groups(grouped_fees)
+            filters: filters(grouped_fees)
           }
         end
       end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -156,6 +156,10 @@ class BaseService
     end
   end
 
+  def self.call!(*, **, &)
+    call(*, **, &).raise_if_error!
+  end
+
   def initialize(args = nil)
     @result = Result.new
     @source = CurrentContext&.source

--- a/app/services/daily_usages/compute_diff_service.rb
+++ b/app/services/daily_usages/compute_diff_service.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module DailyUsages
+  class ComputeDiffService < BaseService
+    def initialize(daily_usage:, previous_daily_usage: nil)
+      @daily_usage = daily_usage
+      @previous_daily_usage = previous_daily_usage
+
+      super
+    end
+
+    def call
+      unless previous_daily_usage
+        result.usage_diff = daily_usage.usage
+        return result
+      end
+
+      diff = daily_usage.usage.deep_dup
+      previous_usage = previous_daily_usage.usage
+
+      diff['amount_cents'] -= previous_usage['amount_cents']
+      diff['taxes_amount_cents'] -= previous_usage['taxes_amount_cents']
+      diff['total_amount_cents'] -= previous_usage['total_amount_cents']
+
+      diff['charges_usage'].each do |current_charge_usage|
+        previous_charge_usage = previous_usage['charges_usage'].find { |cu| cu['charge']['lago_id'] == current_charge_usage['charge']['lago_id'] }
+        next unless previous_charge_usage
+
+        apply_diff(previous_charge_usage, current_charge_usage)
+
+        current_charge_usage['filters'].each do |current_usage_filter|
+          previous_usage_filter = previous_charge_usage['filters'].find { |fu| fu['values'] == current_usage_filter['values'] }
+          next unless previous_usage_filter
+
+          apply_diff(previous_usage_filter, current_usage_filter)
+        end
+
+        current_charge_usage['grouped_usage'].each do |current_grouped_usage|
+          previous_grouped_usage = previous_charge_usage['grouped_usage'].find { |gu| gu['grouped_by'] == current_grouped_usage['grouped_by'] }
+          next unless previous_grouped_usage
+
+          apply_diff(previous_grouped_usage, current_grouped_usage)
+
+          current_grouped_usage['filters'].each do |current_usage_filter|
+            previous_usage_filter = previous_grouped_usage['filters'].find { |fu| fu['values'] == current_usage_filter['values'] }
+            next unless previous_usage_filter
+
+            apply_diff(previous_usage_filter, current_usage_filter)
+          end
+        end
+      end
+
+      result.usage_diff = diff
+      result
+    end
+
+    private
+
+    attr_reader :daily_usage
+
+    delegate :subscription, :refreshed_at, :from_datetime, :to_datetime, to: :daily_usage
+
+    def previous_daily_usage
+      @previous_daily_usage ||= DailyUsage
+        .where(subscription_id: subscription.id, from_datetime:, to_datetime:)
+        .where("refreshed_at < ?", refreshed_at)
+        .order(refreshed_at: :desc)
+        .first
+    end
+
+    def apply_diff(previous_values, current_values)
+      current_values['units'] = (BigDecimal(current_values['units']) - BigDecimal(previous_values['units'])).to_s
+      current_values['events_count'] -= previous_values['events_count']
+      current_values['amount_cents'] -= previous_values['amount_cents']
+    end
+  end
+end

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -14,7 +14,7 @@ module DailyUsages
         return result
       end
 
-      daily_usage = DailyUsage.create!(
+      daily_usage = DailyUsage.new(
         organization: subscription.organization,
         customer: subscription.customer,
         subscription:,
@@ -24,6 +24,9 @@ module DailyUsages
         to_datetime: current_usage.to_datetime,
         refreshed_at: timestamp
       )
+
+      daily_usage.usage_diff = diff_usage(daily_usage)
+      daily_usage.save!
 
       result.daily_usage = daily_usage
       result
@@ -46,6 +49,10 @@ module DailyUsages
     def existing_daily_usage
       @existing_daily_usage ||= DailyUsage.refreshed_at_in_timezone(timestamp)
         .find_by(subscription_id: subscription.id)
+    end
+
+    def diff_usage(daily_usage)
+      DailyUsages::ComputeDiffService.call!(daily_usage:).usage_diff
     end
   end
 end

--- a/db/migrate/20241108103702_add_usage_diff_to_daily_usages.rb
+++ b/db/migrate/20241108103702_add_usage_diff_to_daily_usages.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUsageDiffToDailyUsages < ActiveRecord::Migration[7.1]
+  def change
+    add_column :daily_usages, :usage_diff, :jsonb, default: '{}', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -498,6 +498,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_20_090305) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "refreshed_at", null: false
+    t.jsonb "usage_diff", default: "{}", null: false
     t.index ["customer_id"], name: "index_daily_usages_on_customer_id"
     t.index ["organization_id", "external_subscription_id"], name: "idx_on_organization_id_external_subscription_id_df3a30d96d"
     t.index ["organization_id"], name: "index_daily_usages_on_organization_id"

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -85,7 +85,6 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
         expect(charge_usage[:units]).to eq('4.0')
         expect(charge_usage[:amount_cents]).to eq(5)
         expect(charge_usage[:amount_currency]).to eq('EUR')
-        expect(charge_usage[:groups]).to eq([])
       end
     end
 
@@ -140,31 +139,36 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
         )
       end
 
-      it 'returns the group usage for the customer' do
+      it 'returns the filters usage for the customer' do
         get_with_token(organization, path)
 
         charge_usage = json[:customer_usage][:charges_usage].first
-        groups_usage = charge_usage[:groups]
+        filters_usage = charge_usage[:filters]
 
         aggregate_failures do
           expect(charge_usage[:units]).to eq('8.0')
           expect(charge_usage[:amount_cents]).to eq(5000)
-          expect(groups_usage).to contain_exactly(
+          expect(filters_usage).to contain_exactly(
             {
-              lago_id: "charge-filter-#{charge_filter_aws.id}",
-              key: 'cloud',
-              value: 'aws',
-              units: '3.0',
-              amount_cents: 3000,
-              events_count: 3
+              amount_cents: 0,
+              events_count: 4,
+              invoice_display_name: nil,
+              units: "4.0",
+              values: nil
             },
             {
-              lago_id: "charge-filter-#{charge_filter_gcp.id}",
-              key: 'cloud',
-              value: 'google',
+              units: '3.0',
+              amount_cents: 3000,
+              events_count: 3,
+              invoice_display_name: nil,
+              values: {cloud: ['aws']}
+            },
+            {
               units: '1.0',
               amount_cents: 2000,
-              events_count: 1
+              events_count: 1,
+              invoice_display_name: nil,
+              values: {cloud: ['google']}
             }
           )
         end
@@ -283,39 +287,43 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
         )
       end
 
-      it 'returns the group usage for the customer' do
+      it 'returns the filters usage for the customer' do
         get_with_token(organization, path)
 
         charge_usage = json[:customer_usage][:charges_usage].first
-        groups_usage = charge_usage[:groups]
+        filters_usage = charge_usage[:filters]
 
         aggregate_failures do
           expect(charge_usage[:units]).to eq('8.0')
           expect(charge_usage[:amount_cents]).to eq(7000)
-          expect(groups_usage).to contain_exactly(
+          expect(filters_usage).to contain_exactly(
             {
-              lago_id: "charge-filter-#{charge_filter_aws_usa.id}",
-              key: 'cloud, region',
-              value: 'aws, usa',
+              units: '4.0',
+              amount_cents: 0,
+              events_count: 4,
+              invoice_display_name: nil,
+              values: nil
+            },
+            {
               units: '2.0',
               amount_cents: 2000,
-              events_count: 2
+              events_count: 2,
+              invoice_display_name: nil,
+              values: {cloud: ['aws'], region: ['usa']}
             },
             {
-              lago_id: "charge-filter-#{charge_filter_aws_france.id}",
-              key: 'cloud, region',
-              value: 'aws, france',
               units: '1.0',
               amount_cents: 2000,
-              events_count: 1
+              events_count: 1,
+              invoice_display_name: nil,
+              values: {cloud: ['aws'], region: ['france']}
             },
             {
-              lago_id: "charge-filter-#{charge_filter_google_usa.id}",
-              key: 'cloud, region',
-              value: 'google, usa',
               units: '1.0',
               amount_cents: 3000,
-              events_count: 1
+              events_count: 1,
+              invoice_display_name: nil,
+              values: {cloud: ['google'], region: ['usa']}
             }
           )
         end
@@ -394,7 +402,6 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
         expect(charge_usage[:units]).to eq(fee1.units.to_s)
         expect(charge_usage[:amount_cents]).to eq(fee1.amount_cents)
         expect(charge_usage[:amount_currency]).to eq(fee1.currency)
-        expect(charge_usage[:groups]).to eq([])
       end
     end
 

--- a/spec/scenarios/charge_models/dynamic_spec.rb
+++ b/spec/scenarios/charge_models/dynamic_spec.rb
@@ -117,8 +117,8 @@ describe 'Charge Models - Dynamic Pricing Scenarios', :scenarios, type: :request
 
         expect(json[:customer_usage][:charges_usage][0][:grouped_usage]).to match_array(
           [
-            {amount_cents: 902, events_count: 1, units: "10.0", grouped_by: {group_key: "value 2"}, filters: [], groups: []},
-            {amount_cents: 10, events_count: 1, units: "10.0", grouped_by: {group_key: "value 1"}, filters: [], groups: []}
+            {amount_cents: 902, events_count: 1, units: "10.0", grouped_by: {group_key: "value 2"}, filters: []},
+            {amount_cents: 10, events_count: 1, units: "10.0", grouped_by: {group_key: "value 1"}, filters: []}
           ]
         )
       end

--- a/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
@@ -49,77 +49,16 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
           'aggregation_type' => billable_metric.aggregation_type
         },
         'filters' => [],
-        'groups' => [],
         'grouped_usage' => [
           {
             'amount_cents' => 100,
             'events_count' => 12,
             'units' => '10.0',
             'grouped_by' => {'card_type' => 'visa'},
-            'filters' => [],
-            'groups' => []
+            'filters' => []
           }
         ]
       )
-    end
-  end
-
-  describe '#groups' do
-    subject(:serializer_groups) { serializer.__send__(:groups, fees) }
-
-    let(:fees) { [fee1, fee2] }
-    let(:charge_filter) { create(:charge_filter) }
-
-    context 'when all fees have groups' do
-      let(:fee1) { create(:fee, charge_filter:) }
-      let(:fee2) { create(:fee, charge_filter:) }
-
-      let(:groups) do
-        [
-          {
-            lago_id: "charge-filter-#{fee2.charge_filter_id}",
-            key: fee2.charge_filter.to_h.keys.join(', '),
-            value: fee2.charge_filter.to_h.values.flatten.join(', '),
-            units: fee2.units,
-            amount_cents: fee2.amount_cents,
-            events_count: fee2.events_count
-          },
-          {
-            lago_id: "charge-filter-#{fee1.charge_filter_id}",
-            key: fee1.charge_filter.to_h.keys.join(', '),
-            value: fee1.charge_filter.to_h.values.flatten.join(', '),
-            units: fee1.units,
-            amount_cents: fee1.amount_cents,
-            events_count: fee1.events_count
-          }
-        ]
-      end
-
-      it 'returns groups array' do
-        expect(serializer_groups).to eq(groups)
-      end
-    end
-
-    context 'when one fee does not have a filter' do
-      let(:fee1) { create(:fee) }
-      let(:fee2) { create(:fee, charge_filter:) }
-
-      let(:groups) do
-        [
-          {
-            lago_id: "charge-filter-#{fee2.charge_filter_id}",
-            key: fee2.charge_filter.to_h.keys.join(', '),
-            value: fee2.charge_filter.to_h.values.flatten.join(', '),
-            units: fee2.units,
-            amount_cents: fee2.amount_cents,
-            events_count: fee2.events_count
-          }
-        ]
-      end
-
-      it 'returns groups array' do
-        expect(serializer_groups).to eq(groups)
-      end
     end
   end
 

--- a/spec/serializers/v1/customers/usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/usage_serializer_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe ::V1::Customers::UsageSerializer do
           ),
           units: '4.0',
           amount_cents: 5,
-          amount_currency: 'EUR',
-          groups: []
+          amount_currency: 'EUR'
         )
       ]
     )
@@ -55,7 +54,6 @@ RSpec.describe ::V1::Customers::UsageSerializer do
       expect(charge_usage['units']).to eq('4.0')
       expect(charge_usage['amount_cents']).to eq(5)
       expect(charge_usage['amount_currency']).to eq('EUR')
-      expect(charge_usage['groups']).to eq([])
     end
   end
 end

--- a/spec/services/daily_usages/compute_diff_service_spec.rb
+++ b/spec/services/daily_usages/compute_diff_service_spec.rb
@@ -1,0 +1,282 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DailyUsages::ComputeDiffService, type: :service do
+  subject(:diff_service) { described_class.new(daily_usage:, previous_daily_usage:) }
+
+  let(:daily_usage) { create(:daily_usage, usage:) }
+  let(:previous_daily_usage) { create(:daily_usage, usage: previous_usage) }
+
+  let(:usage) do
+    {
+      "from_datetime" => "2022-07-01T00:00:00Z",
+      "to_datetime" => "2022-07-31T23:59:59Z",
+      "issuing_date" => "2022-08-02",
+      "lago_invoice_id" => "1a901a90-1a90-1a90-1a90-1a901a901a90",
+      "currency" => "EUR",
+      "amount_cents" => 123,
+      "taxes_amount_cents" => 20,
+      "total_amount_cents" => 143,
+      "charges_usage" => [
+        {
+          "units" => "1.5",
+          "events_count" => 11,
+          "amount_cents" => 123,
+          "amount_currency" => "EUR",
+          "charge" => {
+            "lago_id" => "1a901a90-1a90-1a90-1a90-1a901a901a90",
+            "charge_model" => "graduated",
+            "invoice_display_name" => "Setup"
+          },
+          "billable_metric" => {
+            "lago_id" => "1a901a90-1a90-1a90-1a90-1a901a901a90",
+            "name" => "Storage",
+            "code" => "storage",
+            "aggregation_type" => "sum_agg"
+          },
+          "filters" => [
+            {
+              "units" => "1.4",
+              "amount_cents" => 122,
+              "events_count" => 10,
+              "invoice_display_name" => "AWS eu-east-1",
+              "values" => {
+                "region" => "us-east-1"
+              }
+            },
+            {
+              "units" => "0.1",
+              "amount_cents" => 1,
+              "events_count" => 1,
+              "invoice_display_name" => "AWS eu-east-2",
+              "values" => {
+                "region" => "us-east-2"
+              }
+            }
+          ],
+          "grouped_usage" => [
+            {
+              "amount_cents" => 101,
+              "events_count" => 6,
+              "units" => "1.1",
+              "grouped_by" => {"country" => nil},
+              "filters" => [
+                {
+                  "units" => "1.0",
+                  "amount_cents" => 100,
+                  "events_count" => 5,
+                  "invoice_display_name" => "AWS eu-east-1",
+                  "values" => {
+                    "region" => "us-east-1"
+                  }
+                },
+                {
+                  "units" => "0.1",
+                  "amount_cents" => 1,
+                  "events_count" => 1,
+                  "invoice_display_name" => "AWS eu-east-2",
+                  "values" => {
+                    "region" => "us-east-2"
+                  }
+                }
+              ]
+            },
+            {
+              "amount_cents" => 22,
+              "events_count" => 5,
+              "units" => "0.4",
+              "grouped_by" => {"country" => "us"},
+              "filters" => [
+                {
+                  "units" => "0.4",
+                  "amount_cents" => 22,
+                  "events_count" => 5,
+                  "invoice_display_name" => "AWS eu-east-1",
+                  "values" => {
+                    "region" => "us-east-1"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  let(:previous_usage) do
+    {
+      "from_datetime" => "2022-07-01T00:00:00Z",
+      "to_datetime" => "2022-07-31T23:59:59Z",
+      "issuing_date" => "2022-08-01",
+      "lago_invoice_id" => "1a901a90-1a90-1a90-1a90-1a901a901a90",
+      "currency" => "EUR",
+      "amount_cents" => 100,
+      "taxes_amount_cents" => 15,
+      "total_amount_cents" => 115,
+      "charges_usage" => [
+        {
+          "units" => "1.0",
+          "events_count" => 5,
+          "amount_cents" => 100,
+          "amount_currency" => "EUR",
+          "charge" => {
+            "lago_id" => "1a901a90-1a90-1a90-1a90-1a901a901a90",
+            "charge_model" => "graduated",
+            "invoice_display_name" => "Setup"
+          },
+          "billable_metric" => {
+            "lago_id" => "1a901a90-1a90-1a90-1a90-1a901a901a90",
+            "name" => "Storage",
+            "code" => "storage",
+            "aggregation_type" => "sum_agg"
+          },
+          "filters" => [
+            {
+              "units" => "1.0",
+              "amount_cents" => 100,
+              "events_count" => 5,
+              "invoice_display_name" => "AWS eu-east-1",
+              "values" => {
+                "region" => "us-east-1"
+              }
+            }
+          ],
+          "grouped_usage" => [
+            {
+              "amount_cents" => 100,
+              "events_count" => 5,
+              "units" => "1.0",
+              "grouped_by" => {"country" => nil},
+              "filters" => [
+                {
+                  "units" => "1.0",
+                  "amount_cents" => 100,
+                  "events_count" => 5,
+                  "invoice_display_name" => "AWS eu-east-1",
+                  "values" => {
+                    "region" => "us-east-1"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  it 'computes the diff between the two daily usages' do
+    result = diff_service.call
+
+    expect(result).to be_success
+    expect(result.usage_diff).to eq(
+      {
+        "from_datetime" => "2022-07-01T00:00:00Z",
+        "to_datetime" => "2022-07-31T23:59:59Z",
+        "issuing_date" => "2022-08-02",
+        "lago_invoice_id" => "1a901a90-1a90-1a90-1a90-1a901a901a90",
+        "currency" => "EUR",
+        "amount_cents" => 23,
+        "taxes_amount_cents" => 5,
+        "total_amount_cents" => 28,
+        "charges_usage" => [
+          {
+            "units" => "0.5",
+            "events_count" => 6,
+            "amount_cents" => 23,
+            "amount_currency" => "EUR",
+            "charge" => {
+              "lago_id" => "1a901a90-1a90-1a90-1a90-1a901a901a90",
+              "charge_model" => "graduated",
+              "invoice_display_name" => "Setup"
+            },
+            "billable_metric" => {
+              "lago_id" => "1a901a90-1a90-1a90-1a90-1a901a901a90",
+              "name" => "Storage",
+              "code" => "storage",
+              "aggregation_type" => "sum_agg"
+            },
+            "filters" => [
+              {
+                "units" => "0.4",
+                "amount_cents" => 22,
+                "events_count" => 5,
+                "invoice_display_name" => "AWS eu-east-1",
+                "values" => {
+                  "region" => "us-east-1"
+                }
+              },
+              {
+                "units" => "0.1",
+                "amount_cents" => 1,
+                "events_count" => 1,
+                "invoice_display_name" => "AWS eu-east-2",
+                "values" => {
+                  "region" => "us-east-2"
+                }
+              }
+            ],
+            "grouped_usage" => [
+              {
+                "amount_cents" => 1,
+                "events_count" => 1,
+                "units" => "0.1",
+                "grouped_by" => {"country" => nil},
+                "filters" => [
+                  {
+                    "units" => "0.0",
+                    "amount_cents" => 0,
+                    "events_count" => 0,
+                    "invoice_display_name" => "AWS eu-east-1",
+                    "values" => {
+                      "region" => "us-east-1"
+                    }
+                  },
+                  {
+                    "units" => "0.1",
+                    "amount_cents" => 1,
+                    "events_count" => 1,
+                    "invoice_display_name" => "AWS eu-east-2",
+                    "values" => {
+                      "region" => "us-east-2"
+                    }
+                  }
+                ]
+              },
+              {
+                "amount_cents" => 22,
+                "events_count" => 5,
+                "units" => "0.4",
+                "grouped_by" => {"country" => "us"},
+                "filters" => [
+                  {
+                    "units" => "0.4",
+                    "amount_cents" => 22,
+                    "events_count" => 5,
+                    "invoice_display_name" => "AWS eu-east-1",
+                    "values" => {
+                      "region" => "us-east-1"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    )
+  end
+
+  context 'when the previous daily usage is nil' do
+    let(:previous_daily_usage) { nil }
+
+    it 'returns the current usage as diff' do
+      result = diff_service.call
+
+      expect(result).to be_success
+      expect(result.usage_diff).to eq(usage)
+    end
+  end
+end

--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
           customer_id: customer.id,
           subscription_id: subscription.id,
           external_subscription_id: subscription.external_id,
-          usage: Hash
+          usage: Hash,
+          usage_diff: Hash
         )
         expect(daily_usage.refreshed_at).to match_datetime(timestamp)
         expect(daily_usage.from_datetime).to match_datetime(timestamp.beginning_of_month)


### PR DESCRIPTION
## Context

This PR is part of the Usage Revenue and unit.

Today, Lago does not offer a way to retrieve customer usage with a granularity lower than the billing period (via invoices and fees). On the other end, it is possible to get the current usage for a customer/subscription, but this usage is just a “snapshot” of the usage a the current time. 

## Description

This PR adds a new `usage_diff` field to the `DailyUsage`. The logic to compute the daily usage is also updated to fill this new field.