### PR TITLE
Feat(reliability) - Allow sidekiq-pro configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,13 @@ gem "rails", "~> 7.1.3.4"
 gem "redis"
 gem "sidekiq"
 gem "sidekiq-throttled", '1.4.0' # '1.5.0' was losing some jobs
+
+if ENV.fetch("LAGO_ENABLE_SIDEKIQ_PRO", false).to_s == "true"
+  source "https://gems.contribsys.com" do
+    gem "sidekiq-pro"
+  end
+end
+
 gem "throttling"
 gem "dry-validation"
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -29,6 +29,11 @@ Sidekiq.configure_server do |config|
   config.logger.formatter = Sidekiq::Logger::Formatters::JSON.new
   config[:max_retries] = 0
   config[:dead_max_jobs] = ENV.fetch("LAGO_SIDEKIQ_MAX_DEAD_JOBS", 100_000).to_i
+
+  if ENV.fetch("LAGO_ENABLE_SIDEKIQ_PRO", false).to_s == "true"
+    config.super_fetch!
+  end
+
   config.on(:startup) do
     Sidekiq.logger.info "Starting liveness server on #{LIVENESS_PORT}"
     Thread.start do


### PR DESCRIPTION
## description

When running Lago in an unreliable environment (such as Kubernetes), it can be valuable to configure sidekiq with sidekiq-pro to give allows `super_fetch` to be setup.