### PR TITLE
fix(gocardless): Handle GoCardlessPro::ValidationError when creating payment

### DIFF
--- a/app/jobs/invoices/payments/adyen_create_job.rb
+++ b/app/jobs/invoices/payments/adyen_create_job.rb
@@ -10,7 +10,7 @@ module Invoices
       retry_on Faraday::ConnectionFailed, wait: :polynomially_longer, attempts: 6
 
       def perform(invoice)
-        result = Invoices::Payments::AdyenService.new(invoice).create
+        result = Invoices::Payments::AdyenService.call(invoice)
         result.raise_if_error!
       end
     end

--- a/app/jobs/invoices/payments/gocardless_create_job.rb
+++ b/app/jobs/invoices/payments/gocardless_create_job.rb
@@ -8,7 +8,7 @@ module Invoices
       unique :until_executed
 
       def perform(invoice)
-        result = Invoices::Payments::GocardlessService.new(invoice).create
+        result = Invoices::Payments::GocardlessService.call(invoice)
         result.raise_if_error!
       end
     end

--- a/app/jobs/invoices/payments/stripe_create_job.rb
+++ b/app/jobs/invoices/payments/stripe_create_job.rb
@@ -11,7 +11,7 @@ module Invoices
       retry_on ::Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
 
       def perform(invoice)
-        result = Invoices::Payments::StripeService.new(invoice).create
+        result = Invoices::Payments::StripeService.call(invoice)
         result.raise_if_error!
       end
     end

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -13,10 +13,10 @@ module Invoices
       def initialize(invoice = nil)
         @invoice = invoice
 
-        super(nil)
+        super
       end
 
-      def create
+      def call
         result.invoice = invoice
         return result unless should_process_payment?
 

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -13,10 +13,10 @@ module Invoices
       def initialize(invoice = nil)
         @invoice = invoice
 
-        super(nil)
+        super
       end
 
-      def create
+      def call
         result.invoice = invoice
         return result unless should_process_payment?
 

--- a/spec/jobs/invoices/payments/adyen_create_job_spec.rb
+++ b/spec/jobs/invoices/payments/adyen_create_job_spec.rb
@@ -5,18 +5,13 @@ require 'rails_helper'
 RSpec.describe Invoices::Payments::AdyenCreateJob, type: :job do
   let(:invoice) { create(:invoice) }
 
-  let(:adyen_service) { instance_double(Invoices::Payments::AdyenService) }
-
   it 'calls the stripe create service' do
-    allow(Invoices::Payments::AdyenService).to receive(:new)
+    allow(Invoices::Payments::AdyenService).to receive(:call)
       .with(invoice)
-      .and_return(adyen_service)
-    allow(adyen_service).to receive(:create)
       .and_return(BaseService::Result.new)
 
     described_class.perform_now(invoice)
 
-    expect(Invoices::Payments::AdyenService).to have_received(:new)
-    expect(adyen_service).to have_received(:create)
+    expect(Invoices::Payments::AdyenService).to have_received(:call)
   end
 end

--- a/spec/jobs/invoices/payments/gocardless_create_job_spec.rb
+++ b/spec/jobs/invoices/payments/gocardless_create_job_spec.rb
@@ -5,18 +5,13 @@ require 'rails_helper'
 RSpec.describe Invoices::Payments::GocardlessCreateJob, type: :job do
   let(:invoice) { create(:invoice) }
 
-  let(:gocardless_service) { instance_double(Invoices::Payments::GocardlessService) }
-
   it 'calls the stripe create service' do
-    allow(Invoices::Payments::GocardlessService).to receive(:new)
+    allow(Invoices::Payments::GocardlessService).to receive(:call)
       .with(invoice)
-      .and_return(gocardless_service)
-    allow(gocardless_service).to receive(:create)
       .and_return(BaseService::Result.new)
 
     described_class.perform_now(invoice)
 
-    expect(Invoices::Payments::GocardlessService).to have_received(:new)
-    expect(gocardless_service).to have_received(:create)
+    expect(Invoices::Payments::GocardlessService).to have_received(:call)
   end
 end

--- a/spec/jobs/invoices/payments/stripe_create_job_spec.rb
+++ b/spec/jobs/invoices/payments/stripe_create_job_spec.rb
@@ -5,18 +5,13 @@ require 'rails_helper'
 RSpec.describe Invoices::Payments::StripeCreateJob, type: :job do
   let(:invoice) { create(:invoice) }
 
