### PR TITLE
fix(subscription): Ensure consistent ordering on the index end-point

### DIFF
--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -4,7 +4,7 @@ class SubscriptionsQuery < BaseQuery
   def call
     subscriptions = paginate(organization.subscriptions)
     subscriptions = subscriptions.where(status: filtered_statuses)
-    subscriptions = subscriptions.order(started_at: :asc)
+    subscriptions = subscriptions.order("subscriptions.started_at ASC NULLS LAST, subscriptions.created_at ASC")
 
     subscriptions = with_external_customer(subscriptions) if filters.external_customer_id
     subscriptions = with_plan_code(subscriptions) if filters.plan_code

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -89,8 +89,17 @@ RSpec.describe SubscriptionsQuery, type: :query do
     context 'with pending status filter' do
       let(:filters) { {status: [:pending]} }
 
+      let(:subscription_1) do
+        create(:subscription, :pending, customer:, plan:, created_at: Time.zone.parse('2024-10-12T00:01:01'))
+      end
+
+      let(:subscription_2) do
+        create(:subscription, :pending, customer:, plan:, created_at: Time.zone.parse('2024-10-10T00:01:01'))
+      end
+
       it 'returns only pending subscriptions' do
-        create(:subscription, :pending, customer:, plan:)
+        subscription_1
+        subscription_2
         create(:subscription, customer:, plan:, status: :canceled)
         create(:subscription, customer:, plan:, status: :terminated)
 
@@ -98,11 +107,12 @@ RSpec.describe SubscriptionsQuery, type: :query do
 
         aggregate_failures do
           expect(result).to be_success
-          expect(result.subscriptions.count).to eq(1)
+          expect(result.subscriptions.count).to eq(2)
           expect(result.subscriptions.active.count).to eq(0)
-          expect(result.subscriptions.pending.count).to eq(1)
+          expect(result.subscriptions.pending.count).to eq(2)
           expect(result.subscriptions.canceled.count).to eq(0)
           expect(result.subscriptions.terminated.count).to eq(0)
+          expect(result.subscriptions.first).to eq(subscription_1)
         end
       end
     end


### PR DESCRIPTION
## Context

This PR addresses the following issue that was reported by a customer:

```
Problem with the order of results when retrieving subscriptions

When fetching subscriptions via the Lago API (GET /subscriptions) results may be duplicated (i.e. subscription listed on page 1 may also be listed on page 2).
```

The issue appears because subscription are ordered by `started_at asc`, but this value might not be present, leading to an inconsistent ordering.

## Description

The subscription order is now changed to `started_at asc nulls last, created_at asc`
