### PR TITLE
Add organization_id to Fee

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -7,6 +7,7 @@ class Fee < ApplicationRecord
   default_scope -> { kept }
 
   belongs_to :invoice, optional: true
+  belongs_to :organization, optional: true, autosave: false
   belongs_to :charge, -> { with_discarded }, optional: true
   belongs_to :add_on, -> { with_discarded }, optional: true
   belongs_to :applied_add_on, optional: true

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -235,6 +235,7 @@ end
 #  group_id                            :uuid
 #  invoice_id                          :uuid
 #  invoiceable_id                      :uuid
+#  organization_id                     :uuid
 #  pay_in_advance_event_id             :uuid
 #  pay_in_advance_event_transaction_id :string
 #  subscription_id                     :uuid
@@ -251,6 +252,7 @@ end
 #  index_fees_on_group_id                             (group_id)
 #  index_fees_on_invoice_id                           (invoice_id)
 #  index_fees_on_invoiceable                          (invoiceable_type,invoiceable_id)
+#  index_fees_on_organization_id                      (organization_id)
 #  index_fees_on_pay_in_advance_event_transaction_id  (pay_in_advance_event_transaction_id) WHERE (deleted_at IS NULL)
 #  index_fees_on_subscription_id                      (subscription_id)
 #  index_fees_on_true_up_parent_fee_id                (true_up_parent_fee_id)
@@ -262,6 +264,7 @@ end
 #  fk_rails_...  (charge_id => charges.id)
 #  fk_rails_...  (group_id => groups.id)
 #  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (subscription_id => subscriptions.id)
 #  fk_rails_...  (true_up_parent_fee_id => fees.id)
 #

