### PR TITLE
feat(moneyhash): Add customer creation to MoneyHash if checkbox marked

### DIFF
--- a/app/jobs/payment_provider_customers/moneyhash_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/moneyhash_checkout_url_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class MoneyhashCheckoutUrlJob < ApplicationJob
+    queue_as :providers
+
+    retry_on ActiveJob::DeserializationError
+
+    def perform(moneyhash_customer)
+      result = PaymentProviderCustomers::MoneyhashService.new(moneyhash_customer).generate_checkout_url
+      result.raise_if_error!
+    end
+  end
+end

--- a/app/jobs/payment_provider_customers/moneyhash_create_job.rb
+++ b/app/jobs/payment_provider_customers/moneyhash_create_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class MoneyhashCreateJob < ApplicationJob
+    queue_as :providers
+
+    retry_on ActiveJob::DeserializationError
+
+    def perform(moneyhash_customer)
+      result = PaymentProviderCustomers::MoneyhashService.new(moneyhash_customer).create
+      result.raise_if_error!
+    end
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -57,12 +57,13 @@ class Customer < ApplicationRecord
   has_one :stripe_customer, class_name: 'PaymentProviderCustomers::StripeCustomer'
   has_one :gocardless_customer, class_name: 'PaymentProviderCustomers::GocardlessCustomer'
   has_one :adyen_customer, class_name: 'PaymentProviderCustomers::AdyenCustomer'
+  has_one :moneyhash_customer, class_name: 'PaymentProviderCustomers::MoneyhashCustomer'
   has_one :netsuite_customer, class_name: 'IntegrationCustomers::NetsuiteCustomer'
   has_one :anrok_customer, class_name: 'IntegrationCustomers::AnrokCustomer'
   has_one :xero_customer, class_name: 'IntegrationCustomers::XeroCustomer'
   has_one :hubspot_customer, class_name: 'IntegrationCustomers::HubspotCustomer'
 
-  PAYMENT_PROVIDERS = %w[stripe gocardless adyen].freeze
+  PAYMENT_PROVIDERS = %w[stripe gocardless adyen moneyhash].freeze
 
   default_scope -> { kept }
   sequenced scope: ->(customer) { customer.organization.customers.with_discarded },
@@ -144,6 +145,8 @@ class Customer < ApplicationRecord
       gocardless_customer
     when :adyen
       adyen_customer
+    when :moneyhash
+      moneyhash_customer
     end
   end
 

--- a/app/models/payment_provider_customers/moneyhash_customer.rb
+++ b/app/models/payment_provider_customers/moneyhash_customer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class MoneyhashCustomer < BaseCustomer
+    settings_accessors :payment_method_id
+  end
+end
+
+# == Schema Information
+#
+# Table name: payment_provider_customers
+#
+#  id                   :uuid             not null, primary key
+#  deleted_at           :datetime
+#  settings             :jsonb            not null
+#  type                 :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  customer_id          :uuid             not null
+#  payment_provider_id  :uuid
+#  provider_customer_id :string
+#
+# Indexes
+#
+#  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE WHERE (deleted_at IS NULL)
+#  index_payment_provider_customers_on_payment_provider_id   (payment_provider_id)
+#  index_payment_provider_customers_on_provider_customer_id  (provider_customer_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (payment_provider_id => payment_providers.id)
+#

--- a/app/models/payment_providers/moneyhash_provider.rb
+++ b/app/models/payment_providers/moneyhash_provider.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  class MoneyhashProvider < BaseProvider
+    SUCCESS_REDIRECT_URL = 'https://moneyhash.io/'
+
+    validates :api_key, presence: true
+    validates :success_redirect_url, url: true, allow_nil: true, length: {maximum: 1024}
+
+    secrets_accessors :api_key
+
+    def self.api_base_url
+      if Rails.env.production?
+        'https://web.moneyhash.io'
+      else
+        'https://staging-web.moneyhash.io'
+      end
+    end
+
+    def environment
+      if Rails.env.production? && live_prefix.present?
+        :live
+      else
+        :test
+      end
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: payment_providers
+#
+#  id              :uuid             not null, primary key
+#  code            :string           not null
+#  deleted_at      :datetime
+#  name            :string           not null
+#  secrets         :string
+#  settings        :jsonb            not null
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_payment_providers_on_code_and_organization_id  (code,organization_id) UNIQUE WHERE (deleted_at IS NULL)
+#  index_payment_providers_on_organization_id           (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -74,6 +74,9 @@ module V1
       when :adyen
         configuration[:provider_customer_id] = model.adyen_customer&.provider_customer_id
         configuration.merge!(model.adyen_customer&.settings || {})
+      when :moneyhash
+        configuration[:provider_customer_id] = model.moneyhash_customer&.provider_customer_id
+        configuration.merge!(model.moneyhash_customer&.settings || {})
       end
 
       configuration

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -280,7 +280,7 @@ module Customers
 
       if billing.key?(:payment_provider)
         customer.payment_provider = nil
