### PR TITLE
Fix: allow to edit fees with more than 2 decimal price

### DIFF
--- a/app/graphql/types/adjusted_fees/create_input.rb
+++ b/app/graphql/types/adjusted_fees/create_input.rb
@@ -7,7 +7,6 @@ module Types
 
       argument :fee_id, ID, required: true
       argument :invoice_display_name, String, required: false
-      argument :unit_amount_cents, GraphQL::Types::BigInt, required: false
       argument :unit_precise_amount_cents, String, required: false
       argument :units, GraphQL::Types::Float, required: false
     end

--- a/app/graphql/types/adjusted_fees/create_input.rb
+++ b/app/graphql/types/adjusted_fees/create_input.rb
@@ -7,7 +7,7 @@ module Types
 
       argument :fee_id, ID, required: true
       argument :invoice_display_name, String, required: false
-      argument :unit_precise_amount_cents, String, required: false
+      argument :unit_precise_amount, String, required: false
       argument :units, GraphQL::Types::Float, required: false
     end
   end

--- a/app/graphql/types/adjusted_fees/create_input.rb
+++ b/app/graphql/types/adjusted_fees/create_input.rb
@@ -8,6 +8,7 @@ module Types
       argument :fee_id, ID, required: true
       argument :invoice_display_name, String, required: false
       argument :unit_amount_cents, GraphQL::Types::BigInt, required: false
+      argument :unit_precise_amount_cents, String, required: false
       argument :units, GraphQL::Types::Float, required: false
     end
   end

--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -24,23 +24,24 @@ end
 #
 # Table name: adjusted_fees
 #
-#  id                   :uuid             not null, primary key
-#  adjusted_amount      :boolean          default(FALSE), not null
-#  adjusted_units       :boolean          default(FALSE), not null
-#  fee_type             :integer
-#  grouped_by           :jsonb            not null
-#  invoice_display_name :string
-#  properties           :jsonb            not null
-#  unit_amount_cents    :bigint           default(0), not null
-#  units                :decimal(, )      default(0.0), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  charge_filter_id     :uuid
-#  charge_id            :uuid
-#  fee_id               :uuid
-#  group_id             :uuid
-#  invoice_id           :uuid             not null
-#  subscription_id      :uuid
+#  id                        :uuid             not null, primary key
+#  adjusted_amount           :boolean          default(FALSE), not null
+#  adjusted_units            :boolean          default(FALSE), not null
+#  fee_type                  :integer
+#  grouped_by                :jsonb            not null
+#  invoice_display_name      :string
+#  properties                :jsonb            not null
+#  unit_amount_cents         :bigint           default(0), not null
+#  unit_precise_amount_cents :decimal(40, 15)  default(0.0), not null
+#  units                     :decimal(, )      default(0.0), not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  charge_filter_id          :uuid
+#  charge_id                 :uuid
+#  fee_id                    :uuid
+#  group_id                  :uuid
+#  invoice_id                :uuid             not null
+#  subscription_id           :uuid
 #
 # Indexes
 #

--- a/app/services/adjusted_fees/create_service.rb
+++ b/app/services/adjusted_fees/create_service.rb
@@ -17,7 +17,7 @@ module AdjustedFees
       charge = fee.charge
       return result.validation_failure!(errors: {charge: ['invalid_charge_model']}) if disabled_charge_model?(charge)
 
