### PR TITLE
feat(dunning): reset customer dunning campaign last attempt data on threshold changes

### DIFF
--- a/app/models/dunning_campaign_threshold.rb
+++ b/app/models/dunning_campaign_threshold.rb
@@ -10,7 +10,7 @@ class DunningCampaignThreshold < ApplicationRecord
 
   validates :amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :currency, inclusion: {in: currency_list}
-  validates :currency, uniqueness: {scope: :dunning_campaign_id, conditions: -> { where(deleted_at: nil) } }
+  validates :currency, uniqueness: {scope: :dunning_campaign_id, conditions: -> { where(deleted_at: nil) }}
 
   default_scope -> { kept }
 end

--- a/app/models/dunning_campaign_threshold.rb
+++ b/app/models/dunning_campaign_threshold.rb
@@ -10,7 +10,7 @@ class DunningCampaignThreshold < ApplicationRecord
 
   validates :amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :currency, inclusion: {in: currency_list}
-  validates :currency, uniqueness: {scope: :dunning_campaign_id}, unless: :deleted_at
+  validates :currency, uniqueness: {scope: :dunning_campaign_id, conditions: -> { where(deleted_at: nil) } }
 
   default_scope -> { kept }
 end

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -15,7 +15,7 @@ module DunningCampaigns
       return result.not_found_failure!(resource: "dunning_campaign") unless dunning_campaign
 
       ActiveRecord::Base.transaction do
-        update_dunning_campaign_attributes
+        dunning_campaign.assign_attributes(permitted_attributes)
         handle_thresholds if params.key?(:thresholds)
         handle_applied_to_organization_update if params.key?(:applied_to_organization)
 
@@ -31,10 +31,6 @@ module DunningCampaigns
     private
 
     attr_reader :dunning_campaign, :organization, :params
-
-    def update_dunning_campaign_attributes
-      dunning_campaign.assign_attributes(permitted_attributes)
-    end
 
     def permitted_attributes
       params.slice(:name, :code, :description, :days_between_attempts, :max_attempts)
@@ -78,7 +74,6 @@ module DunningCampaigns
         .customers
         .falling_back_to_default_dunning_campaign
         .with_dunning_campaign_not_completed
-        .where(dunning_campaign.applied_to_organization ? nil : "1 = 0")
 
       customers_to_reset = customers_applied_campaign.or(customers_fallback_campaign)
 

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -55,7 +55,7 @@ module DunningCampaigns
           id: threshold_input[:id]
         )
 
-        threshold.assign_attributes(threshold_input.slice(:amount_cents, :currency))
+        threshold.assign_attributes(threshold_input.to_h.slice(:amount_cents, :currency))
 
         thresholds_updated ||= threshold.changed? && threshold.persisted?
         threshold.save!

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -81,8 +81,9 @@ module DunningCampaigns
         .where(invoices: {payment_overdue: true})
         .group("customers.id")
         .having(
-          "customers.currency != ? OR SUM(invoices.total_amount_cents) < ?",
-          threshold.currency, threshold.amount_cents
+          "customers.currency != :currency OR SUM(invoices.total_amount_cents) < :amount_cents",
+          amount_cents: threshold.amount_cents,
+          currency: threshold.currency
         )
         .update_all( # rubocop:disable Rails/SkipsModelValidations
           last_dunning_campaign_attempt: 0,

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -79,7 +79,7 @@ module DunningCampaigns
 
       customers_to_reset
         .includes(:invoices)
-        .where(invoices: {payment_overdue: true}).each do |customer|
+        .where(invoices: {payment_overdue: true}).find_each do |customer|
           threshold_matches = dunning_campaign.thresholds.any? do |threshold|
             threshold.currency == customer.currency &&
               customer.overdue_balance_cents >= threshold.amount_cents

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -65,10 +65,10 @@ module DunningCampaigns
         threshold.save!
       end
 
-      reset_customers_for_threshold if thresholds_updated
+      reset_customers_if_no_threshold_match if thresholds_updated
     end
 
-    def reset_customers_for_threshold
+    def reset_customers_if_no_threshold_match
       customers_applied_campaign = organization
         .customers
         .with_dunning_campaign_not_completed

--- a/spec/models/dunning_campaign_threshold_spec.rb
+++ b/spec/models/dunning_campaign_threshold_spec.rb
@@ -18,15 +18,14 @@ RSpec.describe DunningCampaignThreshold, type: :model do
     let(:dunning_campaign) { create(:dunning_campaign) }
 
     it "validates uniqueness of currency scoped to dunning_campaign_id excluding deleted records" do
-      create(:dunning_campaign_threshold, currency:, dunning_campaign:)
+      existing_record = create(:dunning_campaign_threshold, currency:, dunning_campaign:)
       new_record = build(:dunning_campaign_threshold, currency:, dunning_campaign:)
 
       expect(new_record).not_to be_valid
       expect(new_record.errors[:currency]).to include("value_already_exist")
 
-      # Records with deleted_at set should not conflict
-      deleted_record = create(:dunning_campaign_threshold, :deleted, currency:, dunning_campaign:)
-      expect(deleted_record).to be_valid
+      existing_record.discard
+      expect(new_record).to be_valid
     end
   end
 

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -79,6 +79,40 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           ]
         end
 
