### PR TITLE
fix(unique-jobs): Unique jobs were not enqueuing jobs with keyword args

### DIFF
--- a/app/jobs/integrations/aggregator/credit_notes/create_job.rb
+++ b/app/jobs/integrations/aggregator/credit_notes/create_job.rb
@@ -6,10 +6,14 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
+        # https://github.com/veeqo/activejob-uniqueness/issues/75
+        # retry_on does not work with until_executed strategy
+        unique :until_executed_patch, on_conflict: :log
+
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-        def perform(credit_note:)
+        def perform(credit_note)
           result = Integrations::Aggregator::CreditNotes::CreateService.call(credit_note:)
           result.raise_if_error!
         end

--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -6,10 +6,14 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
+        # https://github.com/veeqo/activejob-uniqueness/issues/75
+        # retry_on does not work with until_executed strategy
+        unique :until_executed_patch, on_conflict: :log
+
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-        def perform(invoice:)
+        def perform(invoice)
           result = Integrations::Aggregator::Invoices::CreateService.call(invoice:)
           result.raise_if_error!
         end

--- a/app/jobs/integrations/aggregator/invoices/crm/create_customer_association_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/create_customer_association_job.rb
@@ -10,7 +10,7 @@ module Integrations
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-          def perform(invoice:)
+          def perform(invoice)
             result = Integrations::Aggregator::Invoices::Crm::CreateCustomerAssociationService.call(invoice:)
             result.raise_if_error!
           end

--- a/app/jobs/integrations/aggregator/invoices/crm/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/create_job.rb
@@ -11,11 +11,11 @@ module Integrations
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-          def perform(invoice:)
+          def perform(invoice)
             result = Integrations::Aggregator::Invoices::Crm::CreateService.call(invoice:)
 
             if result.success?
-              Integrations::Aggregator::Invoices::Crm::CreateCustomerAssociationJob.perform_later(invoice:)
+              Integrations::Aggregator::Invoices::Crm::CreateCustomerAssociationJob.perform_later(invoice)
             end
 
             result.raise_if_error!

--- a/app/jobs/integrations/aggregator/invoices/crm/update_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/crm/update_job.rb
@@ -11,7 +11,7 @@ module Integrations
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-          def perform(invoice:)
+          def perform(invoice)
             result = Integrations::Aggregator::Invoices::Crm::UpdateService.call(invoice:)
             result.raise_if_error!
           end

--- a/app/jobs/integrations/aggregator/payments/create_job.rb
+++ b/app/jobs/integrations/aggregator/payments/create_job.rb
@@ -6,11 +6,15 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
+        # https://github.com/veeqo/activejob-uniqueness/issues/75
+        # retry_on does not work with until_executed strategy
+        unique :until_executed_patch, on_conflict: :log
+
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 5
         retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-        def perform(payment:)
+        def perform(payment)
           result = Integrations::Aggregator::Payments::CreateService.call(payment:)
           result.raise_if_error!
         end

--- a/app/jobs/integrations/aggregator/subscriptions/crm/create_customer_association_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/create_customer_association_job.rb
@@ -10,7 +10,7 @@ module Integrations
           retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-          def perform(subscription:)
+          def perform(subscription)
             result = Integrations::Aggregator::Subscriptions::Crm::CreateCustomerAssociationService.call(subscription:)
             result.raise_if_error!
           end

--- a/app/jobs/integrations/aggregator/subscriptions/crm/create_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/create_job.rb
@@ -11,11 +11,11 @@ module Integrations
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-          def perform(subscription:)
+          def perform(subscription)
             result = Integrations::Aggregator::Subscriptions::Crm::CreateService.call(subscription:)
 
             if result.success?
-              Integrations::Aggregator::Subscriptions::Crm::CreateCustomerAssociationJob.perform_later(subscription:)
+              Integrations::Aggregator::Subscriptions::Crm::CreateCustomerAssociationJob.perform_later(subscription)
             end
 
             result.raise_if_error!

--- a/app/jobs/integrations/aggregator/subscriptions/crm/update_job.rb
+++ b/app/jobs/integrations/aggregator/subscriptions/crm/update_job.rb
@@ -11,7 +11,7 @@ module Integrations
           retry_on Integrations::Aggregator::BasePayload::Failure, wait: :polynomially_longer, attempts: 10
           retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-          def perform(subscription:)
