### PR TITLE
feat(api-key-management): Use permissions defined by API key

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -9,6 +9,7 @@ module Api
     before_action :authenticate
     before_action :set_context_source
     before_action :track_api_key_usage
+    before_action :authorize
     include Trackable
 
     rescue_from ActionController::ParameterMissing, with: :bad_request_error
@@ -47,6 +48,20 @@ module Api
 
     def track_api_key_usage?
       true
+    end
+
+    def authorize
+      return if current_api_key.permit?(resource_name, mode)
+
+      forbidden_error(code: "#{mode}_action_not_allowed_for_#{resource_name}")
+    end
+
+    def resource_name
+      nil
+    end
+
+    def mode
+      (request.method == 'GET') ? 'read' : 'write'
     end
   end
 end

--- a/app/controllers/api/v1/add_ons_controller.rb
+++ b/app/controllers/api/v1/add_ons_controller.rb
@@ -90,6 +90,10 @@ module Api
           )
         )
       end
+
+      def resource_name
+        'add_on'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/analytics/base_controller.rb
+++ b/app/controllers/api/v1/analytics/base_controller.rb
@@ -23,6 +23,10 @@ module Api
             )
           )
         end
+
+        def resource_name
+          'analytic'
+        end
       end
     end
   end

--- a/app/controllers/api/v1/applied_coupons_controller.rb
+++ b/app/controllers/api/v1/applied_coupons_controller.rb
@@ -70,6 +70,10 @@ module Api
       def index_filters
         params.permit(:external_customer_id, :status)
       end
+
+      def resource_name
+        'applied_coupon'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -139,6 +139,10 @@ module Api
           properties: {}
         ])
       end
+
+      def resource_name
+        'billable_metric'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -98,6 +98,10 @@ module Api
           )
         )
       end
+
+      def resource_name
+        'coupon'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -163,6 +163,10 @@ module Api
             ]
           )
       end
+
+      def resource_name
+        'credit_note'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/customers/applied_coupons_controller.rb
+++ b/app/controllers/api/v1/customers/applied_coupons_controller.rb
@@ -18,6 +18,12 @@ module Api
             render_error_response(result)
           end
         end
+
+        private
+
+        def resource_name
+          'applied_coupon'
+        end
       end
     end
   end

--- a/app/controllers/api/v1/customers/usage_controller.rb
+++ b/app/controllers/api/v1/customers/usage_controller.rb
@@ -61,6 +61,10 @@ module Api
             external_customer_id: params[:customer_external_id]
           )
         end
+
+        def resource_name
+          'customer_usage'
+        end
       end
     end
   end

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -161,6 +161,10 @@ module Api
           )
         )
       end
+
+      def resource_name
+        'customer'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -153,6 +153,10 @@ module Api
       def track_api_key_usage?
         action_name&.to_sym != :create
       end
+
+      def resource_name
+        'event'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/fees_controller.rb
+++ b/app/controllers/api/v1/fees_controller.rb
@@ -94,6 +94,10 @@ module Api
           :refunded_at_to
         )
       end
+
+      def resource_name
+        'fee'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -260,6 +260,10 @@ module Api
           organization_id: current_organization.id
         )
       end
+
+      def resource_name
+        'invoice'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/lifetime_usages_controller.rb
+++ b/app/controllers/api/v1/lifetime_usages_controller.rb
@@ -43,6 +43,10 @@ module Api
           )
         )
       end
+
+      def resource_name
+        'lifetime_usage'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -74,6 +74,10 @@ module Api
           ]
         )
       end
+
+      def resource_name
+        'organization'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/payment_requests_controller.rb
+++ b/app/controllers/api/v1/payment_requests_controller.rb
@@ -60,6 +60,10 @@ module Api
       def index_filters
         params.permit(:external_customer_id)
       end
+
+      def resource_name
+        'payment_request'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -127,6 +127,10 @@ module Api
           )
         )
       end
+
+      def resource_name
+        'plan'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -189,6 +189,10 @@ module Api
           )
         )
       end
+
+      def resource_name
+        'subscription'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/taxes_controller.rb
+++ b/app/controllers/api/v1/taxes_controller.rb
@@ -67,6 +67,10 @@ module Api
       def render_tax(tax)
         render(json: ::V1::TaxSerializer.new(tax, root_name: 'tax'))
       end
+
+      def resource_name
+        'tax'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -63,6 +63,10 @@ module Api
           ]
         )
       end
+
+      def resource_name
+        'wallet_transaction'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -144,6 +144,10 @@ module Api
           )
         )
       end
+
+      def resource_name
+        'wallet'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/webhook_endpoints_controller.rb
+++ b/app/controllers/api/v1/webhook_endpoints_controller.rb
@@ -89,6 +89,10 @@ module Api
           )
         )
       end
