### PR TITLE
feat(dunning): Remove dunning_campaign_completed flag

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -72,8 +72,6 @@ class Customer < ApplicationRecord
   scope :falling_back_to_default_dunning_campaign, -> {
     where(applied_dunning_campaign_id: nil, exclude_from_dunning_campaign: false)
   }
-  scope :with_dunning_campaign_completed, -> { where(dunning_campaign_completed: true) }
-  scope :with_dunning_campaign_not_completed, -> { where(dunning_campaign_completed: false) }
 
   validates :country, :shipping_country, country_code: true, allow_nil: true
   validates :document_locale, language_code: true, unless: -> { document_locale.nil? }
@@ -192,7 +190,6 @@ class Customer < ApplicationRecord
 
   def reset_dunning_campaign!
     update!(
-      dunning_campaign_completed: false,
       last_dunning_campaign_attempt: 0,
       last_dunning_campaign_attempt_at: nil
     )
@@ -222,7 +219,6 @@ end
 #  customer_type                    :enum
 #  deleted_at                       :datetime
 #  document_locale                  :string
-#  dunning_campaign_completed       :boolean          default(FALSE)
 #  email                            :string
 #  exclude_from_dunning_campaign    :boolean          default(FALSE), not null
 #  finalize_zero_amount_invoice     :integer          default("inherit"), not null

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -36,7 +36,7 @@ class DunningCampaign < ApplicationRecord
 
   def reset_customers_last_attempt
     # NOTE: Reset last attempt on customers with the campaign applied explicitly
