### PR TITLE
Bug(PayInAdvanceFee) - fix grouped_by logic for Fees::CreatePayInAdvanceService

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -144,7 +144,7 @@ class Fee < ApplicationRecord
     base_clause = "#{invoice_name} #{filter_display_name}".downcase
 
     return base_clause unless charge?
-    return base_clause unless charge.supports_grouping?
+    return base_clause unless charge.supports_grouped_by?
     return base_clause if grouped_by.blank?
 
     "#{invoice_name} #{grouped_by.values.join} #{filter_display_name}".downcase

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -144,8 +144,8 @@ class Fee < ApplicationRecord
     base_clause = "#{invoice_name} #{filter_display_name}".downcase
 
     return base_clause unless charge?
-    return base_clause unless charge.standard?
-    return base_clause if charge.properties['grouped_by'].blank?
+    return base_clause unless charge.supports_grouping?
+    return base_clause if grouped_by.blank?
 
     "#{invoice_name} #{grouped_by.values.join} #{filter_display_name}".downcase
   end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe Fee, type: :model do
       end
 
       it 'returns valid response' do
-        expect(fee.invoice_sorting_clause).to eq("#{fee.invoice_name} #{fee.filter_display_name}".downcase)
+        expect(fee.invoice_sorting_clause).to eq("#{fee.invoice_name} #{fee.grouped_by.values.join} #{fee.filter_display_name}".downcase)
       end
     end
   end


### PR DESCRIPTION
## Description

grouped_by can be stored on charge filters. This PR caches the properties so we're using the correct ones in the service.