### PR TITLE
Feat invoice custom section migrations

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -241,7 +241,7 @@ end
 #  shipping_country                 :string
 #  shipping_state                   :string
 #  shipping_zipcode                 :string
-#  skip_invoice_custom_sections     :boolean          default(FALSE)
+#  skip_invoice_custom_sections     :boolean          default(FALSE), not null
 #  slug                             :string
 #  state                            :string
 #  tax_identification_number        :string

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -241,6 +241,7 @@ end
 #  shipping_country                 :string
 #  shipping_state                   :string
 #  shipping_zipcode                 :string
+#  skip_invoice_custom_sections     :boolean          default(FALSE)
 #  slug                             :string
 #  state                            :string
 #  tax_identification_number        :string

--- a/db/migrate/20241122111534_create_invoice_custom_sections.rb
+++ b/db/migrate/20241122111534_create_invoice_custom_sections.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateInvoiceCustomSections < ActiveRecord::Migration[7.1]
+  def change
+    create_table :invoice_custom_sections, id: :uuid do |t|
+      t.string :name, null: false
+      t.string :code, null: false
+      t.string :description
+      t.string :display_name
+      t.string :details
+      t.references :organization, type: :uuid, null: false, foreign_key: true, index: true
+      t.timestamp :deleted_at
+
+      t.timestamps
+
+      t.index %i[organization_id code], unique: true
+      t.index %i[organization_id deleted_at]
+    end
+  end
+end

--- a/db/migrate/20241122134430_create_invoice_custom_section_selections.rb
+++ b/db/migrate/20241122134430_create_invoice_custom_section_selections.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateInvoiceCustomSectionSelections < ActiveRecord::Migration[7.1]
+  def change
+    create_table :invoice_custom_section_selections, id: :uuid do |t|
+      t.references :invoice_custom_section, type: :uuid, null: false, foreign_key: true
+      t.references :organization, type: :uuid, null: true, foreign_key: true
+      t.references :customer, type: :uuid, null: true, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241122140603_create_applied_invoice_custom_sections.rb
+++ b/db/migrate/20241122140603_create_applied_invoice_custom_sections.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateAppliedInvoiceCustomSections < ActiveRecord::Migration[7.1]
+  def change
+    create_table :applied_invoice_custom_sections, id: :uuid do |t|
+      t.string :name, null: false
+      t.string :code, null: false
+      t.string :display_name
+      t.string :details
+      t.references :invoice, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241122141158_add_skip_invoice_custom_sections_to_customers.rb
+++ b/db/migrate/20241122141158_add_skip_invoice_custom_sections_to_customers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSkipInvoiceCustomSectionsToCustomers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :customers, :skip_invoice_custom_sections, :boolean, default: false
+  end
+end

--- a/db/migrate/20241122141158_add_skip_invoice_custom_sections_to_customers.rb
+++ b/db/migrate/20241122141158_add_skip_invoice_custom_sections_to_customers.rb
@@ -2,6 +2,6 @@
 
 class AddSkipInvoiceCustomSectionsToCustomers < ActiveRecord::Migration[7.1]
   def change
-    add_column :customers, :skip_invoice_custom_sections, :boolean, default: false
+    add_column :customers, :skip_invoice_custom_sections, :boolean, default: false, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -480,7 +480,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_28_132010) do
     t.boolean "exclude_from_dunning_campaign", default: false, null: false
     t.integer "last_dunning_campaign_attempt", default: 0, null: false
     t.datetime "last_dunning_campaign_attempt_at", precision: nil
-    t.boolean "dunning_campaign_completed", default: false
     t.boolean "skip_invoice_custom_sections", default: false, null: false
     t.index ["applied_dunning_campaign_id"], name: "index_customers_on_applied_dunning_campaign_id"
     t.index ["deleted_at"], name: "index_customers_on_deleted_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -481,7 +481,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_28_132010) do
     t.integer "last_dunning_campaign_attempt", default: 0, null: false
     t.datetime "last_dunning_campaign_attempt_at", precision: nil
     t.boolean "dunning_campaign_completed", default: false
-    t.boolean "skip_invoice_custom_sections", default: false
+    t.boolean "skip_invoice_custom_sections", default: false, null: false
     t.index ["applied_dunning_campaign_id"], name: "index_customers_on_applied_dunning_campaign_id"
     t.index ["deleted_at"], name: "index_customers_on_deleted_at"
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true, where: "(deleted_at IS NULL)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -797,6 +797,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_28_132010) do
     t.index ["token"], name: "index_invites_on_token", unique: true
   end
 