+          def perform(subscription)
             result = Integrations::Aggregator::Subscriptions::Crm::UpdateService.call(subscription:)
             result.raise_if_error!
           end

--- a/app/jobs/integrations/hubspot/companies/deploy_properties_job.rb
+++ b/app/jobs/integrations/hubspot/companies/deploy_properties_job.rb
@@ -9,7 +9,7 @@ module Integrations
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-        def perform(integration:)
+        def perform(integration)
           result = Integrations::Hubspot::Companies::DeployPropertiesService.call(integration:)
           result.raise_if_error!
         end

--- a/app/jobs/integrations/hubspot/contacts/deploy_properties_job.rb
+++ b/app/jobs/integrations/hubspot/contacts/deploy_properties_job.rb
@@ -9,7 +9,7 @@ module Integrations
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-        def perform(integration:)
+        def perform(integration)
           result = Integrations::Hubspot::Contacts::DeployPropertiesService.call(integration:)
           result.raise_if_error!
         end

--- a/app/jobs/integrations/hubspot/invoices/deploy_object_job.rb
+++ b/app/jobs/integrations/hubspot/invoices/deploy_object_job.rb
@@ -9,7 +9,7 @@ module Integrations
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-        def perform(integration:)
+        def perform(integration)
           result = Integrations::Hubspot::Invoices::DeployObjectService.call(integration:)
           result.raise_if_error!
         end

--- a/app/jobs/integrations/hubspot/save_portal_id_job.rb
+++ b/app/jobs/integrations/hubspot/save_portal_id_job.rb
@@ -8,7 +8,7 @@ module Integrations
       retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
       retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-      def perform(integration:)
+      def perform(integration)
         result = Integrations::Hubspot::SavePortalIdService.call(integration:)
         result.raise_if_error!
       end

--- a/app/jobs/integrations/hubspot/subscriptions/deploy_object_job.rb
+++ b/app/jobs/integrations/hubspot/subscriptions/deploy_object_job.rb
@@ -9,7 +9,7 @@ module Integrations
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
         retry_on Integrations::Aggregator::RequestLimitError, wait: :polynomially_longer, attempts: 100
 
-        def perform(integration:)
+        def perform(integration)
           result = Integrations::Hubspot::Subscriptions::DeployObjectService.call(integration:)
           result.raise_if_error!
         end

--- a/app/services/events/pay_in_advance_service.rb
+++ b/app/services/events/pay_in_advance_service.rb
@@ -22,11 +22,11 @@ module Events
       end
 
       charges.where(invoiceable: false).find_each do |charge|
-        Fees::CreatePayInAdvanceJob.perform_later(charge:, event: event.as_json)
+        Fees::CreatePayInAdvanceJob.perform_later(charge, event.as_json)
       end
 
       charges.where(invoiceable: true).find_each do |charge|
-        Invoices::CreatePayInAdvanceChargeJob.perform_later(charge:, event: event.as_json, timestamp: event.timestamp)
+        Invoices::CreatePayInAdvanceChargeJob.perform_later(charge, event.as_json, event.timestamp)
       end
 
       result.event = event

--- a/app/services/integrations/aggregator/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/invoices/create_service.rb
@@ -53,7 +53,7 @@ module Integrations
         def call_async
           return result.not_found_failure!(resource: 'invoice') unless invoice
 
-          ::Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:)
+          ::Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice)
 
           result.invoice_id = invoice.id
           result

--- a/app/services/integrations/aggregator/payments/create_service.rb
+++ b/app/services/integrations/aggregator/payments/create_service.rb
@@ -56,7 +56,7 @@ module Integrations
         def call_async
           return result.not_found_failure!(resource: 'payment') unless payment
 
-          ::Integrations::Aggregator::Payments::CreateJob.perform_later(payment:)
+          ::Integrations::Aggregator::Payments::CreateJob.perform_later(payment)
 
           result.payment_id = payment.id
           result

--- a/app/services/integrations/hubspot/create_service.rb
+++ b/app/services/integrations/hubspot/create_service.rb
@@ -31,7 +31,7 @@ module Integrations
 
         if integration.type == 'Integrations::HubspotIntegration'
           Integrations::Aggregator::SyncCustomObjectsAndPropertiesJob.perform_later(integration:)
