### PR TITLE
fix(netsuite): Fix possible duplicate integration resources creation

### DIFF
--- a/app/services/integrations/aggregator/credit_notes/create_service.rb
+++ b/app/services/integrations/aggregator/credit_notes/create_service.rb
@@ -18,8 +18,9 @@ module Integrations
           return result unless integration
           return result unless integration.sync_credit_notes
           return result unless credit_note.finalized?
+          return result if payload.integration_credit_note
 
-          response = http_client.post_with_response(payload, headers)
+          response = http_client.post_with_response(payload.body, headers)
           body = JSON.parse(response.body)
 
           if body.is_a?(Hash)
@@ -73,7 +74,7 @@ module Integrations
           Integrations::Aggregator::CreditNotes::Payloads::Factory.new_instance(
             integration_customer:,
             credit_note:
-          ).body
+          )
         end
 
         def process_hash_result(body)

--- a/app/services/integrations/aggregator/credit_notes/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/credit_notes/payloads/base_payload.rb
@@ -26,6 +26,11 @@ module Integrations
             ]
           end
 
+          def integration_credit_note
+            @integration_credit_note ||=
+              IntegrationResource.find_by(integration:, syncable: credit_note, resource_type: 'credit_note')
+          end
+
           private
 
           attr_reader :integration_customer, :credit_note

--- a/app/services/integrations/aggregator/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/invoices/create_service.rb
@@ -12,6 +12,7 @@ module Integrations
           return result unless integration
           return result unless integration.sync_invoices
           return result unless invoice.finalized?
+          return result if payload.integration_invoice
 
           response = http_client.post_with_response(payload.body, headers)
           body = JSON.parse(response.body)

--- a/app/services/integrations/aggregator/invoices/crm/create_service.rb
+++ b/app/services/integrations/aggregator/invoices/crm/create_service.rb
@@ -9,6 +9,7 @@ module Integrations
             return result unless integration
             return result unless integration.sync_invoices
             return result unless invoice.finalized?
+            return result if payload.integration_invoice
 
             Integrations::Hubspot::Invoices::DeployPropertiesService.call(integration:)
 

--- a/app/services/integrations/aggregator/payments/create_service.rb
+++ b/app/services/integrations/aggregator/payments/create_service.rb
@@ -18,8 +18,9 @@ module Integrations
           return result unless integration
           return result unless integration.sync_payments
           return result unless invoice.finalized?
+          return result if payload.integration_payment
 
-          response = http_client.post_with_response(payload, headers)
+          response = http_client.post_with_response(payload.body, headers)
           body = JSON.parse(response.body)
 
           if body.is_a?(Hash)
@@ -72,7 +73,7 @@ module Integrations
         end
 
         def payload
-          Integrations::Aggregator::Payments::Payloads::Factory.new_instance(integration:, payment:).body
+          Integrations::Aggregator::Payments::Payloads::Factory.new_instance(integration:, payment:)
         end
 
         def process_hash_result(body)

--- a/app/services/integrations/aggregator/payments/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/payments/payloads/base_payload.rb
@@ -22,6 +22,11 @@ module Integrations
             ]
           end
 
+          def integration_payment
+            @integration_payment ||=
+              IntegrationResource.find_by(integration:, syncable: payment, resource_type: 'payment')
+          end
+
           private
 
           attr_reader :payment

--- a/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
@@ -219,6 +219,29 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
   end
 
   describe '#call' do
+    context 'when integration_credit_note exists' do
+      let(:integration_credit_note) do
+        create(:integration_resource, integration:, syncable: credit_note, resource_type: 'credit_note')
+      end
+
+      let(:response) { instance_double(Net::HTTPOK) }
+
+      before do
+        allow(lago_client).to receive(:post_with_response).with(params, headers).and_return(response)
+        integration_credit_note
+      end
+
+      it 'returns result without making an API call' do
+        expect(lago_client).not_to have_received(:post_with_response)
+        result = service_call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.external_id).to be_nil
+        end
+      end
+    end
+
     context 'when service call is successful' do
       let(:response) { instance_double(Net::HTTPOK) }
 

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -249,6 +249,26 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
   end
 
   describe '#call' do
+    context 'when integration_invoice exists' do
+      let(:integration_invoice) { create(:integration_resource, integration:, syncable: invoice) }
+      let(:response) { instance_double(Net::HTTPOK) }
+
+      before do
+        allow(lago_client).to receive(:post_with_response).with(params, headers).and_return(response)
+        integration_invoice
+      end
+
+      it 'returns result without making an API call' do
+        expect(lago_client).not_to have_received(:post_with_response)
+        result = service_call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.external_id).to be_nil
+        end
+      end
+    end
+
     context 'when service call is successful' do
       let(:response) { instance_double(Net::HTTPOK) }
 

--- a/spec/services/integrations/aggregator/payments/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/payments/create_service_spec.rb
@@ -83,6 +83,29 @@ RSpec.describe Integrations::Aggregator::Payments::CreateService do
   end
 
   describe '#call' do
+    context 'when integration_payment exists' do
+      let(:integration_payment) do
+        create(:integration_resource, integration:, syncable: payment, resource_type: 'payment')
+      end
+
+      let(:response) { instance_double(Net::HTTPOK) }
+
+      before do
+        allow(lago_client).to receive(:post_with_response).with(params, headers).and_return(response)
+        integration_payment
+      end
+
+      it 'returns result without making an API call' do
+        expect(lago_client).not_to have_received(:post_with_response)
+        result = service_call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.external_id).to be_nil
+        end
+      end
+    end
+
     context 'when service call is successful' do
       let(:response) { instance_double(Net::HTTPOK) }
 


### PR DESCRIPTION
## Context

When the Netsuite jobs that create invoices, credit note and paymetns were enqueued at the same time, they sometimes created duplicate integration resources.

## Description

This PR fixes this issue by checking if the resource already exists in our DB.
