### PR TITLE
fix(netsuite): Fix quantity sent to netsuite

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -101,7 +101,7 @@ module Integrations
             {
               'item' => mapped_item.external_id,
               'account' => mapped_item.external_account_code,
-              'quantity' => fee.units,
+              'quantity' => limited_rate(fee.units),
               'rate' => limited_rate(fee.precise_unit_amount),
               'amount' => limited_rate(amount(fee.amount_cents, resource: invoice)),
               'taxdetailsreference' => fee.id


### PR DESCRIPTION
## Context

Netsuite cannot accept more than 15 decimal places in invoice line item quantity

## Description

Round the line item quantity in netsuite invoice payload.