-    customers.with_dunning_campaign_not_completed.update_all( # rubocop:disable Rails/SkipsModelValidations
+    customers.update_all( # rubocop:disable Rails/SkipsModelValidations
       last_dunning_campaign_attempt: 0,
       last_dunning_campaign_attempt_at: nil
     )

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -138,7 +138,6 @@ class Organization < ApplicationRecord
   def reset_customers_last_dunning_campaign_attempt
     customers
       .falling_back_to_default_dunning_campaign
-      .with_dunning_campaign_not_completed
       .update_all( # rubocop:disable Rails/SkipsModelValidations
         last_dunning_campaign_attempt: 0,
         last_dunning_campaign_attempt_at: nil

--- a/app/services/dunning_campaigns/bulk_process_service.rb
+++ b/app/services/dunning_campaigns/bulk_process_service.rb
@@ -16,7 +16,6 @@ module DunningCampaigns
 
     def eligible_customers
       Customer
-        .with_dunning_campaign_not_completed
         .joins(:organization)
         .where(exclude_from_dunning_campaign: false)
         .where("organizations.premium_integrations @> ARRAY[?]::varchar[]", ['auto_dunning'])
@@ -31,7 +30,6 @@ module DunningCampaigns
       end
 
       def call
-        return result if customer.dunning_campaign_completed?
         return result unless threshold
         return result if max_attempts_reached?
         return result unless days_between_attempts_satisfied?

--- a/app/services/dunning_campaigns/process_attempt_service.rb
+++ b/app/services/dunning_campaigns/process_attempt_service.rb
@@ -16,6 +16,7 @@ module DunningCampaigns
       return result unless applicable_dunning_campaign?
       return result unless dunning_campaign_threshold_reached?
       return result unless days_between_attempts_passed?
+      return result if max_attempts_reached?
 
       ActiveRecord::Base.transaction do
         payment_request_result = PaymentRequests::CreateService.call(
@@ -61,6 +62,10 @@ module DunningCampaigns
       return true unless customer.last_dunning_campaign_attempt_at
 
       (customer.last_dunning_campaign_attempt_at + dunning_campaign.days_between_attempts.days).past?
+    end
+
+    def max_attempts_reached?
+      customer.last_dunning_campaign_attempt >= dunning_campaign.max_attempts
     end
 
     def overdue_invoices

--- a/app/services/dunning_campaigns/process_attempt_service.rb
+++ b/app/services/dunning_campaigns/process_attempt_service.rb
@@ -16,7 +16,6 @@ module DunningCampaigns
       return result unless applicable_dunning_campaign?
       return result unless dunning_campaign_threshold_reached?
       return result unless days_between_attempts_passed?
-      return result if customer.dunning_campaign_completed?
 
       ActiveRecord::Base.transaction do
         payment_request_result = PaymentRequests::CreateService.call(
@@ -30,7 +29,6 @@ module DunningCampaigns
 
         customer.increment(:last_dunning_campaign_attempt)
         customer.last_dunning_campaign_attempt_at = Time.zone.now
-        customer.dunning_campaign_completed = last_dunning_campaign_attempt?
         customer.save!
 
         result.customer = customer
@@ -63,10 +61,6 @@ module DunningCampaigns
       return true unless customer.last_dunning_campaign_attempt_at
 
       (customer.last_dunning_campaign_attempt_at + dunning_campaign.days_between_attempts.days).past?
-    end
-
-    def last_dunning_campaign_attempt?
-      customer.last_dunning_campaign_attempt >= dunning_campaign.max_attempts
     end
 
     def overdue_invoices

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -344,11 +344,7 @@ module PaymentRequests
         return unless payment_status_succeeded?(payment_status)
         return unless payable.try(:dunning_campaign)
 
-        customer.update!(
-          dunning_campaign_completed: false,
-          last_dunning_campaign_attempt: 0,
-          last_dunning_campaign_attempt_at: nil
-        )
+        customer.reset_dunning_campaign!
       end
     end
   end

--- a/db/migrate/20241128091634_remove_dunning_campaign_completed_from_customers.rb
+++ b/db/migrate/20241128091634_remove_dunning_campaign_completed_from_customers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveDunningCampaignCompletedFromCustomers < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_column :customers, :dunning_campaign_completed, :boolean, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_26_141853) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_28_091634) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -469,7 +469,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_26_141853) do
     t.boolean "exclude_from_dunning_campaign", default: false, null: false
     t.integer "last_dunning_campaign_attempt", default: 0, null: false
     t.datetime "last_dunning_campaign_attempt_at", precision: nil
-    t.boolean "dunning_campaign_completed", default: false
     t.index ["applied_dunning_campaign_id"], name: "index_customers_on_applied_dunning_campaign_id"
     t.index ["deleted_at"], name: "index_customers_on_deleted_at"
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true, where: "(deleted_at IS NULL)"

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -599,7 +599,6 @@ RSpec.describe Customer, type: :model do
     let(:customer) do
       create(
         :customer,
-        dunning_campaign_completed: true,
         last_dunning_campaign_attempt: 5,
         last_dunning_campaign_attempt_at: 1.day.ago
       )
@@ -607,8 +606,7 @@ RSpec.describe Customer, type: :model do
 
     it "changes dunning campaign status counters" do
       expect { customer.reset_dunning_campaign! && customer.reload }
-        .to change(customer, :dunning_campaign_completed).to(false)
-        .and change(customer, :last_dunning_campaign_attempt).to(0)
+        .to change(customer, :last_dunning_campaign_attempt).to(0)
         .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
     end
   end

--- a/spec/models/dunning_campaign_spec.rb
+++ b/spec/models/dunning_campaign_spec.rb
@@ -65,19 +65,6 @@ RSpec.describe DunningCampaign, type: :model do
         .and change { customer.last_dunning_campaign_attempt_at }.from(last_dunning_campaign_attempt_at).to(nil)
     end
 
-    it "does not reset last attempt on customers with dunning campaign already completed" do
-      customer = create(
-        :customer,
-        organization:,
-        applied_dunning_campaign: dunning_campaign,
-        last_dunning_campaign_attempt: 1,
-        dunning_campaign_completed: true
-      )
-
-      expect { dunning_campaign.reset_customers_last_attempt }
-        .not_to change { customer.reload.last_dunning_campaign_attempt }.from(1)
-    end
-
     context "when applied to organization" do
       subject(:dunning_campaign) { create(:dunning_campaign, applied_to_organization: true) }
 
@@ -92,18 +79,6 @@ RSpec.describe DunningCampaign, type: :model do
         expect { dunning_campaign.reset_customers_last_attempt }
           .to change { customer.reload.last_dunning_campaign_attempt }.from(2).to(0)
           .and change { customer.last_dunning_campaign_attempt_at }.from(last_dunning_campaign_attempt_at).to(nil)
-      end
-
-      it "does not reset last attempt on customers with dunning campaign already completed" do
-        customer = create(
-          :customer,
-          organization:,
-          last_dunning_campaign_attempt: 2,
-          dunning_campaign_completed: true
-        )
-
-        expect { dunning_campaign.reset_customers_last_attempt }
-          .not_to change { customer.reload.last_dunning_campaign_attempt }.from(2)
       end
     end
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -245,13 +245,11 @@ RSpec.describe Organization, type: :model do
     it "resets the last dunning campaign attempt for customers" do
       customer1 = create(:customer, organization:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at:)
       customer2 = create(:customer, organization:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at:, applied_dunning_campaign: campaign)
-      customer3 = create(:customer, organization:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at:, dunning_campaign_completed: true)
 
       expect { organization.reset_customers_last_dunning_campaign_attempt }
         .to change { customer1.reload.last_dunning_campaign_attempt }.from(1).to(0)
         .and change(customer1, :last_dunning_campaign_attempt_at).from(last_dunning_campaign_attempt_at).to(nil)
       expect(customer2.reload.last_dunning_campaign_attempt).to eq(1)
-      expect(customer3.reload.last_dunning_campaign_attempt).to eq(1)
     end
   end
 

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -356,7 +356,6 @@ RSpec.describe Customers::UpdateService, type: :service do
         expect { customers_service.call }
           .to not_change(customer, :applied_dunning_campaign_id)
           .and not_change(customer, :exclude_from_dunning_campaign)
-          .and not_change(customer, :dunning_campaign_completed)
           .and not_change(customer, :last_dunning_campaign_attempt)
           .and not_change { customer.last_dunning_campaign_attempt_at.iso8601 }
 
@@ -370,8 +369,7 @@ RSpec.describe Customers::UpdateService, type: :service do
             organization:,
             exclude_from_dunning_campaign: true,
             last_dunning_campaign_attempt: 3,
-            last_dunning_campaign_attempt_at: 2.days.ago,
-            dunning_campaign_completed: true
+            last_dunning_campaign_attempt_at: 2.days.ago
           )
         end
 
