### PR TITLE
misc(api-key-management): Refactor request tests

### DIFF
--- a/spec/requests/api/v1/analytics/gross_revenues_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/gross_revenues_controller_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::Analytics::GrossRevenuesController, type: :request do
   describe 'GET /analytics/gross_revenue' do
+    subject { get_with_token(organization, '/api/v1/analytics/gross_revenue') }
+
     let(:customer) { create(:customer, organization:) }
     let(:organization) { create(:organization) }
 
@@ -11,10 +13,7 @@ RSpec.describe Api::V1::Analytics::GrossRevenuesController, type: :request do
       around { |test| lago_premium!(&test) }
 
       it 'returns the gross revenue' do
-        get_with_token(
-          organization,
-          '/api/v1/analytics/gross_revenue'
-        )
+        subject
 
         aggregate_failures do
           expect(response).to have_http_status(:success)
@@ -25,10 +24,7 @@ RSpec.describe Api::V1::Analytics::GrossRevenuesController, type: :request do
 
     context 'when licence is not premium' do
       it 'returns the gross revenue' do
-        get_with_token(
-          organization,
-          '/api/v1/analytics/gross_revenue'
-        )
+        subject
 
         expect(response).to have_http_status(:success)
         expect(json[:gross_revenues]).to eq([])

--- a/spec/requests/api/v1/analytics/invoice_collections_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/invoice_collections_controller_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::Analytics::InvoiceCollectionsController, type: :request do # rubocop:disable RSpec/FilePath
   describe 'GET /analytics/invoice_collection' do
+    subject { get_with_token(organization, '/api/v1/analytics/invoice_collection') }
+
     let(:customer) { create(:customer, organization:) }
     let(:organization) { create(:organization) }
 
@@ -11,10 +13,7 @@ RSpec.describe Api::V1::Analytics::InvoiceCollectionsController, type: :request 
       around { |test| lago_premium!(&test) }
 
       it 'returns the gross revenue' do
-        get_with_token(
-          organization,
-          '/api/v1/analytics/invoice_collection'
-        )
+        subject
 
         aggregate_failures do
           expect(response).to have_http_status(:success)
@@ -32,11 +31,7 @@ RSpec.describe Api::V1::Analytics::InvoiceCollectionsController, type: :request 
 
     context 'when licence is not premium' do
       it 'returns forbidden status' do
-        get_with_token(
-          organization,
-          '/api/v1/analytics/invoice_collection'
-        )
-
+        subject
         expect(response).to have_http_status(:forbidden)
       end
     end

--- a/spec/requests/api/v1/analytics/invoiced_usages_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/invoiced_usages_controller_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::Analytics::InvoicedUsagesController, type: :request do # rubocop:disable RSpec/FilePath
   describe 'GET /analytics/invoiced_usage' do
+    subject { get_with_token(organization, '/api/v1/analytics/invoiced_usage') }
+
     let(:customer) { create(:customer, organization:) }
     let(:organization) { create(:organization) }
 
@@ -11,10 +13,7 @@ RSpec.describe Api::V1::Analytics::InvoicedUsagesController, type: :request do #
       around { |test| lago_premium!(&test) }
 
       it 'returns the invoiced usage' do
-        get_with_token(
-          organization,
-          '/api/v1/analytics/invoiced_usage'
-        )
+        subject
 
         aggregate_failures do
           expect(response).to have_http_status(:success)
@@ -26,11 +25,7 @@ RSpec.describe Api::V1::Analytics::InvoicedUsagesController, type: :request do #
 
     context 'when license is not premium' do
       it 'returns forbidden status' do
-        get_with_token(
-          organization,
-          '/api/v1/analytics/invoiced_usage'
-        )
-
+        subject
         expect(response).to have_http_status(:forbidden)
       end
     end

--- a/spec/requests/api/v1/analytics/mrrs_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/mrrs_controller_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::Analytics::MrrsController, type: :request do # rubocop:disable RSpec/FilePath
   describe 'GET /analytics/mrr' do
+    subject { get_with_token(organization, '/api/v1/analytics/mrr') }
+
     let(:customer) { create(:customer, organization:) }
     let(:organization) { create(:organization) }
 
@@ -11,7 +13,7 @@ RSpec.describe Api::V1::Analytics::MrrsController, type: :request do # rubocop:d
       around { |test| lago_premium!(&test) }
 
       it 'returns the mrr' do
-        get_with_token(organization, '/api/v1/analytics/mrr')
+        subject
 
         aggregate_failures do
           expect(response).to have_http_status(:success)
@@ -27,8 +29,7 @@ RSpec.describe Api::V1::Analytics::MrrsController, type: :request do # rubocop:d
 
     context 'when license is not premium' do
       it 'returns forbidden status' do
-        get_with_token(organization, '/api/v1/analytics/mrr')
-
+        subject
         expect(response).to have_http_status(:forbidden)
       end
     end

--- a/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Analytics::OverdueBalancesController, type: :request do
-  describe "GET /analytics/overdue_balances" do
+  describe "GET /analytics/overdue_balance" do
+    subject { get_with_token(organization, "/api/v1/analytics/overdue_balance") }
+
     let(:customer) { create(:customer, organization:) }
     let(:organization) { create(:organization, created_at: DateTime.new(2023, 11, 1)) }
 
@@ -14,7 +16,7 @@ RSpec.describe Api::V1::Analytics::OverdueBalancesController, type: :request do
         i2 = create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 5.days.ago, total_amount_cents: 2000)
         i3 = create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.day.ago, total_amount_cents: 3000)
 
