### PR TITLE
fix: Ensure consistent order of results on list responses (frontend and API)

### DIFF
--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -90,10 +90,10 @@ module Api
         if result.success?
           render(
             json: ::CollectionSerializer.new(
-              result.metrics.includes(:filters),
+              result.billable_metrics.includes(:filters),
               ::V1::BillableMetricSerializer,
               collection_name: "billable_metrics",
-              meta: pagination_metadata(result.metrics),
+              meta: pagination_metadata(result.billable_metrics),
               includes: %i[counters] # DEPRECATED since 2024-11-22
             )
           )

--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -52,19 +52,26 @@ module Api
       end
 
       def index
-        coupons = current_organization.coupons
-          .order(created_at: :desc)
-          .page(params[:page])
-          .per(params[:per_page] || PER_PAGE)
-
-        render(
-          json: ::CollectionSerializer.new(
-            coupons,
-            ::V1::CouponSerializer,
-            collection_name: "coupons",
-            meta: pagination_metadata(coupons)
-          )
+        result = CouponsQuery.call(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          }
         )
+
+        if result.success?
+          render(
+            json: ::CollectionSerializer.new(
+              result.coupons,
+              ::V1::CouponSerializer,
+              collection_name: "coupons",
+              meta: pagination_metadata(result.coupons)
+            )
+          )
+        else
+          render_error_response(result)
+        end
       end
 
       private

--- a/app/controllers/api/v1/taxes_controller.rb
+++ b/app/controllers/api/v1/taxes_controller.rb
@@ -43,19 +43,26 @@ module Api
       end
 
       def index
-        taxes = current_organization.taxes
-          .order(created_at: :desc)
-          .page(params[:page])
-          .per(params[:per_page] || PER_PAGE)
-
-        render(
-          json: ::CollectionSerializer.new(
-            taxes,
-            ::V1::TaxSerializer,
-            collection_name: 'taxes',
-            meta: pagination_metadata(taxes)
-          )
+        result = TaxesQuery.call(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          }
         )
+
+        if result.success?
+          render(
+            json: ::CollectionSerializer.new(
+              result.taxes,
+              ::V1::TaxSerializer,
+              collection_name: "taxes",
+              meta: pagination_metadata(result.taxes)
+            )
+          )
+        else
+          render_error_response(result)
+        end
       end
 
       private

--- a/app/controllers/api/v1/webhook_endpoints_controller.rb
+++ b/app/controllers/api/v1/webhook_endpoints_controller.rb
@@ -31,18 +31,26 @@ module Api
       end
 
       def index
-        webhook_endpoints = current_organization.webhook_endpoints
-          .page(params[:page])
-          .per(params[:per_page] || PER_PAGE)
-
-        render(
-          json: ::CollectionSerializer.new(
-            webhook_endpoints,
-            ::V1::WebhookEndpointSerializer,
-            collection_name: 'webhook_endpoints',
-            meta: pagination_metadata(webhook_endpoints)
-          )
+        result = WebhookEndpointsQuery.call(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          }
         )
+
+        if result.success?
+          render(
+            json: ::CollectionSerializer.new(
+              result.webhook_endpoints,
+              ::V1::WebhookEndpointSerializer,
+              collection_name: "webhook_endpoints",
+              meta: pagination_metadata(result.webhook_endpoints)
+            )
+          )
+        else
+          render_error_response(result)
+        end
       end
 
       def show

--- a/app/queries/add_ons_query.rb
+++ b/app/queries/add_ons_query.rb
@@ -4,7 +4,7 @@ class AddOnsQuery < BaseQuery
   def call
     add_ons = base_scope.result
     add_ons = paginate(add_ons)
-    add_ons = add_ons.order(created_at: :desc)
+    add_ons = apply_consistent_ordering(add_ons)
 
     result.add_ons = add_ons
     result

--- a/app/queries/applied_coupons_query.rb
+++ b/app/queries/applied_coupons_query.rb
@@ -3,7 +3,7 @@
 class AppliedCouponsQuery < BaseQuery
   def call
     applied_coupons = paginate(base_scope)
-    applied_coupons = applied_coupons.order(created_at: :desc)
+    applied_coupons = apply_consistent_ordering(applied_coupons)
 
     applied_coupons = with_external_customer(applied_coupons) if filters.external_customer_id
     applied_coupons = with_status(applied_coupons) if valid_status?

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -57,4 +57,9 @@ class BaseQuery < BaseService
     result.single_validation_failure!(field: field_name.to_sym, error_code: 'invalid_date')
       .raise_if_error!
   end
+
+  # Apply consistent ordering across query objects
+  def apply_consistent_ordering(scope, default_order: { created_at: :desc })
+    scope.order(default_order).order(id: :asc)
+  end
 end

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -3,6 +3,7 @@
 class BaseQuery < BaseService
   # nil values force Kaminari to apply its default values for page and limit.
   DEFAULT_PAGINATION_PARAMS = {page: nil, limit: nil}
+  DEFAULT_ORDER = {created_at: :desc}
 
   Pagination = Struct.new(:page, :limit, keyword_init: true)
 
@@ -59,7 +60,7 @@ class BaseQuery < BaseService
   end
 
   # Apply consistent ordering across query objects
-  def apply_consistent_ordering(scope, default_order: { created_at: :desc })
+  def apply_consistent_ordering(scope, default_order: DEFAULT_ORDER)
     scope.order(default_order).order(id: :asc)
   end
 end

--- a/app/queries/billable_metrics_query.rb
+++ b/app/queries/billable_metrics_query.rb
@@ -6,7 +6,7 @@ class BillableMetricsQuery < BaseQuery
 
     metrics = base_scope.result
     metrics = paginate(metrics)
-    metrics = metrics.order(created_at: :desc)
+    metrics = apply_consistent_ordering(metrics)
 
     metrics = with_recurring(metrics) unless filters.recurring.nil?
     metrics = with_aggregation_type(metrics) if filters.aggregation_types.present?

--- a/app/queries/coupons_query.rb
+++ b/app/queries/coupons_query.rb
@@ -5,6 +5,7 @@ class CouponsQuery < BaseQuery
     coupons = base_scope.result
     coupons = paginate(coupons)
     coupons = coupons.order_by_status_and_expiration
+    coupons = apply_consistent_ordering(coupons)
 
     coupons = with_status(coupons) if filters.status.present?
 

--- a/app/queries/credit_notes_query.rb
+++ b/app/queries/credit_notes_query.rb
@@ -6,6 +6,9 @@ class CreditNotesQuery < BaseQuery
     credit_notes = paginate(credit_notes)
     credit_notes = credit_notes.order(created_at: :desc)
 
+    # ensure consistent order on credit_notes with the same created_at
+    credit_notes = credit_notes.order(id: :asc)
+
     credit_notes = with_customer_id(credit_notes) if filters.customer_id.present?
 
     result.credit_notes = credit_notes

--- a/app/queries/credit_notes_query.rb
+++ b/app/queries/credit_notes_query.rb
@@ -4,10 +4,7 @@ class CreditNotesQuery < BaseQuery
   def call
     credit_notes = base_scope.result
     credit_notes = paginate(credit_notes)
-    credit_notes = credit_notes.order(created_at: :desc)
-
-    # ensure consistent order on credit_notes with the same created_at
-    credit_notes = credit_notes.order(id: :asc)
+    credit_notes = apply_consistent_ordering(credit_notes)
 
     credit_notes = with_customer_id(credit_notes) if filters.customer_id.present?
     credit_notes = with_external_customer_id(credit_notes) if filters.external_customer_id.present?

--- a/app/queries/credit_notes_query.rb
+++ b/app/queries/credit_notes_query.rb
@@ -10,6 +10,7 @@ class CreditNotesQuery < BaseQuery
     credit_notes = credit_notes.order(id: :asc)
 
     credit_notes = with_customer_id(credit_notes) if filters.customer_id.present?
+    credit_notes = with_external_customer_id(credit_notes) if filters.external_customer_id.present?
 
     result.credit_notes = credit_notes
     result
@@ -37,5 +38,9 @@ class CreditNotesQuery < BaseQuery
 
   def with_customer_id(scope)
     scope.where(customer_id: filters.customer_id)
+  end
+
+  def with_external_customer_id(scope)
+    scope.joins(:customer).where(customers: {external_id: filters.external_customer_id})
   end
 end

--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -4,7 +4,7 @@ class CustomersQuery < BaseQuery
   def call
     customers = base_scope.result
     customers = paginate(customers)
-    customers = customers.order(created_at: :desc)
+    customers = apply_consistent_ordering(customers)
 
     result.customers = customers
     result

--- a/app/queries/dunning_campaigns_query.rb
+++ b/app/queries/dunning_campaigns_query.rb
@@ -7,6 +7,7 @@ class DunningCampaignsQuery < BaseQuery
     dunning_campaigns = base_scope.result
     dunning_campaigns = paginate(dunning_campaigns)
     dunning_campaigns = dunning_campaigns.order(order)
+    dunning_campaigns = apply_consistent_ordering(dunning_campaigns)
 
     dunning_campaigns = with_applied_to_organization(dunning_campaigns) unless filters.applied_to_organization.nil?
     dunning_campaigns = with_currency_threshold(dunning_campaigns) if filters.currency.present?

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -5,9 +5,9 @@ class EventsQuery < BaseQuery
     events = organization.clickhouse_events_store? ? Clickhouse::EventsRaw : Event
     events = events.where(organization_id: organization.id)
     events = paginate(events)
+
     events = events.order(timestamp: :desc) unless organization.clickhouse_events_store?
     events = events.order(ingested_at: :desc) if organization.clickhouse_events_store?
-    events = apply_consistent_ordering(events)
 
     events = with_code(events) if filters.code
     events = with_external_subscription_id(events) if filters.external_subscription_id

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -5,9 +5,9 @@ class EventsQuery < BaseQuery
     events = organization.clickhouse_events_store? ? Clickhouse::EventsRaw : Event
     events = events.where(organization_id: organization.id)
     events = paginate(events)
-
     events = events.order(timestamp: :desc) unless organization.clickhouse_events_store?
     events = events.order(ingested_at: :desc) if organization.clickhouse_events_store?
+    events = apply_consistent_ordering(events)
 
     events = with_code(events) if filters.code
     events = with_external_subscription_id(events) if filters.external_subscription_id

--- a/app/queries/fees_query.rb
+++ b/app/queries/fees_query.rb
@@ -9,7 +9,7 @@ class FeesQuery < BaseQuery
     end
 
     fees = paginate(base_scope)
-    fees = apply_consistent_ordering(fees, default_order: { created_at: :asc })
+    fees = apply_consistent_ordering(fees, default_order: {created_at: :asc})
 
     fees = with_external_subscription(fees) if filters.external_subscription_id
 

--- a/app/queries/fees_query.rb
+++ b/app/queries/fees_query.rb
@@ -9,7 +9,7 @@ class FeesQuery < BaseQuery
     end
 
     fees = paginate(base_scope)
-    fees = fees.order(created_at: :asc, id: :asc)
+    fees = apply_consistent_ordering(fees, default_order: { created_at: :asc })
 
     fees = with_external_subscription(fees) if filters.external_subscription_id
 

--- a/app/queries/integration_collection_mappings_query.rb
+++ b/app/queries/integration_collection_mappings_query.rb
@@ -3,7 +3,7 @@
 class IntegrationCollectionMappingsQuery < BaseQuery
   def call
     integration_collection_mappings = paginate(base_scope)
-    integration_collection_mappings = integration_collection_mappings.order(created_at: :desc)
+    integration_collection_mappings = apply_consistent_ordering(integration_collection_mappings)
 
     integration_collection_mappings = with_integration_id(integration_collection_mappings) if filters.integration_id
     integration_collection_mappings = with_mapping_type(integration_collection_mappings) if filters.mapping_type

--- a/app/queries/integration_items_query.rb
+++ b/app/queries/integration_items_query.rb
@@ -5,6 +5,7 @@ class IntegrationItemsQuery < BaseQuery
     integration_items = base_scope.result
     integration_items = paginate(integration_items)
     integration_items = integration_items.order(external_name: :asc)
+    integration_items = apply_consistent_ordering(integration_items)
 
     integration_items = with_integration_id(integration_items) if filters.integration_id.present?
     integration_items = with_item_type(integration_items) unless filters.item_type.nil?

--- a/app/queries/integration_mappings_query.rb
+++ b/app/queries/integration_mappings_query.rb
@@ -3,7 +3,7 @@
 class IntegrationMappingsQuery < BaseQuery
   def call
     integration_mappings = paginate(base_scope)
-    integration_mappings = integration_mappings.order(created_at: :desc)
+    integration_mappings = apply_consistent_ordering(integration_mappings)
 
     integration_mappings = with_integration_id(integration_mappings) if filters.integration_id
     integration_mappings = with_mappable_type(integration_mappings) if filters.mappable_type

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -6,7 +6,7 @@ class InvoicesQuery < BaseQuery
     invoices = paginate(invoices)
     invoices = apply_consistent_ordering(
       invoices,
-      default_order: { issuing_date: :desc, created_at: :desc }
+      default_order: {issuing_date: :desc, created_at: :desc}
     )
 
     invoices = with_currency(invoices) if filters.currency

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -4,7 +4,10 @@ class InvoicesQuery < BaseQuery
   def call
     invoices = base_scope.result.includes(:customer).includes(file_attachment: :blob)
     invoices = paginate(invoices)
-    invoices = invoices.order(issuing_date: :desc, created_at: :desc)
+    invoices = apply_consistent_ordering(
+      invoices,
+      default_order: { issuing_date: :desc, created_at: :desc }
+    )
 
     invoices = with_currency(invoices) if filters.currency
     invoices = with_customer_external_id(invoices) if filters.customer_external_id

--- a/app/queries/past_usage_query.rb
+++ b/app/queries/past_usage_query.rb
@@ -5,7 +5,7 @@ class PastUsageQuery < BaseQuery
     validate_filters
     return result if result.error.present?
 
-    query_result = query
+    query_result = apply_consistent_ordering(query)
     result.usage_periods = query_result.map do |invoice_subscription|
       OpenStruct.new(
         invoice_subscription:,

--- a/app/queries/payment_requests_query.rb
+++ b/app/queries/payment_requests_query.rb
@@ -4,7 +4,7 @@ class PaymentRequestsQuery < BaseQuery
   def call
     payment_requests = PaymentRequest.where(organization:)
     payment_requests = paginate(payment_requests)
-    payment_requests = payment_requests.order(created_at: :desc)
+    payment_requests = apply_consistent_ordering(payment_requests)
 
     payment_requests = with_external_customer(payment_requests) if filters.external_customer_id
 

--- a/app/queries/plans_query.rb
+++ b/app/queries/plans_query.rb
@@ -4,7 +4,7 @@ class PlansQuery < BaseQuery
   def call
     plans = base_scope.result
     plans = paginate(plans)
-    plans = plans.order(created_at: :desc)
+    plans = apply_consistent_ordering(plans)
 
     result.plans = plans
     result

--- a/app/queries/plans_query.rb
+++ b/app/queries/plans_query.rb
@@ -6,6 +6,8 @@ class PlansQuery < BaseQuery
     plans = paginate(plans)
     plans = apply_consistent_ordering(plans)
 
+    plans = exclude_pending_deletion(plans) unless filters.include_pending_deletion
+
     result.plans = plans
     result
   end
@@ -13,7 +15,7 @@ class PlansQuery < BaseQuery
   private
 
   def base_scope
-    Plan.parents.where(organization:).where(pending_deletion: false).ransack(search_params)
+    Plan.parents.where(organization:).ransack(search_params)
   end
 
   def search_params
@@ -24,5 +26,9 @@ class PlansQuery < BaseQuery
       name_cont: search_term,
       code_cont: search_term
     }
+  end
+
+  def exclude_pending_deletion(scope)
+    scope.where(pending_deletion: false)
   end
 end

--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -4,7 +4,13 @@ class SubscriptionsQuery < BaseQuery
   def call
     subscriptions = paginate(organization.subscriptions)
     subscriptions = subscriptions.where(status: filtered_statuses)
-    subscriptions = subscriptions.order("subscriptions.started_at ASC NULLS LAST, subscriptions.created_at ASC")
+    subscriptions = apply_consistent_ordering(
+      subscriptions,
+      default_order: <<~SQL.squish
+        subscriptions.started_at ASC NULLS LAST,
+        subscriptions.created_at ASC
+      SQL
+    )
 
     subscriptions = with_external_customer(subscriptions) if filters.external_customer_id
     subscriptions = with_plan_code(subscriptions) if filters.plan_code

--- a/app/queries/taxes_query.rb
+++ b/app/queries/taxes_query.rb
@@ -7,6 +7,7 @@ class TaxesQuery < BaseQuery
     taxes = base_scope.result
     taxes = paginate(taxes)
     taxes = taxes.order(order)
+    taxes = apply_consistent_ordering(taxes)
 
     taxes = with_auto_generated(taxes) if filters.auto_generated.present?
     taxes = with_applied_to_organization(taxes) unless filters.applied_to_organization.nil?

--- a/app/queries/wallet_transactions_query.rb
+++ b/app/queries/wallet_transactions_query.rb
@@ -11,7 +11,7 @@ class WalletTransactionsQuery < BaseQuery
 
     wallet_transactions = wallet.wallet_transactions
     wallet_transactions = paginate(wallet_transactions)
