### PR TITLE
fix: adjust fee serializer for pay in advance fees

### DIFF
--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -102,12 +102,7 @@ module V1
     def pay_in_advance_charge_attributes
       return {} unless model.pay_in_advance?
 
-      event = Event.find_by(
-        organization_id: model.subscription.organization,
-        id: model.pay_in_advance_event_id
-      )
-
-      {event_transaction_id: event&.transaction_id}
+      {event_transaction_id: model.pay_in_advance_event_transaction_id}
     end
 
     def applied_taxes

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe ::V1::FeeSerializer do
           'external_subscription_id' => subscription.external_id,
           'lago_customer_id' => customer.id,
           'external_customer_id' => customer.external_id,
-          'event_transaction_id' => event.transaction_id,
+          'event_transaction_id' => fee.pay_in_advance_event_transaction_id,
           'pay_in_advance' => true,
           'invoiceable' => true
         )


### PR DESCRIPTION
## Context

In some scenarios, there was no `event_transaction_id` attached in fee serializer

## Description

This PR simplifies method in serializer and ensure presence of `event_transaction_id` value