-  let(:stripe_service) { instance_double(Invoices::Payments::StripeService) }
-
   it 'calls the stripe create service' do
-    allow(Invoices::Payments::StripeService).to receive(:new)
+    allow(Invoices::Payments::StripeService).to receive(:call)
       .with(invoice)
-      .and_return(stripe_service)
-    allow(stripe_service).to receive(:create)
       .and_return(BaseService::Result.new)
 
     described_class.perform_now(invoice)
 
-    expect(Invoices::Payments::StripeService).to have_received(:new)
-    expect(stripe_service).to have_received(:create)
+    expect(Invoices::Payments::StripeService).to have_received(:call)
   end
 end

--- a/spec/services/invoices/payments/adyen_service_spec.rb
+++ b/spec/services/invoices/payments/adyen_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
     )
   end
 
-  describe '#create' do
+  describe '#call' do
     before do
       adyen_payment_provider
       adyen_customer
@@ -48,7 +48,7 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
     end
 
     it 'creates an adyen payment' do
-      result = adyen_service.create
+      result = adyen_service.call
 
       expect(result).to be_success
 
@@ -73,14 +73,14 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
     end
 
     it_behaves_like 'syncs payment' do
-      let(:service_call) { adyen_service.create }
+      let(:service_call) { adyen_service.call }
     end
 
     context 'with no payment provider' do
       let(:adyen_payment_provider) { nil }
 
       it 'does not creates a adyen payment' do
-        result = adyen_service.create
+        result = adyen_service.call
 
         expect(result).to be_success
 
@@ -105,7 +105,7 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
       end
 
       it 'does not creates a adyen payment' do
-        result = adyen_service.create
+        result = adyen_service.call
 
         expect(result).to be_success
 
@@ -124,7 +124,7 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
       before { adyen_customer.update!(provider_customer_id: nil) }
 
       it 'does not creates a adyen payment' do
-        result = adyen_service.create
+        result = adyen_service.call
 
         expect(result).to be_success
 
@@ -145,7 +145,7 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
       end
 
       it 'delivers an error webhook' do