+
+      def resource_name
+        'webhook_endpoint'
+      end
     end
   end
 end

--- a/app/controllers/api/v1/webhooks_controller.rb
+++ b/app/controllers/api/v1/webhooks_controller.rb
@@ -18,6 +18,12 @@ module Api
           status: :ok
         )
       end
+
+      private
+
+      def resource_name
+        'webhook_jwt_public_key'
+      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,6 @@ en:
             attributes:
               permissions:
                 forbidden_key: 'contains forbidden keys: %{keys}'
-                missing_key: 'missing required keys: %{keys}'
         not_compatible_with_aggregation_type: not_compatible_with_aggregation_type
         not_compatible_with_pay_in_advance: not_compatible_with_pay_in_advance
         only_compatible_with_pay_in_advance_and_non_invoiceable: only_compatible_with_pay_in_advance_and_non_invoiceable

--- a/spec/requests/api/v1/add_ons_controller_spec.rb
+++ b/spec/requests/api/v1/add_ons_controller_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Api::V1::AddOnsController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'add_on', 'write'
+
     it 'creates a add-on' do
       subject
 
@@ -45,6 +47,7 @@ RSpec.describe Api::V1::AddOnsController, type: :request do
     let(:add_on_applied_tax) { create(:add_on_applied_tax, add_on:, tax:) }
     let(:code) { 'add_on_code' }
     let(:tax2) { create(:tax, organization:) }
