### PR TITLE
Feat invoice custom sections -  models updates

### DIFF
--- a/app/models/applied_invoice_custom_section.rb
+++ b/app/models/applied_invoice_custom_section.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AppliedInvoiceCustomSection < ApplicationRecord
+  belongs_to :invoice
+end

--- a/app/models/applied_invoice_custom_section.rb
+++ b/app/models/applied_invoice_custom_section.rb
@@ -3,3 +3,25 @@
 class AppliedInvoiceCustomSection < ApplicationRecord
   belongs_to :invoice
 end
+
+# == Schema Information
+#
+# Table name: applied_invoice_custom_sections
+#
+#  id           :uuid             not null, primary key
+#  code         :string           not null
+#  details      :string
+#  display_name :string
+#  name         :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  invoice_id   :uuid             not null
+#
+# Indexes
+#
+#  index_applied_invoice_custom_sections_on_invoice_id  (invoice_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (invoice_id => invoices.id)
+#

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -54,6 +54,10 @@ class Customer < ApplicationRecord
   has_many :applied_taxes, class_name: 'Customer::AppliedTax', dependent: :destroy
   has_many :taxes, through: :applied_taxes
 
+  has_many :invoice_custom_sections
+  has_many :invoice_custom_section_selections
+  has_many :selected_invoice_custom_sections, through: :invoice_custom_section_selections, source: :invoice_custom_section
+
   has_one :stripe_customer, class_name: 'PaymentProviderCustomers::StripeCustomer'
   has_one :gocardless_customer, class_name: 'PaymentProviderCustomers::GocardlessCustomer'
   has_one :adyen_customer, class_name: 'PaymentProviderCustomers::AdyenCustomer'

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -38,6 +38,7 @@ class Invoice < ApplicationRecord
 
   has_many :applied_usage_thresholds
   has_many :usage_thresholds, through: :applied_usage_thresholds
+  has_many :applied_invoice_custom_sections
 
   has_one_attached :file
 

--- a/app/models/invoice_custom_section.rb
+++ b/app/models/invoice_custom_section.rb
@@ -6,3 +6,29 @@ class InvoiceCustomSection < ApplicationRecord
 
   belongs_to :organization
 end
+
+# == Schema Information
+#
+# Table name: invoice_custom_sections
+#
+#  id              :uuid             not null, primary key
+#  code            :string           not null
+#  deleted_at      :datetime
+#  description     :string
+#  details         :string
+#  display_name    :string
+#  name            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  idx_on_organization_id_deleted_at_225e3f789d               (organization_id,deleted_at)
+#  index_invoice_custom_sections_on_organization_id           (organization_id)
+#  index_invoice_custom_sections_on_organization_id_and_code  (organization_id,code) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/invoice_custom_section.rb
+++ b/app/models/invoice_custom_section.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class InvoiceCustomSection < ApplicationRecord
+  include Discard::Model
+  self.discard_column = :deleted_at
+
+  belongs_to :organization
+end

--- a/app/models/invoice_custom_section_selection.rb
+++ b/app/models/invoice_custom_section_selection.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class InvoiceCustomSectionSelection < ApplicationRecord
-  belongs_to :ginvoice_custom_section
+  belongs_to :invoice_custom_section
   belongs_to :organization, optional: true
   belongs_to :customer, optional: true
 end

--- a/app/models/invoice_custom_section_selection.rb
+++ b/app/models/invoice_custom_section_selection.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class InvoiceCustomSectionSelection < ApplicationRecord
+  belongs_to :ginvoice_custom_section
+  belongs_to :organization, optional: true
+  belongs_to :customer, optional: true
+end

--- a/app/models/invoice_custom_section_selection.rb
+++ b/app/models/invoice_custom_section_selection.rb
@@ -5,3 +5,27 @@ class InvoiceCustomSectionSelection < ApplicationRecord
   belongs_to :organization, optional: true
   belongs_to :customer, optional: true
 end
+
+# == Schema Information
+#
+# Table name: invoice_custom_section_selections
+#
+#  id                        :uuid             not null, primary key
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  customer_id               :uuid
+#  invoice_custom_section_id :uuid             not null
+#  organization_id           :uuid
+#
+# Indexes
+#
+#  idx_on_invoice_custom_section_id_7edbcef7b5                 (invoice_custom_section_id)
+#  index_invoice_custom_section_selections_on_customer_id      (customer_id)
+#  index_invoice_custom_section_selections_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (invoice_custom_section_id => invoice_custom_sections.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -50,7 +50,9 @@ class Organization < ApplicationRecord
 
   has_one :applied_dunning_campaign, -> { where(applied_to_organization: true) }, class_name: "DunningCampaign"
 
-  has_one :applied_dunning_campaign, -> { where(applied_to_organization: true) }, class_name: "DunningCampaign"
+  has_many :invoice_custom_sections
+  has_many :invoice_custom_section_selections
+  has_many :selected_invoice_custom_sections, through: :invoice_custom_section_selections, source: :invoice_custom_section
 
   has_one_attached :logo
 

--- a/spec/factories/applied_invoice_custom_sections.rb
+++ b/spec/factories/applied_invoice_custom_sections.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :applied_invoice_custom_section do
     invoice
     code { Faker::Lorem.words(number: 3).join('_') }