-        expect { adyen_service.create }.to enqueue_job(SendWebhookJob)
+        expect { adyen_service.call }.to enqueue_job(SendWebhookJob)
           .with(
             'invoice.payment_failure',
             invoice,
@@ -182,7 +182,7 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
         it 'delivers an error webhook' do
           allow(Invoices::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
 
-          adyen_service.create
+          adyen_service.call
 
           expect(Invoices::Payments::DeliverErrorWebhookService).to have_received(:call_async)
           expect(SendWebhookJob).to have_been_enqueued
@@ -204,7 +204,7 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
             invoice.update! status: :open, invoice_type: :credit
             allow(Invoices::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
 
-            adyen_service.create
+            adyen_service.call
 
             expect(Invoices::Payments::DeliverErrorWebhookService).to have_received(:call_async)
             expect(SendWebhookJob).to have_been_enqueued
@@ -228,7 +228,7 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
         end
 
         it 'delivers an error webhook' do
-          expect { adyen_service.create }.to enqueue_job(SendWebhookJob)
+          expect { adyen_service.call }.to enqueue_job(SendWebhookJob)
             .with(
               'invoice.payment_failure',
               invoice,

--- a/spec/services/invoices/payments/gocardless_service_spec.rb
+++ b/spec/services/invoices/payments/gocardless_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
     )
   end
 
-  describe '.create' do
+  describe '.call' do
     before do
       gocardless_payment_provider
       gocardless_customer
@@ -53,7 +53,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
     end
 
     it 'creates a gocardless payment' do
-      result = gocardless_service.create
+      result = gocardless_service.call
 
       expect(result).to be_success
 
@@ -76,14 +76,14 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
     end
 
     it_behaves_like 'syncs payment' do
-      let(:service_call) { gocardless_service.create }
+      let(:service_call) { gocardless_service.call }
     end
 
     context 'with no payment provider' do
       let(:gocardless_payment_provider) { nil }
 
       it 'does not creates a gocardless payment' do
-        result = gocardless_service.create
+        result = gocardless_service.call
 
         expect(result).to be_success
 
@@ -108,7 +108,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
       end
 
       it 'does not creates a gocardless payment' do
-        result = gocardless_service.create
+        result = gocardless_service.call
 
         expect(result).to be_success
 
@@ -127,7 +127,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
       before { gocardless_customer.update!(provider_customer_id: nil) }
 
       it 'does not creates a gocardless payment' do
-        result = gocardless_service.create
+        result = gocardless_service.call
 
         expect(result).to be_success
 
@@ -161,7 +161,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
       it 'delivers an error webhook' do
         allow(Invoices::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
 
-        expect { gocardless_service.create }.to raise_error(GoCardlessPro::Error)
+        expect { gocardless_service.call }.to raise_error(GoCardlessPro::Error)
 
         expect(Invoices::Payments::DeliverErrorWebhookService).to have_received(:call_async)
         expect(SendWebhookJob).to have_been_enqueued
@@ -183,7 +183,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
           invoice.update! status: :open, invoice_type: :credit
           allow(Invoices::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
 
-          expect { gocardless_service.create }.to raise_error(GoCardlessPro::Error)
+          expect { gocardless_service.call }.to raise_error(GoCardlessPro::Error)
 
           expect(Invoices::Payments::DeliverErrorWebhookService).to have_received(:call_async)
           expect(SendWebhookJob).to have_been_enqueued
@@ -213,7 +213,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
       end
 
       it "delivers an error webhook" do
-        result = gocardless_service.create
+        result = gocardless_service.call
 
         aggregate_failures do
           expect(result).not_to be_success

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
     )
   end
 
-  describe '.create' do
+  describe '.call' do
     let(:provider_customer_service) { instance_double(PaymentProviderCustomers::StripeService) }
 
     let(:provider_customer_service_result) do
@@ -65,7 +65,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
     end
 
     it 'creates a stripe payment and a payment' do
-      result = stripe_service.create
+      result = stripe_service.call
 
       expect(result).to be_success
 
@@ -87,14 +87,14 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
     end
 
     it_behaves_like 'syncs payment' do
-      let(:service_call) { stripe_service.create }
+      let(:service_call) { stripe_service.call }
     end
 
     context 'with no payment provider' do
       let(:stripe_payment_provider) { nil }
 
       it 'does not creates a stripe payment' do
-        result = stripe_service.create
+        result = stripe_service.call
 
         expect(result).to be_success
 
@@ -119,7 +119,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       end
 
       it 'does not creates a stripe payment' do
-        result = stripe_service.create
+        result = stripe_service.call
 
         expect(result).to be_success
 
@@ -138,7 +138,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       before { stripe_customer.update!(provider_customer_id: nil) }
 
       it 'does not creates a stripe payment' do
-        result = stripe_service.create
+        result = stripe_service.call
 
         expect(result).to be_success
 
@@ -183,7 +183,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       end
 
       it 'retrieves the payment method' do
-        result = stripe_service.create
+        result = stripe_service.call
 
         expect(result).to be_success
         expect(customer.stripe_customer.reload).to be_present
@@ -216,7 +216,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       it 'delivers an error webhook' do
         allow(Invoices::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
 
-        stripe_service.create
+        stripe_service.call
 
         expect(Invoices::Payments::DeliverErrorWebhookService).to have_received(:call_async)
         expect(SendWebhookJob).to have_been_enqueued
@@ -242,7 +242,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         it 'delivers an error webhook' do
           allow(Invoices::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
 
-          stripe_service.create
+          stripe_service.call
 
           expect(Invoices::Payments::DeliverErrorWebhookService).to have_received(:call_async)
           expect(SendWebhookJob).to have_been_enqueued
@@ -283,7 +283,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       end
 
       it 'does not send mark the invoice as failed' do
-        stripe_service.create
+        stripe_service.call
         invoice.reload
 
         expect(invoice).to be_payment_pending
@@ -294,7 +294,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       let(:payment_status) { 'processing' }
 
       it 'creates a stripe payment and a payment' do
-        result = stripe_service.create
+        result = stripe_service.call
 
         expect(result).to be_success
 
@@ -336,7 +336,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       end
 
       it 'creates a stripe payment and payment with requires_action status' do
-        result = stripe_service.create
+        result = stripe_service.call
 
         expect(result).to be_success
 
@@ -347,7 +347,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       end
 
       it 'has enqueued a SendWebhookJob' do
-        result = stripe_service.create
+        result = stripe_service.call
 
         expect(SendWebhookJob).to have_been_enqueued
           .with(


### PR DESCRIPTION
## Description

This Pull Request adds the handling of `GoCardlessPro::ValidationError` in the `Invoices::Payments::GocardlessService`. It will update the invoice with the `payment_status = failed` and deliver an error webhook to the account owner.

It also adds the `call` pattern to `Invoices::Payments::AdyenService`, `Invoices::Payments::GocardlessService` and `Invoices::Payments::StripeService`
