### PR TITLE
misc: Activate aggregate_failures by default on specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,4 +64,8 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :deletion
     WebMock.disable_net_connect!(allow: ENV.fetch('LAGO_CLICKHOUSE_HOST', 'clickhouse'))
   end
+
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
+  end
 end


### PR DESCRIPTION
RSpec::Core provides metadata integration for aggregating failures by default on RSpec.

Why not activating it, instead of putting everywhere `:aggregate_failures` :) 

The legacy calls could be removed later.