### PR TITLE
fix(customer): Catch ActiveRecord::RecordNotUnique when creating with API

### DIFF
--- a/spec/graphql/mutations/integrations/salesforce/create_spec.rb
+++ b/spec/graphql/mutations/integrations/salesforce/create_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Mutations::Integrations::Salesforce::Create, type: :graphql do
-  let(:required_permission) { 'organization:integrations:create' }
+  let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
-  let(:name) { 'Salesforce 1' }
-  let(:code) { 'salesforce_test' }
+  let(:name) { "Salesforce 1" }
+  let(:code) { "salesforce_test" }
   let(:script_endpoint_url) { Faker::Internet.url }
 
   let(:mutation) do
@@ -24,13 +24,13 @@ RSpec.describe Mutations::Integrations::Salesforce::Create, type: :graphql do
 
   around { |test| lago_premium!(&test) }
 
-  before { membership.organization.update!(premium_integrations: ['salesforce']) }
+  before { membership.organization.update!(premium_integrations: ["salesforce"]) }
 
-  it_behaves_like 'requires current user'
-  it_behaves_like 'requires current organization'
-  it_behaves_like 'requires permission', 'organization:integrations:create'
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "organization:integrations:create"
 
-  it 'creates a salesforce integration' do
+  it "creates a salesforce integration" do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,
@@ -40,18 +40,17 @@ RSpec.describe Mutations::Integrations::Salesforce::Create, type: :graphql do
         input: {
           name:,
           code:,
-          instanceId: 'this-is-random-uuid'
+          instanceId: "this-is-random-uuid"
         }
       }
     )
 
-    pp result
-    result_data = result['data']['createSalesforceIntegration']
+    result_data = result["data"]["createSalesforceIntegration"]
 
     aggregate_failures do
-      expect(result_data['id']).to be_present
-      expect(result_data['code']).to eq(code)
-      expect(result_data['name']).to eq(name)
+      expect(result_data["id"]).to be_present
+      expect(result_data["code"]).to eq(code)
+      expect(result_data["name"]).to eq(name)
     end
   end
 end

--- a/spec/graphql/mutations/integrations/salesforce/update_spec.rb
+++ b/spec/graphql/mutations/integrations/salesforce/update_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Mutations::Integrations::Salesforce::Update, type: :graphql do
-  let(:required_permission) { 'organization:integrations:update' }
+  let(:required_permission) { "organization:integrations:update" }
   let(:integration) { create(:salesforce_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }
-  let(:name) { 'Salesforce 1' }
-  let(:code) { 'salesforce_work' }
-  let(:instance_id) { 'salesforce_link' }
+  let(:name) { "Salesforce 1" }
+  let(:code) { "salesforce_work" }
+  let(:instance_id) { "salesforce_link" }
 
   let(:mutation) do
     <<-GQL
@@ -28,14 +28,14 @@ RSpec.describe Mutations::Integrations::Salesforce::Update, type: :graphql do
 
   before do
     integration
-    membership.organization.update!(premium_integrations: ['salesforce'])
+    membership.organization.update!(premium_integrations: ["salesforce"])
   end
 
-  it_behaves_like 'requires current user'
-  it_behaves_like 'requires current organization'
-  it_behaves_like 'requires permission', 'organization:integrations:update'
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "organization:integrations:update"
 
-  it 'updates a salesforce integration' do
+  it "updates a salesforce integration" do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,
@@ -51,13 +51,12 @@ RSpec.describe Mutations::Integrations::Salesforce::Update, type: :graphql do
       }
     )
 
-    pp result
-    result_data = result['data']['updateSalesforceIntegration']
+    result_data = result["data"]["updateSalesforceIntegration"]
 
     aggregate_failures do
-      expect(result_data['name']).to eq(name)
-      expect(result_data['code']).to eq(code)
-      expect(result_data['instanceId']).to eq(instance_id)
+      expect(result_data["name"]).to eq(name)
+      expect(result_data["code"]).to eq(code)
+      expect(result_data["instanceId"]).to eq(instance_id)
     end
   end
 end


### PR DESCRIPTION
## Description

This PR makes sure that `ActiveRecord::RecordNotUnique` are catched correctly when calling `POST /api/v1/customers` API endpoint and respond with a proper `HTTP 422` rather than with today's `HTTP 500`

Sidenote: It also removes `pp` from some spec files
