### PR TITLE
fix(customer): Fix update customer webhook

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -908,6 +908,7 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-darwin-23

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -100,6 +100,12 @@ module Customers
         new_customer:
       )
 
+      if new_customer
+        SendWebhookJob.perform_later('customer.created', customer)
+      else
+        SendWebhookJob.perform_later('customer.updated', customer)
+      end
+
       track_customer_created(customer)
       result
     rescue BaseService::ServiceFailure => e
@@ -196,6 +202,7 @@ module Customers
         new_customer: true
       )
 
+      SendWebhookJob.perform_later('customer.created', customer)
       track_customer_created(customer)
       result
     rescue ActiveRecord::RecordInvalid => e
@@ -335,7 +342,6 @@ module Customers
           organization_id: customer.organization_id
         }
       )
-      SendWebhookJob.perform_later("customer.created", customer)
     end
 
     def should_create_billing_configuration?(billing, customer)

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -374,6 +374,14 @@ RSpec.describe Customers::CreateService, type: :service do
         end
       end
 
+      it 'calls SendWebhookJob with customer.updated' do
+        customers_service.create_from_api(
+          organization:,
+          params: create_args
+        )
+        expect(SendWebhookJob).to have_received(:perform_later).with('customer.updated', customer)
+      end
+
       context 'with provider customer' do
         let(:payment_provider) { create(:stripe_provider, organization:) }
         let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider:) }


### PR DESCRIPTION
## Context

`customer.created` webhook was called when updating a customer via API instead of `customer.updated`.

## Description

This PR fixes the issue and calls the correct `customer.updated` webhook.