### PR TITLE
feat(dunning): extend DunningCampaigns::UpdateService update all fields

### DIFF
--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -15,6 +15,12 @@ module DunningCampaigns
       return result.not_found_failure!(resource: "dunning_campaign") unless dunning_campaign
 
       ActiveRecord::Base.transaction do
+        dunning_campaign.name = params[:name] if params.key?(:name)
+        dunning_campaign.code = params[:code] if params.key?(:code)
+        dunning_campaign.description = params[:description] if params.key?(:description)
+        dunning_campaign.days_between_attempts = params[:days_between_attempts] if params.key?(:days_between_attempts)
+        dunning_campaign.max_attempts = params[:max_attempts] if params.key?(:max_attempts)
+
         unless params[:applied_to_organization].nil?
           organization
             .dunning_campaigns

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -50,14 +50,33 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           create(:organization, premium_integrations: ["auto_dunning"])
         end
 
+        let(:dunning_campaign_threshold) do
+          create(:dunning_campaign_threshold, dunning_campaign:)
+        end
+
         let(:params) do
           {
             name: "Updated Dunning Campaign",
             code: "updated-dunning-campaign",
             days_between_attempts: Faker::Number.number(digits: 2),
             max_attempts: Faker::Number.number(digits: 2),
-            description: "Updated Dunning Campaign Description"
+            description: "Updated Dunning Campaign Description",
+            thresholds: thresholds_input
           }
+        end
+
+        let(:thresholds_input) do
+          [
+            {
+              id: dunning_campaign_threshold.id,
+              amount_cents: 999_99,
+              currency: "GBP"
+            },
+            {
+              amount_cents: 5_55,
+              currency: "CHF"
+            }
+          ]
         end
 
         it "updates the dunning campaign" do
@@ -67,6 +86,27 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           expect(result.dunning_campaign.days_between_attempts).to eq(params[:days_between_attempts])
           expect(result.dunning_campaign.max_attempts).to eq(params[:max_attempts])
           expect(result.dunning_campaign.description).to eq(params[:description])
+
+          expect(result.dunning_campaign.thresholds.count).to eq(2)
+          expect(result.dunning_campaign.thresholds.find(dunning_campaign_threshold.id))
+            .to have_attributes({amount_cents: 999_99, currency: "GBP"})
+          expect(result.dunning_campaign.thresholds.where.not(id: dunning_campaign_threshold.id).first)
+            .to have_attributes({amount_cents: 5_55, currency: "CHF"})
+        end
+
+        context "when the input does not include a thresholds" do
+          let(:dunning_campaign_threshold_to_be_deleted) do
+            create(:dunning_campaign_threshold, dunning_campaign:, currency: "EUR")
+          end
+
+          before { dunning_campaign_threshold_to_be_deleted }
+
+          it "deletes the thresholds not in the input" do
+            expect(result).to be_success
+            expect(result.dunning_campaign.thresholds.count).to eq(2)
+            expect(result.dunning_campaign.thresholds.find_by(id: dunning_campaign_threshold_to_be_deleted.id)).to be_nil
+            expect(dunning_campaign_threshold_to_be_deleted.reload).to be_discarded
+          end
         end
 
         context "with applied_to_organization false" do
@@ -117,6 +157,7 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
         context "with no dunning campaign record" do
           let(:dunning_campaign) { nil }
+          let(:thresholds_input) { nil }
 
           it "returns a failure" do
             expect(result).not_to be_success


### PR DESCRIPTION
## Roadmap

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We are extending dunning campaigns management to edit and delete campaigns.

 ## Description

This change enables UpdateService to update dunning campaign data and its thresholds.