### PR TITLE
feat(dunning): Dunning Campaign processing skip customers completed

### DIFF
--- a/app/services/dunning_campaigns/bulk_process_service.rb
+++ b/app/services/dunning_campaigns/bulk_process_service.rb
@@ -16,6 +16,7 @@ module DunningCampaigns
 
     def eligible_customers
       Customer
+        .with_dunning_campaign_not_completed
         .joins(:organization)
         .where(exclude_from_dunning_campaign: false)
         .where("organizations.premium_integrations @> ARRAY[?]::varchar[]", ['auto_dunning'])
@@ -30,6 +31,7 @@ module DunningCampaigns
       end
 
       def call
+        return result if customer.dunning_campaign_completed?
         return result unless threshold
         return result if max_attempts_reached?
         return result unless days_between_attempts_satisfied?

--- a/spec/services/dunning_campaigns/bulk_process_service_spec.rb
+++ b/spec/services/dunning_campaigns/bulk_process_service_spec.rb
@@ -65,6 +65,17 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
             .with(customer:, dunning_campaign_threshold:)
         end
 
+        context "when the customer has completed the dunning campaign" do
+          let(:customer) do
+            create :customer, organization:, currency:, dunning_campaign_completed: true
+          end
+
+          it "does not queue a job for the customer" do
+            result
+            expect(DunningCampaigns::ProcessAttemptJob).not_to have_been_enqueued
+          end
+        end
+
         context "when organization does not have auto_dunning feature enabled" do
           let(:organization) { create(:organization, premium_integrations: []) }
 


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We are extending dunning campaigns management to edit and delete campaigns.

 ## Description

On dunning campaign execution skip customers with dunning campaign completed flag set to true.