### PR TITLE
feat(anrok): add new tax related statuses on invoice

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -62,7 +62,11 @@ class Invoice < ApplicationRecord
 
   INVOICE_TYPES = %i[subscription add_on credit one_off advance_charges progressive_billing].freeze
   PAYMENT_STATUS = %i[pending succeeded failed].freeze
-  TAX_STATUSES = %i[pending succeeded failed].freeze
+  TAX_STATUSES = {
+    pending: 'pending',
+    succeeded: 'succeeded',
+    failed: 'failed'
+  }.freeze
 
   VISIBLE_STATUS = {draft: 0, finalized: 1, voided: 2, failed: 4, pending: 7}.freeze
   INVISIBLE_STATUS = {generating: 3, open: 5, closed: 6}.freeze
@@ -72,6 +76,8 @@ class Invoice < ApplicationRecord
   enum invoice_type: INVOICE_TYPES
   enum payment_status: PAYMENT_STATUS, _prefix: :payment
   enum status: STATUS
+
+  attribute :tax_status, :string
   enum tax_status: TAX_STATUSES, _prefix: :tax
 
   aasm column: 'status', timestamps: true do
@@ -471,7 +477,7 @@ end
 #  status                                  :integer          default("finalized"), not null
 #  sub_total_excluding_taxes_amount_cents  :bigint           default(0), not null
 #  sub_total_including_taxes_amount_cents  :bigint           default(0), not null
-#  tax_status                              :integer          default("succeeded"), not null
+#  tax_status                              :enum
 #  taxes_amount_cents                      :bigint           default(0), not null
 #  taxes_rate                              :float            default(0.0), not null
 #  timezone                                :string           default("UTC"), not null

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -62,8 +62,9 @@ class Invoice < ApplicationRecord
 
   INVOICE_TYPES = %i[subscription add_on credit one_off advance_charges progressive_billing].freeze
   PAYMENT_STATUS = %i[pending succeeded failed].freeze
+  TAX_STATUSES = %i[pending succeeded failed].freeze
 
-  VISIBLE_STATUS = {draft: 0, finalized: 1, voided: 2, failed: 4}.freeze
+  VISIBLE_STATUS = {draft: 0, finalized: 1, voided: 2, failed: 4, pending: 7}.freeze
   INVISIBLE_STATUS = {generating: 3, open: 5, closed: 6}.freeze
   STATUS = VISIBLE_STATUS.merge(INVISIBLE_STATUS).freeze
   GENERATED_INVOICE_STATUSES = %w[finalized closed].freeze
@@ -71,6 +72,7 @@ class Invoice < ApplicationRecord
   enum invoice_type: INVOICE_TYPES
   enum payment_status: PAYMENT_STATUS, _prefix: :payment
   enum status: STATUS
+  enum tax_status: TAX_STATUSES,  _prefix: :tax
 
   aasm column: 'status', timestamps: true do
     state :generating
@@ -80,6 +82,7 @@ class Invoice < ApplicationRecord
     state :voided
     state :failed
     state :closed
+    state :pending
 
     event :finalize do
       transitions from: :draft, to: :finalized

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -72,7 +72,7 @@ class Invoice < ApplicationRecord
   enum invoice_type: INVOICE_TYPES
   enum payment_status: PAYMENT_STATUS, _prefix: :payment
   enum status: STATUS
-  enum tax_status: TAX_STATUSES,  _prefix: :tax
+  enum tax_status: TAX_STATUSES, _prefix: :tax
 
   aasm column: 'status', timestamps: true do
     state :generating
@@ -471,6 +471,7 @@ end
 #  status                                  :integer          default("finalized"), not null
 #  sub_total_excluding_taxes_amount_cents  :bigint           default(0), not null
 #  sub_total_including_taxes_amount_cents  :bigint           default(0), not null
+#  tax_status                              :integer          default("succeeded"), not null
 #  taxes_amount_cents                      :bigint           default(0), not null
 #  taxes_rate                              :float            default(0.0), not null
 #  timezone                                :string           default("UTC"), not null

