### PR TITLE
misc(payment): Refactor payment creation on provider

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -171,6 +171,10 @@ class BaseService
     raise NotImplementedError
   end
 
+  def call!(*, &)
+    call(*, &).raise_if_error!
+  end
+
   def call_async(**args, &block)
     raise NotImplementedError
   end

--- a/app/services/payment_providers/adyen/payments/create_service.rb
+++ b/app/services/payment_providers/adyen/payments/create_service.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Adyen
+    module Payments
+      class CreateService < BaseService
+        PENDING_STATUSES = %w[AuthorisedPending Received].freeze
+        SUCCESS_STATUSES = %w[Authorised SentForSettle SettleScheduled Settled Refunded].freeze
+        FAILED_STATUSES = %w[Cancelled CaptureFailed Error Expired Refused].freeze
+
+        def initialize(invoice:, provider_customer:)
+          @invoice = invoice
+          @provider_customer = provider_customer
+
+          super
+        end
+
+        def call
+          result.invoice = invoice
+
+          adyen_result = create_adyen_payment
+
+          if adyen_result.status > 400
+            result.error_message = adyen_result.response["message"]
+            result.error_code = adyen_result.response["errorType"]
+            return result
+          end
+
+          payment = Payment.new(
+            payable: invoice,
+            payment_provider_id: payment_provider.id,
+            payment_provider_customer_id: provider_customer.id,
+            amount_cents: invoice.total_amount_cents,
+            amount_currency: invoice.currency.upcase,
+            provider_payment_id: adyen_result.response["pspReference"],
+            status: adyen_result.response["resultCode"]
+          )
+          payment.save!
+
+          result.payment_status = payment_status_mapping(payment.status)
+          result.payment = payment
+          result
+        rescue ::Adyen::AuthenticationError, ::Adyen::ValidationError => e
+          result.error_message = e.msg
+          result.error_code = e.code
+          result.payment_status = :failed
+          result
+        rescue ::Adyen::AdyenError => e
+          result.error_message = e.msg
+          result.error_code = e.code
+          result.payment_status = :failed
+          result.service_failure!(code: "adyen_error", message: "#{e.code}: #{e.msg}")
+        rescue Faraday::ConnectionFailed => e
+          raise Invoices::Payments::ConnectionError, e
+        end
+
+        private
+
+        attr_reader :invoice, :provider_customer
+
+        delegate :payment_provider, :customer, to: :provider_customer
+
+        def client
+          @client ||= ::Adyen::Client.new(
+            api_key: payment_provider.api_key,
+            env: payment_provider.environment,
+            live_url_prefix: payment_provider.live_prefix
+          )
+        end
+
+        def success_redirect_url
+          payment_provider.success_redirect_url.presence || ::PaymentProviders::AdyenProvider::SUCCESS_REDIRECT_URL
+        end
+
+        def update_payment_method_id
+          result = client.checkout.payments_api.payment_methods(
+            Lago::Adyen::Params.new(payment_method_params).to_h
+          ).response
+
+          payment_method_id = result["storedPaymentMethods"]&.first&.dig("id")
+          provider_customer.update!(payment_method_id:) if payment_method_id
+        end
+
+        def create_adyen_payment
+          update_payment_method_id
+
+          client.checkout.payments_api.payments(Lago::Adyen::Params.new(payment_params).to_h)
+        end
+
+        def payment_method_params
+          {
+            merchantAccount: payment_provider.merchant_account,
+            shopperReference: provider_customer.provider_customer_id
+          }
+        end
+
+        def payment_params
+          prms = {
+            amount: {
+              currency: invoice.currency.upcase,
+              value: invoice.total_amount_cents
+            },
+            reference: invoice.number,
+            paymentMethod: {
+              type: "scheme",
+              storedPaymentMethodId: provider_customer.payment_method_id
+            },
+            shopperReference: provider_customer.provider_customer_id,
+            merchantAccount: payment_provider.merchant_account,
+            shopperInteraction: "ContAuth",
+            recurringProcessingModel: "UnscheduledCardOnFile"
+          }
+          prms[:shopperEmail] = customer.email if customer.email
+          prms
+        end
+
+        def payment_status_mapping(payment_status)
+          return :pending if PENDING_STATUSES.include?(payment_status)
+          return :succeeded if SUCCESS_STATUSES.include?(payment_status)
+          return :failed if FAILED_STATUSES.include?(payment_status)
+
+          payment_status
+        end
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/create_payment_factory.rb
+++ b/app/services/payment_providers/create_payment_factory.rb
@@ -2,8 +2,8 @@
 
 module PaymentProviders
   class CreatePaymentFactory
-    def self.new_instance(provider:, invoice:)
-      service_class(provider:).new(invoice)
+    def self.new_instance(provider:, invoice:, provider_customer:)
+      service_class(provider:).new(invoice:, provider_customer:)
     end
 
     def self.service_class(provider:)
@@ -11,11 +11,11 @@ module PaymentProviders
       #                into PaymentProviders::*::Payments::CreateService#call
       case provider.to_sym
       when :adyen
-        Invoices::Payments::AdyenService
+        PaymentProviders::Adyen::Payments::CreateService
       when :gocardless
-        Invoices::Payments::GocardlessService
+        PaymentProviders::Gocardless::Payments::CreateService
       when :stripe
-        Invoices::Payments::StripeService
+        PaymentProviders::Stripe::Payments::CreateService
       end
     end
   end

--- a/app/services/payment_providers/gocardless/payments/create_service.rb
+++ b/app/services/payment_providers/gocardless/payments/create_service.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Gocardless
+    module Payments
+      class CreateService < BaseService
+        class MandateNotFoundError < StandardError
+          DEFAULT_MESSAGE = "No mandate available for payment"
+          ERROR_CODE = "no_mandate_error"
+
+          def initialize(msg = DEFAULT_MESSAGE)
+            super
+          end
+
+          def code
+            ERROR_CODE
+          end
+        end
+
+        def initialize(invoice:, provider_customer:)
+          @invoice = invoice
+          @provider_customer = provider_customer
+
+          super
+        end
+
+        PENDING_STATUSES = %w[pending_customer_approval pending_submission submitted confirmed]
+          .freeze
+        SUCCESS_STATUSES = %w[paid_out].freeze
+        FAILED_STATUSES = %w[cancelled customer_approval_denied failed charged_back].freeze
+
+        def call
+          result.invoice = invoice
+
+          gocardless_result = create_gocardless_payment
+
+          payment = Payment.new(
+            payable: invoice,
+            payment_provider_id: payment_provider.id,
+            payment_provider_customer_id: provider_customer.id,
+            amount_cents: gocardless_result.amount,
+            amount_currency: gocardless_result.currency&.upcase,
+            provider_payment_id: gocardless_result.id,
+            status: gocardless_result.status
+          )
+          payment.save!
+
+          result.payment_status = payment_status_mapping(payment.status)
+          result.payment = payment
+          result
+        rescue GoCardlessPro::ValidationError => e
+          result.error_message = e.message
+          result.error_code = e.code
+          result.payment_status = :failed
+          result
+        rescue MandateNotFoundError, GoCardlessPro::Error => e
+          result.error_message = e.message
+          result.error_code = e.code
+          result.payment_status = :failed
+          result.service_failure!(code: "gocardless_error", message: "#{e.code}: #{e.message}")
+        end
+
+        attr_reader :invoice, :provider_customer
+
+        delegate :payment_provider, :customer, to: :provider_customer
+
+        def client
+          @client ||= GoCardlessPro::Client.new(
+            access_token: payment_provider.access_token,
+            environment: payment_provider.environment
+          )
+        end
+
+        def mandate_id
+          result = client.mandates.list(
+            params: {
+              customer: provider_customer.provider_customer_id,
+              status: %w[pending_customer_approval pending_submission submitted active]
+            }
+          )
+
+          mandate = result&.records&.first
+
+          raise MandateNotFoundError unless mandate
+
+          provider_customer.provider_mandate_id = mandate.id
+          provider_customer.save!
+
+          mandate.id
+        end
+
+        def create_gocardless_payment
+          client.payments.create(
+            params: {
+              amount: invoice.total_amount_cents,
+              currency: invoice.currency.upcase,
+              retry_if_possible: false,
+              metadata: {
+                lago_customer_id: customer.id,
+                lago_invoice_id: invoice.id,
+                invoice_issuing_date: invoice.issuing_date.iso8601
+              },
+              links: {
+                mandate: mandate_id
+              }
+            },
+            headers: {
+              "Idempotency-Key" => "#{invoice.id}/#{invoice.payment_attempts}"
+            }
+          )
+        end
+
+        def payment_status_mapping(payment_status)
+          return :pending if PENDING_STATUSES.include?(payment_status)
+          return :succeeded if SUCCESS_STATUSES.include?(payment_status)
+          return :failed if FAILED_STATUSES.include?(payment_status)
+
+          payment_status
+        end
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    module Payments
+      class CreateService < BaseService
+        PENDING_STATUSES = %w[processing requires_capture requires_action requires_confirmation requires_payment_method]
+          .freeze
+        SUCCESS_STATUSES = %w[succeeded].freeze
+        FAILED_STATUSES = %w[canceled].freeze
+
+        def initialize(invoice:, provider_customer:)
+          @invoice = invoice
+          @provider_customer = provider_customer
+
+          super
+        end
+
+        def call
+          result.invoice = invoice
+
+          stripe_result = create_payment_intent
+          # NOTE: return if payment was not processed
+          return result unless stripe_result
+
+          payment = Payment.new(
+            payable: invoice,
+            payment_provider_id: payment_provider.id,
+            payment_provider_customer_id: provider_customer.id,
+            amount_cents: stripe_result.amount,
+            amount_currency: stripe_result.currency&.upcase,
+            provider_payment_id: stripe_result.id,
+            status: stripe_result.status
+          )
+
+          payment.provider_payment_data = stripe_result.next_action if stripe_result.status == "requires_action"
+          payment.save!
+
+          handle_requires_action(payment) if payment.status == "requires_action"
+
+          result.payment_status = payment_status_mapping(payment.status)
+          result.payment = payment
+          result
+        rescue ::Stripe::AuthenticationError, ::Stripe::CardError, ::Stripe::InvalidRequestError, ::Stripe::PermissionError => e
+          # NOTE: Do not mark the invoice as failed if the amount is too small for Stripe
+          #       For now we keep it as pending, the user can still update it manually
+          return result if e.code == "amount_too_small"
+
+          result.error_message = e.message
+          result.error_code = e.code
+          result.payment_status = :failed
+          result
+        rescue ::Stripe::RateLimitError => e
+          raise Invoices::Payments::RateLimitError, e
+        rescue ::Stripe::APIConnectionError => e
+          raise Invoices::Payments::ConnectionError, e
+        rescue ::Stripe::StripeError => e
+          result.error_message = e.message
+          result.error_code = e.code
+          result.service_failure!(code: "stripe_error", message: e.message)
+        end
+
+        private
+
+        attr_reader :invoice, :provider_customer
+
+        delegate :payment_provider, to: :provider_customer
+
+        def payment_status_mapping(payment_status)
+          return :pending if PENDING_STATUSES.include?(payment_status)
+          return :succeeded if SUCCESS_STATUSES.include?(payment_status)
+          return :failed if FAILED_STATUSES.include?(payment_status)
+
+          payment_status
+        end
+
+        def handle_requires_action(payment)
+          SendWebhookJob.perform_later("payment.requires_action", payment, {
+            provider_customer_id: provider_customer.provider_customer_id
+          })
+        end
+
+        def stripe_payment_method
+          payment_method_id = provider_customer.payment_method_id
+
+          if payment_method_id
+            # NOTE: Check if payment method still exists
+            customer_service = PaymentProviderCustomers::StripeService.new(provider_customer)
+            customer_service_result = customer_service.check_payment_method(payment_method_id)
+            return customer_service_result.payment_method.id if customer_service_result.success?
+          end
+
+          # NOTE: Retrieve list of existing payment_methods
+          payment_method = ::Stripe::PaymentMethod.list(
+            {customer: provider_customer.provider_customer_id},
+            {api_key: payment_provider.secret_key}
+          ).first
+          provider_customer.update!(payment_method_id: payment_method&.id)
+
+          payment_method&.id
+        end
+
+        def update_payment_method_id
+          result = ::Stripe::Customer.retrieve(
+            provider_customer.provider_customer_id,
+            {api_key: payment_provider.secret_key}
+          )
+
+          # TODO: stripe customer should be updated/deleted
+          # TODO: deliver error webhook
+          # TODO(payment): update payment status
+          return if result.deleted?
+
+          if (payment_method_id = result.invoice_settings.default_payment_method || result.default_source)
+            provider_customer.update!(payment_method_id:)
+          end
+        end
+
+        def create_payment_intent
+          update_payment_method_id
+
+          ::Stripe::PaymentIntent.create(
+            payment_intent_payload,
+            {
+              api_key: payment_provider.secret_key,
+              # TODO(payment): Rely again on idempotency_key
+              idempotency_key: "#{invoice.id}/#{invoice.payment_attempts}"
+            }
+          )
+        end
+
+        def payment_intent_payload
+          {
+            amount: invoice.total_amount_cents,
+            currency: invoice.currency.downcase,
+            customer: provider_customer.provider_customer_id,
+            payment_method: stripe_payment_method,
+            payment_method_types: provider_customer.provider_payment_methods,
+            confirm: true,
+            off_session: off_session?,
+            return_url: success_redirect_url,
+            error_on_requires_action: error_on_requires_action?,
+            description:,
+            metadata: {
+              lago_customer_id: provider_customer.customer_id,
+              lago_invoice_id: invoice.id,
+              invoice_issuing_date: invoice.issuing_date.iso8601,
+              invoice_type: invoice.invoice_type
+            }
+          }
+        end
+
+        def success_redirect_url
+          payment_provider.success_redirect_url.presence || ::PaymentProviders::StripeProvider::SUCCESS_REDIRECT_URL
+        end
+
+        # NOTE: Due to RBI limitation, all indians payment should be off_session
+        # to permit 3D secure authentication
+        # https://docs.stripe.com/india-recurring-payments
+        def off_session?
+          invoice.customer.country != "IN"
+        end
+
+        # NOTE: Same as off_session?
+        def error_on_requires_action?
+          invoice.customer.country != "IN"
+        end
+
+        def description
+          "#{invoice.organization.name} - Invoice #{invoice.number}"
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/payments/adyen_service_spec.rb
+++ b/spec/services/invoices/payments/adyen_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Invoices::Payments::AdyenService, type: :service do
   subject(:adyen_service) { described_class.new(invoice) }