-    wallet_transactions = wallet_transactions.order(created_at: :desc)
+    wallet_transactions = apply_consistent_ordering(wallet_transactions)
 
     if valid_transaction_type?(filters.transaction_type)
       wallet_transactions = with_transaction_type(wallet_transactions)

--- a/app/queries/wallets_query.rb
+++ b/app/queries/wallets_query.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class WalletsQuery < BaseQuery
+  def call
+    validate_filters
+    return result if result.error.present?
+
+    wallets = base_scope
+    wallets = paginate(wallets)
+    wallets = apply_consistent_ordering(wallets)
+
+    wallets = with_external_customer_id(wallets) if filters.external_customer_id
+
+    result.wallets = wallets
+    result
+  end
+
+  private
+
+  def base_scope
+    organization.wallets
+  end
+
+  def with_external_customer_id(scope)
+    scope.joins(:customer).where(customers: {external_id: filters.external_customer_id})
+  end
+
+  def validate_filters
+    if filters.to_h.key? :external_customer_id
+      result.not_found_failure!(resource: "customer") unless customer_exists?
+    end
+  end
+
+  def customer_exists?
+    organization.customers.exists?(external_id: filters.external_customer_id)
+  end
+end

--- a/app/queries/webhook_endpoints_query.rb
+++ b/app/queries/webhook_endpoints_query.rb
@@ -4,7 +4,10 @@ class WebhookEndpointsQuery < BaseQuery
   def call
     webhook_endpoints = base_scope.result
     webhook_endpoints = paginate(webhook_endpoints)
-    webhook_endpoints = webhook_endpoints.order(:webhook_url)
+    webhook_endpoints = apply_consistent_ordering(
+      webhook_endpoints,
+      default_order: {webhook_url: :asc, created_at: :desc}
+    )
 
     result.webhook_endpoints = webhook_endpoints
     result

--- a/app/queries/webhooks_query.rb
+++ b/app/queries/webhooks_query.rb
@@ -9,7 +9,10 @@ class WebhooksQuery < BaseQuery
   def call
     webhooks = base_scope.result
     webhooks = paginate(webhooks)
-    webhooks = webhooks.order(updated_at: :desc)
+    webhooks = apply_consistent_ordering(
+      webhooks,
+      default_order: { updated_at: :desc, created_at: :desc }
+    )
 
     webhooks = with_status(webhooks) if filters.status.present?
 

--- a/app/queries/webhooks_query.rb
+++ b/app/queries/webhooks_query.rb
@@ -11,7 +11,7 @@ class WebhooksQuery < BaseQuery
     webhooks = paginate(webhooks)
     webhooks = apply_consistent_ordering(
       webhooks,
-      default_order: { updated_at: :desc, created_at: :desc }
+      default_order: {updated_at: :desc, created_at: :desc}
     )
 
     webhooks = with_status(webhooks) if filters.status.present?

--- a/spec/queries/add_ons_query_spec.rb
+++ b/spec/queries/add_ons_query_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe AddOnsQuery, type: :query do
     expect(returned_ids).to include(add_on_third.id)
   end
 
-  context "when add ons have the ordering criteria" do
+  context "when add ons have the values for the ordering criteria" do
     let(:add_on_second) do
       create(:add_on, organization:, name: "abcde", code: "22", created_at: add_on_first.created_at).tap do |add_on|
         add_on.update! id: "00000000-0000-0000-0000-000000000000"

--- a/spec/queries/add_ons_query_spec.rb
+++ b/spec/queries/add_ons_query_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe AddOnsQuery, type: :query do
     expect(returned_ids).to include(add_on_third.id)
   end
 
-  context "when add ons have the same created_at" do
+  context "when add ons have the ordering criteria" do
     let(:add_on_second) do
-      create(:add_on, organization:, name: 'abcde', code: '22', created_at: add_on_first.created_at).tap do |add_on|
+      create(:add_on, organization:, name: "abcde", code: "22", created_at: add_on_first.created_at).tap do |add_on|
         add_on.update! id: "00000000-0000-0000-0000-000000000000"
       end
     end

--- a/spec/queries/add_ons_query_spec.rb
+++ b/spec/queries/add_ons_query_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe AddOnsQuery, type: :query do
   subject(:result) do
@@ -10,9 +10,9 @@ RSpec.describe AddOnsQuery, type: :query do
   let(:returned_ids) { result.add_ons.pluck(:id) }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:add_on_first) { create(:add_on, organization:, name: 'defgh', code: '11') }
-  let(:add_on_second) { create(:add_on, organization:, name: 'abcde', code: '22') }
-  let(:add_on_third) { create(:add_on, organization:, name: 'presuv', code: '33') }
+  let(:add_on_first) { create(:add_on, organization:, name: "defgh", code: "11") }
+  let(:add_on_second) { create(:add_on, organization:, name: "abcde", code: "22") }
+  let(:add_on_third) { create(:add_on, organization:, name: "presuv", code: "33") }
   let(:pagination) { {page: 1, limit: 10} }
   let(:search_term) { nil }
 
@@ -22,18 +22,23 @@ RSpec.describe AddOnsQuery, type: :query do
     add_on_third
   end
 
-  it 'returns all add_ons' do
+  it "returns all add_ons" do
     expect(result.add_ons.count).to eq(3)
     expect(returned_ids).to include(add_on_first.id)
     expect(returned_ids).to include(add_on_second.id)
     expect(returned_ids).to include(add_on_third.id)
   end
 
-  context "when add ons have the values for the ordering criteria" do
+  context "when add ons have the same values for the ordering criteria" do
     let(:add_on_second) do
-      create(:add_on, organization:, name: "abcde", code: "22", created_at: add_on_first.created_at).tap do |add_on|
-        add_on.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      create(
+        :add_on,
+        organization:,
+        id: "00000000-0000-0000-0000-000000000000",
+        name: "abcde",
+        code: "22",
+        created_at: add_on_first.created_at
+      )
     end
 
     it "returns a consistent list" do
@@ -45,49 +50,39 @@ RSpec.describe AddOnsQuery, type: :query do
     end
   end
 
-  context 'with pagination' do
+  context "with pagination" do
     let(:pagination) { {page: 2, limit: 2} }
 
-    it 'applies the pagination' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.add_ons.count).to eq(1)
-        expect(result.add_ons.current_page).to eq(2)
-        expect(result.add_ons.prev_page).to eq(1)
-        expect(result.add_ons.next_page).to be_nil
-        expect(result.add_ons.total_pages).to eq(2)
-        expect(result.add_ons.total_count).to eq(3)
-      end
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.add_ons.count).to eq(1)
+      expect(result.add_ons.current_page).to eq(2)
+      expect(result.add_ons.prev_page).to eq(1)
+      expect(result.add_ons.next_page).to be_nil
+      expect(result.add_ons.total_pages).to eq(2)
+      expect(result.add_ons.total_count).to eq(3)
     end
   end
 
-  context 'when searching for /de/ term' do
-    let(:search_term) { 'de' }
+  context "when searching for /de/ term" do
+    let(:search_term) { "de" }
 
-    it 'returns only two add_ons' do
-      returned_ids = result.add_ons.pluck(:id)
-
-      aggregate_failures do
-        expect(result.add_ons.count).to eq(2)
-        expect(returned_ids).to include(add_on_first.id)
-        expect(returned_ids).to include(add_on_second.id)
-        expect(returned_ids).not_to include(add_on_third.id)
-      end
+    it "returns only two add_ons" do
+      expect(result.add_ons.count).to eq(2)
+      expect(returned_ids).to include(add_on_first.id)
+      expect(returned_ids).to include(add_on_second.id)
+      expect(returned_ids).not_to include(add_on_third.id)
     end
   end
 
-  context 'when searching for /1/ term' do
-    let(:search_term) { '1' }
+  context "when searching for /1/ term" do
+    let(:search_term) { "1" }
 
-    it 'returns only two add_ons' do
-      returned_ids = result.add_ons.pluck(:id)
-
-      aggregate_failures do
-        expect(result.add_ons.count).to eq(1)
-        expect(returned_ids).to include(add_on_first.id)
-        expect(returned_ids).not_to include(add_on_second.id)
-        expect(returned_ids).not_to include(add_on_third.id)
-      end
+    it "returns only two add_ons" do
+      expect(result.add_ons.count).to eq(1)
+      expect(returned_ids).to include(add_on_first.id)
+      expect(returned_ids).not_to include(add_on_second.id)
+      expect(returned_ids).not_to include(add_on_third.id)
     end
   end
 end

--- a/spec/queries/applied_coupons_query_spec.rb
+++ b/spec/queries/applied_coupons_query_spec.rb
@@ -26,6 +26,22 @@ RSpec.describe AppliedCouponsQuery, type: :query do
     end
   end
 
+  context "when applied coupons have the same created_at" do
+    let(:applied_coupon_2) do
+      create(:applied_coupon, coupon:, customer:, created_at: applied_coupon.created_at).tap do |applied_coupon|
+        applied_coupon.update! id: "00000000-0000-0000-0000-000000000000"
+      end
+    end
+
+    before { applied_coupon_2 }
+
+    it "returns a consistent list" do
+      expect(result).to be_success
+      expect(result.applied_coupons.count).to eq(2)
+      expect(result.applied_coupons).to eq([applied_coupon_2, applied_coupon])
+    end
+  end
+
   context 'when customer is deleted' do
     let(:customer) { create(:customer, :deleted, organization:) }
 

--- a/spec/queries/applied_coupons_query_spec.rb
+++ b/spec/queries/applied_coupons_query_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe AppliedCouponsQuery, type: :query do
   subject(:result) do
@@ -18,19 +18,21 @@ RSpec.describe AppliedCouponsQuery, type: :query do
 
   before { applied_coupon }
 
-  it 'returns a list of applied_coupons' do
-    aggregate_failures do
-      expect(result).to be_success
-      expect(result.applied_coupons.count).to eq(1)
-      expect(result.applied_coupons).to eq([applied_coupon])
-    end
+  it "returns a list of applied_coupons" do
+    expect(result).to be_success
+    expect(result.applied_coupons.count).to eq(1)
+    expect(result.applied_coupons).to eq([applied_coupon])
   end
 
-  context "when applied coupons have the same created_at" do
+  context "when applied coupons have the same values for the ordering criteria" do
     let(:applied_coupon_2) do
-      create(:applied_coupon, coupon:, customer:, created_at: applied_coupon.created_at).tap do |applied_coupon|
-        applied_coupon.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      create(
+        :applied_coupon,
+        coupon:,
+        customer:,
+        id: "00000000-0000-0000-0000-000000000000",
+        created_at: applied_coupon.created_at
+      )
     end
 
     before { applied_coupon_2 }
@@ -42,48 +44,40 @@ RSpec.describe AppliedCouponsQuery, type: :query do
     end
   end
 
-  context 'when customer is deleted' do
+  context "when customer is deleted" do
     let(:customer) { create(:customer, :deleted, organization:) }
 
-    it 'filters the applied_coupons' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.applied_coupons.count).to eq(0)
-      end
+    it "filters the applied_coupons" do
+      expect(result).to be_success
+      expect(result.applied_coupons.count).to eq(0)
     end
   end
 
-  context 'with pagination' do
+  context "with pagination" do
     let(:pagination) { {page: 2, limit: 10} }
 
-    it 'applies the pagination' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.applied_coupons.count).to eq(0)
-        expect(result.applied_coupons.current_page).to eq(2)
-      end
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.applied_coupons.count).to eq(0)
+      expect(result.applied_coupons.current_page).to eq(2)
     end
   end
 
-  context 'with customer filter' do
+  context "with customer filter" do
     let(:filters) { {external_customer_id: customer.external_id} }
 
-    it 'applies the filter' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.applied_coupons.count).to eq(1)
-      end
+    it "applies the filter" do
+      expect(result).to be_success
+      expect(result.applied_coupons.count).to eq(1)
     end
   end
 
-  context 'with status filter' do
-    let(:filters) { {status: 'terminated'} }
+  context "with status filter" do
+    let(:filters) { {status: "terminated"} }
 
-    it 'applies the filter' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.applied_coupons.count).to eq(0)
-      end
+    it "applies the filter" do
+      expect(result).to be_success
+      expect(result.applied_coupons.count).to eq(0)
     end
   end
 end

--- a/spec/queries/billable_metrics_query_spec.rb
+++ b/spec/queries/billable_metrics_query_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe BillableMetricsQuery, type: :query do
   subject(:result) do
@@ -13,10 +13,10 @@ RSpec.describe BillableMetricsQuery, type: :query do
   let(:filters) { {} }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:billable_metric_first) { create(:billable_metric, organization:, name: 'defgh', code: '11') }
-  let(:billable_metric_second) { create(:billable_metric, organization:, name: 'abcde', code: '22') }
-  let(:billable_metric_third) { create(:billable_metric, organization:, name: 'presuv', code: '33') }
-  let(:billable_metric_fourth) { create(:unique_count_billable_metric, organization:, name: 'qwerty', code: '44') }
+  let(:billable_metric_first) { create(:billable_metric, organization:, name: "defgh", code: "11") }
+  let(:billable_metric_second) { create(:billable_metric, organization:, name: "abcde", code: "22") }
+  let(:billable_metric_third) { create(:billable_metric, organization:, name: "presuv", code: "33") }
+  let(:billable_metric_fourth) { create(:unique_count_billable_metric, organization:, name: "qwerty", code: "44") }
 
   before do
     billable_metric_first
@@ -25,7 +25,7 @@ RSpec.describe BillableMetricsQuery, type: :query do
     billable_metric_fourth
   end
 
-  it 'returns all billable metrics' do
+  it "returns all billable metrics" do
     expect(result).to be_success
     expect(returned_ids.count).to eq(4)
     expect(returned_ids).to include(billable_metric_first.id)
@@ -34,11 +34,16 @@ RSpec.describe BillableMetricsQuery, type: :query do
     expect(returned_ids).to include(billable_metric_fourth.id)
   end
 
-  context "when billable metrics have the same created_at" do
+  context "when billable metrics have the same values for the ordering criteria" do
     let(:billable_metric_second) do
-      create(:billable_metric, organization:, name: 'abcde', code: '22', created_at: billable_metric_first.created_at).tap do |billable_metric|
-        billable_metric.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      create(
+        :billable_metric,
+        organization:,
+        id: "00000000-0000-0000-0000-000000000000",
+        name: "abcde",
+        code: "22",
+        created_at: billable_metric_first.created_at
+      )
     end
 
     it "returns a consistent list" do
@@ -65,31 +70,29 @@ RSpec.describe BillableMetricsQuery, type: :query do
     end
   end
 
-  context 'with pagination' do
+  context "with pagination" do
     let(:pagination) { {page: 2, limit: 3} }
 
-    it 'applies the pagination' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.billable_metrics.count).to eq(1)
-        expect(result.billable_metrics.current_page).to eq(2)
-        expect(result.billable_metrics.prev_page).to eq(1)
-        expect(result.billable_metrics.next_page).to be_nil
-        expect(result.billable_metrics.total_pages).to eq(2)
-        expect(result.billable_metrics.total_count).to eq(4)
-      end
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.billable_metrics.count).to eq(1)
+      expect(result.billable_metrics.current_page).to eq(2)
+      expect(result.billable_metrics.prev_page).to eq(1)
+      expect(result.billable_metrics.next_page).to be_nil
+      expect(result.billable_metrics.total_pages).to eq(2)
+      expect(result.billable_metrics.total_count).to eq(4)
     end
   end
 
-  context 'when filtering by recurring billable metrics' do
+  context "when filtering by recurring billable metrics" do
     let(:billable_metric_recurring) do
       create(
         :billable_metric,
         organization:,
-        aggregation_type: 'unique_count_agg',
-        name: 'defghz',
-        code: '55',
-        field_name: 'test',
+        aggregation_type: "unique_count_agg",
+        name: "defghz",
+        code: "55",
+        field_name: "test",
         recurring: true
       )
     end
@@ -98,64 +101,48 @@ RSpec.describe BillableMetricsQuery, type: :query do
 
     before { billable_metric_recurring }
 
-    it 'returns 1 billable metric' do
-      returned_ids = result.billable_metrics.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(1)
-        expect(returned_ids).not_to include(billable_metric_first.id)
-        expect(returned_ids).not_to include(billable_metric_second.id)
-        expect(returned_ids).not_to include(billable_metric_third.id)
-        expect(returned_ids).not_to include(billable_metric_fourth.id)
-        expect(returned_ids).to include(billable_metric_recurring.id)
-      end
+    it "returns 1 billable metric" do
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).not_to include(billable_metric_first.id)
+      expect(returned_ids).not_to include(billable_metric_second.id)
+      expect(returned_ids).not_to include(billable_metric_third.id)
+      expect(returned_ids).not_to include(billable_metric_fourth.id)
+      expect(returned_ids).to include(billable_metric_recurring.id)
     end
   end
 
-  context 'when filtering by count_agg aggregation type' do
-    let(:filters) { {aggregation_types: ['count_agg']} }
+  context "when filtering by count_agg aggregation type" do
+    let(:filters) { {aggregation_types: ["count_agg"]} }
 
-    it 'returns 3 billable metrics' do
-      returned_ids = result.billable_metrics.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(3)
-        expect(returned_ids).to include(billable_metric_first.id)
-        expect(returned_ids).to include(billable_metric_second.id)
-        expect(returned_ids).to include(billable_metric_third.id)
-        expect(returned_ids).not_to include(billable_metric_fourth.id)
-      end
+    it "returns 3 billable metrics" do
+      expect(returned_ids.count).to eq(3)
+      expect(returned_ids).to include(billable_metric_first.id)
+      expect(returned_ids).to include(billable_metric_second.id)
+      expect(returned_ids).to include(billable_metric_third.id)
+      expect(returned_ids).not_to include(billable_metric_fourth.id)
     end
   end
 