-      unit_precise_amount_cents = (params[:unit_precise_amount].presence || 0).to_f * fee.amount.currency.subunit_to_unit
+      unit_precise_amount_cents = params[:unit_precise_amount].to_f * fee.amount.currency.subunit_to_unit
       adjusted_fee = AdjustedFee.new(
         fee:,
         invoice: fee.invoice,

--- a/app/services/adjusted_fees/create_service.rb
+++ b/app/services/adjusted_fees/create_service.rb
@@ -17,8 +17,8 @@ module AdjustedFees
       charge = fee.charge
       return result.validation_failure!(errors: {charge: ['invalid_charge_model']}) if disabled_charge_model?(charge)
 
-      unit_precise_amount_cents = params[:unit_precise_amount_cents].presence.to_f
-      unit_amount_cents = params[:unit_amount_cents].presence.to_i
+      unit_precise_amount_cents = params[:unit_precise_amount_cents]
+      unit_amount_cents = params[:unit_amount_cents]
       adjusted_fee = AdjustedFee.new(
         fee:,
         invoice: fee.invoice,
@@ -33,8 +33,8 @@ module AdjustedFees
         # these are the values that the user is adjusting
         units: params[:units].presence || 0,
         # TODO: Keeping both of them before changes on the FE, after - use only unit_precise_amount_cents
-        unit_amount_cents: unit_precise_amount_cents.round || unit_amount_cents.round,
-        unit_precise_amount_cents:unit_precise_amount_cents || unit_amount_cents,
+        unit_amount_cents: (unit_precise_amount_cents.presence || unit_amount_cents.presence).to_i.round,
+        unit_precise_amount_cents: (unit_precise_amount_cents.presence || unit_amount_cents.presence).to_f,
         grouped_by: fee.grouped_by,
         charge_filter: fee.charge_filter
       )

--- a/app/services/adjusted_fees/create_service.rb
+++ b/app/services/adjusted_fees/create_service.rb
@@ -18,23 +18,19 @@ module AdjustedFees
       return result.validation_failure!(errors: {charge: ['invalid_charge_model']}) if disabled_charge_model?(charge)
 
       unit_precise_amount_cents = params[:unit_precise_amount_cents]
-      unit_amount_cents = params[:unit_amount_cents]
       adjusted_fee = AdjustedFee.new(
         fee:,
         invoice: fee.invoice,
         subscription: fee.subscription,
         charge:,
-        # these indicate if the user is adjusting the units or the amount
-        adjusted_units: params[:units].present? && params[:unit_precise_amount_cents].blank? && params[:unit_amount_cents].blank?,
-        adjusted_amount: params[:units].present? && (params[:unit_precise_amount_cents].present? || params[:unit_amount_cents].present?),
+        adjusted_units: params[:units].present? && params[:unit_precise_amount_cents].blank?,
+        adjusted_amount: params[:units].present? && params[:unit_precise_amount_cents].present?,
         invoice_display_name: params[:invoice_display_name],
         fee_type: fee.fee_type,
         properties: fee.properties,
-        # these are the values that the user is adjusting
         units: params[:units].presence || 0,
-        # TODO: Keeping both of them before changes on the FE, after - use only unit_precise_amount_cents
-        unit_amount_cents: (unit_precise_amount_cents.presence || unit_amount_cents.presence).to_i.round,
-        unit_precise_amount_cents: (unit_precise_amount_cents.presence || unit_amount_cents.presence).to_f,
+        unit_amount_cents: (unit_precise_amount_cents.presence || 0).to_i.round,
+        unit_precise_amount_cents: (unit_precise_amount_cents.presence || 0).to_f,
         grouped_by: fee.grouped_by,
         charge_filter: fee.charge_filter
       )
@@ -55,7 +51,7 @@ module AdjustedFees
     attr_reader :organization, :fee, :params
 
     def disabled_charge_model?(charge)
-      unit_adjustment = params[:units].present? && params[:unit_precise_amount_cents].blank? && params[:unit_amount_cents].blank?
+      unit_adjustment = params[:units].present? && params[:unit_precise_amount_cents].blank?
 
       charge && unit_adjustment && (charge.percentage? || (charge.prorated? && charge.graduated?))
     end

--- a/app/services/adjusted_fees/create_service.rb
+++ b/app/services/adjusted_fees/create_service.rb
@@ -17,22 +17,27 @@ module AdjustedFees
       charge = fee.charge
       return result.validation_failure!(errors: {charge: ['invalid_charge_model']}) if disabled_charge_model?(charge)
 
+      unit_precise_amount_cents = params[:unit_precise_amount_cents].presence.to_f
+      unit_amount_cents = params[:unit_amount_cents].presence.to_i
       adjusted_fee = AdjustedFee.new(
         fee:,
         invoice: fee.invoice,
         subscription: fee.subscription,
         charge:,
-        adjusted_units: params[:units].present? && params[:unit_amount_cents].blank?,
-        adjusted_amount: params[:units].present? && params[:unit_amount_cents].present?,
+        # these indicate if the user is adjusting the units or the amount
+        adjusted_units: params[:units].present? && params[:unit_precise_amount_cents].blank? && params[:unit_amount_cents].blank?,
+        adjusted_amount: params[:units].present? && (params[:unit_precise_amount_cents].present? || params[:unit_amount_cents].present?),
         invoice_display_name: params[:invoice_display_name],
         fee_type: fee.fee_type,
         properties: fee.properties,
+        # these are the values that the user is adjusting
         units: params[:units].presence || 0,
-        unit_amount_cents: params[:unit_amount_cents].presence || 0,
+        # TODO: Keeping both of them before changes on the FE, after - use only unit_precise_amount_cents
+        unit_amount_cents: unit_precise_amount_cents.round || unit_amount_cents.round,
+        unit_precise_amount_cents:unit_precise_amount_cents || unit_amount_cents,
         grouped_by: fee.grouped_by,
         charge_filter: fee.charge_filter
       )
-
       adjusted_fee.save!
 
       refresh_result = Invoices::RefreshDraftService.call(invoice: fee.invoice)
@@ -50,7 +55,7 @@ module AdjustedFees
     attr_reader :organization, :fee, :params
 
     def disabled_charge_model?(charge)
-      unit_adjustment = params[:units].present? && params[:unit_amount_cents].blank?
+      unit_adjustment = params[:units].present? && params[:unit_precise_amount_cents].blank? && params[:unit_amount_cents].blank?
 
       charge && unit_adjustment && (charge.percentage? || (charge.prorated? && charge.graduated?))
     end

--- a/app/services/adjusted_fees/create_service.rb
+++ b/app/services/adjusted_fees/create_service.rb
@@ -17,20 +17,20 @@ module AdjustedFees
       charge = fee.charge
       return result.validation_failure!(errors: {charge: ['invalid_charge_model']}) if disabled_charge_model?(charge)
 
-      unit_precise_amount_cents = params[:unit_precise_amount_cents]
+      unit_precise_amount_cents = (params[:unit_precise_amount].presence || 0).to_f * fee.amount.currency.subunit_to_unit
       adjusted_fee = AdjustedFee.new(
         fee:,
         invoice: fee.invoice,
         subscription: fee.subscription,
         charge:,
-        adjusted_units: params[:units].present? && params[:unit_precise_amount_cents].blank?,
-        adjusted_amount: params[:units].present? && params[:unit_precise_amount_cents].present?,
+        adjusted_units: params[:units].present? && params[:unit_precise_amount].blank?,
+        adjusted_amount: params[:units].present? && params[:unit_precise_amount].present?,
         invoice_display_name: params[:invoice_display_name],
         fee_type: fee.fee_type,
         properties: fee.properties,
         units: params[:units].presence || 0,
-        unit_amount_cents: (unit_precise_amount_cents.presence || 0).to_i.round,
-        unit_precise_amount_cents: (unit_precise_amount_cents.presence || 0).to_f,
+        unit_amount_cents: unit_precise_amount_cents.round,
+        unit_precise_amount_cents: unit_precise_amount_cents,
         grouped_by: fee.grouped_by,
         charge_filter: fee.charge_filter
       )
@@ -51,7 +51,7 @@ module AdjustedFees
     attr_reader :organization, :fee, :params
 
     def disabled_charge_model?(charge)
-      unit_adjustment = params[:units].present? && params[:unit_precise_amount_cents].blank?
+      unit_adjustment = params[:units].present? && params[:unit_precise_amount].blank?
 
       charge && unit_adjustment && (charge.percentage? || (charge.prorated? && charge.graduated?))
     end

--- a/app/services/fees/init_from_adjusted_charge_fee_service.rb
+++ b/app/services/fees/init_from_adjusted_charge_fee_service.rb
@@ -55,7 +55,7 @@ module Fees
         unit_precise_amount_cents = adjusted_fee.unit_precise_amount_cents
         unit_amount_cents = unit_precise_amount_cents.round
         precise_amount_cents = units * unit_precise_amount_cents
-        amount_cents = (precise_amount_cents).round
+        amount_cents = precise_amount_cents.round
         precise_unit_amount = precise_amount_cents / (currency.subunit_to_unit * units)
         amount_details = {}
       end

--- a/app/services/fees/init_from_adjusted_charge_fee_service.rb
+++ b/app/services/fees/init_from_adjusted_charge_fee_service.rb
@@ -52,10 +52,11 @@ module Fees
         precise_unit_amount = amount_result.unit_amount
         amount_details = amount_result.amount_details
       else
-        unit_amount_cents = adjusted_fee.unit_amount_cents.round
-        amount_cents = (units * unit_amount_cents).round
-        precise_unit_amount = amount_cents / (currency.subunit_to_unit * units)
-        precise_amount_cents = units * adjusted_fee.unit_amount_cents.to_d
+        unit_precise_amount_cents = adjusted_fee.unit_precise_amount_cents
+        unit_amount_cents = unit_precise_amount_cents.round
+        precise_amount_cents = units * unit_precise_amount_cents
+        amount_cents = (precise_amount_cents).round
+        precise_unit_amount = precise_amount_cents / (currency.subunit_to_unit * units)
         amount_details = {}
       end
 

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -62,7 +62,7 @@ module Fees
       end
 
       units = adjusted_fee.units
-      unit_precise_amount_cents = adjusted_fee.unit_precise_amoun_centst
+      unit_precise_amount_cents = adjusted_fee.unit_precise_amount_cents
       amount_cents = adjusted_fee.adjusted_units? ? (units * new_amount_cents) : (units * unit_precise_amount_cents).round
 
       precise_amount_cents = if adjusted_fee.adjusted_units?
@@ -76,7 +76,7 @@ module Fees
       base_fee.units = units
       precise_unit_amount_cents = adjusted_fee.adjusted_units? ? new_amount_cents : unit_precise_amount_cents
       base_fee.unit_amount_cents = precise_unit_amount_cents.round
-      base_fee.precise_unit_amount = precise_unit_amount_cents / plan.amount_currency.subunit_to_unit
+      base_fee.precise_unit_amount = precise_unit_amount_cents / invoice.total_amount.currency.subunit_to_unit
       base_fee.invoice_display_name = adjusted_fee.invoice_display_name
 
       base_fee

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -16,7 +16,6 @@ module Fees
       new_precise_amount_cents = compute_amount
       new_amount_cents = new_precise_amount_cents.round
       new_fee = initialize_fee(new_amount_cents, new_precise_amount_cents)
-      new_fee.precise_unit_amount = new_fee.unit_amount.to_f
 
       ActiveRecord::Base.transaction do
         new_fee.save!
@@ -63,19 +62,21 @@ module Fees
       end
 
       units = adjusted_fee.units
-      unit_amount_cents = adjusted_fee.unit_amount_cents.round
-      amount_cents = adjusted_fee.adjusted_units? ? (units * new_amount_cents) : (units * unit_amount_cents)
+      unit_precise_amount_cents = adjusted_fee.unit_precise_amoun_centst
+      amount_cents = adjusted_fee.adjusted_units? ? (units * new_amount_cents) : (units * unit_precise_amount_cents).round
 
       precise_amount_cents = if adjusted_fee.adjusted_units?
         (units * new_precise_amount_cents)
       else
-        (units * unit_amount_cents)
+        (units * unit_precise_amount_cents)
       end
 
       base_fee.amount_cents = amount_cents.round
       base_fee.precise_amount_cents = precise_amount_cents
       base_fee.units = units
-      base_fee.unit_amount_cents = adjusted_fee.adjusted_units? ? new_amount_cents : unit_amount_cents
+      precise_unit_amount_cents = adjusted_fee.adjusted_units? ? new_amount_cents : unit_precise_amount_cents
+      base_fee.unit_amount_cents = precise_unit_amount_cents.round
+      base_fee.precise_unit_amount = precise_unit_amount_cents / plan.amount_currency.subunit_to_unit
       base_fee.invoice_display_name = adjusted_fee.invoice_display_name
 
       base_fee

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -52,6 +52,7 @@ module Fees
         unit_amount_cents: new_amount_cents,
         amount_details: {plan_amount_cents: plan.amount_cents}
       )
