### PR TITLE
feat(dunning): Reset customers last attempt on dunning campaign deletion

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -71,6 +71,7 @@ class Customer < ApplicationRecord
   scope :falling_back_to_default_dunning_campaign, -> {
     where(applied_dunning_campaign_id: nil, exclude_from_dunning_campaign: false)
   }
+  scope :with_dunning_campaign_not_completed, -> { where(dunning_campaign_completed: false) }
 
   validates :country, :shipping_country, country_code: true, allow_nil: true
   validates :document_locale, language_code: true, unless: -> { document_locale.nil? }

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -68,6 +68,10 @@ class Customer < ApplicationRecord
   sequenced scope: ->(customer) { customer.organization.customers.with_discarded },
     lock_key: ->(customer) { customer.organization_id }
 
+  scope :falling_back_to_default_dunning_campaign, -> {
+    where(applied_dunning_campaign_id: nil, exclude_from_dunning_campaign: false)
+  }
+
   validates :country, :shipping_country, country_code: true, allow_nil: true
   validates :document_locale, language_code: true, unless: -> { document_locale.nil? }
   validates :currency, inclusion: {in: currency_list}, allow_nil: true

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -40,10 +40,7 @@ class DunningCampaign < ApplicationRecord
 
     # NOTE: Reset last attempt on customers falling back to the organization campaign
     if applied_to_organization?
-      organization.customers.where(
-        applied_dunning_campaign_id: nil,
-        exclude_from_dunning_campaign: false
-      ).update_all( # rubocop:disable Rails/SkipsModelValidations
+      organization.customers.falling_back_to_default_dunning_campaign.update_all( # rubocop:disable Rails/SkipsModelValidations
         last_dunning_campaign_attempt: 0,
         last_dunning_campaign_attempt_at: nil
       )

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -30,6 +30,25 @@ class DunningCampaign < ApplicationRecord
   def self.ransackable_attributes(_auth_object = nil)
     %w[name code]
   end
+
+  def reset_customers_last_attempt
+    # NOTE: Reset last attempt on customers with the campaign applied explicitly
+    customers.update_all( # rubocop:disable Rails/SkipsModelValidations
+      last_dunning_campaign_attempt: 0,
+      last_dunning_campaign_attempt_at: nil
+    )
+
+    # NOTE: Reset last attempt on customers falling back to the organization campaign
+    if applied_to_organization?
+      organization.customers.where(
+        applied_dunning_campaign_id: nil,
+        exclude_from_dunning_campaign: false
+      ).update_all( # rubocop:disable Rails/SkipsModelValidations
+        last_dunning_campaign_attempt: 0,
+        last_dunning_campaign_attempt_at: nil
+      )
+    end
+  end
 end
 
 # == Schema Information

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -39,15 +39,7 @@ class DunningCampaign < ApplicationRecord
     )
 
     # NOTE: Reset last attempt on customers falling back to the organization campaign
-    if applied_to_organization?
-      organization.customers
-        .falling_back_to_default_dunning_campaign
-        .with_dunning_campaign_not_completed
-        .update_all( # rubocop:disable Rails/SkipsModelValidations
-          last_dunning_campaign_attempt: 0,
-          last_dunning_campaign_attempt_at: nil
-        )
-    end
+    organization.reset_customers_last_dunning_campaign_attempt if applied_to_organization?
   end
 end
 

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -33,17 +33,20 @@ class DunningCampaign < ApplicationRecord
 
   def reset_customers_last_attempt
     # NOTE: Reset last attempt on customers with the campaign applied explicitly