@@ -16,7 +16,7 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
   let(:checkout) { Adyen::Checkout.new(adyen_client, 70) }
   let(:payments_response) { generate(:adyen_payments_response) }
   let(:payment_methods_response) { generate(:adyen_payment_methods_response) }
-  let(:code) { 'adyen_1' }
+  let(:code) { "adyen_1" }
 
   let(:invoice) do
     create(
@@ -24,234 +24,12 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
       organization:,
       customer:,
       total_amount_cents: 1000,
-      currency: 'USD',
+      currency: "USD",
       ready_for_payment_processing: true
     )
   end
 
-  describe '#call' do
-    before do
-      adyen_payment_provider
-      adyen_customer
-
-      allow(Adyen::Client).to receive(:new)
-        .and_return(adyen_client)
-      allow(adyen_client).to receive(:checkout)
-        .and_return(checkout)
-      allow(checkout).to receive(:payments_api)
-        .and_return(payments_api)
-      allow(payments_api).to receive(:payments)
-        .and_return(payments_response)
-      allow(payments_api).to receive(:payment_methods)
-        .and_return(payment_methods_response)
-      allow(Invoices::PrepaidCreditJob).to receive(:perform_later)
-    end
-
-    it 'creates an adyen payment' do
-      result = adyen_service.call
-
-      expect(result).to be_success
-
-      aggregate_failures do
-        expect(result.invoice).to be_payment_succeeded
-        expect(result.invoice.payment_attempts).to eq(1)
-        expect(result.invoice.reload.ready_for_payment_processing).to eq(false)
-
-        expect(result.payment.id).to be_present
-        expect(result.payment.payable).to eq(invoice)
-        expect(result.payment.payment_provider).to eq(adyen_payment_provider)
-        expect(result.payment.payment_provider_customer).to eq(adyen_customer)
-        expect(result.payment.amount_cents).to eq(invoice.total_amount_cents)
-        expect(result.payment.amount_currency).to eq(invoice.currency)
-        expect(result.payment.status).to eq('Authorised')
-
-        expect(adyen_customer.reload.payment_method_id)
-          .to eq(payment_methods_response.response['storedPaymentMethods'].first['id'])
-      end
-
-      expect(payments_api).to have_received(:payments)
-    end
-
-    it_behaves_like 'syncs payment' do
-      let(:service_call) { adyen_service.call }
-    end
-
-    context 'with no payment provider' do
-      let(:adyen_payment_provider) { nil }
-
-      it 'does not creates a adyen payment' do
-        result = adyen_service.call
-
-        expect(result).to be_success
-
-        aggregate_failures do
-          expect(result.invoice).to eq(invoice)
-          expect(result.payment).to be_nil
-
-          expect(payments_api).not_to have_received(:payments)
-        end
-      end
-    end
-
-    context 'when customer does not have a provider customer id' do
-      before { adyen_customer.update!(provider_customer_id: nil) }
-
-      it 'does not creates a adyen payment' do
-        result = adyen_service.call
-
-        expect(result).to be_success
-
-        aggregate_failures do
-          expect(result.invoice).to eq(invoice)
-          expect(result.payment).to be_nil
-
-          expect(payments_api).not_to have_received(:payments)
-        end
-      end
-    end
-
-    context 'with error response from adyen' do
-      let(:payments_error_response) { generate(:adyen_payments_error_response) }
-
-      before do
-        allow(payments_api).to receive(:payments).and_return(payments_error_response)
-      end
-
-      it 'delivers an error webhook' do
-        expect { adyen_service.call }.to enqueue_job(SendWebhookJob)
-          .with(
-            'invoice.payment_failure',
-            invoice,
-            provider_customer_id: adyen_customer.provider_customer_id,
-            provider_error: {
-              message: 'There are no payment methods available for the given parameters.',
-              error_code: 'validation'
-            }
-          ).on_queue(:webhook)
-      end
-    end
-
-    context 'with validation error on adyen' do
-      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
-
-      let(:subscription) do
-        create(:subscription, organization:, customer:)
-      end
-
-      let(:organization) do
-        create(:organization, webhook_url: 'https://webhook.com')
-      end
-
-      before do
-        subscription
-      end
-
-      context 'when changing payment method fails with invalid card' do
-        before do
-          allow(payments_api).to receive(:payment_methods)
-            .and_raise(Adyen::ValidationError.new('Invalid card number', nil))
-        end
-
-        it 'delivers an error webhook' do
-          allow(Invoices::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
-
-          adyen_service.call
-
-          expect(Invoices::Payments::DeliverErrorWebhookService).to have_received(:call_async)
-          expect(SendWebhookJob).to have_been_enqueued
-            .with(
-              'invoice.payment_failure',
-              invoice,
-              provider_customer_id: adyen_customer.provider_customer_id,
-              provider_error: {
-                message: 'Invalid card number',
-                error_code: nil
-              }
-            ).on_queue(:webhook)
-        end
-
-        context 'when invoice is credit? and open?' do
-          it 'delivers an error webhook' do
-            wallet_transaction = create(:wallet_transaction)
-            create(:fee, fee_type: :credit, invoice: invoice, invoiceable: wallet_transaction)
-            invoice.update! status: :open, invoice_type: :credit
-            allow(Invoices::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
-
-            adyen_service.call
-
-            expect(Invoices::Payments::DeliverErrorWebhookService).to have_received(:call_async)
-            expect(SendWebhookJob).to have_been_enqueued
-              .with(
-                'wallet_transaction.payment_failure',
-                wallet_transaction,
-                provider_customer_id: adyen_customer.provider_customer_id,
-                provider_error: {
-                  message: 'Invalid card number',
-                  error_code: nil
-                }
-              )
-          end
-        end
-      end
-
-      context 'when payment fails with invalid card' do
-        before do
-          allow(payments_api).to receive(:payments)
-            .and_raise(Adyen::ValidationError.new('Invalid card number', nil))
-        end
-
-        it 'delivers an error webhook' do
-          expect { adyen_service.call }.to enqueue_job(SendWebhookJob)
-            .with(
-              'invoice.payment_failure',
-              invoice,
-              provider_customer_id: adyen_customer.provider_customer_id,
-              provider_error: {
-                message: 'Invalid card number',
-                error_code: nil
-              }
-            ).on_queue(:webhook)
-        end
-      end
-    end
-
-    context 'with error on adyen' do
-      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
-
-      let(:subscription) do
-        create(:subscription, organization:, customer:)
-      end
-
-      let(:organization) do
-        create(:organization, webhook_url: 'https://webhook.com')
-      end
-
-      before do
-        subscription
-
-        allow(payments_api).to receive(:payments)
-          .and_raise(Adyen::AdyenError.new(nil, nil, 'error', 'code'))
-      end
-
-      it 'delivers an error webhook' do
-        expect { adyen_service.__send__(:create_adyen_payment) }
-          .to raise_error(Adyen::AdyenError)
-
-        expect(SendWebhookJob).to have_been_enqueued
-          .with(
-            'invoice.payment_failure',
-            invoice,
-            provider_customer_id: adyen_customer.provider_customer_id,
-            provider_error: {
-              message: 'error',
-              error_code: 'code'
-            }
-          )
-      end
-    end
-  end
-
-  describe '#payment_method_params' do
+  describe "#payment_method_params" do
     subject(:payment_method_params) { adyen_service.__send__(:payment_method_params) }
 
     let(:params) do
@@ -266,18 +44,18 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
       adyen_customer
     end
 
-    it 'returns payment method params' do
+    it "returns payment method params" do
       expect(payment_method_params).to eq(params)
     end
   end
 
-  describe '.update_payment_status' do
+  describe ".update_payment_status" do
     let(:payment) do
       create(
         :payment,
         payable: invoice,
-        provider_payment_id: 'ch_123456',
-        status: 'Pending'
+        provider_payment_id: "ch_123456",
+        status: "Pending"
       )
     end
 
@@ -286,67 +64,67 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
       payment
     end
 
-    it 'updates the payment and invoice payment_status' do
+    it "updates the payment and invoice payment_status" do
       result = adyen_service.update_payment_status(
-        provider_payment_id: 'ch_123456',
-        status: 'Authorised'
+        provider_payment_id: "ch_123456",
+        status: "Authorised"
       )
 
       expect(result).to be_success
-      expect(result.payment.status).to eq('Authorised')
+      expect(result.payment.status).to eq("Authorised")
       expect(result.invoice.reload).to have_attributes(
-        payment_status: 'succeeded',
+        payment_status: "succeeded",
         ready_for_payment_processing: false
       )
     end
 
-    context 'when status is failed' do
-      it 'updates the payment and invoice status' do
+    context "when status is failed" do
+      it "updates the payment and invoice status" do
         result = adyen_service.update_payment_status(
-          provider_payment_id: 'ch_123456',
-          status: 'Refused'
+          provider_payment_id: "ch_123456",
+          status: "Refused"
         )
 
         expect(result).to be_success
-        expect(result.payment.status).to eq('Refused')
+        expect(result.payment.status).to eq("Refused")
         expect(result.invoice.reload).to have_attributes(
-          payment_status: 'failed',
+          payment_status: "failed",
           ready_for_payment_processing: true
         )
       end
     end
 
-    context 'when invoice is already payment_succeeded' do
+    context "when invoice is already payment_succeeded" do
       before { invoice.payment_succeeded! }
 
-      it 'does not update the status of invoice and payment' do
+      it "does not update the status of invoice and payment" do
         result = adyen_service.update_payment_status(
-          provider_payment_id: 'ch_123456',
+          provider_payment_id: "ch_123456",
           status: %w[Authorised SentForSettle SettleScheduled Settled Refunded].sample
         )
 
         expect(result).to be_success
-        expect(result.invoice.payment_status).to eq('succeeded')
+        expect(result.invoice.payment_status).to eq("succeeded")
       end
     end
 
-    context 'with invalid status' do
-      it 'does not update the payment_status of invoice' do
+    context "with invalid status" do
+      it "does not update the payment_status of invoice" do
         result = adyen_service.update_payment_status(
-          provider_payment_id: 'ch_123456',
-          status: 'foo-bar'
+          provider_payment_id: "ch_123456",
+          status: "foo-bar"
         )
 
         aggregate_failures do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages.keys).to include(:payment_status)
-          expect(result.error.messages[:payment_status]).to include('value_is_invalid')
+          expect(result.error.messages[:payment_status]).to include("value_is_invalid")
         end
       end
     end
 
-    context 'when payment is not found and it is one time payment' do
+    context "when payment is not found and it is one time payment" do
       let(:payment) { nil }
 
       before do
@@ -354,18 +132,18 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
         adyen_customer
       end
 
-      it 'creates a payment and updates invoice payment status' do
+      it "creates a payment and updates invoice payment status" do
         result = adyen_service.update_payment_status(
-          provider_payment_id: 'ch_123456',
-          status: 'succeeded',
-          metadata: {lago_invoice_id: invoice.id, payment_type: 'one-time'}
+          provider_payment_id: "ch_123456",
+          status: "succeeded",
+          metadata: {lago_invoice_id: invoice.id, payment_type: "one-time"}
         )
 
         aggregate_failures do
           expect(result).to be_success
-          expect(result.payment.status).to eq('succeeded')
+          expect(result.payment.status).to eq("succeeded")
           expect(result.invoice.reload).to have_attributes(
-            payment_status: 'succeeded',
+            payment_status: "succeeded",
             ready_for_payment_processing: false
           )
         end
@@ -373,7 +151,7 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
     end
   end
 
-  describe '#generate_payment_url' do
+  describe "#generate_payment_url" do
     before do
       adyen_payment_provider
       adyen_customer
@@ -388,26 +166,26 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
         .and_return(payment_links_response)
     end
 
-    it 'generates payment url' do
+    it "generates payment url" do
       adyen_service.generate_payment_url
 
       expect(payment_links_api).to have_received(:payment_links)
     end
 
-    context 'when invoice is payment_succeeded' do
+    context "when invoice is payment_succeeded" do
       before { invoice.payment_succeeded! }
 
-      it 'does not generate payment url' do
+      it "does not generate payment url" do
         adyen_service.generate_payment_url
 
         expect(payment_links_api).not_to have_received(:payment_links)
       end
     end
 
-    context 'when invoice is voided' do
+    context "when invoice is voided" do
       before { invoice.voided! }
 
-      it 'does not generate payment url' do
+      it "does not generate payment url" do
         adyen_service.generate_payment_url
 
         expect(payment_links_api).not_to have_received(:payment_links)

--- a/spec/services/invoices/payments/gocardless_service_spec.rb
+++ b/spec/services/invoices/payments/gocardless_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Invoices::Payments::GocardlessService, type: :service do
   subject(:gocardless_service) { described_class.new(argument) }
@@ -14,7 +14,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
   let(:gocardless_mandates_service) { instance_double(GoCardlessPro::Services::MandatesService) }
   let(:gocardless_list_response) { instance_double(GoCardlessPro::ListResponse) }
   let(:argument) { invoice }
-  let(:code) { 'gocardless_1' }
+  let(:code) { "gocardless_1" }
 
   let(:invoice) do
     create(
@@ -22,203 +22,18 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
       organization:,
       customer:,
       total_amount_cents: 200,
-      currency: 'EUR',
+      currency: "EUR",
       ready_for_payment_processing: true
     )
   end
 
-  describe '.call' do
-    before do
-      gocardless_payment_provider
-      gocardless_customer
-
-      allow(GoCardlessPro::Client).to receive(:new)
-        .and_return(gocardless_client)
-      allow(gocardless_client).to receive(:mandates)
-        .and_return(gocardless_mandates_service)
-      allow(gocardless_mandates_service).to receive(:list)
-        .and_return(gocardless_list_response)
-      allow(gocardless_list_response).to receive(:records)
-        .and_return([GoCardlessPro::Resources::Mandate.new('id' => 'mandate_id')])
-      allow(gocardless_client).to receive(:payments)
-        .and_return(gocardless_payments_service)
-      allow(gocardless_payments_service).to receive(:create)
-        .and_return(GoCardlessPro::Resources::Payment.new(
-          'id' => '_ID_',
-          'amount' => invoice.total_amount_cents,
-          'currency' => invoice.currency,
-          'status' => 'paid_out'
-        ))
-      allow(Invoices::PrepaidCreditJob).to receive(:perform_later)
-    end
-
-    it 'creates a gocardless payment' do
-      result = gocardless_service.call
-
-      expect(result).to be_success
-
-      aggregate_failures do
-        expect(result.invoice).to be_payment_succeeded
-        expect(result.invoice.payment_attempts).to eq(1)
-        expect(result.invoice.reload.ready_for_payment_processing).to eq(false)
-
-        expect(result.payment.id).to be_present
-        expect(result.payment.payable).to eq(invoice)
-        expect(result.payment.payment_provider).to eq(gocardless_payment_provider)
-        expect(result.payment.payment_provider_customer).to eq(gocardless_customer)
-        expect(result.payment.amount_cents).to eq(invoice.total_amount_cents)
-        expect(result.payment.amount_currency).to eq(invoice.currency)
-        expect(result.payment.status).to eq('paid_out')
-        expect(gocardless_customer.reload.provider_mandate_id).to eq('mandate_id')
-      end
-
-      expect(gocardless_payments_service).to have_received(:create)
-    end
-
-    it_behaves_like 'syncs payment' do
-      let(:service_call) { gocardless_service.call }
-    end
-
-    context 'with no payment provider' do
-      let(:gocardless_payment_provider) { nil }
-
-      it 'does not creates a gocardless payment' do
-        result = gocardless_service.call
-
-        expect(result).to be_success
-
-        aggregate_failures do
-          expect(result.invoice).to eq(invoice)
-          expect(result.payment).to be_nil
-
-          expect(gocardless_payments_service).not_to have_received(:create)
-        end
-      end
-    end
-
-    context 'when customer does not have a provider customer id' do
-      before { gocardless_customer.update!(provider_customer_id: nil) }
-
-      it 'does not creates a gocardless payment' do
-        result = gocardless_service.call
-
-        expect(result).to be_success
-
-        aggregate_failures do
-          expect(result.invoice).to eq(invoice)
-          expect(result.payment).to be_nil
-
-          expect(gocardless_payments_service).not_to have_received(:create)
-        end
-      end
-    end
-
-    context 'with error on gocardless' do
-      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
-
-      let(:subscription) do
-        create(:subscription, organization:, customer:)
-      end
-
-      let(:organization) do
-        create(:organization, webhook_url: 'https://webhook.com')
-      end
-
-      before do
-        subscription
-
-        allow(gocardless_payments_service).to receive(:create)
-          .and_raise(GoCardlessPro::Error.new('code' => 'code', 'message' => 'error'))
-      end
-
-      it 'delivers an error webhook' do
-        allow(Invoices::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
-
-        expect { gocardless_service.call }.to raise_error(GoCardlessPro::Error)
-
-        expect(Invoices::Payments::DeliverErrorWebhookService).to have_received(:call_async)
-        expect(SendWebhookJob).to have_been_enqueued
-          .with(
-            'invoice.payment_failure',
-            invoice,
-            provider_customer_id: gocardless_customer.provider_customer_id,
-            provider_error: {
-              message: 'error',
-              error_code: 'code'
-            }
-          )
-      end
-
-      context 'when invoice is credit? and open?' do
-        it 'delivers an error webhook' do
-          wallet_transaction = create(:wallet_transaction)
-          create(:fee, fee_type: :credit, invoice: invoice, invoiceable: wallet_transaction)
-          invoice.update! status: :open, invoice_type: :credit
-          allow(Invoices::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
-
-          expect { gocardless_service.call }.to raise_error(GoCardlessPro::Error)
-
-          expect(Invoices::Payments::DeliverErrorWebhookService).to have_received(:call_async)
-          expect(SendWebhookJob).to have_been_enqueued
-            .with(
-              'wallet_transaction.payment_failure',
-              wallet_transaction,
-              provider_customer_id: gocardless_customer.provider_customer_id,
-              provider_error: {
-                message: 'error',
-                error_code: 'code'
-              }
-            )
-        end
-      end
-    end
-
-    context "when customer has no mandate to make a payment" do
-      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
-      let(:organization) { create(:organization, webhook_url: "https://webhook.com") }
-
-      before do
-        allow(gocardless_list_response).to receive(:records)
-          .and_return([])
-
-        allow(gocardless_payments_service).to receive(:create)
-          .and_raise(GoCardlessPro::Error.new("code" => "code", "message" => "error"))
-      end
-
-      it "delivers an error webhook" do
-        result = gocardless_service.call
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::ServiceFailure)
-          expect(result.error.code).to eq("no_mandate_error")
-          expect(result.error.error_message).to eq("No mandate available for payment")
-          expect(result.invoice.reload).to have_attributes(
-            payment_status: "failed",
-            ready_for_payment_processing: true
-          )
-          expect(SendWebhookJob).to have_been_enqueued
-            .with(
-              "invoice.payment_failure",
-              invoice,
-              provider_customer_id: gocardless_customer.provider_customer_id,
-              provider_error: {
-                message: "No mandate available for payment",
-                error_code: "no_mandate_error"
-              }
-            )
-        end
-      end
-    end
-  end
-
-  describe '.update_payment_status' do
+  describe ".update_payment_status" do
     let(:payment) do
       create(
         :payment,
         payable: invoice,
-        provider_payment_id: 'ch_123456',
-        status: 'pending_submission'
+        provider_payment_id: "ch_123456",
+        status: "pending_submission"
       )
     end
 
@@ -227,79 +42,79 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
       payment
     end
 
-    it 'updates the payment and invoice payment_status' do
+    it "updates the payment and invoice payment_status" do
       result = gocardless_service.update_payment_status(
-        provider_payment_id: 'ch_123456',
-        status: 'paid_out'
+        provider_payment_id: "ch_123456",
+        status: "paid_out"
       )
 
       expect(result).to be_success
-      expect(result.payment.status).to eq('paid_out')
+      expect(result.payment.status).to eq("paid_out")
       expect(result.invoice.reload).to have_attributes(
-        payment_status: 'succeeded',
+        payment_status: "succeeded",
         ready_for_payment_processing: false
       )
     end
 
-    context 'when status is failed' do
-      it 'updates the payment and invoice status' do
+    context "when status is failed" do
+      it "updates the payment and invoice status" do
         result = gocardless_service.update_payment_status(
-          provider_payment_id: 'ch_123456',
-          status: 'failed'
+          provider_payment_id: "ch_123456",
+          status: "failed"
         )
 
         expect(result).to be_success
-        expect(result.payment.status).to eq('failed')
+        expect(result.payment.status).to eq("failed")
         expect(result.invoice.reload).to have_attributes(
-          payment_status: 'failed',
+          payment_status: "failed",
           ready_for_payment_processing: true
         )
       end
     end
 
-    context 'when invoice is already payment_succeeded' do
+    context "when invoice is already payment_succeeded" do
       before { invoice.payment_succeeded! }
 
-      it 'does not update the status of invoice and payment' do
+      it "does not update the status of invoice and payment" do
         result = gocardless_service.update_payment_status(
-          provider_payment_id: 'ch_123456',
-          status: 'paid_out'
+          provider_payment_id: "ch_123456",
+          status: "paid_out"
         )
 
         expect(result).to be_success
-        expect(result.invoice.payment_status).to eq('succeeded')
+        expect(result.invoice.payment_status).to eq("succeeded")
       end
     end
 
-    context 'with invalid status' do
-      it 'does not update the payment_status of invoice' do
+    context "with invalid status" do
+      it "does not update the payment_status of invoice" do
         result = gocardless_service.update_payment_status(
-          provider_payment_id: 'ch_123456',
-          status: 'foo-bar'
+          provider_payment_id: "ch_123456",
+          status: "foo-bar"
         )
 
         aggregate_failures do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages.keys).to include(:payment_status)
-          expect(result.error.messages[:payment_status]).to include('value_is_invalid')
+          expect(result.error.messages[:payment_status]).to include("value_is_invalid")
         end
       end
     end
 
-    context 'when invoice is not passed to constructor' do
+    context "when invoice is not passed to constructor" do
       let(:argument) { nil }
 
-      it 'updates the payment and invoice payment_status' do
+      it "updates the payment and invoice payment_status" do
         result = gocardless_service.update_payment_status(
-          provider_payment_id: 'ch_123456',
-          status: 'paid_out'
+          provider_payment_id: "ch_123456",
+          status: "paid_out"
         )
 
         expect(result).to be_success
-        expect(result.payment.status).to eq('paid_out')
+        expect(result.payment.status).to eq("paid_out")
         expect(result.invoice.reload).to have_attributes(
-          payment_status: 'succeeded',
+          payment_status: "succeeded",
           ready_for_payment_processing: false
         )
       end

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Invoices::Payments::StripeService, type: :service do
   subject(:stripe_service) { described_class.new(invoice) }
@@ -8,8 +8,8 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
   let(:customer) { create(:customer, payment_provider_code: code) }
   let(:organization) { customer.organization }
   let(:stripe_payment_provider) { create(:stripe_provider, organization:, code:) }
-  let(:stripe_customer) { create(:stripe_customer, customer:, payment_method_id: 'pm_123456') }
-  let(:code) { 'stripe_1' }
+  let(:stripe_customer) { create(:stripe_customer, customer:, payment_method_id: "pm_123456") }
+  let(:code) { "stripe_1" }
 
   let(:invoice) do
     create(
@@ -17,406 +17,47 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       organization:,
       customer:,
       total_amount_cents: 200,
-      currency: 'EUR',
+      currency: "EUR",
       ready_for_payment_processing: true
     )
   end
 
-  describe '.call' do
-    let(:provider_customer_service) { instance_double(PaymentProviderCustomers::StripeService) }
-
-    let(:provider_customer_service_result) do
-      BaseService::Result.new.tap do |result|
-        result.payment_method = Stripe::PaymentMethod.new(id: 'pm_123456')
-      end
-    end
-
-    let(:customer_response) do
-      File.read(Rails.root.join('spec/fixtures/stripe/customer_retrieve_response.json'))
-    end
-
-    let(:stripe_payment_intent) do
-      Stripe::PaymentIntent.construct_from(
-        id: 'ch_123456',
-        status: payment_status,
-        amount: invoice.total_amount_cents,
-        currency: invoice.currency
-      )
-    end
-
-    let(:payment_status) { 'succeeded' }
-
-    before do
-      stripe_payment_provider
-      stripe_customer
-
-      allow(Stripe::PaymentIntent).to receive(:create)
-        .and_return(stripe_payment_intent)
-      allow(SegmentTrackJob).to receive(:perform_later)
-      allow(Invoices::PrepaidCreditJob).to receive(:perform_later)
-
-      allow(PaymentProviderCustomers::StripeService).to receive(:new)
-        .and_return(provider_customer_service)
-      allow(provider_customer_service).to receive(:check_payment_method)
-        .and_return(provider_customer_service_result)
-
-      stub_request(:get, "https://api.stripe.com/v1/customers/#{stripe_customer.provider_customer_id}")
-        .to_return(status: 200, body: customer_response, headers: {})
-    end
-
-    it 'creates a stripe payment and a payment' do
-      result = stripe_service.call
-
-      expect(result).to be_success
-
-      aggregate_failures do
-        expect(result.invoice).to be_payment_succeeded
-        expect(result.invoice.payment_attempts).to eq(1)
-        expect(result.invoice.ready_for_payment_processing).to eq(false)
-
-        expect(result.payment.id).to be_present
-        expect(result.payment.payable).to eq(invoice)
-        expect(result.payment.payment_provider).to eq(stripe_payment_provider)
-        expect(result.payment.payment_provider_customer).to eq(stripe_customer)
-        expect(result.payment.amount_cents).to eq(invoice.total_amount_cents)
-        expect(result.payment.amount_currency).to eq(invoice.currency)
-        expect(result.payment.status).to eq('succeeded')
-      end
-
-      expect(Stripe::PaymentIntent).to have_received(:create)
-    end
-
-    it_behaves_like 'syncs payment' do
-      let(:service_call) { stripe_service.call }
-    end
-
-    context 'with no payment provider' do
-      let(:stripe_payment_provider) { nil }
-
-      it 'does not creates a stripe payment' do
-        result = stripe_service.call
-
-        expect(result).to be_success
-
-        aggregate_failures do
-          expect(result.invoice).to eq(invoice)
-          expect(result.payment).to be_nil
-
-          expect(Stripe::PaymentIntent).not_to have_received(:create)
-        end
-      end
-    end
-
-    context 'when customer does not have a provider customer id' do
-      before { stripe_customer.update!(provider_customer_id: nil) }
-
-      it 'does not creates a stripe payment' do
-        result = stripe_service.call
-
-        expect(result).to be_success
-
-        aggregate_failures do
-          expect(result.invoice).to eq(invoice)
-          expect(result.payment).to be_nil
-
-          expect(Stripe::PaymentIntent).not_to have_received(:create)
-        end
-      end
-    end
-
-    context 'when customer does not have a payment method' do
-      let(:stripe_customer) { create(:stripe_customer, customer:) }
-
-      before do
-        allow(Stripe::Customer).to receive(:retrieve)
-          .and_return(Stripe::StripeObject.construct_from(
-            {
-              invoice_settings: {
-                default_payment_method: nil
-              },
-              default_source: nil
-            }
-          ))
-
-        allow(Stripe::PaymentMethod).to receive(:list)
-          .and_return(Stripe::ListObject.construct_from(
-            data: [
-              {
-                id: 'pm_123456',
-                object: 'payment_method',
-                card: {brand: 'visa'},
-                created: 1_656_422_973,
-                customer: 'cus_123456',
-                livemode: false,
-                metadata: {},
-                type: 'card'
-              }
-            ]
-          ))
-      end
-
-      it 'retrieves the payment method' do
-        result = stripe_service.call
-
-        expect(result).to be_success
-        expect(customer.stripe_customer.reload).to be_present
-        expect(customer.stripe_customer.provider_customer_id).to eq(stripe_customer.provider_customer_id)
-        expect(customer.stripe_customer.payment_method_id).to eq('pm_123456')
-
-        expect(Stripe::PaymentMethod).to have_received(:list)
-        expect(Stripe::PaymentIntent).to have_received(:create)
-      end
-    end
-
-    context 'with card error on stripe' do
-      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
-
-      let(:subscription) do
-        create(:subscription, organization:, customer:)
-      end
-
-      let(:organization) do
-        create(:organization, webhook_url: 'https://webhook.com')
-      end
-
-      before do
-        subscription
-
-        allow(Stripe::PaymentIntent).to receive(:create)
-          .and_raise(::Stripe::CardError.new('error', {}))
-      end
-
-      it 'delivers an error webhook' do
-        allow(Invoices::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
-
-        stripe_service.call
-
-        expect(Invoices::Payments::DeliverErrorWebhookService).to have_received(:call_async)
-        expect(SendWebhookJob).to have_been_enqueued
-          .with(
-            'invoice.payment_failure',
-            invoice,
-            provider_customer_id: stripe_customer.provider_customer_id,
-            provider_error: {
-              message: 'error',
-              error_code: nil
-            }
-          )
-      end
-
-      context 'when invoice is credit? and open?' do
-        let(:wallet_transaction) { create(:wallet_transaction) }
-
-        before do
-          create(:fee, fee_type: :credit, invoice: invoice, invoiceable: wallet_transaction)
-          invoice.update! status: :open, invoice_type: :credit
-        end
-
-        it 'delivers an error webhook' do
-          allow(Invoices::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
-
-          stripe_service.call
-
-          expect(Invoices::Payments::DeliverErrorWebhookService).to have_received(:call_async)
-          expect(SendWebhookJob).to have_been_enqueued
-            .with(
-              'wallet_transaction.payment_failure',
-              wallet_transaction,
-              provider_customer_id: stripe_customer.provider_customer_id,
-              provider_error: {
-                message: 'error',
-                error_code: nil
-              }
-            )
-        end
-      end
-    end
-
-    context 'when invoice has a too small amount' do
-      let(:organization) { create(:organization) }
-      let(:customer) { create(:customer, organization:) }
-      let(:subscription) { create(:subscription, organization:, customer:) }
-
-      let(:invoice) do
-        create(
-          :invoice,
-          organization:,
-          customer:,
-          total_amount_cents: 20,
-          currency: 'EUR',
-          ready_for_payment_processing: true
-        )
-      end
-
-      before do
-        subscription
-
-        allow(Stripe::PaymentIntent).to receive(:create)
-          .and_raise(::Stripe::InvalidRequestError.new('amount_too_small', {}, code: 'amount_too_small'))
-      end
-
-      it 'does not send mark the invoice as failed' do
-        stripe_service.call
-        invoice.reload
-
-        expect(invoice).to be_payment_pending
-      end
-    end
-
-    context 'when payment status is processing' do
-      let(:payment_status) { 'processing' }
-
-      it 'creates a stripe payment and a payment' do
-        result = stripe_service.call
-
-        expect(result).to be_success
-
-        aggregate_failures do
-          expect(result.invoice).to be_payment_pending
-          expect(result.invoice.payment_attempts).to eq(1)
-          expect(result.invoice.ready_for_payment_processing).to eq(false)
-
-          expect(result.payment.id).to be_present
-          expect(result.payment.payable).to eq(invoice)
-          expect(result.payment.payment_provider).to eq(stripe_payment_provider)
-          expect(result.payment.payment_provider_customer).to eq(stripe_customer)
-          expect(result.payment.amount_cents).to eq(invoice.total_amount_cents)
-          expect(result.payment.amount_currency).to eq(invoice.currency)
-          expect(result.payment.status).to eq('processing')
-        end
-
-        expect(Stripe::PaymentIntent).to have_received(:create)
-      end
-    end
-
-    context 'when customers country is IN' do
-      let(:payment_status) { 'requires_action' }
-
-      let(:stripe_payment_intent) do
-        Stripe::PaymentIntent.construct_from(
-          id: 'ch_123456',
-          status: payment_status,
-          amount: invoice.total_amount_cents,
-          currency: invoice.currency,
-          next_action: {
-            redirect_to_url: {url: 'https://foo.bar'}
-          }
-        )
-      end
-
-      before do
-        customer.update(country: 'IN')
-      end
-
-      it 'creates a stripe payment and payment with requires_action status' do
-        result = stripe_service.call
-
-        expect(result).to be_success
-
-        aggregate_failures do
-          expect(result.payment.status).to eq('requires_action')
-          expect(result.payment.provider_payment_data).not_to be_empty
-        end
-      end
-
-      it 'has enqueued a SendWebhookJob' do
-        result = stripe_service.call
-
-        expect(SendWebhookJob).to have_been_enqueued
-          .with(
-            'payment.requires_action',
-            result.payment,
-            provider_customer_id: stripe_customer.provider_customer_id
-          )
-      end
-    end
-
-    context 'with #payment_intent_payload' do
-      let(:payment_intent_payload) { stripe_service.__send__(:payment_intent_payload) }
-      let(:payload) do
-        {
-          amount: invoice.total_amount_cents,
-          currency: invoice.currency.downcase,
-          customer: customer.stripe_customer.provider_customer_id,
-          payment_method: customer.stripe_customer.payment_method_id,
-          payment_method_types: customer.stripe_customer.provider_payment_methods,
-          confirm: true,
-          off_session: true,
-          return_url: stripe_service.__send__(:success_redirect_url),
-          error_on_requires_action: true,
-          description: stripe_service.__send__(:description),
-          metadata: {
-            lago_customer_id: customer.id,
-            lago_invoice_id: invoice.id,
-            invoice_issuing_date: invoice.issuing_date.iso8601,
-            invoice_type: invoice.invoice_type
-          }
-        }
-      end
-
-      it 'returns the payload' do
-        expect(payment_intent_payload).to eq(payload)
-      end
-
-      context 'when customers country is IN' do
-        before do
-          payload[:off_session] = false
-          payload[:error_on_requires_action] = false
-          customer.update!(country: 'IN')
-        end
-
-        it 'returns the payload' do
-          expect(payment_intent_payload).to eq(payload)
-        end
-      end
-    end
-
-    context 'with #description' do
-      let(:description_call) { stripe_service.__send__(:description) }
-      let(:description) { "#{organization.name} - Invoice #{invoice.number}" }
-
-      it 'returns the description' do
-        expect(description_call).to eq(description)
-      end
-    end
-  end
-
-  describe '#generate_payment_url' do
+  describe "#generate_payment_url" do
     before do
       stripe_payment_provider
       stripe_customer
 
       allow(::Stripe::Checkout::Session).to receive(:create)
-        .and_return({'url' => 'https://example.com'})
+        .and_return({"url" => "https://example.com"})
     end
 
-    it 'generates payment url' do
+    it "generates payment url" do
       stripe_service.generate_payment_url
 
       expect(::Stripe::Checkout::Session).to have_received(:create)
     end
 
-    context 'when invoice is payment_succeeded' do
+    context "when invoice is payment_succeeded" do
       before { invoice.payment_succeeded! }
 
-      it 'does not generate payment url' do
+      it "does not generate payment url" do
         stripe_service.generate_payment_url
 
         expect(::Stripe::Checkout::Session).not_to have_received(:create)
       end
     end
 
-    context 'when invoice is voided' do
+    context "when invoice is voided" do
       before { invoice.voided! }
 
-      it 'does not generate payment url' do
+      it "does not generate payment url" do
         stripe_service.generate_payment_url
 
         expect(::Stripe::Checkout::Session).not_to have_received(:create)
       end
     end
 
-    context 'with #payment_url_payload' do
+    context "with #payment_url_payload" do
       let(:payment_url_payload) { stripe_service.__send__(:payment_url_payload) }
       let(:payload) do
         {
@@ -432,7 +73,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
               }
             }
           ],
-          mode: 'payment',
+          mode: "payment",
           success_url: stripe_service.__send__(:success_redirect_url),
           customer: customer.stripe_customer.provider_customer_id,
           payment_method_types: customer.stripe_customer.provider_payment_methods,
@@ -443,31 +84,31 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
               lago_invoice_id: invoice.id,
               invoice_issuing_date: invoice.issuing_date.iso8601,
               invoice_type: invoice.invoice_type,
-              payment_type: 'one-time'
+              payment_type: "one-time"
             }
           }
         }
       end
 
