### PR TITLE
feat(salesforce): Add create customer without external id

### DIFF
--- a/app/services/integration_customers/factory.rb
+++ b/app/services/integration_customers/factory.rb
@@ -16,6 +16,8 @@ module IntegrationCustomers
         IntegrationCustomers::XeroService
       when 'Integrations::HubspotIntegration'
         IntegrationCustomers::HubspotService
+      when 'Integrations::SalesforceIntegration'
+        IntegrationCustomers::SalesforceService
       else
         raise(NotImplementedError)
       end

--- a/app/services/integration_customers/salesforce_service.rb
+++ b/app/services/integration_customers/salesforce_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class SalesforceService < ::BaseService
+    def initialize(integration:, customer:, subsidiary_id:, **params)
+      @customer = customer
+      @subsidiary_id = subsidiary_id
+      @integration = integration
+      @params = params&.with_indifferent_access
+
+      super(nil)
+    end
+
+    def create
+      new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
+        integration:,
+        customer:,
+        type: 'IntegrationCustomers::SalesforceCustomer',
+        sync_with_provider: true
+      )
+
+      result.integration_customer = new_integration_customer
+      result
+    end
+
+    private
+
+    attr_reader :integration, :customer, :subsidiary_id, :params
+  end
+end

--- a/spec/services/integration_customers/factory_spec.rb
+++ b/spec/services/integration_customers/factory_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# spec/factories/integration_customers/factory_spec.rb
+require 'rails_helper'
+
+RSpec.describe IntegrationCustomers::Factory do
+  describe '.new_instance' do
+    subject { described_class.new_instance(integration:, customer:, subsidiary_id:, **params) }
+
+    let(:organization) { membership.organization }
+    let(:membership) { create(:membership) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subsidiary_id) {}
+    let(:params) {{}}
+
+    context 'when the integration is NetsuiteIntegration' do
+      let(:integration) { create(:netsuite_integration, organization:) }
+
+      it 'returns an instance of IntegrationCustomers::NetsuiteService' do
+        expect(subject).to be_an_instance_of(IntegrationCustomers::NetsuiteService)
+      end
+    end
+
+    context 'when the integration is AnrokIntegration' do
+      let(:integration) { create(:anrok_integration, organization:) }
+
+      it 'returns an instance of IntegrationCustomers::AnrokService' do
+        expect(subject).to be_an_instance_of(IntegrationCustomers::AnrokService)
+      end
+    end
+
+    context 'when the integration is XeroIntegration' do
+      let(:integration) { create(:xero_integration, organization:) }
+
+      it 'returns an instance of IntegrationCustomers::XeroService' do
+        expect(subject).to be_an_instance_of(IntegrationCustomers::XeroService)
+      end
+    end
+
+    context 'when the integration is HubspotIntegration' do
+      let(:integration) { create(:hubspot_integration, organization:) }
+
+      it 'returns an instance of IntegrationCustomers::HubspotService' do
+        expect(subject).to be_an_instance_of(IntegrationCustomers::HubspotService)
+      end
+    end
+
+    context 'when the integration is SalesforceIntegration' do
+      let(:integration) { create(:salesforce_integration, organization:) }
+
+      it 'returns an instance of IntegrationCustomers::SalesforceService' do
+        expect(subject).to be_an_instance_of(IntegrationCustomers::SalesforceService)
+      end
+    end
+
+    context 'when integration is nil' do
+      let(:integration) { nil }
+
+      it 'raises a NotImplementedError' do
+        expect { subject }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+end

--- a/spec/services/integration_customers/factory_spec.rb
+++ b/spec/services/integration_customers/factory_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe IntegrationCustomers::Factory do
     let(:membership) { create(:membership) }
     let(:customer) { create(:customer, organization:) }
     let(:subsidiary_id) {}
-    let(:params) {{}}
+    let(:params) { {} }
 
     context 'when the integration is NetsuiteIntegration' do
       let(:integration) { create(:netsuite_integration, organization:) }

--- a/spec/services/integration_customers/salesforce_service_spec.rb
+++ b/spec/services/integration_customers/salesforce_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntegrationCustomers::SalesforceService, type: :service do
+  let(:integration) { create(:salesforce_integration, organization:) }
+  let(:organization) { membership.organization }
+  let(:membership) { create(:membership) }
+  let(:customer) { create(:customer, organization:, customer_type: 'individual') }
+
+  describe '#create' do
+    subject(:service_call) { described_class.new(integration:, customer:, subsidiary_id: nil).create }
+
+    it 'returns integration customer' do
+      result = service_call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.integration_customer.integration_id).to eq(integration.id)
+        expect(result.integration_customer.customer_id).to eq(customer.id)
+        expect(result.integration_customer.type).to eq('IntegrationCustomers::SalesforceCustomer')
+      end
+    end
+
+    it 'creates integration customer' do
+      expect { service_call }.to change(IntegrationCustomers::SalesforceCustomer, :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Add the ability to create a new salesforce customer without passing the external customer id so it can be filled later by the salesforce integration


<img width="700" alt="Screenshot 2024-11-27 at 7 11 54 PM" src="https://github.com/user-attachments/assets/70710c21-ac8c-4149-ba00-afac32a30c8d">
