### PR TITLE
misc(invoice): Bypass aggregation queries when no event in period

### DIFF
--- a/app/services/billable_metrics/aggregation_factory.rb
+++ b/app/services/billable_metrics/aggregation_factory.rb
@@ -2,21 +2,9 @@
 
 module BillableMetrics
   class AggregationFactory
-    class << self
-      def supports_clickhouse?
-        ENV['LAGO_CLICKHOUSE_ENABLED'].present?
-      end
-    end
-
     def self.new_instance(charge:, current_usage: false, **attributes)
-      event_store = Events::Stores::PostgresStore
-
-      if supports_clickhouse? && charge.billable_metric.organization.clickhouse_events_store?
-        event_store = Events::Stores::ClickhouseStore
-      end
-
       aggregator_class(charge, current_usage).new(
-        event_store_class: event_store,
+        event_store_class: Events::Stores::StoreFactory.store_class(organization: charge.billable_metric.organization),
         charge:,
         **attributes
       )

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -4,6 +4,8 @@ module BillableMetrics
   module Aggregations
     class CountService < BillableMetrics::Aggregations::BaseService
       def compute_aggregation(options: {})
+        return empty_result if should_bypass_aggregation?
+
         result.aggregation = event_store.count
         result.current_usage_units = result.aggregation
         result.count = result.aggregation
@@ -21,6 +23,8 @@ module BillableMetrics
       #       as pay in advance aggregation will be computed on a single group
       #       with the grouped_by_values filter
       def compute_grouped_by_aggregation(*)
+        return empty_results if should_bypass_aggregation?
+
         aggregations = event_store.grouped_count
         return empty_results if aggregations.blank?
 

--- a/app/services/billable_metrics/aggregations/custom_service.rb
+++ b/app/services/billable_metrics/aggregations/custom_service.rb
@@ -7,6 +7,8 @@ module BillableMetrics
       BATCH_SIZE = 1000
 
       def compute_aggregation(options: {})
+        return empty_result if should_bypass_aggregation?
+
         result.count = event_store.count
 
         aggregation_result = perform_custom_aggregation(grouped_by_values:)
@@ -33,6 +35,8 @@ module BillableMetrics
       #       as pay in advance aggregation will be computed on a single group
       #       with the grouped_by_values filter
       def compute_grouped_by_aggregation(options: {})
+        return empty_results if should_bypass_aggregation?
+
         counts = event_store.grouped_count
         return empty_results if counts.blank?
 

--- a/app/services/billable_metrics/aggregations/latest_service.rb
+++ b/app/services/billable_metrics/aggregations/latest_service.rb
@@ -11,6 +11,8 @@ module BillableMetrics
       end
 
       def compute_aggregation(options: {})
+        return empty_result if should_bypass_aggregation?
+
         result.aggregation = compute_aggregation_value(event_store.last)
         result.count = event_store.count
         result.options = options
@@ -23,6 +25,8 @@ module BillableMetrics
       #       Result will have an aggregations attribute
       #       containing the aggregation result of each group
       def compute_grouped_by_aggregation(*)
+        return empty_results if should_bypass_aggregation?
+
         aggregations = event_store.grouped_last
         return empty_results if aggregations.blank?
 

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -11,6 +11,8 @@ module BillableMetrics
       end
 
       def compute_aggregation(options: {})
+        return empty_result if should_bypass_aggregation?
+
         result.aggregation = event_store.max || 0
         result.count = event_store.count
         result.options = options
@@ -20,6 +22,8 @@ module BillableMetrics
       end
 
       def compute_grouped_by_aggregation(options)
+        return empty_results if should_bypass_aggregation?
+
         aggregations = event_store.grouped_max
         return empty_results if aggregations.blank?
 

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -12,6 +12,8 @@ module BillableMetrics
       end
 
       def compute_aggregation(options: {})
+        return empty_result if should_bypass_aggregation?
+
         aggregation = event_store.sum
 
         if options[:is_pay_in_advance] && options[:is_current_usage]
@@ -37,6 +39,8 @@ module BillableMetrics
       #       as pay in advance aggregation will be computed on a single group
       #       with the grouped_by_values filter
       def compute_grouped_by_aggregation(options: {})