-  context 'when filtering by max_agg aggregation type' do
-    let(:filters) { {aggregation_types: ['max_agg']} }
+  context "when filtering by max_agg aggregation type" do
+    let(:filters) { {aggregation_types: ["max_agg"]} }
 
-    it 'returns 0 billable metrics' do
-      returned_ids = result.billable_metrics.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(0)
-        expect(returned_ids).not_to include(billable_metric_first.id)
-        expect(returned_ids).not_to include(billable_metric_second.id)
-        expect(returned_ids).not_to include(billable_metric_third.id)
-        expect(returned_ids).not_to include(billable_metric_fourth.id)
-      end
+    it "returns 0 billable metrics" do
+      expect(returned_ids.count).to eq(0)
+      expect(returned_ids).not_to include(billable_metric_first.id)
+      expect(returned_ids).not_to include(billable_metric_second.id)
+      expect(returned_ids).not_to include(billable_metric_third.id)
+      expect(returned_ids).not_to include(billable_metric_fourth.id)
     end
   end
 
-  context 'when searching for /de/ term' do
-    let(:search_term) { 'de' }
+  context "when searching for /de/ term" do
+    let(:search_term) { "de" }
 
-    it 'returns only two billable metrics' do
-      returned_ids = result.billable_metrics.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(2)
-        expect(returned_ids).to include(billable_metric_first.id)
-        expect(returned_ids).to include(billable_metric_second.id)
-        expect(returned_ids).not_to include(billable_metric_third.id)
-      end
+    it "returns only two billable metrics" do
+      expect(returned_ids.count).to eq(2)
+      expect(returned_ids).to include(billable_metric_first.id)
+      expect(returned_ids).to include(billable_metric_second.id)
+      expect(returned_ids).not_to include(billable_metric_third.id)
     end
   end
 end

--- a/spec/queries/coupons_query_spec.rb
+++ b/spec/queries/coupons_query_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe CouponsQuery, type: :query do
   subject(:result) do
@@ -13,9 +13,9 @@ RSpec.describe CouponsQuery, type: :query do
   let(:filters) { {} }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:coupon_first) { create(:coupon, organization:, status: 'active', name: 'defgh', code: '11') }
-  let(:coupon_second) { create(:coupon, organization:, status: 'terminated', name: 'abcde', code: '22') }
-  let(:coupon_third) { create(:coupon, organization:, status: 'active', name: 'presuv', code: '33') }
+  let(:coupon_first) { create(:coupon, organization:, status: "active", name: "defgh", code: "11") }
+  let(:coupon_second) { create(:coupon, organization:, status: "terminated", name: "abcde", code: "22") }
+  let(:coupon_third) { create(:coupon, organization:, status: "active", name: "presuv", code: "33") }
 
   before do
     coupon_first
@@ -23,18 +23,24 @@ RSpec.describe CouponsQuery, type: :query do
     coupon_third
   end
 
-  it 'returns all coupons' do
+  it "returns all coupons" do
     expect(result.coupons.count).to eq(3)
     expect(returned_ids).to include(coupon_first.id)
     expect(returned_ids).to include(coupon_second.id)
     expect(returned_ids).to include(coupon_third.id)
   end
 
-  context "when coupons have the same created_at" do
+  context "when coupons have the same values for the ordering criteria" do
     let(:coupon_second) do
-      create(:coupon, organization:, status: "active", name: "defgh", code: "22", created_at: coupon_first.created_at).tap do |coupon|
-        coupon.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      create(
+        :coupon,
+        organization:,
+        id: "00000000-0000-0000-0000-000000000000",
+        status: "active",
+        name: "defgh",
+        code: "22",
+        created_at: coupon_first.created_at
+      )
     end
 
     it "returns a consistent list" do
@@ -46,49 +52,39 @@ RSpec.describe CouponsQuery, type: :query do
     end
   end
 
-  context 'with pagination' do
+  context "with pagination" do
     let(:pagination) { {page: 2, limit: 2} }
 
-    it 'applies the pagination' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.coupons.count).to eq(1)
-        expect(result.coupons.current_page).to eq(2)
-        expect(result.coupons.prev_page).to eq(1)
-        expect(result.coupons.next_page).to be_nil
-        expect(result.coupons.total_pages).to eq(2)
-        expect(result.coupons.total_count).to eq(3)
-      end
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.coupons.count).to eq(1)
+      expect(result.coupons.current_page).to eq(2)
+      expect(result.coupons.prev_page).to eq(1)
+      expect(result.coupons.next_page).to be_nil
+      expect(result.coupons.total_pages).to eq(2)
+      expect(result.coupons.total_count).to eq(3)
     end
   end
 
-  context 'when searching for /de/ term' do
-    let(:search_term) { 'de' }
+  context "when searching for /de/ term" do
+    let(:search_term) { "de" }
 
-    it 'returns only two coupons' do
-      returned_ids = result.coupons.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(2)
-        expect(returned_ids).to include(coupon_first.id)
-        expect(returned_ids).to include(coupon_second.id)
-        expect(returned_ids).not_to include(coupon_third.id)
-      end
+    it "returns only two coupons" do
+      expect(returned_ids.count).to eq(2)
+      expect(returned_ids).to include(coupon_first.id)
+      expect(returned_ids).to include(coupon_second.id)
+      expect(returned_ids).not_to include(coupon_third.id)
     end
   end
 
-  context 'when filtering by terminated status' do
-    let(:filters) { {status: 'terminated'} }
+  context "when filtering by terminated status" do
+    let(:filters) { {status: "terminated"} }
 
-    it 'returns only two coupons' do
-      returned_ids = result.coupons.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(1)
-        expect(returned_ids).not_to include(coupon_first.id)
-        expect(returned_ids).to include(coupon_second.id)
-        expect(returned_ids).not_to include(coupon_third.id)
-      end
+    it "returns only two coupons" do
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).not_to include(coupon_first.id)
+      expect(returned_ids).to include(coupon_second.id)
+      expect(returned_ids).not_to include(coupon_third.id)
     end
   end
 end

--- a/spec/queries/credit_notes_query_spec.rb
+++ b/spec/queries/credit_notes_query_spec.rb
@@ -99,6 +99,18 @@ RSpec.describe CreditNotesQuery, type: :query do
     end
   end
 
+  context 'with external_customer_id filter' do
+    let(:filters) { {external_customer_id: customer.external_id} }
+
+    it 'applies the filter' do
+      returned_ids = result.credit_notes.pluck(:id)
+
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(3)
+      expect(returned_ids).not_to include(credit_note_fourth.id)
+    end
+  end
+
   context 'when searching for /imthe/ term and filtering by customer_id' do
     let(:search_term) { 'imthe' }
     let(:filters) { {customer_id: customer.id} }

--- a/spec/queries/credit_notes_query_spec.rb
+++ b/spec/queries/credit_notes_query_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe CreditNotesQuery, type: :query do
   subject(:result) do
     described_class.call(organization:, search_term:, pagination:, filters:)
   end
+
+  let(:returned_ids) { result.credit_notes.pluck(:id) }
 
   let(:pagination) { nil }
   let(:search_term) { nil }
@@ -14,11 +16,11 @@ RSpec.describe CreditNotesQuery, type: :query do
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
   let(:other_org_customer) { create(:customer) }
-  let(:credit_note_first) { create(:credit_note, customer:, number: '11imthefirstone') }
-  let(:credit_note_second) { create(:credit_note, customer:, number: '22imthesecondone') }
-  let(:credit_note_third) { create(:credit_note, customer:, number: '33imthethirdone') }
-  let(:credit_note_fourth) { create(:credit_note, customer: create(:customer, organization:), number: '44imthefourthone') }
-  let(:other_org_credit_note) { create(:credit_note, customer: other_org_customer, number: '55imthefifthone') }
+  let(:credit_note_first) { create(:credit_note, customer:, number: "11imthefirstone") }
+  let(:credit_note_second) { create(:credit_note, customer:, number: "22imthesecondone") }
+  let(:credit_note_third) { create(:credit_note, customer:, number: "33imthethirdone") }
+  let(:credit_note_fourth) { create(:credit_note, customer: create(:customer, organization:), number: "44imthefourthone") }
+  let(:other_org_credit_note) { create(:credit_note, customer: other_org_customer, number: "55imthefifthone") }
 
   before do
     credit_note_first
@@ -28,29 +30,27 @@ RSpec.describe CreditNotesQuery, type: :query do
     other_org_credit_note
   end
 
-  it 'returns all credit_notes' do
-    returned_ids = result.credit_notes.pluck(:id)
-
-    aggregate_failures do
-      expect(result).to be_success
-      expect(returned_ids.count).to eq(4)
-      expect(returned_ids).to include(credit_note_first.id)
-      expect(returned_ids).to include(credit_note_second.id)
-      expect(returned_ids).to include(credit_note_third.id)
-      expect(returned_ids).to include(credit_note_fourth.id)
-    end
+  it "returns all credit_notes" do
+    expect(result).to be_success
+    expect(returned_ids.count).to eq(4)
+    expect(returned_ids).to include(credit_note_first.id)
+    expect(returned_ids).to include(credit_note_second.id)
+    expect(returned_ids).to include(credit_note_third.id)
+    expect(returned_ids).to include(credit_note_fourth.id)
   end
 
-  context "when credit notes have the same created_at" do
+  context "when credit notes have the same values for the ordering criteria" do
     let(:credit_note_second) do
-      create(:credit_note, customer:, number: "22imthesecondone", created_at: credit_note_first.created_at).tap do |credit_note|
-        credit_note.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      create(
+        :credit_note,
+        customer:,
+        id: "00000000-0000-0000-0000-000000000000",
+        number: "22imthesecondone",
+        created_at: credit_note_first.created_at
+      )
     end
 
     it "returns a consistent list" do
-      returned_ids = result.credit_notes.pluck(:id)
-
       expect(result).to be_success
       expect(returned_ids.count).to eq(4)
       expect(returned_ids).to include(credit_note_first.id)
@@ -59,104 +59,84 @@ RSpec.describe CreditNotesQuery, type: :query do
     end
   end
 
-  context 'with pagination' do
+  context "with pagination" do
     let(:pagination) { {page: 2, limit: 3} }
 
-    it 'applies the pagination' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.credit_notes.count).to eq(1)
-        expect(result.credit_notes.current_page).to eq(2)
-        expect(result.credit_notes.prev_page).to eq(1)
-        expect(result.credit_notes.next_page).to be_nil
-        expect(result.credit_notes.total_pages).to eq(2)
-        expect(result.credit_notes.total_count).to eq(4)
-      end
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.credit_notes.count).to eq(1)
+      expect(result.credit_notes.current_page).to eq(2)
+      expect(result.credit_notes.prev_page).to eq(1)
+      expect(result.credit_notes.next_page).to be_nil
+      expect(result.credit_notes.total_pages).to eq(2)
+      expect(result.credit_notes.total_count).to eq(4)
     end
   end
 
-  context 'when filtering by customer_id' do
+  context "when filtering by customer_id" do
     let(:filters) { {customer_id: customer.id} }
 
-    it 'returns all credit_notes of the customer' do
-      returned_ids = result.credit_notes.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(3)
-        expect(returned_ids).to include(credit_note_first.id)
-        expect(returned_ids).to include(credit_note_second.id)
-        expect(returned_ids).to include(credit_note_third.id)
-        expect(returned_ids).not_to include(credit_note_fourth.id)
-      end
+    it "returns all credit_notes of the customer" do
+      expect(returned_ids.count).to eq(3)
+      expect(returned_ids).to include(credit_note_first.id)
+      expect(returned_ids).to include(credit_note_second.id)
+      expect(returned_ids).to include(credit_note_third.id)
+      expect(returned_ids).not_to include(credit_note_fourth.id)
     end
   end
 
-  context 'when filtering by a customer_id from other organization' do
+  context "when filtering by a customer_id from other organization" do
     let(:filters) { {customer_id: other_org_credit_note.customer.id} }
 
-    it 'returns an empty result' do
+    it "returns an empty result" do
       expect(result.credit_notes).to be_empty
     end
   end
 
-  context 'with external_customer_id filter' do
+  context "with external_customer_id filter" do
     let(:filters) { {external_customer_id: customer.external_id} }
 
-    it 'applies the filter' do
-      returned_ids = result.credit_notes.pluck(:id)
-
+    it "applies the filter" do
       expect(result).to be_success
       expect(returned_ids.count).to eq(3)
       expect(returned_ids).not_to include(credit_note_fourth.id)
     end
   end
 
-  context 'when searching for /imthe/ term and filtering by customer_id' do
-    let(:search_term) { 'imthe' }
+  context "when searching for /imthe/ term and filtering by customer_id" do
+    let(:search_term) { "imthe" }
     let(:filters) { {customer_id: customer.id} }
 
-    it 'returns matching credit_notes' do
-      returned_ids = result.credit_notes.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(3)
-        expect(returned_ids).to include(credit_note_first.id)
-        expect(returned_ids).to include(credit_note_second.id)
-        expect(returned_ids).to include(credit_note_third.id)
-        expect(returned_ids).not_to include(credit_note_fourth.id)
-      end
+    it "returns matching credit_notes" do
+      expect(returned_ids.count).to eq(3)
+      expect(returned_ids).to include(credit_note_first.id)
+      expect(returned_ids).to include(credit_note_second.id)
+      expect(returned_ids).to include(credit_note_third.id)
+      expect(returned_ids).not_to include(credit_note_fourth.id)
     end
   end
 
-  context 'when searching for /done/ term' do
-    let(:search_term) { 'done' }
+  context "when searching for /done/ term" do
+    let(:search_term) { "done" }
 
-    it 'returns matching credit_notes' do
-      returned_ids = result.credit_notes.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(2)
-        expect(returned_ids).not_to include(credit_note_first.id)
-        expect(returned_ids).to include(credit_note_second.id)
-        expect(returned_ids).to include(credit_note_third.id)
-        expect(returned_ids).not_to include(credit_note_fourth.id)
-      end
+    it "returns matching credit_notes" do
+      expect(returned_ids.count).to eq(2)
+      expect(returned_ids).not_to include(credit_note_first.id)
+      expect(returned_ids).to include(credit_note_second.id)
+      expect(returned_ids).to include(credit_note_third.id)
+      expect(returned_ids).not_to include(credit_note_fourth.id)
     end
   end
 
-  context 'when searching for an id' do
+  context "when searching for an id" do
     let(:search_term) { credit_note_second.id.scan(/.{10}/).first }
 
-    it 'returns matching credit_notes' do
-      returned_ids = result.credit_notes.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(1)
-        expect(returned_ids).not_to include(credit_note_first.id)
-        expect(returned_ids).to include(credit_note_second.id)
-        expect(returned_ids).not_to include(credit_note_third.id)
-        expect(returned_ids).not_to include(credit_note_fourth.id)
-      end
+    it "returns matching credit_notes" do
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).not_to include(credit_note_first.id)
+      expect(returned_ids).to include(credit_note_second.id)
+      expect(returned_ids).not_to include(credit_note_third.id)
+      expect(returned_ids).not_to include(credit_note_fourth.id)
     end
   end
 end

--- a/spec/queries/credit_notes_query_spec.rb
+++ b/spec/queries/credit_notes_query_spec.rb
@@ -41,6 +41,24 @@ RSpec.describe CreditNotesQuery, type: :query do
     end
   end
 
+  context "when credit notes have the same created_at" do
+    let(:credit_note_second) do
+      create(:credit_note, customer:, number: "22imthesecondone", created_at: credit_note_first.created_at).tap do |credit_note|
+        credit_note.update! id: "00000000-0000-0000-0000-000000000000"
+      end
+    end
+
+    it "returns a consistent list" do
+      returned_ids = result.credit_notes.pluck(:id)
+
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(4)
+      expect(returned_ids).to include(credit_note_first.id)
+      expect(returned_ids).to include(credit_note_second.id)
+      expect(returned_ids.index(credit_note_first.id)).to be > returned_ids.index(credit_note_second.id)
+    end
+  end
+
   context 'with pagination' do
     let(:pagination) { {page: 2, limit: 3} }
 

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe CustomersQuery, type: :query do
   subject(:result) do
@@ -15,13 +15,13 @@ RSpec.describe CustomersQuery, type: :query do
   let(:organization) { membership.organization }
 
   let(:customer_first) do
-    create(:customer, organization:, name: 'defgh', firstname: 'John', lastname: 'Doe', legal_name: "Legalname", external_id: '11', email: '1@example.com')
+    create(:customer, organization:, name: "defgh", firstname: "John", lastname: "Doe", legal_name: "Legalname", external_id: "11", email: "1@example.com")
   end
   let(:customer_second) do
-    create(:customer, organization:, name: 'abcde', firstname: 'Jane', lastname: 'Smith', legal_name: "other name", external_id: '22', email: '2@example.com')
+    create(:customer, organization:, name: "abcde", firstname: "Jane", lastname: "Smith", legal_name: "other name", external_id: "22", email: "2@example.com")
   end
   let(:customer_third) do
-    create(:customer, organization:, name: 'presuv', firstname: 'Mary', lastname: 'Johnson', legal_name: "Company name", external_id: '33', email: '3@example.com')
+    create(:customer, organization:, name: "presuv", firstname: "Mary", lastname: "Johnson", legal_name: "Company name", external_id: "33", email: "3@example.com")
   end
 
   before do