-      it 'returns the payload' do
+      it "returns the payload" do
         expect(payment_url_payload).to eq(payload)
       end
     end
   end
 
-  describe '.update_payment_status' do
+  describe ".update_payment_status" do
     let(:payment) do
       create(
         :payment,
         payable: invoice,
-        provider_payment_id: 'ch_123456'
+        provider_payment_id: "ch_123456"
       )
     end
 
     let(:stripe_payment) do
       PaymentProviders::StripeProvider::StripePayment.new(
-        id: 'ch_123456',
-        status: 'succeeded',
+        id: "ch_123456",
+        status: "succeeded",
         metadata: {}
       )
     end
@@ -478,66 +119,66 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       payment
     end
 
-    it 'updates the payment and invoice status' do
+    it "updates the payment and invoice status" do
       result = stripe_service.update_payment_status(
         organization_id: organization.id,
-        status: 'succeeded',
+        status: "succeeded",
         stripe_payment:
       )
 
       expect(result).to be_success
-      expect(result.payment.status).to eq('succeeded')
+      expect(result.payment.status).to eq("succeeded")
       expect(result.invoice.reload).to have_attributes(
-        payment_status: 'succeeded',
+        payment_status: "succeeded",
         ready_for_payment_processing: false
       )
     end
 
-    context 'when status is failed' do
+    context "when status is failed" do
       let(:stripe_payment) do
         PaymentProviders::StripeProvider::StripePayment.new(
-          id: 'ch_123456',
-          status: 'canceled',
+          id: "ch_123456",
+          status: "canceled",
           metadata: {}
         )
       end
 
