### PR TITLE
misc(throttling): Add concurrent jobs throttling config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "puma", "~> 6.4"
 gem "rails", "~> 7.1.3.4"
 gem "redis"
 gem "sidekiq"
+gem "sidekiq-throttled", '1.4.0' # '1.5.0' was losing some jobs
 gem "dry-validation"
 
 # Security

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "rails", "~> 7.1.3.4"
 gem "redis"
 gem "sidekiq"
 gem "sidekiq-throttled", '1.4.0' # '1.5.0' was losing some jobs
+gem "throttling"
 gem "dry-validation"
 
 # Security

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -702,6 +702,7 @@ GEM
       redis-client (>= 0.22.0)
     redis-client (0.22.2)
       connection_pool
+    redis-prescription (2.6.0)
     redlock (2.0.6)
       redis-client (>= 0.14.1, < 1.0.0)
     regexp_parser (2.9.2)
@@ -816,6 +817,10 @@ GEM
       logger
       rack (>= 2.2.4)
       redis-client (>= 0.22.2)
+    sidekiq-throttled (1.4.0)
+      concurrent-ruby (>= 1.2.0)
+      redis-prescription (~> 2.2)
+      sidekiq (>= 6.5)
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -981,6 +986,7 @@ DEPENDENCIES
   sentry-sidekiq (~> 5.18.0)
   shoulda-matchers
   sidekiq
+  sidekiq-throttled (= 1.4.0)
   simplecov
   slim
   slim-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -870,6 +870,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.1)
+    throttling (0.4.0)
     tilt (2.0.11)
     timecop (0.9.10)
     timeout (0.4.2)
@@ -993,6 +994,7 @@ DEPENDENCIES
   standard
   stripe
   strong_migrations
+  throttling
   timecop
   tzinfo-data
   uglifier

--- a/app/jobs/concerns/concurrency_throttlable.rb
+++ b/app/jobs/concerns/concurrency_throttlable.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ConcurrencyThrottlable
+  extend ActiveSupport::Concern
+
+  included do
+    include Sidekiq::Throttled::Job
+
+    # The limit of concurrent API calls defined in: config/initializers/throttling.rb
+    sidekiq_throttle_as :concurrency_limit
+  end
+end

--- a/app/jobs/integration_customers/create_job.rb
+++ b/app/jobs/integration_customers/create_job.rb
@@ -5,6 +5,7 @@ module IntegrationCustomers
     queue_as 'integrations'
 
     retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
+    retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 100
 
     def perform(integration_customer_params:, integration:, customer:)
       result = IntegrationCustomers::CreateService.call(params: integration_customer_params, integration:, customer:)

--- a/app/jobs/integration_customers/create_job.rb
+++ b/app/jobs/integration_customers/create_job.rb
@@ -5,7 +5,7 @@ module IntegrationCustomers
     queue_as 'integrations'
 
     retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-    retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 100
+    retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
     def perform(integration_customer_params:, integration:, customer:)
       result = IntegrationCustomers::CreateService.call(params: integration_customer_params, integration:, customer:)

--- a/app/jobs/integration_customers/update_job.rb
+++ b/app/jobs/integration_customers/update_job.rb
@@ -5,7 +5,7 @@ module IntegrationCustomers
     queue_as 'integrations'
 
     retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
