### PR TITLE
fix: Ability to delete assigned customer taxes from the API

### DIFF
--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -77,7 +77,7 @@ module Customers
           params[:tax_codes] = (params[:tax_codes] + [eu_tax_code]).uniq
         end
 
-        if params[:tax_codes].present?
+        if params.key?(:tax_codes)
           taxes_result = Customers::ApplyTaxesService.call(customer:, tax_codes: params[:tax_codes])
           taxes_result.raise_if_error!
         end


### PR DESCRIPTION
The goal of this PR is to be able to delete assigned taxes to a customer from the API.