+      base_fee.precise_unit_amount = base_fee.unit_amount.to_f
 
       return base_fee if !invoice.draft? || !adjusted_fee
 

--- a/db/migrate/20241113181629_add_precise_amount_cents_to_adjusted_fee.rb
+++ b/db/migrate/20241113181629_add_precise_amount_cents_to_adjusted_fee.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddPreciseAmountCentsToAdjustedFee < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      change_table :adjusted_fees, bulk: true do |t|
+        t.decimal :unit_precise_amount_cents, precision: 40, scale: 15, default: '0.0', null: false
+      end
+    end
+  end
+end

--- a/db/migrate/20241118103032_fulfill_adjusted_fee_unit_precise_amount_cents.rb
+++ b/db/migrate/20241118103032_fulfill_adjusted_fee_unit_precise_amount_cents.rb
@@ -9,9 +9,12 @@ class FulfillAdjustedFeeUnitPreciseAmountCents < ActiveRecord::Migration[7.1]
     enum status: {draft: 0}
   end
 
-  def change
+  def up
     AdjustedFee.joins(:invoice).where(invoice: {status: 'draft'}).where(unit_precise_amount_cents: 0).find_each do |af|
       af.update_attribute(:unit_precise_amount_cents, af.unit_amount_cents.to_f) # rubocop:disable Rails/SkipsModelValidations
     end
