### PR TITLE
misc: Deprecate counters at billable metric index level

### DIFF
--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -12,7 +12,8 @@ module Api
           render(
             json: ::V1::BillableMetricSerializer.new(
               result.billable_metric,
-              root_name: "billable_metric"
+              root_name: "billable_metric",
+              includes: %i[counters]
             )
           )
         else
@@ -35,7 +36,8 @@ module Api
           render(
             json: ::V1::BillableMetricSerializer.new(
               result.billable_metric,
-              root_name: "billable_metric"
+              root_name: "billable_metric",
+              includes: %i[counters]
             )
           )
         else
@@ -52,7 +54,8 @@ module Api
           render(
             json: ::V1::BillableMetricSerializer.new(
               result.billable_metric,
-              root_name: "billable_metric"
+              root_name: "billable_metric",
+              includes: %i[counters]
             )
           )
         else
@@ -87,7 +90,8 @@ module Api
             metrics,
             ::V1::BillableMetricSerializer,
             collection_name: "billable_metrics",
-            meta: pagination_metadata(metrics)
+            meta: pagination_metadata(metrics),
+            includes: %i[counters] # DEPRECATED since 2024-11-22
           )
         )
       end

--- a/app/serializers/v1/billable_metric_serializer.rb
+++ b/app/serializers/v1/billable_metric_serializer.rb
@@ -15,18 +15,24 @@ module V1
         rounding_precision: model.rounding_precision,
         created_at: model.created_at.iso8601,
         field_name: model.field_name,
-        expression: model.expression,
-        active_subscriptions_count:,
-        draft_invoices_count:,
-        plans_count:
+        expression: model.expression
       }
 
+      payload.merge!(counters) if include?(:counters)
       payload.merge!(filters)
 
       payload
     end
 
     private
+
+    def counters
+      {
+        active_subscriptions_count:,
+        draft_invoices_count:,
+        plans_count:
+      }
+    end
 
     def active_subscriptions_count
       Subscription.active.where(plan_id: model.charges.select(:plan_id).distinct).count
@@ -49,7 +55,7 @@ module V1
       ::CollectionSerializer.new(
         model.filters,
         ::V1::BillableMetricFilterSerializer,
-        collection_name: 'filters'
+        collection_name: "filters"
       ).serialize
     end
   end

--- a/spec/serializers/v1/billable_metric_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_serializer_spec.rb
@@ -1,65 +1,66 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ::V1::BillableMetricSerializer do
-  subject(:serializer) { described_class.new(billable_metric, root_name: 'billable_metric') }
+  subject(:serializer) { described_class.new(billable_metric, root_name: "billable_metric", includes:) }
 
   let(:billable_metric) { create(:weighted_sum_billable_metric) }
   let(:result) { JSON.parse(serializer.to_json) }
 
-  it 'serializes the object' do
-    aggregate_failures do
-      expect(result['billable_metric']['lago_id']).to eq(billable_metric.id)
-      expect(result['billable_metric']['name']).to eq(billable_metric.name)
-      expect(result['billable_metric']['code']).to eq(billable_metric.code)
-      expect(result['billable_metric']['description']).to eq(billable_metric.description)
-      expect(result['billable_metric']['aggregation_type']).to eq(billable_metric.aggregation_type)
-      expect(result['billable_metric']['field_name']).to eq(billable_metric.field_name)
-      expect(result['billable_metric']['created_at']).to eq(billable_metric.created_at.iso8601)
-      expect(result['billable_metric']['rounding_function']).to eq(billable_metric.rounding_function)
-      expect(result['billable_metric']['rounding_precision']).to eq(billable_metric.rounding_precision)
-      expect(result['billable_metric']['weighted_interval']).to eq(billable_metric.weighted_interval)
-      expect(result['billable_metric']['expression']).to eq(billable_metric.expression)
-      expect(result['billable_metric']['active_subscriptions_count']).to eq(0)
-      expect(result['billable_metric']['draft_invoices_count']).to eq(0)
-      expect(result['billable_metric']['plans_count']).to eq(0)
+  let(:includes) { %i[] }
 