-      it 'updates the payment and invoice status' do
+      it "updates the payment and invoice status" do
         result = stripe_service.update_payment_status(
           organization_id: organization.id,
-          status: 'failed',
+          status: "failed",
           stripe_payment:
         )
 
         expect(result).to be_success
-        expect(result.payment.status).to eq('failed')
+        expect(result.payment.status).to eq("failed")
         expect(result.invoice.reload).to have_attributes(
-          payment_status: 'failed',
+          payment_status: "failed",
           ready_for_payment_processing: true
         )
       end
     end
 
-    context 'when invoice is already payment_succeeded' do
+    context "when invoice is already payment_succeeded" do
       before { invoice.payment_succeeded! }
 
-      it 'does not update the status of invoice and payment' do
+      it "does not update the status of invoice and payment" do
         result = stripe_service.update_payment_status(
           organization_id: organization.id,
-          status: 'succeeded',
+          status: "succeeded",
           stripe_payment:
         )
 
         expect(result).to be_success
-        expect(result.invoice.payment_status).to eq('succeeded')
+        expect(result.invoice.payment_status).to eq("succeeded")
       end
     end
 
-    context 'with invalid status' do
-      it 'does not update the status of invoice and payment' do
+    context "with invalid status" do
+      it "does not update the status of invoice and payment" do
         result = stripe_service.update_payment_status(
           organization_id: organization.id,
-          status: 'foo-bar',
+          status: "foo-bar",
           stripe_payment:
         )
 
