### PR TITLE
fix(netsuite): Aggregator jobs should be unique

### DIFF
--- a/app/jobs/integrations/aggregator/credit_notes/create_job.rb
+++ b/app/jobs/integrations/aggregator/credit_notes/create_job.rb
@@ -6,7 +6,7 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
-        unique :until_executed
+        unique :until_executed, on_conflict: :log
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/integrations/aggregator/credit_notes/create_job.rb
+++ b/app/jobs/integrations/aggregator/credit_notes/create_job.rb
@@ -6,6 +6,8 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
+        unique :until_executed
+
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 

--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -6,7 +6,7 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
-        unique :until_executed
+        unique :until_executed, on_conflict: :log
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -6,6 +6,8 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
+        unique :until_executed
+
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 

--- a/app/jobs/integrations/aggregator/invoices/crm/create_customer_association_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/create_customer_association_job.rb
@@ -7,6 +7,8 @@ module Integrations
         class CreateCustomerAssociationJob < ApplicationJob
           queue_as 'integrations'
 
+          unique :until_executed
+
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 

--- a/app/jobs/integrations/aggregator/invoices/crm/create_customer_association_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/create_customer_association_job.rb
@@ -7,7 +7,7 @@ module Integrations
         class CreateCustomerAssociationJob < ApplicationJob
           queue_as 'integrations'
 
-          unique :until_executed
+          unique :until_executed, on_conflict: :log
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/integrations/aggregator/invoices/crm/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/create_job.rb
@@ -7,6 +7,8 @@ module Integrations
         class CreateJob < ApplicationJob
           queue_as 'integrations'
 
+          unique :until_executed
+
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/integrations/aggregator/invoices/crm/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/create_job.rb
@@ -7,7 +7,7 @@ module Integrations
         class CreateJob < ApplicationJob
           queue_as 'integrations'
 
-          unique :until_executed
+          unique :until_executed, on_conflict: :log
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10

--- a/app/jobs/integrations/aggregator/invoices/crm/update_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/update_job.rb
@@ -7,7 +7,7 @@ module Integrations
         class UpdateJob < ApplicationJob
           queue_as 'integrations'
 
-          unique :until_executed
+          unique :until_executed, on_conflict: :log
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10

--- a/app/jobs/integrations/aggregator/invoices/crm/update_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/update_job.rb
@@ -7,6 +7,8 @@ module Integrations
         class UpdateJob < ApplicationJob
           queue_as 'integrations'
 
+          unique :until_executed
+
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/integrations/aggregator/payments/create_job.rb
+++ b/app/jobs/integrations/aggregator/payments/create_job.rb
@@ -6,6 +6,8 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
+        unique :until_executed
+
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 5
         retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/integrations/aggregator/payments/create_job.rb
+++ b/app/jobs/integrations/aggregator/payments/create_job.rb
@@ -6,7 +6,7 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
-        unique :until_executed
+        unique :until_executed, on_conflict: :log
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 5
         retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10

--- a/app/jobs/integrations/aggregator/subscriptions/crm/create_customer_association_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/create_customer_association_job.rb
@@ -7,6 +7,8 @@ module Integrations
         class CreateCustomerAssociationJob < ApplicationJob
           queue_as 'integrations'
 
+          unique :until_executed
+
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 

--- a/app/jobs/integrations/aggregator/subscriptions/crm/create_customer_association_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/create_customer_association_job.rb
@@ -7,7 +7,7 @@ module Integrations
         class CreateCustomerAssociationJob < ApplicationJob
           queue_as 'integrations'
 
-          unique :until_executed
+          unique :until_executed, on_conflict: :log
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/integrations/aggregator/subscriptions/crm/create_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/create_job.rb
@@ -7,6 +7,8 @@ module Integrations
         class CreateJob < ApplicationJob
           queue_as 'integrations'
 
+          unique :until_executed
+
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/integrations/aggregator/subscriptions/crm/create_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/create_job.rb
@@ -7,7 +7,7 @@ module Integrations
         class CreateJob < ApplicationJob
           queue_as 'integrations'
 
-          unique :until_executed
+          unique :until_executed, on_conflict: :log
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10

--- a/app/jobs/integrations/aggregator/subscriptions/crm/update_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/update_job.rb
@@ -7,7 +7,7 @@ module Integrations
         class UpdateJob < ApplicationJob
           queue_as 'integrations'
 
-          unique :until_executed
+          unique :until_executed, on_conflict: :log
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10

--- a/app/jobs/integrations/aggregator/subscriptions/crm/update_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/update_job.rb
@@ -7,6 +7,8 @@ module Integrations
         class UpdateJob < ApplicationJob
           queue_as 'integrations'
 
+          unique :until_executed
+
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100


### PR DESCRIPTION
## Context

While syncing invoices to Netsuite, some invoices were sent twice

## Description

Add `unique :until_executed` to aggregator jobs so that the resources are only sync'd once.