-          Integrations::Hubspot::SavePortalIdJob.perform_later(integration:)
+          Integrations::Hubspot::SavePortalIdJob.perform_later(integration)
         end
 
         result.integration = integration

--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -37,11 +37,11 @@ module Invoices
       GeneratePdfAndNotifyJob.perform_later(invoice: result.invoice, email: should_deliver_email?)
 
       if result.invoice.should_sync_invoice?
-        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice: result.invoice)
+        Integrations::Aggregator::Invoices::CreateJob.perform_later(result.invoice)
       end
 
       if result.invoice.should_sync_crm_invoice?
-        Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice: result.invoice)
+        Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(result.invoice)
       end
 
       create_payment(result.invoice)

--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -23,8 +23,8 @@ module Invoices
       if invoice && !invoice.closed?
         SendWebhookJob.perform_later('invoice.created', invoice)
         Invoices::GeneratePdfAndNotifyJob.perform_later(invoice:, email: false)
-        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-        Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice:) if invoice.should_sync_crm_invoice?
+        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice) if invoice.should_sync_invoice?
+        Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice) if invoice.should_sync_crm_invoice?
         Utils::SegmentTrack.invoice_created(invoice)
       end
 

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -44,8 +44,8 @@ module Invoices
         Utils::SegmentTrack.invoice_created(invoice)
         SendWebhookJob.perform_later('invoice.one_off_created', invoice)
         GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
-        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-        Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice:) if invoice.should_sync_crm_invoice?
+        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice) if invoice.should_sync_invoice?
+        Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice) if invoice.should_sync_crm_invoice?
         Invoices::Payments::CreateService.new(invoice).call
       end
 

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -51,8 +51,8 @@ module Invoices
         Utils::SegmentTrack.invoice_created(invoice)
         deliver_webhooks
         GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
-        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-        Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice:) if invoice.should_sync_crm_invoice?
+        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice) if invoice.should_sync_invoice?
+        Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice) if invoice.should_sync_crm_invoice?
         Invoices::Payments::CreateService.new(invoice).call
       end
 

--- a/app/services/invoices/finalize_open_credit_service.rb
+++ b/app/services/invoices/finalize_open_credit_service.rb
@@ -22,8 +22,8 @@ module Invoices
 
       SendWebhookJob.perform_later('invoice.paid_credit_added', result.invoice)
       GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
-      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-      Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice:) if invoice.should_sync_crm_invoice?
+      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice) if invoice.should_sync_invoice?
+      Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice) if invoice.should_sync_crm_invoice?
       Utils::SegmentTrack.invoice_created(result.invoice)
 
       result

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -34,8 +34,8 @@ module Invoices
         Utils::SegmentTrack.invoice_created(result.invoice)
         SendWebhookJob.perform_later('invoice.paid_credit_added', result.invoice)
         GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
-        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-        Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice:) if invoice.should_sync_crm_invoice?
+        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice) if invoice.should_sync_invoice?
+        Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice) if invoice.should_sync_crm_invoice?
       end
 
       create_payment(result.invoice)

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -47,7 +47,7 @@ module Invoices
         invoice_payment_status = invoice_payment_status(payment.status)
         update_invoice_payment_status(payment_status: invoice_payment_status)
 
-        Integrations::Aggregator::Payments::CreateJob.perform_later(payment:) if payment.should_sync_payment?
+        Integrations::Aggregator::Payments::CreateJob.perform_later(payment) if payment.should_sync_payment?
 
         result.payment = payment
         result

--- a/app/services/invoices/payments/gocardless_service.rb
+++ b/app/services/invoices/payments/gocardless_service.rb
@@ -56,7 +56,7 @@ module Invoices
         invoice_payment_status = invoice_payment_status(payment.status)
         update_invoice_payment_status(payment_status: invoice_payment_status)
 
-        Integrations::Aggregator::Payments::CreateJob.perform_later(payment:) if payment.should_sync_payment?
+        Integrations::Aggregator::Payments::CreateJob.perform_later(payment) if payment.should_sync_payment?
 
         result.payment = payment
         result

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -50,7 +50,7 @@ module Invoices
           processing: payment.status == 'processing'
         )
 