@@ -545,19 +186,19 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages.keys).to include(:payment_status)
-          expect(result.error.messages[:payment_status]).to include('value_is_invalid')
+          expect(result.error.messages[:payment_status]).to include("value_is_invalid")
         end
       end
     end
 
-    context 'when payment is not found and it is one time payment' do
+    context "when payment is not found and it is one time payment" do
       let(:payment) { nil }
 
       let(:stripe_payment) do
         PaymentProviders::StripeProvider::StripePayment.new(
-          id: 'ch_123456',
-          status: 'succeeded',
-          metadata: {lago_invoice_id: invoice.id, payment_type: 'one-time'}
+          id: "ch_123456",
+          status: "succeeded",
+          metadata: {lago_invoice_id: invoice.id, payment_type: "one-time"}
         )
       end
 
@@ -566,55 +207,55 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         stripe_customer
       end
 
-      it 'creates a payment and updates invoice payment status' do
+      it "creates a payment and updates invoice payment status" do
         result = stripe_service.update_payment_status(
           organization_id: organization.id,
-          status: 'succeeded',
+          status: "succeeded",
           stripe_payment:
         )
 
         aggregate_failures do
           expect(result).to be_success
-          expect(result.payment.status).to eq('succeeded')
+          expect(result.payment.status).to eq("succeeded")
           expect(result.invoice.reload).to have_attributes(
-            payment_status: 'succeeded',
+            payment_status: "succeeded",
             ready_for_payment_processing: false
           )
         end
       end
 
