### PR TITLE
Fix(anrok): Taxes not fully applied

### DIFF
--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -197,7 +197,7 @@ module Fees
       result.fees_taxes = taxes_result.fees
 
       fees_result.each do |fee|
-        fee_taxes = result.fees_taxes.find { |item| item.item_id == fee.item_id }
+        fee_taxes = result.fees_taxes.find { |item| item.item_id == fee.id }
 
         res = Fees::ApplyProviderTaxesService.call(fee:, fee_taxes:)
         res.raise_if_error!

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -105,7 +105,7 @@ module Fees
       result.fees_taxes = taxes_result.fees
 
       fees_result.each do |fee|
-        fee_taxes = result.fees_taxes.find { |item| item.item_id == fee.item_id }
+        fee_taxes = result.fees_taxes.find { |item| item.item_id == fee.id }
 
         res = Fees::ApplyProviderTaxesService.call(fee:, fee_taxes:)
         res.raise_if_error!

--- a/app/services/integrations/aggregator/taxes/base_service.rb
+++ b/app/services/integrations/aggregator/taxes/base_service.rb
@@ -75,7 +75,7 @@ module Integrations
               )
             elsif b['rate']
               # If there are taxes, that client shouldn't pay, we nullify the taxes
-              if taxes_to_pay.zero?
+              if taxes_to_pay.zero? && b['tax_amount'].positive?
                 OpenStruct.new(
                   name: 'Tax',
                   rate: '0.00',

--- a/app/services/integrations/aggregator/taxes/invoices/payload.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payload.rb
@@ -47,7 +47,7 @@ module Integrations
             mapped_item ||= empty_struct
 
             {
-              'item_id' => fee.item_id,
+              'item_id' => fee.id,
               'item_code' => mapped_item.external_id,
               'amount_cents' => fee.sub_total_excluding_taxes_amount_cents&.to_i
             }

--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -56,7 +56,7 @@ module Invoices
     end
 
     def fee_taxes(fee)
-      provider_taxes.find { |item| item.item_id == fee.item_id }
+      provider_taxes.find { |item| item.item_id == fee.id }
     end
 
     def should_apply_fee_taxes?

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -164,7 +164,7 @@ module Invoices
       result.fees_taxes = taxes_result.fees
 
       invoice.fees.each do |fee|
-        fee_taxes = result.fees_taxes.find { |item| item.item_id == fee.item_id }
+        fee_taxes = result.fees_taxes.find { |item| item.item_id == fee.id }
 
         res = Fees::ApplyProviderTaxesService.call(fee:, fee_taxes:)
         res.raise_if_error!

--- a/spec/graphql/mutations/invoices/retry_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Mutations::Invoices::Retry, type: :graphql do
 
     # setting item_id based on the test example
     response = JSON.parse(json)
-    response['succeededInvoices'].first['fees'].first['item_id'] = subscription.id
+    response['succeededInvoices'].first['fees'].first['item_id'] = fee_subscription.id
 
     response.to_json
   end

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
-        allow_any_instance_of(Fee).to receive(:id).and_return('lago_fee_id')
+        allow_any_instance_of(Fee).to receive(:id).and_return('lago_fee_id') # rubocop:disable RSpec/AnyInstance
       end
 
       it 'creates fees' do

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -111,13 +111,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
       let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
       let(:body) do
         p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
-        json = File.read(p)
-
-        # setting item_id based on the test example
-        response = JSON.parse(json)
-        response['succeededInvoices'].first['fees'].first['item_id'] = billable_metric.id
-
-        response.to_json
+        File.read(p)
       end
       let(:integration_collection_mapping) do
         create(
@@ -135,6 +129,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
+        allow_any_instance_of(Fee).to receive(:id).and_return('lago_fee_id')
       end
 
       it 'creates fees' do

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -258,14 +258,8 @@ RSpec.describe Fees::OneOffService do
 
         it 'creates fees' do
           result = one_off_service.create
-
-          # This is very bad. I'm sorry. I'm just trying to get the test to pass.
-          # first_fee = result.fees[0].reload
-          first_fee_id = result.fees[0].attributes['id']
-          first_fee = Fee.find_by(id: first_fee_id)
-          # second_fee = result.fees[1].reload
-          second_fee_id = result.fees[1].attributes['id']
-          second_fee = Fee.find_by(id: second_fee_id)
+          first_fee = result.fees[0]
+          second_fee = result.fees[1]
 
           aggregate_failures do
             expect(result).to be_success

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Fees::OneOffService do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
-        allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args|
+        allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args| # rubocop:disable RSpec/AnyInstance
           fee = m.receiver
           if fee.add_on_id == add_on_first.id
             'fee_id_1'

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -188,14 +188,8 @@ RSpec.describe Fees::OneOffService do
 
       it 'creates fees' do
         result = one_off_service.create
-
-        # This is very bad. I'm sorry. I'm just trying to get the test to pass.
-        # first_fee = result.fees[0].reload
-        first_fee_id = result.fees[0].attributes['id']
-        first_fee = Fee.find_by(id: first_fee_id)
-        # second_fee = result.fees[1].reload
-        second_fee_id = result.fees[1].attributes['id']
-        second_fee = Fee.find_by(id: second_fee_id)
+        first_fee = result.fees[0]
+        second_fee = result.fees[1]
 
         aggregate_failures do
           expect(result).to be_success

--- a/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
@@ -82,12 +82,12 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
         },
         'fees' => [
           {
-            'item_id' => fee_add_on.item_id,
+            'item_id' => fee_add_on.id,
             'item_code' => 'm1',
             'amount_cents' => 200
           },
           {
-            'item_id' => fee_add_on_two.item_id,
+            'item_id' => fee_add_on_two.id,
             'item_code' => '1',
             'amount_cents' => 200
           }

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -83,12 +83,12 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
         },
         'fees' => [
           {
-            'item_id' => fee_add_on.item_id,
+            'item_id' => fee_add_on.id,
             'item_code' => 'm1',
             'amount_cents' => 200
           },
           {
-            'item_id' => fee_add_on_two.item_id,
+            'item_id' => fee_add_on_two.id,
             'item_code' => '1',
             'amount_cents' => 200
           }

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           allow(response).to receive(:body).and_return(body)
           allow(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to receive(:call).and_call_original
           allow(Integrations::Aggregator::Taxes::Invoices::CreateService).to receive(:call).and_call_original
-          allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args|
+          allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args| # rubocop:disable RSpec/AnyInstance
             fee = m.receiver
             if fee.charge_id == charge.id
               'charge_fee_id-12345'

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Invoices::ComputeAmountsFromFees, type: :service do
 
     let(:fee_taxes) do
       OpenStruct.new(
-        item_id: fee1.subscription.id,
+        item_id: fee1.id,
         item_code: "lago_default_b2b",
         tax_breakdown: [
           OpenStruct.new(name: 'tax 1', type: 'type1', rate: '0.50', tax_amount: 75.5),

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -118,9 +118,9 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
 
         # setting item_id based on the test example
         response = JSON.parse(json)
-        response['succeededInvoices'].first['fees'].first['item_id'] = add_on_first.id
+        response['succeededInvoices'].first['fees'].first['item_id'] = 'fee_id_1'
         response['succeededInvoices'].first['fees'].first['tax_breakdown'].first['tax_amount'] = 240
-        response['succeededInvoices'].first['fees'].last['item_id'] = add_on_second.id
+        response['succeededInvoices'].first['fees'].last['item_id'] = 'fee_id_2'
         response['succeededInvoices'].first['fees'].last['tax_breakdown'].first['tax_amount'] = 60
 
         response.to_json
@@ -141,6 +141,16 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
+        allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args|
+          fee = m.receiver
+          if fee.add_on_id == add_on_first.id
+            'fee_id_1'
+          elsif fee.add_on_id == add_on_second.id
+            'fee_id_2'
+          else
+            m.call(*args)
+          end
+        end
       end
 
       it 'creates an invoice' do

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
-        allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args|
+        allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args| # rubocop:disable RSpec/AnyInstance
           fee = m.receiver
           if fee.add_on_id == add_on_first.id
             'fee_id_1'

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -205,13 +205,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
       let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
       let(:body) do
         p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
-        json = File.read(p)
-
-        # setting item_id based on the test example
-        response = JSON.parse(json)
-        response['succeededInvoices'].first['fees'].first['item_id'] = billable_metric.id
-
-        response.to_json
+        File.read(p)
       end
       let(:integration_collection_mapping) do
         create(
@@ -229,6 +223,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
+        allow_any_instance_of(Fee).to receive(:id).and_return('lago_fee_id') # rubocop:disable RSpec/AnyInstance
       end
 
       it 'creates an invoice and fees' do

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
-        allow_any_instance_of(Fee).to receive(:id).and_return('lago_fee_id')
+        allow_any_instance_of(Fee).to receive(:id).and_return('lago_fee_id') # rubocop:disable RSpec/AnyInstance
       end
 
       it 'initializes an invoice' do

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -133,13 +133,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
       let(:endpoint) { 'https://api.nango.dev/v1/anrok/draft_invoices' }
       let(:body) do
         p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
-        json = File.read(p)
-
-        # setting item_id based on the test example
-        response = JSON.parse(json)
-        response['succeededInvoices'].first['fees'].last['item_id'] = charge.billable_metric.id
-
-        response.to_json
+        File.read(p)
       end
       let(:integration_collection_mapping) do
         create(
@@ -157,6 +151,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
+        allow_any_instance_of(Fee).to receive(:id).and_return('lago_fee_id')
       end
 
       it 'initializes an invoice' do

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service do
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
         allow(Integrations::Aggregator::Taxes::Invoices::CreateService).to receive(:call).and_call_original
-        allow_any_instance_of(Fee).to receive(:id).and_return('lago_fee_id')
+        allow_any_instance_of(Fee).to receive(:id).and_return('lago_fee_id') # rubocop:disable RSpec/AnyInstance
       end
 
       it 'creates a progressive billing invoice', aggregate_failures: true do

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -76,13 +76,7 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service do
       let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
       let(:body) do
         p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
-        json = File.read(p)
-
-        # setting item_id based on the test example
-        response = JSON.parse(json)
-        response['succeededInvoices'].first['fees'].last['item_id'] = charge.billable_metric.id
-
-        response.to_json
+        File.read(p)
       end
       let(:integration_collection_mapping) do
         create(
@@ -101,6 +95,7 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service do
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
         allow(Integrations::Aggregator::Taxes::Invoices::CreateService).to receive(:call).and_call_original
+        allow_any_instance_of(Fee).to receive(:id).and_return('lago_fee_id')
       end
 
       it 'creates a progressive billing invoice', aggregate_failures: true do

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
         allow(Integrations::Aggregator::Invoices::CreateJob).to receive(:perform_later).and_call_original
         allow(Invoices::Payments::CreateService).to receive(:new).and_call_original
         allow(Utils::SegmentTrack).to receive(:invoice_created).and_call_original
-        allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args|
+        allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args| # rubocop:disable RSpec/AnyInstance
           fee = m.receiver
           if fee.charge_id == standard_charge.id
             'charge_fee_id-12345'

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Invoices::RefreshDraftService, type: :service do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
-        allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args|
+        allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args| # rubocop:disable RSpec/AnyInstance
           fee = m.receiver
           if fee.charge_id == charge.id
             'charge_fee_id-12345'

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe Invoices::RetryService, type: :service do
 
       # setting item_id based on the test example
       response = JSON.parse(json)
-      response['succeededInvoices'].first['fees'].first['item_id'] = subscription.id
-      response['succeededInvoices'].first['fees'].last['item_id'] = billable_metric.id
+      response['succeededInvoices'].first['fees'].first['item_id'] = fee_subscription.id
+      response['succeededInvoices'].first['fees'].last['item_id'] = fee_charge.id
 
       response.to_json
     end

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
 
-        allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args|
+        allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args| # rubocop:disable RSpec/AnyInstance
           fee = m.receiver
           if fee.charge_id == plan.charges.first.id
             'charge_fee_id-12345'

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -140,14 +140,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
       let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
       let(:body) do
         p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response_multiple_fees.json')
-        json = File.read(p)
-
-        # setting item_id based on the test example
-        response = JSON.parse(json)
-        response['succeededInvoices'].first['fees'].first['item_id'] = subscription.id
-        response['succeededInvoices'].first['fees'].last['item_id'] = plan.charges.first.billable_metric.id
-
-        response.to_json
+        File.read(p)
       end
       let(:integration_collection_mapping) do
         create(
@@ -165,6 +158,17 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
+
+        allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args|
+          fee = m.receiver
+          if fee.charge_id == plan.charges.first.id
+            'charge_fee_id-12345'
+          elsif fee.subscription_id == subscription.id
+            'sub_fee_id-12345'
+          else
+            m.call(*args)
+          end
+        end
       end
 
       it 'creates an invoice' do


### PR DESCRIPTION
## Context

We faced a bug when an invoice has more than one fee related to the same item_id, as in anrok payload we're using the item_id to identify line_item.
as result, we might have more than one line_item with the same item_id - one of them with 0 tax, as fee amount_cents is 0, one with more than 0, as fee amount_cents is not 0, and we can't correctly assign the returned line_item with taxes to the right fee.

## Description

when sending a payload to Anrok, send fee.id instead of item_id, as fee_id is uniquely identifies the line_item
