### PR TITLE
fix(subscription upgrade): Upgrade subscriptions previously considered downgrade on amount increase

### DIFF
--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -18,8 +18,8 @@ module Plans
       plan.description = params[:description] if params.key?(:description)
       plan.amount_cents = params[:amount_cents] if params.key?(:amount_cents)
 
-      # NOTE: Only name and description are editable if plan
-      #       is attached to subscriptions
+      # NOTE: If plan is attached to subscriptions the editable attributes are:
+      #       name, invoice_display_name, description, amount_cents
       unless plan.attached_to_subscriptions?
         plan.code = params[:code] if params.key?(:code)
         plan.interval = params[:interval].to_sym if params.key?(:interval)

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -136,7 +136,9 @@ module Subscriptions
     end
 
     def upgrade_subscription
-      PlanUpgradeService.call(current_subscription:, plan:, params:).subscription
+      PlanUpgradeService.call(current_subscription:, plan:, params:).tap do |result|
+        result.raise_if_error!
+      end.subscription
     end
 
     def downgrade_subscription

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -1,0 +1,113 @@
+module Subscriptions
+  class PlanUpgradeService < BaseService
+    def initialize(current_subscription:, plan:, params:)
+      @current_subscription = current_subscription
+      @plan = plan
+
+      @params = params
+      @name = params[:name].to_s.strip
+      super
+    end
+
+    def call
+      if current_subscription.starting_in_the_future?
+        update_pending_subscription
+
+        result.subscription = current_subscription
+        return result
+      end
+
+      new_subscription = new_subcription_with_overrides
+
+      ActiveRecord::Base.transaction do
+        cancel_pending_subscription if pending_subscription?
+
+        # Group subscriptions for billing
+        billable_subscriptions = billable_subscriptions(new_subscription)
+
+        # Terminate current subscription as part of the upgrade process
+        Subscriptions::TerminateService.call(
+          subscription: current_subscription,
+          upgrade: true
+        )
+
+        new_subscription.mark_as_active!
+        after_commit do
+          SendWebhookJob.perform_later("subscription.started", new_subscription)
+        end
+
+        bill_subscriptions(billable_subscriptions) if billable_subscriptions.any?
+      end
+
+      result.subscription = new_subscription
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      result.fail_with_error!(e)
+    end
+
+    private
+
+    attr_reader :current_subscription, :plan, :params, :name
+
+    def new_subcription_with_overrides
+      Subscription.new(
+        customer: current_subscription.customer,
+        plan: params.key?(:plan_overrides) ? override_plan : plan,
+        name:,
+        external_id: current_subscription.external_id,
+        previous_subscription_id: current_subscription.id,
+        subscription_at: current_subscription.subscription_at,
+        billing_time: current_subscription.billing_time,
+        ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at
+      )
+    end
+
+    def update_pending_subscription
+      current_subscription.plan = plan
+      current_subscription.name = name if name.present?
+      current_subscription.save!
+
+      if current_subscription.should_sync_crm_subscription?
+        Integrations::Aggregator::Subscriptions::Crm::UpdateJob.perform_later(subscription: current_subscription)
+      end
+    end
+
+    def override_plan
+      Plans::OverrideService.call(plan:, params: params[:plan_overrides].to_h.with_indifferent_access).plan
+    end
+
+    def cancel_pending_subscription
+      current_subscription.next_subscription.mark_as_canceled!
+    end
+
+    def pending_subscription?
+      return false unless current_subscription.next_subscription
+
+      current_subscription.next_subscription.pending?
+    end
+
+    def billable_subscriptions(new_subscription)
+      billable_subscriptions = if current_subscription.starting_in_the_future?
+        []
+      elsif current_subscription.pending?
+        []
+      elsif !current_subscription.terminated?
+        [current_subscription]
+      end.to_a
+
+      billable_subscriptions << new_subscription if plan.pay_in_advance? && !new_subscription.in_trial_period?
+
+      billable_subscriptions
+    end
+
+    def bill_subscriptions(billable_subscriptions)
+      after_commit do
+        billing_at = Time.current + 1.second
+        BillSubscriptionJob.perform_later(billable_subscriptions, billing_at.to_i, invoicing_reason: :upgrading)
+        BillNonInvoiceableFeesJob.perform_later(billable_subscriptions, billing_at)
+      end
+    end
+  end
+end

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Subscriptions
   class PlanUpgradeService < BaseService
     def initialize(current_subscription:, plan:, params:)

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -449,7 +449,7 @@ RSpec.describe Plans::UpdateService, type: :service do
 
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages).to eq({ billing_time: ["value_is_invalid"] })
+            expect(result.error.messages).to eq({billing_time: ["value_is_invalid"]})
           end
         end
       end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -512,7 +512,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
               expect(result).not_to be_success
               expect(result.error).to be_a(BaseService::ValidationFailure)