-        Integrations::Aggregator::Payments::CreateJob.perform_later(payment:) if payment.should_sync_payment?
+        Integrations::Aggregator::Payments::CreateJob.perform_later(payment) if payment.should_sync_payment?
 
         handle_requires_action(payment) if payment.status == 'requires_action'
 

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -48,8 +48,8 @@ module Invoices
       Utils::SegmentTrack.invoice_created(invoice)
       SendWebhookJob.perform_later('invoice.created', invoice)
       Invoices::GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
-      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-      Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice:) if invoice.should_sync_crm_invoice?
+      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice) if invoice.should_sync_invoice?
+      Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice) if invoice.should_sync_crm_invoice?
       Invoices::Payments::CreateService.call(invoice)
 
       result.invoice = invoice

--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -33,8 +33,8 @@ module Invoices
         unless invoice.closed?
           SendWebhookJob.perform_later('invoice.created', invoice)
           GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
-          Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-          Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice:) if invoice.should_sync_crm_invoice?
+          Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice) if invoice.should_sync_invoice?
+          Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice) if invoice.should_sync_crm_invoice?
           Invoices::Payments::CreateService.new(invoice).call
           Utils::SegmentTrack.invoice_created(invoice)
         end

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -42,8 +42,8 @@ module Invoices
 
       SendWebhookJob.perform_later('invoice.created', invoice)
       GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
-      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-      Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice:) if invoice.should_sync_crm_invoice?
+      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice) if invoice.should_sync_invoice?
+      Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice) if invoice.should_sync_crm_invoice?
       Invoices::Payments::CreateService.new(invoice).call
       Utils::SegmentTrack.invoice_created(invoice)
 

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -67,8 +67,8 @@ module Invoices
         unless invoice.closed? # we dont need to send the webhooks if the invoice was closed ( skip 0 invoice setting )
           SendWebhookJob.perform_later('invoice.created', invoice)
           GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_finalized_email?)
-          Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-          Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice:) if invoice.should_sync_crm_invoice?
+          Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice) if invoice.should_sync_invoice?
+          Integrations::Aggregator::Invoices::Crm::CreateJob.perform_later(invoice) if invoice.should_sync_crm_invoice?
           Invoices::Payments::CreateService.new(invoice).call
           Utils::SegmentTrack.invoice_created(invoice)
         end

--- a/app/services/payment_requests/payments/adyen_service.rb
+++ b/app/services/payment_requests/payments/adyen_service.rb
@@ -52,7 +52,7 @@ module PaymentRequests
         update_payable_payment_status(payment_status: payable_payment_status)
         update_invoices_payment_status(payment_status: payable_payment_status)
 
-        Integrations::Aggregator::Payments::CreateJob.perform_later(payment:) if payment.should_sync_payment?
+        Integrations::Aggregator::Payments::CreateJob.perform_later(payment) if payment.should_sync_payment?
 
         result.payment = payment
         result

--- a/app/services/payment_requests/payments/gocardless_service.rb
+++ b/app/services/payment_requests/payments/gocardless_service.rb
@@ -59,7 +59,7 @@ module PaymentRequests
         update_payable_payment_status(payment_status: payable_payment_status)
         update_invoices_payment_status(payment_status: payable_payment_status)
 
-        Integrations::Aggregator::Payments::CreateJob.perform_later(payment:) if payment.should_sync_payment?
+        Integrations::Aggregator::Payments::CreateJob.perform_later(payment) if payment.should_sync_payment?
 
         result.payment = payment
         result

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,3 +42,5 @@ module LagoApi
     config.active_support.cache_format_version = 7.1
   end
 end
+
+require_relative "../lib/active_job/uniqueness/strategies/until_executed_patch"

