### PR TITLE
perf(EventsApi) - order events by timestamp rather than created_at

### DIFF
--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -6,7 +6,7 @@ class EventsQuery < BaseQuery
     events = events.where(organization_id: organization.id)
     events = paginate(events)
 
-    events = events.order(created_at: :desc) unless organization.clickhouse_events_store?
+    events = events.order(timestamp: :desc) unless organization.clickhouse_events_store?
     events = events.order(ingested_at: :desc) if organization.clickhouse_events_store?
 
     events = with_code(events) if filters.code


### PR DESCRIPTION
## Description

We've got an index on (organization_id, timestamp). I don't think there's much downside to ordering by timestamp rather than created_at.