+  end
+
+  def down
   end
 end

--- a/db/migrate/20241118103032_fulfill_adjusted_fee_unit_precise_amount_cents.rb
+++ b/db/migrate/20241118103032_fulfill_adjusted_fee_unit_precise_amount_cents.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class FulfillAdjustedFeeUnitPreciseAmountCents < ActiveRecord::Migration[7.1]
+  class AdjustedFee < ApplicationRecord
+    belongs_to :invoice
+  end
+
+  class Invoice < ApplicationRecord
+    enum status: {draft: 0}
+  end
+
+  def change
+    AdjustedFee.joins(:invoice).where(invoice: {status: 'draft'}).where(unit_precise_amount_cents: 0).each do |af|
+      af.update_attribute(:unit_precise_amount_cents, af.unit_amount_cents.to_f)
+    end
+  end
+end

--- a/db/migrate/20241118103032_fulfill_adjusted_fee_unit_precise_amount_cents.rb
+++ b/db/migrate/20241118103032_fulfill_adjusted_fee_unit_precise_amount_cents.rb
@@ -10,8 +10,8 @@ class FulfillAdjustedFeeUnitPreciseAmountCents < ActiveRecord::Migration[7.1]
   end
 
   def change
-    AdjustedFee.joins(:invoice).where(invoice: {status: 'draft'}).where(unit_precise_amount_cents: 0).each do |af|
-      af.update_attribute(:unit_precise_amount_cents, af.unit_amount_cents.to_f)
+    AdjustedFee.joins(:invoice).where(invoice: {status: 'draft'}).where(unit_precise_amount_cents: 0).find_each do |af|
+      af.update_attribute(:unit_precise_amount_cents, af.unit_amount_cents.to_f) # rubocop:disable Rails/SkipsModelValidations
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -374,7 +374,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_20_090305) do
     t.decimal "precise_coupons_adjustment_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "precise_taxes_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
     t.float "taxes_rate", default: 0.0, null: false