-    retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 100
+    retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
     def perform(integration_customer_params:, integration:, integration_customer:)
       result = IntegrationCustomers::UpdateService.call(

--- a/app/jobs/integration_customers/update_job.rb
+++ b/app/jobs/integration_customers/update_job.rb
@@ -5,6 +5,7 @@ module IntegrationCustomers
     queue_as 'integrations'
 
     retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
+    retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 100
 
     def perform(integration_customer_params:, integration:, integration_customer:)
       result = IntegrationCustomers::UpdateService.call(

--- a/app/jobs/integrations/aggregator/credit_notes/create_job.rb
+++ b/app/jobs/integrations/aggregator/credit_notes/create_job.rb
@@ -4,6 +4,8 @@ module Integrations
   module Aggregator
     module CreditNotes
       class CreateJob < ApplicationJob
+        include ConcurrencyThrottlable
+
         queue_as 'integrations'
 
         unique :until_executed, on_conflict: :log

--- a/app/jobs/integrations/aggregator/credit_notes/create_job.rb
+++ b/app/jobs/integrations/aggregator/credit_notes/create_job.rb
@@ -12,7 +12,7 @@ module Integrations
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
-        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 100
+        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
         def perform(credit_note:)
           result = Integrations::Aggregator::CreditNotes::CreateService.call(credit_note:)

--- a/app/jobs/integrations/aggregator/credit_notes/create_job.rb
+++ b/app/jobs/integrations/aggregator/credit_notes/create_job.rb
@@ -12,6 +12,7 @@ module Integrations
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
+        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 100
 
         def perform(credit_note:)
           result = Integrations::Aggregator::CreditNotes::CreateService.call(credit_note:)

--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -12,7 +12,7 @@ module Integrations
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
-        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 100
+        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
         def perform(invoice:)
           result = Integrations::Aggregator::Invoices::CreateService.call(invoice:)

--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -4,6 +4,8 @@ module Integrations
   module Aggregator
     module Invoices
       class CreateJob < ApplicationJob
+        include ConcurrencyThrottlable
+
         queue_as 'integrations'
 
         unique :until_executed, on_conflict: :log

--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -12,6 +12,7 @@ module Integrations
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
+        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 100
 
         def perform(invoice:)
           result = Integrations::Aggregator::Invoices::CreateService.call(invoice:)

--- a/app/jobs/integrations/aggregator/invoices/hubspot/create_customer_association_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/hubspot/create_customer_association_job.rb
@@ -9,6 +9,7 @@ module Integrations
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
+          retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
           def perform(invoice:)
             result = Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssociationService.call(invoice:)

--- a/app/jobs/integrations/aggregator/invoices/hubspot/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/hubspot/create_job.rb
@@ -10,6 +10,7 @@ module Integrations
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
+          retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
           def perform(invoice:)
             result = Integrations::Aggregator::Invoices::Hubspot::CreateService.call(invoice:)

--- a/app/jobs/integrations/aggregator/invoices/hubspot/update_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/hubspot/update_job.rb
@@ -10,6 +10,7 @@ module Integrations
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
+          retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
           def perform(invoice:)
             result = Integrations::Aggregator::Invoices::Hubspot::UpdateService.call(invoice:)

--- a/app/jobs/integrations/aggregator/payments/create_job.rb
+++ b/app/jobs/integrations/aggregator/payments/create_job.rb
@@ -13,7 +13,7 @@ module Integrations
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 5
         retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
-        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 100
+        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
         def perform(payment:)
           result = Integrations::Aggregator::Payments::CreateService.call(payment:)

--- a/app/jobs/integrations/aggregator/payments/create_job.rb
+++ b/app/jobs/integrations/aggregator/payments/create_job.rb
@@ -13,6 +13,7 @@ module Integrations
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 5
         retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
+        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 100
 
         def perform(payment:)
           result = Integrations::Aggregator::Payments::CreateService.call(payment:)

--- a/app/jobs/integrations/aggregator/payments/create_job.rb
+++ b/app/jobs/integrations/aggregator/payments/create_job.rb
@@ -4,6 +4,8 @@ module Integrations
   module Aggregator
     module Payments
       class CreateJob < ApplicationJob
+        include ConcurrencyThrottlable
+
         queue_as 'integrations'
 
         unique :until_executed, on_conflict: :log

--- a/app/jobs/integrations/aggregator/subscriptions/hubspot/create_customer_association_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/hubspot/create_customer_association_job.rb
@@ -9,6 +9,7 @@ module Integrations
 
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
+          retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
           def perform(subscription:)
             result = Integrations::Aggregator::Subscriptions::Hubspot::CreateCustomerAssociationService.call(subscription:)

--- a/app/jobs/integrations/aggregator/subscriptions/hubspot/create_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/hubspot/create_job.rb
@@ -10,6 +10,7 @@ module Integrations
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
+          retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
           def perform(subscription:)
             result = Integrations::Aggregator::Subscriptions::Hubspot::CreateService.call(subscription:)

--- a/app/jobs/integrations/aggregator/subscriptions/hubspot/update_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/hubspot/update_job.rb
@@ -10,6 +10,7 @@ module Integrations
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
+          retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
           def perform(subscription:)
             result = Integrations::Aggregator::Subscriptions::Hubspot::UpdateService.call(subscription:)

--- a/app/jobs/integrations/aggregator/sync_custom_objects_and_properties_job.rb
+++ b/app/jobs/integrations/aggregator/sync_custom_objects_and_properties_job.rb
@@ -5,6 +5,8 @@ module Integrations
     class SyncCustomObjectsAndPropertiesJob < ApplicationJob
       queue_as 'integrations'
 
+      retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
+
       def perform(integration:)
         Integrations::Hubspot::Invoices::DeployObjectService.call(integration:)
         Integrations::Hubspot::Subscriptions::DeployObjectService.call(integration:)

--- a/app/jobs/integrations/hubspot/companies/deploy_properties_job.rb
+++ b/app/jobs/integrations/hubspot/companies/deploy_properties_job.rb
@@ -8,6 +8,7 @@ module Integrations
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
+        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
         def perform(integration:)
           result = Integrations::Hubspot::Companies::DeployPropertiesService.call(integration:)

--- a/app/jobs/integrations/hubspot/contacts/deploy_properties_job.rb
+++ b/app/jobs/integrations/hubspot/contacts/deploy_properties_job.rb
@@ -8,6 +8,7 @@ module Integrations
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
+        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
         def perform(integration:)
           result = Integrations::Hubspot::Contacts::DeployPropertiesService.call(integration:)

--- a/app/jobs/integrations/hubspot/invoices/deploy_object_job.rb
+++ b/app/jobs/integrations/hubspot/invoices/deploy_object_job.rb
@@ -8,6 +8,7 @@ module Integrations
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
+        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
         def perform(integration:)
           result = Integrations::Hubspot::Invoices::DeployObjectService.call(integration:)

--- a/app/jobs/integrations/hubspot/save_portal_id_job.rb
+++ b/app/jobs/integrations/hubspot/save_portal_id_job.rb
@@ -7,6 +7,7 @@ module Integrations
 
       retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
       retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
+      retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
       def perform(integration:)
         result = Integrations::Hubspot::SavePortalIdService.call(integration:)

--- a/app/jobs/integrations/hubspot/subscriptions/deploy_object_job.rb
+++ b/app/jobs/integrations/hubspot/subscriptions/deploy_object_job.rb
@@ -8,6 +8,7 @@ module Integrations
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
+        retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
         def perform(integration:)
           result = Integrations::Hubspot::Subscriptions::DeployObjectService.call(integration:)

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -13,6 +13,8 @@ class BaseService
     end
   end
 
+  class ThrottlingError < StandardError; end
+
   class NotFoundFailure < FailedResult
     attr_reader :resource
 

--- a/app/services/integrations/aggregator/account_information_service.rb
+++ b/app/services/integrations/aggregator/account_information_service.rb
@@ -8,6 +8,8 @@ module Integrations
       end
 
       def call
+        throttle!(:hubspot)
+
         response = http_client.get(headers:)
 
         result.account_information = OpenStruct.new(response)

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -50,6 +50,26 @@ module Integrations
         end
       end
 
+      def throttle!(*providers)
+        providers.each do |provider_name|
+          if provider == provider_name.to_s
+            raise BaseService::ThrottlingError unless Throttling.for(provider_name.to_sym).check(:client, throttle_key)
+          end
+        end
+      end
+
+      def throttle_key
+        # Hubspot and Xero calls are throttled globally, others are throttled per api key or token
+        case provider
+        when 'netsuite'
+          integration.token_id
+        when 'anrok'
+          integration.api_key
+        else
+          provider.to_s
+        end
+      end
+
       def http_client
         LagoHttpClient::Client.new(endpoint_url)
       end

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -59,10 +59,10 @@ module Integrations
       end
 
       def throttle_key
-        # Hubspot and Xero calls are throttled globally, others are throttled per api key or token
+        # Hubspot and Xero calls are throttled globally, others are throttled per api key or client id
         case provider
         when 'netsuite'
-          Digest::SHA2.hexdigest(integration.token_id)
+          Digest::SHA2.hexdigest(integration.client_id)
         when 'anrok'
           Digest::SHA2.hexdigest(integration.api_key)
         else

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -62,9 +62,9 @@ module Integrations
         # Hubspot and Xero calls are throttled globally, others are throttled per api key or token
         case provider
         when 'netsuite'
-          integration.token_id
+          Digest::SHA2.hexdigest(integration.token_id)
         when 'anrok'
-          integration.api_key
+          Digest::SHA2.hexdigest(integration.api_key)
         else
           provider.to_s
         end

--- a/app/services/integrations/aggregator/companies/create_service.rb
+++ b/app/services/integrations/aggregator/companies/create_service.rb
@@ -14,6 +14,8 @@ module Integrations
         def call
           Integrations::Hubspot::Companies::DeployPropertiesService.call(integration:)
 
+          throttle!(:hubspot)
+
           response = http_client.post_with_response(params, headers)
           body = JSON.parse(response.body)
 

--- a/app/services/integrations/aggregator/companies/update_service.rb
+++ b/app/services/integrations/aggregator/companies/update_service.rb
@@ -15,6 +15,8 @@ module Integrations
         def call
           Integrations::Hubspot::Companies::DeployPropertiesService.call(integration:)
 
+          throttle!(:hubspot)
+
           response = http_client.put_with_response(params, headers)
           body = JSON.parse(response.body)
 

--- a/app/services/integrations/aggregator/contacts/create_service.rb
+++ b/app/services/integrations/aggregator/contacts/create_service.rb
@@ -14,6 +14,8 @@ module Integrations
         def call
           Integrations::Hubspot::Contacts::DeployPropertiesService.call(integration:)
 
+          throttle!(:anrok, :hubspot, :netsuite, :xero)
+
           response = http_client.post_with_response(params, headers)
           body = JSON.parse(response.body)
 

--- a/app/services/integrations/aggregator/contacts/update_service.rb
+++ b/app/services/integrations/aggregator/contacts/update_service.rb
@@ -13,6 +13,8 @@ module Integrations
         def call
           Integrations::Hubspot::Contacts::DeployPropertiesService.call(integration:)
 
+          throttle!(:anrok, :hubspot, :netsuite, :xero)
+
           response = http_client.put_with_response(params, headers)
           body = JSON.parse(response.body)
 

--- a/app/services/integrations/aggregator/credit_notes/create_service.rb
+++ b/app/services/integrations/aggregator/credit_notes/create_service.rb
@@ -20,6 +20,8 @@ module Integrations
           return result unless credit_note.finalized?
           return result if payload.integration_credit_note
 
+          throttle!(:anrok, :netsuite, :xero)
+
           response = http_client.post_with_response(payload.body, headers)
           body = JSON.parse(response.body)
 

--- a/app/services/integrations/aggregator/custom_object_service.rb
+++ b/app/services/integrations/aggregator/custom_object_service.rb
@@ -13,6 +13,8 @@ module Integrations
       end
 
       def call
+        throttle!(:hubspot)
+
         response = http_client.get(headers:, body:)
 
         result.custom_object = OpenStruct.new(response)

--- a/app/services/integrations/aggregator/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/invoices/create_service.rb
@@ -14,6 +14,8 @@ module Integrations
           return result unless invoice.finalized?
           return result if payload.integration_invoice
 
+          throttle!(:anrok, :netsuite, :xero)
+
           response = http_client.post_with_response(payload.body, headers)
           body = JSON.parse(response.body)
 

--- a/app/services/integrations/aggregator/invoices/hubspot/create_customer_association_service.rb
+++ b/app/services/integrations/aggregator/invoices/hubspot/create_customer_association_service.rb
@@ -14,6 +14,8 @@ module Integrations
 
             Integrations::Hubspot::Invoices::DeployObjectService.call(integration:)
 
+            throttle!(:hubspot)
+
             http_client.put_with_response(payload.customer_association_body, headers)
 
             result

--- a/app/services/integrations/aggregator/invoices/hubspot/create_service.rb
+++ b/app/services/integrations/aggregator/invoices/hubspot/create_service.rb
@@ -13,6 +13,8 @@ module Integrations
 
             Integrations::Hubspot::Invoices::DeployPropertiesService.call(integration:)
 
+            throttle!(:hubspot)
+
             response = http_client.post_with_response(payload.create_body, headers)
             body = JSON.parse(response.body)
 

--- a/app/services/integrations/aggregator/invoices/hubspot/update_service.rb
+++ b/app/services/integrations/aggregator/invoices/hubspot/update_service.rb
@@ -12,6 +12,8 @@ module Integrations
 
             Integrations::Hubspot::Invoices::DeployPropertiesService.call(integration:)
 
+            throttle!(:hubspot)
+
             response = http_client.put_with_response(payload.update_body, headers)
             body = JSON.parse(response.body)
 

--- a/app/services/integrations/aggregator/payments/create_service.rb
+++ b/app/services/integrations/aggregator/payments/create_service.rb
@@ -20,6 +20,8 @@ module Integrations
           return result unless invoice.finalized?
           return result if payload.integration_payment
 
+          throttle!(:netsuite, :xero)
+
           response = http_client.post_with_response(payload.body, headers)
           body = JSON.parse(response.body)
 

--- a/app/services/integrations/aggregator/subscriptions/hubspot/create_customer_association_service.rb
+++ b/app/services/integrations/aggregator/subscriptions/hubspot/create_customer_association_service.rb
@@ -14,6 +14,8 @@ module Integrations
 
             Integrations::Hubspot::Subscriptions::DeployObjectService.call(integration:)
 
+            throttle!(:hubspot)
+
             http_client.put_with_response(payload.customer_association_body, headers)
 
             result

--- a/app/services/integrations/aggregator/subscriptions/hubspot/create_service.rb
+++ b/app/services/integrations/aggregator/subscriptions/hubspot/create_service.rb
@@ -9,6 +9,8 @@ module Integrations
             return result unless integration
             return result unless integration.sync_subscriptions
 
+            throttle!(:hubspot)
+
             Integrations::Hubspot::Subscriptions::DeployPropertiesService.call(integration:)
 
             response = http_client.post_with_response(payload.create_body, headers)

--- a/app/services/integrations/aggregator/subscriptions/hubspot/update_service.rb
+++ b/app/services/integrations/aggregator/subscriptions/hubspot/update_service.rb
@@ -10,6 +10,8 @@ module Integrations
             return result unless integration.sync_subscriptions
             return result unless payload.integration_subscription
 
+            throttle!(:hubspot)
+
             Integrations::Hubspot::Subscriptions::DeployPropertiesService.call(integration:)
 
             response = http_client.put_with_response(payload.update_body, headers)

--- a/app/services/integrations/hubspot/companies/deploy_properties_service.rb
+++ b/app/services/integrations/hubspot/companies/deploy_properties_service.rb
@@ -13,6 +13,9 @@ module Integrations
         def call
           return result unless integration.type == 'Integrations::HubspotIntegration'
           return result if integration.companies_properties_version == VERSION
+
+          throttle!(:hubspot)
+
           response = http_client.post_with_response(payload, headers)
           ActiveRecord::Base.transaction do
             integration.settings = integration.reload.settings

--- a/app/services/integrations/hubspot/contacts/deploy_properties_service.rb
+++ b/app/services/integrations/hubspot/contacts/deploy_properties_service.rb
@@ -13,6 +13,9 @@ module Integrations
         def call
           return result unless integration.type == 'Integrations::HubspotIntegration'
           return result if integration.contacts_properties_version == VERSION
+
+          throttle!(:hubspot)
+
           response = http_client.post_with_response(payload, headers)
           ActiveRecord::Base.transaction do
             integration.settings = integration.reload.settings

--- a/app/services/integrations/hubspot/invoices/deploy_object_service.rb
+++ b/app/services/integrations/hubspot/invoices/deploy_object_service.rb
@@ -22,6 +22,8 @@ module Integrations
             return result
           end
 
+          throttle!(:hubspot)
+
           response = http_client.post_with_response(payload, headers)
           ActiveRecord::Base.transaction do
             save_object_type_id(response['objectTypeId'])

--- a/app/services/integrations/hubspot/invoices/deploy_properties_service.rb
+++ b/app/services/integrations/hubspot/invoices/deploy_properties_service.rb
@@ -13,6 +13,9 @@ module Integrations
         def call
           return result unless integration.type == 'Integrations::HubspotIntegration'
           return result if integration.invoices_properties_version == VERSION
+
+          throttle!(:hubspot)
+
           response = http_client.post_with_response(payload, headers)
           ActiveRecord::Base.transaction do
             integration.settings = integration.reload.settings

--- a/app/services/integrations/hubspot/subscriptions/deploy_object_service.rb
+++ b/app/services/integrations/hubspot/subscriptions/deploy_object_service.rb
@@ -23,6 +23,8 @@ module Integrations
             return result
           end
 
+          throttle!(:hubspot)
+
           response = http_client.post_with_response(payload, headers)
           ActiveRecord::Base.transaction do
             save_object_type_id(response['objectTypeId'])

--- a/app/services/integrations/hubspot/subscriptions/deploy_properties_service.rb
+++ b/app/services/integrations/hubspot/subscriptions/deploy_properties_service.rb
@@ -13,6 +13,9 @@ module Integrations
         def call
           return unless integration.type == 'Integrations::HubspotIntegration'
           return result if integration.subscriptions_properties_version == VERSION
+
+          throttle!(:hubspot)
+
           response = http_client.post_with_response(payload, headers)
           ActiveRecord::Base.transaction do
             integration.settings = integration.reload.settings

--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'sidekiq/throttled'
+require 'sidekiq/throttled/web'
+
+# this is the limit of concurrent API calls for Xero and Anrok
+Sidekiq::Throttled::Registry.add(:concurrency_limit, concurrency: {limit: 5})

--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -3,5 +3,45 @@
 require 'sidekiq/throttled'
 require 'sidekiq/throttled/web'
 
-# this is the limit of concurrent API calls for Xero and Anrok
+##
+# Configuration of 'sidekiq-throttled' gem
+#
+# This is the limit of concurrent API calls for Xero and Anrok
 Sidekiq::Throttled::Registry.add(:concurrency_limit, concurrency: {limit: 5})
+
+##
+# Configuration of 'throttling' gem
+#
+Throttling.storage = Rails.cache
+Throttling.logger = Rails.logger
+
+# Limits per integration and per API key
+Throttling.limits = {
+  hubspot_requests: { # Rate limit: 110 requests per connected account 'hubspot'
+    tensecondly: {
+      limit: 110,
+      period: 10
+    }
+  },
+  xero_requests: {
+    minutely: {
+      limit: 60,
+      period: 60
+    },
+    daily: {
+      limit: 5000,
+      period: 86400
+    }
+  },
+  netsuite_requests: { # Rate limit: 10 requests per second per API key. 'integration.client_id' is used
+    secondly: {
+      limit: 10,
+      period: 1
+    }
+  }
+}
+
+# Examples of how to use the throttling gem
+# Throttling.for(:hubspot_requests).check(:api_key, 'hubspot')
+# Throttling.for(:xero_requests).check(:api_key, integration.client_id)
+# Throttling.for(:netsuite_requests).check(:api_key, integration.client_id)

--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -41,7 +41,9 @@ Throttling.limits = {
   },
   anrok: { # Rate limit: 10 requests per second
     secondly: {
-      limit: 10,
+      # this mutation can bypass the limit of 10, so lets set it to 9
+      # app/graphql/mutations/integrations/anrok/fetch_draft_invoice_taxes.rb
+      limit: 9,
       period: 1
     }
   }
@@ -50,5 +52,5 @@ Throttling.limits = {
 # Examples of how to use the throttling gem
 # Throttling.for(:hubspot).check(:client, 'hubspot')
 # Throttling.for(:xero).check(:client, 'xero')
-# Throttling.for(:netsuite).check(:client, integration.token_id)
+# Throttling.for(:netsuite).check(:client, integration.client_id)
 # Throttling.for(:anrok).check(:client, integration.api_key)

--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -6,7 +6,7 @@ require 'sidekiq/throttled/web'
 ##
 # Configuration of 'sidekiq-throttled' gem
 #
-# This is the limit of concurrent API calls for Xero and Anrok
+# This is the limit of concurrent API calls for Xero and Netsuite
 Sidekiq::Throttled::Registry.add(:concurrency_limit, concurrency: {limit: 5})
 
 ##
@@ -17,23 +17,29 @@ Throttling.logger = Rails.logger
 
 # Limits per integration and per API key
 Throttling.limits = {
-  hubspot_requests: { # Rate limit: 110 requests per connected account 'hubspot'
+  hubspot: { # Rate limit: 110 requests per 10 seconds
     tensecondly: {
       limit: 110,
       period: 10
     }
   },
-  xero_requests: {
-    minutely: {
+  xero: {
+    minutely: { # Rate limit: 60 requests per minute
       limit: 60,
       period: 60
     },
     daily: {
-      limit: 5000,
+      limit: 5000, # Rate limit: 5000 requests per day
       period: 86400
     }
   },
-  netsuite_requests: { # Rate limit: 10 requests per second per API key. 'integration.client_id' is used
+  netsuite: { # Rate limit: 10 requests per second
+    secondly: {
+      limit: 10,
+      period: 1
+    }
+  },
+  anrok: { # Rate limit: 10 requests per second
     secondly: {
       limit: 10,
       period: 1
@@ -42,6 +48,7 @@ Throttling.limits = {
 }
 
 # Examples of how to use the throttling gem
-# Throttling.for(:hubspot_requests).check(:api_key, 'hubspot')
-# Throttling.for(:xero_requests).check(:api_key, integration.client_id)
-# Throttling.for(:netsuite_requests).check(:api_key, integration.client_id)
+# Throttling.for(:hubspot).check(:client, 'hubspot')
+# Throttling.for(:xero).check(:client, 'xero')
+# Throttling.for(:netsuite).check(:client, integration.token_id)
+# Throttling.for(:anrok).check(:client, integration.api_key)

--- a/spec/services/integrations/aggregator/account_information_service_spec.rb
+++ b/spec/services/integrations/aggregator/account_information_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Integrations::Aggregator::AccountInformationService do
-  subject(:account_information_service) { described_class.new(integration:) }
+  subject(:service) { described_class.new(integration:) }
 
   let(:integration) { create(:hubspot_integration) }
 
@@ -30,7 +30,7 @@ RSpec.describe Integrations::Aggregator::AccountInformationService do
     end
 
     it 'successfully fetches account information' do
-      result = account_information_service.call
+      result = service.call
       account_information = result.account_information
 
       aggregate_failures do
@@ -39,5 +39,7 @@ RSpec.describe Integrations::Aggregator::AccountInformationService do
         expect(account_information.id).to eq('1234567890')
       end
     end
+
+    it_behaves_like 'throttles!', :hubspot
   end
 end

--- a/spec/services/integrations/aggregator/companies/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/companies/create_service_spec.rb
@@ -96,6 +96,8 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
               customer
             ).on_queue(:webhook)
         end
+
+        it_behaves_like 'throttles!', :hubspot
       end
 
       context 'when response is a hash' do
@@ -139,6 +141,8 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
                 customer
               ).on_queue(:webhook)
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
 
         context 'when contact is not created' do
@@ -159,6 +163,8 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
           it 'does not create integration resource object' do
             expect { service_call }.not_to change(IntegrationResource, :count)
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
       end
     end
@@ -221,6 +227,8 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
               }
             )
         end
+
+        it_behaves_like 'throttles!', :hubspot
       end
 
       context 'when it is a server payload error' do
@@ -256,6 +264,8 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
               }
             )
         end
+
+        it_behaves_like 'throttles!', :hubspot
       end
 
       context 'when it is a client error' do
@@ -291,6 +301,8 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
               }
             )
         end
+
+        it_behaves_like 'throttles!', :hubspot
       end
     end
   end

--- a/spec/services/integrations/aggregator/companies/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/companies/update_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Integrations::Aggregator::Companies::UpdateService do
   subject(:service_call) { described_class.call(integration:, integration_customer:) }
 
+  let(:service) { described_class.new(integration:, integration_customer:) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
@@ -26,6 +27,7 @@ RSpec.describe Integrations::Aggregator::Companies::UpdateService do
 
   before do
     allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(service).to receive(:throttle!)
   end
 
   describe '#initialize' do
@@ -98,6 +100,8 @@ RSpec.describe Integrations::Aggregator::Companies::UpdateService do
             expect(result.contact_id).to eq('1')
           end
         end
+
+        it_behaves_like 'throttles!', :hubspot
       end
 
       context 'when response is a hash' do
@@ -141,6 +145,8 @@ RSpec.describe Integrations::Aggregator::Companies::UpdateService do
             expect(result.contact_id).to eq('2e50c200-9a54-4a66-b241-1e75fb87373f')
           end
         end
+
+        it_behaves_like 'throttles!', :hubspot
       end
     end
 
@@ -212,6 +218,8 @@ RSpec.describe Integrations::Aggregator::Companies::UpdateService do
               }
             )
         end
+
+        it_behaves_like 'throttles!', :hubspot
       end
 
       context 'when it is a server payload error' do
@@ -247,6 +255,8 @@ RSpec.describe Integrations::Aggregator::Companies::UpdateService do
               }
             )
         end
