### PR TITLE
fix(stripe): Handle missing payment

### DIFF
--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -2,6 +2,8 @@
 
 module PaymentProviders
   class StripeProvider < BaseProvider
+    StripePayment = Data.define(:id, :status, :metadata)
+
     SUCCESS_REDIRECT_URL = 'https://stripe.com/'
 
     # NOTE: find the complete list of event types at https://stripe.com/docs/api/events/types

--- a/app/services/payment_providers/stripe/handle_event_service.rb
+++ b/app/services/payment_providers/stripe/handle_event_service.rb
@@ -41,18 +41,24 @@ module PaymentProviders
           payment_service_klass(event)
             .new.update_payment_status(
               organization_id: organization.id,
-              provider_payment_id: event.data.object.payment_intent,
               status: 'succeeded',
-              metadata: event.data.object.metadata.to_h.symbolize_keys
+              stripe_payment: PaymentProviders::StripeProvider::StripePayment.new(
+                id: event.data.object.payment_intent,
+                status: event.data.object.status,
+                metadata: event.data.object.metadata.to_h.symbolize_keys
+              )
             ).raise_if_error!
         when 'payment_intent.payment_failed', 'payment_intent.succeeded'
           status = (event.type == 'payment_intent.succeeded') ? 'succeeded' : 'failed'
           payment_service_klass(event)
             .new.update_payment_status(
               organization_id: organization.id,
-              provider_payment_id: event.data.object.id,
               status:,
-              metadata: event.data.object.metadata.to_h.symbolize_keys
+              stripe_payment: PaymentProviders::StripeProvider::StripePayment.new(
+                id: event.data.object.id,
+                status: event.data.object.status,
+                metadata: event.data.object.metadata.to_h.symbolize_keys
+              )
             ).raise_if_error!
         when 'payment_method.detached'
           PaymentProviderCustomers::StripeService

--- a/spec/services/payment_providers/stripe/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/stripe/handle_event_service_spec.rb
@@ -33,11 +33,14 @@ RSpec.describe PaymentProviders::Stripe::HandleEventService do
       expect(payment_service).to have_received(:update_payment_status)
         .with(
           organization_id: organization.id,
-          provider_payment_id: 'pi_1JKS2Y2VYugoKSBzNHPFBNj9',
           status: 'succeeded',
-          metadata: {
-            lago_invoice_id: 'a587e552-36bc-4334-81f2-abcbf034ad3f'
-          }
+          stripe_payment: PaymentProviders::StripeProvider::StripePayment.new(
+            id: 'pi_1JKS2Y2VYugoKSBzNHPFBNj9',
+            status: 'success',
+            metadata: {
+              lago_invoice_id: 'a587e552-36bc-4334-81f2-abcbf034ad3f'
+            }
+          )
         )
     end
   end
@@ -66,12 +69,15 @@ RSpec.describe PaymentProviders::Stripe::HandleEventService do
       expect(payment_service).to have_received(:update_payment_status)
         .with(
           organization_id: organization.id,
-          provider_payment_id: "pi_1JKS2Y2VYugoKSBzNHPFBNj9",
           status: "succeeded",
-          metadata: {
-            lago_payment_request_id: "a587e552-36bc-4334-81f2-abcbf034ad3f",
-            lago_payable_type: "PaymentRequest"
-          }
+          stripe_payment: PaymentProviders::StripeProvider::StripePayment.new(
+            id: 'pi_1JKS2Y2VYugoKSBzNHPFBNj9',
+            status: 'success',
+            metadata: {
+              lago_payment_request_id: "a587e552-36bc-4334-81f2-abcbf034ad3f",
+              lago_payable_type: "PaymentRequest"
+            }
+          )
         )
     end
   end
@@ -102,9 +108,12 @@ RSpec.describe PaymentProviders::Stripe::HandleEventService do
       expect(payment_service).to have_received(:update_payment_status)
         .with(
           organization_id: organization.id,
-          provider_payment_id: 'pi_123456',
           status: 'succeeded',
-          metadata: {}
+          stripe_payment: PaymentProviders::StripeProvider::StripePayment.new(
+            id: 'pi_123456',
+            status: 'succeeded',
+            metadata: {}
+          )
         )
     end
   end
@@ -133,12 +142,15 @@ RSpec.describe PaymentProviders::Stripe::HandleEventService do
       expect(payment_service).to have_received(:update_payment_status)
         .with(
           organization_id: organization.id,
-          provider_payment_id: 'pi_123456',
           status: "succeeded",
-          metadata: {
-            lago_payment_request_id: "a587e552-36bc-4334-81f2-abcbf034ad3f",
-            lago_payable_type: "PaymentRequest"
-          }
+          stripe_payment: PaymentProviders::StripeProvider::StripePayment.new(
+            id: 'pi_123456',
+            status: 'succeeded',
+            metadata: {
+              lago_payment_request_id: "a587e552-36bc-4334-81f2-abcbf034ad3f",
+              lago_payable_type: "PaymentRequest"
+            }
+          )
         )
     end
   end


### PR DESCRIPTION
## Context

Some `PaymentProviders::Stripe::HandleEventJob` with 'payment_intent.payment_failed' or 'payment_intent.succeeded' event type are failing with `BaseService::NotFoundFailure - stripe_payment_not_found`.

The webhook contains metadata of lago's invoices but the related `Payment` cannot be found in the database. It is probably because the job creating the stripe payment was killed allong with the worker running it under heavy load.

## Description

This PR changes the logic to re-create the `Payment` record when missing using the data from the webhook object. It will allow to update the `invoice.payment_status` accordingly
