### PR TITLE
misc: Add deleted_at to index_charges_on_billable_metric_id

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -181,7 +181,7 @@ end
 #
 # Indexes
 #
-#  index_charges_on_billable_metric_id  (billable_metric_id)
+#  index_charges_on_billable_metric_id  (billable_metric_id) WHERE (deleted_at IS NULL)
 #  index_charges_on_deleted_at          (deleted_at)
 #  index_charges_on_parent_id           (parent_id)
 #  index_charges_on_plan_id             (plan_id)

--- a/db/migrate/20241126141853_update_index_charges_on_billable_metric_id.rb
+++ b/db/migrate/20241126141853_update_index_charges_on_billable_metric_id.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class UpdateIndexChargesOnBillableMetricId < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :charges, %i[billable_metric_id], algorithm: :concurrently
+
+    add_index :charges,
+      %i[billable_metric_id],
+      algorithm: :concurrently,
+      where: "deleted_at IS NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_25_194753) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_26_141853) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -259,7 +259,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_25_194753) do
     t.string "invoice_display_name"
     t.integer "regroup_paid_fees"
     t.uuid "parent_id"
-    t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id"
+    t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id", where: "(deleted_at IS NULL)"
     t.index ["deleted_at"], name: "index_charges_on_deleted_at"
     t.index ["parent_id"], name: "index_charges_on_parent_id"
     t.index ["plan_id"], name: "index_charges_on_plan_id"


### PR DESCRIPTION
For performance reason, we want to change the existing index `index_charges_on_billable_metric_id` to take into consideration `where deleted_at is null`.

Indeed, when fetching a single subscription, the request is now using this index.