-    t.string "tax_provider_id"
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -374,6 +374,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_20_090305) do
     t.decimal "precise_coupons_adjustment_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "precise_taxes_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
     t.float "taxes_rate", default: 0.0, null: false
+    t.string "tax_provider_id"
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,6 +94,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_20_090305) do
     t.uuid "group_id"
     t.jsonb "grouped_by", default: {}, null: false
     t.uuid "charge_filter_id"
+    t.decimal "unit_precise_amount_cents", precision: 40, scale: 15, default: "0.0", null: false
     t.index ["charge_filter_id"], name: "index_adjusted_fees_on_charge_filter_id"
     t.index ["charge_id"], name: "index_adjusted_fees_on_charge_id"
     t.index ["fee_id"], name: "index_adjusted_fees_on_fee_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1810,7 +1810,6 @@ input CreateAdjustedFeeInput {
   clientMutationId: String
   feeId: ID!
   invoiceDisplayName: String
-  unitAmountCents: BigInt
   unitPreciseAmountCents: String
   units: Float
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -1811,6 +1811,7 @@ input CreateAdjustedFeeInput {
   feeId: ID!
   invoiceDisplayName: String
   unitAmountCents: BigInt
+  unitPreciseAmountCents: String
   units: Float
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1810,7 +1810,7 @@ input CreateAdjustedFeeInput {
   clientMutationId: String
   feeId: ID!
   invoiceDisplayName: String
-  unitPreciseAmountCents: String
+  unitPreciseAmount: String
   units: Float
 }
 

--- a/schema.json
+++ b/schema.json
@@ -6507,18 +6507,6 @@
               "deprecationReason": null
             },
             {
-              "name": "unitAmountCents",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "BigInt",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "unitPreciseAmountCents",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -6507,7 +6507,7 @@
               "deprecationReason": null
             },
             {
-              "name": "unitPreciseAmountCents",
+              "name": "unitPreciseAmount",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/schema.json
+++ b/schema.json
@@ -6519,6 +6519,18 @@
               "deprecationReason": null
             },
             {
+              "name": "unitPreciseAmountCents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "units",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/adjusted_fees/create_spec.rb
+++ b/spec/graphql/mutations/adjusted_fees/create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Mutations::AdjustedFees::Create, type: :graphql do
     {
       feeId: fee.id,
       units: 4,
-      unitAmountCents: 1000,
+      unitPreciseAmountCents: '1000.001',
       invoiceDisplayName: 'Hello'
     }
   end

--- a/spec/graphql/mutations/adjusted_fees/create_spec.rb
+++ b/spec/graphql/mutations/adjusted_fees/create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Mutations::AdjustedFees::Create, type: :graphql do
     {
       feeId: fee.id,
       units: 4,
-      unitPreciseAmountCents: '1000.001',
+      unitPreciseAmount: '10.00001',
       invoiceDisplayName: 'Hello'
     }
   end

--- a/spec/scenarios/invoices/adjusted_charge_fees_spec.rb
+++ b/spec/scenarios/invoices/adjusted_charge_fees_spec.rb
@@ -8,12 +8,12 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
   let(:customer) { create(:customer, organization:, invoice_grace_period: 5) }
   let(:subscription_at) { DateTime.new(2023, 7, 19, 12, 12) }
   let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: 'sum_agg', field_name: 'custom') }