-      expect(result['billable_metric']['filters']).to eq([])
+  it "serializes the object", aggregate_failures: true do
+    expect(result["billable_metric"]["lago_id"]).to eq(billable_metric.id)
+    expect(result["billable_metric"]["name"]).to eq(billable_metric.name)
+    expect(result["billable_metric"]["code"]).to eq(billable_metric.code)
+    expect(result["billable_metric"]["description"]).to eq(billable_metric.description)
+    expect(result["billable_metric"]["aggregation_type"]).to eq(billable_metric.aggregation_type)
+    expect(result["billable_metric"]["field_name"]).to eq(billable_metric.field_name)
+    expect(result["billable_metric"]["created_at"]).to eq(billable_metric.created_at.iso8601)
+    expect(result["billable_metric"]["rounding_function"]).to eq(billable_metric.rounding_function)
+    expect(result["billable_metric"]["rounding_precision"]).to eq(billable_metric.rounding_precision)
+    expect(result["billable_metric"]["weighted_interval"]).to eq(billable_metric.weighted_interval)
+    expect(result["billable_metric"]["expression"]).to eq(billable_metric.expression)
+
+    expect(result["billable_metric"]["filters"]).to eq([])
+  end
+
+  context "with counters inclusion" do
+    let(:includes) { %i[counters] }
+
+    it "returns the count number of active subscriptions" do
+      terminated_subscription = create(:subscription, :terminated)
+      create(:standard_charge, plan: terminated_subscription.plan, billable_metric:)
+
+      subscription = create(:subscription)
+      create(:standard_charge, plan: subscription.plan, billable_metric:)
+
+      expect(result["billable_metric"]["active_subscriptions_count"]).to eq(1)
     end
-  end
 
-  it 'returns the count number of active subscriptions' do
-    terminated_subscription = create(:subscription, :terminated)
-    create(:standard_charge, plan: terminated_subscription.plan, billable_metric:)
+    it "returns the count number of draft invoices" do
+      customer = create(:customer, organization: billable_metric.organization)
+      subscription = create(:subscription)
+      subscription2 = create(:subscription)
+      charge = create(:standard_charge, plan: subscription.plan, billable_metric:)
+      charge2 = create(:standard_charge, plan: subscription2.plan, billable_metric:)
 
-    subscription = create(:subscription)
-    create(:standard_charge, plan: subscription.plan, billable_metric:)
+      invoice = create(:invoice, customer:, organization: billable_metric.organization)
+      create(:fee, invoice:, charge:)
 
-    expect(result['billable_metric']['active_subscriptions_count']).to eq(1)
-  end
+      draft_invoice = create(:invoice, :draft, customer:, organization: billable_metric.organization)
+      create(:fee, invoice: draft_invoice, charge: charge2)
+      create(:fee, invoice: draft_invoice, charge: charge2)
 
-  it 'returns the count number of draft invoices' do
-    customer = create(:customer, organization: billable_metric.organization)
-    subscription = create(:subscription)
-    subscription2 = create(:subscription)
-    charge = create(:standard_charge, plan: subscription.plan, billable_metric:)
-    charge2 = create(:standard_charge, plan: subscription2.plan, billable_metric:)
+      expect(result["billable_metric"]["draft_invoices_count"]).to eq(1)
+    end
 
-    invoice = create(:invoice, customer:, organization: billable_metric.organization)
-    create(:fee, invoice:, charge:)
+    it "returns the number of plans" do
+      plan = create(:plan, organization: billable_metric.organization)
+      create(:standard_charge, billable_metric:, plan:)
 
-    draft_invoice = create(:invoice, :draft, customer:, organization: billable_metric.organization)
-    create(:fee, invoice: draft_invoice, charge: charge2)
-    create(:fee, invoice: draft_invoice, charge: charge2)
-
-    expect(result['billable_metric']['draft_invoices_count']).to eq(1)
-  end
-
-  it 'returns the number of plans' do
-    plan = create(:plan, organization: billable_metric.organization)
-    create(:standard_charge, billable_metric:, plan:)
-
-    expect(result['billable_metric']['plans_count']).to eq(1)
+      expect(result["billable_metric"]["plans_count"]).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
## Context
Related to https://github.com/getlago/lago-openapi/pull/303

## Description

This PR updates the `V1::BillableMetricSerializer` to makes `active_subscriptions_count`, `draft_invoices_count`, and `plans_count` optional by using `includes: %[counters]`