### PR TITLE
misc(stripe): Refact payment method update webhooks

### DIFF
--- a/app/jobs/invoices/payments/stripe_create_job.rb
+++ b/app/jobs/invoices/payments/stripe_create_job.rb
@@ -7,8 +7,8 @@ module Invoices
 
       unique :until_executed, on_conflict: :log
 
-      retry_on Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
-      retry_on Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
+      retry_on ::Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
+      retry_on ::Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
 
       def perform(invoice)
         result = Invoices::Payments::StripeService.new(invoice).create

--- a/app/jobs/payment_provider_customers/stripe_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_checkout_url_job.rb
@@ -4,9 +4,9 @@ module PaymentProviderCustomers
   class StripeCheckoutUrlJob < ApplicationJob
     queue_as :providers
 
-    retry_on Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
-    retry_on Stripe::APIError, wait: :polynomially_longer, attempts: 6
-    retry_on Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
+    retry_on ::Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
+    retry_on ::Stripe::APIError, wait: :polynomially_longer, attempts: 6
+    retry_on ::Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
     retry_on ActiveJob::DeserializationError
 
     def perform(stripe_customer)

--- a/app/jobs/payment_provider_customers/stripe_create_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_create_job.rb
@@ -4,9 +4,9 @@ module PaymentProviderCustomers
   class StripeCreateJob < ApplicationJob
     queue_as :providers
 
-    retry_on Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
-    retry_on Stripe::APIError, wait: :polynomially_longer, attempts: 6
-    retry_on Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
+    retry_on ::Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
+    retry_on ::Stripe::APIError, wait: :polynomially_longer, attempts: 6
+    retry_on ::Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
     retry_on ActiveJob::DeserializationError
 
     def perform(stripe_customer)

--- a/app/jobs/payment_requests/payments/stripe_create_job.rb
+++ b/app/jobs/payment_requests/payments/stripe_create_job.rb
@@ -7,8 +7,8 @@ module PaymentRequests
 
       unique :until_executed, on_conflict: :log
 
-      retry_on Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
-      retry_on Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
+      retry_on ::Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
+      retry_on ::Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
 
       def perform(payable)
         result = PaymentRequests::Payments::StripeService.new(payable).create

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -20,6 +20,12 @@ module PaymentProviderCustomers
 
     settings_accessors :provider_mandate_id, :sync_with_provider
 
+    scope :by_provider_id_from_organization, ->(organization_id, provider_id) do
+      joins(:customer)
+        .where(customers: {organization_id: organization_id})
+        .where(provider_customer_id: provider_id)
+    end
+
     def provider_payment_methods
       nil
     end

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -86,7 +86,7 @@ module CreditNotes
             idempotency_key: credit_note.id
           }
         )
-      rescue Stripe::InvalidRequestError => e
+      rescue ::Stripe::InvalidRequestError => e
         deliver_error_webhook(message: e.message, code: e.code)
         update_credit_note_status(:failed)
 

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -56,7 +56,7 @@ module Invoices
 
         result.payment = payment
         result
-      rescue Stripe::AuthenticationError, Stripe::CardError, Stripe::InvalidRequestError, Stripe::PermissionError => e
+      rescue ::Stripe::AuthenticationError, ::Stripe::CardError, ::Stripe::InvalidRequestError, Stripe::PermissionError => e
         # NOTE: Do not mark the invoice as failed if the amount is too small for Stripe
         #       For now we keep it as pending, the user can still update it manually
         return result if e.code == 'amount_too_small'
@@ -64,9 +64,9 @@ module Invoices
         deliver_error_webhook(e)
         update_invoice_payment_status(payment_status: :failed, deliver_webhook: false)
         result
-      rescue Stripe::RateLimitError, Stripe::APIConnectionError
+      rescue ::Stripe::RateLimitError, Stripe::APIConnectionError
         raise # Let the auto-retry process do its own job