+
+        it_behaves_like 'throttles!', :hubspot
       end
 
       context 'when it is a client error' do
@@ -282,6 +292,8 @@ RSpec.describe Integrations::Aggregator::Companies::UpdateService do
               }
             )
         end
+
+        it_behaves_like 'throttles!', :hubspot
       end
     end
   end

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -105,6 +105,8 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
               customer
             ).on_queue(:webhook)
         end
+
+        it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero
       end
 
       context 'when response is a hash' do
@@ -150,6 +152,8 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
                 customer
               ).on_queue(:webhook)
           end
+
+          it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero
         end
 
         context 'when contact is not created' do
@@ -170,6 +174,8 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
           it 'does not create integration resource object' do
             expect { service_call }.not_to change(IntegrationResource, :count)
           end
+
+          it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero
         end
       end
     end
@@ -258,6 +264,8 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
               }
             )
         end
+
+        it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero
       end
 
       context 'when it is a server payload error' do
@@ -293,6 +301,8 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
               }
             )
         end
+
+        it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero
       end
 
       context 'when it is a client error' do
@@ -328,6 +338,8 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
               }
             )
         end
+
+        it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero
       end
     end
   end

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
   subject(:service_call) { described_class.call(integration:, integration_customer:) }
 
+  let(:service) { described_class.new(integration:, integration_customer:) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
@@ -76,6 +77,8 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
             expect(result.contact_id).to eq('1')
           end
         end
+
+        it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero
       end
 
       context 'when response is a hash' do
@@ -119,6 +122,8 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
             expect(result.contact_id).to eq('2e50c200-9a54-4a66-b241-1e75fb87373f')
           end
         end
+
+        it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero
       end
     end
 
@@ -192,6 +197,8 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
               }
             )
         end
