### PR TITLE
bug(Coupon) - Use advisory lock to make sure coupon application is correct

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,7 +318,7 @@ GEM
     hashie (5.0.0)
     highline (2.1.0)
     httpclient (2.8.3)
-    i18n (1.14.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
     irb (1.14.0)
@@ -390,7 +390,7 @@ GEM
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     multipart-post (2.4.1)
-    mutex_m (0.2.0)
+    mutex_m (0.3.0)
     nenv (0.3.0)
     net-imap (0.4.14)
       date
@@ -867,7 +867,7 @@ GEM
     thor (1.3.1)
     tilt (2.0.11)
     timecop (0.9.10)
-    timeout (0.4.1)
+    timeout (0.4.2)
     trailblazer-option (0.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -892,8 +892,9 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    with_advisory_lock (4.6.0)
-      activerecord (>= 4.2)
+    with_advisory_lock (5.1.0)
+      activerecord (>= 6.1)
+      zeitwerk (>= 2.6)
     zeitwerk (2.6.17)
 
 PLATFORMS

--- a/app/services/applied_coupons/lock_service.rb
+++ b/app/services/applied_coupons/lock_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module AppliedCoupons
+  class LockService < BaseService
+    def initialize(customer:)
+      @customer = customer
+
+      super
+    end
+
+    def call
+      customer.with_advisory_lock("COUPONS-#{customer.id}", timeout_seconds: 5) do
+        yield
+      end
+    end
+
+    def locked?
+      customer.advisory_lock_exists?("COUPONS-#{customer.id}")
+    end
+
+    private
+
+    attr_reader :customer
+  end
+end

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -10,7 +10,7 @@ module Credits
     end
 
     def call
-      if !customer.advisory_lock_exists?("COUPONS-#{customer.id}")
+      if !AppliedCoupons::LockService.new(customer:).locked?
         return result.service_failure!(code: 'no_lock_acquired', message: "Calling this service without acquiring a lock is not allowed")
       end
 

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -10,6 +10,10 @@ module Credits
     end
 
     def call
+      if !customer.advisory_lock_exists?("COUPONS-#{customer.id}")
+        return result.service_failure!(code: 'no_lock_acquired', message: "Calling this service without acquiring a lock is not allowed")
+      end
+
       return result unless matches_currency?
       return result if already_applied?
       return result unless fees.any?
@@ -56,6 +60,7 @@ module Credits
     attr_accessor :invoice, :applied_coupon
 
     delegate :coupon, to: :applied_coupon
+    delegate :customer, to: :invoice
 
     def matches_currency?
       return true unless applied_coupon.coupon.fixed_amount?

--- a/app/services/credits/applied_coupons_service.rb
+++ b/app/services/credits/applied_coupons_service.rb
@@ -17,7 +17,7 @@ module Credits
       # We're not locking individual coupons as that might lead to deadlocks.
       # This will also keep the lock for the shortest time possible, otherwise
       # we'd have to wait for the transaction to either rollback / commit.
-      customer.with_advisory_lock("COUPONS-#{customer.id}", timeout_seconds: 5) do
+      AppliedCoupons::LockService.new(customer:).call do
         # reload coupons now that we've acquired the lock
         applied_coupons.reload
 

--- a/app/services/credits/applied_coupons_service.rb
+++ b/app/services/credits/applied_coupons_service.rb
@@ -13,13 +13,22 @@ module Credits
 
       result.credits = []
 
-      applied_coupons.each do |applied_coupon|
-        break unless invoice.sub_total_excluding_taxes_amount_cents&.positive?
+      ## take an advisory lock on coupons for this customer
+      # We're not locking individual coupons as that might lead to deadlocks.
+      # This will also keep the lock for the shortest time possible, otherwise
+      # we'd have to wait for the transaction to either rollback / commit.
+      customer.with_advisory_lock("COUPONS-#{customer.id}", timeout_seconds: 5) do
+        # reload coupons now that we've acquired the lock
+        applied_coupons.reload
 
-        credit_result = Credits::AppliedCouponService.call(invoice:, applied_coupon:)
-        credit_result.raise_if_error!
+        applied_coupons.each do |applied_coupon|
+          break unless invoice.sub_total_excluding_taxes_amount_cents&.positive?
 
-        result.credits << credit_result.credit
+          credit_result = Credits::AppliedCouponService.call(invoice:, applied_coupon:)
+          credit_result.raise_if_error!
+
+          result.credits << credit_result.credit
+        end
       end
 
       result.invoice = invoice

--- a/spec/services/applied_coupons/lock_service_spec.rb
+++ b/spec/services/applied_coupons/lock_service_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AppliedCoupons::LockService, type: :service do
+  subject(:lock_service) { described_class.new(customer:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  describe "#call" do
+    it "takes an advisory lock" do
+      expect(lock_service).not_to be_locked
+
+      lock_service.call do
+        expect(lock_service).to be_locked
+      end
+
+      expect(lock_service).not_to be_locked
+    end
+  end
+end


### PR DESCRIPTION
## Description

Coupon deduction was not resistant to concurrency issues. This PR introduces safe-guards so coupons are applied correctly.