### PR TITLE
improvement(Cascade) - Improve cascade jobs by passing in the expected amount_cents

### DIFF
--- a/app/jobs/plans/update_amount_job.rb
+++ b/app/jobs/plans/update_amount_job.rb
@@ -4,8 +4,8 @@ module Plans
   class UpdateAmountJob < ApplicationJob
     queue_as 'default'
 
-    def perform(plan:, amount_cents:)
-      Plans::UpdateAmountService.call(plan:, amount_cents:)
+    def perform(plan:, amount_cents:, expected_amount_cents:)
+      Plans::UpdateAmountService.call(plan:, amount_cents:, expected_amount_cents:).raise_if_error!
     end
   end
 end

--- a/app/services/plans/update_amount_service.rb
+++ b/app/services/plans/update_amount_service.rb
@@ -2,9 +2,10 @@
 
 module Plans
   class UpdateAmountService < BaseService
-    def initialize(plan:, amount_cents:)
+    def initialize(plan:, amount_cents:, expected_amount_cents:)
       @plan = plan
       @amount_cents = amount_cents
+      @expected_amount_cents = expected_amount_cents
 
       super
     end
@@ -12,15 +13,17 @@ module Plans
     def call
       return result.not_found_failure!(resource: 'plan') unless plan
 
+      result.plan = plan
+      return result if plan.amount_cents != expected_amount_cents
+
       plan.amount_cents = amount_cents
       plan.save!
 
-      result.plan = plan
       result
     end
 
     private
 
-    attr_reader :plan, :amount_cents
+    attr_reader :plan, :amount_cents, :expected_amount_cents
   end
 end

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -95,7 +95,7 @@ module Plans
       return if plan.children.empty?
 
       plan.children.where(amount_cents: old_amount_cents).find_each do |p|
-        Plans::UpdateAmountJob.perform_later(plan: p, amount_cents: plan.amount_cents)
+        Plans::UpdateAmountJob.perform_later(plan: p, amount_cents: plan.amount_cents, expected_amount_cents: old_amount_cents)
       end
     end
 

--- a/spec/jobs/plans/update_amount_job_spec.rb
+++ b/spec/jobs/plans/update_amount_job_spec.rb
@@ -5,14 +5,15 @@ require 'rails_helper'
 RSpec.describe Plans::UpdateAmountJob, type: :job do
   let(:plan) { create(:plan) }
   let(:amount_cents) { 200 }
+  let(:expected_amount_cents) { 100 }
 
   before do
-    allow(Plans::UpdateAmountService).to receive(:call).with(plan:, amount_cents:)
+    allow(Plans::UpdateAmountService).to receive(:call).with(plan:, amount_cents:, expected_amount_cents:).and_call_original
   end
 
   it 'calls the service' do
-    described_class.perform_now(plan:, amount_cents:)
+    described_class.perform_now(plan:, amount_cents:, expected_amount_cents:)
 
-    expect(Plans::UpdateAmountService).to have_received(:call)
+    expect(Plans::UpdateAmountService).to have_received(:call).with(plan:, amount_cents:, expected_amount_cents:)
   end
 end

--- a/spec/services/plans/update_amount_service_spec.rb
+++ b/spec/services/plans/update_amount_service_spec.rb
@@ -3,12 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe Plans::UpdateAmountService, type: :service do
-  subject(:update_service) { described_class.new(plan:, amount_cents:) }
+  subject(:update_service) { described_class.new(plan:, amount_cents:, expected_amount_cents:) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:plan) { create(:plan, organization:, amount_cents: 111) }
   let(:amount_cents) { 222 }
+  let(:expected_amount_cents) { 111 }
 
   before { plan }
 
@@ -28,6 +29,19 @@ RSpec.describe Plans::UpdateAmountService, type: :service do
         aggregate_failures do
           expect(result).not_to be_success
           expect(result.error.error_code).to eq('plan_not_found')
+        end
+      end
+    end
+
+    context 'when the expected_amount_cents does not match the plan amount_cents' do
+      let(:expected_amount_cents) { 10 }
+
+      it 'does not update the plan' do
+        result = update_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.plan.reload.amount_cents).to eq(111)
         end
       end
     end


### PR DESCRIPTION
## Description

Plans might receive updates between the cascade being enqueued and the job starting. Although an unlikely edge case, idempotency is important should we enable retries for this job in the future.