-      rescue Stripe::StripeError => e
+      rescue ::Stripe::StripeError => e
         deliver_error_webhook(e)
         raise
       end
@@ -98,7 +98,7 @@ module Invoices
       def generate_payment_url
         return result unless should_process_payment?
 
-        res = Stripe::Checkout::Session.create(
+        res = ::Stripe::Checkout::Session.create(
           payment_url_payload,
           {
             api_key: stripe_api_key
@@ -108,7 +108,7 @@ module Invoices
         result.payment_url = res['url']
 
         result
-      rescue Stripe::CardError, Stripe::InvalidRequestError, Stripe::AuthenticationError, Stripe::PermissionError => e
+      rescue ::Stripe::CardError, ::Stripe::InvalidRequestError, ::Stripe::AuthenticationError, Stripe::PermissionError => e
         deliver_error_webhook(e)
 
         result.single_validation_failure!(error_code: 'payment_provider_error')

--- a/app/services/payment_provider_customers/stripe/update_payment_method_service.rb
+++ b/app/services/payment_provider_customers/stripe/update_payment_method_service.rb
@@ -1,0 +1,43 @@
+# frozen_String_literal: true
+
+module PaymentProviderCustomers
+  module Stripe
+    class UpdatePaymentMethodService < BaseService
+      def initialize(stripe_customer:, payment_method_id:)
+        @stripe_customer = stripe_customer
+        @payment_method_id = payment_method_id
+
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: 'stripe_customer') unless stripe_customer
+
+        stripe_customer.payment_method_id = payment_method_id
+        stripe_customer.save!
+
+        reprocess_pending_invoices
+
+        result.stripe_customer = stripe_customer
+        result
+      end
+
+      private
+
+      attr_reader :stripe_customer, :payment_method_id
+
+      delegate :customer, to: :stripe_customer
+
+      def reprocess_pending_invoices
+        invoices = customer.invoices
+          .payment_pending
+          .where(ready_for_payment_processing: true)
+          .where(status: 'finalized')
+
+        invoices.find_each do |invoice|
+          Invoices::Payments::StripeCreateJob.perform_later(invoice)
+        end
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/webhooks/base_service.rb
+++ b/app/services/payment_providers/webhooks/base_service.rb
@@ -13,6 +13,26 @@ module PaymentProviders
       private
 
       attr_reader :organization, :event_json
+
+      def event
+        @event ||= ::Stripe::Event.construct_from(JSON.parse(event_json))
+      end
+
+      def metadata
+        @metadata ||= event.data.object.metadata.to_h.symbolize_keys
+      end
+
+      def handle_missing_customer
+        # NOTE: Stripe customer was not created from lago
+        return result unless metadata&.key?(:lago_customer_id)
+
+        # NOTE: Customer does not belong to this lago instance or
+        #       exists but does not belong to the organizations
+        #       (Happens when the Stripe API key is shared between organizations)
+        return result if Customer.find_by(id: metadata[:lago_customer_id], organization_id: organization.id).nil?
+
+        result.not_found_failure!(resource: 'stripe_customer')
+      end
     end
   end
 end

--- a/app/services/payment_providers/webhooks/stripe/charge_dispute_closed_service.rb
+++ b/app/services/payment_providers/webhooks/stripe/charge_dispute_closed_service.rb
@@ -21,10 +21,6 @@ module PaymentProviders
 
         private
 
-        def event
-          @event ||= ::Stripe::Event.construct_from(JSON.parse(event_json))
-        end
-
         def payment_dispute_lost_at
           Time.zone.at(event.created)
         end

--- a/app/services/payment_providers/webhooks/stripe/customer_updated_service.rb
+++ b/app/services/payment_providers/webhooks/stripe/customer_updated_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Webhooks
+    module Stripe
+      class CustomerUpdatedService < BaseService
+        def call
+          return handle_missing_customer unless stripe_customer
+
+          PaymentProviderCustomers::Stripe::UpdatePaymentMethodService.call(
+            stripe_customer:,
+            payment_method_id: payment_method_id
+          )
+        rescue ActiveRecord::RecordInvalid => e
+          result.record_validation_failure!(record: e.record)
+        end
+
+        private
+
+        def stripe_customer_id
+          event.data.object.id
+        end
+
+        def stripe_customer
+          @stripe_customer ||= PaymentProviderCustomers::StripeCustomer
+            .by_provider_id_from_organization(organization.id, stripe_customer_id)
+            .first
+        end
+
+        def payment_method_id
+          event.data.object.invoice_settings.default_payment_method || event.data.object.default_source
+        end
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/webhooks/stripe/setup_intent_succeeded_service.rb
+++ b/app/services/payment_providers/webhooks/stripe/setup_intent_succeeded_service.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Webhooks
+    module Stripe
+      class SetupIntentSucceededService < BaseService
+        include Customers::PaymentProviderFinder
+
+        def call
+          return result if stripe_customer_id.nil?
+          return handle_missing_customer unless stripe_customer
+
+          update_stripe_customer_default_payment_method
+          result.payment_method_id = payment_method_id
+
+          PaymentProviderCustomers::Stripe::UpdatePaymentMethodService.call(
+            stripe_customer:,
+            payment_method_id: payment_method_id
+          ).raise_if_error!
+
+          result.stripe_customer = stripe_customer
+          result
+        rescue ::Stripe::PermissionError => e
+          result.service_failure!(code: 'stripe_error', message: e.message)
+        end
+
+        private
+
+        def stripe_customer
+          @stripe_customer ||= PaymentProviderCustomers::StripeCustomer
+            .by_provider_id_from_organization(organization.id, stripe_customer_id)
+            .first
+        end
+
+        def stripe_customer_id
+          event.data.object.customer
+        end
+
+        def payment_method_id
+          event.data.object.payment_method
+        end
+
+        def update_stripe_customer_default_payment_method
+          ::Stripe::Customer.update(
+            stripe_customer_id,
+            {invoice_settings: {default_payment_method: payment_method_id}},
+            {api_key: stripe_payment_provider.secret_key}
+          )
+        end
+
+        def stripe_payment_provider
+          @stripe_payment_provider ||= payment_provider(stripe_customer.customer)
+        end
+      end
+    end
+  end
+end

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -55,7 +55,7 @@ module PaymentRequests
 
         result.payment = payment
         result
-      rescue Stripe::AuthenticationError, Stripe::CardError, Stripe::InvalidRequestError, Stripe::PermissionError => e
+      rescue ::Stripe::AuthenticationError, ::Stripe::CardError, ::Stripe::InvalidRequestError, Stripe::PermissionError => e
         # NOTE: Do not mark the payable as failed if the amount is too small for Stripe
         #       For now we keep it as pending.
         return result if e.code == "amount_too_small"
@@ -63,9 +63,9 @@ module PaymentRequests
         deliver_error_webhook(e)
         update_payable_payment_status(payment_status: :failed, deliver_webhook: false)
         result
-      rescue Stripe::RateLimitError, Stripe::APIConnectionError
+      rescue ::Stripe::RateLimitError, ::Stripe::APIConnectionError
         raise # Let the auto-retry process do its own job
-      rescue Stripe::StripeError => e
+      rescue ::Stripe::StripeError => e
         deliver_error_webhook(e)
         raise
       end
@@ -73,7 +73,7 @@ module PaymentRequests
       def generate_payment_url
         return result unless should_process_payment?
 
-        result_url = Stripe::Checkout::Session.create(
+        result_url = ::Stripe::Checkout::Session.create(
           payment_url_payload,
           {
             api_key: stripe_api_key
@@ -83,7 +83,7 @@ module PaymentRequests
         result.payment_url = result_url["url"]
 
         result
-      rescue Stripe::CardError, Stripe::InvalidRequestError, Stripe::AuthenticationError, Stripe::PermissionError => e
+      rescue ::Stripe::CardError, ::Stripe::InvalidRequestError, ::Stripe::AuthenticationError, Stripe::PermissionError => e
         deliver_error_webhook(e)
 
         result.single_validation_failure!(error_code: "payment_provider_error")

--- a/spec/fixtures/stripe/customer_updated_event_with_metadata.json
+++ b/spec/fixtures/stripe/customer_updated_event_with_metadata.json
@@ -25,10 +25,15 @@
         "rendering_options": null
       },
       "livemode": false,
-      "metadata": {},
+      "metadata": {
+        "lago_customer_id": "123456-1234-1234-1234-1234567890",
+        "customer_id": "test_5"
+      },
       "name": "Test 5",
       "phone": null,
-      "preferred_locales": [],
+      "preferred_locales": [
+
+      ],
       "shipping": null,
       "tax_exempt": "none",
       "test_clock": null

--- a/spec/fixtures/stripe/setup_intent_event_with_metadata.json
+++ b/spec/fixtures/stripe/setup_intent_event_with_metadata.json
@@ -1,0 +1,50 @@
+{
+  "id": "evt_1LEBtZDu4p87RxPwbHKmfr13",
+  "object": "event",
+  "api_version": "2020-08-27",
+  "created": 1656074757,
+  "data": {
+    "object": {
+      "id": "seti_1LFeh5Du4p87RxPwCKBRSNzO",
+      "object": "setup_intent",
+      "application": null,
+      "cancellation_reason": null,
+      "client_secret": "seti_1LFeh5Du4p87RxPwCKBRSNzO_secret_LxZqWjIzFT06Hyqw9wfMcUbtnhmcTNC",
+      "created": 1656423787,
+      "customer": "cus_LxZqfhNCKS6abv",
+      "description": null,
+      "flow_directions": null,
+      "last_setup_error": null,
+      "latest_attempt": null,
+      "livemode": false,
+      "mandate": null,
+      "metadata": {
+        "lago_customer_id": "879541c8-63ac-4bd0-bcad-06c3004afc6c"
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": "pm_1LFeTwDu4p87RxPwh3lMmhvu",
+      "payment_method_options": {
+        "card": {
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": ["card"],
+      "single_use_mandate": null,
+      "status": "requires_payment_method",
+      "usage": "off_session"
+    },
+    "previous_attributes": {
+      "default_source": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 0,
+  "request": {
+    "id": null,
+    "idempotency_key": null
+  },
+  "type": "setup_intent.succeeded"
+}

--- a/spec/fixtures/stripe/setup_intent_event_without_customer.json
+++ b/spec/fixtures/stripe/setup_intent_event_without_customer.json
@@ -1,0 +1,48 @@
+{
+  "id": "evt_1LEBtZDu4p87RxPwbHKmfr13",
+  "object": "event",
+  "api_version": "2020-08-27",
+  "created": 1656074757,
+  "data": {
+    "object": {
+      "id": "seti_1LFeh5Du4p87RxPwCKBRSNzO",
+      "object": "setup_intent",
+      "application": null,
+      "cancellation_reason": null,
+      "client_secret": "seti_1LFeh5Du4p87RxPwCKBRSNzO_secret_LxZqWjIzFT06Hyqw9wfMcUbtnhmcTNC",
+      "created": 1656423787,
+      "customer": null,
+      "description": null,
+      "flow_directions": null,
+      "last_setup_error": null,
+      "latest_attempt": null,
+      "livemode": false,
+      "mandate": null,
+      "metadata": {},
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": "pm_1LFeTwDu4p87RxPwh3lMmhvu",
+      "payment_method_options": {
+        "card": {
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": ["card"],
+      "single_use_mandate": null,
+      "status": "requires_payment_method",
+      "usage": "off_session"
+    },
+    "previous_attributes": {
+      "default_source": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 0,
+  "request": {
+    "id": null,
+    "idempotency_key": null
+  },
+  "type": "setup_intent.succeeded"
+}

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         stub_request(:post, 'https://api.stripe.com/v1/checkout/sessions')
           .to_return(status: 200, body: body.to_json, headers: {})
 
-        allow(Stripe::Checkout::Session).to receive(:create)
+        allow(::Stripe::Checkout::Session).to receive(:create)
           .and_return({'url' => 'https://example.com'})
 
         post_with_token(organization, '/api/v1/customers', {customer: create_params})
@@ -360,7 +360,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
 
       customer.update(payment_provider: 'stripe', payment_provider_code: stripe_provider.code)
 
-      allow(Stripe::Checkout::Session).to receive(:create)
+      allow(::Stripe::Checkout::Session).to receive(:create)
         .and_return({'url' => 'https://example.com'})
     end
 

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -725,7 +725,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
 
       customer.update(payment_provider: 'stripe')
 
-      allow(Stripe::Checkout::Session).to receive(:create)
+      allow(::Stripe::Checkout::Session).to receive(:create)
         .and_return({'url' => 'https://example.com'})
     end
 

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -88,12 +88,12 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
     context 'with an error on stripe' do
       before do
         allow(Stripe::Refund).to receive(:create)
-          .and_raise(Stripe::InvalidRequestError.new('error', {}))
+          .and_raise(::Stripe::InvalidRequestError.new('error', {}))
       end
 
       it 'delivers an error webhook' do
         expect { stripe_service.create }
-          .to raise_error(Stripe::InvalidRequestError)
+          .to raise_error(::Stripe::InvalidRequestError)
 
         expect(SendWebhookJob).to have_been_enqueued
           .with(

--- a/spec/services/invoices/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/invoices/payments/generate_payment_url_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Invoices::Payments::GeneratePaymentUrlService, type: :service do
 
         customer.update(payment_provider: 'stripe')
 
-        allow(Stripe::Checkout::Session).to receive(:create)
+        allow(::Stripe::Checkout::Session).to receive(:create)
           .and_return({'url' => 'https://example55.com'})
       end
 

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         subscription
 
         allow(Stripe::PaymentIntent).to receive(:create)
-          .and_raise(Stripe::CardError.new('error', {}))
+          .and_raise(::Stripe::CardError.new('error', {}))
       end
 
       it 'delivers an error webhook' do
@@ -279,7 +279,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         subscription
 
         allow(Stripe::PaymentIntent).to receive(:create)
-          .and_raise(Stripe::InvalidRequestError.new('amount_too_small', {}, code: 'amount_too_small'))
+          .and_raise(::Stripe::InvalidRequestError.new('amount_too_small', {}, code: 'amount_too_small'))
       end
 
       it 'does not send mark the invoice as failed' do
@@ -413,14 +413,14 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       stripe_payment_provider
       stripe_customer
 
-      allow(Stripe::Checkout::Session).to receive(:create)
+      allow(::Stripe::Checkout::Session).to receive(:create)
         .and_return({'url' => 'https://example.com'})
     end
 
     it 'generates payment url' do
       stripe_service.generate_payment_url
 
-      expect(Stripe::Checkout::Session).to have_received(:create)
+      expect(::Stripe::Checkout::Session).to have_received(:create)
     end
 
     context 'when invoice is payment_succeeded' do
@@ -429,7 +429,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       it 'does not generate payment url' do
         stripe_service.generate_payment_url
 
-        expect(Stripe::Checkout::Session).not_to have_received(:create)
+        expect(::Stripe::Checkout::Session).not_to have_received(:create)
       end
     end
 
@@ -439,7 +439,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       it 'does not generate payment url' do
         stripe_service.generate_payment_url
 
-        expect(Stripe::Checkout::Session).not_to have_received(:create)
+        expect(::Stripe::Checkout::Session).not_to have_received(:create)
       end
     end
 

--- a/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentProviderCustomers::Stripe::UpdatePaymentMethodService, type: :service do
+  subject(:update_service) { described_class.new(stripe_customer:, payment_method_id:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:stripe_customer) { create(:stripe_customer, customer:) }
+  let(:payment_method_id) { 'pm_123456' }
+
+  describe '#call' do
+    it 'updates the customer payment method', aggregate_failures: true do
+      result = update_service.call
+
+      expect(result).to be_success
+      expect(result.stripe_customer.payment_method_id).to eq(payment_method_id)
+    end
+
+    context 'with pending invoices' do
+      let(:invoice) do
+        create(
+          :invoice,
+          customer:,
+          total_amount_cents: 200,
+          currency: 'EUR',
+          status:,
+          ready_for_payment_processing:
+        )
+      end
+
+      let(:status) { 'finalized' }
+      let(:ready_for_payment_processing) { true }
+
+      before { invoice }
+
+      it 'enqueues jobs to reprocess the pending payment', aggregate_failure: true do
+        result = update_service.call
+
+        expect(result).to be_success
+        expect(Invoices::Payments::StripeCreateJob).to have_been_enqueued
+          .with(invoice)
+      end
+
+      context 'when invoices are not finalized' do
+        let(:status) { 'draft' }
+
+        it 'does not enqueue jobs to reprocess pending payment', aggregate_failure: true do
+          result = update_service.call
+
+          expect(result).to be_success
+          expect(Invoices::Payments::StripeCreateJob).not_to have_been_enqueued
+            .with(invoice)
+        end
+      end
+
+      context 'when invoices are not ready for payment processing' do
+        let(:ready_for_payment_processing) { 'false' }
+
+        it 'does not enqueue jobs to reprocess pending payment', aggregate_failure: true do
+          result = update_service.call
+
+          expect(result).to be_success
+          expect(Invoices::Payments::StripeCreateJob).not_to have_been_enqueued
+            .with(invoice)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/payment_providers/stripe_service_spec.rb
+++ b/spec/services/payment_providers/stripe_service_spec.rb
@@ -397,11 +397,7 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
       end
 
       before do
-        allow(PaymentProviderCustomers::StripeService).to receive(:new)
-          .and_return(provider_customer_service)
-        allow(provider_customer_service).to receive(:update_payment_method)
-          .and_return(service_result)
-        allow(provider_customer_service).to receive(:update_provider_default_payment_method)
+        allow(PaymentProviders::Webhooks::Stripe::SetupIntentSucceededService).to receive(:call)
           .and_return(service_result)
       end
 
@@ -413,9 +409,7 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
 
         expect(result).to be_success
 
-        expect(PaymentProviderCustomers::StripeService).to have_received(:new)
-        expect(provider_customer_service).to have_received(:update_payment_method)
-        expect(provider_customer_service).to have_received(:update_provider_default_payment_method)
+        expect(PaymentProviders::Webhooks::Stripe::SetupIntentSucceededService).to have_received(:call)
       end
     end
 
@@ -426,9 +420,7 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
       end
 
       before do
-        allow(PaymentProviderCustomers::StripeService).to receive(:new)
-          .and_return(provider_customer_service)
-        allow(provider_customer_service).to receive(:update_payment_method)
+        allow(PaymentProviders::Webhooks::Stripe::CustomerUpdatedService).to receive(:call)
           .and_return(service_result)
       end
 
@@ -440,17 +432,7 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
 
         expect(result).to be_success
 
-        expect(PaymentProviderCustomers::StripeService).to have_received(:new)
-        expect(provider_customer_service).to have_received(:update_payment_method)
-          .with(
-            metadata: {
-              customer_id: 'test_5',
-              lago_customer_id: '123456-1234-1234-1234-1234567890'
-            },
-            organization_id: organization.id,
-            stripe_customer_id: 'cus_123456789',
-            payment_method_id: 'card_123456789'
-          )
+        expect(PaymentProviders::Webhooks::Stripe::CustomerUpdatedService).to have_received(:call)
       end
     end
 

--- a/spec/services/payment_providers/webhooks/stripe/customer_updated_service_spec.rb
+++ b/spec/services/payment_providers/webhooks/stripe/customer_updated_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentProviders::Webhooks::Stripe::CustomerUpdatedService, type: :service do
+  subject(:webhook_service) { described_class.new(organization_id: organization.id, event_json:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:event_json) { File.read('spec/fixtures/stripe/customer_updated_event.json') }
+
+  let(:event) { Stripe::Event.construct_from(JSON.parse(event_json)) }
+  let(:provider_customer_id) { event.data.object.id }
+  let(:payment_method_id) { event.data.object.default_source }
+
+  let(:stripe_provider) { create(:stripe_provider, organization:) }
+  let(:stripe_customer) do
+    create(:stripe_customer, payment_provider: stripe_provider, customer:, provider_customer_id:)
+  end
+
+  before { stripe_customer }
+
+  describe '#call' do
+    it 'updates the customer payment method', aggregate_failures: true do
+      result = webhook_service.call
+
+      expect(result).to be_success
+      expect(result.stripe_customer.payment_method_id).to eq(payment_method_id)
+    end
+
+    context 'when customer is not found' do
+      let(:provider_customer_id) { 'cus_InvaLid' }
+
+      it 'returns an empty result', aggregate_failures: true do
+        result = webhook_service.call
+
+        expect(result).to be_success
+        expect(result.stripe_customer).to be_nil
+      end
+
+      context 'when customer in metadata is not found' do
+        let(:event_json) { File.read('spec/fixtures/stripe/customer_updated_event_with_metadata.json') }
+
+        it 'returns an empty response', aggregate_failures: true do
+          result = webhook_service.call
+
+          expect(result).to be_success
+          expect(result.stripe_customer).to be_nil
+        end
+      end
+
+      context 'when customer in metadata exists' do
+        let(:event_json) { File.read('spec/fixtures/stripe/setup_intent_event_with_metadata.json') }
+        let(:customer) { create(:customer, id: event.data.object.metadata['lago_customer_id'], organization:) }
+
+        it 'returns a not found error', aggregate_failures: true do
+          result = webhook_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('stripe_customer_not_found')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/payment_providers/webhooks/stripe/setup_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/webhooks/stripe/setup_intent_succeeded_service_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentProviders::Webhooks::Stripe::SetupIntentSucceededService, type: :service do
+  subject(:webhook_service) { described_class.new(organization_id: organization.id, event_json:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:event_json) { File.read('spec/fixtures/stripe/setup_intent_event.json') }
+
+  let(:event) { Stripe::Event.construct_from(JSON.parse(event_json)) }
+  let(:provider_customer_id) { event.data.object.customer }
+  let(:payment_method_id) { event.data.object.payment_method }
+
+  let(:stripe_provider) { create(:stripe_provider, organization:) }
+  let(:stripe_customer) do
+    create(:stripe_customer, payment_provider: stripe_provider, customer:, provider_customer_id:)
+  end
+
+  before { stripe_customer }
+
+  describe '#call' do
+    it 'updates provider default payment method', aggregate_failures: true do
+      allow(Stripe::Customer).to receive(:update).and_return(true)
+
+      result = webhook_service.call
+
+      expect(result).to be_success
+      expect(result.payment_method_id).to eq(payment_method_id)
+      expect(result.stripe_customer).to eq(stripe_customer)
+      expect(result.stripe_customer.payment_method_id).to eq(payment_method_id)
+
+      expect(Stripe::Customer).to have_received(:update).with(
+        provider_customer_id,
+        {invoice_settings: {default_payment_method: payment_method_id}},
+        {api_key: stripe_provider.secret_key}
+      )
+    end
+
+    context 'when stripe customer is not found', aggregate_failures: true do
+      let(:provider_customer_id) { 'cus_InvaLid' }
+
+      it 'returns an empty result' do
+        result = webhook_service.call
+
+        expect(result).to be_success
+        expect(result.payment_method).to be_nil
+      end
+
+      context 'when customer in metadata is not found' do
+        let(:event_json) { File.read('spec/fixtures/stripe/setup_intent_event_with_metadata.json') }
+
+        it 'returns an empty response', aggregate_failures: true do
+          result = webhook_service.call
+
+          expect(result).to be_success
+          expect(result.payment_method).to be_nil
+        end
+      end
+
+      context 'when customer in metadata exists' do
+        let(:event_json) { File.read('spec/fixtures/stripe/setup_intent_event_with_metadata.json') }
+        let(:customer) { create(:customer, id: event.data.object.metadata['lago_customer_id'], organization:) }
+
+        it 'returns a not found error', aggregate_failures: true do
+          result = webhook_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('stripe_customer_not_found')
+        end
+      end
+    end
+
+    context 'when stripe customer id is nil' do
+      let(:event_json) { File.read('spec/fixtures/stripe/setup_intent_event_without_customer.json') }
+      let(:provider_customer_id) { 'cus_InvaLid' }
+
+      it 'returns an empty result', aggregate_failures: true do
+        result = webhook_service.call
+
+        expect(result).to be_success
+        expect(result.payment_method).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService, type: :serv
         payment_provider: stripe_provider
       )
 
-      allow(Stripe::Checkout::Session).to receive(:create)
+      allow(::Stripe::Checkout::Session).to receive(:create)
         .and_return({"url" => "https://example55.com"})
     end
 

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
 
       before do
         allow(Stripe::PaymentIntent).to receive(:create)
-          .and_raise(Stripe::CardError.new("error", {}))
+          .and_raise(::Stripe::CardError.new("error", {}))
         allow(PaymentRequests::Payments::DeliverErrorWebhookService)
           .to receive(:call_async)
           .and_call_original
@@ -324,7 +324,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
 
       before do
         allow(Stripe::PaymentIntent).to receive(:create)
-          .and_raise(Stripe::InvalidRequestError.new("amount_too_small", {}, code: "amount_too_small"))
+          .and_raise(::Stripe::InvalidRequestError.new("amount_too_small", {}, code: "amount_too_small"))
       end
 
       it "does not mark the payment request as failed" do
@@ -401,14 +401,14 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
       stripe_payment_provider
       stripe_customer
 
-      allow(Stripe::Checkout::Session).to receive(:create)
+      allow(::Stripe::Checkout::Session).to receive(:create)
         .and_return({"url" => "https://example.com"})
     end
 
     it "generates payment url" do
       stripe_service.generate_payment_url
 
-      expect(Stripe::Checkout::Session)
+      expect(::Stripe::Checkout::Session)
         .to have_received(:create)
         .with(
           {
@@ -448,7 +448,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
       it "does not generate payment url" do
         stripe_service.generate_payment_url
 
-        expect(Stripe::Checkout::Session).not_to have_received(:create)
+        expect(::Stripe::Checkout::Session).not_to have_received(:create)
       end
     end
   end


### PR DESCRIPTION
## Context

This PR is related to the remaining ` PaymentProviders::Stripe::HandleEventJob` dead jobs with `BaseService::NotFoundFailure: stripe_customer_not_found`  error

## Description

The main goal of the PR is to refactor the handling of the `setup_intent.succeeded` and `customer.updated` to move the logic in a dedicated webhook service (in the objective of killing the unmaintainable `PaymentProviderCustomers::StripeService`).

It also fixes a case in `setup_intent.succeeded` when the webhook has a `customer` with null value and no Lago ids in the metadata. Since in this specif case the webhook does not target a lago resource, the handling should not raise an error but should be ignored.