+
     let(:update_params) do
       {
         name: 'add_on1',
@@ -58,6 +61,8 @@ RSpec.describe Api::V1::AddOnsController, type: :request do
     end
 
     before { add_on_applied_tax }
+
+    include_examples 'requires API permission', 'add_on', 'write'
 
     it 'updates an add-on' do
       subject
@@ -84,7 +89,6 @@ RSpec.describe Api::V1::AddOnsController, type: :request do
 
       it 'returns unprocessable_entity error' do
         subject
-
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
@@ -95,6 +99,8 @@ RSpec.describe Api::V1::AddOnsController, type: :request do
 
     let(:add_on) { create(:add_on, organization:) }
     let(:add_on_code) { add_on.code }
+
+    include_examples 'requires API permission', 'add_on', 'read'
 
     it 'returns a add-on' do
       subject
@@ -120,6 +126,8 @@ RSpec.describe Api::V1::AddOnsController, type: :request do
 
     let!(:add_on) { create(:add_on, organization:) }
     let(:add_on_code) { add_on.code }
+
+    include_examples 'requires API permission', 'add_on', 'write'
 
     it 'deletes a add-on' do
       expect { subject }.to change(AddOn, :count).by(-1)
@@ -150,6 +158,8 @@ RSpec.describe Api::V1::AddOnsController, type: :request do
     let(:params) { {} }
 
     before { create(:add_on_applied_tax, add_on:, tax:) }
+
+    include_examples 'requires API permission', 'add_on', 'read'
 
     it 'returns add-ons' do
       subject

--- a/spec/requests/api/v1/analytics/gross_revenues_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/gross_revenues_controller_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Api::V1::Analytics::GrossRevenuesController, type: :request do
     context 'when licence is premium' do
       around { |test| lago_premium!(&test) }
 
+      include_examples 'requires API permission', 'analytic', 'read'
+
       it 'returns the gross revenue' do
         subject
 

--- a/spec/requests/api/v1/analytics/invoice_collections_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/invoice_collections_controller_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Api::V1::Analytics::InvoiceCollectionsController, type: :request 
     context 'when licence is premium' do
       around { |test| lago_premium!(&test) }
 
+      include_examples 'requires API permission', 'analytic', 'read'
+
       it 'returns the gross revenue' do
         subject
 

--- a/spec/requests/api/v1/analytics/invoiced_usages_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/invoiced_usages_controller_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Api::V1::Analytics::InvoicedUsagesController, type: :request do #
     context 'when license is premium' do
       around { |test| lago_premium!(&test) }
 
+      include_examples 'requires API permission', 'analytic', 'read'
+
       it 'returns the invoiced usage' do
         subject
 

--- a/spec/requests/api/v1/analytics/mrrs_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/mrrs_controller_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Api::V1::Analytics::MrrsController, type: :request do # rubocop:d
     context 'when license is premium' do
       around { |test| lago_premium!(&test) }
 
+      include_examples 'requires API permission', 'analytic', 'read'
+
       it 'returns the mrr' do
         subject
 

--- a/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Api::V1::Analytics::OverdueBalancesController, type: :request do
     let(:customer) { create(:customer, organization:) }
     let(:organization) { create(:organization, created_at: DateTime.new(2023, 11, 1)) }
 
+    include_examples "requires API permission", "analytic", "read"
+
     it "returns the overdue balance" do
       travel_to(DateTime.new(2024, 1, 15)) do
         create(:invoice, customer:, organization:)

--- a/spec/requests/api/v1/applied_coupons_controller_spec.rb
+++ b/spec/requests/api/v1/applied_coupons_controller_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
 
     before { create(:subscription, customer:) }
 
+    include_examples 'requires API permission', 'applied_coupon', 'write'
+
     it 'returns a success' do
       subject
 
@@ -69,6 +71,8 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
     before do
       create(:credit, applied_coupon:, amount_cents: 2, amount_currency: customer.currency)
     end
+
+    include_examples 'requires API permission', 'applied_coupon', 'read'
 
     it 'returns applied coupons' do
       subject

--- a/spec/requests/api/v1/billable_metrics_controller_spec.rb
+++ b/spec/requests/api/v1/billable_metrics_controller_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'billable_metric', 'write'
+
     it 'creates a billable_metric' do
       subject
 
@@ -90,6 +92,8 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'billable_metric', 'write'
+
     it 'updates a billable_metric' do
       subject
 
@@ -151,6 +155,8 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
     let(:billable_metric) { create(:billable_metric, organization:) }
     let(:billable_metric_code) { billable_metric.code }
 
+    include_examples 'requires API permission', 'billable_metric', 'read'
+
     it 'returns a billable metric' do
       subject
 
@@ -186,6 +192,8 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
     let!(:billable_metric) { create(:billable_metric, organization:) }
     let(:billable_metric_code) { billable_metric.code }
 
+    include_examples 'requires API permission', 'billable_metric', 'write'
+
     it 'deletes a billable_metric' do
       expect { subject }.to change(BillableMetric, :count).by(-1)
     end
@@ -213,6 +221,8 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
 
     let!(:billable_metric) { create(:billable_metric, organization:) }
     let(:params) { {} }
+
+    include_examples 'requires API permission', 'billable_metric', 'read'
 
     it 'returns billable metrics' do
       subject
@@ -253,6 +263,8 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
 
     let(:expression) { 'round(event.properties.value)' }
     let(:event) { {code: 'bm_code', timestamp: Time.current.to_i, properties: {value: '2.4'}} }
+
+    include_examples 'requires API permission', 'billable_metric', 'write'
 
     context 'with valid inputs' do
       it 'evaluates the expression', :aggregate_failures do

--- a/spec/requests/api/v1/coupons_controller_spec.rb
+++ b/spec/requests/api/v1/coupons_controller_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Api::V1::CouponsController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'coupon', 'write'
+
     it 'creates a coupon' do
       subject
 
@@ -65,6 +67,8 @@ RSpec.describe Api::V1::CouponsController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'coupon', 'write'
+
     it 'updates a coupon' do
       subject
 
@@ -100,6 +104,8 @@ RSpec.describe Api::V1::CouponsController, type: :request do
     let(:coupon) { create(:coupon, organization:) }
     let(:coupon_code) { coupon.code }
 
+    include_examples 'requires API permission', 'coupon', 'read'
+
     it 'returns a coupon' do
       subject
 
@@ -123,6 +129,8 @@ RSpec.describe Api::V1::CouponsController, type: :request do
 
     let!(:coupon) { create(:coupon, organization:) }
     let(:coupon_code) { coupon.code }
+
+    include_examples 'requires API permission', 'coupon', 'write'
 
     it 'deletes a coupon' do
       expect { subject }.to change(Coupon, :count).by(-1)
@@ -151,6 +159,8 @@ RSpec.describe Api::V1::CouponsController, type: :request do
 
     let!(:coupon) { create(:coupon, organization:) }
     let(:params) { {} }
+
+    include_examples 'requires API permission', 'coupon', 'read'
 
     it 'returns coupons' do
       subject

--- a/spec/requests/api/v1/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes_controller_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
     let(:credit_note_id) { credit_note.id }
     let!(:credit_note_items) { create_list(:credit_note_item, 2, credit_note:) }
 
+    include_examples 'requires API permission', 'credit_note', 'read'
+
     it 'returns a credit note' do
       subject
 
@@ -107,6 +109,8 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
     let(:credit_note_id) { credit_note.id }
     let(:update_params) { {refund_status: 'succeeded'} }
 
+    include_examples 'requires API permission', 'credit_note', 'write'
+
     context 'when credit not exists' do
       it 'updates the credit note' do
         subject
@@ -139,12 +143,14 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
     end
   end
 
-  describe 'GET /api/v1/credit_notes/:id/download' do
+  describe 'POST /api/v1/credit_notes/:id/download' do
     subject do
       post_with_token(organization, "/api/v1/credit_notes/#{credit_note_id}/download")
     end
 
     let(:credit_note_id) { credit_note.id }
+
+    include_examples 'requires API permission', 'credit_note', 'write'
 
     it 'enqueues a job to generate the PDF' do
       subject
@@ -202,6 +208,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
 
     let(:second_customer) { create(:customer, organization:) }
     let(:second_invoice) { create(:invoice, customer: second_customer, organization:) }
+    let(:params) { {} }
 
     let(:another_customer_credit_note) do
       create(:credit_note, invoice: second_invoice, customer: second_invoice.customer)
@@ -214,18 +221,16 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
       ].pluck(:id)
     end
 
