### PR TITLE
fix (grace_period): refactor how issuing date is set

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -99,14 +99,13 @@ class Invoice < ApplicationRecord
   scope :ready_to_be_refreshed, -> { where(ready_to_be_refreshed: true) }
   scope :ready_to_be_finalized,
     lambda {
-      date = <<-SQL
-            (
-              invoices.created_at +
-              COALESCE(customers.invoice_grace_period, organizations.invoice_grace_period) * INTERVAL '1 DAY'
-            )
-      SQL
-
-      draft.joins(:customer, :organization).where("#{Arel.sql(date)} < ?", Time.current)
+      draft
+        .joins(customer: :organization)
+        .where(
+          "issuing_date#{Utils::Timezone.at_time_zone_sql} <= " \
+          "DATE(?#{Utils::Timezone.at_time_zone_sql})",
+          Time.current
+        )
     }
 
   scope :created_before,

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -97,16 +97,7 @@ class Invoice < ApplicationRecord
   scope :invisible, -> { where(status: INVISIBLE_STATUS.keys) }
   scope :with_generated_number, -> { where(status: %w[finalized voided]) }
   scope :ready_to_be_refreshed, -> { where(ready_to_be_refreshed: true) }
-  scope :ready_to_be_finalized,
-    lambda {
-      draft
-        .joins(customer: :organization)
-        .where(
-          "issuing_date#{Utils::Timezone.at_time_zone_sql} <= " \
-          "DATE(?#{Utils::Timezone.at_time_zone_sql})",
-          Time.current
-        )
-    }
+  scope :ready_to_be_finalized, -> { draft.where('issuing_date <= ?', Time.current.to_date) }
 
   scope :created_before,
     lambda { |invoice|

--- a/app/services/customers/update_invoice_grace_period_service.rb
+++ b/app/services/customers/update_invoice_grace_period_service.rb
@@ -10,11 +10,13 @@ module Customers
 
     def call
       old_grace_period = customer.invoice_grace_period.to_i
-      grace_period_diff = customer.applicable_invoice_grace_period.to_i - customer.applicable_invoice_grace_period.to_i
+      old_applicable_grace_period = customer.applicable_invoice_grace_period.to_i
 
       if grace_period != old_grace_period
         customer.invoice_grace_period = grace_period
         customer.save!
+
+        grace_period_diff = customer.applicable_invoice_grace_period.to_i - old_applicable_grace_period
 
         # NOTE: Update issuing_date on draft invoices.
         customer.invoices.draft.find_each do |invoice|

--- a/app/services/customers/update_invoice_grace_period_service.rb
+++ b/app/services/customers/update_invoice_grace_period_service.rb
@@ -4,26 +4,28 @@ module Customers
   class UpdateInvoiceGracePeriodService < BaseService
     def initialize(customer:, grace_period:)
       @customer = customer
-      @grace_period = grace_period
+      @grace_period = grace_period.to_i
       super
     end
 
     def call
-      if grace_period != customer.invoice_grace_period
+      old_grace_period = customer.invoice_grace_period.to_i
+      grace_period_diff = grace_period - old_grace_period
+
+      if grace_period != old_grace_period
         customer.invoice_grace_period = grace_period
         customer.save!
+
+        # NOTE: Update issuing_date on draft invoices.
+        customer.invoices.draft.each do |invoice|
+          invoice.issuing_date = invoice.issuing_date + grace_period_diff.days
+          invoice.payment_due_date = grace_period_payment_due_date(invoice)
+          invoice.save!
+        end
 
         # NOTE: Finalize related draft invoices.
         customer.invoices.ready_to_be_finalized.each do |invoice|
           Invoices::RefreshDraftAndFinalizeService.call(invoice:)
-        end
-
-        # NOTE: Update issuing_date on draft invoices.
-        customer.invoices.draft.each do |invoice|
-          invoice.update!(
-            issuing_date: grace_period_issuing_date(invoice),
-            payment_due_date: grace_period_payment_due_date(invoice)
-          )
         end
       end
 
@@ -35,16 +37,8 @@ module Customers
 
     attr_reader :customer, :grace_period
 
-    def invoice_created_at(invoice)
-      invoice.created_at.in_time_zone(customer.applicable_timezone).to_date
-    end
-
-    def grace_period_issuing_date(invoice)
-      invoice_created_at(invoice) + customer.applicable_invoice_grace_period.days
-    end
-
     def grace_period_payment_due_date(invoice)
-      grace_period_issuing_date(invoice) + customer.applicable_net_payment_term.days
+      invoice.issuing_date + customer.applicable_net_payment_term.days
     end
   end
 end

--- a/app/services/organizations/update_invoice_grace_period_service.rb
+++ b/app/services/organizations/update_invoice_grace_period_service.rb
@@ -4,26 +4,28 @@ module Organizations
   class UpdateInvoiceGracePeriodService < BaseService
     def initialize(organization:, grace_period:)
       @organization = organization
-      @grace_period = grace_period
+      @grace_period = grace_period.to_i
       super
     end
 
     def call
-      if grace_period != organization.invoice_grace_period
+      old_grace_period = organization.invoice_grace_period.to_i
+      grace_period_diff = grace_period - old_grace_period
+
+      if grace_period != old_grace_period
         organization.invoice_grace_period = grace_period
         organization.save!
+
+        # NOTE: Update issuing_date on draft invoices.
+        organization.invoices.draft.each do |invoice|
+          invoice.issuing_date = invoice.issuing_date + grace_period_diff.days
+          invoice.payment_due_date = grace_period_payment_due_date(invoice)
+          invoice.save!
+        end
 
         # NOTE: Finalize related draft invoices.
         organization.invoices.ready_to_be_finalized.each do |invoice|
           Invoices::RefreshDraftAndFinalizeService.call(invoice:)
-        end
-
-        # NOTE: Update issuing_date on draft invoices.
-        organization.invoices.draft.each do |invoice|
-          invoice.update!(
-            issuing_date: grace_period_issuing_date(invoice),
-            payment_due_date: grace_period_payment_due_date(invoice)
-          )
         end
       end
 
@@ -35,16 +37,8 @@ module Organizations
 
     attr_reader :organization, :grace_period
 
-    def invoice_created_at(invoice)
-      invoice.created_at.in_time_zone(invoice.customer.applicable_timezone).to_date
-    end
-
-    def grace_period_issuing_date(invoice)
-      invoice_created_at(invoice) + invoice.customer.applicable_invoice_grace_period.days
-    end
-
     def grace_period_payment_due_date(invoice)
-      grace_period_issuing_date(invoice) + invoice.customer.applicable_net_payment_term.days
+      invoice.issuing_date + invoice.customer.applicable_net_payment_term.days
     end
   end
 end

--- a/app/services/organizations/update_invoice_grace_period_service.rb
+++ b/app/services/organizations/update_invoice_grace_period_service.rb
@@ -10,21 +10,23 @@ module Organizations
 
     def call
       old_grace_period = organization.invoice_grace_period.to_i
-      grace_period_diff = grace_period - old_grace_period
 
       if grace_period != old_grace_period
         organization.invoice_grace_period = grace_period
         organization.save!
 
         # NOTE: Update issuing_date on draft invoices.
-        organization.invoices.draft.each do |invoice|
+        organization.invoices.draft.find_each do |invoice|
+          grace_period_diff = invoice.customer.applicable_invoice_grace_period.to_i -
+            old_applicable_grace_period(invoice.customer, old_grace_period)
+
           invoice.issuing_date = invoice.issuing_date + grace_period_diff.days
           invoice.payment_due_date = grace_period_payment_due_date(invoice)
           invoice.save!
         end
 
         # NOTE: Finalize related draft invoices.
-        organization.invoices.ready_to_be_finalized.each do |invoice|
+        organization.invoices.ready_to_be_finalized.find_each do |invoice|
           Invoices::RefreshDraftAndFinalizeService.call(invoice:)
         end
       end
@@ -39,6 +41,12 @@ module Organizations
 
     def grace_period_payment_due_date(invoice)
       invoice.issuing_date + invoice.customer.applicable_net_payment_term.days
+    end
+
+    def old_applicable_grace_period(customer, old_org_grace_period)
+      return customer.invoice_grace_period if customer.invoice_grace_period.present?
+
+      old_org_grace_period
     end
   end
 end

--- a/spec/jobs/clock/finalize_invoices_job_spec.rb
+++ b/spec/jobs/clock/finalize_invoices_job_spec.rb
@@ -11,7 +11,7 @@ describe Clock::FinalizeInvoicesJob, job: true do
       create(
         :invoice,
         status: :draft,
-        created_at: DateTime.parse('20 Jun 2022'),
+        issuing_date: DateTime.parse('23 Jun 2022').to_date,
         customer:,
         organization: customer.organization
       )
@@ -20,7 +20,7 @@ describe Clock::FinalizeInvoicesJob, job: true do
       create(
         :invoice,
         status: :finalized,
-        created_at: DateTime.parse('20 Jun 2022'),
+        issuing_date: DateTime.parse('23 Jun 2022').to_date,
         customer:,
         organization: customer.organization
       )

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -137,6 +137,24 @@ RSpec.describe Invoice, type: :model do
     end
   end
 
+  describe 'ready_to_be_finalized' do
+    let(:invoice) { create(:invoice, status: :draft, issuing_date: Time.current - 1.day) }
+
+    before { invoice }
+
+    it 'returns all invoices that are ready for finalization' do
+      expect(Invoice.ready_to_be_finalized.pluck(:id)).to include(invoice.id)
+    end
+
+    context 'when issuing date has not been reached' do
+      let(:invoice) { create(:invoice, status: :draft, issuing_date: Time.current + 1.day) }
+
+      it 'returns all invoices that are ready for finalization' do
+        expect(Invoice.ready_to_be_finalized.pluck(:id)).not_to include(invoice.id)
+      end
+    end
+  end
+
   describe 'when status is visible' do
     it do
       described_class::VISIBLE_STATUS.keys.each do |status|

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -143,14 +143,14 @@ RSpec.describe Invoice, type: :model do
     before { invoice }
 
     it 'returns all invoices that are ready for finalization' do
-      expect(Invoice.ready_to_be_finalized.pluck(:id)).to include(invoice.id)
+      expect(described_class.ready_to_be_finalized.pluck(:id)).to include(invoice.id)
     end
 
     context 'when issuing date has not been reached' do
       let(:invoice) { create(:invoice, status: :draft, issuing_date: Time.current + 1.day) }
 
       it 'returns all invoices that are ready for finalization' do
-        expect(Invoice.ready_to_be_finalized.pluck(:id)).not_to include(invoice.id)
+        expect(described_class.ready_to_be_finalized.pluck(:id)).not_to include(invoice.id)
       end
     end
   end

--- a/spec/services/customers/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/customers/update_invoice_grace_period_service_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Customers::UpdateInvoiceGracePeriodService, type: :service do
 
   describe '#call' do
     let(:invoice_to_be_finalized) do
-      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'), organization:)
+      create(:invoice, status: :draft, customer:, issuing_date: DateTime.parse('19 Jun 2022').to_date, organization:)
     end
 
     let(:invoice_to_not_be_finalized) do
-      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'), organization:)
+      create(:invoice, status: :draft, customer:, issuing_date: DateTime.parse('21 Jun 2022').to_date, organization:)
     end
 
     before do

--- a/spec/services/organizations/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/organizations/update_invoice_grace_period_service_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Organizations::UpdateInvoiceGracePeriodService, type: :service do
 
   describe '#call' do
     let(:invoice_to_be_finalized) do
-      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'), organization:)
+      create(:invoice, status: :draft, customer:, issuing_date: DateTime.parse('19 Jun 2022').to_date, organization:)
     end
 
     let(:invoice_to_not_be_finalized) do
-      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'), organization:)
+      create(:invoice, status: :draft, customer:, issuing_date: DateTime.parse('21 Jun 2022').to_date, organization:)
     end
 
     before do

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -114,11 +114,11 @@ RSpec.describe Organizations::UpdateService do
         let(:customer) { create(:customer, organization:) }
 
         let(:invoice_to_be_finalized) do
-          create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'), organization:)
+          create(:invoice, status: :draft, customer:, issuing_date: DateTime.parse('19 Jun 2022').to_date, organization:)
         end
 
         let(:invoice_to_not_be_finalized) do
-          create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'), organization:)
+          create(:invoice, status: :draft, customer:, issuing_date: DateTime.parse('21 Jun 2022').to_date, organization:)
         end
 
         let(:invoice_grace_period) { 2 }


### PR DESCRIPTION
## Context

When billing job is triggered in the past, `issuing_date` is not set correctly.

## Description

`issuing_date` is set based on the billing job timestamp and grace period.

However, when we check if it is correct time to finalize invoice or in services that set grace period we calculate issuing date again based on `invoice.created_at`. If `invoice.created_at` is different than billing day timestamp, we could end-up with invalid issuing date. This especially affects when the draft invoice is finalized.

@vincent-pochet @rsempe Can you see any downside of this approach?