+        let(:customer_completed) do
+          create(
+            :customer,
+            currency: dunning_campaign_threshold.currency,
+            applied_dunning_campaign: dunning_campaign,
+            last_dunning_campaign_attempt: 4,
+            last_dunning_campaign_attempt_at: 1.day.ago,
+            dunning_campaign_completed: true,
+            organization: organization
+          )
+        end
+        let(:customer_defaulting) do
+          create(
+            :customer,
+            currency: dunning_campaign_threshold.currency,
+            applied_dunning_campaign: nil,
+            last_dunning_campaign_attempt: 4,
+            last_dunning_campaign_attempt_at: 1.day.ago,
+            dunning_campaign_completed: false,
+            organization: organization
+          )
+        end
+        let(:customer_assigned) do
+          create(
+            :customer,
+            currency: dunning_campaign_threshold.currency,
+            applied_dunning_campaign: dunning_campaign,
+            last_dunning_campaign_attempt: 4,
+            last_dunning_campaign_attempt_at: 1.day.ago,
+            dunning_campaign_completed: false,
+            organization: organization
+          )
+        end
+
         it "updates the dunning campaign" do
           expect(result).to be_success
           expect(result.dunning_campaign.name).to eq(params[:name])
@@ -101,8 +135,8 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           it "resets the customer's dunning campaign fields" do
             expect { result && customer.reload }
-              .to change { customer.last_dunning_campaign_attempt }.to(0)
-              .and change { customer.last_dunning_campaign_attempt_at }.to(nil)
+              .to change(customer, :last_dunning_campaign_attempt).to(0)
+              .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
 
             expect(result).to be_success
           end
@@ -120,42 +154,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
             expect(result).to be_success
           end
-        end
-
-        let(:customer_assigned) do
-          create(
-            :customer,
-            currency: dunning_campaign_threshold.currency,
-            applied_dunning_campaign: dunning_campaign,
-            last_dunning_campaign_attempt: 4,
-            last_dunning_campaign_attempt_at: 1.day.ago,
-            dunning_campaign_completed: false,
-            organization: organization
-          )
-        end
-
-        let(:customer_defaulting) do
-          create(
-            :customer,
-            currency: dunning_campaign_threshold.currency,
-            applied_dunning_campaign: nil,
-            last_dunning_campaign_attempt: 4,
-            last_dunning_campaign_attempt_at: 1.day.ago,
-            dunning_campaign_completed: false,
-            organization: organization
-          )
-        end
-
-        let(:customer_completed) do
-          create(
-            :customer,
-            currency: dunning_campaign_threshold.currency,
-            applied_dunning_campaign: dunning_campaign,
-            last_dunning_campaign_attempt: 4,
-            last_dunning_campaign_attempt_at: 1.day.ago,
-            dunning_campaign_completed: true,
-            organization: organization
-          )
         end
 
         context "when threshold amount_cents changes and does not apply anymore to the customer" do
@@ -343,7 +341,7 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
             [
               {
                 amount_cents: threshold_amount_cents,
-                currency: dunning_campaign_threshold.currency 
+                currency: dunning_campaign_threshold.currency
               }
             ]
           end

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -267,7 +267,37 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           end
         end
 
-        xcontext "when threshold currency changes but it still applies to the customer" do
+        context "when threshold currency changes but it still applies to the customer" do
+          let(:thresholds_input) do
+            [
+              {
+                id: not_matching_threshold.id,
+                amount_cents: 999_99,
+                currency: "GBP"
+              },
+              {
+                id: dunning_campaign_threshold.id,
+                amount_cents: dunning_campaign_threshold.amount_cents,
+                currency: dunning_campaign_threshold.currency
+              }
+            ]
+          end
+
+          let(:not_matching_threshold) do
+            create(:dunning_campaign_threshold, dunning_campaign:, currency: "CHF")
+          end
+
+          before do
+            create(
+              :invoice,
+              organization:,
+              customer:,
+              payment_overdue: true,
+              total_amount_cents: dunning_campaign_threshold.amount_cents + 1,
+              currency: dunning_campaign_threshold.currency
+            )
+          end
+
           context "when the campaign is assigned to the customer" do
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_assigned
           end


### PR DESCRIPTION
## Roadmap

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We are extending dunning campaigns management to edit and delete campaigns.

 ## Description

When a dunning campaign threshold changes, it resets customers last_dunning_campaign_attempt fields with the updated campaign applicable (through direct association or falling back to it through the organization default) when the thresholds does not match anymore (currency and/or amount_cents changed or deletion of the threshold).