@@ -391,7 +389,6 @@ RSpec.describe Customers::UpdateService, type: :service do
           expect { customers_service.call }
             .to change(customer, :applied_dunning_campaign_id).to(dunning_campaign.id)
             .and change(customer, :exclude_from_dunning_campaign).to(false)
-            .and change(customer, :dunning_campaign_completed).to(false)
             .and change(customer, :last_dunning_campaign_attempt).to(0)
             .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
 
@@ -405,8 +402,7 @@ RSpec.describe Customers::UpdateService, type: :service do
               organization:,
               applied_dunning_campaign: dunning_campaign,
               last_dunning_campaign_attempt: 3,
-              last_dunning_campaign_attempt_at: 2.days.ago,
-              dunning_campaign_completed: true
+              last_dunning_campaign_attempt_at: 2.days.ago
             )
           end
 
@@ -418,7 +414,6 @@ RSpec.describe Customers::UpdateService, type: :service do
             expect { customers_service.call }
               .to change(customer, :applied_dunning_campaign_id).to(nil)
               .and change(customer, :exclude_from_dunning_campaign).to(true)
-              .and change(customer, :dunning_campaign_completed).to(false)
               .and change(customer, :last_dunning_campaign_attempt).to(0)
               .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
 
@@ -434,8 +429,7 @@ RSpec.describe Customers::UpdateService, type: :service do
               applied_dunning_campaign: dunning_campaign,
               exclude_from_dunning_campaign: false,
               last_dunning_campaign_attempt: 3,
-              last_dunning_campaign_attempt_at: 2.days.ago,
-              dunning_campaign_completed: true
+              last_dunning_campaign_attempt_at: 2.days.ago
             )
           end
 
@@ -445,7 +439,6 @@ RSpec.describe Customers::UpdateService, type: :service do
             expect { customers_service.call }
               .to change(customer, :applied_dunning_campaign_id).to(nil)
               .and not_change(customer, :exclude_from_dunning_campaign)
-              .and change(customer, :dunning_campaign_completed).to(false)
               .and change(customer, :last_dunning_campaign_attempt).to(0)
               .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
 
@@ -461,8 +454,7 @@ RSpec.describe Customers::UpdateService, type: :service do
               applied_dunning_campaign: dunning_campaign,
               exclude_from_dunning_campaign: false,
               last_dunning_campaign_attempt: 3,