--- a/db/migrate/20241216140931_add_tax_status_to_invoices.rb
+++ b/db/migrate/20241216140931_add_tax_status_to_invoices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTaxStatusToInvoices < ActiveRecord::Migration[7.1]
+  def change
+    add_column :invoices, :tax_status, :integer, null: false, default: 1
+  end
+end

--- a/db/migrate/20241216140931_add_tax_status_to_invoices.rb
+++ b/db/migrate/20241216140931_add_tax_status_to_invoices.rb
@@ -2,6 +2,12 @@
 
 class AddTaxStatusToInvoices < ActiveRecord::Migration[7.1]
   def change
-    add_column :invoices, :tax_status, :integer, null: false, default: 1
+    create_enum :tax_status, %w[pending succeeded failed]
+
+    safety_assured do
+      change_table :invoices do |t|
+        t.enum :tax_status, enum_type: 'tax_status', null: true
+      end
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_28_132010) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_16_140931) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -911,6 +911,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_28_132010) do
     t.boolean "payment_overdue", default: false
     t.bigint "negative_amount_cents", default: 0, null: false
     t.bigint "progressive_billing_credit_amount_cents", default: 0, null: false
+    t.integer "tax_status", default: 1, null: false
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["number"], name: "index_invoices_on_number"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_16_140931) do
   create_enum "billable_metric_weighted_interval", ["seconds"]
   create_enum "customer_type", ["company", "individual"]
   create_enum "subscription_invoicing_reason", ["subscription_starting", "subscription_periodic", "subscription_terminating", "in_advance_charge", "in_advance_charge_periodic", "progressive_billing"]
+  create_enum "tax_status", ["pending", "succeeded", "failed"]
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
@@ -911,7 +912,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_16_140931) do
     t.boolean "payment_overdue", default: false
     t.bigint "negative_amount_cents", default: 0, null: false
     t.bigint "progressive_billing_credit_amount_cents", default: 0, null: false
-    t.integer "tax_status", default: 1, null: false
+    t.enum "tax_status", enum_type: "tax_status"
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["number"], name: "index_invoices_on_number"

--- a/schema.graphql
+++ b/schema.graphql
@@ -4540,6 +4540,7 @@ enum InvoiceStatusTypeEnum {
   finalized
   generating
   open
+  pending
   voided
 }
 

--- a/schema.json
+++ b/schema.json
@@ -23315,6 +23315,12 @@
               "deprecationReason": null
             },
             {
+              "name": "pending",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "generating",
               "description": null,
               "isDeprecated": false,

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -40,6 +40,10 @@ FactoryBot.define do
       status { :failed }
     end
 
+    trait :pending do
+      status { :pending }
+    end
+
     trait :subscription do
       transient do
         subscriptions { [create(:subscription)] }

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Invoice, type: :model do
   it { is_expected.to have_many(:usage_thresholds).through(:applied_usage_thresholds) }
 
   it 'has fixed status mapping' do
-    expect(described_class::VISIBLE_STATUS).to match(draft: 0, finalized: 1, voided: 2, failed: 4)
+    expect(described_class::VISIBLE_STATUS).to match(draft: 0, finalized: 1, voided: 2, failed: 4, pending: 7)
     expect(described_class::INVISIBLE_STATUS).to match(generating: 3, open: 5, closed: 6)
-    expect(described_class::STATUS).to match(draft: 0, finalized: 1, voided: 2, generating: 3, failed: 4, open: 5, closed: 6)
+    expect(described_class::STATUS).to match(draft: 0, finalized: 1, voided: 2, generating: 3, failed: 4, open: 5, closed: 6, pending: 7)
   end
 
   describe 'validation' do


### PR DESCRIPTION
## Context

Currently Anrok calls are sync and performed during invoice generation

## Description

The goal of this improvement is to make calls to Anrok in dedicated job so that we can implement throttling for rate limit issues.

This PR adds necessary DB changes
