### PR TITLE
Fix: missing parent charge in the database

### DIFF
--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -242,7 +242,7 @@ module Plans
         create_charge_result = Charges::CreateService.call(plan:, params: payload_charge)
         create_charge_result.raise_if_error!
 
-        cascade_charge_creation(payload_charge.merge(parent_id: create_charge_result.charge.id))
+        after_commit { cascade_charge_creation(payload_charge.merge(parent_id: create_charge_result.charge.id)) }
         created_charges_ids.push(create_charge_result.charge.id)
       end
 


### PR DESCRIPTION
## Context

We started having errors in sidekiq that charge cannot be saved because parent_id charge does not exist in the database

## Description

Wrap cascade_charge_creation in after_commit block