-              last_dunning_campaign_attempt_at: 2.days.ago,
-              dunning_campaign_completed: true
+              last_dunning_campaign_attempt_at: 2.days.ago
             )
           end
 
@@ -472,7 +464,6 @@ RSpec.describe Customers::UpdateService, type: :service do
             expect { customers_service.call }
               .to not_change(customer, :applied_dunning_campaign_id)
               .and not_change(customer, :exclude_from_dunning_campaign)
-              .and not_change(customer, :dunning_campaign_completed)
               .and not_change(customer, :last_dunning_campaign_attempt)
               .and not_change(customer, :last_dunning_campaign_attempt_at)
 

--- a/spec/services/dunning_campaigns/bulk_process_service_spec.rb
+++ b/spec/services/dunning_campaigns/bulk_process_service_spec.rb
@@ -65,17 +65,6 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
             .with(customer:, dunning_campaign_threshold:)
         end
 
-        context "when the customer has completed the dunning campaign" do
-          let(:customer) do
-            create :customer, organization:, currency:, dunning_campaign_completed: true
-          end
-
-          it "does not queue a job for the customer" do
-            result
-            expect(DunningCampaigns::ProcessAttemptJob).not_to have_been_enqueued
-          end
-        end
-
         context "when organization does not have auto_dunning feature enabled" do
           let(:organization) { create(:organization, premium_integrations: []) }
 

--- a/spec/services/dunning_campaigns/process_attempt_service_spec.rb
+++ b/spec/services/dunning_campaigns/process_attempt_service_spec.rb
@@ -74,6 +74,23 @@ RSpec.describe DunningCampaigns::ProcessAttemptService, type: :service, aggregat
       end
     end
 
+    context "when dunning campaign max attempt is reached" do
+      let(:customer) do
+        create(
+          :customer,
+          organization:,
+          currency:,
+          last_dunning_campaign_attempt: dunning_campaign.max_attempts,
+          last_dunning_campaign_attempt_at: dunning_campaign.days_between_attempts.days.ago
+        )
+      end
+
+      it "does nothing" do
+        result
+        expect(PaymentRequests::CreateService).not_to have_received(:call)
+      end
+    end
+
     context "when the campaign threshold is not reached" do
       let(:dunning_campaign_threshold) do
         create :dunning_campaign_threshold, dunning_campaign:, currency:, amount_cents: 99_01

--- a/spec/services/dunning_campaigns/process_attempt_service_spec.rb
+++ b/spec/services/dunning_campaigns/process_attempt_service_spec.rb
@@ -71,25 +71,6 @@ RSpec.describe DunningCampaigns::ProcessAttemptService, type: :service, aggregat
         expect { result && customer.reload }
           .to change(customer, :last_dunning_campaign_attempt).by(1)
           .and change(customer, :last_dunning_campaign_attempt_at).to(Time.zone.now)
-          .and not_change(customer, :dunning_campaign_completed).from(false)
-      end
-    end
-
-    context "when dunning campaign max attemp is reached" do
-      let(:customer) do
-        create(
-          :customer,
-          organization:,
-          currency:,
-          last_dunning_campaign_attempt: dunning_campaign.max_attempts - 1,
-          last_dunning_campaign_attempt_at: dunning_campaign.days_between_attempts.days.ago,
-          dunning_campaign_completed: false
-        )
-      end
-
-      it "updates customer's dunning campaign completed flag" do
-        expect { result && customer.reload }
-          .to change(customer, :dunning_campaign_completed).to(true)
       end
     end
 
@@ -128,22 +109,6 @@ RSpec.describe DunningCampaigns::ProcessAttemptService, type: :service, aggregat
     context "when the customer is excluded from auto dunning" do
       let(:customer) do
         create :customer, organization:, currency:, exclude_from_dunning_campaign: true
-      end
-
-      it "does nothing" do
-        result
-        expect(PaymentRequests::CreateService).not_to have_received(:call)
-      end
-    end
-
-    context "when the customer has completed the dunning campaign" do
-      let(:customer) do
-        create(
-          :customer,
-          organization:,
-          currency:,
-          dunning_campaign_completed: true
-        )
       end
 
       it "does nothing" do

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -79,17 +79,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           ]
         end
 
