### PR TITLE
feat: Increase metadata max value length

### DIFF
--- a/app/models/metadata/customer_metadata.rb
+++ b/app/models/metadata/customer_metadata.rb
@@ -7,7 +7,7 @@ module Metadata
     belongs_to :customer
 
     validates :key, presence: true, uniqueness: {scope: :customer_id}, length: {maximum: 20}
-    validates :value, presence: true, length: {maximum: 40}
+    validates :value, presence: true, length: {maximum: 100}
 
     scope :displayable, -> { where(display_in_invoice: true) }
   end

--- a/app/services/validators/metadata_validator.rb
+++ b/app/services/validators/metadata_validator.rb
@@ -5,7 +5,7 @@ module Validators
     DEFAULT_CONFIG = {
       max_keys: 5,
       max_key_length: 20,
-      max_value_length: 40
+      max_value_length: 100
     }.freeze
 
     attr_reader :metadata, :errors, :config

--- a/spec/models/metadata/customer_metadata_spec.rb
+++ b/spec/models/metadata/customer_metadata_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe Metadata::CustomerMetadata, type: :model do
     end
 
     context 'when value length is invalid' do
-      let(:value) { 'abcde-abcde-abcde-abcde-abcde-abcde' }
+      let(:value) { 'a' * 101 }
 
-      it { expect(metadata).to be_valid }
+      it { expect(metadata).not_to be_valid }
     end
   end
 end


### PR DESCRIPTION

## Context

increased customer and  wallet transactions metadata value size limit to 100 
