### PR TITLE
fix: Ability to create fee with negative units or amount

### DIFF
--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -107,6 +107,12 @@ module Fees
         return
       end
 
+      # Prevent trying to create a fee with negative units or amount.
+      if amount_result.units.negative? || amount_result.amount.negative?
+        amount_result.amount = amount_result.unit_amount = BigDecimal(0)
+        amount_result.full_units_number = amount_result.units = amount_result.total_aggregated_units = BigDecimal(0)
+      end
+
       # NOTE: amount_result should be a BigDecimal, we need to round it
       # to the currency decimals and transform it into currency cents
       rounded_amount = amount_result.amount.round(currency.exponent)


### PR DESCRIPTION
We still have some invoices stuck in generating status, when units or amount are negative.

The goal of this PR is to permit the creation of the fee by converting the value to 0 when it's negative for `units` and `amount` fields.

But we keep the calculation details on `amount_details`.

Example:
<img width="961" alt="Screenshot 2024-12-17 at 10 12 46" src="https://github.com/user-attachments/assets/01270a74-bdcb-4e1a-a811-19c52455d049" />