+  create_table "invoice_custom_sections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "code", null: false
+    t.string "description"
+    t.string "display_name"
+    t.string "details"
+    t.uuid "organization_id", null: false
+    t.datetime "deleted_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id", "code"], name: "index_invoice_custom_sections_on_organization_id_and_code", unique: true
+    t.index ["organization_id", "deleted_at"], name: "idx_on_organization_id_deleted_at_225e3f789d"
+    t.index ["organization_id"], name: "index_invoice_custom_sections_on_organization_id"
+  end
+
   create_table "invoice_errors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "backtrace"
     t.json "invoice"
@@ -1375,6 +1390,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_28_132010) do
   add_foreign_key "integrations", "organizations"
   add_foreign_key "invites", "memberships"
   add_foreign_key "invites", "organizations"
+  add_foreign_key "invoice_custom_sections", "organizations"
   add_foreign_key "invoice_metadata", "invoices"
   add_foreign_key "invoice_subscriptions", "invoices"
   add_foreign_key "invoice_subscriptions", "subscriptions"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -145,6 +145,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_28_132010) do
     t.index ["customer_id"], name: "index_applied_coupons_on_customer_id"
   end
 
+  create_table "applied_invoice_custom_sections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "code", null: false
+    t.string "display_name"
+    t.string "details"
+    t.uuid "invoice_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["invoice_id"], name: "index_applied_invoice_custom_sections_on_invoice_id"
+  end
+
   create_table "applied_usage_thresholds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "usage_threshold_id", null: false
     t.uuid "invoice_id", null: false
@@ -469,6 +480,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_28_132010) do
     t.boolean "exclude_from_dunning_campaign", default: false, null: false
     t.integer "last_dunning_campaign_attempt", default: 0, null: false
     t.datetime "last_dunning_campaign_attempt_at", precision: nil
+    t.boolean "dunning_campaign_completed", default: false
+    t.boolean "skip_invoice_custom_sections", default: false
     t.index ["applied_dunning_campaign_id"], name: "index_customers_on_applied_dunning_campaign_id"
     t.index ["deleted_at"], name: "index_customers_on_deleted_at"
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true, where: "(deleted_at IS NULL)"
@@ -795,6 +808,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_28_132010) do
     t.index ["membership_id"], name: "index_invites_on_membership_id"
     t.index ["organization_id"], name: "index_invites_on_organization_id"
     t.index ["token"], name: "index_invites_on_token", unique: true
+  end
+
+  create_table "invoice_custom_section_selections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "invoice_custom_section_id", null: false
+    t.uuid "organization_id"
+    t.uuid "customer_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_invoice_custom_section_selections_on_customer_id"
+    t.index ["invoice_custom_section_id"], name: "idx_on_invoice_custom_section_id_7edbcef7b5"
+    t.index ["organization_id"], name: "index_invoice_custom_section_selections_on_organization_id"
   end
 
   create_table "invoice_custom_sections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1324,6 +1348,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_28_132010) do
   add_foreign_key "api_keys", "organizations"
   add_foreign_key "applied_add_ons", "add_ons"
   add_foreign_key "applied_add_ons", "customers"
+  add_foreign_key "applied_invoice_custom_sections", "invoices"
   add_foreign_key "applied_usage_thresholds", "invoices"
   add_foreign_key "applied_usage_thresholds", "usage_thresholds"
   add_foreign_key "billable_metric_filters", "billable_metrics"
@@ -1390,6 +1415,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_28_132010) do
   add_foreign_key "integrations", "organizations"
   add_foreign_key "invites", "memberships"
   add_foreign_key "invites", "organizations"
+  add_foreign_key "invoice_custom_section_selections", "customers"
+  add_foreign_key "invoice_custom_section_selections", "invoice_custom_sections"
+  add_foreign_key "invoice_custom_section_selections", "organizations"
   add_foreign_key "invoice_custom_sections", "organizations"
   add_foreign_key "invoice_metadata", "invoices"
   add_foreign_key "invoice_subscriptions", "invoices"


### PR DESCRIPTION
## Context

In order to save invoice custom sections, we need to make some changes in the DB

## Description

Added
- invoice_custom_sections
- invoice_custom_section_selections
- applied_invoice_custom_sections

Updated
- Customer