--- a/lib/active_job/uniqueness/strategies/until_executed_patch.rb
+++ b/lib/active_job/uniqueness/strategies/until_executed_patch.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "active_job/uniqueness/strategies/until_executed"
+
+module ActiveJob
+  module Uniqueness
+    module Strategies
+      class UntilExecutedPatch < UntilExecuted
+        def before_enqueue
+          return if lock(resource: lock_key, ttl: lock_ttl)
+          # We're retrying the job, so we don't need to lock again
+          return if job.executions > 0
+
+          handle_conflict(resource: lock_key, on_conflict: on_conflict)
+          abort_job
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/fees/create_pay_in_advance_job_spec.rb
+++ b/spec/jobs/fees/create_pay_in_advance_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Fees::CreatePayInAdvanceJob, type: :job do
       .with(charge:, event:, billing_at: nil)
       .and_return(result)
 
-    described_class.perform_now(charge:, event:)
+    described_class.perform_now(charge, event)
 
     expect(Fees::CreatePayInAdvanceService).to have_received(:call)
   end

--- a/spec/jobs/integrations/aggregator/credit_notes/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/credit_notes/create_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateJob, type: :job do
   end
 
   it 'calls the aggregator create credit_note service' do
-    described_class.perform_now(credit_note:)
+    described_class.perform_now(credit_note)
 
     aggregate_failures do
       expect(Integrations::Aggregator::CreditNotes::CreateService).to have_received(:new)

--- a/spec/jobs/integrations/aggregator/invoices/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/create_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateJob, type: :job do
   end
 
   it 'calls the aggregator create invoice service' do
-    described_class.perform_now(invoice:)
+    described_class.perform_now(invoice)
 
     aggregate_failures do
       expect(Integrations::Aggregator::Invoices::CreateService).to have_received(:new)

--- a/spec/jobs/integrations/aggregator/invoices/crm/create_customer_association_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/crm/create_customer_association_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Crm::CreateCustomerAssociatio
   end
 
   it 'calls the aggregator create invoice crm service' do
-    described_class.perform_now(invoice:)
+    described_class.perform_now(invoice)
 
     aggregate_failures do
       expect(Integrations::Aggregator::Invoices::Crm::CreateCustomerAssociationService).to have_received(:new)

--- a/spec/jobs/integrations/aggregator/invoices/crm/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/crm/create_job_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe Integrations::Aggregator::Invoices::Crm::CreateJob, type: :job do
     end
 
     it 'raises an error' do
-      expect { create_job.perform_now(invoice:) }.to raise_error(StandardError)
+      expect { create_job.perform_now(invoice) }.to raise_error(StandardError)
     end
   end
 
   context 'when the service call is successful' do
     it 'calls the aggregator create invoice crm service' do
-      described_class.perform_now(invoice:)
+      described_class.perform_now(invoice)
 
       aggregate_failures do
         expect(Integrations::Aggregator::Invoices::Crm::CreateService).to have_received(:new)
@@ -37,8 +37,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Crm::CreateJob, type: :job do
 
     it 'enqueues the aggregator create customer association invoice job' do
       expect do
-        described_class.perform_now(invoice:)
-      end.to have_enqueued_job(Integrations::Aggregator::Invoices::Crm::CreateCustomerAssociationJob).with(invoice:)
+        described_class.perform_now(invoice)
+      end.to have_enqueued_job(Integrations::Aggregator::Invoices::Crm::CreateCustomerAssociationJob).with(invoice)
     end
   end
 end

--- a/spec/jobs/integrations/aggregator/invoices/crm/update_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/crm/update_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Crm::UpdateJob, type: :job do
   end
 
   it 'calls the aggregator create invoice crm service' do
-    described_class.perform_now(invoice:)
+    described_class.perform_now(invoice)
 
     aggregate_failures do
       expect(Integrations::Aggregator::Invoices::Crm::UpdateService).to have_received(:new)

--- a/spec/jobs/integrations/aggregator/payments/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/payments/create_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Integrations::Aggregator::Payments::CreateJob, type: :job do
   end
 
   it 'calls the aggregator create payment service' do
-    described_class.perform_now(payment:)
+    described_class.perform_now(payment)
 
     aggregate_failures do
       expect(Integrations::Aggregator::Payments::CreateService).to have_received(:new)

--- a/spec/jobs/integrations/aggregator/subscriptions/crm/create_customer_association_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/subscriptions/crm/create_customer_association_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Crm::CreateCustomerAssoc
   end
 
   it 'calls the aggregator create subscription crm service' do
