### PR TITLE
fix: update regrouped invoice pdf with percentage details on fees

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -61,12 +61,6 @@ class Charge < ApplicationRecord
     standard? || dynamic?
   end
 
-  def basic_rate_percentage?
-    return false unless percentage?
-
-    properties.keys == ['rate']
-  end
-
   def equal_properties?(charge)
     charge_model == charge.charge_model && properties == charge.properties
   end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -155,6 +155,17 @@ class Fee < ApplicationRecord
     amount_currency
   end
 
+  def basic_rate_percentage?
+    return false unless charge?
+    return false unless charge.percentage?
+
+    if charge_filter
+      charge_filter.properties.keys == ['rate']
+    else
+      charge.properties.keys == ['rate']
+    end
+  end
+
   def sub_total_excluding_taxes_amount_cents
     amount_cents - precise_coupons_amount_cents
   end

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -456,7 +456,7 @@ html
           - fees.order(:succeeded_at, :created_at).each do |fee|
             tr
               - if fee.charge.percentage? && fee.amount_details.present?
-                - if fee.charge.basic_rate_percentage?
+                - if fee.basic_rate_percentage?
                   tr
                     td.body-1
                       = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -546,20 +546,6 @@ RSpec.describe Charge, type: :model do
     end
   end
 
-  describe '#basic_rate_percentage?' do
-    it 'returns false if charge model is not percentage' do
-      expect(build(:standard_charge)).not_to be_basic_rate_percentage
-    end
-
-    it 'returns false if charge model is percentage but has other properties except rate' do
-      expect(build(:charge, charge_model: 'percentage', properties: {fixed_amount: '20'})).not_to be_basic_rate_percentage
-    end
-
-    it 'returns true only if properties of percentage charge contain only rate' do
-      expect(build(:charge, charge_model: 'percentage', properties: {rate: '0.20'})).to be_basic_rate_percentage
-    end
-  end
-
   describe '#equal_properties?' do
     let(:charge1) { build(:standard_charge, properties: {amount: 100}) }
 

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -453,4 +453,51 @@ RSpec.describe Fee, type: :model do
       end
     end
   end
+
+  describe '#basic_rate_percentage?' do
+    let(:fee) { create(:fee, fee_type: :charge, charge:, amount_cents: 1000, total_aggregated_units: 1) }
+    let(:charge) { create(:standard_charge) }
+
+    it 'returns false if charge model is not percentage' do
+      expect(fee).not_to be_basic_rate_percentage
+    end
+
+    context 'when charge model is percentage but has other properties except rate' do
+      let(:charge) { create(:charge, charge_model: 'percentage', properties: {rate: '0', fixed_amount: '20'}) }
+
+      it 'returns false' do
+        expect(fee).not_to be_basic_rate_percentage
+      end
+    end
+
+    context 'when properties of percentage charge contain only rate' do
+      let(:charge) { create(:charge, charge_model: 'percentage', properties: {rate: '0'}) }
+
+      it 'returns true' do
+        expect(fee).to be_basic_rate_percentage
+      end
+    end
+
+    context 'when charge is percentage and there are charge filters' do
+      let(:charge) { create(:charge, charge_model: 'percentage', properties: {rate: '0'}) }
+
+      before { fee.update!(charge_filter:) }
+
+      context 'when filter has other properties except rate' do
+        let(:charge_filter) { create(:charge_filter, charge:, properties: {rate: '0', fixed_amount: '20'}) }
+
+        it 'returns false' do
+          expect(fee).not_to be_basic_rate_percentage
+        end
+      end
+
+      context 'when filter properties contain only rate' do
+        let(:charge_filter) { create(:charge_filter, charge:, properties: {rate: '0'}) }
+
+        it 'returns true' do
+          expect(fee).to be_basic_rate_percentage
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

When charge has filters, fee details are not displayed for percentage charge model in the invoice PDF

## Description

This PR ensures that fee details are properly displayed in the invoice PDF