--- a/app/services/fees/add_on_service.rb
+++ b/app/services/fees/add_on_service.rb
@@ -15,6 +15,7 @@ module Fees
 
       new_fee = Fee.new(
         invoice:,
+        organization:,
         applied_add_on:,
         amount_cents:,
         precise_amount_cents: amount_cents.to_d,
@@ -44,7 +45,7 @@ module Fees
 
     attr_reader :invoice, :applied_add_on
 
-    delegate :customer, to: :invoice
+    delegate :customer, :organization, to: :invoice
 
     def already_billed?
       existing_fee = invoice.fees.find_by(applied_add_on_id: applied_add_on.id)

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -55,6 +55,7 @@ module Fees
     attr_accessor :invoice, :charge, :subscription, :boundaries, :current_usage, :currency, :cache_middleware
 
     delegate :billable_metric, to: :charge
+    delegate :organization, to: :subscription
     delegate :plan, to: :subscription
 
     def init_fees
@@ -123,6 +124,7 @@ module Fees
 
       new_fee = Fee.new(
         invoice:,
+        organization:,
         subscription:,
         charge:,
         amount_cents:,

--- a/app/services/fees/commitments/minimum/create_service.rb
+++ b/app/services/fees/commitments/minimum/create_service.rb
@@ -22,6 +22,7 @@ module Fees
 
           new_fee = Fee.new(
             invoice:,
+            organization:,
             subscription:,
             fee_type: :commitment,
             invoiceable_type: 'Commitment',
@@ -49,6 +50,7 @@ module Fees
         attr_reader :minimum_commitment, :invoice_subscription
 
         delegate :invoice, :subscription, to: :invoice_subscription
+        delegate :organization, to: :invoice
 
         def invoice_has_minimum_commitment_fee?
           invoice.fees.commitment_kind.where(subscription:).any? { |fee| fee.invoiceable.minimum_commitment? }

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -50,6 +50,7 @@ module Fees
 
     delegate :billable_metric, to: :charge
     delegate :subscription, to: :event
+    delegate :organization, to: :customer
 
     def create_fee(properties:, charge_filter: nil)
       ActiveRecord::Base.transaction do
@@ -63,6 +64,7 @@ module Fees
         fee = Fee.new(
           subscription:,
           charge:,
+          organization:,
           amount_cents: result.amount,
           precise_amount_cents: result.precise_amount,
           amount_currency: subscription.plan.amount_currency,

--- a/app/services/fees/init_from_adjusted_charge_fee_service.rb
+++ b/app/services/fees/init_from_adjusted_charge_fee_service.rb
@@ -23,6 +23,7 @@ module Fees
     attr_reader :adjusted_fee, :boundaries, :properties
 
     delegate :charge, :charge_filter, :invoice, :subscription, to: :adjusted_fee
+    delegate :organization, to: :invoice
 
     def compute_amount
       adjusted_fee_result = BaseService::Result.new
@@ -62,6 +63,7 @@ module Fees
 
       Fee.new(
         invoice:,
+        organization:,
         subscription:,
         charge:,
         amount_cents:,

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -24,6 +24,7 @@ module Fees
 
           fee = Fee.new(
             invoice:,
+            organization:,
             add_on:,
             invoice_display_name: fee[:invoice_display_name].presence,
             description: fee[:description] || add_on.description,
@@ -77,7 +78,7 @@ module Fees
 
     attr_reader :invoice, :fees
 
-    delegate :customer, to: :invoice
+    delegate :customer, :organization, to: :invoice
 
     def add_on(identifier:)
       finder = api_context? ? :code : :id

--- a/app/services/fees/paid_credit_service.rb
+++ b/app/services/fees/paid_credit_service.rb
@@ -20,6 +20,7 @@ module Fees
 
       new_fee = Fee.new(
         invoice:,
+        organization:,
         fee_type: :credit,
         invoiceable_type: 'WalletTransaction',
         invoiceable: wallet_transaction,
@@ -47,6 +48,7 @@ module Fees
     private
 
     attr_reader :invoice, :wallet_transaction, :customer
+    delegate :organization, to: :customer
 
     def already_billed?
       existing_fee = invoice.fees.find_by(invoiceable_id: wallet_transaction.id, invoiceable_type: 'WalletTransaction')

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -32,12 +32,13 @@ module Fees
 
     attr_reader :invoice, :subscription, :boundaries
 
-    delegate :customer, to: :invoice
+    delegate :customer, :organization, to: :invoice
     delegate :previous_subscription, :plan, to: :subscription
 
     def initialize_fee(new_amount_cents, new_precise_amount_cents)
       base_fee = Fee.new(
         invoice:,
+        organization:,
         subscription:,
         amount_cents: new_amount_cents,
         precise_amount_cents: new_precise_amount_cents.to_d,

--- a/db/migrate/20241122104537_add_organization_id_to_fees.rb
+++ b/db/migrate/20241122104537_add_organization_id_to_fees.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToFees < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :fees, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20241122105133_add_organization_id_fk_to_fees.rb
+++ b/db/migrate/20241122105133_add_organization_id_fk_to_fees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToFees < ActiveRecord::Migration[7.1]
+  def change
+    add_foreign_key :fees, :organizations, validate: false
+  end
+end

--- a/db/migrate/20241122105327_validate_fees_organizations_foreign_key.rb
+++ b/db/migrate/20241122105327_validate_fees_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateFeesOrganizationsForeignKey < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :fees, :organizations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+
 ActiveRecord::Schema[7.1].define(version: 2024_11_25_194753) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -646,6 +647,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_25_194753) do
     t.decimal "precise_amount_cents", precision: 40, scale: 15, default: "0.0", null: false
     t.decimal "taxes_precise_amount_cents", precision: 40, scale: 15, default: "0.0", null: false
     t.float "taxes_base_rate", default: 1.0, null: false
+    t.uuid "organization_id"
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_filter_id"], name: "index_fees_on_charge_filter_id"
@@ -655,6 +657,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_25_194753) do
     t.index ["group_id"], name: "index_fees_on_group_id"
     t.index ["invoice_id"], name: "index_fees_on_invoice_id"
     t.index ["invoiceable_type", "invoiceable_id"], name: "index_fees_on_invoiceable"
+    t.index ["organization_id"], name: "index_fees_on_organization_id"
     t.index ["pay_in_advance_event_transaction_id"], name: "index_fees_on_pay_in_advance_event_transaction_id", where: "(deleted_at IS NULL)"
     t.index ["subscription_id"], name: "index_fees_on_subscription_id"
     t.index ["true_up_parent_fee_id"], name: "index_fees_on_true_up_parent_fee_id"
@@ -1354,6 +1357,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_25_194753) do
   add_foreign_key "fees", "fees", column: "true_up_parent_fee_id"
   add_foreign_key "fees", "groups"
   add_foreign_key "fees", "invoices"
+  add_foreign_key "fees", "organizations"
   add_foreign_key "fees", "subscriptions"
   add_foreign_key "fees_taxes", "fees"
   add_foreign_key "fees_taxes", "taxes"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema[7.1].define(version: 2024_11_25_194753) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
     fee_type { 'subscription' }
     subscription
 
+    organization { invoice&.organization || build(:organization) }
+
     amount_cents { 200 }
     precise_amount_cents { 200.0000000001 }
     amount_currency { 'EUR' }

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -8,7 +8,9 @@ FactoryBot.define do
     fee_type { 'subscription' }
     subscription
 
-    organization { invoice&.organization || build(:organization) }
+    after(:create) do |fee, context|
+      fee.organization = fee.invoice&.organization || fee.subscription&.organization
+    end
 
     amount_cents { 200 }
     precise_amount_cents { 200.0000000001 }

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
 
     let(:timestamp) { Time.zone.now - 1.year }
     let(:started_at) { Time.zone.now - 2.years }
-    let(:fee) { create(:fee, invoice:, subscription:) }
+    let(:fee) { create(:fee, invoice:, subscription:, organization:) }
     let(:plan) { create(:plan, organization:, interval: 'monthly') }
     let(:credit_note) { create(:credit_note, :draft, invoice:) }
     let(:standard_charge) { create(:standard_charge, plan: subscription.plan, charge_model: 'standard') }

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
       create(
         :invoice,
         :draft,
+        organization:,
         customer:,
         subscriptions: [subscription],
         currency: 'EUR',
@@ -23,6 +24,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
     let(:subscription) do
       create(
         :subscription,
+        customer:,
         plan:,
         subscription_at: started_at,
         started_at:,
@@ -32,7 +34,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
 
     let(:timestamp) { Time.zone.now - 1.year }
     let(:started_at) { Time.zone.now - 2.years }
-    let(:fee) { create(:fee, invoice:, subscription:, organization:) }
+    let(:fee) { create(:fee, invoice:, subscription:) }
     let(:plan) { create(:plan, organization:, interval: 'monthly') }
     let(:credit_note) { create(:credit_note, :draft, invoice:) }
     let(:standard_charge) { create(:standard_charge, plan: subscription.plan, charge_model: 'standard') }


### PR DESCRIPTION
## Description

The `from_organization` scope on Fee is rather slow and produces queries that can't be optimized further. To simplify accessing these we're adding `organization_id` column to Fee.

This is the first PR, in which we add the migration and adapt the code to start filling in the organization_id.

Next up: 
- backfilling
- marking the column `not_null`