### PR TITLE
feat(dunning): flag customer as dunning campaign completed on last attempt execution

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -190,6 +190,14 @@ class Customer < ApplicationRecord
     invoices.payment_overdue.where(currency:).sum(:total_amount_cents)
   end
 
+  def reset_dunning_campaign!
+    update!(
+      dunning_campaign_completed: false,
+      last_dunning_campaign_attempt: 0,
+      last_dunning_campaign_attempt_at: nil
+    )
+  end
+
   private
 
   def ensure_slug

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -105,18 +105,16 @@ module Customers
           customer.exclude_from_dunning_campaign = args[:exclude_from_dunning_campaign]
           customer.applied_dunning_campaign = nil if args[:exclude_from_dunning_campaign]
         end
-
-        if customer.applied_dunning_campaign_id_changed? || customer.exclude_from_dunning_campaign_changed?
-          customer.last_dunning_campaign_attempt = 0
-          customer.last_dunning_campaign_attempt_at = nil
-          customer.dunning_campaign_completed = false
-        end
       end
 
       ActiveRecord::Base.transaction do
         if old_provider_customer && args[:payment_provider].nil? && args[:payment_provider_code].present?
           old_provider_customer.discard!
           customer.payment_provider_code = nil
+        end
+
+        if customer.applied_dunning_campaign_id_changed? || customer.exclude_from_dunning_campaign_changed?
+          customer.reset_dunning_campaign!
         end
 
         customer.save!

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -44,11 +44,7 @@ module Invoices
           invoice.payment_overdue = false
 
           if invoice.payment_requests.where.not(dunning_campaign_id: nil).exists?
-            invoice.customer.update!(
-              dunning_campaign_completed: false,
-              last_dunning_campaign_attempt: 0,
-              last_dunning_campaign_attempt_at: nil
-            )
+            invoice.customer.reset_dunning_campaign!
           end
         end
 

--- a/app/services/payment_requests/payments/adyen_service.rb
+++ b/app/services/payment_requests/payments/adyen_service.rb
@@ -272,11 +272,7 @@ module PaymentRequests
         return unless payment_status_succeeded?(payment_status)
         return unless payable.try(:dunning_campaign)
 
-        customer.update!(
-          dunning_campaign_completed: false,
-          last_dunning_campaign_attempt: 0,
-          last_dunning_campaign_attempt_at: nil
-        )
+        customer.reset_dunning_campaign!
       end
     end
   end

--- a/app/services/payment_requests/payments/gocardless_service.rb
+++ b/app/services/payment_requests/payments/gocardless_service.rb
@@ -212,11 +212,7 @@ module PaymentRequests
         return unless payment_status_succeeded?(payment_status)
         return unless payable.try(:dunning_campaign)
 
-        customer.update!(
-          dunning_campaign_completed: false,
-          last_dunning_campaign_attempt: 0,
-          last_dunning_campaign_attempt_at: nil
-        )
+        customer.reset_dunning_campaign!
       end
     end
   end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -594,4 +594,22 @@ RSpec.describe Customer, type: :model do
       end
     end
   end
+
+  describe "#reset_dunning_campaign!" do
+    let(:customer) do
+      create(
+        :customer,
+        dunning_campaign_completed: true,
+        last_dunning_campaign_attempt: 5,
+        last_dunning_campaign_attempt_at: 1.day.ago
+      )
+    end
+
+    it "changes dunning campaign status counters" do
+      expect { customer.reset_dunning_campaign! && customer.reload }
+        .to change(customer, :dunning_campaign_completed).to(false)
+        .and change(customer, :last_dunning_campaign_attempt).to(0)
+        .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
+    end
+  end
 end

--- a/spec/services/dunning_campaigns/process_attempt_service_spec.rb
+++ b/spec/services/dunning_campaigns/process_attempt_service_spec.rb
@@ -68,9 +68,28 @@ RSpec.describe DunningCampaigns::ProcessAttemptService, type: :service, aggregat
 
     it "updates customer last dunning attempt data" do
       freeze_time do
-        expect { result }
-          .to change(customer.reload, :last_dunning_campaign_attempt).by(1)
-          .and change(customer.reload, :last_dunning_campaign_attempt_at).to(Time.zone.now)
+        expect { result && customer.reload }
+          .to change(customer, :last_dunning_campaign_attempt).by(1)
+          .and change(customer, :last_dunning_campaign_attempt_at).to(Time.zone.now)
+          .and not_change(customer, :dunning_campaign_completed).from(false)
+      end
+    end
+
+    context "when dunning campaign max attemp is reached" do
+      let(:customer) do
+        create(
+          :customer,
+          organization:,
+          currency:,
+          last_dunning_campaign_attempt: dunning_campaign.max_attempts - 1,
+          last_dunning_campaign_attempt_at: dunning_campaign.days_between_attempts.days.ago,
+          dunning_campaign_completed: false
+        )
+      end
+
+      it "updates customer's dunning campaign completed flag" do
+        expect { result && customer.reload }
+          .to change(customer, :dunning_campaign_completed).to(true)
       end
     end
 
@@ -117,13 +136,13 @@ RSpec.describe DunningCampaigns::ProcessAttemptService, type: :service, aggregat
       end
     end
 
-    context "when the customer reaches dunning campaign max attempts" do
+    context "when the customer has completed the dunning campaign" do
       let(:customer) do
         create(
           :customer,
           organization:,
           currency:,
-          last_dunning_campaign_attempt: dunning_campaign.max_attempts
+          dunning_campaign_completed: true
         )
       end
 


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We are extending dunning campaigns management to edit and delete campaigns.

 ## Description

Flag customers as dunning campaign completed on last attempt execution, also check the completed flag instead of the campaign max attempts as execution exit condition.

Also, extracts code to reset customer dunning campaign status fields to be reused.