### PR TITLE
feat(dunning): unflag customers as dunning campaign completed...

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -72,6 +72,7 @@ class Customer < ApplicationRecord
   scope :falling_back_to_default_dunning_campaign, -> {
     where(applied_dunning_campaign_id: nil, exclude_from_dunning_campaign: false)
   }
+  scope :with_dunning_campaign_completed, -> { where(dunning_campaign_completed: true) }
   scope :with_dunning_campaign_not_completed, -> { where(dunning_campaign_completed: false) }
 
   validates :country, :shipping_country, country_code: true, allow_nil: true

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -84,21 +84,17 @@ module DunningCampaigns
     end
 
     def customers_to_reset
-      @customers_to_reset ||= customers_applied_campaign.or(customers_fallback_campaign)
+      @customers_to_reset ||= customers_applied_campaign
+        .or(customers_fallback_campaign)
+        .with_dunning_campaign_not_completed
     end
 
     def customers_applied_campaign
-      organization
-        .customers
-        .with_dunning_campaign_not_completed
-        .where(applied_dunning_campaign: dunning_campaign)
+      organization.customers.where(applied_dunning_campaign: dunning_campaign)
     end
 
     def customers_fallback_campaign
-      organization
-        .customers
-        .falling_back_to_default_dunning_campaign
-        .with_dunning_campaign_not_completed
+      organization.customers.falling_back_to_default_dunning_campaign
     end
 
     def handle_applied_to_organization_update
@@ -112,6 +108,12 @@ module DunningCampaigns
         .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
 
       organization.reset_customers_last_dunning_campaign_attempt
+
+      customers_fallback_campaign.update_all(
+        dunning_campaign_completed: false,
+        last_dunning_campaign_attempt_at: nil,
+        last_dunning_campaign_attempt: 0
+      )
     end
 
     def handle_max_attempts_change

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -109,7 +109,7 @@ module DunningCampaigns
 
       organization.reset_customers_last_dunning_campaign_attempt
 
-      customers_fallback_campaign.update_all(
+      customers_fallback_campaign.update_all( # rubocop:disable Rails/SkipsModelValidations
         dunning_campaign_completed: false,
         last_dunning_campaign_attempt_at: nil,
         last_dunning_campaign_attempt: 0

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -554,6 +554,21 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
             expect { result }.to change { customer.reload.last_dunning_campaign_attempt }.from(1).to(0)
               .and change { customer.last_dunning_campaign_attempt_at }.from(a_value).to(nil)
           end
+
+          it "flags customers as not dunning campaign completed" do
+            customer = create(
+              :customer,
+              organization:,
+              dunning_campaign_completed: true,
+              last_dunning_campaign_attempt: 3,
+              last_dunning_campaign_attempt_at: Time.zone.now
+            )
+
+            expect { result && customer.reload }
+              .to change(customer, :dunning_campaign_completed).to(false)
+              .and change(customer, :last_dunning_campaign_attempt).to(0)
+              .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
+          end
         end
 
         context "with no dunning campaign record" do


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We are extending dunning campaigns management to edit and delete campaigns.

 ## Description

When dunning campaign applied to organization flag changes, all customers falling back to the organization's default campaign with a campaign completed will be reseted as not completed, attempts counter will be set to 0 and last attempt timestamp to nil.