+        return empty_results if should_bypass_aggregation?
+
         aggregations = event_store.grouped_sum
         return empty_results if aggregations.blank?
 

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -11,6 +11,8 @@ module BillableMetrics
       end
 
       def compute_aggregation(options: {})
+        return empty_result if should_bypass_aggregation?
+
         aggregation = event_store.unique_count.ceil(5)
 
         if options[:is_pay_in_advance] && options[:is_current_usage]
@@ -34,6 +36,8 @@ module BillableMetrics
       #       as pay in advance aggregation will be computed on a single group
       #       with the grouped_by_values filter
       def compute_grouped_by_aggregation(options: {})
+        return empty_results if should_bypass_aggregation?
+
         aggregations = event_store.grouped_unique_count
         return empty_results if aggregations.blank?
 

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -11,6 +11,8 @@ module BillableMetrics
       end
 
       def compute_aggregation(*)
+        return empty_result if should_bypass_aggregation?
+
         result.aggregation = event_store.weighted_sum(initial_value:).ceil(20)
         result.count = event_store.count
         result.variation = event_store.sum || 0
@@ -29,6 +31,8 @@ module BillableMetrics
       #       Result will have an aggregations attribute
       #       containing the aggregation result of each group.
       def compute_grouped_by_aggregation(*)
+        return empty_results if should_bypass_aggregation?
+
         aggregations = event_store.grouped_weighted_sum(initial_values: grouped_latest_values)
         return empty_results if aggregations.blank?
 

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -3,7 +3,7 @@
 module Events
   module Stores
     class BaseStore
-      def initialize(code:, subscription:, boundaries:, filters: {})
+      def initialize(subscription:, boundaries:, code: nil, filters: {})
         @code = code
         @subscription = subscription
         @boundaries = boundaries

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -22,6 +22,14 @@ module Events
         filters_scope(scope)
       end
 
+      def distinct_codes
+        Event.where(external_subscription_id: subscription.external_id)
+          .where(organization_id: subscription.organization.id)
+          .from_datetime(from_datetime)
+          .to_datetime(to_datetime)
+          .pluck('DISTINCT(code)')
+      end
+
       def events_values(limit: nil, force_from: false, exclude_event: false)
         field_name = sanitized_property_name
         field_name = "(#{field_name})::numeric" if numeric_property

--- a/app/services/events/stores/store_factory.rb
+++ b/app/services/events/stores/store_factory.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    class StoreFactory
+      class << self
+        def supports_clickhouse?
+          ENV['LAGO_CLICKHOUSE_ENABLED'].present?
+        end
+      end
+
+      def self.store_class(organization:)
+        event_store = Events::Stores::PostgresStore
+
+        if supports_clickhouse? && organization.clickhouse_events_store?
+          event_store = Events::Stores::ClickhouseStore
+        end
+
+        event_store
+      end
+    end
+  end
+end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -2,7 +2,7 @@
 
 module Fees
   class ChargeService < BaseService
-    def initialize(invoice:, charge:, subscription:, boundaries:, current_usage: false, cache_middleware: nil)
+    def initialize(invoice:, charge:, subscription:, boundaries:, current_usage: false, cache_middleware: nil, bypass_aggregation: false)
       @invoice = invoice
       @charge = charge
       @subscription = subscription
@@ -13,6 +13,9 @@ module Fees
       @cache_middleware = cache_middleware || Subscriptions::ChargeCacheMiddleware.new(
         subscription:, charge:, to_datetime: boundaries[:charges_to_datetime], cache: false
       )
+
+      # Allow the service to ignore events aggregation
+      @bypass_aggregation = bypass_aggregation
 
       super(nil)
     end
@@ -52,7 +55,7 @@ module Fees
 
     private
 
-    attr_accessor :invoice, :charge, :subscription, :boundaries, :current_usage, :currency, :cache_middleware
+    attr_accessor :invoice, :charge, :subscription, :boundaries, :current_usage, :currency, :cache_middleware, :bypass_aggregation
 
     delegate :billable_metric, to: :charge
     delegate :organization, to: :subscription
@@ -242,7 +245,8 @@ module Fees
           to_datetime: boundaries.charges_to_datetime,
           charges_duration: boundaries.charges_duration
         },
