### PR TITLE
fix: Ability to generate legacy invoice pdfs without charges duration

### DIFF
--- a/app/services/events/stores/clickhouse/unique_count_query.rb
+++ b/app/services/events/stores/clickhouse/unique_count_query.rb
@@ -299,7 +299,7 @@ module Events
                 )
                 /
                 -- NOTE: full duration of the period
-                #{charges_duration},
+                #{charges_duration || 1},
 
                 -- NOTE: operation was a remove, so the duration is 0
                 0
@@ -329,7 +329,7 @@ module Events
                 )
                 /
                 -- NOTE: full duration of the period
-                #{charges_duration},
+                #{charges_duration || 1},
 
                 -- NOTE: operation was a remove, so the duration is 0
                 0

--- a/app/services/events/stores/postgres/unique_count_query.rb
+++ b/app/services/events/stores/postgres/unique_count_query.rb
@@ -293,7 +293,7 @@ module Events
               )
               /
               -- NOTE: full duration of the period
-              #{charges_duration}::numeric
+              #{charges_duration || 1}::numeric
             ELSE
               0 -- NOTE: duration was null so usage is null
             END
@@ -323,7 +323,7 @@ module Events
               )
               /
               -- NOTE: full duration of the period
-              #{charges_duration}::numeric
+              #{charges_duration || 1}::numeric
             ELSE
               0 -- NOTE: duration was null so usage is null
             END


### PR DESCRIPTION
It's sometimes not possible to generate the pdf template of a legacy invoice when it's related to unique count aggregation but without `charges_duration` in the boundaries.

The goal of this PR is to avoid having a deadjob and instead use `1`as the default charges duration.