### PR TITLE
fix(api-key-management): API key editing

### DIFF
--- a/app/graphql/mutations/api_keys/update.rb
+++ b/app/graphql/mutations/api_keys/update.rb
@@ -14,17 +14,9 @@ module Mutations
 
       type Types::ApiKeys::Object
 
-      def resolve(id:, name: nil, permissions: nil)
+      def resolve(id:, **params)
         api_key = current_organization.api_keys.find_by(id:)
-
-        result = ::ApiKeys::UpdateService.call(
-          api_key:,
-          params: {
-            name:,
-            permissions:
-          }
-        )
-
+        result = ::ApiKeys::UpdateService.call(api_key:, params:)
         result.success? ? result.api_key : result_error(result)
       end
     end


### PR DESCRIPTION
## Context

Fix editing API key when 'api_permissions' add-on is not enabled.

## Description

Avoid setting permissions to `nil` if it's no passed to prevent nullifying of the value.