-        filters: aggregation_filters(charge_filter:)
+        filters: aggregation_filters(charge_filter:),
+        bypass_aggregation:
       )
     end
 

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -12,11 +12,13 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
         from_datetime:,
         to_datetime:
       },
-      filters:
+      filters:,
+      bypass_aggregation:
     )
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:bypass_aggregation) { false }
   let(:filters) do
     {event: pay_in_advance_event, grouped_by:, matching_filters:, ignored_filters:}
   end
@@ -146,6 +148,19 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
     end
   end
 
+  context 'when bypass_aggregation is set to true' do
+    let(:bypass_aggregation) { true }
+
+    it 'returns a default empty result' do
+      result = count_service.aggregate
+
+      expect(result.aggregation).to eq(0)
+      expect(result.count).to eq(0)
+      expect(result.current_usage_units).to eq(0)
+      expect(result.options).to eq({running_total: []})
+    end
+  end
+
   describe '.per_event_aggregation' do
     it 'aggregates per events' do
       result = count_service.per_event_aggregation
@@ -200,6 +215,21 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
 
     context 'without events' do
       let(:event_list) { [] }
+
+      it 'returns an empty result' do
+        result = count_service.aggregate
+
+        expect(result.aggregations.count).to eq(1)
+
+        aggregation = result.aggregations.first
+        expect(aggregation.aggregation).to eq(0)
+        expect(aggregation.count).to eq(0)
+        expect(aggregation.grouped_by).to eq({'agent_name' => nil})
+      end
+    end
+
+    context 'when bypass_aggregation is set to true' do
+      let(:bypass_aggregation) { true }
 
       it 'returns an empty result' do
         result = count_service.aggregate

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -12,11 +12,13 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
         from_datetime:,
         to_datetime:
       },
-      filters:
+      filters:,
+      bypass_aggregation:
     )
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:bypass_aggregation) { false }
   let(:filters) { {grouped_by:, matching_filters:, ignored_filters:} }
 
   let(:subscription) { create(:subscription) }
@@ -231,6 +233,19 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
     end
   end
 
+  context 'when bypass_aggregation is set to true' do
+    let(:bypass_aggregation) { true }
+
+    it 'returns a default empty result' do
+      result = latest_service.aggregate
+
+      expect(result.aggregation).to eq(0)
+      expect(result.count).to eq(0)
+      expect(result.current_usage_units).to eq(0)
+      expect(result.options).to eq({running_total: []})
+    end
+  end
+
   describe '.grouped_by_aggregation' do
     let(:grouped_by) { ['agent_name'] }
     let(:agent_names) { %w[aragorn frodo gimli legolas] }
@@ -279,6 +294,21 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
 
     context 'without events' do
       let(:events) { [] }
+
+      it 'returns an empty result' do
+        result = latest_service.aggregate
+
+        expect(result.aggregations.count).to eq(1)
+
+        aggregation = result.aggregations.first
+        expect(aggregation.aggregation).to eq(0)
+        expect(aggregation.count).to eq(0)
+        expect(aggregation.grouped_by).to eq({'agent_name' => nil})
+      end
+    end
+
+    context 'when bypass_aggregation is set to true' do
+      let(:bypass_aggregation) { true }
 
       it 'returns an empty result' do
         result = latest_service.aggregate

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -12,11 +12,13 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
         from_datetime:,
         to_datetime:
       },
-      filters:
+      filters:,
+      bypass_aggregation:
     )
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:bypass_aggregation) { false }
   let(:filters) do
     {event: pay_in_advance_event, grouped_by:, charge_filter:, matching_filters:, ignored_filters:}
   end
@@ -740,6 +742,19 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
     end
   end
 
+  context 'when bypass_aggregation is set to true' do
+    let(:bypass_aggregation) { true }
+
+    it 'returns a default empty result' do
+      result = sum_service.aggregate
+
+      expect(result.aggregation).to eq(0)
+      expect(result.count).to eq(0)
+      expect(result.current_usage_units).to eq(0)
+      expect(result.options).to eq({running_total: []})
+    end
+  end
+
   describe ".per_event_aggregation" do
     it "aggregates per events" do
       result = sum_service.per_event_aggregation