-    described_class.perform_now(subscription:)
+    described_class.perform_now(subscription)
 
     aggregate_failures do
       expect(Integrations::Aggregator::Subscriptions::Crm::CreateCustomerAssociationService).to have_received(:new)

--- a/spec/jobs/integrations/aggregator/subscriptions/crm/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/subscriptions/crm/create_job_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Crm::CreateJob, type: :j
     end
 
     it 'raises an error' do
-      expect { create_job.perform_now(subscription:) }.to raise_error(StandardError)
+      expect { create_job.perform_now(subscription) }.to raise_error(StandardError)
     end
   end
 
   context 'when the service call is successful' do
     it 'calls the aggregator create subscription crm service' do
-      described_class.perform_now(subscription:)
+      described_class.perform_now(subscription)
 
       aggregate_failures do
         expect(Integrations::Aggregator::Subscriptions::Crm::CreateService).to have_received(:new)
@@ -37,8 +37,9 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Crm::CreateJob, type: :j
 
     it 'enqueues the aggregator create customer association subscription job' do
       expect do
-        described_class.perform_now(subscription:)
-      end.to have_enqueued_job(Integrations::Aggregator::Subscriptions::Crm::CreateCustomerAssociationJob).with(subscription:)
+        described_class.perform_now(subscription)
+      end.to have_enqueued_job(Integrations::Aggregator::Subscriptions::Crm::CreateCustomerAssociationJob)
+        .with(subscription)
     end
   end
 end

--- a/spec/jobs/integrations/aggregator/subscriptions/crm/update_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/subscriptions/crm/update_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Crm::UpdateJob, type: :j
   end
 
   it 'calls the aggregator create subscription crm service' do
-    described_class.perform_now(subscription:)
+    described_class.perform_now(subscription)
 
     aggregate_failures do
       expect(Integrations::Aggregator::Subscriptions::Crm::UpdateService).to have_received(:new)

--- a/spec/jobs/integrations/hubspot/companies/deploy_properties_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/companies/deploy_properties_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Integrations::Hubspot::Companies::DeployPropertiesJob, type: :job
     end
 
     it 'calls the DeployPropertiesService to sync companies custom properties' do
-      deploy_properties_job.perform_now(integration:)
+      deploy_properties_job.perform_now(integration)
       expect(Integrations::Hubspot::Companies::DeployPropertiesService).to have_received(:new)
       expect(deploy_company_service).to have_received(:call)
     end

--- a/spec/jobs/integrations/hubspot/contacts/deploy_properties_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/contacts/deploy_properties_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Integrations::Hubspot::Contacts::DeployPropertiesJob, type: :job 
     end
 
     it 'calls the DeployPropertiesService to sync contacts custom properties' do
-      deploy_properties_job.perform_now(integration:)
+      deploy_properties_job.perform_now(integration)
 
       expect(Integrations::Hubspot::Contacts::DeployPropertiesService).to have_received(:new)
       expect(deploy_contact_service).to have_received(:call)

--- a/spec/jobs/integrations/hubspot/invoices/deploy_object_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/invoices/deploy_object_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Integrations::Hubspot::Invoices::DeployObjectJob, type: :job do
     end
 
     it 'calls the DeployObjectService to deploy invoice custom object' do
-      deploy_object_job.perform_now(integration:)
+      deploy_object_job.perform_now(integration)
 
       expect(Integrations::Hubspot::Invoices::DeployObjectService).to have_received(:new)
       expect(deploy_object_service).to have_received(:call)

--- a/spec/jobs/integrations/hubspot/save_portal_id_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/save_portal_id_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Integrations::Hubspot::SavePortalIdJob, type: :job do
     end
 
     it 'saves portal id to the integration' do
-      described_class.perform_now(integration:)
+      described_class.perform_now(integration)
 
       expect(Integrations::Hubspot::SavePortalIdService).to have_received(:new)
       expect(service).to have_received(:call)

--- a/spec/jobs/integrations/hubspot/subscriptions/deploy_object_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/subscriptions/deploy_object_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Integrations::Hubspot::Subscriptions::DeployObjectJob, type: :job
     end
 
     it 'calls the DeployObjectService to deploy subscription custom object' do
-      deploy_object_job.perform_now(integration:)
+      deploy_object_job.perform_now(integration)
 
       expect(Integrations::Hubspot::Subscriptions::DeployObjectService).to have_received(:new)
       expect(deploy_object_service).to have_received(:call)