+
+        it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero
       end
 
       context 'when it is a server payload error' do
@@ -227,6 +234,8 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
               }
             )
         end
+
+        it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero
       end
 
       context 'when it is a client error' do
@@ -262,6 +271,8 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
               }
             )
         end
+
+        it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero
       end
     end
   end

--- a/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
   subject(:service_call) { described_class.call(credit_note: credit_note.reload) }
 
+  let(:service) { described_class.new(credit_note: credit_note.reload) }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
   let(:customer) { create(:customer, organization:) }
@@ -276,6 +277,8 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
             expect(integration_resource.syncable_type).to eq('CreditNote')
             expect(integration_resource.resource_type).to eq('credit_note')
           end
+
+          it_behaves_like 'throttles!', :anrok, :netsuite, :xero
         end
 
         context 'when credit note is not created' do
@@ -296,6 +299,8 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
           it 'does not create integration resource object' do
             expect { service_call }.not_to change(IntegrationResource, :count)
           end
+
+          it_behaves_like 'throttles!', :anrok, :netsuite, :xero
         end
       end
 
@@ -324,6 +329,8 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
           expect(integration_resource.syncable_type).to eq('CreditNote')
           expect(integration_resource.resource_type).to eq('credit_note')
         end
+
+        it_behaves_like 'throttles!', :anrok, :netsuite, :xero
       end
     end
 
