### PR TITLE
feat(dunning): reset customer dunning campaign status on payment request succeeded payment status

### DIFF
--- a/app/services/payment_requests/payments/adyen_service.rb
+++ b/app/services/payment_requests/payments/adyen_service.rb
@@ -94,6 +94,7 @@ module PaymentRequests
         payable_payment_status = payable_payment_status(status)
         update_payable_payment_status(payment_status: payable_payment_status)
         update_invoices_payment_status(payment_status: payable_payment_status)
+        reset_customer_dunning_campaign_status(payable_payment_status)
 
         PaymentRequestMailer.with(payment_request: payment.payable).requested.deliver_later if result.payable.payment_failed?
 
@@ -265,6 +266,17 @@ module PaymentRequests
             error_code: adyen_error.code
           }
         })
+      end
+
+      def reset_customer_dunning_campaign_status(payment_status)
+        return unless payment_status_succeeded?(payment_status)
+        return unless payable.try(:dunning_campaign)
+
+        customer.update!(
+          dunning_campaign_completed: false,
+          last_dunning_campaign_attempt: 0,
+          last_dunning_campaign_attempt_at: nil
+        )
       end
     end
   end

--- a/app/services/payment_requests/payments/adyen_service.rb
+++ b/app/services/payment_requests/payments/adyen_service.rb
@@ -219,7 +219,7 @@ module PaymentRequests
           payable: result.payable,
           params: {
             payment_status:,
-            ready_for_payment_processing: payment_status.to_sym != :succeeded
+            ready_for_payment_processing: !payment_status_succeeded?(payment_status)
           },
           webhook_notification: deliver_webhook
         ).raise_if_error!
@@ -231,11 +231,15 @@ module PaymentRequests
             invoice:,
             params: {
               payment_status:,
-              ready_for_payment_processing: payment_status.to_sym != :succeeded
+              ready_for_payment_processing: !payment_status_succeeded?(payment_status)
             },
             webhook_notification: deliver_webhook
           ).raise_if_error!
         end
+      end
+
+      def payment_status_succeeded?(payment_status)
+        payment_status.to_sym == :succeeded
       end
 
       def create_payment(provider_payment_id:, metadata:)

--- a/app/services/payment_requests/payments/gocardless_service.rb
+++ b/app/services/payment_requests/payments/gocardless_service.rb
@@ -174,7 +174,7 @@ module PaymentRequests
           payable: result.payable,
           params: {
             payment_status:,
-            ready_for_payment_processing: payment_status.to_sym != :succeeded
+            ready_for_payment_processing: !payment_status_succeeded?(payment_status)
           },
           webhook_notification: deliver_webhook
         ).raise_if_error!
@@ -186,7 +186,7 @@ module PaymentRequests
             invoice:,
             params: {
               payment_status:,
-              ready_for_payment_processing: payment_status.to_sym != :succeeded
+              ready_for_payment_processing: !payment_status_succeeded?(payment_status)
             },
             webhook_notification: deliver_webhook
           ).raise_if_error!
@@ -201,6 +201,10 @@ module PaymentRequests
             error_code: gocardless_error.code
           }
         })
+      end
+
+      def payment_status_succeeded?(payment_status)
+        payment_status.to_sym == :succeeded
       end
     end
   end

--- a/app/services/payment_requests/payments/gocardless_service.rb
+++ b/app/services/payment_requests/payments/gocardless_service.rb
@@ -84,6 +84,7 @@ module PaymentRequests
         payable_payment_status = payable_payment_status(status)
         update_payable_payment_status(payment_status: payable_payment_status)
         update_invoices_payment_status(payment_status: payable_payment_status)
+        reset_customer_dunning_campaign_status(payable_payment_status)
 
         PaymentRequestMailer.with(payment_request: payment.payable).requested.deliver_later if result.payable.payment_failed?
 
@@ -205,6 +206,17 @@ module PaymentRequests
 
       def payment_status_succeeded?(payment_status)
         payment_status.to_sym == :succeeded
+      end
+
+      def reset_customer_dunning_campaign_status(payment_status)
+        return unless payment_status_succeeded?(payment_status)
+        return unless payable.try(:dunning_campaign)
+
+        customer.update!(
+          dunning_campaign_completed: false,
+          last_dunning_campaign_attempt: 0,
+          last_dunning_campaign_attempt_at: nil
+        )
       end
     end
   end

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -233,7 +233,7 @@ module PaymentRequests
           params: {
             payment_status:,
             # NOTE: A proper `processing` payment status should be introduced for payment_requests
-            ready_for_payment_processing: !processing && payment_status.to_sym != :succeeded
+            ready_for_payment_processing: !processing && !payment_status_succeeded?(payment_status)
           },
           webhook_notification: deliver_webhook
         ).raise_if_error!
