### PR TITLE
improve(CreditNote::FromTermination) - Use creditable_amount_cents rather than duplicating the logic

### DIFF
--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -19,11 +19,8 @@ module CreditNotes
       # NOTE: In some cases, if the fee was already prorated (in case of multiple upgrade) the amount
       #       could be greater than the last subscription fee amount.
       #       In that case, we have to use the last subscription fee amount
-      amount = last_subscription_fee.amount_cents if amount > last_subscription_fee.amount_cents
+      amount = last_subscription_fee.creditable_amount_cents if amount > last_subscription_fee.creditable_amount_cents
 
-      # NOTE: if credit notes were already issued on the fee,
-      #       we have to deduct them from the prorated amount
-      amount -= last_subscription_fee.credit_note_items.sum(:amount_cents)
       return result unless amount.positive?
 
       CreditNotes::CreateService.new(

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -37,7 +37,6 @@ module CreditNotes
           credit_status: 'available',
           status: invoice.status
         )
-
         create_items
         result.raise_if_error!
 

--- a/spec/factories/credit_notes.rb
+++ b/spec/factories/credit_notes.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     total_amount_cents { 120 }
     total_amount_currency { 'EUR' }
     taxes_amount_cents { 20 }
+    precise_taxes_amount_cents { 20 }
 
     credit_status { 'available' }
     credit_amount_cents { 120 }


### PR DESCRIPTION
## Description

Rather than duplicating the logic for calculating how much can be credited, we can rely on the `creditable_amount_cents` on Fee.