-        let(:customer_completed) do
-          create(
-            :customer,
-            currency: dunning_campaign_threshold.currency,
-            applied_dunning_campaign: dunning_campaign,
-            last_dunning_campaign_attempt: 4,
-            last_dunning_campaign_attempt_at: 1.day.ago,
-            dunning_campaign_completed: true,
-            organization: organization
-          )
-        end
         let(:customer_defaulting) do
           create(
             :customer,
@@ -97,7 +86,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
             applied_dunning_campaign: nil,
             last_dunning_campaign_attempt: 4,
             last_dunning_campaign_attempt_at: 1.day.ago,
-            dunning_campaign_completed: false,
             organization: organization
           )
         end
@@ -108,7 +96,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
             applied_dunning_campaign: dunning_campaign,
             last_dunning_campaign_attempt: 4,
             last_dunning_campaign_attempt_at: 1.day.ago,
-            dunning_campaign_completed: false,
             organization: organization
           )
         end
@@ -126,105 +113,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
             .to have_attributes({amount_cents: 999_99, currency: "GBP"})
           expect(result.dunning_campaign.thresholds.where.not(id: dunning_campaign_threshold.id).first)
             .to have_attributes({amount_cents: 5_55, currency: "CHF"})
-        end
-
-        context "when max_attempts is changed and some customers exceed it" do
-          let(:params) { {max_attempts: 3} }
-
-          before do
-            create(
-              :invoice,
-              organization:,
-              customer:,
-              payment_overdue: true,
-              total_amount_cents: dunning_campaign_threshold.amount_cents,
-              currency: dunning_campaign_threshold.currency
-            )
-          end
-
-          context "when the campaign is applied to the customer" do
-            let(:dunning_campaign) do
-              create(:dunning_campaign, organization:, applied_to_organization: false)
-            end
-
-            let(:customer) do
-              create(
-                :customer,
-                currency: dunning_campaign_threshold.currency,
-                applied_dunning_campaign: dunning_campaign,
-                last_dunning_campaign_attempt: 3,
-                last_dunning_campaign_attempt_at: 1.day.ago,
-                dunning_campaign_completed: false,
-                organization: organization
-              )
-            end
-
-            before { customer }
-
-            it "sets dunning_campaign_completed to true for customers whose last_dunning_campaign_attempt exceeds max_attempts" do
-              expect { result && customer.reload }
-                .to change(customer, :dunning_campaign_completed).to true
-            end
-
-            it "does not update customers whose last_dunning_campaign_attempt is within the new max_attempts" do
-              another_customer = create(
-                :customer,
-                currency: dunning_campaign_threshold.currency,
-                applied_dunning_campaign: dunning_campaign,
-                last_dunning_campaign_attempt: 2,
-                last_dunning_campaign_attempt_at: 1.day.ago,
-                dunning_campaign_completed: false,
-                organization: organization
-              )
-
-              expect { result && another_customer.reload }
-                .not_to change { another_customer.dunning_campaign_completed }
-
-              expect(result).to be_success
-            end
-          end
-
-          context "when the customer falls back to the campaign through the organization" do
-            let(:customer) do
-              create(
-                :customer,
-                currency: dunning_campaign_threshold.currency,
-                applied_dunning_campaign: nil,
-                last_dunning_campaign_attempt: 4,
-                last_dunning_campaign_attempt_at: 1.day.ago,
-                dunning_campaign_completed: false,
-                organization: organization
-              )
-            end
-
-            let(:dunning_campaign) do
-              create(:dunning_campaign, organization:, applied_to_organization: true)
-            end
-
-            before { customer }
-
-            it "sets dunning_campaign_completed to true for customers whose last_dunning_campaign_attempt exceeds max_attempts" do
-              expect { result && customer.reload }
-                .to change(customer, :dunning_campaign_completed).to true
-            end
-
-            it "does not update customers whose last_dunning_campaign_attempt is within the new max_attempts" do
-              another_customer = create(
-                :customer,
-                currency: dunning_campaign_threshold.currency,
-                applied_dunning_campaign: dunning_campaign,
-                last_dunning_campaign_attempt: 2,
-                last_dunning_campaign_attempt_at: 1.day.ago,
-                dunning_campaign_completed: false,
-                organization: organization
-              )
-
-              expect { result && another_customer.reload }
-                .not_to change { another_customer.dunning_campaign_completed }
-
-              expect(result).to be_success
-            end
-          end
         end
 
         shared_examples "resets customer last dunning campaign attempt fields" do |customer_name|