-  let(:unit_amount_cents) { nil }
+  let(:unit_precise_amount_cents) { nil }
 
   let(:adjusted_fee_params) do
     {
       invoice_display_name: 'test-name-25',
-      unit_amount_cents:,
+      unit_precise_amount_cents:,
       units: 3
     }
   end
@@ -90,7 +90,7 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
   end
 
   context 'with adjusted amount' do
-    let(:unit_amount_cents) { 15_000 }
+    let(:unit_precise_amount_cents) { 15_000 }
 
     it 'creates invoices correctly' do
       # NOTE: Jul 19th: create the subscription

--- a/spec/scenarios/invoices/adjusted_charge_fees_spec.rb
+++ b/spec/scenarios/invoices/adjusted_charge_fees_spec.rb
@@ -8,12 +8,12 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
   let(:customer) { create(:customer, organization:, invoice_grace_period: 5) }
   let(:subscription_at) { DateTime.new(2023, 7, 19, 12, 12) }
   let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: 'sum_agg', field_name: 'custom') }
-  let(:unit_precise_amount_cents) { nil }
+  let(:unit_precise_amount) { nil }
 
   let(:adjusted_fee_params) do
     {
       invoice_display_name: 'test-name-25',
-      unit_precise_amount_cents:,
+      unit_precise_amount:,
       units: 3
     }
   end
@@ -90,7 +90,7 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
   end
 
   context 'with adjusted amount' do
-    let(:unit_precise_amount_cents) { 15_000 }
+    let(:unit_precise_amount) { '150.00' }
 
     it 'creates invoices correctly' do
       # NOTE: Jul 19th: create the subscription

--- a/spec/scenarios/invoices/adjusted_subscription_fees_spec.rb
+++ b/spec/scenarios/invoices/adjusted_subscription_fees_spec.rb
@@ -7,12 +7,12 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
 
   let(:customer) { create(:customer, organization:, invoice_grace_period: 5) }
   let(:subscription_at) { DateTime.new(2023, 7, 19, 12, 12) }
-  let(:unit_amount_cents) { nil }
+  let(:unit_precise_amount_cents) { nil }
 
   let(:adjusted_fee_params) do
     {
       invoice_display_name: 'test-name-25',
-      unit_amount_cents:,
+      unit_precise_amount_cents:,
       units: 3
     }
   end
