### PR TITLE
Fix: progressive billing invoice for subscription period

### DIFF
--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -13,8 +13,10 @@ module Credits
       invoice.invoice_subscriptions.each do |invoice_subscription|
         subscription = invoice_subscription.subscription
 
-        # We can use invoice_subscription.timestamp as that will _always_ be between the subscription charges_from and to times
-        progressive_billed_result = Subscriptions::ProgressiveBilledAmount.call(subscription:, timestamp: invoice_subscription.timestamp).raise_if_error!
+        # We can use invoice_subscription.charges_from_datetime as we're looking for the progressive billing invoices
+        # that are associated to a subscription with boundaries charges_from_datetime <= timestamp; charges_to_datetime > timestamp
+        progressive_billed_result = Subscriptions::ProgressiveBilledAmount.call(subscription:,
+                                                                                timestamp: invoice_subscription.charges_from_datetime).raise_if_error!
         progressive_billing_invoice = progressive_billed_result.progressive_billing_invoice
 
         next unless progressive_billing_invoice

--- a/spec/scenarios/invoices/progressive_billing_spec.rb
+++ b/spec/scenarios/invoices/progressive_billing_spec.rb
@@ -4,13 +4,14 @@ require 'rails_helper'
 
 describe 'Progressive billing invoices', :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: [], premium_integrations: ['progressive_billing']) }
-  let(:plan) { create(:plan, organization: organization, interval: 'monthly', amount_cents: 12_900, pay_in_advance: false) }
-  let(:new_plan) { create(:plan, organization: organization, interval: 'monthly', amount_cents: 25_000, pay_in_advance: false) }
+  let(:plan) { create(:plan, organization: organization, interval: 'monthly', amount_cents: 31_00, pay_in_advance: false) }
+  let(:upgrade_plan) { create(:plan, organization: organization, interval: 'monthly', amount_cents: 62_000, pay_in_advance: false) }
+  let(:downgrade_plan) { create(:plan, organization: organization, interval: 'monthly', amount_cents: 31, pay_in_advance: false) }
   let(:customer) { create(:customer, organization: organization) }
   let(:billable_metric) { create(:billable_metric, organization: organization, field_name: 'total', aggregation_type: "sum_agg") }
   let(:charge) { create(:charge, plan: plan, billable_metric: billable_metric, charge_model: 'standard', properties: {'amount' => '0.0002'}) }
-  let(:usage_threshold) { create(:usage_threshold, plan: plan, amount_cents: 1000) }
-  let(:usage_threshold2) { create(:usage_threshold, plan: plan, amount_cents: 2000) }
+  let(:usage_threshold) { create(:usage_threshold, plan: plan, amount_cents: 20000) }
+  let(:usage_threshold2) { create(:usage_threshold, plan: plan, amount_cents: 50000) }
 
   before do
     usage_threshold
@@ -21,15 +22,239 @@ describe 'Progressive billing invoices', :scenarios, type: :request do
 
   def ingest_event(subscription, amount)
     create_event({
-      transaction_id: SecureRandom.uuid,
-      code: billable_metric.code,
-      external_subscription_id: subscription.external_id,
-      properties: { 'total' => amount }
-    })
+                   transaction_id: SecureRandom.uuid,
+                   code: billable_metric.code,
+                   external_subscription_id: subscription.external_id,
+                   properties: { 'total' => amount }
+                 })
     perform_usage_update
   end
 
   it 'generates an invoice in the middle of the month and a final invoice at the end of the month' do
