### PR TITLE
misc: Delete webhooks directly from the database when deleting webhook endpoint

### DIFF
--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -9,7 +9,7 @@ class WebhookEndpoint < ApplicationRecord
   ].freeze
 
   belongs_to :organization
-  has_many :webhooks, dependent: :destroy
+  has_many :webhooks, dependent: :delete_all
 
   validates :webhook_url, presence: true, url: true
   validates :webhook_url, uniqueness: {scope: :organization_id}

--- a/spec/models/webhook_endpoint_spec.rb
+++ b/spec/models/webhook_endpoint_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe WebhookEndpoint, type: :model do
   it { is_expected.to belong_to(:organization) }
-  it { is_expected.to have_many(:webhooks).dependent(:destroy) }
+  it { is_expected.to have_many(:webhooks).dependent(:delete_all) }
 
   it { is_expected.to validate_presence_of(:webhook_url) }
 


### PR DESCRIPTION
The goal of this PR is to improve performance when deleting a webhook endpoint associated to several webhooks.