### PR TITLE
feat(dunning): Assign dunning campaign when creating a payment request

### DIFF
--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -11,6 +11,7 @@ class DunningCampaign < ApplicationRecord
 
   has_many :thresholds, class_name: "DunningCampaignThreshold", dependent: :destroy
   has_many :customers, foreign_key: :applied_dunning_campaign_id, dependent: :nullify
+  has_many :payment_requests, dependent: :nullify
 
   accepts_nested_attributes_for :thresholds
 

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -50,15 +50,18 @@ end
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  customer_id                  :uuid             not null
+#  dunning_campaign_id          :uuid
 #  organization_id              :uuid             not null
 #
 # Indexes
 #
-#  index_payment_requests_on_customer_id      (customer_id)
-#  index_payment_requests_on_organization_id  (organization_id)
+#  index_payment_requests_on_customer_id          (customer_id)
+#  index_payment_requests_on_dunning_campaign_id  (dunning_campaign_id)
+#  index_payment_requests_on_organization_id      (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (dunning_campaign_id => dunning_campaigns.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -9,6 +9,7 @@ class PaymentRequest < ApplicationRecord
 
   belongs_to :organization
   belongs_to :customer, -> { with_discarded }
+  belongs_to :dunning_campaign, -> { with_discarded }, optional: true
 
   validates :amount_cents, presence: true
   validates :amount_currency, presence: true

--- a/app/services/dunning_campaigns/process_attempt_service.rb
+++ b/app/services/dunning_campaigns/process_attempt_service.rb
@@ -24,7 +24,8 @@ module DunningCampaigns
           params: {
             external_customer_id: customer.external_id,
             lago_invoice_ids: overdue_invoices.pluck(:id)
-          }
+          },
+          dunning_campaign:
         ).raise_if_error!
 
         customer.increment(:last_dunning_campaign_attempt)

--- a/app/services/payment_requests/create_service.rb
+++ b/app/services/payment_requests/create_service.rb
@@ -2,9 +2,10 @@
 
 module PaymentRequests
   class CreateService < BaseService
-    def initialize(organization:, params:)
+    def initialize(organization:, params:, dunning_campaign: nil)
       @organization = organization
       @params = params
+      @dunning_campaign = dunning_campaign
 
       super
     end
@@ -16,6 +17,7 @@ module PaymentRequests
       payment_request = ActiveRecord::Base.transaction do
         customer.payment_requests.create!(
           organization:,
+          dunning_campaign:,
           amount_cents: invoices.sum(:total_amount_cents),
           amount_currency: currency,
           email:,
@@ -37,7 +39,7 @@ module PaymentRequests
 
     private
 
-    attr_reader :organization, :params
+    attr_reader :organization, :params, :dunning_campaign
 
     def check_preconditions
       # NOTE: Prevent creation of payment request if:

--- a/db/migrate/20241126103448_add_dunning_campaign_id_to_payment_requests.rb
+++ b/db/migrate/20241126103448_add_dunning_campaign_id_to_payment_requests.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddDunningCampaignIdToPaymentRequests < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      add_reference :payment_requests, :dunning_campaign, type: :uuid, foreign_key: true, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1033,7 +1033,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_26_141853) do
     t.integer "payment_status", default: 0, null: false
     t.integer "payment_attempts", default: 0, null: false
     t.boolean "ready_for_payment_processing", default: true, null: false
+    t.uuid "dunning_campaign_id"
     t.index ["customer_id"], name: "index_payment_requests_on_customer_id"
+    t.index ["dunning_campaign_id"], name: "index_payment_requests_on_dunning_campaign_id"
     t.index ["organization_id"], name: "index_payment_requests_on_organization_id"
   end
 
@@ -1392,6 +1394,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_26_141853) do
   add_foreign_key "payment_provider_customers", "payment_providers"
   add_foreign_key "payment_providers", "organizations"
   add_foreign_key "payment_requests", "customers"