+    time_0 = DateTime.new(2022, 12, 1)
+    travel_to time_0 do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        }
+      )
+    end
+    subscription = customer.subscriptions.first
+
+    travel_to time_0 + 5.days do
+      ingest_event(subscription, 1000000)
+      expect(Invoice.count).to eq(1)
+      expect(Invoice.last.total_amount_cents).to eq(20000)
+    end
+
+    travel_to time_0 + 15.days do
+      ingest_event(subscription, 1000000)
+      expect(Invoice.count).to eq(1)
+      progressive_billing_invoice = subscription.invoices.first
+      expect(progressive_billing_invoice.total_amount_cents).to eq(20000)
+    end
+
+    travel_to time_0 + 1.month do
+      perform_billing
+      expect(Invoice.count).to eq(2)
+      termination_invoice = subscription.invoices.order(:created_at).last
+      expect(termination_invoice.total_amount_cents).to eq(31_00 + 20_000)
+      expect(termination_invoice.fees_amount_cents).to eq(31_00 + 40_000)
+      expect(termination_invoice.progressive_billing_credit_amount_cents).to eq(20_000)
+    end
+  end
+
+  it 'generates an invoice in the middle of the month and terminates the subscription before the end of the month' do
+    time_0 = DateTime.new(2022, 12, 1)
+    travel_to time_0 do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        }
+      )
+    end
+    subscription = customer.subscriptions.first
+
+    travel_to time_0 + 15.days do
+      ingest_event(subscription, 1000000)
+      expect(Invoice.count).to eq(1)
+      expect(Invoice.last.total_amount_cents).to eq(20000)
+    end
+
+    travel_to time_0 + 17.days do
+      terminate_subscription(subscription)
+      expect(Invoice.count).to eq(2)
+      termination_invoice = subscription.invoices.order(:created_at).last
+      # ASK VINCENT, why when terminating it's 1800, and when upgrading it's 1700
+      expect(termination_invoice.total_amount_cents).to eq(1800)
+      expect(termination_invoice.fees_amount_cents).to eq(21800)
+      expect(termination_invoice.progressive_billing_credit_amount_cents).to eq(20000)
+    end
+  end
+
+  it 'generates an invoice in the middle of the month and upgrades the subscription before the end of the month' do
+    time_0 = DateTime.new(2022, 12, 1)
+    travel_to time_0 do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        }
+      )
+    end
+    subscription = customer.subscriptions.first
+
+    travel_to time_0 + 15.days do
+      ingest_event(subscription, 1000000)
+      expect(Invoice.count).to eq(1)
+      expect(Invoice.last.total_amount_cents).to eq(20000)
+    end
+
+    travel_to time_0 + 17.days do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: upgrade_plan.code
+        }
+      )
+      expect(Invoice.count).to eq(2)
+      termination_invoice = subscription.invoices.order(:created_at).last
+      expect(termination_invoice.total_amount_cents).to eq(1700)
+      expect(termination_invoice.fees_amount_cents).to eq(21700)
+      expect(termination_invoice.progressive_billing_credit_amount_cents).to eq(20000)
+    end
+  end
+
+  it 'generates an invoice during the grace period and finalizes it at the end of the next month' do
+    organization.update!(invoice_grace_period: 30)
+    time_0 = DateTime.new(2022, 12, 1)
+    travel_to time_0 do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        }
+      )
+    end
+    subscription = customer.subscriptions.first
+
+    travel_to time_0 + 1.month + 2.hours do
+      perform_billing
+      expect(Invoice.count).to eq(1)
+      subscription_invoice_1 = subscription.invoices.first
+      expect(subscription_invoice_1.total_amount_cents).to eq(31_00)
+      expect(subscription_invoice_1.progressive_billing_credit_amount_cents).to eq(0)
+      expect(subscription_invoice_1.status).to eq('draft')
+    end
+
+    travel_to time_0 + 1.month + 15.days do
+      ingest_event(subscription, 3000000)
+      expect(Invoice.count).to eq(2)
+      progressive_invoice = subscription.invoices.order(:created_at).last
+      expect(progressive_invoice.total_amount_cents).to eq(60000)
+    end
+
+    travel_to time_0 + 2.month do
+      perform_finalize_refresh
+      perform_billing
+      expect(Invoice.count).to eq(3)
+      expect(CreditNote.count).to eq(0)
+      subscription_invoice_1 = subscription.invoices.order(:created_at).subscription.first
+      expect(subscription_invoice_1.total_amount_cents).to eq(31_00)
+      expect(subscription_invoice_1.progressive_billing_credit_amount_cents).to eq(0)
+      expect(subscription_invoice_1.status).to eq('finalized')
+      expect(subscription_invoice_1.fees_amount_cents).to eq(31_00)
+
+      subscription_invoice_2 = subscription.invoices.order(:created_at).subscription.last
+      expect(subscription_invoice_2.total_amount_cents).to eq(3100)
+      expect(subscription_invoice_2.progressive_billing_credit_amount_cents).to eq(60000)
+      expect(subscription_invoice_2.status).to eq('draft')
+      expect(subscription_invoice_2.fees_amount_cents).to eq(631_00)
+    end
+  end
+
+  it 'generates an invoice in the middle of the month and downgrades the subscription before the end of the month' do
+    time_0 = DateTime.new(2022, 12, 1)
+    travel_to time_0 do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        }
+      )
+    end
+    subscription = customer.subscriptions.first
+
+    travel_to time_0 + 15.days do
+      ingest_event(subscription, 1000000)
+      expect(Invoice.count).to eq(1)
+      expect(Invoice.last.total_amount_cents).to eq(20000)
+    end
+
+    travel_to time_0 + 1.month - 1.day do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: downgrade_plan.code
+        }
+      )
+      perform_billing
+      expect(Invoice.count).to eq(2)
+      subscription_invoice = subscription.invoices.subscription.last
+      expect(subscription_invoice.total_amount_cents).to eq(3100)
+    end
+  end
+
+  it 'generates invoices for multiple usage thresholds within the same billing period' do
+    usage_threshold2
+    time_0 = DateTime.new(2022, 12, 1)
+    travel_to time_0 do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        }
+      )
+    end
+    subscription = customer.subscriptions.first
+
+    travel_to time_0 + 15.days do
+      ingest_event(subscription, 1000000)
+      expect(Invoice.count).to eq(1)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(20000)
+    end
+
+    travel_to time_0 + 20.days do
+      ingest_event(subscription, 1000000)
+      expect(Invoice.count).to eq(1)
+    end
+
+    travel_to time_0 + 25.days do
+      ingest_event(subscription, 1000000)
+      expect(Invoice.count).to eq(2)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(40000)
+    end
+
+    travel_to time_0 + 1.month do
+      perform_billing
+      expect(Invoice.count).to eq(3)
+      subscription_invoice = subscription.invoices.subscription.last
+      expect(subscription_invoice.total_amount_cents).to eq(31_00)
+      expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(60000)
+    end
+  end
+
+  it 'generates only the final invoice at the end of the month' do
     time_0 = Time.current.beginning_of_month
     travel_to time_0 do
       create_subscription(
@@ -39,93 +264,133 @@ describe 'Progressive billing invoices', :scenarios, type: :request do
           plan_code: plan.code
         }
       )
