### PR TITLE
fix: Plans::UpdateAmountService handle pending subscription upgrades

### DIFF
--- a/app/services/plans/update_amount_service.rb
+++ b/app/services/plans/update_amount_service.rb
@@ -17,13 +17,35 @@ module Plans
       return result if plan.amount_cents != expected_amount_cents
 
       plan.amount_cents = amount_cents
-      plan.save!
+
+      ActiveRecord::Base.transaction do
+        plan.save!
+        process_pending_subscriptions
+      end
 
       result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
     end
 
     private
 
     attr_reader :plan, :amount_cents, :expected_amount_cents
+
+    def process_pending_subscriptions
+      Subscription.where(plan:, status: :pending).find_each do |subscription|
+        next unless subscription.previous_subscription
+
+        if plan.yearly_amount_cents >= subscription.previous_subscription.plan.yearly_amount_cents
+          Subscriptions::PlanUpgradeService.call(
+            current_subscription: subscription.previous_subscription,
+            plan: plan,
+            params: {name: subscription.name}
+          ).raise_if_error!
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
 ## Context
in `cascade_subscription_fee_update` we call `Plans::UpdateAmountJob`. This job should deal with pending subscriptions similar to how the `Plans::UpdateService` does it. (see `process_downgrade`|`pending_subscriptions`)

 ## Description
This changes handles subscription upgrades when plan amount_cents changes because of cascading from parent plan and there are pending subscriptions.