@@ -31,14 +31,14 @@ RSpec.describe CustomersQuery, type: :query do
   end
 
   it "returns all customers" do
-      expect(result).to be_success
-      expect(returned_ids.count).to eq(3)
-      expect(returned_ids).to include(customer_first.id)
-      expect(returned_ids).to include(customer_second.id)
-      expect(returned_ids).to include(customer_third.id)
+    expect(result).to be_success
+    expect(returned_ids.count).to eq(3)
+    expect(returned_ids).to include(customer_first.id)
+    expect(returned_ids).to include(customer_second.id)
+    expect(returned_ids).to include(customer_third.id)
   end
 
-  context "when customers have the same created_at" do
+  context "when customers have the same values for the ordering criteria" do
     let(:customer_second) do
       create(
         :customer,
@@ -64,79 +64,61 @@ RSpec.describe CustomersQuery, type: :query do
     end
   end
 
-  context 'with pagination' do
+  context "with pagination" do
     let(:pagination) { {page: 2, limit: 2} }
 
-    it 'applies the pagination' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.customers.count).to eq(1)
-        expect(result.customers.current_page).to eq(2)
-        expect(result.customers.prev_page).to eq(1)
-        expect(result.customers.next_page).to be_nil
-        expect(result.customers.total_pages).to eq(2)
-        expect(result.customers.total_count).to eq(3)
-      end
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.customers.count).to eq(1)
+      expect(result.customers.current_page).to eq(2)
+      expect(result.customers.prev_page).to eq(1)
+      expect(result.customers.next_page).to be_nil
+      expect(result.customers.total_pages).to eq(2)
+      expect(result.customers.total_count).to eq(3)
     end
   end
 
-  context 'when searching for /de/ term' do
-    let(:search_term) { 'de' }
+  context "when searching for /de/ term" do
+    let(:search_term) { "de" }
 
-    it 'returns only two customers' do
-      returned_ids = result.customers.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(2)
-        expect(returned_ids).to include(customer_first.id)
-        expect(returned_ids).to include(customer_second.id)
-        expect(returned_ids).not_to include(customer_third.id)
-      end
+    it "returns only two customers" do
+      expect(returned_ids.count).to eq(2)
+      expect(returned_ids).to include(customer_first.id)
+      expect(returned_ids).to include(customer_second.id)
+      expect(returned_ids).not_to include(customer_third.id)
     end
   end
 
-  context 'when searching for firstname "Jane"' do
-    let(:search_term) { 'Jane' }
+  context "when searching for firstname 'Jane'" do
+    let(:search_term) { "Jane" }
 
-    it 'returns only one customer' do
-      returned_ids = result.customers.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(1)
-        expect(returned_ids).to include(customer_second.id)
-        expect(returned_ids).not_to include(customer_first.id)
-        expect(returned_ids).not_to include(customer_third.id)
-      end
+    it "returns only one customer" do
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).to include(customer_second.id)
+      expect(returned_ids).not_to include(customer_first.id)
+      expect(returned_ids).not_to include(customer_third.id)
     end
   end
 
-  context 'when searching for lastname "Johnson"' do
-    let(:search_term) { 'Johnson' }
+  context "when searching for lastname 'Johnson'" do
+    let(:search_term) { "Johnson" }
 
-    it 'returns only one customer' do
-      returned_ids = result.customers.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(1)
-        expect(returned_ids).not_to include(customer_first.id)
-        expect(returned_ids).not_to include(customer_second.id)
-        expect(returned_ids).to include(customer_third.id)
-      end
+    it "returns only one customer" do
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).not_to include(customer_first.id)
+      expect(returned_ids).not_to include(customer_second.id)
+      expect(returned_ids).to include(customer_third.id)
     end
   end
 
-  context 'when searching for legalname "Company"' do
-    let(:search_term) { 'Company' }
+  context "when searching for legalname 'Company'" do
+    let(:search_term) { "Company" }
 
-    it 'returns only one customer' do
-      returned_ids = result.customers.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(1)
-        expect(returned_ids).not_to include(customer_first.id)
-        expect(returned_ids).not_to include(customer_second.id)
-        expect(returned_ids).to include(customer_third.id)
-      end
+    it "returns only one customer" do
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).not_to include(customer_first.id)
+      expect(returned_ids).not_to include(customer_second.id)
+      expect(returned_ids).to include(customer_third.id)
     end
   end
 end

--- a/spec/queries/dunning_campaigns_query_spec.rb
+++ b/spec/queries/dunning_campaigns_query_spec.rb
@@ -43,18 +43,17 @@ RSpec.describe DunningCampaignsQuery, type: :query do
     )
   end
 
-  context "when dunning campaigns have the same value for the ordering criteria" do
+  context "when dunning campaigns have the same values for the ordering criteria" do
     let(:dunning_campaign_second) do
       create(
         :dunning_campaign,
         organization:,
+        id: "00000000-0000-0000-0000-000000000000",
         name: dunning_campaign_first.name,
         code: "22",
         applied_to_organization: false,
         created_at: dunning_campaign_first.created_at
-      ).tap do |dunning_campaign|
-        dunning_campaign.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      )
     end
 
     it "returns a consistent list" do
@@ -69,7 +68,7 @@ RSpec.describe DunningCampaignsQuery, type: :query do
   context "with pagination" do
     let(:pagination) { {page: 2, limit: 2} }
 
-    it "applies the pagination", :aggregate_failures do
+    it "applies the pagination" do
       expect(result).to be_success
       expect(result.dunning_campaigns.count).to eq(1)
       expect(result.dunning_campaigns.current_page).to eq(2)

--- a/spec/queries/dunning_campaigns_query_spec.rb
+++ b/spec/queries/dunning_campaigns_query_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe DunningCampaignsQuery, type: :query do
     described_class.call(organization:, pagination:, search_term:, filters:, order:)
   end
 
+  let(:returned_ids) { result.dunning_campaigns.pluck(:id) }
   let(:pagination) { nil }
   let(:search_term) { nil }
   let(:filters) { nil }
@@ -40,6 +41,29 @@ RSpec.describe DunningCampaignsQuery, type: :query do
     expect(result.dunning_campaigns).to eq(
       [dunning_campaign_second, dunning_campaign_first, dunning_campaign_third]
     )
+  end
+
+  context "when dunning campaigns have the same value for the ordering criteria" do
+    let(:dunning_campaign_second) do
+      create(
+        :dunning_campaign,
+        organization:,
+        name: dunning_campaign_first.name,
+        code: "22",
+        applied_to_organization: false,
+        created_at: dunning_campaign_first.created_at
+      ).tap do |dunning_campaign|
+        dunning_campaign.update! id: "00000000-0000-0000-0000-000000000000"
+      end
+    end
+
+    it "returns a consistent list" do
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(3)
+      expect(returned_ids).to include(dunning_campaign_first.id)
+      expect(returned_ids).to include(dunning_campaign_second.id)
+      expect(returned_ids.index(dunning_campaign_first.id)).to be > returned_ids.index(dunning_campaign_second.id)
+    end
   end
 
   context "with pagination" do

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -19,16 +19,15 @@ RSpec.describe EventsQuery, type: :query do
     expect(result.events).to eq([event])
   end
 
-  context "when events have the ordering criteria" do
+  context "when events have the same values for the ordering criteria" do
     let(:event_2) do
       create(
         :event,
         organization:,
+        id: "00000000-0000-0000-0000-000000000000",
         timestamp: event.timestamp,
         created_at: event.created_at
-      ).tap do |event|
-        event.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      )
     end
 
     it "returns a consistent list" do

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe EventsQuery, type: :query do
-  subject(:result) { described_class.call(organization:, pagination:, filters:) }
+  subject(:events_query) { described_class.new(organization:, pagination:, filters:) }
 
   let(:organization) { create(:organization) }
   let(:pagination) { nil }
@@ -13,74 +13,79 @@ RSpec.describe EventsQuery, type: :query do
 
   before { event }
 
-  it "returns a list of events" do
-    expect(result).to be_success
-    expect(result.events.count).to eq(1)
-    expect(result.events).to eq([event])
-  end
+  describe 'call' do
+    it 'returns a list of events' do
+      result = events_query.call
 
-  context "when events have the same values for the ordering criteria" do
-    let(:event_2) do
-      create(
-        :event,
-        organization:,
-        id: "00000000-0000-0000-0000-000000000000",
-        timestamp: event.timestamp,
-        created_at: event.created_at
-      )
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.events.count).to eq(1)
+        expect(result.events).to eq([event])
+      end
     end
 
-    it "returns a consistent list" do
-      expect(result).to be_success
-      expect(result.events).to eq([event_2, event])
+    context 'with pagination' do
+      let(:pagination) { {page: 2, limit: 10} }
+
+      it 'applies the pagination' do
+        result = events_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.events.count).to eq(0)
+          expect(result.events.current_page).to eq(2)
+        end
+      end
     end
-  end
 
-  context "with pagination" do
-    let(:pagination) { {page: 2, limit: 10} }
+    context 'with code filter' do
+      let(:event2) { create(:event, organization:) }
+      let(:filters) { {code: event.code} }
 
-    it "applies the pagination" do
-      expect(result).to be_success
-      expect(result.events.count).to eq(0)
-      expect(result.events.current_page).to eq(2)
+      before { event2 }
+
+      it 'applies the filter' do
+        result = events_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.events.count).to eq(1)
+        end
+      end
     end
-  end
 
-  context "with code filter" do
-    let(:event2) { create(:event, organization:) }
-    let(:filters) { {code: event.code} }
+    context 'with external subscription id filter' do
+      let(:event2) { create(:event, organization:) }
+      let(:filters) { {external_subscription_id: event.external_subscription_id} }
 
-    before { event2 }
+      before { event2 }
 
-    it "applies the filter" do
-      expect(result).to be_success
-      expect(result.events.count).to eq(1)
+      it 'applies the filter' do
+        result = events_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.events.count).to eq(1)
+        end
+      end
     end
-  end
 
-  context "with external subscription id filter" do
-    let(:event2) { create(:event, organization:) }
-    let(:filters) { {external_subscription_id: event.external_subscription_id} }
-
-    before { event2 }
-
-    it "applies the filter" do
-      expect(result).to be_success
-      expect(result.events.count).to eq(1)
-    end
-  end
-
-  context "with timestamp from filter" do
-    let(:filters) {
-      {
-        timestamp_from: 2.days.ago.iso8601.to_date.to_s,
-        timestamp_to: Date.tomorrow.iso8601.to_date.to_s
+    context 'with timestamp from filter' do
+      let(:filters) {
+        {
+          timestamp_from: 2.days.ago.iso8601.to_date.to_s,
+          timestamp_to: Date.tomorrow.iso8601.to_date.to_s
+        }
       }
-    }
 
-    it "applies the filter" do
-      expect(result).to be_success
-      expect(result.events.count).to eq(1)
+      it 'applies the filter' do
+        result = events_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.events.count).to eq(1)
+        end
+      end
     end
   end
 end

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe EventsQuery, type: :query do
-  subject(:events_query) { described_class.new(organization:, pagination:, filters:) }
+  subject(:result) { described_class.call(organization:, pagination:, filters:) }
 
   let(:organization) { create(:organization) }
   let(:pagination) { nil }
@@ -13,79 +13,75 @@ RSpec.describe EventsQuery, type: :query do
 
   before { event }
 
-  describe 'call' do
-    it 'returns a list of events' do
-      result = events_query.call
+  it "returns a list of events" do
+    expect(result).to be_success
+    expect(result.events.count).to eq(1)
+    expect(result.events).to eq([event])
+  end
 
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.events.count).to eq(1)
-        expect(result.events).to eq([event])
+  context "when events have the ordering criteria" do
+    let(:event_2) do
+      create(
+        :event,
+        organization:,
+        timestamp: event.timestamp,
+        created_at: event.created_at
+      ).tap do |event|
+        event.update! id: "00000000-0000-0000-0000-000000000000"
       end
     end
 
-    context 'with pagination' do
-      let(:pagination) { {page: 2, limit: 10} }
-
-      it 'applies the pagination' do
-        result = events_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.events.count).to eq(0)
-          expect(result.events.current_page).to eq(2)
-        end
-      end
+    it "returns a consistent list" do
+      expect(result).to be_success
+      expect(result.events).to eq([event_2, event])
     end
+  end
 
-    context 'with code filter' do
-      let(:event2) { create(:event, organization:) }
-      let(:filters) { {code: event.code} }
+  context "with pagination" do
+    let(:pagination) { {page: 2, limit: 10} }
 
-      before { event2 }
-
-      it 'applies the filter' do
-        result = events_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.events.count).to eq(1)
-        end
-      end
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.events.count).to eq(0)
+      expect(result.events.current_page).to eq(2)
     end
+  end
 
-    context 'with external subscription id filter' do
-      let(:event2) { create(:event, organization:) }
-      let(:filters) { {external_subscription_id: event.external_subscription_id} }
+  context "with code filter" do
+    let(:event2) { create(:event, organization:) }
+    let(:filters) { {code: event.code} }
 
-      before { event2 }
+    before { event2 }
 
-      it 'applies the filter' do
-        result = events_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.events.count).to eq(1)
-        end
-      end
+    it "applies the filter" do
+      expect(result).to be_success
+      expect(result.events.count).to eq(1)
     end
+  end
 
-    context 'with timestamp from filter' do
-      let(:filters) {
-        {
-          timestamp_from: 2.days.ago.iso8601.to_date.to_s,
-          timestamp_to: Date.tomorrow.iso8601.to_date.to_s
-        }
+  context "with external subscription id filter" do
+    let(:event2) { create(:event, organization:) }
+    let(:filters) { {external_subscription_id: event.external_subscription_id} }
+
+    before { event2 }
+
+    it "applies the filter" do
+      expect(result).to be_success
+      expect(result.events.count).to eq(1)
+    end
+  end
+
+  context "with timestamp from filter" do
+    let(:filters) {
+      {
+        timestamp_from: 2.days.ago.iso8601.to_date.to_s,
+        timestamp_to: Date.tomorrow.iso8601.to_date.to_s
       }
+    }
 
-      it 'applies the filter' do
-        result = events_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.events.count).to eq(1)
-        end
-      end
+    it "applies the filter" do
+      expect(result).to be_success
+      expect(result.events.count).to eq(1)
     end
   end
 end

--- a/spec/queries/integration_collection_mappings_query_spec.rb
+++ b/spec/queries/integration_collection_mappings_query_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe IntegrationCollectionMappingsQuery, type: :query do
-  subject(:collection_mappings_query) { described_class.new(organization:, pagination:, filters:) }
+  subject(:result) { described_class.call(organization:, pagination:, filters:) }
 
+  let(:returned_ids) { result.integration_collection_mappings.pluck(:id) }
   let(:pagination) { nil }
   let(:filters) { {} }
   let(:membership) { create(:membership) }
@@ -35,55 +36,58 @@ RSpec.describe IntegrationCollectionMappingsQuery, type: :query do
     netsuite_collection_mapping_fourth
   end
 
-  context 'when filters are empty' do
-    it 'returns all mappings' do
-      result = collection_mappings_query.call
-
-      returned_ids = result.integration_collection_mappings.pluck(:id)
-
-      aggregate_failures do
-        expect(result.integration_collection_mappings.count).to eq(3)
-        expect(returned_ids).to include(netsuite_collection_mapping_first.id)
-        expect(returned_ids).to include(netsuite_collection_mapping_second.id)
-        expect(returned_ids).to include(netsuite_collection_mapping_third.id)
-        expect(returned_ids).not_to include(netsuite_collection_mapping_fourth.id)
-      end
+  context "when filters are empty" do
+    it "returns all mappings" do
+      expect(result.integration_collection_mappings.count).to eq(3)
+      expect(returned_ids).to include(netsuite_collection_mapping_first.id)
+      expect(returned_ids).to include(netsuite_collection_mapping_second.id)
+      expect(returned_ids).to include(netsuite_collection_mapping_third.id)
+      expect(returned_ids).not_to include(netsuite_collection_mapping_fourth.id)
     end
   end
 
-  context 'when filtering by integration id' do
+  context "when integration collection mappings have the ordering criteria" do
+    let(:netsuite_collection_mapping_second) do
+      create(
+        :netsuite_collection_mapping,
+        integration:,
+        mapping_type: :coupon,
+        created_at: netsuite_collection_mapping_first.created_at
+      ).tap do |netsuite_collection_mapping|
+        netsuite_collection_mapping.update! id: "00000000-0000-0000-0000-000000000000"
+      end
+    end
+
+    it "returns a consistent list" do
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(3)
+      expect(returned_ids).to include(netsuite_collection_mapping_first.id)
+      expect(returned_ids).to include(netsuite_collection_mapping_second.id)
+      expect(returned_ids.index(netsuite_collection_mapping_first.id)).to be > returned_ids.index(netsuite_collection_mapping_second.id)
+    end
+  end
+
+  context "when filtering by integration id" do
     let(:filters) { {integration_id: integration.id} }
 