-      context 'when invoice is not found' do
+      context "when invoice is not found" do
         let(:stripe_payment) do
           PaymentProviders::StripeProvider::StripePayment.new(
-            id: 'ch_123456',
-            status: 'succeeded',
-            metadata: {lago_invoice_id: 'invalid', payment_type: 'one-time'}
+            id: "ch_123456",
+            status: "succeeded",
+            metadata: {lago_invoice_id: "invalid", payment_type: "one-time"}
           )
         end
 
-        it 'raises a not found failure' do
+        it "raises a not found failure" do
           result = stripe_service.update_payment_status(
             organization_id: organization.id,
-            status: 'succeeded',
+            status: "succeeded",
             stripe_payment:
           )
 
           aggregate_failures do
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq('invoice_not_found')
+            expect(result.error.message).to eq("invoice_not_found")
           end
         end
       end
     end
 
-    context 'when payment is not found' do
+    context "when payment is not found" do
       let(:payment) { nil }
 
-      it 'returns an empty result' do
+      it "returns an empty result" do
         result = stripe_service.update_payment_status(
           organization_id: organization.id,
-          status: 'succeeded',
+          status: "succeeded",
           stripe_payment:
         )
 
@@ -624,19 +265,19 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         end
       end
 
-      context 'with invoice id in metadata' do
+      context "with invoice id in metadata" do
         let(:stripe_payment) do
           PaymentProviders::StripeProvider::StripePayment.new(
-            id: 'ch_123456',
-            status: 'succeeded',
+            id: "ch_123456",
+            status: "succeeded",
             metadata: {lago_invoice_id: SecureRandom.uuid}
           )
         end
 
-        it 'returns an empty result' do
+        it "returns an empty result" do
           result = stripe_service.update_payment_status(
             organization_id: organization.id,
-            status: 'succeeded',
+            status: "succeeded",
             stripe_payment:
           )
 
@@ -646,11 +287,11 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
           end
         end
 
-        context 'when the invoice is found for organization' do
+        context "when the invoice is found for organization" do
           let(:stripe_payment) do
             PaymentProviders::StripeProvider::StripePayment.new(
-              id: 'ch_123456',
-              status: 'succeeded',
+              id: "ch_123456",
+              status: "succeeded",
               metadata: {lago_invoice_id: invoice.id}
             )
           end
@@ -660,17 +301,17 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
             stripe_payment_provider
           end
 
-          it 'creates the missing payment and updates invoice status' do
+          it "creates the missing payment and updates invoice status" do
             result = stripe_service.update_payment_status(
               organization_id: organization.id,
-              status: 'succeeded',
+              status: "succeeded",
               stripe_payment:
             )
 
             expect(result).to be_success
-            expect(result.payment.status).to eq('succeeded')
+            expect(result.payment.status).to eq("succeeded")
             expect(result.invoice.reload).to have_attributes(
-              payment_status: 'succeeded',
+              payment_status: "succeeded",
               ready_for_payment_processing: false
             )
 
@@ -682,8 +323,8 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
               payment_provider_customer_id: stripe_customer.id,
               amount_cents: invoice.total_amount_cents,
               amount_currency: invoice.currency,
-              provider_payment_id: 'ch_123456',
-              status: 'succeeded'
+              provider_payment_id: "ch_123456",
+              status: "succeeded"
             )
           end
         end

