### PR TITLE
Revert "fix(netsuite): Aggregator jobs should be unique (#2818)"

### DIFF
--- a/app/jobs/fees/create_pay_in_advance_job.rb
+++ b/app/jobs/fees/create_pay_in_advance_job.rb
@@ -4,8 +4,6 @@ module Fees
   class CreatePayInAdvanceJob < ApplicationJob
     queue_as :default
 
-    unique :until_executed, on_conflict: :log
-
     def perform(charge:, event:, billing_at: nil)
       result = Fees::CreatePayInAdvanceService.call(charge:, event:, billing_at:)
 

--- a/app/jobs/integrations/aggregator/credit_notes/create_job.rb
+++ b/app/jobs/integrations/aggregator/credit_notes/create_job.rb
@@ -6,8 +6,6 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
-        unique :until_executed, on_conflict: :log
-
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 

--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -6,8 +6,6 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
-        unique :until_executed, on_conflict: :log
-
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 

--- a/app/jobs/integrations/aggregator/invoices/crm/create_customer_association_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/create_customer_association_job.rb
@@ -7,8 +7,6 @@ module Integrations
         class CreateCustomerAssociationJob < ApplicationJob
           queue_as 'integrations'
 
-          unique :until_executed, on_conflict: :log
-
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 

--- a/app/jobs/integrations/aggregator/invoices/crm/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/create_job.rb
@@ -7,8 +7,6 @@ module Integrations
         class CreateJob < ApplicationJob
           queue_as 'integrations'
 
-          unique :until_executed, on_conflict: :log
-
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/integrations/aggregator/invoices/crm/update_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/update_job.rb
@@ -7,8 +7,6 @@ module Integrations
         class UpdateJob < ApplicationJob
           queue_as 'integrations'
 
-          unique :until_executed, on_conflict: :log
-
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/integrations/aggregator/payments/create_job.rb
+++ b/app/jobs/integrations/aggregator/payments/create_job.rb
@@ -6,8 +6,6 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
-        unique :until_executed, on_conflict: :log
-
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 5
         retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/integrations/aggregator/subscriptions/crm/create_customer_association_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/create_customer_association_job.rb
@@ -7,8 +7,6 @@ module Integrations
         class CreateCustomerAssociationJob < ApplicationJob
           queue_as 'integrations'
 
-          unique :until_executed, on_conflict: :log
-
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 

--- a/app/jobs/integrations/aggregator/subscriptions/crm/create_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/create_job.rb
@@ -7,8 +7,6 @@ module Integrations
         class CreateJob < ApplicationJob
           queue_as 'integrations'
 
-          unique :until_executed, on_conflict: :log
-
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/integrations/aggregator/subscriptions/crm/update_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/update_job.rb
@@ -7,8 +7,6 @@ module Integrations
         class UpdateJob < ApplicationJob
           queue_as 'integrations'
 
-          unique :until_executed, on_conflict: :log
-
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100

--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -6,8 +6,6 @@ module Invoices
 
     retry_on Sequenced::SequenceError
 
-    unique :until_executed, on_conflict: :log
-
     def perform(charge:, event:, timestamp:, invoice: nil)
       result = Invoices::CreatePayInAdvanceChargeService.call(charge:, event:, timestamp:, invoice:)
       return if result.success?


### PR DESCRIPTION
This reverts commit 0d43376467dad3ef2035599bae6d69011b4a71d2.

## Context

There is a activejob-uniqueness bug that does not enqueue integration jobs.

when using named arguments