-    context 'without params' do
-      let(:params) { {} }
+    include_examples 'requires API permission', 'credit_note', 'read'
 
-      it 'returns a list of credit_notes' do
-        subject
+    it 'returns a list of credit_notes' do
+      subject
 
-        aggregate_failures do
-          expect(response).to have_http_status(:success)
-          expect(json[:credit_notes].count).to eq(2)
-          expect(json[:credit_notes].first[:items]).to be_empty
-          expect(json[:credit_notes].map { |i| i[:lago_id] }).to match_array credit_note_ids
-        end
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:credit_notes].count).to eq(2)
+        expect(json[:credit_notes].first[:items]).to be_empty
+        expect(json[:credit_notes].map { |i| i[:lago_id] }).to match_array credit_note_ids
       end
     end
 
@@ -297,6 +302,8 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
 
     around { |test| lago_premium!(&test) }
 
+    include_examples 'requires API permission', 'credit_note', 'write'
+
     it 'creates a credit note' do
       subject
 
@@ -342,6 +349,8 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
     subject { put_with_token(organization, "/api/v1/credit_notes/#{credit_note_id}/void") }
 
     let(:credit_note_id) { credit_note.id }
+
+    include_examples 'requires API permission', 'credit_note', 'write'
 
     it 'voids the credit note' do
       subject
@@ -394,6 +403,8 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
     end
 
     around { |test| lago_premium!(&test) }
+
+    include_examples 'requires API permission', 'credit_note', 'write'
 
     it 'returns the computed amounts for credit note creation' do
       subject

--- a/spec/requests/api/v1/customers/applied_coupons_controller_spec.rb
+++ b/spec/requests/api/v1/customers/applied_coupons_controller_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Api::V1::Customers::AppliedCouponsController, type: :request do
     let(:external_id) { customer.external_id }
     let(:identifier) { applied_coupon.id }
 
+    include_examples 'requires API permission', 'applied_coupon', 'write'
+
     it 'terminates the applied coupon' do
       expect { subject }
         .to change { applied_coupon.reload.status }.from('active').to('terminated')

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
       )
     end
 
+    include_examples 'requires API permission', 'customer_usage', 'read'
+
     it 'returns the usage for the customer' do
       subject
 
@@ -376,6 +378,8 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
       fee1
       fee2
     end
+
+    include_examples 'requires API permission', 'customer_usage', 'read'
 
     it 'returns the past usage' do
       subject

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'customer', 'write'
+
     it 'returns a success' do
       subject
 
@@ -243,6 +245,8 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     let(:organization) { create(:organization) }
     let(:external_id) { customer.external_id }
 
+    include_examples 'requires API permission', 'customer', 'read'
+
     it 'returns the portal url' do
       subject
 
@@ -269,6 +273,8 @@ RSpec.describe Api::V1::CustomersController, type: :request do
 
     before { create_pair(:customer, organization:) }
 
+    include_examples 'requires API permission', 'customer', 'read'
+
     it 'returns all customers from organization' do
       subject
 
@@ -288,6 +294,8 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     let(:external_id) { customer.external_id }
 
     context 'when customer exists' do
+      include_examples 'requires API permission', 'customer', 'read'
+
       it 'returns the customer' do
         subject
 
@@ -315,6 +323,8 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     let(:organization) { create(:organization) }
     let!(:customer) { create(:customer, organization:) }
     let(:external_id) { customer.external_id }
+
+    include_examples 'requires API permission', 'customer', 'write'
 
     it 'deletes a customer' do
       expect { subject }.to change(Customer, :count).by(-1)
@@ -362,6 +372,8 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       allow(::Stripe::Checkout::Session).to receive(:create)
         .and_return({'url' => 'https://example.com'})
     end
+
+    include_examples 'requires API permission', 'customer', 'write'
 
     it 'returns the new generated checkout url' do
       subject

--- a/spec/requests/api/v1/events_controller_spec.rb
+++ b/spec/requests/api/v1/events_controller_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe Api::V1::EventsController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'event', 'write'
+
     it 'returns a success' do
       expect { subject }.to change(Event, :count).by(1)
 
@@ -78,6 +80,8 @@ RSpec.describe Api::V1::EventsController, type: :request do
       ]
     end
 
+    include_examples 'requires API permission', 'event', 'write'
+
     it 'returns a success' do
       expect { subject }.to change(Event, :count).by(1)
 
