### PR TITLE
feat(netsuite): Add fees period dates to invoice payload

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -98,13 +98,18 @@ module Integrations
               raise Integrations::Aggregator::BasePayload::Failure.new(nil, code: 'invalid_mapping')
             end
 
+            from_property = fee.charge? ? 'charges_from_datetime' : 'from_datetime'
+            to_property = fee.charge? ? 'charges_to_datetime' : 'to_datetime'
+
             {
               'item' => mapped_item.external_id,
               'account' => mapped_item.external_account_code,
               'quantity' => limited_rate(fee.units),
               'rate' => limited_rate(fee.precise_unit_amount),
               'amount' => limited_rate(amount(fee.amount_cents, resource: invoice)),
-              'taxdetailsreference' => fee.id
+              'taxdetailsreference' => fee.id,
+              'custcol_service_period_date_from' => fee.properties[from_property]&.to_date&.strftime("%-m/%-d/%Y"),
+              'custcol_service_period_date_to' => fee.properties[to_property]&.to_date&.strftime("%-m/%-d/%Y")
             }
           end
 

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -160,7 +160,9 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
               'quantity' => 0.0,
               'rate' => 0.0,
               'amount' => 2.0,
-              'taxdetailsreference' => anything
+              'taxdetailsreference' => anything,
+              'custcol_service_period_date_from' => anything,
+              'custcol_service_period_date_to' => anything
             },
             {
               'item' => '4',
@@ -168,7 +170,9 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
               'quantity' => 0.0,
               'rate' => 0.0,
               'amount' => 2.0,
-              'taxdetailsreference' => anything
+              'taxdetailsreference' => anything,
+              'custcol_service_period_date_from' => anything,
+              'custcol_service_period_date_to' => anything
             },
             {
               'item' => 'm2',
@@ -176,7 +180,9 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
               'quantity' => 2,
               'rate' => 4.1212121212334,
               'amount' => 2.0,
-              'taxdetailsreference' => anything
+              'taxdetailsreference' => anything,
+              'custcol_service_period_date_from' => anything,
+              'custcol_service_period_date_to' => anything
             },
             {
               'item' => '2',

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -168,7 +168,10 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
                 'quantity' => 0.0,
                 'rate' => 0.0,
                 'amount' => 100.0,
-                'taxdetailsreference' => fee_sub.id
+                'taxdetailsreference' => fee_sub.id,
+                'custcol_service_period_date_from' =>
+                  fee_sub.properties['from_datetime']&.to_date&.strftime("%-m/%-d/%Y"),
+                'custcol_service_period_date_to' => fee_sub.properties['to_datetime']&.to_date&.strftime("%-m/%-d/%Y")
               },
               {
                 'item' => '4',
@@ -176,7 +179,11 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
                 'quantity' => 0.0,
                 'rate' => 0.0,
                 'amount' => 2.0,
-                'taxdetailsreference' => minimum_commitment_fee.id
+                'taxdetailsreference' => minimum_commitment_fee.id,
+                'custcol_service_period_date_from' =>
+                  minimum_commitment_fee.properties['from_datetime']&.to_date&.strftime("%-m/%-d/%Y"),
+                'custcol_service_period_date_to' =>
+                  minimum_commitment_fee.properties['to_datetime']&.to_date&.strftime("%-m/%-d/%Y")
               },
               {
                 'item' => 'm2',
@@ -184,7 +191,11 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
                 'quantity' => 2,
                 'rate' => 4.1212121212334,
                 'amount' => 2.0,
-                'taxdetailsreference' => charge_fee.id
+                'taxdetailsreference' => charge_fee.id,
+                'custcol_service_period_date_from' =>
+                  charge_fee.properties['charges_from_datetime']&.to_date&.strftime("%-m/%-d/%Y"),
+                'custcol_service_period_date_to' =>
+                  charge_fee.properties['charges_to_datetime']&.to_date&.strftime("%-m/%-d/%Y")
               },
               {
                 'item' => '2',


### PR DESCRIPTION
## Description

Add `custcol_service_period_date_from` and `custcol_service_period_date_to` attributes to the invoice payload for fee lines items.

Coupons, credits and credit notes will not contain these fields.