### PR TITLE
feat(dunning): Populate dunning_campaign_completed on existing customers

### DIFF
--- a/db/migrate/20241126102447_set_dunning_campaign_completed_to_customers.rb
+++ b/db/migrate/20241126102447_set_dunning_campaign_completed_to_customers.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class SetDunningCampaignCompletedToCustomers < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        safety_assured do
+          # Set dunning_campaign_completed when the explicit assigned campaign is completed.
+          execute <<-SQL
+            UPDATE customers c
+            SET dunning_campaign_completed = true
+            FROM dunning_campaigns dc
+            WHERE c.applied_dunning_campaign_id = dc.id
+            AND c.dunning_campaign_completed = false
+            AND c.last_dunning_campaign_attempt >= dc.max_attempts;
+          SQL
+
+          # Set dunning_campaign_completed when the campaign inherited from organization is completed.
+          execute <<-SQL
+            UPDATE customers c
+            SET dunning_campaign_completed = true
+            FROM dunning_campaigns dc
+            WHERE c.organization_id = dc.organization_id
+            AND dc.applied_to_organization = true
+            AND c.applied_dunning_campaign_id IS NULL
+            AND c.dunning_campaign_completed = false
+            AND c.exclude_from_dunning_campaign = false
+            AND c.last_dunning_campaign_attempt >= dc.max_attempts;
+          SQL
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We are extending dunning campaigns management to edit and delete campaigns.

 ## Description

The goal of this PR is to set `dunning_campaign_completed: true` to customers when existing dunning campaigns are considered as completed.