@@ -93,6 +97,8 @@ RSpec.describe Api::V1::EventsController, type: :request do
 
     context 'without params' do
       let(:params) { {} }
+
+      include_examples 'requires API permission', 'event', 'read'
 
       it 'returns events' do
         subject
@@ -170,10 +176,13 @@ RSpec.describe Api::V1::EventsController, type: :request do
   end
 
   describe 'GET /api/v1/events/:id' do
-    subject { get_with_token(event.organization, "/api/v1/events/#{transaction_id}") }
+    subject { get_with_token(organization, "/api/v1/events/#{transaction_id}") }
 
     let(:event) { create(:event) }
+    let(:organization) { event.organization }
     let(:transaction_id) { event.transaction_id }
+
+    include_examples 'requires API permission', 'event', 'read'
 
     it 'returns an event' do
       subject
@@ -231,6 +240,8 @@ RSpec.describe Api::V1::EventsController, type: :request do
       charge
       tax
     end
+
+    include_examples 'requires API permission', 'event', 'write'
 
     it 'returns a success' do
       subject

--- a/spec/requests/api/v1/fees_controller_spec.rb
+++ b/spec/requests/api/v1/fees_controller_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Api::V1::FeesController, type: :request do
     let(:fee) { create(:fee, subscription:, invoice: nil) }
     let(:fee_id) { fee.id }
 
+    include_examples 'requires API permission', 'fee', 'read'
+
     it 'returns a fee' do
       subject
 
@@ -97,6 +99,8 @@ RSpec.describe Api::V1::FeesController, type: :request do
 
     before { fee.charge.update!(invoiceable: false) }
 
+    include_examples 'requires API permission', 'fee', 'write'
+
     it 'updates the fee' do
       subject
 
@@ -148,10 +152,11 @@ RSpec.describe Api::V1::FeesController, type: :request do
       let(:fee) do
         create(:charge_fee, fee_type: 'charge', pay_in_advance: true, subscription:, invoice:)
       end
+      let(:invoice) { nil }
+
+      include_examples 'requires API permission', 'fee', 'write'
 
       context 'when fee does not attached to an invoice' do
-        let(:invoice) { nil }
-
         it 'deletes the fee' do
           subject
           expect(response).to have_http_status(:ok)
@@ -187,6 +192,8 @@ RSpec.describe Api::V1::FeesController, type: :request do
 
     context 'without params' do
       let(:params) { {} }
+
+      include_examples 'requires API permission', 'fee', 'read'
 
       it 'returns a list of fees' do
         subject

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'invoice', 'write'
+
     it 'creates an invoice' do
       subject
 
@@ -103,6 +105,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       {payment_status: 'succeeded'}
     end
 
+    include_examples 'requires API permission', 'invoice', 'write'
+
     it 'updates an invoice' do
       subject
 
@@ -155,6 +159,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
 
     let(:invoice) { create(:invoice, customer:, organization:) }
     let(:invoice_id) { invoice.id }
+
+    include_examples 'requires API permission', 'invoice', 'read'
 
     it 'returns an invoice' do
       charge_filter = create(:charge_filter)
@@ -257,6 +263,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     context 'without params' do
       let(:params) { {} }
       let!(:invoice) { create(:invoice, :draft, customer:, organization:) }
+
+      include_examples 'requires API permission', 'invoice', 'read'
 
       it 'returns invoices' do
         subject
@@ -492,6 +500,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     context 'when invoice is draft' do
       let(:invoice) { create(:invoice, :draft, customer:, organization:) }
 
+      include_examples 'requires API permission', 'invoice', 'write'
+
       it 'updates the invoice' do
         expect { subject }.to change { invoice.reload.updated_at }
       end
@@ -545,6 +555,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'when invoice is draft' do
+      include_examples 'requires API permission', 'invoice', 'write'
+
       it 'finalizes the invoice' do
         expect { subject }.to change { invoice.reload.status }.from('draft').to('finalized')
       end
@@ -608,6 +620,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       context 'when the payment status is not succeeded' do
         let(:payment_status) { [:pending, :failed].sample }
 
+        include_examples 'requires API permission', 'invoice', 'write'
+
         it 'voids the invoice' do
           expect { subject }.to change { invoice.reload.status }.from('finalized').to('voided')
         end
@@ -643,6 +657,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
 
       context 'when invoice is finalized' do
         let(:status) { :finalized }
+
+        include_examples 'requires API permission', 'invoice', 'write'
 
         it 'marks the dispute as lost' do
           expect { subject }.to change { invoice.reload.payment_dispute_lost_at }.from(nil)
@@ -691,6 +707,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     let(:invoice) { create(:invoice, :draft, customer:, organization:) }
     let(:invoice_id) { invoice.id }
 
+    include_examples 'requires API permission', 'invoice', 'write'
+
     context 'when invoice is draft' do
       it 'returns not found' do
         subject
