### PR TITLE
bug(CustomerQuery) - Allow searching on legal_name

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -82,7 +82,7 @@ class Customer < ApplicationRecord
   validates :email, email: true, if: :email?
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[id name firstname lastname external_id email]
+    %w[id name firstname lastname legal_name external_id email]
   end
 
   def display_name(prefer_legal_name: true)

--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -24,6 +24,7 @@ class CustomersQuery < BaseQuery
       name_cont: search_term,
       firstname_cont: search_term,
       lastname_cont: search_term,
+      legal_name_cont: search_term,
       external_id_cont: search_term,
       email_cont: search_term
     }

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe CustomersQuery, type: :query do
   let(:organization) { membership.organization }
 
   let(:customer_first) do
-    create(:customer, organization:, name: 'defgh', firstname: 'John', lastname: 'Doe', external_id: '11', email: '1@example.com')
+    create(:customer, organization:, name: 'defgh', firstname: 'John', lastname: 'Doe', legal_name: "Legalname", external_id: '11', email: '1@example.com')
   end
   let(:customer_second) do
-    create(:customer, organization:, name: 'abcde', firstname: 'Jane', lastname: 'Smith', external_id: '22', email: '2@example.com')
+    create(:customer, organization:, name: 'abcde', firstname: 'Jane', lastname: 'Smith', legal_name: "other name", external_id: '22', email: '2@example.com')
   end
   let(:customer_third) do
-    create(:customer, organization:, name: 'presuv', firstname: 'Mary', lastname: 'Johnson', external_id: '33', email: '3@example.com')
+    create(:customer, organization:, name: 'presuv', firstname: 'Mary', lastname: 'Johnson', legal_name: "Company name", external_id: '33', email: '3@example.com')
   end
 
   before do
@@ -89,6 +89,21 @@ RSpec.describe CustomersQuery, type: :query do
 
   context 'when searching for lastname "Johnson"' do
     let(:search_term) { 'Johnson' }
+
+    it 'returns only one customer' do
+      returned_ids = result.customers.pluck(:id)
+
+      aggregate_failures do
+        expect(returned_ids.count).to eq(1)
+        expect(returned_ids).not_to include(customer_first.id)
+        expect(returned_ids).not_to include(customer_second.id)
+        expect(returned_ids).to include(customer_third.id)
+      end
+    end
+  end
+
+  context 'when searching for legalname "Company"' do
+    let(:search_term) { 'Company' }
 
     it 'returns only one customer' do
       returned_ids = result.customers.pluck(:id)


### PR DESCRIPTION
## Description

We're allowing searching on name, firstname, lastname.
we've forgotten legal_name. This PR fixes that.