-    it 'returns two mappings' do
-      result = collection_mappings_query.call
-
-      returned_ids = result.integration_collection_mappings.pluck(:id)
-
-      aggregate_failures do
-        expect(result.integration_collection_mappings.count).to eq(2)
-        expect(returned_ids).to include(netsuite_collection_mapping_first.id)
-        expect(returned_ids).to include(netsuite_collection_mapping_second.id)
-        expect(returned_ids).not_to include(netsuite_collection_mapping_third.id)
-        expect(returned_ids).not_to include(netsuite_collection_mapping_fourth.id)
-      end
+    it "returns two mappings" do
+      expect(result.integration_collection_mappings.count).to eq(2)
+      expect(returned_ids).to include(netsuite_collection_mapping_first.id)
+      expect(returned_ids).to include(netsuite_collection_mapping_second.id)
+      expect(returned_ids).not_to include(netsuite_collection_mapping_third.id)
+      expect(returned_ids).not_to include(netsuite_collection_mapping_fourth.id)
     end
   end
 
-  context 'when filtering by mapping type' do
-    let(:filters) { {mapping_type: 'fallback_item'} }
+  context "when filtering by mapping type" do
+    let(:filters) { {mapping_type: "fallback_item"} }
 
-    it 'returns one netsuite mappings' do
-      result = collection_mappings_query.call
-
-      returned_ids = result.integration_collection_mappings.pluck(:id)
-
-      aggregate_failures do
-        expect(result.integration_collection_mappings.count).to eq(1)
-        expect(returned_ids).to include(netsuite_collection_mapping_first.id)
-        expect(returned_ids).not_to include(netsuite_collection_mapping_second.id)
-        expect(returned_ids).not_to include(netsuite_collection_mapping_third.id)
-        expect(returned_ids).not_to include(netsuite_collection_mapping_fourth.id)
-      end
+    it "returns one netsuite mappings" do
+      expect(result.integration_collection_mappings.count).to eq(1)
+      expect(returned_ids).to include(netsuite_collection_mapping_first.id)
+      expect(returned_ids).not_to include(netsuite_collection_mapping_second.id)
+      expect(returned_ids).not_to include(netsuite_collection_mapping_third.id)
+      expect(returned_ids).not_to include(netsuite_collection_mapping_fourth.id)
     end
   end
 end

--- a/spec/queries/integration_collection_mappings_query_spec.rb
+++ b/spec/queries/integration_collection_mappings_query_spec.rb
@@ -46,16 +46,15 @@ RSpec.describe IntegrationCollectionMappingsQuery, type: :query do
     end
   end
 
-  context "when integration collection mappings have the ordering criteria" do
+  context "when integration collection mappings have the same values for the ordering criteria" do
     let(:netsuite_collection_mapping_second) do
       create(
         :netsuite_collection_mapping,
         integration:,
+        id: "00000000-0000-0000-0000-000000000000",
         mapping_type: :coupon,
         created_at: netsuite_collection_mapping_first.created_at
-      ).tap do |netsuite_collection_mapping|
-        netsuite_collection_mapping.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      )
     end
 
     it "returns a consistent list" do

--- a/spec/queries/integration_items_query_spec.rb
+++ b/spec/queries/integration_items_query_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe IntegrationItemsQuery, type: :query do
   subject(:result) do
@@ -18,10 +18,10 @@ RSpec.describe IntegrationItemsQuery, type: :query do
   let(:integration_second) { create(:netsuite_integration, organization:) }
   let(:integration_third) { create(:netsuite_integration) }
 
-  let(:integration_item_first) { create(:integration_item, item_type: 'tax', integration:) }
+  let(:integration_item_first) { create(:integration_item, item_type: "tax", integration:) }
   let(:integration_item_second) { create(:integration_item, integration: integration_second) }
   let(:integration_item_third) { create(:integration_item, integration: integration_third) }
-  let(:integration_item_fourth) { create(:integration_item, external_name: 'Findme', integration:) }
+  let(:integration_item_fourth) { create(:integration_item, external_name: "Findme", integration:) }
 
   before do
     integration_item_first
@@ -30,7 +30,7 @@ RSpec.describe IntegrationItemsQuery, type: :query do
     integration_item_fourth
   end
 
-  it 'returns all integration items of an organization' do
+  it "returns all integration items of an organization" do
     expect(result).to be_success
     expect(returned_ids.count).to eq(3)
     expect(returned_ids).to include(integration_item_first.id)
@@ -39,16 +39,15 @@ RSpec.describe IntegrationItemsQuery, type: :query do
     expect(returned_ids).to include(integration_item_fourth.id)
   end
 
-  context "when add ons have the ordering criteria" do
+  context "when integration items have the same values for the ordering criteria" do
     let(:integration_item_second) do
       create(
         :integration_item,
+        id: "00000000-0000-0000-0000-000000000000",
         integration: integration_second,
         external_id: integration_item_first.external_id,
         created_at: integration_item_first.created_at
-      ).tap do |integration_item|
-        integration_item.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      )
     end
 
     it "returns a consistent list" do
@@ -60,67 +59,53 @@ RSpec.describe IntegrationItemsQuery, type: :query do
     end
   end
 
-  context 'with pagination' do
+  context "with pagination" do
     let(:pagination) { {page: 2, limit: 2} }
 
-    it 'applies the pagination' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.integration_items.count).to eq(1)
-        expect(result.integration_items.current_page).to eq(2)
-        expect(result.integration_items.prev_page).to eq(1)
-        expect(result.integration_items.next_page).to be_nil
-        expect(result.integration_items.total_pages).to eq(2)
-        expect(result.integration_items.total_count).to eq(3)
-      end
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.integration_items.count).to eq(1)
+      expect(result.integration_items.current_page).to eq(2)
+      expect(result.integration_items.prev_page).to eq(1)
+      expect(result.integration_items.next_page).to be_nil
+      expect(result.integration_items.total_pages).to eq(2)
+      expect(result.integration_items.total_count).to eq(3)
     end
   end
 
-  context 'when filtering by integration_id' do
+  context "when filtering by integration_id" do
     let(:filters) { {integration_id: integration.id} }
 
-    it 'returns all integration items of an integration' do
-      returned_ids = result.integration_items.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(2)
-        expect(returned_ids).to include(integration_item_first.id)
-        expect(returned_ids).not_to include(integration_item_second.id)
-        expect(returned_ids).not_to include(integration_item_third.id)
-        expect(returned_ids).to include(integration_item_fourth.id)
-      end
+    it "returns all integration items of an integration" do
+      expect(returned_ids.count).to eq(2)
+      expect(returned_ids).to include(integration_item_first.id)
+      expect(returned_ids).not_to include(integration_item_second.id)
+      expect(returned_ids).not_to include(integration_item_third.id)
+      expect(returned_ids).to include(integration_item_fourth.id)
     end
   end
 
-  context 'when filtering by item type' do
-    let(:filters) { {item_type: 'tax'} }
+  context "when filtering by item type" do
+    let(:filters) { {item_type: "tax"} }
 
-    it 'returns one integration item' do
-      returned_ids = result.integration_items.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(1)
-        expect(returned_ids).to include(integration_item_first.id)
-        expect(returned_ids).not_to include(integration_item_second.id)
-        expect(returned_ids).not_to include(integration_item_third.id)
-        expect(returned_ids).not_to include(integration_item_fourth.id)
-      end
+    it "returns one integration item" do
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).to include(integration_item_first.id)
+      expect(returned_ids).not_to include(integration_item_second.id)
+      expect(returned_ids).not_to include(integration_item_third.id)
+      expect(returned_ids).not_to include(integration_item_fourth.id)
     end
   end
 
-  context 'when searching by name' do
-    let(:search_term) { 'Findme' }
+  context "when searching by name" do
+    let(:search_term) { "Findme" }
 
-    it 'returns one integration item' do
-      returned_ids = result.integration_items.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(1)
-        expect(returned_ids).not_to include(integration_item_first.id)
-        expect(returned_ids).not_to include(integration_item_second.id)
-        expect(returned_ids).not_to include(integration_item_third.id)
-        expect(returned_ids).to include(integration_item_fourth.id)
-      end
+    it "returns one integration item" do
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).not_to include(integration_item_first.id)
+      expect(returned_ids).not_to include(integration_item_second.id)
+      expect(returned_ids).not_to include(integration_item_third.id)
+      expect(returned_ids).to include(integration_item_fourth.id)
     end
   end
 end

--- a/spec/queries/integration_mappings_query_spec.rb
+++ b/spec/queries/integration_mappings_query_spec.rb
@@ -41,9 +41,13 @@ RSpec.describe IntegrationMappingsQuery, type: :query do
 
   context "when mappings have the same values for the ordering criteria" do
     let(:integration_mapping_second) do
-      create(:netsuite_mapping, integration:, mappable:, created_at: integration_mapping_first.created_at).tap do |integration_mapping|
-        integration_mapping.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      create(
+        :netsuite_mapping,
+        integration:,
+        mappable:,
+        id: "00000000-0000-0000-0000-000000000000",
+        created_at: integration_mapping_first.created_at
+      )
     end
 
     it "returns a consistent list" do

--- a/spec/queries/integration_mappings_query_spec.rb
+++ b/spec/queries/integration_mappings_query_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe IntegrationMappingsQuery, type: :query do
-  subject(:integration_mappings_query) { described_class.new(organization:, pagination:, filters:) }
+  subject(:result) { described_class.call(organization:, pagination:, filters:) }
 
+  let(:returned_ids) { result.integration_mappings.pluck(:id) }
   let(:pagination) { nil }
   let(:filters) { {} }
   let(:membership) { create(:membership) }
@@ -28,73 +29,67 @@ RSpec.describe IntegrationMappingsQuery, type: :query do
     integration_mapping_fourth
   end
 
-  context 'when filters are empty' do
-    it 'returns all mappings' do
-      result = integration_mappings_query.call
-
-      returned_ids = result.integration_mappings.pluck(:id)
-
-      aggregate_failures do
-        expect(result.integration_mappings.count).to eq(3)
-        expect(returned_ids).to include(integration_mapping_first.id)
-        expect(returned_ids).to include(integration_mapping_second.id)
-        expect(returned_ids).to include(integration_mapping_third.id)
-        expect(returned_ids).not_to include(integration_mapping_fourth.id)
-      end
+  context "when filters are empty" do
+    it "returns all mappings" do
+      expect(result.integration_mappings.count).to eq(3)
+      expect(returned_ids).to include(integration_mapping_first.id)
+      expect(returned_ids).to include(integration_mapping_second.id)
+      expect(returned_ids).to include(integration_mapping_third.id)
+      expect(returned_ids).not_to include(integration_mapping_fourth.id)
     end
   end
 
-  context 'with pagination' do
+  context "when mappings have the same values for the ordering criteria" do
+    let(:integration_mapping_second) do
+      create(:netsuite_mapping, integration:, mappable:, created_at: integration_mapping_first.created_at).tap do |integration_mapping|
+        integration_mapping.update! id: "00000000-0000-0000-0000-000000000000"
+      end
+    end
+
+    it "returns a consistent list" do
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(3)
+      expect(returned_ids).to include(integration_mapping_first.id)
+      expect(returned_ids).to include(integration_mapping_second.id)
+      expect(returned_ids.index(integration_mapping_first.id)).to be > returned_ids.index(integration_mapping_second.id)
+    end
+  end
+
+  context "with pagination" do
     let(:pagination) { {page: 2, limit: 2} }
 
-    it 'applies the pagination' do
-      result = integration_mappings_query.call
-
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.integration_mappings.count).to eq(1)
-        expect(result.integration_mappings.current_page).to eq(2)
-        expect(result.integration_mappings.prev_page).to eq(1)
-        expect(result.integration_mappings.next_page).to be_nil
-        expect(result.integration_mappings.total_pages).to eq(2)
-        expect(result.integration_mappings.total_count).to eq(3)
-      end
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.integration_mappings.count).to eq(1)
+      expect(result.integration_mappings.current_page).to eq(2)
+      expect(result.integration_mappings.prev_page).to eq(1)
+      expect(result.integration_mappings.next_page).to be_nil
+      expect(result.integration_mappings.total_pages).to eq(2)
+      expect(result.integration_mappings.total_count).to eq(3)
     end
   end
 
-  context 'when filtering by integration id' do
+  context "when filtering by integration id" do
     let(:filters) { {integration_id: integration.id} }
 
-    it 'returns two mappings' do
-      result = integration_mappings_query.call
-
-      returned_ids = result.integration_mappings.pluck(:id)
-
-      aggregate_failures do
-        expect(result.integration_mappings.count).to eq(2)
-        expect(returned_ids).to include(integration_mapping_first.id)
-        expect(returned_ids).to include(integration_mapping_second.id)
-        expect(returned_ids).not_to include(integration_mapping_third.id)
-        expect(returned_ids).not_to include(integration_mapping_fourth.id)
-      end
+    it "returns two mappings" do
+      expect(result.integration_mappings.count).to eq(2)
+      expect(returned_ids).to include(integration_mapping_first.id)
+      expect(returned_ids).to include(integration_mapping_second.id)
+      expect(returned_ids).not_to include(integration_mapping_third.id)
+      expect(returned_ids).not_to include(integration_mapping_fourth.id)
     end
   end
 
-  context 'when filtering by mappable type' do
-    let(:filters) { {mappable_type: 'BillableMetric'} }
+  context "when filtering by mappable type" do
+    let(:filters) { {mappable_type: "BillableMetric"} }
 
-    it 'returns one mapping' do
-      result = integration_mappings_query.call
-
-      returned_ids = result.integration_mappings.pluck(:id)
-
-      aggregate_failures do
-        expect(result.integration_mappings.count).to eq(1)
-        expect(returned_ids).not_to include(integration_mapping_first.id)
-        expect(returned_ids).to include(integration_mapping_second.id)
-        expect(returned_ids).not_to include(integration_mapping_third.id)
-        expect(returned_ids).not_to include(integration_mapping_fourth.id)
-      end
+    it "returns one mapping" do
+      expect(result.integration_mappings.count).to eq(1)
+      expect(returned_ids).not_to include(integration_mapping_first.id)
+      expect(returned_ids).to include(integration_mapping_second.id)
+      expect(returned_ids).not_to include(integration_mapping_third.id)
+      expect(returned_ids).not_to include(integration_mapping_fourth.id)
     end
   end
 end

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -102,20 +102,19 @@ RSpec.describe InvoicesQuery, type: :query do
     expect(returned_ids).to include(invoice_sixth.id)
   end
 
-  context "when invoices have the values for the ordering criteria" do
+  context "when invoices have the same values for the ordering criteria" do
     let(:invoice_second) do
       create(
         :invoice,
         organization:,
+        id: "00000000-0000-0000-0000-000000000000",
         status: 'finalized',
         payment_status: 'pending',
         customer: customer_second,
         number: '2222222222',
         issuing_date: invoice_first.issuing_date,
         created_at: invoice_first.created_at
-      ).tap do |invoice|
-        invoice.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      )
     end
 
     it "returns a consistent list" do

--- a/spec/queries/past_usage_query_spec.rb
+++ b/spec/queries/past_usage_query_spec.rb
@@ -56,17 +56,16 @@ RSpec.describe PastUsageQuery, type: :query do
     expect(result.usage_periods.count).to eq(2)
   end
 
-  context "when invoice subscriptions have the values for the ordering criteria" do
+  context "when invoice subscriptions have the same values for the ordering criteria" do
     let(:invoice_subscription2) do
       create(
         :invoice_subscription,
+        id: "00000000-0000-0000-0000-000000000000",
         charges_from_datetime: invoice_subscription1.charges_from_datetime,
         charges_to_datetime: invoice_subscription1.charges_to_datetime,
         subscription:,
         created_at: invoice_subscription1.created_at
-      ).tap do |invoice_subscription|
-        invoice_subscription.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      )
     end
 
     it "returns a consistent list" do

--- a/spec/queries/past_usage_query_spec.rb
+++ b/spec/queries/past_usage_query_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe PastUsageQuery, type: :query do
-  subject(:usage_query) { described_class.new(organization:, pagination:, filters:) }
+  subject(:result) { described_class.call(organization:, pagination:, filters:) }
 
   let(:organization) { create(:organization) }
   let(:pagination) { nil }
@@ -22,8 +22,8 @@ RSpec.describe PastUsageQuery, type: :query do
   let(:invoice_subscription1) do
     create(
       :invoice_subscription,
-      charges_from_datetime: DateTime.parse('2023-08-17T00:00:00'),
-      charges_to_datetime: DateTime.parse('2023-09-16T23:59:59'),
+      charges_from_datetime: DateTime.parse("2023-08-17T00:00:00"),
+      charges_to_datetime: DateTime.parse("2023-09-16T23:59:59"),
       subscription:
     )
   end
@@ -31,8 +31,8 @@ RSpec.describe PastUsageQuery, type: :query do
   let(:invoice_subscription2) do
     create(
       :invoice_subscription,
-      charges_from_datetime: DateTime.parse('2023-07-17T00:00:00'),
-      charges_to_datetime: DateTime.parse('2023-08-16T23:59:59'),
+      charges_from_datetime: DateTime.parse("2023-07-17T00:00:00"),
+      charges_to_datetime: DateTime.parse("2023-08-16T23:59:59"),
       subscription:
     )
   end
@@ -40,8 +40,8 @@ RSpec.describe PastUsageQuery, type: :query do
   let(:invoice_subscription3) do
     create(
       :invoice_subscription,
-      charges_from_datetime: DateTime.parse('2023-07-17T00:00:00'),
-      charges_to_datetime: DateTime.parse('2023-08-16T23:59:59'),
+      charges_from_datetime: DateTime.parse("2023-07-17T00:00:00"),
+      charges_to_datetime: DateTime.parse("2023-08-16T23:59:59"),
       subscription: subscription2
     )
   end