@@ -246,7 +246,7 @@ module PaymentRequests
             params: {
               payment_status:,
               # NOTE: A proper `processing` payment status should be introduced for invoices
-              ready_for_payment_processing: !processing && payment_status.to_sym != :succeeded
+              ready_for_payment_processing: !processing && !payment_status_succeeded?(payment_status)
             },
             webhook_notification: deliver_webhook
           ).raise_if_error!
@@ -333,6 +333,10 @@ module PaymentRequests
 
       def stripe_payment_provider
         @stripe_payment_provider ||= payment_provider(customer)
+      end
+
+      def payment_status_succeeded?(payment_status)
+        payment_status.to_sym == :succeeded
       end
     end
   end

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -114,6 +114,7 @@ module PaymentRequests
         payment_status = payable_payment_status(status)
         update_payable_payment_status(payment_status:, processing:)
         update_invoices_payment_status(payment_status:, processing:)
+        reset_customer_dunning_campaign_status(payment_status)
 
         PaymentRequestMailer.with(payment_request: payment.payable).requested.deliver_later if result.payable.payment_failed?
 
@@ -337,6 +338,17 @@ module PaymentRequests
 
       def payment_status_succeeded?(payment_status)
         payment_status.to_sym == :succeeded
+      end
+
+      def reset_customer_dunning_campaign_status(payment_status)
+        return unless payment_status_succeeded?(payment_status)
+        return unless payable.try(:dunning_campaign)
+
+        customer.update!(
+          dunning_campaign_completed: false,
+          last_dunning_campaign_attempt: 0,
+          last_dunning_campaign_attempt_at: nil
+        )
       end
     end
   end

--- a/spec/services/payment_requests/payments/adyen_service_spec.rb
+++ b/spec/services/payment_requests/payments/adyen_service_spec.rb
@@ -488,6 +488,19 @@ RSpec.describe PaymentRequests::Payments::AdyenService, type: :service do
 
         expect(result).to be_success
       end
+
+      context "when status is failed" do
+        let(:status) { "failed" }
+
+        it "doest not reset the customer dunning campaign counters" do
+          expect { result && customer.reload }
+            .to not_change(customer, :dunning_campaign_completed)
+            .and not_change(customer, :last_dunning_campaign_attempt)
+            .and not_change { customer.last_dunning_campaign_attempt_at&.to_i }
+
+          expect(result).to be_success
+        end
+      end
     end
 
     context "when status is failed" do

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -503,6 +503,52 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
       expect { result }.not_to have_enqueued_mail(PaymentRequestMailer, :requested)
     end
 
+    context "when the payment request belongs to a dunning campaign" do
+      let(:customer) do
+        create(
+          :customer,
+          payment_provider_code: code,
+          dunning_campaign_completed: true,
+          last_dunning_campaign_attempt: 3,
+          last_dunning_campaign_attempt_at: Time.zone.now
+        )
+      end
+
+      let(:payment_request) do
+        create(
+          :payment_request,
+          organization:,
+          customer:,
+          amount_cents: 799,
+          amount_currency: "USD",
+          invoices: [invoice_1, invoice_2],
+          dunning_campaign: create(:dunning_campaign)
+        )
+      end
+
+      it "resets the customer dunning campaign counters" do
+        expect { result && customer.reload }
+          .to change(customer, :dunning_campaign_completed).to(false)
+          .and change(customer, :last_dunning_campaign_attempt).to(0)
+          .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
+
+        expect(result).to be_success
+      end
+
+      context "when status is failed" do
+        let(:status) { "failed" }
+
+        it "doest not reset the customer dunning campaign counters" do
+          expect { result && customer.reload }
+            .to not_change(customer, :dunning_campaign_completed)
+            .and not_change(customer, :last_dunning_campaign_attempt)
+            .and not_change { customer.last_dunning_campaign_attempt_at&.to_i }
+
+          expect(result).to be_success
+        end
+      end
+    end
+
     context "when status is failed" do
       let(:status) { "failed" }
 


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We are extending dunning campaigns management to edit and delete campaigns.

 ## Description

Reset customer dunning campaign status (last attempt count, last attempt timestamp and completed status) on payment request succeeded payment status response.