### PR TITLE
Bug(Events) - make sure to cleanup clickhouse events after billable metric removal

### DIFF
--- a/app/jobs/billable_metrics/delete_events_job.rb
+++ b/app/jobs/billable_metrics/delete_events_job.rb
@@ -25,6 +25,23 @@ module BillableMetrics
           .where(billable_metric_id: metric.id)
           .joins(plan: :subscriptions).pluck('subscriptions.external_id')
       ).update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
+
+      # Delete events_raw & events_enriched on clickhouse using `external_subscription_id`
+      Clickhouse::EventsRaw.where(
+        organization_id: metric.organization.id,
+        code: metric.code,
+        external_subscription_id: Charge.with_discarded
+          .where(billable_metric_id: metric.id)
+          .joins(plan: :subscriptions).pluck('subscriptions.external_id')
+      ).delete_all
+
+      Clickhouse::EventsEnriched.where(
+        organization_id: metric.organization.id,
+        code: metric.code,
+        external_subscription_id: Charge.with_discarded
+          .where(billable_metric_id: metric.id)
+          .joins(plan: :subscriptions).pluck('subscriptions.external_id')
+      ).delete_all
     end
   end
 end

--- a/spec/factories/clickhouse/events_enriched.rb
+++ b/spec/factories/clickhouse/events_enriched.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
       subscription { create(:subscription, customer:) }
       customer { create(:customer) }
       organization { customer.organization }
+      billable_metric { create(:billable_metric, organization: organization) }
     end
 
     organization_id { organization.id }

--- a/spec/jobs/billable_metrics/delete_events_job_spec.rb
+++ b/spec/jobs/billable_metrics/delete_events_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BillableMetrics::DeleteEventsJob, type: :job, transaction: false do
+RSpec.describe BillableMetrics::DeleteEventsJob, type: :job, transaction: false, clickhouse: true do
   let(:billable_metric) { create(:billable_metric, :deleted) }
   let(:subscription) { create(:subscription) }
 
@@ -29,6 +29,30 @@ RSpec.describe BillableMetrics::DeleteEventsJob, type: :job, transaction: false 
         .to change { event.reload.deleted_at }.from(nil).to(Time.current)
 
       expect(not_impacted_event.reload.deleted_at).to be_nil
+    end
+  end
+
+  it 'deletes new-style external_subscription based events stored in clickhouse' do
+    create(:standard_charge, plan: subscription.plan, billable_metric:)
+    not_impacted_event = create(:clickhouse_events_raw, external_subscription_id: SecureRandom.uuid, organization_id: billable_metric.organization_id)
+    event = create(:clickhouse_events_raw, code: billable_metric.code, external_subscription_id: subscription.external_id, organization_id: billable_metric.organization_id)
+
+    freeze_time do
+      described_class.perform_now(billable_metric)
+      expect(Clickhouse::EventsRaw.find_by(transaction_id: event.transaction_id)).to eq(nil)
+      expect(Clickhouse::EventsRaw.find_by(transaction_id: not_impacted_event.transaction_id)).not_to eq(nil)
+    end
+  end
+
+  it 'deletes new-style external_subscription based events_enriched stored in clickhouse' do
+    create(:standard_charge, plan: subscription.plan, billable_metric:)
+    not_impacted_event = create(:clickhouse_events_enriched, external_subscription_id: SecureRandom.uuid, organization_id: billable_metric.organization_id)
+    event = create(:clickhouse_events_enriched, code: billable_metric.code, external_subscription_id: subscription.external_id, organization_id: billable_metric.organization_id)
+
+    freeze_time do
+      described_class.perform_now(billable_metric)
+      expect(Clickhouse::EventsEnriched.find_by(transaction_id: event.transaction_id)).to eq(nil)
+      expect(Clickhouse::EventsEnriched.find_by(transaction_id: not_impacted_event.transaction_id)).not_to eq(nil)
     end
   end
 end


### PR DESCRIPTION
## description

We recently fixed the case where events were not correctly removed for new-style subscriptions (using `external_subscription_id`). We forgot about clickhouse events, this PR fixes that and will also remove those. 