--- a/spec/services/payment_providers/adyen/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/adyen/payments/create_service_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Adyen::Payments::CreateService, type: :service do
+  subject(:create_service) { described_class.new(invoice:, provider_customer: adyen_customer) }
+
+  let(:customer) { create(:customer, payment_provider_code: code) }
+  let(:organization) { customer.organization }
+  let(:adyen_payment_provider) { create(:adyen_provider, organization:, code:) }
+  let(:adyen_customer) { create(:adyen_customer, customer:, payment_provider: adyen_payment_provider) }
+  let(:adyen_client) { instance_double(Adyen::Client) }
+  let(:payments_api) { Adyen::PaymentsApi.new(adyen_client, 70) }
+  let(:payment_links_api) { Adyen::PaymentLinksApi.new(adyen_client, 70) }
+  let(:payment_links_response) { generate(:adyen_payment_links_response) }
+  let(:checkout) { Adyen::Checkout.new(adyen_client, 70) }
+  let(:payments_response) { generate(:adyen_payments_response) }
+  let(:payment_methods_response) { generate(:adyen_payment_methods_response) }
+  let(:code) { "adyen_1" }
+
+  let(:invoice) do
+    create(
+      :invoice,
+      organization:,
+      customer:,
+      total_amount_cents: 1000,
+      currency: "USD",
+      ready_for_payment_processing: true
+    )
+  end
+
+  describe "#call" do
+    before do
+      adyen_payment_provider
+      adyen_customer
+
+      allow(::Adyen::Client).to receive(:new)
+        .and_return(adyen_client)
+      allow(adyen_client).to receive(:checkout)
+        .and_return(checkout)
+      allow(checkout).to receive(:payments_api)
+        .and_return(payments_api)
+      allow(payments_api).to receive(:payments)
+        .and_return(payments_response)
+      allow(payments_api).to receive(:payment_methods)
+        .and_return(payment_methods_response)
+      allow(Invoices::PrepaidCreditJob).to receive(:perform_later)
+    end
+
+    it "creates an adyen payment" do
+      result = create_service.call
+
+      expect(result).to be_success
+      expect(result.payment.id).to be_present
+      expect(result.payment.payable).to eq(invoice)
+      expect(result.payment.payment_provider).to eq(adyen_payment_provider)
+      expect(result.payment.payment_provider_customer).to eq(adyen_customer)
+      expect(result.payment.amount_cents).to eq(invoice.total_amount_cents)
+      expect(result.payment.amount_currency).to eq(invoice.currency)
+      expect(result.payment.status).to eq("Authorised")
+
+      expect(result.payment_status).to eq(:succeeded)
+
+      expect(adyen_customer.reload.payment_method_id)
+        .to eq(payment_methods_response.response["storedPaymentMethods"].first["id"])
+
+      expect(payments_api).to have_received(:payments)
+    end
+
+    context "with error response from adyen" do
+      let(:payments_error_response) { generate(:adyen_payments_error_response) }
+
+      before do
+        allow(payments_api).to receive(:payments).and_return(payments_error_response)
+      end
+
+      it "returns a success result with error messages" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.error_message).to eq("There are no payment methods available for the given parameters.")
+        expect(result.error_code).to eq("validation")
+      end
+    end
+
+    context "with validation error on adyen" do
+      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
+
+      let(:subscription) do
+        create(:subscription, organization:, customer:)
+      end
+
+      let(:organization) do
+        create(:organization, webhook_url: "https://webhook.com")
+      end
+
+      before do
+        subscription
+      end
+
+      context "when changing payment method fails with invalid card" do
+        before do
+          allow(payments_api).to receive(:payment_methods)
+            .and_raise(Adyen::ValidationError.new("Invalid card number", nil))
+        end
+
+        it "returns a success result with error messages" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.error_message).to eq("Invalid card number")
+          expect(result.error_code).to be_nil
+          expect(result.payment_status).to eq(:failed)
+        end
+      end
+
+      context "when payment fails with invalid card" do
+        before do
+          allow(payments_api).to receive(:payments)
+            .and_raise(Adyen::ValidationError.new("Invalid card number", nil))
+        end
+
+        it "returns a success result with error messages" do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.error_message).to eq("Invalid card number")
+          expect(result.error_code).to be_nil
+          expect(result.payment_status).to eq(:failed)
+        end
+      end
+    end
+
+    context "with error on adyen" do
+      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
+
+      let(:subscription) do
+        create(:subscription, organization:, customer:)
+      end
+
+      let(:organization) do
+        create(:organization, webhook_url: "https://webhook.com")
+      end
+
+      before do
+        subscription
+
+        allow(payments_api).to receive(:payments)
+          .and_raise(Adyen::AdyenError.new(nil, nil, "error", "code"))
+      end
+
+      it "returns a failed result" do
+        result = create_service.call
+
+        expect(result).not_to be_success
+
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code).to eq("adyen_error")
+        expect(result.error.error_message).to eq("code: error")
+
+        expect(result.error_message).to eq("error")
+        expect(result.error_code).to eq("code")
+        expect(result.payment_status).to eq(:failed)
+      end
+    end
+  end
+end

--- a/spec/services/payment_providers/create_payment_factory_spec.rb
+++ b/spec/services/payment_providers/create_payment_factory_spec.rb
@@ -3,29 +3,32 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviders::CreatePaymentFactory, type: :service do
-  subject(:new_instance) { described_class.new_instance(provider:, invoice:) }
+  subject(:new_instance) { described_class.new_instance(provider:, invoice:, provider_customer:) }
 
   let(:provider) { "stripe" }
   let(:invoice) { create(:invoice) }
+  let(:provider_customer) { create(:stripe_customer) }
 
   describe ".new_instance" do
     it "creates an instance of the stripe service" do
-      expect(new_instance).to be_instance_of(Invoices::Payments::StripeService)
+      expect(new_instance).to be_instance_of(PaymentProviders::Stripe::Payments::CreateService)
     end
 
     context "when provider is adyen" do
       let(:provider) { "adyen" }
+      let(:provider_customer) { create(:adyen_customer) }
 
       it "creates an instance of the adyen service" do
-        expect(new_instance).to be_instance_of(Invoices::Payments::AdyenService)
+        expect(new_instance).to be_instance_of(PaymentProviders::Adyen::Payments::CreateService)
       end
     end
 
     context "when provider is gocardless" do
       let(:provider) { "gocardless" }
+      let(:provider_customer) { create(:gocardless_customer) }
 
       it "creates an instance of the gocardless service" do
-        expect(new_instance).to be_instance_of(Invoices::Payments::GocardlessService)
+        expect(new_instance).to be_instance_of(PaymentProviders::Gocardless::Payments::CreateService)
       end
     end
   end