@@ -710,6 +728,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       allow(Invoices::Payments::RetryService).to receive(:new).and_return(retry_service)
       allow(retry_service).to receive(:call).and_return(BaseService::Result.new)
     end
+
+    include_examples 'requires API permission', 'invoice', 'write'
 
     it 'calls retry service' do
       subject
@@ -755,6 +775,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       allow(retry_service).to receive(:call).and_return(result)
     end
 
+    include_examples 'requires API permission', 'invoice', 'write'
+
     it 'calls retry service' do
       subject
 
@@ -799,6 +821,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'when invoice exists' do
+      include_examples 'requires API permission', 'invoice', 'write'
+
       it 'calls sync salesforce id service' do
         subject
 
@@ -843,6 +867,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'when invoice exists' do
+      include_examples 'requires API permission', 'invoice', 'write'
+
       it 'returns the generated payment url' do
         subject
 

--- a/spec/requests/api/v1/lifetime_usages_controller_spec.rb
+++ b/spec/requests/api/v1/lifetime_usages_controller_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Api::V1::LifetimeUsagesController, type: :request do
 
     let(:external_id) { subscription.external_id }
 
+    include_examples 'requires API permission', 'lifetime_usage', 'read'
+
     it 'returns the lifetime_usage' do
       subject
 
@@ -57,6 +59,8 @@ RSpec.describe Api::V1::LifetimeUsagesController, type: :request do
     let(:update_params) { {external_historical_usage_amount_cents: 20} }
 
     context 'when subscription exists' do
+      include_examples 'requires API permission', 'lifetime_usage', 'write'
+
       it 'updates the lifetime_usage' do
         subject
 

--- a/spec/requests/api/v1/organizations_controller_spec.rb
+++ b/spec/requests/api/v1/organizations_controller_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'organization', 'write'
+
     it 'updates an organization' do
       put_with_token(
         organization,
@@ -90,6 +92,8 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
   describe 'GET /api/v1/organizations/grpc_token' do
     subject { get_with_token(organization, '/api/v1/organizations/grpc_token') }
 
+    include_examples 'requires API permission', 'organization', 'read'
+
     it 'returns the grpc_token' do
       subject
 
@@ -100,6 +104,8 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
 
   describe 'GET /api/v1/organizations' do
     subject { get_with_token(organization, '/api/v1/organizations') }
+
+    include_examples 'requires API permission', 'organization', 'read'
 
     it 'returns the organization' do
       subject

--- a/spec/requests/api/v1/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/payment_requests_controller_spec.rb
@@ -24,12 +24,17 @@ RSpec.describe Api::V1::PaymentRequestsController, type: :request do
       }
     end
 
-    it "delegates to PaymentRequests::CreateService", :aggregate_failures do
-      payment_request = create(:payment_request, invoices: [invoice], customer:)
+    let(:payment_request) { create(:payment_request, invoices: [invoice], customer:) }
+
+    before do
       allow(PaymentRequests::CreateService).to receive(:call).and_return(
         BaseService::Result.new.tap { |r| r.payment_request = payment_request }
       )
+    end
 