@@ -290,10 +178,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           context "when the customer defaults to the campaign applied to organization" do
             include_examples "resets customer last dunning campaign attempt fields", :customer_defaulting
           end
-
-          context "when the customer already completed the campaign" do
-            include_examples "does not reset customer last dunning campaign attempt fields", :customer_completed
-          end
         end
 
         context "when threshold currency changes and does not apply anymore to the customer" do
@@ -328,10 +212,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the customer defaults to the campaign applied to organization" do
             include_examples "resets customer last dunning campaign attempt fields", :customer_defaulting
-          end
-
-          context "when the customer already completed the campaign" do
-            include_examples "does not reset customer last dunning campaign attempt fields", :customer_completed
           end
         end
 
@@ -369,10 +249,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the customer defaults to the campaign applied to organization" do
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_defaulting
-          end
-
-          context "when the customer already completed the campaign" do
-            include_examples "does not reset customer last dunning campaign attempt fields", :customer_completed
           end
         end
 
@@ -418,10 +294,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           context "when the customer defaults to the campaign applied to organization" do
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_defaulting
           end
-
-          context "when the customer already completed the campaign" do
-            include_examples "does not reset customer last dunning campaign attempt fields", :customer_completed
-          end
         end
 
         context "when a threshold is discarded and the campaign does not apply anymore to the customer" do
@@ -448,10 +320,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the customer defaults to the campaign applied to organization" do
             include_examples "resets customer last dunning campaign attempt fields", :customer_defaulting
-          end
-
-          context "when the customer already completed the campaign" do
-            include_examples "does not reset customer last dunning campaign attempt fields", :customer_completed
           end
         end
 
@@ -488,10 +356,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the customer defaults to the campaign applied to organization" do
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_defaulting
-          end
-
-          context "when the customer already completed the campaign" do
-            include_examples "does not reset customer last dunning campaign attempt fields", :customer_completed
           end
         end
 
@@ -555,18 +419,16 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
               .and change { customer.last_dunning_campaign_attempt_at }.from(a_value).to(nil)
           end
 
-          it "flags customers as not dunning campaign completed" do
+          it "resets last attempt" do
             customer = create(
               :customer,
               organization:,
-              dunning_campaign_completed: true,
               last_dunning_campaign_attempt: 3,
               last_dunning_campaign_attempt_at: Time.zone.now
             )
 
             expect { result && customer.reload }
-              .to change(customer, :dunning_campaign_completed).to(false)
-              .and change(customer, :last_dunning_campaign_attempt).to(0)
+              .to change(customer, :last_dunning_campaign_attempt).to(0)
               .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
           end
         end

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe Invoices::UpdateService do
       let(:customer) do
         create(
           :customer,
-          dunning_campaign_completed: true,
           last_dunning_campaign_attempt: 3,
           last_dunning_campaign_attempt_at: 1.day.ago
         )
@@ -58,8 +57,7 @@ RSpec.describe Invoices::UpdateService do
 
       it "does not reset customer dunning campaign status counters" do
         expect { result && customer.reload }
-          .to not_change(customer, :dunning_campaign_completed)
-          .and not_change(customer, :last_dunning_campaign_attempt)
+          .to not_change(customer, :last_dunning_campaign_attempt)
           .and not_change { customer.last_dunning_campaign_attempt_at.to_i }
       end
 
@@ -71,8 +69,7 @@ RSpec.describe Invoices::UpdateService do
 
         it "resets customer dunning campaign status counters" do
           expect { result && customer.reload }
-            .to change(customer, :dunning_campaign_completed).to(false)
-            .and change(customer, :last_dunning_campaign_attempt).to(0)
+            .to change(customer, :last_dunning_campaign_attempt).to(0)
             .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
         end
       end