-        get_with_token(organization, "/api/v1/analytics/overdue_balance")
+        subject
 
         expect(response).to have_http_status(:success)
         expect(json[:overdue_balances]).to match_array(

--- a/spec/requests/api/v1/applied_coupons_controller_spec.rb
+++ b/spec/requests/api/v1/applied_coupons_controller_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
   let(:customer) { create(:customer, organization:) }
   let(:coupon) { create(:coupon, organization:) }
 
-  describe 'apply' do
-    before do
-      create(:subscription, customer:)
+  describe 'POST /api/v1/applied_coupons' do
+    subject do
+      post_with_token(organization, '/api/v1/applied_coupons', {applied_coupon: params})
     end
 
     let(:params) do
@@ -19,12 +19,10 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
       }
     end
 
+    before { create(:subscription, customer:) }
+
     it 'returns a success' do
-      post_with_token(
-        organization,
-        '/api/v1/applied_coupons',
-        {applied_coupon: params}
-      )
+      subject
 
       expect(response).to have_http_status(:success)
 
@@ -47,19 +45,17 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
       end
 
       it 'returns an unprocessable_entity' do
-        post_with_token(organization, '/api/v1/applied_coupons', {applied_coupon: params})
-
+        subject
         expect(response).to have_http_status(:not_found)
       end
     end
   end
 
-  describe 'index' do
-    let(:customer) { create(:customer, organization:) }
+  describe 'GET /api/v1/applied_coupons' do
+    subject { get_with_token(organization, '/api/v1/applied_coupons') }
+
     let(:coupon) { create(:coupon, coupon_type: 'fixed_amount', organization:) }
-    let(:credit) do
-      create(:credit, applied_coupon:, amount_cents: 2, amount_currency: customer.currency)
-    end
+
     let(:applied_coupon) do
       create(
         :applied_coupon,
@@ -71,12 +67,11 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
     end
 
     before do
-      applied_coupon
-      credit
+      create(:credit, applied_coupon:, amount_cents: 2, amount_currency: customer.currency)
     end
 
     it 'returns applied coupons' do
-      get_with_token(organization, '/api/v1/applied_coupons')
+      subject
 
       aggregate_failures do
         expect(response).to have_http_status(:success)

--- a/spec/requests/api/v1/organizations_controller_spec.rb
+++ b/spec/requests/api/v1/organizations_controller_spec.rb
@@ -6,7 +6,15 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
   let(:organization) { create(:organization) }
   let(:webhook_url) { Faker::Internet.url }
 
-  describe 'update' do
+  describe 'PUT /api/v1/organizations' do
+    subject do
+      put_with_token(
+        organization,
+        '/api/v1/organizations',
+        {organization: update_params}
+      )
+    end
+
     let(:update_params) do
       {
         country: 'pl',
@@ -64,11 +72,7 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
       around { |test| lago_premium!(&test) }
 
       it 'updates an organization' do
-        put_with_token(
-          organization,
-          '/api/v1/organizations',
-          {organization: update_params}
-        )
+        subject
 
         expect(response).to have_http_status(:success)
 
@@ -83,24 +87,22 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
     end
   end
 
-  describe 'GET /grpc_token' do
+  describe 'GET /api/v1/organizations/grpc_token' do
+    subject { get_with_token(organization, '/api/v1/organizations/grpc_token') }
+
     it 'returns the grpc_token' do
-      get_with_token(
-        organization,
-        '/api/v1/organizations/grpc_token'
-      )
+      subject
 
       expect(response).to have_http_status(:success)
       expect(json[:organization][:grpc_token]).not_to be_nil
     end
   end
 
-  describe 'GET' do
+  describe 'GET /api/v1/organizations' do
+    subject { get_with_token(organization, '/api/v1/organizations') }
+
     it 'returns the organization' do
-      get_with_token(
-        organization,
-        '/api/v1/organizations'
-      )
+      subject
 
       expect(response).to have_http_status(:success)
       expect(json[:organization][:name]).to eq(organization.name)

--- a/spec/requests/api/v1/webhooks_controller_spec.rb
+++ b/spec/requests/api/v1/webhooks_controller_spec.rb
@@ -5,18 +5,22 @@ require 'rails_helper'
 RSpec.describe Api::V1::WebhooksController, type: :request do
   let(:organization) { create(:organization) }
 
-  describe 'public_key' do
+  describe 'GET /api/v1/webhooks/public_key' do
+    subject { get_with_token(organization, '/api/v1/webhooks/public_key') }
+
     it 'returns the public key used to verify webhook signatures' do
-      get_with_token(organization, '/api/v1/webhooks/public_key')
+      subject
 
       expect(response).to have_http_status(:success)
       expect(response.body).to eq(Base64.encode64(RsaPublicKey.to_s))
     end
   end
 
-  describe 'json_public_key' do
+  describe 'GET /api/v1/webhooks/json_public_key' do
+    subject { get_with_token(organization, '/api/v1/webhooks/json_public_key') }
+
     it 'returns the public key in JSON response used to verify webhook signatures' do
-      get_with_token(organization, '/api/v1/webhooks/json_public_key')
+      subject
 
       expect(response).to have_http_status(:success)
       expect(json[:webhook][:public_key]).to eq(Base64.encode64(RsaPublicKey.to_s))


### PR DESCRIPTION
## Context

Extracting request tests refactoring into dedicated PR for easier review.

## Description

Use `subject` in request tests.
Add few missing tests.
Use `let!` where possible.
Reduce amount of `entity1` like variable names.
