### PR TITLE
feat(api-key-management): Add permissions to the ApiKey

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -31,7 +31,7 @@ class ApiKey < ApplicationRecord
   def permit?(resource, mode)
     return true unless organization.premium_integrations.include?('api_permissions')
 
-    permissions[resource].include?(mode)
+    Array(permissions[resource]).include?(mode)
   end
 
   def self.default_permissions
@@ -43,12 +43,7 @@ class ApiKey < ApplicationRecord
   def permissions_keys_compliance
     return unless permissions
 
-    missing_permissions = RESOURCES - permissions.keys
     forbidden_permissions = permissions.keys - RESOURCES
-
-    if missing_permissions.any?
-      errors.add(:permissions, :missing_keys, keys: missing_permissions)
-    end
 
     if forbidden_permissions.any?
       errors.add(:permissions, :forbidden_keys, keys: forbidden_permissions)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -60,7 +60,7 @@ class Organization < ApplicationRecord
   ].freeze
 
   INTEGRATIONS = %w[
-    netsuite okta anrok xero progressive_billing hubspot auto_dunning revenue_analytics salesforce
+    netsuite okta anrok xero progressive_billing hubspot auto_dunning revenue_analytics salesforce api_permissions
   ].freeze
   PREMIUM_INTEGRATIONS = INTEGRATIONS - %w[anrok]
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,12 @@ en:
         less_than_or_equal_to: value_is_out_of_range
         missing_graduated_ranges: missing_graduated_ranges
         missing_volume_ranges: missing_volume_ranges
+        models:
+          api_key:
+            attributes:
+              permissions:
+                forbidden_key: 'contains forbidden keys: %{keys}'
+                missing_key: 'missing required keys: %{keys}'
         not_compatible_with_aggregation_type: not_compatible_with_aggregation_type
         not_compatible_with_pay_in_advance: not_compatible_with_pay_in_advance
         only_compatible_with_pay_in_advance_and_non_invoiceable: only_compatible_with_pay_in_advance_and_non_invoiceable
@@ -41,12 +47,6 @@ en:
         unsupported_value: unsupported_value
         url_invalid: url_is_invalid
         value_already_exist: value_already_exist
-        models:
-          api_key:
-            attributes:
-              permissions:
-                missing_key: "missing required keys: %{keys}"
-                forbidden_key: "contains forbidden keys: %{keys}"
   date:
     formats:
       default: "%b %d, %Y"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,12 @@ en:
         unsupported_value: unsupported_value
         url_invalid: url_is_invalid
         value_already_exist: value_already_exist
+        models:
+          api_key:
+            attributes:
+              permissions:
+                missing_key: "missing required keys: %{keys}"
+                forbidden_key: "contains forbidden keys: %{keys}"
   date:
     formats:
       default: "%b %d, %Y"

--- a/db/migrate/20241120094557_add_permissions_to_api_keys.rb
+++ b/db/migrate/20241120094557_add_permissions_to_api_keys.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddPermissionsToApiKeys < ActiveRecord::Migration[7.1]
+  def up
+    add_column :api_keys, :permissions, :jsonb, null: false, default: {}
+
+    ApiKey.update_all(permissions: ApiKey.default_permissions) # rubocop:disable Rails/SkipsModelValidations
+
+    change_column_default :api_keys, :permissions, nil
+  end
+
+  def down
+    remove_column :api_keys, :permissions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,6 +111,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_25_194753) do
     t.datetime "expires_at"
     t.datetime "last_used_at"
     t.string "name"
