### PR TITLE
misc: Add longer lock for Invoices::FinalizeJob

### DIFF
--- a/app/jobs/invoices/finalize_job.rb
+++ b/app/jobs/invoices/finalize_job.rb
@@ -10,7 +10,7 @@ module Invoices
       end
     end
 
-    unique :until_executed, on_conflict: :log
+    unique :until_executed, on_conflict: :log, lock_ttl: 6.hours
 
     retry_on Sequenced::SequenceError, wait: :polynomially_longer
 


### PR DESCRIPTION
Set `lock_ttl` to 6 hours in `Invoices::FinalizeJob` to align with `Invoices::RefreshDraftJob`.