### PR TITLE
feat (anrok): add error that indicates that tax is unknown

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -66,6 +66,17 @@ class BaseService
     end
   end
 
+  class UnknownTaxFailure < FailedResult
+    attr_reader :code, :error_message
+
+    def initialize(result, code:, error_message:)
+      @code = code
+      @error_message = error_message
+
+      super(result, "#{code}: #{error_message}")
+    end
+  end
+
   class ForbiddenFailure < FailedResult
     attr_reader :code
 
@@ -125,6 +136,10 @@ class BaseService
 
     def service_failure!(code:, message:)
       fail_with_error!(ServiceFailure.new(self, code:, error_message: message))
+    end
+
+    def unknown_tax_failure!(code:, message:)
+      fail_with_error!(UnknownTaxFailure.new(self, code:, error_message: message))
     end
 
     def forbidden_failure!(code: "feature_unavailable")


### PR DESCRIPTION
## Context

Currently Anrok calls are sync and performed during invoice generation

## Description

The goal of this improvement is to make calls to Anrok in dedicated job so that we can implement throttling for rate limit issues.

This PR adds new error definition that will represent the state where tax is not pulled yet from external provider
