### PR TITLE
Fix: greater_than usage

### DIFF
--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -25,7 +25,7 @@ class AppliedCoupon < ApplicationRecord
 
   monetize :amount_cents, disable_validation: true, allow_nil: true
 
-  validates :amount_cents, numericality: {greater_than: 0}, allow_nil: true
+  validates :amount_cents, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
   validates :amount_currency, inclusion: {in: currency_list}, allow_nil: true
 
   def mark_as_terminated!(timestamp = Time.zone.now)

--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -25,7 +25,7 @@ class AppliedCoupon < ApplicationRecord
 
   monetize :amount_cents, disable_validation: true, allow_nil: true
 
-  validates :amount_cents, numericality: {greater_than_or_equal_to: 0}, allow_nil: true
+  validates :amount_cents, numericality: {greater_than: 0}, allow_nil: true
   validates :amount_currency, inclusion: {in: currency_list}, allow_nil: true
 
   def mark_as_terminated!(timestamp = Time.zone.now)

--- a/app/services/credit_notes/validate_item_service.rb
+++ b/app/services/credit_notes/validate_item_service.rb
@@ -53,9 +53,9 @@ module CreditNotes
       false
     end
 
-    # NOTE: Check if item amount is >= 0 (CreditNoteItem.amount_cents has numericality validation: greater_than_or_equal_to: 0)
+    # NOTE: Check if item amount is positive
     def valid_item_amount?
-      return true if item.amount_cents >= 0
+      return true if item.amount_cents.positive?
 
       add_error(field: :amount_cents, error_code: 'invalid_value')
     end

--- a/app/services/credit_notes/validate_item_service.rb
+++ b/app/services/credit_notes/validate_item_service.rb
@@ -53,9 +53,9 @@ module CreditNotes
       false
     end
 
-    # NOTE: Check if item amount is positive
+    # NOTE: Check if item amount is >= 0 (CreditNoteItem.amount_cents has numericality validation: greater_than_or_equal_to: 0)
     def valid_item_amount?
-      return true if item.amount_cents.positive?
+      return true if item.amount_cents >= 0
 
       add_error(field: :amount_cents, error_code: 'invalid_value')
     end


### PR DESCRIPTION
## Context

Credit Note Item model allows amount_cents to be 0; Because of roundings, applied_coupon.amount_cents can also be 0