@@ -796,6 +811,21 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
         expect(aggregation.aggregation).to eq(0)
         expect(aggregation.count).to eq(0)
         expect(aggregation.grouped_by).to eq({"agent_name" => nil})
+      end
+    end
+
+    context 'when bypass_aggregation is set to true' do
+      let(:bypass_aggregation) { true }
+
+      it 'returns an empty result' do
+        result = sum_service.aggregate
+
+        expect(result.aggregations.count).to eq(1)
+
+        aggregation = result.aggregations.first
+        expect(aggregation.aggregation).to eq(0)
+        expect(aggregation.count).to eq(0)
+        expect(aggregation.grouped_by).to eq({'agent_name' => nil})
       end
     end
 

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -13,11 +13,13 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
         to_datetime:,
         charges_duration:
       },
-      filters:
+      filters:,
+      bypass_aggregation:
     )
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:bypass_aggregation) { false }
   let(:filters) { {grouped_by:, matching_filters:, ignored_filters:} }
 
   let(:subscription) { create(:subscription, started_at: DateTime.parse('2023-04-01 22:22:22')) }
@@ -101,6 +103,19 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
       expect(result.aggregation.round(5).to_s).to eq('0.0')
       expect(result.count).to eq(0)
       expect(result.options).to eq({})
+    end
+  end
+
+  context 'when bypass_aggregation is set to true' do
+    let(:bypass_aggregation) { true }
+
+    it 'returns a default empty result' do
+      result = aggregator.aggregate
+
+      expect(result.aggregation).to eq(0)
+      expect(result.count).to eq(0)
+      expect(result.current_usage_units).to eq(0)
+      expect(result.options).to eq({running_total: []})
     end
   end
 
@@ -293,6 +308,21 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
 
     context 'with no events' do
       let(:events_values) { [] }
+
+      it 'returns an empty result' do
+        result = aggregator.aggregate
+
+        expect(result.aggregations.count).to eq(1)
+
+        aggregation = result.aggregations.first
+        expect(aggregation.aggregation).to eq(0)
+        expect(aggregation.count).to eq(0)
+        expect(aggregation.grouped_by).to eq({'agent_name' => nil})
+      end
+    end
+
+    context 'when bypass_aggregation is set to true' do
+      let(:bypass_aggregation) { true }
 
       it 'returns an empty result' do
         result = aggregator.aggregate

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -122,6 +122,25 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     end
   end
 
+  describe '#distinct_codes' do
+    before do
+      Clickhouse::EventsEnriched.create!(
+        transaction_id: SecureRandom.uuid,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        code: 'other_code',
+        timestamp: boundaries[:from_datetime] + (1..10).to_a.sample.days,
+        value: "value",
+        decimal_value: 0,
+        precise_total_amount_cents: 0
+      )
+    end
+
+    it 'returns the distinct event codes' do
+      expect(event_store.distinct_codes).to match_array([code, 'other_code'])
+    end
+  end
+
   describe '.count' do
     it 'returns the number of unique events' do
       expect(event_store.count).to eq(5)

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -115,6 +115,22 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
+  describe '#distinct_codes' do
+    before do
+      create(
+        :event,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        code: 'other_code',
+        timestamp: boundaries[:from_datetime] + (1..10).to_a.sample.days
+      )
+    end
+
+    it 'returns the distinct event codes' do
+      expect(event_store.distinct_codes).to match_array([code, 'other_code'])
+    end
+  end
+
   describe '#count' do
     it 'returns the number of unique events' do
       expect(event_store.count).to eq(5)


### PR DESCRIPTION
## Context

The current approach for generating a subscription invoice with charge fees is to perform one aggregation request per charge (and possibly per charge filter when defined) no matter the number of events received during the billing period.
For plans counting a lot of charges this could be very slow when many invoices are generated in parallel (on a 1st day of a month for example).

After some research, it appears that in many cases, most of the aggregation result for both charges or filters results in a zero fee as no event were received.

## Description

The goal of this PR is to add a pre-check on events before performing the charge billing. It will detect the distinct event code received for a specific subscription during the billing period, and use this list to perform the aggregation only on charge having at least one event.

NOTE: this aggregation byepassing will not apply in in-advance or recurring billing as in these cases the aggregation result relies on more than the event received during the billing period.
