### PR TITLE
bug(BillableMetric) - BillableMetrics::DeleteEventsJob remove new-style events as well

### DIFF
--- a/app/jobs/billable_metrics/delete_events_job.rb
+++ b/app/jobs/billable_metrics/delete_events_job.rb
@@ -9,11 +9,21 @@ module BillableMetrics
 
       deleted_at = Time.current
 
+      # Delete events having an old-style `subscription_id`
       Event.where(
         code: metric.code,
         subscription_id: Charge.with_discarded
           .where(billable_metric_id: metric.id)
           .joins(plan: :subscriptions).pluck('subscriptions.id')
+      ).update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
+
+      # Delete events using the new `external_subscription_id`
+      Event.where(
+        organization_id: metric.organization.id,
+        code: metric.code,
+        external_subscription_id: Charge.with_discarded
+          .where(billable_metric_id: metric.id)
+          .joins(plan: :subscriptions).pluck('subscriptions.external_id')
       ).update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
     end
   end

--- a/spec/jobs/billable_metrics/delete_events_job_spec.rb
+++ b/spec/jobs/billable_metrics/delete_events_job_spec.rb
@@ -18,4 +18,17 @@ RSpec.describe BillableMetrics::DeleteEventsJob, type: :job, transaction: false 
       expect(not_impacted_event.reload.deleted_at).to be_nil
     end
   end
+
+  it 'deletes new-style external_subscription based events' do
+    create(:standard_charge, plan: subscription.plan, billable_metric:)
+    not_impacted_event = create(:event, external_subscription_id: SecureRandom.uuid, organization_id: billable_metric.organization_id)
+    event = create(:event, code: billable_metric.code, external_subscription_id: subscription.external_id, organization_id: billable_metric.organization_id)
+
+    freeze_time do
+      expect { described_class.perform_now(billable_metric) }
+        .to change { event.reload.deleted_at }.from(nil).to(Time.current)
+
+      expect(not_impacted_event.reload.deleted_at).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Description

when switching events over to use `external_subscription_id` we forgot to adapt this job to also remove those events.
I decided to also keep the old query in there as it might be that a very old billable metric is removed at some point in the future.