### PR TITLE
fix: update applied prepaid credits service exit case

### DIFF
--- a/app/jobs/clock/finalize_invoices_job.rb
+++ b/app/jobs/clock/finalize_invoices_job.rb
@@ -6,6 +6,8 @@ module Clock
 
     queue_as 'clock'
 
+    unique :until_executed, on_conflict: :log
+
     def perform
       Invoice.ready_to_be_finalized.each do |invoice|
         Invoices::FinalizeJob.perform_later(invoice)

--- a/app/jobs/invoices/finalize_job.rb
+++ b/app/jobs/invoices/finalize_job.rb
@@ -4,6 +4,8 @@ module Invoices
   class FinalizeJob < ApplicationJob
     queue_as 'invoices'
 
+    unique :until_executed, on_conflict: :log
+
     retry_on Sequenced::SequenceError, wait: :polynomially_longer
 
     def perform(invoice)

--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -10,7 +10,9 @@ module Credits
     end
 
     def call
-      return result if already_applied?
+      if already_applied?
+        return result.service_failure!(code: 'already_applied', message: 'Prepaid credits already applied')
+      end
 
       amount_cents = compute_amount
       amount = compute_amount_from_cents(amount_cents)

--- a/spec/services/credits/applied_prepaid_credit_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credit_service_spec.rb
@@ -77,5 +77,21 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
         expect(wallet.credits_balance).to eq(0.0)
       end
     end
+
+    context 'when already applied' do
+      let(:wallet_transaction) { create(:wallet_transaction, wallet:, invoice:, transaction_type: 'outbound') }
+
+      before { wallet_transaction }
+
+      it 'returns error' do
+        result = credit_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.code).to eq('already_applied')
+          expect(result.error.error_message).to eq('Prepaid credits already applied')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Prepaid credits should be applied on invoice only once. This condition should be basic check in the depending service.

## Description

Currently we are just returning result instead of proper error for the described case, which leads to errors that are hard to track