+    name { Faker::Lorem.words(number: 3).join(' ') }
     display_name { Faker::Lorem.words(number: 3).join(' ') }
     details { 'These details are shown in the invoice' }
   end

--- a/spec/factories/applied_invoice_custom_sections.rb
+++ b/spec/factories/applied_invoice_custom_sections.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :applied_invoice_custom_section do
+    invoice
+    code { Faker::Lorem.words(number: 3).join('_') }
+    display_name { Faker::Lorem.words(number: 3).join(' ') }
+    details { 'These details are shown in the invoice' }
+  end
+end

--- a/spec/factories/applied_invoice_custom_sections.rb
+++ b/spec/factories/applied_invoice_custom_sections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :applied_invoice_custom_section do
     invoice

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -57,5 +57,19 @@ FactoryBot.define do
         create(:salesforce_customer, customer:)
       end
     end
+
+    trait :with_inherited_invoice_custom_sections do
+      organization { create(:organization, :with_invoice_custom_sections) }
+    end
+
+    trait :with_custom_invoice_custom_section_selections do
+      after :create do |customer|
+        customer.invoice_custom_section_selections = create_list(:invoice_custom_section, 3, organization: customer.organization)
+      end
+    end
+
+    trait :with_skipped_invoice_custom_section_selections do
+      skip_invoice_custom_sections { true }
+    end
   end
 end

--- a/spec/factories/invoice_custom_sections.rb
+++ b/spec/factories/invoice_custom_sections.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :invoice_custom_section do
     organization
     code { Faker::Lorem.words(number: 3).join('_') }
+    name { Faker::Lorem.words(number: 3).join(' ') }
     display_name { Faker::Lorem.words(number: 3).join(' ') }
     details { 'These details are shown in the invoice' }
   end

--- a/spec/factories/invoice_custom_sections.rb
+++ b/spec/factories/invoice_custom_sections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :invoice_custom_section do
     organization

--- a/spec/factories/invoice_custom_sections.rb
+++ b/spec/factories/invoice_custom_sections.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :invoice_custom_section do
+    organization
+    code { Faker::Lorem.words(number: 3).join('_') }
+    display_name { Faker::Lorem.words(number: 3).join(' ') }
+    details { 'These details are shown in the invoice' }
+  end
+end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -19,5 +19,15 @@ FactoryBot.define do
         organization.webhook_endpoints.create!(webhook_url: evaluator.webhook_url)
       end
     end
+
+    trait :with_invoice_custom_sections do
+      after :create do |org|
+        sections = []
+        3.times do
+          sections << create(:invoice_custom_section, organization: org)
+        end
+        org.invoice_custom_section_selections = sections
+      end
+    end
   end
 end

--- a/spec/models/applied_invoice_custom_section_spec.rb
+++ b/spec/models/applied_invoice_custom_section_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe AppliedInvoiceCustomSection, type: :model do
+  subject(:applied_invoice_custom_section) { create(:applied_invoice_custom_section) }
+
+  it { is_expected.to belong_to(:invoice) }
+end

--- a/spec/models/applied_invoice_custom_section_spec.rb
+++ b/spec/models/applied_invoice_custom_section_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AppliedInvoiceCustomSection, type: :model do

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe Customer, type: :model do
   it { is_expected.to have_one(:hubspot_customer) }
   it { is_expected.to have_one(:salesforce_customer) }
 
+  it { is_expected.to have_many(:invoice_custom_section_selections) }
+  it { is_expected.to have_many(:selected_invoice_custom_sections) }
+
   it 'sets the default value to inherit' do
     expect(customer.finalize_zero_amount_invoice).to eq "inherit"
   end

--- a/spec/models/invoice_custom_section_spec.rb
+++ b/spec/models/invoice_custom_section_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe InvoiceCustomSection, type: :model do
+  subject(:invoice_custom_section) { create(:invoice_custom_section) }
+
+  it { is_expected.to belong_to(:organization) }
+end

--- a/spec/models/invoice_custom_section_spec.rb
+++ b/spec/models/invoice_custom_section_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe InvoiceCustomSection, type: :model do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:data_exports) }
   it { is_expected.to have_many(:dunning_campaigns) }
   it { is_expected.to have_many(:daily_usages) }
+  it { is_expected.to have_many(:invoice_custom_sections) }
+  it { is_expected.to have_many(:invoice_custom_sections_selections) }
+  it { is_expected.to have_many(:selected_custom_sections_selections) }
 
   it { is_expected.to have_one(:applied_dunning_campaign).conditions(applied_to_organization: true) }
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:dunning_campaigns) }
   it { is_expected.to have_many(:daily_usages) }
   it { is_expected.to have_many(:invoice_custom_sections) }
-  it { is_expected.to have_many(:invoice_custom_sections_selections) }
-  it { is_expected.to have_many(:selected_custom_sections_selections) }
+  it { is_expected.to have_many(:invoice_custom_section_selections) }
+  it { is_expected.to have_many(:selected_invoice_custom_sections) }
 
   it { is_expected.to have_one(:applied_dunning_campaign).conditions(applied_to_organization: true) }
 


### PR DESCRIPTION
## Context

In order to save invoice custom sections, we need to make create new models related to the new tables

## Description

Added 
- InvoiceCustomSection
- AppliedInvoiceCustomSection
- InvoiceCustomSectionSelection

Updated
- Organization
- Customer