+  add_foreign_key "payment_requests", "dunning_campaigns"
   add_foreign_key "payment_requests", "organizations"
   add_foreign_key "payments", "invoices"
   add_foreign_key "payments", "payment_providers"

--- a/spec/models/dunning_campaign_spec.rb
+++ b/spec/models/dunning_campaign_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe DunningCampaign, type: :model do
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to have_many(:thresholds).dependent(:destroy) }
   it { is_expected.to have_many(:customers).dependent(:nullify) }
+  it { is_expected.to have_many(:payment_requests).dependent(:nullify) }
 
   it { is_expected.to validate_presence_of(:name) }
 

--- a/spec/models/payment_request_spec.rb
+++ b/spec/models/payment_request_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe PaymentRequest, type: :model do
 
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:customer) }
+  it { is_expected.to belong_to(:dunning_campaign).optional }
 
   describe "Validations" do
     it "is valid with valid attributes" do

--- a/spec/services/dunning_campaigns/process_attempt_service_spec.rb
+++ b/spec/services/dunning_campaigns/process_attempt_service_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe DunningCampaigns::ProcessAttemptService, type: :service, aggregat
           params: {
             external_customer_id: customer.external_id,
             lago_invoice_ids: [invoice_2.id]
-          }
+          },
+          dunning_campaign:
         )
     end
 

--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
         allow(License).to receive(:premium?).and_return(false)
       end
 
-      it "returns forbidden failure", :aggregate_failures do
+      it "returns forbidden failure" do
         result = create_service.call
 
         expect(result).not_to be_success
@@ -38,7 +38,7 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
     context "when customer does not exist" do
       before { params[:external_customer_id] = "non-existing-id" }
 
-      it "returns not found failure", :aggregate_failures do
+      it "returns not found failure" do
         result = create_service.call
 
         expect(result).not_to be_success
@@ -50,7 +50,7 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
     context "when invoices are not found" do
       before { params[:lago_invoice_ids] = [] }
 
-      it "returns not found failure", :aggregate_failures do
+      it "returns not found failure" do
         result = create_service.call
 
         expect(result).not_to be_success
@@ -62,7 +62,7 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
     context "when invoices are not overdue" do
       before { first_invoice.update!(payment_overdue: false) }
 
-      it "returns not allowed failure", :aggregate_failures do
+      it "returns not allowed failure" do
         result = create_service.call
 
         expect(result).not_to be_success
@@ -74,7 +74,7 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
     context "when invoices have different currencies" do
       before { second_invoice.update!(currency: "USD") }
 
-      it "returns not allowed failure", :aggregate_failures do
+      it "returns not allowed failure" do
         result = create_service.call
 
         expect(result).not_to be_success
@@ -86,7 +86,7 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
     context "when invoices are not ready for payment processing" do
       before { first_invoice.update!(ready_for_payment_processing: false) }
 
-      it "returns not allowed failure", :aggregate_failures do
+      it "returns not allowed failure" do
         result = create_service.call
 
         expect(result).not_to be_success
@@ -128,13 +128,15 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
       end
     end
 
-    it "returns the payment request", :aggregate_failures do
-      result = create_service.call
+    it "returns the payment request" do
+      dunning_campaign = create(:dunning_campaign, organization:)
+      result = described_class.call(organization:, params:, dunning_campaign:)
 
       expect(result.payment_request).to be_a(PaymentRequest)
       expect(result.payment_request).to have_attributes(
         organization:,
         customer:,
+        dunning_campaign:,
         amount_cents: first_invoice.total_amount_cents + second_invoice.total_amount_cents,
         amount_currency: "EUR",
         email: "john.doe@example.com"


### PR DESCRIPTION
## Roadmap

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We are extending dunning campaigns management to edit and delete campaigns.

 ## Description

The goal of this PR is to assign the dunning campaign when creating a payment request via the auto dunning flow.