### PR TITLE
feat(dunning): flag customers as dunning campaign completed...

### DIFF
--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -99,7 +99,6 @@ module DunningCampaigns
         .customers
         .falling_back_to_default_dunning_campaign
         .with_dunning_campaign_not_completed
-        .where(dunning_campaign.applied_to_organization ? nil : "1 = 0")
     end
 
     def handle_applied_to_organization_update

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -119,7 +119,7 @@ module DunningCampaigns
       # we assume there is matching threshold at this point or it was reseted
       customers_to_reset
         .where("last_dunning_campaign_attempt >= ?", dunning_campaign.max_attempts)
-        .update_all(dunning_campaign_completed: true)
+        .update_all(dunning_campaign_completed: true) # rubocop:disable Rails/SkipsModelValidations
     end
   end
 end

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -128,6 +128,105 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
             .to have_attributes({amount_cents: 5_55, currency: "CHF"})
         end
 
+        context "when max_attempts is changed and some customers exceed it" do
+          let(:params) { {max_attempts: 3} }
+
+          before do
+            create(
+              :invoice,
+              organization:,
+              customer:,
+              payment_overdue: true,
+              total_amount_cents: dunning_campaign_threshold.amount_cents,
+              currency: dunning_campaign_threshold.currency
+            )
+          end
+
+          context "when the campaign is applied to the customer" do
+            let(:dunning_campaign) do
+              create(:dunning_campaign, organization:, applied_to_organization: false)
+            end
+
+            let(:customer) do
+              create(
+                :customer,
+                currency: dunning_campaign_threshold.currency,
+                applied_dunning_campaign: dunning_campaign,
+                last_dunning_campaign_attempt: 3,
+                last_dunning_campaign_attempt_at: 1.day.ago,
+                dunning_campaign_completed: false,
+                organization: organization
+              )
+            end
+
+            before { customer }
+
+            it "sets dunning_campaign_completed to true for customers whose last_dunning_campaign_attempt exceeds max_attempts" do
+              expect { result && customer.reload }
+                .to change { customer.dunning_campaign_completed }.to true
+            end
+
+            it "does not update customers whose last_dunning_campaign_attempt is within the new max_attempts" do
+              another_customer = create(
+                :customer,
+                currency: dunning_campaign_threshold.currency,
+                applied_dunning_campaign: dunning_campaign,
+                last_dunning_campaign_attempt: 2,
+                last_dunning_campaign_attempt_at: 1.day.ago,
+                dunning_campaign_completed: false,
+                organization: organization
+              )
+
+              expect { result && another_customer.reload }
+                .not_to change { another_customer.dunning_campaign_completed }
+
+              expect(result).to be_success
+            end
+          end
+
+          context "when the customer falls back to the campaign through the organization" do
+            let(:customer) do
+              create(
+                :customer,
+                currency: dunning_campaign_threshold.currency,
+                applied_dunning_campaign: nil,
+                last_dunning_campaign_attempt: 4,
+                last_dunning_campaign_attempt_at: 1.day.ago,
+                dunning_campaign_completed: false,
+                organization: organization
+              )
+            end
+
+            let(:dunning_campaign) do
+              create(:dunning_campaign, organization:, applied_to_organization: true)
+            end
+
+            before { customer }
+
+            it "sets dunning_campaign_completed to true for customers whose last_dunning_campaign_attempt exceeds max_attempts" do
+              expect { result && customer.reload }
+                .to change { customer.dunning_campaign_completed }.to true
+            end
+
+            it "does not update customers whose last_dunning_campaign_attempt is within the new max_attempts" do
+              another_customer = create(
+                :customer,
+                currency: dunning_campaign_threshold.currency,
+                applied_dunning_campaign: dunning_campaign,
+                last_dunning_campaign_attempt: 2,
+                last_dunning_campaign_attempt_at: 1.day.ago,
+                dunning_campaign_completed: false,
+                organization: organization
+              )
+
+              expect { result && another_customer.reload }
+                .not_to change { another_customer.dunning_campaign_completed }
+
+              expect(result).to be_success
+            end
+          end
+        end
+
         shared_examples "resets customer last dunning campaign attempt fields" do |customer_name|
           let(:customer) { send(customer_name) }
 
@@ -181,6 +280,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           end
 
           context "when the campaign is assigned to the customer" do
+            let(:dunning_campaign) do
+              create(:dunning_campaign, organization:, applied_to_organization: false)
+            end
+
             include_examples "resets customer last dunning campaign attempt fields", :customer_assigned
           end
 
@@ -216,6 +319,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           end
 
           context "when the campaign is assigned to the customer" do
+            let(:dunning_campaign) do
+              create(:dunning_campaign, organization:, applied_to_organization: false)
+            end
+
             include_examples "resets customer last dunning campaign attempt fields", :customer_assigned
           end
 
@@ -253,6 +360,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           end
 
           context "when the campaign is assigned to the customer" do
+            let(:dunning_campaign) do
+              create(:dunning_campaign, organization:, applied_to_organization: false)
+            end
+
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_assigned
           end
 
@@ -297,6 +408,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           end
 
           context "when the campaign is assigned to the customer" do
+            let(:dunning_campaign) do
+              create(:dunning_campaign, organization:, applied_to_organization: false)
+            end
+
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_assigned
           end
 
@@ -324,6 +439,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           end
 
           context "when the campaign is assigned to the customer" do
+            let(:dunning_campaign) do
+              create(:dunning_campaign, organization:, applied_to_organization: false)
+            end
+
             include_examples "resets customer last dunning campaign attempt fields", :customer_assigned
           end
 
@@ -360,6 +479,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           end
 
           context "when the campaign is assigned to the customer" do
+            let(:dunning_campaign) do
+              create(:dunning_campaign, organization:, applied_to_organization: false)
+            end
+
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_assigned
           end
 

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
             it "sets dunning_campaign_completed to true for customers whose last_dunning_campaign_attempt exceeds max_attempts" do
               expect { result && customer.reload }
-                .to change { customer.dunning_campaign_completed }.to true
+                .to change(customer, :dunning_campaign_completed).to true
             end
 
             it "does not update customers whose last_dunning_campaign_attempt is within the new max_attempts" do
@@ -205,7 +205,7 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
             it "sets dunning_campaign_completed to true for customers whose last_dunning_campaign_attempt exceeds max_attempts" do
               expect { result && customer.reload }
-                .to change { customer.dunning_campaign_completed }.to true
+                .to change(customer, :dunning_campaign_completed).to true
             end
 
             it "does not update customers whose last_dunning_campaign_attempt is within the new max_attempts" do


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We are extending dunning campaigns management to edit and delete campaigns.

 ## Description

When a dunning campaign max attempts decreases, flag customers as dunning campaign completed when last dunning campaign attempt is greater or equal than the new campaign max attempts value.