--- a/spec/services/payment_requests/payments/adyen_service_spec.rb
+++ b/spec/services/payment_requests/payments/adyen_service_spec.rb
@@ -462,7 +462,6 @@ RSpec.describe PaymentRequests::Payments::AdyenService, type: :service do
         create(
           :customer,
           payment_provider_code: code,
-          dunning_campaign_completed: true,
           last_dunning_campaign_attempt: 3,
           last_dunning_campaign_attempt_at: Time.zone.now
         )
@@ -482,8 +481,7 @@ RSpec.describe PaymentRequests::Payments::AdyenService, type: :service do
 
       it "resets the customer dunning campaign counters" do
         expect { result && customer.reload }
-          .to change(customer, :dunning_campaign_completed).to(false)
-          .and change(customer, :last_dunning_campaign_attempt).to(0)
+          .to change(customer, :last_dunning_campaign_attempt).to(0)
           .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
 
         expect(result).to be_success
@@ -494,8 +492,7 @@ RSpec.describe PaymentRequests::Payments::AdyenService, type: :service do
 
         it "doest not reset the customer dunning campaign counters" do
           expect { result && customer.reload }
-            .to not_change(customer, :dunning_campaign_completed)
-            .and not_change(customer, :last_dunning_campaign_attempt)
+            .to not_change(customer, :last_dunning_campaign_attempt)
             .and not_change { customer.last_dunning_campaign_attempt_at&.to_i }
 
           expect(result).to be_success

--- a/spec/services/payment_requests/payments/gocardless_service_spec.rb
+++ b/spec/services/payment_requests/payments/gocardless_service_spec.rb
@@ -321,7 +321,6 @@ RSpec.describe PaymentRequests::Payments::GocardlessService, type: :service do
         create(
           :customer,
           payment_provider_code: code,
-          dunning_campaign_completed: true,
           last_dunning_campaign_attempt: 3,
           last_dunning_campaign_attempt_at: Time.zone.now
         )
@@ -341,8 +340,7 @@ RSpec.describe PaymentRequests::Payments::GocardlessService, type: :service do
 
       it "resets the customer dunning campaign counters" do
         expect { result && customer.reload }
-          .to change(customer, :dunning_campaign_completed).to(false)
-          .and change(customer, :last_dunning_campaign_attempt).to(0)
+          .to change(customer, :last_dunning_campaign_attempt).to(0)
           .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
 
         expect(result).to be_success
@@ -353,8 +351,7 @@ RSpec.describe PaymentRequests::Payments::GocardlessService, type: :service do
 
         it "doest not reset the customer dunning campaign counters" do
           expect { result && customer.reload }
-            .to not_change(customer, :dunning_campaign_completed)
-            .and not_change(customer, :last_dunning_campaign_attempt)
+            .to not_change(customer, :last_dunning_campaign_attempt)
             .and not_change { customer.last_dunning_campaign_attempt_at&.to_i }
 
           expect(result).to be_success

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -508,7 +508,6 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
         create(
           :customer,
           payment_provider_code: code,
-          dunning_campaign_completed: true,
           last_dunning_campaign_attempt: 3,
           last_dunning_campaign_attempt_at: Time.zone.now
         )
@@ -528,8 +527,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
 
       it "resets the customer dunning campaign counters" do
         expect { result && customer.reload }
-          .to change(customer, :dunning_campaign_completed).to(false)
-          .and change(customer, :last_dunning_campaign_attempt).to(0)
+          .to change(customer, :last_dunning_campaign_attempt).to(0)
           .and change(customer, :last_dunning_campaign_attempt_at).to(nil)
 
         expect(result).to be_success
@@ -540,8 +538,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
 
         it "doest not reset the customer dunning campaign counters" do
           expect { result && customer.reload }
-            .to not_change(customer, :dunning_campaign_completed)
-            .and not_change(customer, :last_dunning_campaign_attempt)
+            .to not_change(customer, :last_dunning_campaign_attempt)
             .and not_change { customer.last_dunning_campaign_attempt_at&.to_i }
 
           expect(result).to be_success


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/set-up-payment-retry-logic

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to automate dunning process so that our users don't have to look at each customer to maximize their chances of being paid retrying payments of overdue balances and sending email reminders.

We are extending dunning campaigns management to edit and delete campaigns.

 ## Description

The goal of this PR is to remove the flag `dunning_campaign_completed` on customers.
We don't need this complexity and prefer retrying the dunning process when number of attempts is changed.