@@ -363,6 +370,8 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
         it 'enqueues a SendWebhookJob' do
           expect { service_call }.to have_enqueued_job(SendWebhookJob)
         end
+
+        it_behaves_like 'throttles!', :anrok, :netsuite, :xero
       end
     end
 
@@ -400,6 +409,8 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
       it 'sends error webhook' do
         expect { service_call }.to have_enqueued_job(SendWebhookJob)
       end
+
+      it_behaves_like 'throttles!', :anrok, :netsuite, :xero
     end
   end
 end

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Integrations::Aggregator::Invoices::CreateService do
   subject(:service_call) { described_class.call(invoice:) }
 
+  let(:service) { described_class.new(invoice:) }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
   let(:customer) { create(:customer, organization:) }
@@ -302,6 +303,8 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
             expect(integration_resource.syncable_type).to eq('Invoice')
             expect(integration_resource.resource_type).to eq('invoice')
           end
+
+          it_behaves_like 'throttles!', :anrok, :netsuite, :xero
         end
 
         context 'when invoice is not created' do
@@ -322,6 +325,8 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
           it 'does not create integration resource object' do
             expect { service_call }.not_to change(IntegrationResource, :count)
           end
+
+          it_behaves_like 'throttles!', :anrok, :netsuite, :xero
         end
       end
 