--- a/spec/jobs/invoices/create_pay_in_advance_charge_job_spec.rb
+++ b/spec/jobs/invoices/create_pay_in_advance_charge_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeJob, type: :job do
   end
 
   it 'calls the create pay in advance charge service' do
-    described_class.perform_now(charge:, event:, timestamp:)
+    described_class.perform_now(charge, event, timestamp)
 
     expect(Invoices::CreatePayInAdvanceChargeService).to have_received(:new)
     expect(invoice_service).to have_received(:call)
@@ -33,7 +33,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeJob, type: :job do
 
     it 'raises an error' do
       expect do
-        described_class.perform_now(charge:, event:, timestamp:)
+        described_class.perform_now(charge, event, timestamp)
       end.to raise_error(BaseService::FailedResult)
 
       expect(Invoices::CreatePayInAdvanceChargeService).to have_received(:new)
@@ -45,7 +45,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeJob, type: :job do
 
       it 'raises an error' do
         expect do
-          described_class.perform_now(charge:, event:, timestamp:, invoice:)
+          described_class.perform_now(charge, event, timestamp, invoice)
         end.to raise_error(BaseService::FailedResult)
 
         expect(Invoices::CreatePayInAdvanceChargeService).to have_received(:new)
@@ -59,13 +59,13 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeJob, type: :job do
       before { result.invoice = result_invoice }
 
       it 'retries the job with the invoice' do
-        described_class.perform_now(charge:, event:, timestamp:)
+        described_class.perform_now(charge, event, timestamp)
 
         expect(Invoices::CreatePayInAdvanceChargeService).to have_received(:new)
         expect(invoice_service).to have_received(:call)
 
         expect(described_class).to have_been_enqueued
-          .with(charge:, event:, timestamp:, invoice: result_invoice)
+          .with(charge, event, timestamp, result_invoice)
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeJob, type: :job do
 
       it 'raises an error' do
         expect do
-          described_class.perform_now(charge:, event:, timestamp:)
+          described_class.perform_now(charge, event, timestamp)
         end.to raise_error(BaseService::FailedResult)
 
         expect(Invoices::CreatePayInAdvanceChargeService).to have_received(:new)

--- a/spec/services/integrations/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/hubspot/create_service_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Integrations::Hubspot::CreateService, type: :service do
 
             integration = Integrations::HubspotIntegration.order(:created_at).last
             expect(Integrations::Aggregator::SyncCustomObjectsAndPropertiesJob).to have_received(:perform_later).with(integration:)
-            expect(Integrations::Hubspot::SavePortalIdJob).to have_received(:perform_later).with(integration:)
+            expect(Integrations::Hubspot::SavePortalIdJob).to have_received(:perform_later).with(integration)
           end
         end
 

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
       it 'creates invoices' do
         result = invoice_service.call
 
-        expect(Integrations::Aggregator::Invoices::CreateJob).to have_been_enqueued.with(invoice: result.invoice)
+        expect(Integrations::Aggregator::Invoices::CreateJob).to have_been_enqueued.with(result.invoice)
       end
     end
   end

--- a/spec/services/invoices/finalize_open_credit_service_spec.rb
+++ b/spec/services/invoices/finalize_open_credit_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Invoices::FinalizeOpenCreditService, type: :service do
 
       expect(SendWebhookJob).to have_been_enqueued.with('invoice.paid_credit_added', result.invoice)
       expect(Invoices::GeneratePdfAndNotifyJob).to have_been_enqueued.with(invoice: result.invoice, email: false)
-      expect(Integrations::Aggregator::Invoices::CreateJob).to have_been_enqueued.with(invoice: result.invoice)
+      expect(Integrations::Aggregator::Invoices::CreateJob).to have_been_enqueued.with(result.invoice)
       expect(SegmentTrackJob).to have_been_enqueued.with(membership_id: anything, event: 'invoice_created', properties: {
         organization_id: result.invoice.organization.id,
         invoice_id: result.invoice.id,


### PR DESCRIPTION
## Context

There is a activejob-uniqueness bug that does not enqueue integration jobs when using named arguments.
This PR fixes that.