-
     end
     subscription = customer.subscriptions.first
-    # creates invoice when threshold is reached first time
-    travel_to time_0 + 5.days do
-      ingest_event(subscription, 1000000)
-      expect(Invoice.count).to eq(1)
-      expect(Invoice.last.total_amount_cents).to eq(20000)
-    end
 
-    # creates invoice when threshold is reached second time
+    travel_to time_0 + 1.month do
+      perform_billing
+      expect(Invoice.count).to eq(1)
+      expect(subscription.invoices.subscription.first.total_amount_cents).to eq(31_00)
+    end
+  end
+
+  it 'generates progressive billing invoices only once when not recurring' do
+    time_0 = DateTime.new(2022, 12, 1)
+    travel_to time_0 do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        }
+      )
+    end
+    subscription = customer.subscriptions.first
+
+    # First billing period
     travel_to time_0 + 15.days do
       ingest_event(subscription, 1000000)
       expect(Invoice.count).to eq(1)
-      expect(Invoice.last.total_amount_cents).to eq(20000)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(20000)
     end
-
 
     travel_to time_0 + 1.month do
       perform_billing
       expect(Invoice.count).to eq(2)
-      expect(Invoice.last.total_amount_cents).to eq(32900)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(31_00)
+      expect(subscription.invoices.order(:created_at).last.fees_amount_cents).to eq(31_00 + 20000)
+    end
+
+    # Second billing period
+    travel_to time_0 + 1.month + 15.days do
+      ingest_event(subscription, 2000000)
+      expect(Invoice.count).to eq(2)
+    end
+
+    travel_to time_0 + 2.months do
+      perform_billing
+      expect(Invoice.count).to eq(3)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(431_00)
+    end
+
+    # Third billing period
+    travel_to time_0 + 2.months + 15.days do
+      ingest_event(subscription, 3000000)
+      expect(Invoice.count).to eq(3)
+    end
+
+    travel_to time_0 + 3.months do
+      perform_billing
+      expect(Invoice.count).to eq(4)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(631_00)
     end
   end
 
-  it 'generates an invoice in the middle of the month and terminates the subscription before the end of the month' do
-    travel_to Time.current.middle_of_month
-    ingest_event(100)
-    expect(Invoice.count).to eq(1)
+  it 'generates correct invoices when there is a combination of single thresholds and recurring' do
+    usage_threshold.update(amount_cents: 200)
+    create(:usage_threshold, plan: plan, amount_cents: 500)
+    create(:usage_threshold, plan: plan, amount_cents: 700)
+    create(:usage_threshold, plan: plan, amount_cents: 1000, recurring: true)
+    date_0 = DateTime.new(2022, 12, 1)
+    travel_to date_0 do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        }
+      )
+    end
+    subscription = customer.subscriptions.first
 