@@ -350,6 +355,8 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
           expect(integration_resource.syncable_type).to eq('Invoice')
           expect(integration_resource.resource_type).to eq('invoice')
         end
+
+        it_behaves_like 'throttles!', :anrok, :netsuite, :xero
       end
     end
 
@@ -434,6 +441,8 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
       it 'returns result' do
         expect(service_call).to be_a(BaseService::Result)
       end
+
+      it_behaves_like 'throttles!', :anrok, :netsuite, :xero
     end
   end
 end

--- a/spec/services/integrations/aggregator/invoices/hubspot/create_customer_association_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/create_customer_association_service_spec.rb
@@ -76,6 +76,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssoci
         it 'returns result' do
           expect(service_call).to be_a(BaseService::Result)
         end
+
+        it_behaves_like 'throttles!', :hubspot
       end
     end
   end

--- a/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
@@ -164,6 +164,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
               expect(integration_resource.syncable_type).to eq('Invoice')
               expect(integration_resource.resource_type).to eq('invoice')
             end
+
+            it_behaves_like 'throttles!', :hubspot
           end
 
           context 'when invoice is not created' do
@@ -184,6 +186,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
             it 'does not create integration resource object' do
               expect { service_call }.not_to change(IntegrationResource, :count)
             end
+
+            it_behaves_like 'throttles!', :hubspot
           end
         end
 
