### PR TITLE
feat: rubocop

### DIFF
--- a/app/graphql/types/credit_notes/object.rb
+++ b/app/graphql/types/credit_notes/object.rb
@@ -59,7 +59,7 @@ module Types
         object.should_sync_credit_note? &&
           object.integration_resources
             .joins(:integration)
-            .where(integration: {type: Integrations::BaseIntegration::INTEGRATION_ACCOUNTING_TYPES})
+            .where(integration: {type: ::Integrations::BaseIntegration::INTEGRATION_ACCOUNTING_TYPES})
             .where(resource_type: 'credit_note', syncable_type: 'CreditNote').none?
       end
 


### PR DESCRIPTION
## Context

The GraphqlController#execute method was throwing a NameError due to an uninitialized constant Types::Integrations::BaseIntegration. This issue affected the production environment 

The root cause was an incorrect namespace resolution for Integrations::BaseIntegration::INTEGRATION_ACCOUNTING_TYPES in the integration_syncable method for credit notes.