-    customers.update_all( # rubocop:disable Rails/SkipsModelValidations
+    customers.with_dunning_campaign_not_completed.update_all( # rubocop:disable Rails/SkipsModelValidations
       last_dunning_campaign_attempt: 0,
       last_dunning_campaign_attempt_at: nil
     )
 
     # NOTE: Reset last attempt on customers falling back to the organization campaign
     if applied_to_organization?
-      organization.customers.falling_back_to_default_dunning_campaign.update_all( # rubocop:disable Rails/SkipsModelValidations
-        last_dunning_campaign_attempt: 0,
-        last_dunning_campaign_attempt_at: nil
-      )
+      organization.customers
+        .falling_back_to_default_dunning_campaign
+        .with_dunning_campaign_not_completed
+        .update_all( # rubocop:disable Rails/SkipsModelValidations
+          last_dunning_campaign_attempt: 0,
+          last_dunning_campaign_attempt_at: nil
+        )
     end
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -135,6 +135,16 @@ class Organization < ApplicationRecord
     License.premium? && premium_integrations.include?("auto_dunning")
   end
 
+  def reset_customers_last_dunning_campaign_attempt
+    customers
+      .falling_back_to_default_dunning_campaign
+      .with_dunning_campaign_not_completed
+      .update_all( # rubocop:disable Rails/SkipsModelValidations
+        last_dunning_campaign_attempt: 0,
+        last_dunning_campaign_attempt_at: nil
+      )
+  end
+
   private
 
   # NOTE: After creating an organization, default document_number_prefix needs to be generated.

--- a/app/services/dunning_campaigns/create_service.rb
+++ b/app/services/dunning_campaigns/create_service.rb
@@ -15,16 +15,10 @@ module DunningCampaigns
 
       ActiveRecord::Base.transaction do
         if params[:applied_to_organization]
-          organization
-            .dunning_campaigns
-            .applied_to_organization
+          organization.dunning_campaigns.applied_to_organization
             .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
 
-          # NOTE: Stop and reset existing campaigns.
-          organization.customers.falling_back_to_default_dunning_campaign.update_all( # rubocop:disable Rails/SkipsModelValidations
-            last_dunning_campaign_attempt: 0,
-            last_dunning_campaign_attempt_at: nil
-          )
+          organization.reset_customers_last_dunning_campaign_attempt
         end
 
         dunning_campaign = organization.dunning_campaigns.create!(

--- a/app/services/dunning_campaigns/create_service.rb
+++ b/app/services/dunning_campaigns/create_service.rb
@@ -21,10 +21,7 @@ module DunningCampaigns
             .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
 
           # NOTE: Stop and reset existing campaigns.
-          organization.customers.where(
-            applied_dunning_campaign_id: nil,
-            exclude_from_dunning_campaign: false
-          ).update_all( # rubocop:disable Rails/SkipsModelValidations
+          organization.customers.falling_back_to_default_dunning_campaign.update_all( # rubocop:disable Rails/SkipsModelValidations
             last_dunning_campaign_attempt: 0,
             last_dunning_campaign_attempt_at: nil
           )

--- a/app/services/dunning_campaigns/destroy_service.rb
+++ b/app/services/dunning_campaigns/destroy_service.rb
@@ -13,6 +13,7 @@ module DunningCampaigns
       return result.forbidden_failure! unless dunning_campaign.organization.auto_dunning_enabled?
 
       ActiveRecord::Base.transaction do
+        dunning_campaign.reset_customers_last_attempt
         dunning_campaign.discard!
         dunning_campaign.thresholds.discard_all
       end

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -22,10 +22,7 @@ module DunningCampaigns
             .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
 
           # NOTE: Stop and reset existing campaigns.
-          organization.customers.where(
-            applied_dunning_campaign_id: nil,
-            exclude_from_dunning_campaign: false
-          ).update_all( # rubocop:disable Rails/SkipsModelValidations
+          organization.customers.falling_back_to_default_dunning_campaign.update_all( # rubocop:disable Rails/SkipsModelValidations
             last_dunning_campaign_attempt: 0,
             last_dunning_campaign_attempt_at: nil
           )

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -16,16 +16,10 @@ module DunningCampaigns
 
       ActiveRecord::Base.transaction do
         unless params[:applied_to_organization].nil?
-          organization
-            .dunning_campaigns
-            .applied_to_organization
+          organization.dunning_campaigns.applied_to_organization
             .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
 
-          # NOTE: Stop and reset existing campaigns.
-          organization.customers.falling_back_to_default_dunning_campaign.update_all( # rubocop:disable Rails/SkipsModelValidations
-            last_dunning_campaign_attempt: 0,
-            last_dunning_campaign_attempt_at: nil
-          )
+          organization.reset_customers_last_dunning_campaign_attempt
 
           dunning_campaign.applied_to_organization = params[:applied_to_organization]
         end

--- a/spec/models/dunning_campaign_spec.rb
+++ b/spec/models/dunning_campaign_spec.rb
@@ -64,6 +64,19 @@ RSpec.describe DunningCampaign, type: :model do
         .and change { customer.last_dunning_campaign_attempt_at }.from(last_dunning_campaign_attempt_at).to(nil)
     end
 
+    it "does not reset last attempt on customers with dunning campaign already completed" do
+      customer = create(
+        :customer,
+        organization:,
+        applied_dunning_campaign: dunning_campaign,
+        last_dunning_campaign_attempt: 1,
+        dunning_campaign_completed: true
+      )
+
+      expect { dunning_campaign.reset_customers_last_attempt }
+        .not_to change { customer.reload.last_dunning_campaign_attempt }.from(1)
+    end
+
     context "when applied to organization" do
       subject(:dunning_campaign) { create(:dunning_campaign, applied_to_organization: true) }
 
@@ -78,6 +91,18 @@ RSpec.describe DunningCampaign, type: :model do
         expect { dunning_campaign.reset_customers_last_attempt }
           .to change { customer.reload.last_dunning_campaign_attempt }.from(2).to(0)
           .and change { customer.last_dunning_campaign_attempt_at }.from(last_dunning_campaign_attempt_at).to(nil)
+      end
+
+      it "does not reset last attempt on customers with dunning campaign already completed" do
+        customer = create(
+          :customer,
+          organization:,
+          last_dunning_campaign_attempt: 2,
+          dunning_campaign_completed: true
+        )
+
+        expect { dunning_campaign.reset_customers_last_attempt }
+          .not_to change { customer.reload.last_dunning_campaign_attempt }.from(2)
       end
     end
   end

--- a/spec/models/dunning_campaign_spec.rb
+++ b/spec/models/dunning_campaign_spec.rb
@@ -45,4 +45,40 @@ RSpec.describe DunningCampaign, type: :model do
       expect(described_class.with_discarded).to eq([deleted_dunning_campaign])
     end
   end
+
+  describe "#reset_customers_last_attempt" do
+    let(:last_dunning_campaign_attempt_at) { Time.current }
+    let(:organization) { dunning_campaign.organization }
+
+    it "resets last attempt on customers with the campaign applied explicitly" do
+      customer = create(
+        :customer,
+        organization:,
+        applied_dunning_campaign: dunning_campaign,
+        last_dunning_campaign_attempt: 1,
+        last_dunning_campaign_attempt_at:
+      )
+
+      expect { dunning_campaign.reset_customers_last_attempt }
+        .to change { customer.reload.last_dunning_campaign_attempt }.from(1).to(0)
+        .and change { customer.last_dunning_campaign_attempt_at }.from(last_dunning_campaign_attempt_at).to(nil)
+    end
+
+    context "when applied to organization" do
+      subject(:dunning_campaign) { create(:dunning_campaign, applied_to_organization: true) }
+
+      it "resets last attempt on customers falling back to the organization campaign" do
+        customer = create(
+          :customer,
+          organization:,
+          last_dunning_campaign_attempt: 2,
+          last_dunning_campaign_attempt_at:
+        )
+
+        expect { dunning_campaign.reset_customers_last_attempt }
+          .to change { customer.reload.last_dunning_campaign_attempt }.from(2).to(0)
+          .and change { customer.last_dunning_campaign_attempt_at }.from(last_dunning_campaign_attempt_at).to(nil)
+      end
+    end
+  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -238,6 +238,23 @@ RSpec.describe Organization, type: :model do
     end
   end
 
+  describe "#reset_customers_last_dunning_campaign_attempt" do
+    let(:last_dunning_campaign_attempt_at) { 1.day.ago }
+    let(:campaign) { create(:dunning_campaign, organization:) }
+
+    it "resets the last dunning campaign attempt for customers" do
+      customer1 = create(:customer, organization:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at:)
+      customer2 = create(:customer, organization:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at:, applied_dunning_campaign: campaign)
+      customer3 = create(:customer, organization:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at:, dunning_campaign_completed: true)
+
+      expect { organization.reset_customers_last_dunning_campaign_attempt }
+        .to change { customer1.reload.last_dunning_campaign_attempt }.from(1).to(0)
+        .and change(customer1, :last_dunning_campaign_attempt_at).from(last_dunning_campaign_attempt_at).to(nil)
+      expect(customer2.reload.last_dunning_campaign_attempt).to eq(1)
+      expect(customer3.reload.last_dunning_campaign_attempt).to eq(1)
+    end
+  end
+
   describe '#admins' do
     subject { organization.admins }
 

--- a/spec/services/dunning_campaigns/destroy_service_spec.rb
+++ b/spec/services/dunning_campaigns/destroy_service_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe DunningCampaigns::DestroyService, type: :service do
           create(:organization, premium_integrations: ["auto_dunning"])
         end
 
+        it "resets last attempt on customers" do
+          customer = create(:customer, organization:, applied_dunning_campaign: dunning_campaign, last_dunning_campaign_attempt: 1)
+
+          expect { destroy_service.call }.to change { customer.reload.last_dunning_campaign_attempt }.from(1).to(0)
+        end
+
         it "soft deletes the dunning campaign" do
           freeze_time do
             expect { destroy_service.call }.to change(DunningCampaign, :count).by(-1)


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We are extending dunning campaigns management to edit and delete campaigns.

 ## Description

This change adds the ability to reset last attempt on customers when deleting a dunning campaign.