-              expect(result.error.messages).to eq({ billing_time: ["value_is_invalid"] })
+              expect(result.error.messages).to eq({billing_time: ["value_is_invalid"]})
             end
           end
 

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::PlanUpgradeService, type: :service do
+  subject(:result) do
+    described_class.call(current_subscription: subscription, plan:, params:)
+  end
+
+  let(:subscription) do
+    create(
+      :subscription,
+      customer:,
+      plan: old_plan,
+      status: :active,
+      subscription_at: Time.current,
+      started_at: Time.current,
+      external_id: SecureRandom.uuid,
+    )
+  end
+
+  let(:old_plan) { create(:plan, amount_cents: 100, organization:, amount_currency: currency) }
+  let(:customer) { create(:customer, :with_hubspot_integration, organization:, currency:) }
+  let(:organization) { create(:organization) }
+  let(:currency) { "EUR" }
+  let(:plan) { create(:plan, amount_cents: 100, organization:) }
+  let(:params) { {name: subscription_name} }
+  let(:subscription_name) { "new invoice display name" }
+
+  describe "#call", :aggregate_failures do
+    before do
+      subscription.mark_as_active!
+    end
+
+    it "terminates the existing subscription" do
+      expect { result }
+        .to change { subscription.reload.status }.from("active").to("terminated")
+    end
+
+    it "moves the lifetime_usage to the new subscription" do
+      lifetime_usage = subscription.lifetime_usage
+      expect(result.subscription.lifetime_usage).to eq(lifetime_usage.reload)
+      expect(subscription.reload.lifetime_usage).to be_nil
+    end
+
+    it "sends terminated and started subscription webhooks" do
+      result
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.terminated", subscription)
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.started", result.subscription)
+    end
+
+    it "enqueues the CRM update job" do
+      # TODO: review this one, this one should fail because the code conditional
+      # is not meet by the test setup...
+      # The subscription does not start in the future
+      result
+      expect(Integrations::Aggregator::Subscriptions::Crm::UpdateJob).to have_been_enqueued.with(subscription:)
+    end
+
+    it "creates a new subscription" do
+      expect(result).to be_success
+      expect(result.subscription.id).not_to eq(subscription.id)
+      expect(result.subscription).to be_active
+      expect(result.subscription.name).to eq(subscription_name)
+      expect(result.subscription.plan.id).to eq(plan.id)
+      expect(result.subscription.previous_subscription_id).to eq(subscription.id)
+      expect(result.subscription.subscription_at).to eq(subscription.subscription_at)
+    end
+
+    context "when current subscription is pending" do
+      before { subscription.pending! }
+
+      it "returns existing subscription with updated attributes" do
+        expect(result).to be_success
+        expect(result.subscription.id).to eq(subscription.id)
+        expect(result.subscription.plan_id).to eq(plan.id)
+        expect(result.subscription.name).to eq(subscription_name)
+      end
+    end
+
+    context "when old subscription is payed in arrear" do
+      let(:old_plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: false) }
+
+      it "enqueues a job to bill the existing subscription" do
+        expect { result }.to have_enqueued_job(BillSubscriptionJob)
+      end
+    end
+
+    context "when old subscription was payed in advance" do
+      let(:creation_time) { Time.current.beginning_of_month - 1.month }
+      let(:date_service) do
+        Subscriptions::DatesService.new_instance(
+          subscription,
+          Time.current.beginning_of_month,
+          current_usage: false
+        )
+      end
+
+      let(:invoice_subscription) do
+        create(
+          :invoice_subscription,
+          invoice:,
+          subscription:,
+          recurring: true,
+          from_datetime: date_service.from_datetime,
+          to_datetime: date_service.to_datetime,
+          charges_from_datetime: date_service.charges_from_datetime,
+          charges_to_datetime: date_service.charges_to_datetime
+        )
+      end
+
+      let(:invoice) do
+        create(
+          :invoice,
+          customer:,
+          currency:,
+          sub_total_excluding_taxes_amount_cents: 100,
+          fees_amount_cents: 100,
+          taxes_amount_cents: 20,
+          total_amount_cents: 120
+        )
+      end
+
+      let(:last_subscription_fee) do
+        create(
+          :fee,
+          subscription:,
+          invoice:,
+          amount_cents: 100,
+          taxes_amount_cents: 20,
+          invoiceable_type: "Subscription",
+          invoiceable_id: subscription.id,
+          taxes_rate: 20
+        )
+      end
+
+      let(:subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan: old_plan,
+          status: :active,
+          subscription_at: creation_time,
+          started_at: creation_time,
+          external_id: SecureRandom.uuid,
+          billing_time: "anniversary"
+        )
+      end
+
+      let(:old_plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true) }
+
+      before do
+        invoice_subscription
+        last_subscription_fee
+      end
+
+      it "creates a credit note for the remaining days" do
+        expect { result }.to change(CreditNote, :count)
+      end
+    end
+
+    context "when new subscription is payed in advance" do
+      let(:plan) { create(:plan, amount_cents: 200, organization:, pay_in_advance: true) }
+
+      it "enqueues a job to bill the existing subscription" do
+        expect { result }.to have_enqueued_job(BillSubscriptionJob)
+      end
+    end
+
+    context "with pending next subscription" do
+      let(:next_subscription) do
+        create(
+          :subscription,
+          status: :pending,
+          previous_subscription: subscription,
+          organization:,
+          customer:
+        )
+      end
+
+      before { next_subscription }
+
+      it "canceled the next subscription" do
+        expect(result).to be_success
+        expect(next_subscription.reload).to be_canceled
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Subscriptions::PlanUpgradeService, type: :service do
       status: :active,
       subscription_at: Time.current,
       started_at: Time.current,
-      external_id: SecureRandom.uuid,
+      external_id: SecureRandom.uuid
     )
   end
 


### PR DESCRIPTION
## Context

Currently, when a user updates the subscription fee amount for a plan associated with a pending downgrade (scheduled to activate at the end of the billing period), the system does not treat the pending subscription as an upgrade. As a result, the new subscription is not activated, and the previous one is not terminated.

## Description

This change extracts the subscription upgrade logic into a dedicated service, ensuring it can be consistently applied across flows that trigger subscription upgrades. Currently, this includes plan updates and initial subscription creation.

An additional edge case, involving plan subscription overrides, is not addressed in this PR. Handling this scenario introduces extra technical and product complexities that require further consideration.