### PR TITLE
fix(adyen): Handle Adyen::AuthenticationError when creating the customer

### DIFF
--- a/app/services/payment_provider_customers/adyen_service.rb
+++ b/app/services/payment_provider_customers/adyen_service.rb
@@ -20,6 +20,11 @@ module PaymentProviderCustomers
 
       result.checkout_url = checkout_url_result.checkout_url
       result
+    rescue Adyen::AuthenticationError
+      # NOTE: Authentication errors will be sent to the account owner with a webhook.
+      #       Since nothing can be done on Lago's side, we should not raise the error.
+      # TODO: Flag the error on the PaymentProvider instance.
+      result
     end
 
     def update


### PR DESCRIPTION
## Description

This Pull Request adds the handling of `Adyen::AuthenticationError` in the `PaymentProviderCustomers::AdyenService#create` method.
It will keep delivering an error webhook, but will not raise the authentication error anymore as nothing can be handled at Lago's level.

NOTE: In a future, the related `PaymentProvider` should marked as failed/disconnected/invalid and the error logged to make it visible in the web application and in the API
