### PR TITLE
fix(daily_usage): targets only charge fees

### DIFF
--- a/app/services/daily_usages/fill_from_invoice_service.rb
+++ b/app/services/daily_usages/fill_from_invoice_service.rb
@@ -54,7 +54,7 @@ module DailyUsages
         amount_cents: invoice.fees_amount_cents,
         total_amount_cents: invoice.fees.sum(&:total_amount_cents),
         taxes_amount_cents: invoice.fees.sum(:taxes_amount_cents),
-        fees: invoice.fees.select { |f| f.subscription_id == subscription.id }
+        fees: invoice.fees.charge.select { |f| f.subscription_id == subscription.id }
       )
     end
 


### PR DESCRIPTION
## Description

This PR is a fix for `undefined method charge_model for nil` raised in `DailyUsages::FillFromInvoiceJob`.
The issue is raised because the job was not excluding subscription fees when serializing the usage data for the `DailyUsage` computation.