+    include_examples 'requires API permission', 'payment_request', 'write'
+
+    it "delegates to PaymentRequests::CreateService", :aggregate_failures do
       subject
 
       expect(PaymentRequests::CreateService).to have_received(:call).with(
@@ -52,6 +57,8 @@ RSpec.describe Api::V1::PaymentRequestsController, type: :request do
     subject { get_with_token(organization, "/api/v1/payment_requests", params) }
 
     let(:params) { {} }
+
+    include_examples 'requires API permission', 'payment_request', 'read'
 
     it "returns organization's payment requests", :aggregate_failures do
       first_customer = create(:customer, organization:)

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe Api::V1::PlansController, type: :request do
     context 'when interval is present' do
       let(:interval) { 'weekly' }
 
+      include_examples 'requires API permission', 'plan', 'write'
+
       it 'creates a plan' do
         subject
 
@@ -314,6 +316,8 @@ RSpec.describe Api::V1::PlansController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'plan', 'write'
+
     it 'updates a plan' do
       subject
 
@@ -537,6 +541,8 @@ RSpec.describe Api::V1::PlansController, type: :request do
     let(:plan) { create(:plan, organization:) }
     let(:plan_code) { plan.code }
 
+    include_examples 'requires API permission', 'plan', 'read'
+
     it 'returns a plan' do
       subject
 
@@ -590,6 +596,8 @@ RSpec.describe Api::V1::PlansController, type: :request do
     let(:plan) { create(:plan, organization:) }
     let(:plan_code) { plan.code }
 
+    include_examples 'requires API permission', 'plan', 'write'
+
     context 'when plan exists' do
       it 'marks plan as pending_deletion' do
         expect { subject }.to change { plan.reload.pending_deletion }.from(false).to(true)
@@ -627,6 +635,8 @@ RSpec.describe Api::V1::PlansController, type: :request do
     let(:plan) { create(:plan, organization:) }
 
     before { create(:usage_threshold, plan:) }
+
+    include_examples 'requires API permission', 'plan', 'read'
 
     it 'returns plans' do
       subject

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
     let(:override_amount_cents) { 777 }
     let(:override_display_name) { 'Overriden Threshold 12' }
 
+    include_examples 'requires API permission', 'subscription', 'write'
+
     it 'returns a success', :aggregate_failures do
       create(:plan, code: plan.code, parent_id: plan.id, organization:, description: 'foo')
 
@@ -197,6 +199,8 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
     let(:subscription) { create(:subscription, customer:, plan:) }
     let(:external_id) { subscription.external_id }
 
+    include_examples 'requires API permission', 'subscription', 'write'
+
     it 'terminates a subscription' do
       subject
 
@@ -256,6 +260,8 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       subscription
       usage_threshold
     end
+
+    include_examples 'requires API permission', 'subscription', 'write'
 
     it 'updates a subscription', :aggregate_failures do
       subject
@@ -351,6 +357,8 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
     let(:subscription) { create(:subscription, customer:, plan:) }
     let(:external_id) { subscription.external_id }
 
+    include_examples 'requires API permission', 'subscription', 'read'
+
     it 'returns a subscription' do
       subject
 
@@ -395,6 +403,8 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
     let!(:subscription) { create(:subscription, customer:, plan:) }
     let(:params) { {external_customer_id: external_customer_id} }
     let(:external_customer_id) { customer.external_id }
+
+    include_examples 'requires API permission', 'subscription', 'read'
 
     it 'returns subscriptions' do
       subject

--- a/spec/requests/api/v1/taxes_controller_spec.rb
+++ b/spec/requests/api/v1/taxes_controller_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Api::V1::TaxesController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'tax', 'write'
+
     it 'creates a tax' do
       expect { subject }.to change(Tax, :count).by(1)
 
@@ -53,6 +55,8 @@ RSpec.describe Api::V1::TaxesController, type: :request do
     let(:update_params) do
       {code:, name:, rate:, applied_to_organization:}
     end
+
+    include_examples 'requires API permission', 'tax', 'write'
 
     it 'updates a tax' do
       subject
@@ -93,6 +97,8 @@ RSpec.describe Api::V1::TaxesController, type: :request do
     let(:tax) { create(:tax, organization:) }
     let(:tax_code) { tax.code }
 
+    include_examples 'requires API permission', 'tax', 'read'
+
     it 'returns a tax' do
       subject
 
@@ -118,6 +124,8 @@ RSpec.describe Api::V1::TaxesController, type: :request do
 
     let!(:tax) { create(:tax, organization:) }
     let(:tax_code) { tax.code }
+
+    include_examples 'requires API permission', 'tax', 'write'
 
     it 'deletes a tax' do
       expect { subject }.to change(Tax, :count).by(-1)
@@ -147,6 +155,8 @@ RSpec.describe Api::V1::TaxesController, type: :request do
     subject { get_with_token(organization, '/api/v1/taxes?page=1&per_page=1') }
 
     let!(:tax) { create(:tax, organization:) }
+
+    include_examples 'requires API permission', 'tax', 'read'
 
     it 'returns taxes' do
       subject

--- a/spec/requests/api/v1/wallet_transactions_controller_spec.rb
+++ b/spec/requests/api/v1/wallet_transactions_controller_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'wallet_transaction', 'write'
+
     it 'creates a wallet transactions' do
       subject
 
@@ -117,6 +119,8 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
       wallet_transaction_second
       wallet_transaction_third
     end
+
+    include_examples 'requires API permission', 'wallet_transaction', 'read'
 
     it 'returns wallet transactions' do
       subject

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'wallet', 'write'
+
     it 'creates a wallet' do
       subject
 
@@ -241,6 +243,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
 
     before { wallet }
 
+    include_examples 'requires API permission', 'wallet', 'write'
+
     it 'updates a wallet' do
       subject
 
@@ -443,6 +447,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
     let(:wallet) { create(:wallet, customer:) }
     let(:id) { wallet.id }
 
+    include_examples 'requires API permission', 'wallet', 'read'
+
     it 'returns a wallet' do
       subject
 
@@ -466,6 +472,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
 
     let(:wallet) { create(:wallet, customer:) }
     let(:id) { wallet.id }
+
+    include_examples 'requires API permission', 'wallet', 'write'
 
     it 'terminates a wallet' do
       subject
@@ -507,6 +515,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
 
     let!(:wallet) { create(:wallet, customer:) }
     let(:external_id) { customer.external_id }
+
+    include_examples 'requires API permission', 'wallet', 'read'
 
     it 'returns wallets' do
       subject

--- a/spec/requests/api/v1/webhook_endpoints_controller_spec.rb
+++ b/spec/requests/api/v1/webhook_endpoints_controller_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Api::V1::WebhookEndpointsController, type: :request do
       }
     end
 
