### PR TITLE
feat(dunning): Add flag to customers when completed a dunning campaign

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -207,6 +207,7 @@ end
 #  customer_type                    :enum
 #  deleted_at                       :datetime
 #  document_locale                  :string
+#  dunning_campaign_completed       :boolean          default(FALSE)
 #  email                            :string
 #  exclude_from_dunning_campaign    :boolean          default(FALSE), not null
 #  finalize_zero_amount_invoice     :integer          default("inherit"), not null

--- a/db/migrate/20241119114948_add_dunning_campaign_completed_to_customers.rb
+++ b/db/migrate/20241119114948_add_dunning_campaign_completed_to_customers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDunningCampaignCompletedToCustomers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :customers, :dunning_campaign_completed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -467,6 +467,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_20_090305) do
     t.boolean "exclude_from_dunning_campaign", default: false, null: false
     t.integer "last_dunning_campaign_attempt", default: 0, null: false
     t.datetime "last_dunning_campaign_attempt_at", precision: nil
+    t.boolean "dunning_campaign_completed", default: false
     t.index ["applied_dunning_campaign_id"], name: "index_customers_on_applied_dunning_campaign_id"
     t.index ["deleted_at"], name: "index_customers_on_deleted_at"
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true, where: "(deleted_at IS NULL)"


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We are extending dunning campaigns management to edit and delete campaigns.

 ## Description

This change adds `completed_dunning_campaign` boolean flag to customers. The goal of this flag is to identify when a customer has exhausted all dunning campaign attemps and exclude it from further dunning campaign executions until one of its payment requests is being paid, the customer get a custom campaign assigned, or other edge cases...