### PR TITLE
misc: extend tax error details for validationError

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -51,7 +51,7 @@ module Invoices
           taxes_result = fetch_taxes_for_invoice
 
           unless taxes_result.success?
-            create_error_detail(taxes_result.error.code)
+            create_error_detail(taxes_result.error)
 
             # only fail invoices that are finalizing
             invoice.failed! if finalizing_invoice?
@@ -338,15 +338,17 @@ module Invoices
       @customer_provider_taxation ||= invoice.customer.anrok_customer
     end
 
-    def create_error_detail(code)
+    def create_error_detail(error)
       error_result = ErrorDetails::CreateService.call(
         owner: invoice,
         organization: invoice.organization,
         params: {
           error_code: :tax_error,
           details: {
-            tax_error: code
-          }
+            tax_error: error.code
+          }.tap do |details|
+            details[:tax_error_message] = error.error_message if error.code == 'validationError'
+          end
         }
       )
       error_result.raise_if_error!

--- a/spec/fixtures/integration_aggregator/taxes/invoices/api_limit_response.json
+++ b/spec/fixtures/integration_aggregator/taxes/invoices/api_limit_response.json
@@ -1,0 +1,27 @@
+{
+  "succeededInvoices": [],
+  "failedInvoices": [
+    {
+      "issuing_date": "2024-12-03",
+      "currency": "EUR",
+      "contact": {
+        "external_id": "sync-1-test-1",
+        "name": "sync-1-test-1",
+        "address_line_1": "88 rue du Chemin Vert",
+        "city": "Paris",
+        "zip": "75011",
+        "country": "fr",
+        "taxable": true,
+        "tax_number": "FR86894827773"
+      },
+      "fees": [
+        {
+          "item_id": "sync-1",
+          "item_code": "lago_default_b2b",
+          "amount_cents": 2000
+        }
+      ],
+      "validation_errors": "You've exceeded your API limit of 10 per second"
+    }
+  ]
+}

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -318,6 +318,28 @@ RSpec.describe Fees::OneOffService do
             expect(invoice.reload.error_details.first.details['tax_error']).to eq('taxDateTooFarInFuture')
           end
         end
+
+        context 'with api limit error' do
+          let(:body) do
+            p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/api_limit_response.json')
+            File.read(p)
+          end
+
+          it 'returns and store proper error details' do
+            result = one_off_service.create
+
+            aggregate_failures do
+              expect(result).not_to be_success
+              expect(result.error.code).to eq('tax_error')
+              expect(result.error.error_message).to eq('validationError')
+
+              expect(invoice.reload.error_details.count).to eq(1)
+              expect(invoice.reload.error_details.first.details['tax_error']).to eq('validationError')
+              expect(invoice.reload.error_details.first.details['tax_error_message'])
+                .to eq("You've exceeded your API limit of 10 per second")
+            end
+          end
+        end
       end
     end
   end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -235,6 +235,28 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
               expect(invoice.reload.error_details.first.details['tax_error']).to eq('taxDateTooFarInFuture')
             end
           end
+
+          context 'with api limit error' do
+            let(:body) do
+              p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/api_limit_response.json')
+              File.read(p)
+            end
+
+            it 'returns and store proper error details' do
+              result = invoice_service.call
+
+              aggregate_failures do
+                expect(result).not_to be_success
+                expect(result.error.code).to eq('tax_error')
+                expect(result.error.error_message).to eq('validationError')
+
+                expect(invoice.reload.error_details.count).to eq(1)
+                expect(invoice.reload.error_details.first.details['tax_error']).to eq('validationError')
+                expect(invoice.reload.error_details.first.details['tax_error_message'])
+                  .to eq("You've exceeded your API limit of 10 per second")
+              end
+            end
+          end
         end
 
         context 'when calculating fees for draft invoice' do


### PR DESCRIPTION
## Context

In case of Anrok validation error, Lago does not store more details

## Description

This PR adds more details to the error_details collection so that issues can be reproduced more easily
