### PR TITLE
perf(API) - Set all _count values in API to zero

### DIFF
--- a/app/serializers/v1/billable_metric_serializer.rb
+++ b/app/serializers/v1/billable_metric_serializer.rb
@@ -28,24 +28,10 @@ module V1
 
     def counters
       {
-        active_subscriptions_count:,
-        draft_invoices_count:,
-        plans_count:
+        active_subscriptions_count: 0,
+        draft_invoices_count: 0,
+        plans_count: 0
       }
-    end
-
-    def active_subscriptions_count
-      Subscription.active.where(plan_id: model.charges.select(:plan_id).distinct).count
-    end
-
-    def draft_invoices_count
-      Invoice.draft.where(id: model.charges
-        .joins(:fees)
-        .select(:invoice_id)).count
-    end
-
-    def plans_count
-      model.plans.distinct.count
     end
 
     def filters

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -16,9 +16,9 @@ module V1
         trial_period: model.trial_period,
         pay_in_advance: model.pay_in_advance,
         bill_charges_monthly: model.bill_charges_monthly,
-        customers_count: model.customers_count,
-        active_subscriptions_count: model.active_subscriptions_count,
-        draft_invoices_count: model.draft_invoices_count,
+        customers_count: 0,
+        active_subscriptions_count: 0,
+        draft_invoices_count: 0,
         parent_id: model.parent_id
       }
 

--- a/app/serializers/v1/tax_serializer.rb
+++ b/app/serializers/v1/tax_serializer.rb
@@ -10,19 +10,13 @@ module V1
         rate: model.rate,
         description: model.description,
         applied_to_organization: model.applied_to_organization,
-        add_ons_count: model.add_ons.count,
-        customers_count: model.customers_count,
-        plans_count: model.plans.count,
-        charges_count:,
-        commitments_count: model.commitments.count,
+        add_ons_count: 0,
+        customers_count: 0,
+        plans_count: 0,
+        charges_count: 0,
+        commitments_count: 0,
         created_at: model.created_at.iso8601
       }
-    end
-
-    private
-
-    def charges_count
-      Charge::AppliedTax.where(tax_id: model.id).count('charge_id')
     end
   end
 end

--- a/spec/serializers/v1/billable_metric_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_serializer_spec.rb
@@ -29,17 +29,17 @@ RSpec.describe ::V1::BillableMetricSerializer do
   context "with counters inclusion" do
     let(:includes) { %i[counters] }
 
-    it "returns the count number of active subscriptions" do
+    it "returns a zero count for number of active subscriptions" do
       terminated_subscription = create(:subscription, :terminated)
       create(:standard_charge, plan: terminated_subscription.plan, billable_metric:)
 
       subscription = create(:subscription)
       create(:standard_charge, plan: subscription.plan, billable_metric:)
 
-      expect(result["billable_metric"]["active_subscriptions_count"]).to eq(1)
+      expect(result["billable_metric"]["active_subscriptions_count"]).to eq(0)
     end
 
-    it "returns the count number of draft invoices" do
+    it "returns a zero count for number of draft invoices" do
       customer = create(:customer, organization: billable_metric.organization)
       subscription = create(:subscription)
       subscription2 = create(:subscription)
@@ -53,14 +53,14 @@ RSpec.describe ::V1::BillableMetricSerializer do
       create(:fee, invoice: draft_invoice, charge: charge2)
       create(:fee, invoice: draft_invoice, charge: charge2)
 
-      expect(result["billable_metric"]["draft_invoices_count"]).to eq(1)
+      expect(result["billable_metric"]["draft_invoices_count"]).to eq(0)
     end
 
-    it "returns the number of plans" do
+    it "returns a zero number of plans" do
       plan = create(:plan, organization: billable_metric.organization)
       create(:standard_charge, billable_metric:, plan:)
 
-      expect(result["billable_metric"]["plans_count"]).to eq(1)
+      expect(result["billable_metric"]["plans_count"]).to eq(0)
     end
   end
 end

--- a/spec/serializers/v1/commitment_serializer_spec.rb
+++ b/spec/serializers/v1/commitment_serializer_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ::V1::CommitmentSerializer do
       'rate' => tax.rate,
       'description' => tax.description,
       'applied_to_organization' => tax.applied_to_organization,
-      'commitments_count' => 1
+      'commitments_count' => 0
     }
   end
 

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe ::V1::PlanSerializer do
         'trial_period' => plan.trial_period,
         'pay_in_advance' => plan.pay_in_advance,
         'bill_charges_monthly' => plan.bill_charges_monthly,
-        'customers_count' => 2,
-        'active_subscriptions_count' => 2,
+        'customers_count' => 0,
+        'active_subscriptions_count' => 0,
         'draft_invoices_count' => 0,
         'parent_id' => nil,
         'taxes' => []
@@ -101,8 +101,8 @@ RSpec.describe ::V1::PlanSerializer do
         'trial_period' => plan.trial_period,
         'pay_in_advance' => plan.pay_in_advance,
         'bill_charges_monthly' => plan.bill_charges_monthly,
-        'customers_count' => 2,
-        'active_subscriptions_count' => 2,
+        'customers_count' => 0,
+        'active_subscriptions_count' => 0,
         'draft_invoices_count' => 0,
         'parent_id' => nil,
         'taxes' => []


### PR DESCRIPTION
## Description

These count queries are hard to optimize and executed way too often. We're going to start returning zero so we don't break API clients, but these fields will be removed.