--- a/spec/services/payment_providers/gocardless/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/payments/create_service_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Gocardless::Payments::CreateService, type: :service do
+  subject(:create_service) { described_class.new(invoice:, provider_customer: gocardless_customer) }
+
+  let(:customer) { create(:customer, payment_provider_code: code) }
+  let(:organization) { customer.organization }
+  let(:gocardless_payment_provider) { create(:gocardless_provider, organization:, code:) }
+  let(:gocardless_customer) { create(:gocardless_customer, customer:, payment_provider: gocardless_payment_provider) }
+  let(:gocardless_client) { instance_double(GoCardlessPro::Client) }
+  let(:gocardless_payments_service) { instance_double(GoCardlessPro::Services::PaymentsService) }
+  let(:gocardless_mandates_service) { instance_double(GoCardlessPro::Services::MandatesService) }
+  let(:gocardless_list_response) { instance_double(GoCardlessPro::ListResponse) }
+  let(:code) { "gocardless_1" }
+
+  let(:invoice) do
+    create(
+      :invoice,
+      organization:,
+      customer:,
+      total_amount_cents: 200,
+      currency: "EUR",
+      ready_for_payment_processing: true
+    )
+  end
+
+  describe ".call" do
+    before do
+      gocardless_customer
+
+      allow(GoCardlessPro::Client).to receive(:new)
+        .and_return(gocardless_client)
+      allow(gocardless_client).to receive(:mandates)
+        .and_return(gocardless_mandates_service)
+      allow(gocardless_mandates_service).to receive(:list)
+        .and_return(gocardless_list_response)
+      allow(gocardless_list_response).to receive(:records)
+        .and_return([GoCardlessPro::Resources::Mandate.new("id" => "mandate_id")])
+      allow(gocardless_client).to receive(:payments)
+        .and_return(gocardless_payments_service)
+      allow(gocardless_payments_service).to receive(:create)
+        .and_return(GoCardlessPro::Resources::Payment.new(
+          "id" => "_ID_",
+          "amount" => invoice.total_amount_cents,
+          "currency" => invoice.currency,
+          "status" => "paid_out"
+        ))
+      allow(Invoices::PrepaidCreditJob).to receive(:perform_later)
+    end
+
+    it "creates a gocardless payment" do
+      result = create_service.call
+
+      expect(result).to be_success
+
+      expect(result.payment.id).to be_present
+      expect(result.payment.payable).to eq(invoice)
+      expect(result.payment.payment_provider).to eq(gocardless_payment_provider)
+      expect(result.payment.payment_provider_customer).to eq(gocardless_customer)
+      expect(result.payment.amount_cents).to eq(invoice.total_amount_cents)
+      expect(result.payment.amount_currency).to eq(invoice.currency)
+      expect(result.payment.status).to eq("paid_out")
+      expect(gocardless_customer.reload.provider_mandate_id).to eq("mandate_id")
+
+      expect(result.payment_status).to eq(:succeeded)
+
+      expect(gocardless_payments_service).to have_received(:create)
+    end
+
+    context "with error on gocardless" do
+      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
+
+      let(:subscription) do
+        create(:subscription, organization:, customer:)
+      end
+
+      let(:organization) do
+        create(:organization, webhook_url: "https://webhook.com")
+      end
+
+      before do
+        subscription
+
+        allow(gocardless_payments_service).to receive(:create)
+          .and_raise(GoCardlessPro::Error.new("code" => "code", "message" => "error"))
+      end
+
+      it "returns a failed result" do
+        result = create_service.call
+
+        expect(result).not_to be_success
+
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code).to eq("gocardless_error")
+        expect(result.error.error_message).to eq("code: error")
+
+        expect(result.error_message).to eq("error")
+        expect(result.error_code).to eq("code")
+        expect(result.payment_status).to eq(:failed)
+      end
+    end
+
+    context "when customer has no mandate to make a payment" do
+      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
+      let(:organization) { create(:organization, webhook_url: "https://webhook.com") }
+
+      before do
+        allow(gocardless_list_response).to receive(:records)
+          .and_return([])
+
+        allow(gocardless_payments_service).to receive(:create)
+          .and_raise(GoCardlessPro::Error.new("code" => "code", "message" => "error"))
+      end
+
+      it "delivers an error webhook" do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq("gocardless_error")
+          expect(result.error.error_message).to eq("no_mandate_error: No mandate available for payment")
+
+          expect(result.error_message).to eq("No mandate available for payment")
+          expect(result.error_code).to eq("no_mandate_error")
+          expect(result.payment_status).to eq(:failed)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -1,0 +1,328 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service do
+  subject(:create_service) { described_class.new(invoice:, provider_customer: stripe_customer) }
+
+  let(:customer) { create(:customer, payment_provider_code: code) }
+  let(:organization) { customer.organization }
+  let(:stripe_payment_provider) { create(:stripe_provider, organization:, code:) }
+  let(:stripe_customer) { create(:stripe_customer, customer:, payment_method_id: "pm_123456", payment_provider: stripe_payment_provider) }
+  let(:code) { "stripe_1" }
+
+  let(:invoice) do
+    create(
+      :invoice,
+      organization:,
+      customer:,
+      total_amount_cents: 200,
+      currency: "EUR",
+      ready_for_payment_processing: true
+    )
+  end
+
+  describe ".call" do
+    let(:provider_customer_service) { instance_double(PaymentProviderCustomers::StripeService) }
+
+    let(:provider_customer_service_result) do
+      BaseService::Result.new.tap do |result|
+        result.payment_method = Stripe::PaymentMethod.new(id: "pm_123456")
+      end
+    end
+
+    let(:customer_response) do
+      File.read(Rails.root.join("spec/fixtures/stripe/customer_retrieve_response.json"))
+    end
+
+    let(:stripe_payment_intent) do
+      Stripe::PaymentIntent.construct_from(
+        id: "ch_123456",
+        status: payment_status,
+        amount: invoice.total_amount_cents,
+        currency: invoice.currency
+      )
+    end
+
+    let(:payment_status) { "succeeded" }
+
+    before do
+      stripe_payment_provider
+      stripe_customer
+
+      allow(Stripe::PaymentIntent).to receive(:create)
+        .and_return(stripe_payment_intent)
+      allow(SegmentTrackJob).to receive(:perform_later)
+      allow(Invoices::PrepaidCreditJob).to receive(:perform_later)
+
+      allow(PaymentProviderCustomers::StripeService).to receive(:new)
+        .and_return(provider_customer_service)
+      allow(provider_customer_service).to receive(:check_payment_method)
+        .and_return(provider_customer_service_result)
+
+      stub_request(:get, "https://api.stripe.com/v1/customers/#{stripe_customer.provider_customer_id}")
+        .to_return(status: 200, body: customer_response, headers: {})
+    end
+
+    it "creates a stripe payment and a payment" do
+      result = create_service.call
+
+      expect(result).to be_success
+
+      expect(result.payment.id).to be_present
+      expect(result.payment.payable).to eq(invoice)
+      expect(result.payment.payment_provider).to eq(stripe_payment_provider)
+      expect(result.payment.payment_provider_customer).to eq(stripe_customer)
+      expect(result.payment.amount_cents).to eq(invoice.total_amount_cents)
+      expect(result.payment.amount_currency).to eq(invoice.currency)
+      expect(result.payment.status).to eq("succeeded")
+
+      expect(result.payment_status).to eq(:succeeded)
+
+      expect(Stripe::PaymentIntent).to have_received(:create)
+    end
+
+    context "when customer does not have a payment method" do
+      let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider: stripe_payment_provider) }
+
+      before do
+        allow(Stripe::Customer).to receive(:retrieve)
+          .and_return(Stripe::StripeObject.construct_from(
+            {
+              invoice_settings: {
+                default_payment_method: nil
+              },
+              default_source: nil
+            }
+          ))
+
+        allow(Stripe::PaymentMethod).to receive(:list)
+          .and_return(Stripe::ListObject.construct_from(
+            data: [
+              {
+                id: "pm_123456",
+                object: "payment_method",
+                card: {brand: "visa"},
+                created: 1_656_422_973,
+                customer: "cus_123456",
+                livemode: false,
+                metadata: {},
+                type: "card"
+              }
+            ]
+          ))
+      end
+
+      it "retrieves the payment method" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(customer.stripe_customer.reload).to be_present
+        expect(customer.stripe_customer.provider_customer_id).to eq(stripe_customer.provider_customer_id)
+        expect(customer.stripe_customer.payment_method_id).to eq("pm_123456")
+
+        expect(Stripe::PaymentMethod).to have_received(:list)
+        expect(Stripe::PaymentIntent).to have_received(:create)
+      end
+    end
+
+    context "with card error on stripe" do
+      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
+
+      let(:subscription) do
+        create(:subscription, organization:, customer:)
+      end
+
+      let(:organization) do
+        create(:organization, webhook_url: "https://webhook.com")
+      end
+
+      before do
+        subscription
+
+        allow(Stripe::PaymentIntent).to receive(:create)
+          .and_raise(::Stripe::CardError.new("error", {}))
+      end
+
+      it "returns a success result with error messages" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.error_message).to eq("error")
+        expect(result.error_code).to be_nil
+        expect(result.payment_status).to eq(:failed)
+      end
+    end
+
+    context "with stripe error" do
+      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
+
+      let(:subscription) do
+        create(:subscription, organization:, customer:)
+      end
+
+      let(:organization) do
+        create(:organization, webhook_url: "https://webhook.com")
+      end
+
+      before do
+        subscription
+
+        allow(Stripe::PaymentIntent).to receive(:create)
+          .and_raise(::Stripe::StripeError.new("error"))
+      end
+
+      it "returns a success result with error messages" do
+        result = create_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code).to eq("stripe_error")
+        expect(result.error.error_message).to eq("error")
+
+        expect(result.error_message).to eq("error")
+        expect(result.error_code).to be_nil
+      end
+    end
+
+    context "when invoice has a too small amount" do
+      let(:organization) { create(:organization) }
+      let(:customer) { create(:customer, organization:) }
+      let(:subscription) { create(:subscription, organization:, customer:) }
+
+      let(:invoice) do
+        create(
+          :invoice,
+          organization:,
+          customer:,
+          total_amount_cents: 20,
+          currency: "EUR",
+          ready_for_payment_processing: true
+        )
+      end
+
+      before do
+        subscription
+
+        allow(Stripe::PaymentIntent).to receive(:create)
+          .and_raise(::Stripe::InvalidRequestError.new("amount_too_small", {}, code: "amount_too_small"))
+      end
+
+      it "returns an empty result" do
+        result = create_service.call
+
+        expect(result).to be_success
+      end
+    end
+
+    context "when payment status is processing" do
+      let(:payment_status) { "processing" }
+
+      it "creates a stripe payment and a payment" do
+        result = create_service.call
+
+        expect(result).to be_success
+
+        expect(result.payment.id).to be_present
+        expect(result.payment.payable).to eq(invoice)
+        expect(result.payment.payment_provider).to eq(stripe_payment_provider)
+        expect(result.payment.payment_provider_customer).to eq(stripe_customer)
+        expect(result.payment.amount_cents).to eq(invoice.total_amount_cents)
+        expect(result.payment.amount_currency).to eq(invoice.currency)
+        expect(result.payment.status).to eq("processing")
+
+        expect(result.payment_status).to eq(:pending)
+
+        expect(Stripe::PaymentIntent).to have_received(:create)
+      end
+    end
+
+    context "when customers country is IN" do
+      let(:payment_status) { "requires_action" }
+
+      let(:stripe_payment_intent) do
+        Stripe::PaymentIntent.construct_from(
+          id: "ch_123456",
+          status: payment_status,
+          amount: invoice.total_amount_cents,
+          currency: invoice.currency,
+          next_action: {
+            redirect_to_url: {url: "https://foo.bar"}
+          }
+        )
+      end
+
+      before do
+        customer.update(country: "IN")
+      end
+
+      it "creates a stripe payment and payment with requires_action status" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.payment.status).to eq("requires_action")
+        expect(result.payment.provider_payment_data).not_to be_empty
+      end
+
+      it "has enqueued a SendWebhookJob" do
+        result = create_service.call
+
+        expect(SendWebhookJob).to have_been_enqueued
+          .with(
+            "payment.requires_action",
+            result.payment,
+            provider_customer_id: stripe_customer.provider_customer_id
+          )
+      end
+    end
+
+    context "with #payment_intent_payload" do
+      let(:payment_intent_payload) { create_service.__send__(:payment_intent_payload) }
+      let(:payload) do
+        {
+          amount: invoice.total_amount_cents,
+          currency: invoice.currency.downcase,
+          customer: customer.stripe_customer.provider_customer_id,
+          payment_method: customer.stripe_customer.payment_method_id,
+          payment_method_types: customer.stripe_customer.provider_payment_methods,
+          confirm: true,
+          off_session: true,
+          return_url: create_service.__send__(:success_redirect_url),
+          error_on_requires_action: true,
+          description: create_service.__send__(:description),
+          metadata: {
+            lago_customer_id: customer.id,
+            lago_invoice_id: invoice.id,
+            invoice_issuing_date: invoice.issuing_date.iso8601,
+            invoice_type: invoice.invoice_type
+          }
+        }
+      end
+
+      it "returns the payload" do
+        expect(payment_intent_payload).to eq(payload)
+      end
+
+      context "when customers country is IN" do
+        before do
+          payload[:off_session] = false
+          payload[:error_on_requires_action] = false
+          customer.update!(country: "IN")
+        end
+
+        it "returns the payload" do
+          expect(payment_intent_payload).to eq(payload)
+        end
+      end
+    end
+
+    context "with #description" do
+      let(:description_call) { create_service.__send__(:description) }
+      let(:description) { "#{organization.name} - Invoice #{invoice.number}" }
+
+      it "returns the description" do
+        expect(description_call).to eq(description)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR follow https://github.com/getlago/lago-api/pull/2930 and https://github.com/getlago/lago-api/pull/2935 in the refactor of the payment processing.

The main goal of this refactor will be to:
- Avoid double payment at all cost
- Avoid code duplication between payment processor integration to make maintenance easier

## Description

This PR:
- Extract the payment creation logic from `Invoices::Payments::*Service#call` into dedicated services in `PaymentProviders::*::Payments::CreateService#call`. These services are only responsible for the payment creation itself and the related error handling
- Extract webhook deliveries, invoice payment status handling and integration notification in from each provider services in the main `Invoices::Payments::CreateService`

In the next step this last service will be updated to create a payment before delegating the payment processing to the providers and to ensure that no processing payment already exists.

