### PR TITLE
fix(netsuite): Add amount to invoice line items

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -103,6 +103,7 @@ module Integrations
               'account' => mapped_item.external_account_code,
               'quantity' => fee.units,
               'rate' => limited_rate(fee.precise_unit_amount),
+              'amount' => limited_rate(amount(fee.amount_cents, resource: invoice)),
               'taxdetailsreference' => fee.id
             }
           end

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
               'account' => '33',
               'quantity' => 0.0,
               'rate' => 0.0,
+              'amount' => 2.0,
               'taxdetailsreference' => anything
             },
             {
@@ -165,6 +166,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
               'account' => '44',
               'quantity' => 0.0,
               'rate' => 0.0,
+              'amount' => 2.0,
               'taxdetailsreference' => anything
             },
             {
@@ -172,6 +174,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
               'account' => 'm22',
               'quantity' => 2,
               'rate' => 4.1212121212334,
+              'amount' => 2.0,
               'taxdetailsreference' => anything
             },
             {

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
                 'account' => '33',
                 'quantity' => 0.0,
                 'rate' => 0.0,
+                'amount' => 100.0,
                 'taxdetailsreference' => fee_sub.id
               },
               {
@@ -174,6 +175,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
                 'account' => '44',
                 'quantity' => 0.0,
                 'rate' => 0.0,
+                'amount' => 2.0,
                 'taxdetailsreference' => minimum_commitment_fee.id
               },
               {
@@ -181,6 +183,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
                 'account' => 'm22',
                 'quantity' => 2,
                 'rate' => 4.1212121212334,
+                'amount' => 2.0,
                 'taxdetailsreference' => charge_fee.id
               },
               {


### PR DESCRIPTION
## Context

When we calculate the line item price with big decimals, Netsuite rounds it to 8 decimal places.
And in that case the Netsuite prices are different to what is saved in Lago.

## Description

Add `amount` attribute to Netsuite payload with precalculated price.