-        if %w[stripe gocardless adyen].include?(billing[:payment_provider])
+        if %w[stripe gocardless adyen moneyhash].include?(billing[:payment_provider])
           customer.payment_provider = billing[:payment_provider]
           customer.payment_provider_code = billing[:payment_provider_code] if billing.key?(:payment_provider_code)
         end
@@ -310,6 +310,8 @@ module Customers
         PaymentProviderCustomers::GocardlessCustomer
       when 'adyen'
         PaymentProviderCustomers::AdyenCustomer
+      when 'moneyhash'
+        PaymentProviderCustomers::MoneyhashCustomer
       end
 
       create_result = PaymentProviderCustomers::CreateService.new(customer).create_or_update(

--- a/app/services/payment_provider_customers/create_service.rb
+++ b/app/services/payment_provider_customers/create_service.rb
@@ -65,6 +65,10 @@ module PaymentProviderCustomers
         return PaymentProviderCustomers::AdyenCreateJob.perform_later(result.provider_customer) if async
 
         PaymentProviderCustomers::AdyenCreateJob.perform_now(result.provider_customer)
+      elsif result.provider_customer.type == 'PaymentProviderCustomers::MoneyhashCustomer'
+        return PaymentProviderCustomers::MoneyhashCreateJob.perform_later(result.provider_customer) if async
+
+        PaymentProviderCustomers::MoneyhashCreateJob.perform_now(result.provider_customer)
       else
         return PaymentProviderCustomers::GocardlessCreateJob.perform_later(result.provider_customer) if async
 

--- a/app/services/payment_provider_customers/factory.rb
+++ b/app/services/payment_provider_customers/factory.rb
@@ -14,6 +14,8 @@ module PaymentProviderCustomers
         PaymentProviderCustomers::GocardlessService
       when 'PaymentProviderCustomers::AdyenCustomer'
         PaymentProviderCustomers::AdyenService
+      when 'PaymentProviderCustomers::MoneyhashCustomer'
+        PaymentProviderCustomers::MoneyhashService
       else
         raise(NotImplementedError)
       end

--- a/app/services/payment_provider_customers/moneyhash_service.rb
+++ b/app/services/payment_provider_customers/moneyhash_service.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class MoneyhashService < BaseService
+    include Customers::PaymentProviderFinder
+
+    def initialize(moneyhash_customer = nil)
+      @moneyhash_customer = moneyhash_customer
+
+      super(nil)
+    end
+
+    def create
+      result.moneyhash_customer = moneyhash_customer
+      return result if moneyhash_customer.provider_customer_id?
+      moneyhash_result = create_moneyhash_customer
+
+      moneyhash_customer.update!(
+        provider_customer_id: moneyhash_result["data"]["id"]
+      )
+      deliver_success_webhook
+      result.moneyhash_customer = moneyhash_customer
+      result
+    end
+
+    def update
+      result
+    end
+
+    private
+
+    attr_accessor :moneyhash_customer
+
+    delegate :customer, to: :moneyhash_customer
+
+    def client
+      @client || LagoHttpClient::Client.new("#{PaymentProviders::MoneyhashProvider.api_base_url}/api/v1.1/customers/")
+    end
+
+    def api_key
+      moneyhash_payment_provider.secret_key
+    end
+
+    def moneyhash_payment_provider
+      @moneyhash_payment_provider ||= payment_provider(customer)
+    end
+
+    def create_moneyhash_customer
+      customer_params = {
+        first_name: customer&.firstname,
+        last_name: customer&.lastname,
+        email: customer&.email,
+        phone_number: customer&.phone,
+        tax_id: customer&.tax_identification_number,
+        address: customer&.address_line1,
+        contact_person_name: customer&.legal_name
+      }.compact
+
+      response = client.post_with_response(customer_params, headers)
+      JSON.parse(response.body)
+    rescue LagoHttpClient::HttpError => e
+      deliver_error_webhook(e)
+      raise
+    end
+
+    def deliver_error_webhook(moneyhash_error)
+      SendWebhookJob.perform_later(
+        'customer.payment_provider_error',
+        customer,
+        provider_error: {
+          message: moneyhash_error.message,
+          error_code: moneyhash_error.error_code
+        }
+      )
+    end
+
+    def deliver_success_webhook
+      SendWebhookJob.perform_later(
+        'customer.payment_provider_created',
+        customer
+      )
+    end
+
+    def headers
+      {
+        'Content-Type' => 'application/json',
+        'x-Api-Key' => moneyhash_payment_provider.api_key
+      }
+    end
+  end
+end


### PR DESCRIPTION
## Context

This feature adds integration with the MoneyHash payment provider, allowing customers to be created in MoneyHash when the "sync with provider" checkbox is selected during customer creation in Lago. Previously, there was no integration with MoneyHash, so this adds a new workflow for syncing customers to the external system

## Description

This PR implements the following changes:

- When a new customer is created in Lago and the "sync with MoneyHash" checkbox is marked, a new customer is also created in MoneyHash.
- Integrated with the MoneyHash API to facilitate the customer creation process.
- Updated Lago's customer service logic to sync with MoneyHash.


List any dependencies that are required.

- MoneyHash Payment Provider needs to be created in Lago.
- MoneyHash API credentials need to be added in the Payment Provider details section.