@@ -209,6 +213,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
             it 'enqueues a SendWebhookJob' do
               expect { service_call }.to have_enqueued_job(SendWebhookJob)
             end
+
+            it_behaves_like 'throttles!', :hubspot
           end
 
           context 'when it is a client error' do
@@ -225,6 +231,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
             it 'enqueues a SendWebhookJob' do
               expect { service_call }.to have_enqueued_job(SendWebhookJob)
             end
+
+            it_behaves_like 'throttles!', :hubspot
           end
         end
       end

--- a/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
@@ -116,6 +116,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
               expect(result.external_id).to eq('123456789')
             end
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
 
         context 'when invoice is not updated' do
@@ -132,6 +134,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
               expect(result.external_id).to be(nil)
             end
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
       end
 
@@ -157,6 +161,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
           it 'enqueues a SendWebhookJob' do
             expect { service_call }.to have_enqueued_job(SendWebhookJob)
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
 
         context 'when it is a client error' do
@@ -173,6 +179,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
           it 'enqueues a SendWebhookJob' do
             expect { service_call }.to have_enqueued_job(SendWebhookJob)
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
       end
     end

--- a/spec/services/integrations/aggregator/payments/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/payments/create_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Integrations::Aggregator::Payments::CreateService do
   subject(:service_call) { described_class.call(payment:) }
 