@@ -51,190 +51,177 @@ RSpec.describe PastUsageQuery, type: :query do
     invoice_subscription2
   end
 
-  describe 'call' do
-    it 'returns a list of invoice_subscription' do
-      result = usage_query.call
+  it "returns a list of invoice_subscription" do
+    expect(result).to be_success
+    expect(result.usage_periods.count).to eq(2)
+  end
 
-      aggregate_failures do
+  context "when invoice subscriptions have the values for the ordering criteria" do
+    let(:invoice_subscription2) do
+      create(
+        :invoice_subscription,
+        charges_from_datetime: invoice_subscription1.charges_from_datetime,
+        charges_to_datetime: invoice_subscription1.charges_to_datetime,
+        subscription:,
+        created_at: invoice_subscription1.created_at
+      ).tap do |invoice_subscription|
+        invoice_subscription.update! id: "00000000-0000-0000-0000-000000000000"
+      end
+    end
+
+    it "returns a consistent list" do
+      result_invoice_subscriptions_ids = result.usage_periods.map(&:invoice_subscription).map(&:id)
+
+      expect(result).to be_success
+      expect(result.usage_periods.count).to eq(2)
+      expect(result_invoice_subscriptions_ids).to include(invoice_subscription1.id)
+      expect(result_invoice_subscriptions_ids).to include(invoice_subscription2.id)
+      expect(result_invoice_subscriptions_ids.index(invoice_subscription1.id))
+        .to be > result_invoice_subscriptions_ids.index(invoice_subscription2.id)
+    end
+  end
+
+  context "with pagination" do
+    let(:pagination) { {page: 2, limit: 2} }
+
+    before do
+      create(
+        :invoice_subscription,
+        charges_from_datetime: DateTime.parse("2023-06-17T00:00:00"),
+        charges_to_datetime: DateTime.parse("2023-07-16T23:59:59"),
+        subscription:
+      )
+    end
+
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.current_page).to eq(2)
+      expect(result.prev_page).to eq(1)
+      expect(result.next_page).to be_nil
+      expect(result.total_pages).to eq(2)
+      expect(result.total_count).to eq(3)
+    end
+  end
+
+  context "when external_customer_id is missing" do
+    let(:filters) { {external_subscription_id: subscription.external_id} }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+      expect(result.error.messages.keys).to include(:external_customer_id)
+      expect(result.error.messages[:external_customer_id]).to include("value_is_mandatory")
+    end
+  end
+
+  context "when external_subscription_id is missing" do
+    let(:filters) { {external_customer_id: customer.external_id} }
+
+    it "returns a validation failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+      expect(result.error.messages.keys).to include(:external_subscription_id)
+      expect(result.error.messages[:external_subscription_id]).to include("value_is_mandatory")
+    end
+  end
+
+  context "with fees belonging to multiple subscriptions" do
+    let(:billable_metric1) { create(:billable_metric, organization:) }
+    let(:billable_metric_code) { billable_metric1&.code }
+
+    let(:billable_metric2) { create(:billable_metric, organization:) }
+
+    let(:charge1) { create(:standard_charge, plan:, billable_metric: billable_metric1) }
+    let(:charge2) { create(:standard_charge, plan:, billable_metric: billable_metric2) }
+
+    let(:fee1) { create(:charge_fee, charge: charge1, subscription:, invoice: invoice_subscription1.invoice) }
+    let(:fee2) { create(:charge_fee, charge: charge2, subscription: subscription2, invoice: invoice_subscription1.invoice) }
+
+    let(:filters) do
+      {
+        external_customer_id: customer.external_id,
+        external_subscription_id: subscription.external_id
+      }
+    end
+
+    before do
+      invoice_subscription3
+      fee1
+      fee2
+    end
+
+    it "filters the fees accordingly" do
+      expect(result).to be_success
+      expect(result.usage_periods.count).to eq(2)
+      expect(result.usage_periods.first.fees.count).to eq(1)
+      expect(result.usage_periods.first.fees.first.subscription).to eq(subscription)
+    end
+  end
+
+  context "with billable_metric_code" do
+    let(:billable_metric1) { create(:billable_metric, organization:) }
+    let(:billable_metric_code) { billable_metric1&.code }
+
+    let(:billable_metric2) { create(:billable_metric, organization:) }
+
+    let(:charge1) { create(:standard_charge, plan:, billable_metric: billable_metric1) }
+    let(:charge2) { create(:standard_charge, plan:, billable_metric: billable_metric2) }
+
+    let(:fee1) { create(:charge_fee, charge: charge1, subscription:, invoice: invoice_subscription1.invoice) }
+    let(:fee2) { create(:charge_fee, charge: charge2, subscription:, invoice: invoice_subscription1.invoice) }
+
+    let(:filters) do
+      {
+        external_customer_id: customer.external_id,
+        external_subscription_id: subscription.external_id,
+        billable_metric_code:
+      }
+    end
+
+    before do
+      fee1
+      fee2
+    end
+
+    it "filters the fees accordingly" do
+      expect(result).to be_success
+      expect(result.usage_periods.count).to eq(2)
+      expect(result.usage_periods.first.fees.count).to eq(1)
+    end
+
+    context "when billable metric is not found" do
+      let(:billable_metric_code) { "unknown_code" }
+
+      it "returns a not found failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.error_code).to eq("billable_metric_not_found")
+      end
+    end
+  end
+
+  context "with periods_count filter" do
+    let(:periods_count) { 1 }
+    let(:filters) do
+      {
+        external_customer_id: customer.external_id,
+        external_subscription_id: subscription.external_id,
+        periods_count:
+      }
+    end
+
+    it "returns last requested periods" do
+      expect(result).to be_success
+      expect(result.usage_periods.count).to eq(1)
+      expect(result.usage_periods.first.invoice_subscription).to eq(invoice_subscription1)
+    end
+
+    context "when periods_count is higher than billed period count" do
+      let(:periods_count) { 10 }
+
+      it "returns all periods" do
         expect(result).to be_success
         expect(result.usage_periods.count).to eq(2)
-      end
-    end
-
-    context 'with pagination' do
-      let(:pagination) { {page: 2, limit: 2} }
-
-      before do
-        create(
-          :invoice_subscription,
-          charges_from_datetime: DateTime.parse('2023-06-17T00:00:00'),
-          charges_to_datetime: DateTime.parse('2023-07-16T23:59:59'),
-          subscription:
-        )
-      end
-
-      it 'applies the pagination' do
-        result = usage_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.current_page).to eq(2)
-          expect(result.prev_page).to eq(1)
-          expect(result.next_page).to be_nil
-          expect(result.total_pages).to eq(2)
-          expect(result.total_count).to eq(3)
-        end
-      end
-    end
-
-    context 'when external_customer_id is missing' do
-      let(:filters) { {external_subscription_id: subscription.external_id} }
-
-      it 'returns a validation failure' do
-        result = usage_query.call
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages.keys).to include(:external_customer_id)
-          expect(result.error.messages[:external_customer_id]).to include('value_is_mandatory')
-        end
-      end
-    end
-
-    context 'when external_subscription_id is missing' do
-      let(:filters) { {external_customer_id: customer.external_id} }
-
-      it 'returns a validation failure' do
-        result = usage_query.call
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages.keys).to include(:external_subscription_id)
-          expect(result.error.messages[:external_subscription_id]).to include('value_is_mandatory')
-        end
-      end
-    end
-
-    context 'with fees belonging to multiple subscriptions' do
-      let(:billable_metric1) { create(:billable_metric, organization:) }
-      let(:billable_metric_code) { billable_metric1&.code }
-
-      let(:billable_metric2) { create(:billable_metric, organization:) }
-
-      let(:charge1) { create(:standard_charge, plan:, billable_metric: billable_metric1) }
-      let(:charge2) { create(:standard_charge, plan:, billable_metric: billable_metric2) }
-
-      let(:fee1) { create(:charge_fee, charge: charge1, subscription:, invoice: invoice_subscription1.invoice) }
-      let(:fee2) { create(:charge_fee, charge: charge2, subscription: subscription2, invoice: invoice_subscription1.invoice) }
-
-      let(:filters) do
-        {
-          external_customer_id: customer.external_id,
-          external_subscription_id: subscription.external_id
-        }
-      end
-
-      before do
-        invoice_subscription3
-        fee1
-        fee2
-      end
-
-      it 'filters the fees accordingly' do
-        result = usage_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.usage_periods.count).to eq(2)
-          expect(result.usage_periods.first.fees.count).to eq(1)
-          expect(result.usage_periods.first.fees.first.subscription).to eq(subscription)
-        end
-      end
-    end
-
-    context 'with billable_metric_code' do
-      let(:billable_metric1) { create(:billable_metric, organization:) }
-      let(:billable_metric_code) { billable_metric1&.code }
-
-      let(:billable_metric2) { create(:billable_metric, organization:) }
-
-      let(:charge1) { create(:standard_charge, plan:, billable_metric: billable_metric1) }
-      let(:charge2) { create(:standard_charge, plan:, billable_metric: billable_metric2) }
-
-      let(:fee1) { create(:charge_fee, charge: charge1, subscription:, invoice: invoice_subscription1.invoice) }
-      let(:fee2) { create(:charge_fee, charge: charge2, subscription:, invoice: invoice_subscription1.invoice) }
-
-      let(:filters) do
-        {
-          external_customer_id: customer.external_id,
-          external_subscription_id: subscription.external_id,
-          billable_metric_code:
-        }
-      end
-
-      before do
-        fee1
-        fee2
-      end
-
-      it 'filters the fees accordingly' do
-        result = usage_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.usage_periods.count).to eq(2)
-          expect(result.usage_periods.first.fees.count).to eq(1)
-        end
-      end
-
-      context 'when billable metric is not found' do
-        let(:billable_metric_code) { 'unknown_code' }
-
-        it 'returns a not found failure' do
-          result = usage_query.call
-
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.error_code).to eq('billable_metric_not_found')
-          end
-        end
-      end
-    end
-
-    context 'with periods_count filter' do
-      let(:periods_count) { 1 }
-      let(:filters) do
-        {
-          external_customer_id: customer.external_id,
-          external_subscription_id: subscription.external_id,
-          periods_count:
-        }
-      end
-
-      it 'returns last requested periods' do
-        result = usage_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.usage_periods.count).to eq(1)
-          expect(result.usage_periods.first.invoice_subscription).to eq(invoice_subscription1)
-        end
-      end
-
-      context 'when periods_count is higher than billed period count' do
-        let(:periods_count) { 10 }
-
-        it 'returns all periods' do
-          result = usage_query.call
-
-          aggregate_failures do
-            expect(result).to be_success
-            expect(result.usage_periods.count).to eq(2)
-          end
-        end
       end
     end
   end

--- a/spec/queries/payment_requests_query_spec.rb
+++ b/spec/queries/payment_requests_query_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe PaymentRequestsQuery, type: :query do
     described_class.call(organization:, pagination:, filters:)
   end
 
+  let(:returned_ids) { result.payment_requests.pluck(:id) }
+
   let(:pagination) { nil }
   let(:filters) { {} }
 
@@ -27,6 +29,22 @@ RSpec.describe PaymentRequestsQuery, type: :query do
       payment_request_first.id,
       payment_request_second.id
     )
+  end
+
+  context "when payment requests have the values for the ordering criteria" do
+    let(:payment_request_second) do
+      create(:payment_request, organization:, customer:, created_at: payment_request_first.created_at).tap do |payment_request|
+        payment_request.update! id: "00000000-0000-0000-0000-000000000000"
+      end
+    end
+
+    it "returns a consistent list" do
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(2)
+      expect(returned_ids).to include(payment_request_first.id)
+      expect(returned_ids).to include(payment_request_second.id)
+      expect(returned_ids.index(payment_request_first.id)).to be > returned_ids.index(payment_request_second.id)
+    end
   end
 
   context "with pagination" do

--- a/spec/queries/payment_requests_query_spec.rb
+++ b/spec/queries/payment_requests_query_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PaymentRequestsQuery, type: :query do
     payment_request_second
   end
 
-  it "returns all payment requests", :aggregate_failures do
+  it "returns all payment requests" do
     expect(result).to be_success
     expect(result.payment_requests.pluck(:id)).to contain_exactly(
       payment_request_first.id,
@@ -31,11 +31,15 @@ RSpec.describe PaymentRequestsQuery, type: :query do
     )
   end
 
-  context "when payment requests have the values for the ordering criteria" do
+  context "when payment requests have the same values for the ordering criteria" do
     let(:payment_request_second) do
-      create(:payment_request, organization:, customer:, created_at: payment_request_first.created_at).tap do |payment_request|
-        payment_request.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      create(
+        :payment_request,
+        organization:,
+        customer:,
+        id: "00000000-0000-0000-0000-000000000000",
+        created_at: payment_request_first.created_at
+      )
     end
 
     it "returns a consistent list" do
@@ -50,7 +54,7 @@ RSpec.describe PaymentRequestsQuery, type: :query do
   context "with pagination" do
     let(:pagination) { {page: 2, limit: 1} }
 
-    it "applies the pagination", :aggregate_failures do
+    it "applies the pagination" do
       expect(result).to be_success
       expect(result.payment_requests.count).to eq(1)
       expect(result.payment_requests.current_page).to eq(2)
@@ -64,7 +68,7 @@ RSpec.describe PaymentRequestsQuery, type: :query do
   context "when filtering by customer_id" do
     let(:filters) { {external_customer_id: customer.external_id} }
 
-    it "returns all payment_requests of the customer", :aggregate_failures do
+    it "returns all payment_requests of the customer" do
       expect(result).to be_success
       expect(result.payment_requests.pluck(:id)).to contain_exactly(
         payment_request_second.id

--- a/spec/queries/plans_query_spec.rb
+++ b/spec/queries/plans_query_spec.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe PlansQuery, type: :query do
   subject(:result) do
     described_class.call(organization:, pagination:, search_term:, filters:)
   end
 
+  let(:returned_ids) { result.plans.pluck(:id) }
   let(:pagination) { nil }
   let(:search_term) { nil }
   let(:filters) { nil }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan_first) { create(:plan, organization:, name: 'defgh', code: '11') }
-  let(:plan_second) { create(:plan, organization:, name: 'abcde', code: '22') }
-  let(:plan_third) { create(:plan, organization:, name: 'presuv', code: '33') }
+  let(:plan_first) { create(:plan, organization:, name: "defgh", code: "11") }
+  let(:plan_second) { create(:plan, organization:, name: "abcde", code: "22") }
+  let(:plan_third) { create(:plan, organization:, name: "presuv", code: "33") }
 
   before do
     plan_first
@@ -22,23 +23,39 @@ RSpec.describe PlansQuery, type: :query do
     plan_third
   end
 
-  it 'returns all plans' do
-    returned_ids = result.plans.pluck(:id)
-
-    aggregate_failures do
+  it "returns all plans" do
       expect(result).to be_success
       expect(returned_ids.count).to eq(3)
       expect(returned_ids).to include(plan_first.id)
       expect(returned_ids).to include(plan_second.id)
       expect(returned_ids).to include(plan_third.id)
+  end
+
+  context "when plans have the values for the ordering criteria" do
+    let(:plan_second) do
+      create(
+        :plan,
+        organization:,
+        id: "00000000-0000-0000-0000-000000000000",
+        name: "abcde",
+        code: "22",
+        created_at: plan_first.created_at
+      )
+    end
+
+    it "returns a consistent list" do
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(3)
+      expect(returned_ids).to include(plan_first.id)
+      expect(returned_ids).to include(plan_second.id)
+      expect(returned_ids.index(plan_first.id)).to be > returned_ids.index(plan_second.id)
     end
   end
 
-  context 'with pagination' do
+  context "with pagination" do
     let(:pagination) { {page: 2, limit: 2} }
 
-    it 'applies the pagination' do
-      aggregate_failures do
+    it "applies the pagination" do
         expect(result).to be_success
         expect(result.plans.count).to eq(1)
         expect(result.plans.current_page).to eq(2)
@@ -46,22 +63,19 @@ RSpec.describe PlansQuery, type: :query do
         expect(result.plans.next_page).to be_nil
         expect(result.plans.total_pages).to eq(2)
         expect(result.plans.total_count).to eq(3)
-      end
     end
   end
 
-  context 'when searching for /de/ term' do
-    let(:search_term) { 'de' }
+  context "when searching for /de/ term" do
+    let(:search_term) { "de" }
 
-    it 'returns only two plans' do
+    it "returns only two plans" do
       returned_ids = result.plans.pluck(:id)
 
-      aggregate_failures do
         expect(returned_ids.count).to eq(2)
         expect(returned_ids).to include(plan_first.id)
         expect(returned_ids).to include(plan_second.id)
         expect(returned_ids).not_to include(plan_third.id)
-      end
     end
   end
 end

--- a/spec/queries/plans_query_spec.rb
+++ b/spec/queries/plans_query_spec.rb
@@ -16,19 +16,22 @@ RSpec.describe PlansQuery, type: :query do
   let(:plan_first) { create(:plan, organization:, name: "defgh", code: "11") }
   let(:plan_second) { create(:plan, organization:, name: "abcde", code: "22") }
   let(:plan_third) { create(:plan, organization:, name: "presuv", code: "33") }
+  let(:plan_fourth) { create(:plan, organization:, name: "pending deletion", code: "44", pending_deletion: true) }
 
   before do
     plan_first
     plan_second
     plan_third
+    plan_fourth
   end
 