-    travel_to Time.current.end_of_month - 1.day
-    subscription.terminate!
-    Invoice.finalize_all!
-    expect(Invoice.count).to eq(2)
-  end
+    # First billing period
+    travel_to date_0 + 5.days do
+      ingest_event(subscription, 11000)
+      expect(Invoice.count).to eq(1)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(220)
+    end
 
-  it 'generates an invoice in the middle of the month and upgrades the subscription before the end of the month' do
-    travel_to Time.current.middle_of_month
-    ingest_event(100)
-    expect(Invoice.count).to eq(1)
+    travel_to date_0 + 10.days do
+      ingest_event(subscription, 11000)
+      expect(Invoice.count).to eq(1)
+    end
 
-    travel_to Time.current.end_of_month - 1.day
-    subscription.update!(plan: new_plan)
-    Invoice.finalize_all!
-    expect(Invoice.count).to eq(2)
-  end
+    travel_to date_0 + 15.days do
+      ingest_event(subscription, 11000)
+      expect(Invoice.count).to eq(2)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(440)
+    end
 
-  it 'generates an invoice during the grace period and finalizes it at the end of the next month' do
-    organization.update!(grace_period: 1.month)
-    travel_to Time.current.middle_of_month
-    ingest_event(100)
-    expect(Invoice.count).to eq(1)
+    travel_to date_0 + 20.days do
+      ingest_event(subscription, 11000)
+      expect(Invoice.count).to eq(3)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(220)
+    end
 
-    travel_to Time.current.end_of_month + 1.month
-    ingest_event(100)
-    Invoice.finalize_all!
-    expect(Invoice.count).to eq(2)
-  end
+    travel_to date_0 + 25.days do
+      ingest_event(subscription, 110000)
+      expect(Invoice.count).to eq(4)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(2200)
+    end
 
-  it 'generates an invoice in the middle of the month and downgrades the subscription before the end of the month' do
-    travel_to Time.current.middle_of_month
-    ingest_event(100)
-    expect(Invoice.count).to eq(1)
+    travel_to date_0 + 27.days do
+      ingest_event(subscription, 110000)
+      expect(Invoice.count).to eq(5)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(2200)
+    end
 
-    travel_to Time.current.end_of_month - 1.day
-    subscription.update!(plan: new_plan)
-    Invoice.finalize_all!
-    expect(Invoice.count).to eq(2)
-  end
+    # second billing period
+    travel_to date_0 + 1.month do
+      perform_billing
+      expect(Invoice.count).to eq(6)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(3100)
+      expect(subscription.invoices.order(:created_at).last.progressive_billing_credit_amount_cents).to eq(5280)
+    end
 
-  it 'generates invoices for multiple usage thresholds within the same billing period' do
-    travel_to Time.current.middle_of_month
-    ingest_event(100)
-    expect(Invoice.count).to eq(1)
-
-    travel_to Time.current.middle_of_month + 5.days
-    ingest_event(100)
-    expect(Invoice.count).to eq(2)
-
-    travel_to Time.current.end_of_month
-    Invoice.finalize_all!
-    expect(Invoice.count).to eq(3)
-  end
-
-  it 'generates only the final invoice at the end of the month' do
-    travel_to Time.current.end_of_month
-    Invoice.finalize_all!
-    expect(Invoice.count).to eq(1)
+    travel_to date_0 + 1.month + 5.days do
+      ingest_event(subscription, 110000)
+      expect(Invoice.count).to eq(7)
+      expect(subscription.invoices.order(:created_at).last.total_amount_cents).to eq(2200)
+    end
   end
 end