+    include_examples 'requires API permission', 'webhook_endpoint', 'write'
+
     it 'returns a success' do
       subject
 
@@ -39,6 +41,8 @@ RSpec.describe Api::V1::WebhookEndpointsController, type: :request do
 
     before { create_pair(:webhook_endpoint, organization:) }
 
+    include_examples 'requires API permission', 'webhook_endpoint', 'read'
+
     it 'returns all webhook endpoints from organization' do
       subject
 
@@ -57,6 +61,8 @@ RSpec.describe Api::V1::WebhookEndpointsController, type: :request do
 
     context 'with existing id' do
       let(:id) { webhook_endpoint.id }
+
+      include_examples 'requires API permission', 'webhook_endpoint', 'read'
 
       it 'returns the customer' do
         subject
@@ -86,6 +92,8 @@ RSpec.describe Api::V1::WebhookEndpointsController, type: :request do
 
     context 'when webhook endpoint exists' do
       let(:id) { webhook_endpoint.id }
+
+      include_examples 'requires API permission', 'webhook_endpoint', 'write'
 
       it 'deletes a webhook endpoint' do
         expect { subject }.to change(WebhookEndpoint, :count).by(-1)
@@ -135,6 +143,8 @@ RSpec.describe Api::V1::WebhookEndpointsController, type: :request do
 
     context 'when webhook endpoint exists' do
       let(:id) { webhook_endpoint.id }
+
+      include_examples 'requires API permission', 'webhook_endpoint', 'write'
 
       it 'updates a webhook endpoint' do
         subject

--- a/spec/requests/api/v1/webhooks_controller_spec.rb
+++ b/spec/requests/api/v1/webhooks_controller_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Api::V1::WebhooksController, type: :request do
   describe 'GET /api/v1/webhooks/public_key' do
     subject { get_with_token(organization, '/api/v1/webhooks/public_key') }
 
+    include_examples 'requires API permission', 'webhook_jwt_public_key', 'read'
+
     it 'returns the public key used to verify webhook signatures' do
       subject
 
@@ -18,6 +20,8 @@ RSpec.describe Api::V1::WebhooksController, type: :request do
 
   describe 'GET /api/v1/webhooks/json_public_key' do
     subject { get_with_token(organization, '/api/v1/webhooks/json_public_key') }
+
+    include_examples 'requires API permission', 'webhook_jwt_public_key', 'read'
 
     it 'returns the public key in JSON response used to verify webhook signatures' do
       subject

--- a/spec/support/shared_examples/api_requirements.rb
+++ b/spec/support/shared_examples/api_requirements.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "requires API permission" do |resource, mode|
+  describe "permissions" do
+    let(:api_key) { organization.api_keys.first }
+
+    before do
+      organization.update!(premium_integrations:)
+      api_key.update!(permissions: api_key.permissions.merge(resource => modes))
+      subject
+    end
+
+    context "when organization has 'api_permissions' premium integration" do
+      let(:premium_integrations) { organization.premium_integrations.including("api_permissions") }
+
+      context "when API key allows #{mode} action for #{resource}" do
+        let(:modes) { [ApiKey::MODES, [mode]].sample }
+
+        it "does not return 403 Forbidden" do
+          expect(response).not_to have_http_status(:forbidden)
+        end
+      end
+
+      context "when API key forbids #{mode} action for #{resource}" do
+        let(:modes) { ApiKey::MODES.excluding(mode) }
+
+        it "returns 403 Forbidden" do
+          aggregate_failures do
+            expect(response).to have_http_status(:forbidden)
+            expect(json).to match hash_including(code: "#{mode}_action_not_allowed_for_#{resource}")
+          end
+        end
+      end
+    end
+
+    context "when organization has no 'api_permissions' premium integration" do
+      let(:premium_integrations) { organization.premium_integrations.excluding("api_permissions") }
+
+      context "when API key allows #{mode} action for #{resource}" do
+        let(:modes) { [ApiKey::MODES, [mode]].sample }
+
+        it "does not return 403 Forbidden" do
+          expect(response).not_to have_http_status(:forbidden)
+        end
+      end
+
+      context "when API key forbids #{mode} action for #{resource}" do
+        let(:modes) { ApiKey::MODES.excluding(mode) }
+
+        it "does not return 403 Forbidden" do
+          expect(response).not_to have_http_status(:forbidden)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Switch to using defined by API key permissions in case when organization has `api_permissions` premium integration.

## Description

Use API key defined permissions for API.
Add shared example for easier permission testing in request specs.