@@ -82,7 +82,7 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
   end
 
   context 'with adjusted amount' do
-    let(:unit_amount_cents) { 15_000 }
+    let(:unit_precise_amount_cents) { 15_000 }
 
     it 'creates invoices correctly' do
       # NOTE: Jul 19th: create the subscription

--- a/spec/scenarios/invoices/adjusted_subscription_fees_spec.rb
+++ b/spec/scenarios/invoices/adjusted_subscription_fees_spec.rb
@@ -7,12 +7,12 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
 
   let(:customer) { create(:customer, organization:, invoice_grace_period: 5) }
   let(:subscription_at) { DateTime.new(2023, 7, 19, 12, 12) }
-  let(:unit_precise_amount_cents) { nil }
+  let(:unit_precise_amount) { nil }
 
   let(:adjusted_fee_params) do
     {
       invoice_display_name: 'test-name-25',
-      unit_precise_amount_cents:,
+      unit_precise_amount:,
       units: 3
     }
   end
@@ -82,7 +82,7 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
   end
 
   context 'with adjusted amount' do
-    let(:unit_precise_amount_cents) { 15_000 }
+    let(:unit_precise_amount) { '150.00' }
 
     it 'creates invoices correctly' do
       # NOTE: Jul 19th: create the subscription

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -1084,7 +1084,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
     let(:adjusted_fee_params) do
       {
-        unit_precise_amount_cents: 500,
+        unit_precise_amount: '5.00',
         units: 3
       }
     end
@@ -1181,7 +1181,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     context 'with updated fee with attached credit note' do
       let(:adjusted_fee_params) do
         {
-          unit_precise_amount_cents: 50,
+          unit_precise_amount: '0.50',
           units: 18 # 50 x 18 = 900
         }
       end
@@ -1262,7 +1262,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     context 'with updated fee equal to zero' do
       let(:adjusted_fee_params) do
         {
-          unit_precise_amount_cents: 0,
+          unit_precise_amount: 0,
           units: 1
         }
       end

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -1084,7 +1084,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
     let(:adjusted_fee_params) do
       {
-        unit_amount_cents: 500,
+        unit_precise_amount_cents: 500,
         units: 3
       }
     end
@@ -1181,7 +1181,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     context 'with updated fee with attached credit note' do
       let(:adjusted_fee_params) do
         {
-          unit_amount_cents: 50,
+          unit_precise_amount_cents: 50,
           units: 18 # 50 x 18 = 900
         }
       end
@@ -1262,7 +1262,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     context 'with updated fee equal to zero' do
       let(:adjusted_fee_params) do
         {
-          unit_amount_cents: 0,
+          unit_precise_amount_cents: 0,
           units: 1
         }
       end

--- a/spec/services/adjusted_fees/create_service_spec.rb
+++ b/spec/services/adjusted_fees/create_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
   let(:params) do
     {
       units: 5,
-      unit_precise_amount_cents: 1200.2,
+      unit_precise_amount: 12.002,
       invoice_display_name: 'new-dis-name'
     }
   end

--- a/spec/services/adjusted_fees/create_service_spec.rb
+++ b/spec/services/adjusted_fees/create_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
   let(:params) do
     {
       units: 5,
-      unit_amount_cents: 1200,
+      unit_precise_amount_cents: 1200.2,
       invoice_display_name: 'new-dis-name'
     }
   end
@@ -47,6 +47,34 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
 
         expect(Invoices::RefreshDraftService).to have_received(:new)
         expect(refresh_service).to have_received(:call)
+      end
+
+      it 'populates precise and not precise values for the created adjusted fee' do
+        result = create_service.call
+        expect(result.adjusted_fee).to have_attributes(
+          units: 5,
+          unit_amount_cents: 1200,
+          unit_precise_amount_cents: 1200.2
+        )
+      end
+
+      context 'when unit_amount_cents is sent instead of unit_precise_amount_cents' do
+        let(:params) do
+          {
+            units: 5,
+            unit_precise_amount_cents: 1200,
+            invoice_display_name: 'new-dis-name'
+          }
+        end
+
+        it 'populates precise and not precise values for the created adjusted fee' do
+          result = create_service.call
+          expect(result.adjusted_fee).to have_attributes(
+            units: 5,
+            unit_amount_cents: 1200,
+            unit_precise_amount_cents: 1200.0
+          )
+        end
       end
 
       context 'when invoice is NOT in draft status' do