-  it "returns all plans" do
+  it "returns all plans not pending for deletion" do
     expect(result).to be_success
     expect(returned_ids.count).to eq(3)
     expect(returned_ids).to include(plan_first.id)
     expect(returned_ids).to include(plan_second.id)
     expect(returned_ids).to include(plan_third.id)
+    expect(returned_ids).not_to include(plan_fourth.id)
   end
 
   context "when plans have the same values for the ordering criteria" do
@@ -63,6 +66,16 @@ RSpec.describe PlansQuery, type: :query do
       expect(result.plans.next_page).to be_nil
       expect(result.plans.total_pages).to eq(2)
       expect(result.plans.total_count).to eq(3)
+    end
+  end
+
+  context "when filtering to include pending for deletion plans" do
+    let(:filters) { {include_pending_deletion: true} }
+
+    it "includes pending for deletion plans" do
+      expect(result).to be_success
+      expect(result.plans.count).to eq(4)
+      expect(result.plans).to include(plan_fourth)
     end
   end
 

--- a/spec/queries/plans_query_spec.rb
+++ b/spec/queries/plans_query_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe PlansQuery, type: :query do
   end
 
   it "returns all plans" do
-      expect(result).to be_success
-      expect(returned_ids.count).to eq(3)
-      expect(returned_ids).to include(plan_first.id)
-      expect(returned_ids).to include(plan_second.id)
-      expect(returned_ids).to include(plan_third.id)
+    expect(result).to be_success
+    expect(returned_ids.count).to eq(3)
+    expect(returned_ids).to include(plan_first.id)
+    expect(returned_ids).to include(plan_second.id)
+    expect(returned_ids).to include(plan_third.id)
   end
 
-  context "when plans have the values for the ordering criteria" do
+  context "when plans have the same values for the ordering criteria" do
     let(:plan_second) do
       create(
         :plan,
@@ -56,13 +56,13 @@ RSpec.describe PlansQuery, type: :query do
     let(:pagination) { {page: 2, limit: 2} }
 
     it "applies the pagination" do
-        expect(result).to be_success
-        expect(result.plans.count).to eq(1)
-        expect(result.plans.current_page).to eq(2)
-        expect(result.plans.prev_page).to eq(1)
-        expect(result.plans.next_page).to be_nil
-        expect(result.plans.total_pages).to eq(2)
-        expect(result.plans.total_count).to eq(3)
+      expect(result).to be_success
+      expect(result.plans.count).to eq(1)
+      expect(result.plans.current_page).to eq(2)
+      expect(result.plans.prev_page).to eq(1)
+      expect(result.plans.next_page).to be_nil
+      expect(result.plans.total_pages).to eq(2)
+      expect(result.plans.total_count).to eq(3)
     end
   end
 
@@ -70,12 +70,10 @@ RSpec.describe PlansQuery, type: :query do
     let(:search_term) { "de" }
 
     it "returns only two plans" do
-      returned_ids = result.plans.pluck(:id)
-
-        expect(returned_ids.count).to eq(2)
-        expect(returned_ids).to include(plan_first.id)
-        expect(returned_ids).to include(plan_second.id)
-        expect(returned_ids).not_to include(plan_third.id)
+      expect(returned_ids.count).to eq(2)
+      expect(returned_ids).to include(plan_first.id)
+      expect(returned_ids).to include(plan_second.id)
+      expect(returned_ids).not_to include(plan_third.id)
     end
   end
 end

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -30,11 +30,10 @@ RSpec.describe SubscriptionsQuery, type: :query do
         :subscription,
         customer:,
         plan:,
+        id: "00000000-0000-0000-0000-000000000000",
         started_at: subscription.started_at,
         created_at: subscription.created_at
-      ).tap do |subs|
-        subs.update! id: "00000000-0000-0000-0000-000000000000"
-      end
+      )
     end
 
     before { subscription_2 }

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe SubscriptionsQuery, type: :query do
-  subject(:subscriptions_query) { described_class.new(organization:, pagination:, filters:) }
+  subject(:result) { described_class.call(organization:, pagination:, filters:) }
 
   let(:organization) { create(:organization) }
   let(:pagination) { nil }
@@ -15,165 +15,128 @@ RSpec.describe SubscriptionsQuery, type: :query do
 
   before { subscription }
 
-  describe 'call' do
-    it 'returns a list of subscriptions' do
-      result = subscriptions_query.call
+  it "returns a list of subscriptions" do
+    expect(result).to be_success
+    expect(result.subscriptions.count).to eq(1)
+    expect(result.subscriptions).to eq([subscription])
+  end
 
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.subscriptions.count).to eq(1)
-        expect(result.subscriptions).to eq([subscription])
-      end
+  context "with pagination" do
+    let(:pagination) { {page: 2, limit: 10} }
+
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.subscriptions.count).to eq(0)
+      expect(result.subscriptions.current_page).to eq(2)
+    end
+  end
+
+  context "with customer filter" do
+    let(:filters) { {external_customer_id: customer.external_id} }
+
+    it "applies the filter" do
+      expect(result).to be_success
+      expect(result.subscriptions.count).to eq(1)
+    end
+  end
+
+  context "with plan filter" do
+    let(:filters) { {plan_code: plan.code} }
+
+    it "applies the filter" do
+      expect(result).to be_success
+      expect(result.subscriptions.count).to eq(1)
+    end
+  end
+
+  context "with multiple status filter" do
+    let(:filters) { {status: [:active, :pending]} }
+
+    it "returns correct subscriptions" do
+      create(:subscription, :pending, customer:, plan:)
+      create(:subscription, customer:, plan:, status: :canceled)
+      create(:subscription, customer:, plan:, status: :terminated)
+
+      expect(result).to be_success
+      expect(result.subscriptions.count).to eq(2)
+      expect(result.subscriptions.active.count).to eq(1)
+      expect(result.subscriptions.pending.count).to eq(1)
+      expect(result.subscriptions.canceled.count).to eq(0)
+      expect(result.subscriptions.terminated.count).to eq(0)
+    end
+  end
+
+  context "with pending status filter" do
+    let(:filters) { {status: [:pending]} }
+
+    let(:subscription_1) do
+      create(:subscription, :pending, customer:, plan:, created_at: Time.zone.parse("2024-10-12T00:01:01"))
     end
 
-    context 'with pagination' do
-      let(:pagination) { {page: 2, limit: 10} }
-
-      it 'applies the pagination' do
-        result = subscriptions_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.subscriptions.count).to eq(0)
-          expect(result.subscriptions.current_page).to eq(2)
-        end
-      end
+    let(:subscription_2) do
+      create(:subscription, :pending, customer:, plan:, created_at: Time.zone.parse("2024-10-10T00:01:01"))
     end
 
-    context 'with customer filter' do
-      let(:filters) { {external_customer_id: customer.external_id} }
+    it "returns only pending subscriptions" do
+      subscription_1
+      subscription_2
+      create(:subscription, customer:, plan:, status: :canceled)
+      create(:subscription, customer:, plan:, status: :terminated)
 
-      it 'applies the filter' do
-        result = subscriptions_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.subscriptions.count).to eq(1)
-        end
-      end
+      expect(result).to be_success
+      expect(result.subscriptions.count).to eq(2)
+      expect(result.subscriptions.active.count).to eq(0)
+      expect(result.subscriptions.pending.count).to eq(2)
+      expect(result.subscriptions.canceled.count).to eq(0)
+      expect(result.subscriptions.terminated.count).to eq(0)
+      expect(result.subscriptions.first).to eq(subscription_1)
     end
+  end
 
-    context 'with plan filter' do
-      let(:filters) { {plan_code: plan.code} }
+  context "with canceled status filter" do
+    let(:filters) { {status: [:canceled]} }
 
-      it 'applies the filter' do
-        result = subscriptions_query.call
+    it "returns only pending subscriptions" do
+      create(:subscription, :pending, customer:, plan:)
+      create(:subscription, customer:, plan:, status: :canceled)
+      create(:subscription, customer:, plan:, status: :terminated)
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.subscriptions.count).to eq(1)
-        end
-      end
+      expect(result).to be_success
+      expect(result.subscriptions.count).to eq(1)
+      expect(result.subscriptions.active.count).to eq(0)
+      expect(result.subscriptions.pending.count).to eq(0)
+      expect(result.subscriptions.canceled.count).to eq(1)
+      expect(result.subscriptions.terminated.count).to eq(0)
     end
+  end
 
-    context 'with multiple status filter' do
-      let(:filters) { {status: [:active, :pending]} }
+  context "with terminated status filter" do
+    let(:filters) { {status: [:terminated]} }
 
-      it 'returns correct subscriptions' do
-        create(:subscription, :pending, customer:, plan:)
-        create(:subscription, customer:, plan:, status: :canceled)
-        create(:subscription, customer:, plan:, status: :terminated)
-        result = subscriptions_query.call
+    it "returns only pending subscriptions" do
+      create(:subscription, :pending, customer:, plan:)
+      create(:subscription, customer:, plan:, status: :canceled)
+      create(:subscription, customer:, plan:, status: :terminated)
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.subscriptions.count).to eq(2)
-          expect(result.subscriptions.active.count).to eq(1)
-          expect(result.subscriptions.pending.count).to eq(1)
-          expect(result.subscriptions.canceled.count).to eq(0)
-          expect(result.subscriptions.terminated.count).to eq(0)
-        end
-      end
+      expect(result).to be_success
+      expect(result.subscriptions.count).to eq(1)
+      expect(result.subscriptions.active.count).to eq(0)
+      expect(result.subscriptions.pending.count).to eq(0)
+      expect(result.subscriptions.canceled.count).to eq(0)
+      expect(result.subscriptions.terminated.count).to eq(1)
     end
+  end
 
-    context 'with pending status filter' do
-      let(:filters) { {status: [:pending]} }
+  context "with no status filter" do
+    it "returns only active subscriptions" do
+      create(:subscription, :pending, customer:, plan:)
 
-      let(:subscription_1) do
-        create(:subscription, :pending, customer:, plan:, created_at: Time.zone.parse('2024-10-12T00:01:01'))
-      end
-
-      let(:subscription_2) do
-        create(:subscription, :pending, customer:, plan:, created_at: Time.zone.parse('2024-10-10T00:01:01'))
-      end
-
-      it 'returns only pending subscriptions' do
-        subscription_1
-        subscription_2
-        create(:subscription, customer:, plan:, status: :canceled)
-        create(:subscription, customer:, plan:, status: :terminated)
-
-        result = subscriptions_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.subscriptions.count).to eq(2)
-          expect(result.subscriptions.active.count).to eq(0)
-          expect(result.subscriptions.pending.count).to eq(2)
-          expect(result.subscriptions.canceled.count).to eq(0)
-          expect(result.subscriptions.terminated.count).to eq(0)
-          expect(result.subscriptions.first).to eq(subscription_1)
-        end
-      end
-    end
-
-    context 'with canceled status filter' do
-      let(:filters) { {status: [:canceled]} }
-
-      it 'returns only pending subscriptions' do
-        create(:subscription, :pending, customer:, plan:)
-        create(:subscription, customer:, plan:, status: :canceled)
-        create(:subscription, customer:, plan:, status: :terminated)
-
-        result = subscriptions_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.subscriptions.count).to eq(1)
-          expect(result.subscriptions.active.count).to eq(0)
-          expect(result.subscriptions.pending.count).to eq(0)
-          expect(result.subscriptions.canceled.count).to eq(1)
-          expect(result.subscriptions.terminated.count).to eq(0)
-        end
-      end
-    end
-
-    context 'with terminated status filter' do
-      let(:filters) { {status: [:terminated]} }
-
-      it 'returns only pending subscriptions' do
-        create(:subscription, :pending, customer:, plan:)
-        create(:subscription, customer:, plan:, status: :canceled)
-        create(:subscription, customer:, plan:, status: :terminated)
-
-        result = subscriptions_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.subscriptions.count).to eq(1)
-          expect(result.subscriptions.active.count).to eq(0)
-          expect(result.subscriptions.pending.count).to eq(0)
-          expect(result.subscriptions.canceled.count).to eq(0)
-          expect(result.subscriptions.terminated.count).to eq(1)
-        end
-      end
-    end
-
-    context 'with no status filter' do
-      it 'returns only active subscriptions' do
-        create(:subscription, :pending, customer:, plan:)
-
-        result = subscriptions_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.subscriptions.count).to eq(1)
-          expect(result.subscriptions.active.count).to eq(1)
-          expect(result.subscriptions.pending.count).to eq(0)
-          expect(result.subscriptions.canceled.count).to eq(0)
-          expect(result.subscriptions.terminated.count).to eq(0)
-        end
-      end
+      expect(result).to be_success
+      expect(result.subscriptions.count).to eq(1)
+      expect(result.subscriptions.active.count).to eq(1)
+      expect(result.subscriptions.pending.count).to eq(0)
+      expect(result.subscriptions.canceled.count).to eq(0)
+      expect(result.subscriptions.terminated.count).to eq(0)
     end
   end
 end

--- a/spec/queries/taxes_query_spec.rb
+++ b/spec/queries/taxes_query_spec.rb
@@ -76,15 +76,13 @@ RSpec.describe TaxesQuery, type: :query do
     let(:pagination) { {page: 2, limit: 3} }
 
     it 'applies the pagination' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.taxes.count).to eq(1)
-        expect(result.taxes.current_page).to eq(2)
-        expect(result.taxes.prev_page).to eq(1)
-        expect(result.taxes.next_page).to be_nil
-        expect(result.taxes.total_pages).to eq(2)
-        expect(result.taxes.total_count).to eq(4)
-      end
+      expect(result).to be_success
+      expect(result.taxes.count).to eq(1)
+      expect(result.taxes.current_page).to eq(2)
+      expect(result.taxes.prev_page).to eq(1)
+      expect(result.taxes.next_page).to be_nil
+      expect(result.taxes.total_pages).to eq(2)
+      expect(result.taxes.total_count).to eq(4)
     end
   end
 

--- a/spec/queries/taxes_query_spec.rb
+++ b/spec/queries/taxes_query_spec.rb
@@ -7,14 +7,16 @@ RSpec.describe TaxesQuery, type: :query do
     described_class.call(organization:, pagination:, search_term:, filters:, order:)
   end
 
+  let(:returned_ids) { result.taxes.pluck(:id) }
+
   let(:pagination) { nil }
   let(:search_term) { nil }
   let(:filters) { nil }
   let(:order) { nil }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:tax_first) { create(:tax, organization:, name: 'defgh', code: '11') }
-  let(:tax_second) { create(:tax, organization:, name: 'abcde', code: '22') }
+  let(:tax_first) { create(:tax, organization:, name: 'defgh', code: '11', rate: 10) }
+  let(:tax_second) { create(:tax, organization:, name: 'abcde', code: '22', rate: 5) }
 
   let(:tax_third) do
     create(
@@ -22,7 +24,8 @@ RSpec.describe TaxesQuery, type: :query do
       organization:,
       name: 'presuv',
       code: '33',
-      applied_to_organization: false
+      applied_to_organization: false,
+      rate: 20
     )
   end
 
@@ -46,6 +49,27 @@ RSpec.describe TaxesQuery, type: :query do
 
   it 'returns all taxes ordered by name asc' do
     expect(result.taxes).to eq([tax_second, auto_generated_tax, tax_first, tax_third])
+  end
+
+  context "when taxes have the same values for the ordering criteria" do
+    let(:tax_second) do
+      create(
+        :tax,
+        organization:,
+        id: "00000000-0000-0000-0000-000000000000",
+        name: tax_first.name,
+        code: '22',
+        created_at: tax_first.created_at
+      )
+    end
+
+    it "returns a consistent list" do
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(4)
+      expect(returned_ids).to include(tax_first.id)
+      expect(returned_ids).to include(tax_second.id)
+      expect(returned_ids.index(tax_first.id)).to be > returned_ids.index(tax_second.id)
+    end
   end
 
   context 'with pagination' do
@@ -92,7 +116,7 @@ RSpec.describe TaxesQuery, type: :query do
     let(:order) { 'rate' }
 
     it 'returns the taxes ordered by rate' do
-      expect(result.taxes).to eq([auto_generated_tax, tax_first, tax_second, tax_third])
+      expect(result.taxes).to eq([auto_generated_tax, tax_second, tax_first, tax_third])
     end
   end
 end

--- a/spec/queries/wallet_transactions_query_spec.rb
+++ b/spec/queries/wallet_transactions_query_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe WalletTransactionsQuery, type: :query do
   subject(:result) do
@@ -11,6 +11,8 @@ RSpec.describe WalletTransactionsQuery, type: :query do
       filters:
     )
   end
+
+  let(:returned_ids) { result.wallet_transactions.pluck(:id) }
 
   let(:wallet_id) { wallet.id }
   let(:pagination) { nil }
@@ -32,79 +34,82 @@ RSpec.describe WalletTransactionsQuery, type: :query do
     wallet_transaction_fourth
   end
 
-  it 'returns all wallet transactions for a certain wallet' do
-    returned_ids = result.wallet_transactions.pluck(:id)
+  it "returns all wallet transactions for a certain wallet" do
+    expect(returned_ids.count).to eq(3)
+    expect(returned_ids).to include(wallet_transaction_first.id)
+    expect(returned_ids).to include(wallet_transaction_second.id)
+    expect(returned_ids).to include(wallet_transaction_third.id)
+    expect(returned_ids).not_to include(wallet_transaction_fourth.id)
+  end
 