+    t.jsonb "permissions", null: false
     t.index ["organization_id"], name: "index_api_keys_on_organization_id"
     t.index ["value"], name: "index_api_keys_on_value", unique: true
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4311,6 +4311,7 @@ enum IntegrationItemTypeEnum {
 
 enum IntegrationTypeEnum {
   anrok
+  api_permissions
   auto_dunning
   hubspot
   netsuite
@@ -6180,6 +6181,7 @@ input PlanOverridesInput {
 }
 
 enum PremiumIntegrationTypeEnum {
+  api_permissions
   auto_dunning
   hubspot
   netsuite

--- a/schema.json
+++ b/schema.json
@@ -21118,6 +21118,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "api_permissions",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -31187,6 +31193,12 @@
             },
             {
               "name": "salesforce",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "api_permissions",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -114,10 +114,10 @@ RSpec.describe ApiKey, type: :model do
         end
       end
 
-      context 'when permission contains forbidden values' do
+      context 'when permission contains only allowed values' do
         let(:permissions) { {'add_on': ['read', 'write']} }
 
-        it 'does not adds an error' do
+        it 'does not add an error' do
           expect(error).not_to be_present
         end
       end

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe ApiKey, type: :model do
       before { subject }
 
       context 'when permission contains forbidden values' do
-        let(:permissions) { {'add_on': ['forbidden', 'read']} }
+        let(:permissions) { {add_on: ['forbidden', 'read']} }
 
         it 'adds an error' do
           expect(error).to be_present
@@ -115,7 +115,7 @@ RSpec.describe ApiKey, type: :model do
       end
 
       context 'when permission contains only allowed values' do
-        let(:permissions) { {'add_on': ['read', 'write']} }
+        let(:permissions) { {add_on: ['read', 'write']} }
 
         it 'does not add an error' do
           expect(error).not_to be_present
@@ -186,7 +186,7 @@ RSpec.describe ApiKey, type: :model do
     let(:resource) { described_class::RESOURCES.sample }
     let(:mode) { described_class::MODES.sample }
 
-    before { api_key.organization.update!(premium_integrations: ) }
+    before { api_key.organization.update!(premium_integrations:) }
 
     context "when organization has 'api_permissions' add-on enabled" do
       let(:premium_integrations) { ["api_permissions"] }

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe ApiKey, type: :model do
   it { is_expected.to belong_to(:organization) }
 
+  it { is_expected.to validate_presence_of(:permissions) }
+
   describe 'validations' do
     describe 'of value uniqueness' do
       before { create(:api_key) }
@@ -25,6 +27,99 @@ RSpec.describe ApiKey, type: :model do
         let(:api_key) { create(:api_key) }
 
         it { is_expected.to validate_presence_of(:value) }
+      end
+    end
+
+    describe 'of permissions structure' do
+      subject { api_key.valid? }
+
+      let(:api_key) { build_stubbed(:api_key) }
+      let(:missing_error) { api_key.errors.where(:permissions, :missing_keys) }
+      let(:forbidden_error) { api_key.errors.where(:permissions, :forbidden_keys) }
+
+      context 'when permissions has forbidden keys' do
+        before { api_key.permissions = api_key.permissions.merge(forbidden: []) }
+
+        context 'when permissions has required keys missing' do
+          before do
+            api_key.permissions.delete('add_on')
+            subject
+          end
+
+          it 'adds forbidden keys error' do
+            expect(forbidden_error).to be_present
+          end
+
+          it 'adds missing keys error' do
+            expect(missing_error).to be_present
+          end
+        end
+
+        context 'when permissions all required keys present' do
+          before { subject }
+
+          it 'adds forbidden keys error' do
+            expect(forbidden_error).to be_present
+          end
+
+          it 'does not add missing keys error' do
+            expect(missing_error).not_to be_present
+          end
+        end
+      end
+
+      context 'when permissions has no forbidden keys' do
+        context 'when permissions has required keys missing' do
+          before do
+            api_key.permissions.delete('add_on')
+            subject
+          end
+
+          it 'does not add forbidden keys error' do
+            expect(forbidden_error).not_to be_present
+          end
+
+          it 'adds missing keys error' do
+            expect(missing_error).to be_present
+          end
+        end
+
+        context 'when permissions all required keys present' do
+          before { subject }
+
+          it 'does not add forbidden keys error' do
+            expect(forbidden_error).not_to be_present
+          end
+
+          it 'does not add missing keys error' do
+            expect(missing_error).not_to be_present
+          end
+        end
+      end
+    end
+
+    describe 'of permissions values' do
+      subject { api_key.valid? }
+
+      let(:api_key) { build_stubbed(:api_key, permissions:) }
+      let(:error) { api_key.errors.where(:permissions, :forbidden_values) }
+
+      before { subject }
+
+      context 'when permission contains forbidden values' do
+        let(:permissions) { {'add_on': ['forbidden', 'read']} }
+
+        it 'adds an error' do
+          expect(error).to be_present
+        end
+      end
+
+      context 'when permission contains forbidden values' do
+        let(:permissions) { {'add_on': ['read', 'write']} }
+
+        it 'does not adds an error' do
+          expect(error).not_to be_present
+        end
       end
     end
   end
@@ -81,6 +176,56 @@ RSpec.describe ApiKey, type: :model do
 
     it 'returns API keys with no expiration date' do
       expect(subject).to contain_exactly scoped
+    end
+  end
+
+  describe "#permit?" do
+    subject { api_key.permit?(resource, mode) }
+
+    let(:api_key) { create(:api_key) }
+    let(:resource) { described_class::RESOURCES.sample }
+    let(:mode) { described_class::MODES.sample }
+
+    before { api_key.organization.update!(premium_integrations: ) }
+
+    context "when organization has 'api_permissions' add-on enabled" do
+      let(:premium_integrations) { ["api_permissions"] }
+
+      context "when corresponding resource allows provided mode" do
+        it "returns true" do
+          expect(subject).to be true
+        end
+      end
+
+      context "when corresponding resource does not allow provided mode" do
+        before do
+          api_key.permissions = api_key.permissions.merge(resource => described_class::MODES.excluding(mode))
+        end
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+    end
+
+    context "when organization has 'api_permissions' add-on disabled" do
+      let(:premium_integrations) { [] }
+
+      context "when corresponding resource allows provided mode" do
+        it "returns true" do
+          expect(subject).to be true
+        end
+      end
+
+      context "when corresponding resource does not allow provided mode" do
+        before do
+          api_key.permissions = api_key.permissions.merge(resource => described_class::MODES.excluding(mode))
+        end
+
+        it "returns true" do
+          expect(subject).to be true
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Preparation step for implementing endpoint permissions for api keys.

## Description

Define permissions on each api key, fill with default access rights.