--- a/spec/services/adjusted_fees/create_service_spec.rb
+++ b/spec/services/adjusted_fees/create_service_spec.rb
@@ -58,25 +58,6 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
         )
       end
 
-      context 'when unit_amount_cents is sent instead of unit_precise_amount_cents' do
-        let(:params) do
-          {
-            units: 5,
-            unit_precise_amount_cents: 1200,
-            invoice_display_name: 'new-dis-name'
-          }
-        end
-
-        it 'populates precise and not precise values for the created adjusted fee' do
-          result = create_service.call
-          expect(result.adjusted_fee).to have_attributes(
-            units: 5,
-            unit_amount_cents: 1200,
-            unit_precise_amount_cents: 1200.0
-          )
-        end
-      end
-
       context 'when invoice is NOT in draft status' do
         before { fee.invoice.finalized! }
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -640,8 +640,9 @@ RSpec.describe Fees::ChargeService do
               fee_type: :charge,
               adjusted_units: false,
               adjusted_amount: true,
-              units: 4,
-              unit_amount_cents: 200
+              units: 1000,
+              unit_amount_cents: 0,
+              unit_precise_amount_cents: 0.1
             )
           end
 
@@ -653,13 +654,13 @@ RSpec.describe Fees::ChargeService do
               id: String,
               invoice_id: invoice.id,
               charge_id: charge.id,
-              amount_cents: 800,
-              precise_amount_cents: 800.0,
+              amount_cents: 100,
+              precise_amount_cents: 100.0,
               taxes_precise_amount_cents: 0.0,
               amount_currency: 'EUR',
-              units: 4,
-              unit_amount_cents: 200,
-              precise_unit_amount: 2,
+              units: 1000,
+              unit_amount_cents: 0,
+              precise_unit_amount: 0.001,
               events_count: 0,
               payment_status: 'pending'
             )

--- a/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
+++ b/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
@@ -91,7 +91,8 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService, type: :service do
         adjusted_units: false,
         adjusted_amount: true,
         units: 4,
-        unit_amount_cents: 200
+        unit_amount_cents: 200,
+        unit_precise_amount_cents: 200.0
       )
     end
 

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -158,7 +158,8 @@ RSpec.describe Fees::SubscriptionService do
             adjusted_units: false,
             adjusted_amount: true,
             units: 3,
-            unit_amount_cents: 200
+            unit_amount_cents: 200,
+            unit_precise_amount: 2.0
           )
         end
 
@@ -177,6 +178,39 @@ RSpec.describe Fees::SubscriptionService do
             unit_amount_cents: 200,
             precise_unit_amount: 2
           )
+        end
+
+        context 'when precise unit amounts are used' do
+          let(:adjusted_fee) do
+            create(
+              :adjusted_fee,
+              invoice:,
+              subscription:,
+              properties:,
+              adjusted_units: false,
+              adjusted_amount: true,
+              units: 1000,
+              unit_amount_cents: 0,
+              unit_precise_amount_cents: 0.1
+            )
+          end
+
+          it 'creates a fee' do
+            result = fees_subscription_service.create
+
+            expect(result.fee).to have_attributes(
+              id: String,
+              invoice_id: invoice.id,
+              amount_cents: 100,
+              precise_amount_cents: 100.0,
+              amount_currency: 'EUR',
+              units: 1000,
+              events_count: nil,
+              payment_status: 'pending',
+              unit_amount_cents: 0,
+              precise_unit_amount: 0.001
+            )
+          end
         end
       end
 

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Fees::SubscriptionService do
             adjusted_amount: true,
             units: 3,
             unit_amount_cents: 200,
-            unit_precise_amount: 2.0
+            unit_precise_amount_cents: 200.0
           )
         end
 


### PR DESCRIPTION
## Context

currently when an organization is editing fee, they can enter only 2 digits after the comma for new unit_amount. Instead, they want to be able to enter as many digits as they want as it already works for unit amount in plans.

## Description

Added unit_precise_amount_cents to adjusted fee;
Added this new field into consideration when creating fees;
Added a migration to populate unit_precise_amount_cents for currently existing adjusted fees