-    aggregate_failures do
+  context "when wallet transactions have the same values for the ordering criteria" do
+    let(:wallet_transaction_second) do
+      create(
+        :wallet_transaction,
+        wallet:,
+        id: "00000000-0000-0000-0000-000000000000",
+        created_at: wallet_transaction_first.created_at
+      )
+    end
+
+    it "returns a consistent list" do
+      expect(result).to be_success
       expect(returned_ids.count).to eq(3)
       expect(returned_ids).to include(wallet_transaction_first.id)
       expect(returned_ids).to include(wallet_transaction_second.id)
+      expect(returned_ids.index(wallet_transaction_first.id)).to be > returned_ids.index(wallet_transaction_second.id)
+    end
+  end
+
+  context "with pagination" do
+    let(:pagination) { {page: 2, limit: 2} }
+
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.wallet_transactions.count).to eq(1)
+      expect(result.wallet_transactions.current_page).to eq(2)
+      expect(result.wallet_transactions.prev_page).to eq(1)
+      expect(result.wallet_transactions.next_page).to be_nil
+      expect(result.wallet_transactions.total_pages).to eq(2)
+      expect(result.wallet_transactions.total_count).to eq(3)
+    end
+  end
+
+  context "when filtering by status" do
+    let(:wallet_transaction_third) { create(:wallet_transaction, wallet:, status: "pending") }
+
+    let(:filters) { {status: "pending"} }
+
+    it "returns only one wallet transaction" do
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).not_to include(wallet_transaction_first.id)
+      expect(returned_ids).not_to include(wallet_transaction_second.id)
       expect(returned_ids).to include(wallet_transaction_third.id)
       expect(returned_ids).not_to include(wallet_transaction_fourth.id)
     end
   end
 
-  context 'with pagination' do
-    let(:pagination) { {page: 2, limit: 2} }
+  context "when filtering by transaction type" do
+    let(:wallet_transaction_third) { create(:wallet_transaction, wallet:, transaction_type: "outbound") }
 
-    it 'applies the pagination' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.wallet_transactions.count).to eq(1)
-        expect(result.wallet_transactions.current_page).to eq(2)
-        expect(result.wallet_transactions.prev_page).to eq(1)
-        expect(result.wallet_transactions.next_page).to be_nil
-        expect(result.wallet_transactions.total_pages).to eq(2)
-        expect(result.wallet_transactions.total_count).to eq(3)
-      end
+    let(:filters) { {transaction_type: "outbound"} }
+
+    it "returns only one wallet transaction" do
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).not_to include(wallet_transaction_first.id)
+      expect(returned_ids).not_to include(wallet_transaction_second.id)
+      expect(returned_ids).to include(wallet_transaction_third.id)
+      expect(returned_ids).not_to include(wallet_transaction_fourth.id)
     end
   end
 
-  context 'when filtering by status' do
-    let(:wallet_transaction_third) { create(:wallet_transaction, wallet:, status: 'pending') }
-
-    let(:filters) { {status: 'pending'} }
-
-    it 'returns only one wallet transaction' do
-      returned_ids = result.wallet_transactions.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(1)
-        expect(returned_ids).not_to include(wallet_transaction_first.id)
-        expect(returned_ids).not_to include(wallet_transaction_second.id)
-        expect(returned_ids).to include(wallet_transaction_third.id)
-        expect(returned_ids).not_to include(wallet_transaction_fourth.id)
-      end
-    end
-  end
-
-  context 'when filtering by transaction type' do
-    let(:wallet_transaction_third) { create(:wallet_transaction, wallet:, transaction_type: 'outbound') }
-
-    let(:filters) { {transaction_type: 'outbound'} }
-
-    it 'returns only one wallet transaction' do
-      returned_ids = result.wallet_transactions.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(1)
-        expect(returned_ids).not_to include(wallet_transaction_first.id)
-        expect(returned_ids).not_to include(wallet_transaction_second.id)
-        expect(returned_ids).to include(wallet_transaction_third.id)
-        expect(returned_ids).not_to include(wallet_transaction_fourth.id)
-      end
-    end
-  end
-
-  context 'when wallet is not found' do
+  context "when wallet is not found" do
     let(:wallet_id) { "#{wallet.id}abc" }
 
-    it 'returns not found error' do
-      aggregate_failures do
-        expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::NotFoundFailure)
-        expect(result.error.message).to eq('wallet_not_found')
-      end
+    it "returns not found error" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::NotFoundFailure)
+      expect(result.error.message).to eq("wallet_not_found")
     end
   end
 end

--- a/spec/queries/wallets_query_spec.rb
+++ b/spec/queries/wallets_query_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WalletsQuery, type: :query do
+  subject(:result) do
+    described_class.call(organization:, pagination:, filters:)
+  end
+
+  let(:returned_ids) { result.wallets.pluck(:id) }
+  let(:organization) { create :organization }
+  let(:customer_1) { create :customer, organization:, external_id: "customer_1" }
+  let(:customer_2) { create :customer, organization:, external_id: "customer_2" }
+  let(:wallet_1) { create :wallet, customer: customer_1 }
+  let(:wallet_2) { create :wallet, customer: customer_1 }
+  let(:wallet_3) { create :wallet, customer: customer_2 }
+  let(:wallet_4) { create :wallet }
+  let(:pagination) { {page: 1, limit: 10} }
+  let(:filters) { nil }
+
+  before do
+    wallet_1
+    wallet_2
+    wallet_3
+    wallet_4
+  end
+
+  it "returns all wallets" do
+    expect(result.wallets.count).to eq(3)
+    expect(returned_ids).to include(wallet_1.id)
+    expect(returned_ids).to include(wallet_2.id)
+    expect(returned_ids).to include(wallet_3.id)
+    expect(returned_ids).not_to include(wallet_4.id)
+  end
+
+  context "when wallets have the same values for the ordering criteria" do
+    let(:wallet_2) do
+      create(
+        :wallet,
+        customer: customer_1,
+        id: "00000000-0000-0000-0000-000000000000",
+        created_at: wallet_1.created_at
+      )
+    end
+
+    it "returns a consistent list" do
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(3)
+      expect(returned_ids).to include(wallet_1.id)
+      expect(returned_ids).to include(wallet_2.id)
+      expect(returned_ids.index(wallet_1.id)).to be > returned_ids.index(wallet_2.id)
+    end
+  end
+
+  context "with pagination" do
+    let(:pagination) { {page: 2, limit: 2} }
+
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.wallets.count).to eq(1)
+      expect(result.wallets.current_page).to eq(2)
+      expect(result.wallets.prev_page).to eq(1)
+      expect(result.wallets.next_page).to be_nil
+      expect(result.wallets.total_pages).to eq(2)
+      expect(result.wallets.total_count).to eq(3)
+    end
+  end
+
+  context "when filtering by external_customer_id" do
+    let(:filters) { {external_customer_id: customer_1.external_id} }
+
+    it "returns only two wallets" do
+      expect(result.wallets.count).to eq(2)
+      expect(returned_ids).to include(wallet_1.id)
+      expect(returned_ids).to include(wallet_2.id)
+      expect(returned_ids).not_to include(wallet_3.id)
+      expect(returned_ids).not_to include(wallet_4.id)
+    end
+
+    context "when customer is not found" do
+      let(:filters) { {external_customer_id: "not_found_external_id"} }
+
+      it "returns a not found error" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.error_code).to eq("customer_not_found")
+      end
+    end
+  end
+end

--- a/spec/queries/webhook_endpoints_query_spec.rb
+++ b/spec/queries/webhook_endpoints_query_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe WebhookEndpointsQuery, type: :query do
   subject(:result) do
     described_class.call(organization:, pagination:, search_term:)
   end
+
+  let(:returned_ids) { result.webhook_endpoints.pluck(:id) }
 
   let(:pagination) { nil }
   let(:search_term) { nil }
@@ -24,47 +26,37 @@ RSpec.describe WebhookEndpointsQuery, type: :query do
     webhook_endpoint_fourth
   end
 
-  it 'returns all webhook endpoints of the organization' do
-    returned_ids = result.webhook_endpoints.pluck(:id)
-
-    aggregate_failures do
-      expect(result.webhook_endpoints.count).to eq(3)
-      expect(returned_ids).to include(webhook_endpoint_first.id)
-      expect(returned_ids).to include(webhook_endpoint_second.id)
-      expect(returned_ids).to include(webhook_endpoint_third.id)
-      expect(returned_ids).not_to include(webhook_endpoint_fourth.id)
-    end
+  it "returns all webhook endpoints of the organization" do
+    expect(result.webhook_endpoints.count).to eq(3)
+    expect(returned_ids).to include(webhook_endpoint_first.id)
+    expect(returned_ids).to include(webhook_endpoint_second.id)
+    expect(returned_ids).to include(webhook_endpoint_third.id)
+    expect(returned_ids).not_to include(webhook_endpoint_fourth.id)
   end
 
-  context 'with pagination' do
+  context "with pagination" do
     let(:pagination) { {page: 2, limit: 2} }
 
-    it 'applies the pagination' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.webhook_endpoints.count).to eq(1)
-        expect(result.webhook_endpoints.current_page).to eq(2)
-        expect(result.webhook_endpoints.prev_page).to eq(1)
-        expect(result.webhook_endpoints.next_page).to be_nil
-        expect(result.webhook_endpoints.total_pages).to eq(2)
-        expect(result.webhook_endpoints.total_count).to eq(3)
-      end
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.webhook_endpoints.count).to eq(1)
+      expect(result.webhook_endpoints.current_page).to eq(2)
+      expect(result.webhook_endpoints.prev_page).to eq(1)
+      expect(result.webhook_endpoints.next_page).to be_nil
+      expect(result.webhook_endpoints.total_pages).to eq(2)
+      expect(result.webhook_endpoints.total_count).to eq(3)
     end
   end
 
-  context 'when searching for /lago/ term' do
-    let(:search_term) { 'lago' }
+  context "when searching for /lago/ term" do
+    let(:search_term) { "lago" }
 
-    it 'returns only two webhook_endpoints' do
-      returned_ids = result.webhook_endpoints.pluck(:id)
-
-      aggregate_failures do
-        expect(result.webhook_endpoints.count).to eq(2)
-        expect(returned_ids).to include(webhook_endpoint_first.id)
-        expect(returned_ids).to include(webhook_endpoint_second.id)
-        expect(returned_ids).not_to include(webhook_endpoint_third.id)
-        expect(returned_ids).not_to include(webhook_endpoint_fourth.id)
-      end
+    it "returns only two webhook_endpoints" do
+      expect(result.webhook_endpoints.count).to eq(2)
+      expect(returned_ids).to include(webhook_endpoint_first.id)
+      expect(returned_ids).to include(webhook_endpoint_second.id)
+      expect(returned_ids).not_to include(webhook_endpoint_third.id)
+      expect(returned_ids).not_to include(webhook_endpoint_fourth.id)
     end
   end
 end

--- a/spec/queries/webhooks_query_spec.rb
+++ b/spec/queries/webhooks_query_spec.rb
@@ -32,6 +32,27 @@ RSpec.describe WebhooksQuery, type: :query do
     expect(returned_ids).to include(webhook_other_type.id)
   end
 
+  context "when webhooks have the same values for the ordering criteria" do
+    let(:webhook_failed) do
+      create(
+        :webhook,
+        :failed,
+        webhook_endpoint:,
+        id: "00000000-0000-0000-0000-000000000000",
+        created_at: webhook_succeeded.created_at,
+        updated_at: webhook_succeeded.updated_at
+      )
+    end
+
+    it "returns a consistent list" do
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(3)
+      expect(returned_ids).to include(webhook_succeeded.id)
+      expect(returned_ids).to include(webhook_failed.id)
+      expect(returned_ids.index(webhook_succeeded.id)).to be > returned_ids.index(webhook_failed.id)
+    end
+  end
+
   context "with pagination" do
     let(:pagination) { {page: 2, limit: 2} }
 

--- a/spec/queries/webhooks_query_spec.rb
+++ b/spec/queries/webhooks_query_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe WebhooksQuery, type: :query do
     let(:search_term) { "generated" }
 
     it "returns only one webhook" do
-
       expect(returned_ids.count).to eq(1)
       expect(returned_ids).to include(webhook_other_type.id)
     end
@@ -82,7 +81,6 @@ RSpec.describe WebhooksQuery, type: :query do
     let(:filters) { {status: "succeeded"} }
 
     it "returns only one webhook" do
-
       expect(returned_ids.count).to eq(1)
       expect(returned_ids).to include(webhook_succeeded.id)
     end

--- a/spec/queries/webhooks_query_spec.rb
+++ b/spec/queries/webhooks_query_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe WebhooksQuery, type: :query do
   subject(:result) do
     described_class.call(webhook_endpoint:, pagination:, search_term:, filters:)
   end
+
+  let(:returned_ids) { result.webhooks.pluck(:id) }
 
   let(:pagination) { nil }
   let(:search_term) { nil }
@@ -15,7 +17,7 @@ RSpec.describe WebhooksQuery, type: :query do
   let(:webhook_endpoint) { create(:webhook_endpoint) }
   let(:webhook_succeeded) { create(:webhook, :succeeded, webhook_endpoint:) }
   let(:webhook_failed) { create(:webhook, :failed, webhook_endpoint:) }
-  let(:webhook_other_type) { create(:webhook, :succeeded, webhook_endpoint:, webhook_type: 'invoice.generated') }
+  let(:webhook_other_type) { create(:webhook, :succeeded, webhook_endpoint:, webhook_type: "invoice.generated") }
 
   before do
     webhook_succeeded
@@ -23,57 +25,45 @@ RSpec.describe WebhooksQuery, type: :query do
     webhook_other_type
   end
 
-  it 'returns all webhooks' do
-    returned_ids = result.webhooks.pluck(:id)
+  it "returns all webhooks" do
+    expect(returned_ids.count).to eq(3)
+    expect(returned_ids).to include(webhook_succeeded.id)
+    expect(returned_ids).to include(webhook_failed.id)
+    expect(returned_ids).to include(webhook_other_type.id)
+  end
 
-    aggregate_failures do
-      expect(returned_ids.count).to eq(3)
-      expect(returned_ids).to include(webhook_succeeded.id)
-      expect(returned_ids).to include(webhook_failed.id)
+  context "with pagination" do
+    let(:pagination) { {page: 2, limit: 2} }
+
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.webhooks.count).to eq(1)
+      expect(result.webhooks.current_page).to eq(2)
+      expect(result.webhooks.prev_page).to eq(1)
+      expect(result.webhooks.next_page).to be_nil
+      expect(result.webhooks.total_pages).to eq(2)
+      expect(result.webhooks.total_count).to eq(3)
+    end
+  end
+
+  context "when search for /generated/ term" do
+    let(:search_term) { "generated" }
+
+    it "returns only one webhook" do
+
+      expect(returned_ids.count).to eq(1)
       expect(returned_ids).to include(webhook_other_type.id)
     end
   end
 
-  context 'with pagination' do
-    let(:pagination) { {page: 2, limit: 2} }
+  context "when search for /created/ term and filtering by status" do
+    let(:search_term) { "created" }
+    let(:filters) { {status: "succeeded"} }
 
-    it 'applies the pagination' do
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.webhooks.count).to eq(1)
-        expect(result.webhooks.current_page).to eq(2)
-        expect(result.webhooks.prev_page).to eq(1)
-        expect(result.webhooks.next_page).to be_nil
-        expect(result.webhooks.total_pages).to eq(2)
-        expect(result.webhooks.total_count).to eq(3)
-      end
-    end
-  end
+    it "returns only one webhook" do
 
-  context 'when search for /generated/ term' do
-    let(:search_term) { 'generated' }
-
-    it 'returns only one webhook' do
-      returned_ids = result.webhooks.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(1)
-        expect(returned_ids).to include(webhook_other_type.id)
-      end
-    end
-  end
-
-  context 'when search for /created/ term and filtering by status' do
-    let(:search_term) { 'created' }
-    let(:filters) { {status: 'succeeded'} }
-
-    it 'returns only one webhook' do
-      returned_ids = result.webhooks.pluck(:id)
-
-      aggregate_failures do
-        expect(returned_ids.count).to eq(1)
-        expect(returned_ids).to include(webhook_succeeded.id)
-      end
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).to include(webhook_succeeded.id)
     end
   end
 end

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -649,6 +649,25 @@ RSpec.describe Api::V1::PlansController, type: :request do
       expect(json[:plans].first[:usage_thresholds].count).to eq(1)
     end
 
+    context "when pending for deletion plan exists" do
+      subject { get_with_token(organization, "/api/v1/plans") }
+
+      let(:plan_pending_for_deletion) do
+        create(:plan, organization:, pending_deletion: true)
+      end
+
+      before { plan_pending_for_deletion }
+
+      it "includes the plan in the response" do
+        subject
+
+        expect(response).to have_http_status(:success)
+
+        expect(json[:plans].count).to eq(2)
+        expect(json[:plans].map { |p| p[:lago_id] }).to include(plan_pending_for_deletion.id)
+      end
+    end
+
     context 'with pagination' do
       before { create(:plan, organization:) }
 


### PR DESCRIPTION
## Context

Some endpoints like `GET /api/v1/credit_notes`  provide duplicate results on pagination as created_at is not accurate enough to effectively order resources by itself.

## Description

This change updates all API/v1 controllers to use query objects to retrieve records for the `GET / (index)` endpoints. Also, apply default ordering by created_at :desc and id :asc to ensure records stay in their position when going through pages.

Query classes specs are re-styled to the current rules we are following.