+  let(:service) { described_class.new(payment:) }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
   let(:customer) { create(:customer, organization:) }
@@ -138,6 +139,8 @@ RSpec.describe Integrations::Aggregator::Payments::CreateService do
           expect(integration_resource.syncable_type).to eq('Payment')
           expect(integration_resource.resource_type).to eq('payment')
         end
+
+        it_behaves_like 'throttles!', :netsuite, :xero
       end
 
       context 'when response is a hash' do
@@ -165,6 +168,8 @@ RSpec.describe Integrations::Aggregator::Payments::CreateService do
             expect(integration_resource.syncable_type).to eq('Payment')
             expect(integration_resource.resource_type).to eq('payment')
           end
+
+          it_behaves_like 'throttles!', :netsuite, :xero
         end
 
         context 'when payment is not created' do
@@ -185,6 +190,8 @@ RSpec.describe Integrations::Aggregator::Payments::CreateService do
           it 'does not create integration resource object' do
             expect { service_call }.not_to change(IntegrationResource, :count)
           end
+
+          it_behaves_like 'throttles!', :netsuite, :xero
         end
       end
     end
@@ -229,6 +236,8 @@ RSpec.describe Integrations::Aggregator::Payments::CreateService do
         it 'enqueues a SendWebhookJob' do
           expect { service_call }.to have_enqueued_job(SendWebhookJob)
         end
+
+        it_behaves_like 'throttles!', :netsuite, :xero
       end
     end
   end

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/create_customer_association_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/create_customer_association_service_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateCustomerA
         it 'returns result' do
           expect(service_call).to be_a(BaseService::Result)
         end
+
+        it_behaves_like 'throttles!', :hubspot
       end
     end
   end

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/create_service_spec.rb
@@ -113,6 +113,8 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateService d
             expect(integration_resource.syncable_type).to eq('Subscription')
             expect(integration_resource.resource_type).to eq('subscription')
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
 
         context 'when subscription is not created' do
@@ -133,6 +135,8 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateService d
           it 'does not create integration resource object' do
             expect { service_call }.not_to change(IntegrationResource, :count)
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
       end
 
@@ -159,6 +163,8 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateService d
           it 'enqueues a SendWebhookJob' do
             expect { service_call }.to have_enqueued_job(SendWebhookJob)
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
 
         context 'when it is a client error' do
@@ -175,6 +181,8 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateService d
           it 'enqueues a SendWebhookJob' do
             expect { service_call }.to have_enqueued_job(SendWebhookJob)
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
       end
     end

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/update_service_spec.rb
@@ -105,6 +105,8 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::UpdateService d
               expect(result.external_id).to eq('123456789123')
             end
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
 
         context 'when subscription is not updated' do
@@ -121,6 +123,8 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::UpdateService d
               expect(result.external_id).to be(nil)
             end
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
       end
 
@@ -147,6 +151,8 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::UpdateService d
           it 'enqueues a SendWebhookJob' do
             expect { service_call }.to have_enqueued_job(SendWebhookJob)
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
 
         context 'when it is a client error' do
@@ -163,6 +169,8 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::UpdateService d
           it 'enqueues a SendWebhookJob' do
             expect { service_call }.to have_enqueued_job(SendWebhookJob)
           end
+
+          it_behaves_like 'throttles!', :hubspot
         end
       end
     end

--- a/spec/support/shared_examples/integrations.rb
+++ b/spec/support/shared_examples/integrations.rb
@@ -50,3 +50,12 @@ RSpec.shared_examples 'syncs payment' do
     end
   end
 end
+
+RSpec.shared_examples 'throttles!' do |*providers|
+  before { allow(service).to receive(:throttle!) }
+
+  it 'calls throttle!' do
+    service.call
+    expect(service).to have_received(:throttle!).with(*providers)
+  end
+end


### PR DESCRIPTION
## Context

Fix external apps rate limits or concurrency limits

## Description

This PR adds sidekiq-throttled gem and configures some aggregator jobs to have a limit of max 5 concurrent jobs.
It also adds a new "Throttled" tab in Sidekiq UI.