--- a/spec/scenarios/invoices/progressive_billing_spec.rb
+++ b/spec/scenarios/invoices/progressive_billing_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Progressive billing invoices', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil, email_settings: [], premium_integrations: ['progressive_billing']) }
+  let(:plan) { create(:plan, organization: organization, interval: 'monthly', amount_cents: 12_900, pay_in_advance: false) }
+  let(:new_plan) { create(:plan, organization: organization, interval: 'monthly', amount_cents: 25_000, pay_in_advance: false) }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:billable_metric) { create(:billable_metric, organization: organization, field_name: 'total', aggregation_type: "sum_agg") }
+  let(:charge) { create(:charge, plan: plan, billable_metric: billable_metric, charge_model: 'standard', properties: {'amount' => '0.0002'}) }
+  let(:usage_threshold) { create(:usage_threshold, plan: plan, amount_cents: 1000) }
+  let(:usage_threshold2) { create(:usage_threshold, plan: plan, amount_cents: 2000) }
+
+  before do
+    usage_threshold
+    charge
+  end
+
+  around { |test| lago_premium!(&test) }
+
+  def ingest_event(subscription, amount)
+    create_event({
+      transaction_id: SecureRandom.uuid,
+      code: billable_metric.code,
+      external_subscription_id: subscription.external_id,
+      properties: { 'total' => amount }
+    })
+    perform_usage_update
+  end
+
+  it 'generates an invoice in the middle of the month and a final invoice at the end of the month' do
+    time_0 = Time.current.beginning_of_month
+    travel_to time_0 do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        }
+      )
+
+    end
+    subscription = customer.subscriptions.first
+    # creates invoice when threshold is reached first time
+    travel_to time_0 + 5.days do
+      ingest_event(subscription, 1000000)
+      expect(Invoice.count).to eq(1)
+      expect(Invoice.last.total_amount_cents).to eq(20000)
+    end
+
+    # creates invoice when threshold is reached second time
+    travel_to time_0 + 15.days do
+      ingest_event(subscription, 1000000)
+      expect(Invoice.count).to eq(1)
+      expect(Invoice.last.total_amount_cents).to eq(20000)
+    end
+
+
+    travel_to time_0 + 1.month do
+      perform_billing
+      expect(Invoice.count).to eq(2)
+      expect(Invoice.last.total_amount_cents).to eq(32900)
+    end
+  end
+
+  it 'generates an invoice in the middle of the month and terminates the subscription before the end of the month' do
+    travel_to Time.current.middle_of_month
+    ingest_event(100)
+    expect(Invoice.count).to eq(1)
+
+    travel_to Time.current.end_of_month - 1.day
+    subscription.terminate!
+    Invoice.finalize_all!
+    expect(Invoice.count).to eq(2)
+  end
+
+  it 'generates an invoice in the middle of the month and upgrades the subscription before the end of the month' do
+    travel_to Time.current.middle_of_month
+    ingest_event(100)
+    expect(Invoice.count).to eq(1)
+
+    travel_to Time.current.end_of_month - 1.day
+    subscription.update!(plan: new_plan)
+    Invoice.finalize_all!
+    expect(Invoice.count).to eq(2)
+  end
+
+  it 'generates an invoice during the grace period and finalizes it at the end of the next month' do
+    organization.update!(grace_period: 1.month)
+    travel_to Time.current.middle_of_month
+    ingest_event(100)
+    expect(Invoice.count).to eq(1)
+
+    travel_to Time.current.end_of_month + 1.month
+    ingest_event(100)
+    Invoice.finalize_all!
+    expect(Invoice.count).to eq(2)
+  end
+
+  it 'generates an invoice in the middle of the month and downgrades the subscription before the end of the month' do
+    travel_to Time.current.middle_of_month
+    ingest_event(100)
+    expect(Invoice.count).to eq(1)
+
+    travel_to Time.current.end_of_month - 1.day
+    subscription.update!(plan: new_plan)
+    Invoice.finalize_all!
+    expect(Invoice.count).to eq(2)
+  end
+
+  it 'generates invoices for multiple usage thresholds within the same billing period' do
+    travel_to Time.current.middle_of_month
+    ingest_event(100)
+    expect(Invoice.count).to eq(1)
+
+    travel_to Time.current.middle_of_month + 5.days
+    ingest_event(100)
+    expect(Invoice.count).to eq(2)
+
+    travel_to Time.current.end_of_month
+    Invoice.finalize_all!
+    expect(Invoice.count).to eq(3)
+  end
+
+  it 'generates only the final invoice at the end of the month' do
+    travel_to Time.current.end_of_month
+    Invoice.finalize_all!
+    expect(Invoice.count).to eq(1)
+  end
+end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -171,4 +171,10 @@ module ScenariosHelper
     Clock::FinalizeInvoicesJob.perform_later
     perform_all_enqueued_jobs
   end
+
+  def perform_usage_update
+    Clock::ComputeAllDailyUsagesJob.perform_later
+    Clock::RefreshLifetimeUsagesJob.perform_later
+    perform_all_enqueued_jobs
+  end
 end


### PR DESCRIPTION
## Context

because invoices are billed after the billing period, invoice_subscription.timestamp would contain date that is after the period, as result `Subscriptions::ProgressiveBilledAmount` might return a progressive billing invoice associated to the next billing period

## Description

Changed the timestamp sent to `Subscriptions::ProgressiveBilledAmount`
Added scenario tests
