### PR TITLE
hotfix(taxes): Remove charges count from taxes serializer

### DIFF
--- a/app/serializers/v1/tax_serializer.rb
+++ b/app/serializers/v1/tax_serializer.rb
@@ -13,7 +13,8 @@ module V1
         add_ons_count: model.add_ons.count,
         customers_count: model.customers_count,
         plans_count: model.plans.count,
-        charges_count: model.charges.count,
+        # DEPRECATED: this is creating a major performance issue
+        # charges_count: model.charges.count,
         commitments_count: model.commitments.count,
         created_at: model.created_at.iso8601
       }

--- a/spec/serializers/v1/tax_serializer_spec.rb
+++ b/spec/serializers/v1/tax_serializer_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe ::V1::TaxSerializer do
       'add_ons_count' => 0,
       'customers_count' => 0,
       'plans_count' => 0,
-      'charges_count' => 0,
       'created_at' => tax.created_at.iso8601
     )
   end


### PR DESCRIPTION

- `count` on API serializer is causing a major performance issue