### PR TITLE
fix: Persist inbound stripe webhooks

### DIFF
--- a/app/jobs/clock/inbound_webhooks_cleanup_job.rb
+++ b/app/jobs/clock/inbound_webhooks_cleanup_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Clock
+  class InboundWebhooksCleanupJob < ApplicationJob
+    include SentryCronConcern
+
+    queue_as 'clock'
+
+    def perform
+      InboundWebhook.where('updated_at < ?', 90.days.ago).destroy_all
+    end
+  end
+end

--- a/app/jobs/clock/inbound_webhooks_cleanup_job.rb
+++ b/app/jobs/clock/inbound_webhooks_cleanup_job.rb
@@ -4,10 +4,10 @@ module Clock
   class InboundWebhooksCleanupJob < ApplicationJob
     include SentryCronConcern
 
-    queue_as 'clock'
+    queue_as "clock"
 
     def perform
-      InboundWebhook.where('updated_at < ?', 90.days.ago).destroy_all
+      InboundWebhook.where("updated_at < ?", 90.days.ago).destroy_all
     end
   end
 end

--- a/app/jobs/clock/inbound_webhooks_retry_job.rb
+++ b/app/jobs/clock/inbound_webhooks_retry_job.rb
@@ -7,10 +7,7 @@ module Clock
     queue_as "clock"
 
     def perform
-      InboundWebhook
-        .where(status: ["pending", "processing"])
-        .where("updated_at < ?", 2.hours.ago)
-        .find_each do |inbound_webhook|
+      InboundWebhook.retriable.find_each do |inbound_webhook|
         InboundWebhooks::ProcessJob.perform_later(inbound_webhook:)
       end
     end

--- a/app/jobs/clock/inbound_webhooks_retry_job.rb
+++ b/app/jobs/clock/inbound_webhooks_retry_job.rb
@@ -4,10 +4,13 @@ module Clock
   class InboundWebhooksRetryJob < ApplicationJob
     include SentryCronConcern
 
-    queue_as 'clock'
+    queue_as "clock"
 
     def perform
-      InboundWebhook.failed.find_each do |inbound_webhook|
+      InboundWebhook
+        .where(status: ["pending", "processing"])
+        .where("updated_at < ?", 12.hours.ago)
+        .find_each do |inbound_webhook|
         InboundWebhooks::ProcessJob.perform_later(inbound_webhook:)
       end
     end

--- a/app/jobs/clock/inbound_webhooks_retry_job.rb
+++ b/app/jobs/clock/inbound_webhooks_retry_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Clock
+  class InboundWebhooksRetryJob < ApplicationJob
+    include SentryCronConcern
+
+    queue_as 'clock'
+
+    def perform
+      InboundWebhook.failed.find_each do |inbound_webhook|
+        InboundWebhooks::ProcessJob.perform_later(inbound_webhook:)
+      end
+    end
+  end
+end

--- a/app/jobs/clock/inbound_webhooks_retry_job.rb
+++ b/app/jobs/clock/inbound_webhooks_retry_job.rb
@@ -9,7 +9,7 @@ module Clock
     def perform
       InboundWebhook
         .where(status: ["pending", "processing"])
-        .where("updated_at < ?", 12.hours.ago)
+        .where("updated_at < ?", 2.hours.ago)
         .find_each do |inbound_webhook|
         InboundWebhooks::ProcessJob.perform_later(inbound_webhook:)
       end

--- a/app/jobs/inbound_webhooks/process_job.rb
+++ b/app/jobs/inbound_webhooks/process_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module InboundWebhooks
+  class ProcessJob < ApplicationJob
+    queue_as :default
+
+    def perform(inbound_webhook:)
+      InboundWebhooks::ProcessService.call(inbound_webhook:).raise_if_error!
+    end
+  end
+end

--- a/app/jobs/inbound_webhooks/process_job.rb
+++ b/app/jobs/inbound_webhooks/process_job.rb
@@ -5,7 +5,7 @@ module InboundWebhooks
     queue_as :default
 
     def perform(inbound_webhook:)
-      InboundWebhooks::ProcessService.call(inbound_webhook:).raise_if_error!
+      InboundWebhooks::ProcessService.call!(inbound_webhook:)
     end
   end
 end

--- a/app/models/inbound_webhook.rb
+++ b/app/models/inbound_webhook.rb
@@ -14,6 +14,10 @@ class InboundWebhook < ApplicationRecord
 
   enum :status, STATUSES
 
+  scope :retriable, -> { reprocessable.or(old_pending) }
+  scope :reprocessable, -> { processing.where("processing_at <= ?", 2.hours.ago) }
+  scope :old_pending, -> { pending.where("created_at <= ?", 2.hours.ago) }
+
   def processing!
     update!(status: :processing, processing_at: Time.zone.now)
   end

--- a/app/models/inbound_webhook.rb
+++ b/app/models/inbound_webhook.rb
@@ -5,7 +5,12 @@ class InboundWebhook < ApplicationRecord
 
   validates :event_type, :payload, :source, :status, presence: true
 
-  STATUSES = {pending: "pending"}
+  STATUSES = {
+    pending: "pending",
+    processing: "processing",
+    processed: "processed",
+    failed: "failed"
+  }
 
   enum :status, STATUSES
 end

--- a/app/models/inbound_webhook.rb
+++ b/app/models/inbound_webhook.rb
@@ -10,7 +10,7 @@ class InboundWebhook < ApplicationRecord
   STATUSES = {
     pending: "pending",
     processing: "processing",
-    processed: "processed",
+    succeeded: "succeeded",
     failed: "failed"
   }
 
@@ -36,14 +36,16 @@ end
 #  processing_at   :datetime
 #  signature       :string
 #  source          :string           not null
-#  status          :string           default("pending"), not null
+#  status          :enum             default("pending"), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :uuid             not null
 #
 # Indexes
 #
-#  index_inbound_webhooks_on_organization_id  (organization_id)
+#  index_inbound_webhooks_on_organization_id           (organization_id)
+#  index_inbound_webhooks_on_status_and_created_at     (status,created_at) WHERE (status = 'pending'::inbound_webhook_status)
+#  index_inbound_webhooks_on_status_and_processing_at  (status,processing_at) WHERE (status = 'processing'::inbound_webhook_status)
 #
 # Foreign Keys
 #

--- a/app/models/inbound_webhook.rb
+++ b/app/models/inbound_webhook.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class InboundWebhook < ApplicationRecord
+  belongs_to :organization
+
+  validates :event_type, :payload, :source, :status, presence: true
+
+  STATUSES = {pending: "pending"}
+
+  enum :status, STATUSES
+end
+
+# == Schema Information
+#
+# Table name: inbound_webhooks
+#
+#  id              :uuid             not null, primary key
+#  code            :string
+#  event_type      :string           not null
+#  payload         :jsonb            not null
+#  signature       :string
+#  source          :string           not null
+#  status          :string           default("pending"), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_inbound_webhooks_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/inbound_webhook.rb
+++ b/app/models/inbound_webhook.rb
@@ -13,6 +13,10 @@ class InboundWebhook < ApplicationRecord
   }
 
   enum :status, STATUSES
+
+  def processing!
+    update!(status: :processing, processing_at: Time.zone.now)
+  end
 end
 
 # == Schema Information
@@ -23,6 +27,7 @@ end
 #  code            :string
 #  event_type      :string           not null
 #  payload         :jsonb            not null
+#  processing_at   :datetime
 #  signature       :string
 #  source          :string           not null
 #  status          :string           default("pending"), not null

--- a/app/services/inbound_webhooks/create_service.rb
+++ b/app/services/inbound_webhooks/create_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module InboundWebhooks
+  class CreateService < BaseService
+    def initialize(organization_id:, webhook_source:, payload:, event_type:, code: nil, signature: nil)
+      @organization_id = organization_id
+      @webhook_source = webhook_source
+      @code = code
+      @payload = payload
+      @signature = signature
+      @event_type = event_type
+
+      super
+    end
+
+    def call
+      inbound_webhook = InboundWebhook.create!(
+        organization_id:,
+        source: webhook_source,
+        code:,
+        payload:,
+        signature:,
+        event_type:
+      )
+
+      after_commit do
+        InboundWebhooks::ProcessJob.perform_later(inbound_webhook:)
+      end
+
+      result.inbound_webhook = inbound_webhook
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :organization_id, :webhook_source, :code, :payload, :signature, :event_type
+  end
+end

--- a/app/services/inbound_webhooks/create_service.rb
+++ b/app/services/inbound_webhooks/create_service.rb
@@ -14,6 +14,8 @@ module InboundWebhooks
     end
 
     def call
+      return validate_payload_result unless validate_payload_result.success?
+
       inbound_webhook = InboundWebhook.create!(
         organization_id:,
         source: webhook_source,
@@ -36,5 +38,15 @@ module InboundWebhooks
     private
 
     attr_reader :organization_id, :webhook_source, :code, :payload, :signature, :event_type
+
+    def validate_payload_result
+      @validate_payload_result ||= InboundWebhooks::ValidatePayloadService.call(
+        organization_id:,
+        code:,
+        payload:,
+        signature:,
+        webhook_source:
+      )
+    end
   end
 end

--- a/app/services/inbound_webhooks/create_service.rb
+++ b/app/services/inbound_webhooks/create_service.rb
@@ -25,9 +25,7 @@ module InboundWebhooks
         event_type:
       )
 
-      after_commit do
-        InboundWebhooks::ProcessJob.perform_later(inbound_webhook:)
-      end
+      InboundWebhooks::ProcessJob.perform_later(inbound_webhook:)
 
       result.inbound_webhook = inbound_webhook
       result

--- a/app/services/inbound_webhooks/process_service.rb
+++ b/app/services/inbound_webhooks/process_service.rb
@@ -2,8 +2,6 @@
 
 module InboundWebhooks
   class ProcessService < BaseService
-    WEBHOOK_PROCESSING_WINDOW = 2.hours
-
     WEBHOOK_HANDLER_SERVICES = {
       stripe: PaymentProviders::Stripe::HandleIncomingWebhookService
     }
@@ -52,7 +50,7 @@ module InboundWebhooks
     end
 
     def within_processing_window?
-      inbound_webhook.processing? && inbound_webhook.processing_at > WEBHOOK_PROCESSING_WINDOW.ago
+      inbound_webhook.processing? && inbound_webhook.processing_at > InboundWebhook::WEBHOOK_PROCESSING_WINDOW.ago
     end
   end
 end

--- a/app/services/inbound_webhooks/process_service.rb
+++ b/app/services/inbound_webhooks/process_service.rb
@@ -15,7 +15,7 @@ module InboundWebhooks
     def call
       return result if within_processing_window?
       return result if inbound_webhook.failed?
-      return result if inbound_webhook.processed?
+      return result if inbound_webhook.succeeded?
 
       inbound_webhook.processing!
 
@@ -26,7 +26,7 @@ module InboundWebhooks
         return handler_result
       end
 
-      inbound_webhook.processed!
+      inbound_webhook.succeeded!
 
       result.inbound_webhook = inbound_webhook
       result

--- a/app/services/inbound_webhooks/process_service.rb
+++ b/app/services/inbound_webhooks/process_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module InboundWebhooks
+  class ProcessService < BaseService
+    WEBHOOK_HANDLER_SERVICES = {
+      stripe: PaymentProviders::Stripe::HandleIncomingWebhookService
+    }
+
+    def initialize(inbound_webhook:)
+      @inbound_webhook = inbound_webhook
+
+      super
+    end
+
+    def call
+      inbound_webhook.processing!
+
+      handler_result = handler_service_klass.call(inbound_webhook:)
+
+      unless handler_result.success?
+        inbound_webhook.failed!
+        return handler_result
+      end
+
+      inbound_webhook.processed!
+
+      result.inbound_webhook = inbound_webhook
+      result
+    rescue
+      inbound_webhook.failed!
+      raise
+    end
+
+    private
+
+    attr_reader :inbound_webhook
+
+    def handler_service_klass
+      WEBHOOK_HANDLER_SERVICES.fetch(webhook_source) do
+        raise NameError, "Invalid inbound webhook source: #{webhook_source}"
+      end
+    end
+
+    def webhook_source
+      inbound_webhook.source.to_sym
+    end
+  end
+end

--- a/app/services/inbound_webhooks/validate_payload_service.rb
+++ b/app/services/inbound_webhooks/validate_payload_service.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module InboundWebhooks
+  class ValidatePayloadService < BaseService
+    WEBHOOK_SOURCES = {
+      stripe: PaymentProviders::Stripe::ValidateIncomingWebhookService
+    }
+
+    def initialize(organization_id:, code:, payload:, webhook_source:, signature:)
+      @organization_id = organization_id
+      @code = code
+      @payload = payload
+      @signature = signature
+      @webhook_source = webhook_source&.to_sym
+
+      super
+    end
+
+    def call
+      return result.service_failure!(code: "webhook_error", message: "Invalid webhook source") unless webhook_source_valid?
+      return payment_provider_result unless payment_provider_result.success?
+
+      validate_webhook_payload_result
+    end
+
+    private
+
+    attr_reader :organization_id, :code, :payload, :signature, :webhook_source
+
+    def webhook_source_valid?
+      WEBHOOK_SOURCES.include?(webhook_source)
+    end
+
+    def validate_webhook_payload_result
+      WEBHOOK_SOURCES[webhook_source].call(
+        payload:,
+        signature:,
+        payment_provider:
+      )
+    end
+
+    def payment_provider
+      payment_provider_result.payment_provider
+    end
+
+    def payment_provider_result
+      @payment_provider_result ||= PaymentProviders::FindService.call(
+        organization_id:,
+        code:,
+        payment_provider_type: webhook_source.to_s
+      )
+    end
+  end
+end

--- a/app/services/payment_providers/stripe/handle_incoming_webhook_service.rb
+++ b/app/services/payment_providers/stripe/handle_incoming_webhook_service.rb
@@ -12,36 +12,28 @@ module PaymentProviders
       end
 
       def call
-        payment_provider_result = PaymentProviders::FindService.call(
-          organization_id:,
-          code:,
-          payment_provider_type: "stripe"
-        )
-
-        return payment_provider_result unless payment_provider_result.success?
-
-        event = ::Stripe::Webhook.construct_event(
-          payload,
-          signature,
-          payment_provider_result.payment_provider&.webhook_secret
-        )
-
         PaymentProviders::Stripe::HandleEventJob.perform_later(
-          organization: payment_provider_result.payment_provider.organization,
-          event: event.to_json
+          organization:,
+          event: stripe_event.to_json
         )
 
-        result.event = event
+        result.event = stripe_event
         result
       rescue JSON::ParserError
         result.service_failure!(code: "webhook_error", message: "Invalid payload")
-      rescue ::Stripe::SignatureVerificationError
-        result.service_failure!(code: "webhook_error", message: "Invalid signature")
       end
 
       private
 
-      def_delegators :@inbound_webhook, :code, :organization_id, :payload, :signature
+      def_delegators :@inbound_webhook, :organization, :payload
+
+      def stripe_event
+        @stripe_event ||= ::Stripe::Event.construct_from(json_payload)
+      end
+
+      def json_payload
+        JSON.parse(payload, symbolize_names: true)
+      end
     end
   end
 end

--- a/app/services/payment_providers/stripe/handle_incoming_webhook_service.rb
+++ b/app/services/payment_providers/stripe/handle_incoming_webhook_service.rb
@@ -3,11 +3,10 @@
 module PaymentProviders
   module Stripe
     class HandleIncomingWebhookService < BaseService
-      def initialize(organization_id:, body:, signature:, code: nil)
-        @organization_id = organization_id
-        @body = body
-        @signature = signature
-        @code = code
+      extend Forwardable
+
+      def initialize(inbound_webhook:)
+        @inbound_webhook = inbound_webhook
 
         super
       end
@@ -22,7 +21,7 @@ module PaymentProviders
         return payment_provider_result unless payment_provider_result.success?
 
         event = ::Stripe::Webhook.construct_event(
-          body,
+          payload,
           signature,
           payment_provider_result.payment_provider&.webhook_secret
         )
@@ -42,7 +41,7 @@ module PaymentProviders
 
       private
 
-      attr_reader :organization_id, :body, :signature, :code
+      def_delegators :@inbound_webhook, :code, :organization_id, :payload, :signature
     end
   end
 end

--- a/app/services/payment_providers/stripe/validate_incoming_webhook_service.rb
+++ b/app/services/payment_providers/stripe/validate_incoming_webhook_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    class ValidateIncomingWebhookService < BaseService
+      def initialize(payload:, signature:, payment_provider:)
+        @payload = payload
+        @signature = signature
+        @provider = payment_provider
+
+        super
+      end
+
+      def call
+        ::Stripe::Webhook::Signature.verify_header(
+          payload,
+          signature,
+          webhook_secret,
+          tolerance: ::Stripe::Webhook::DEFAULT_TOLERANCE
+        )
+
+        result
+      rescue ::Stripe::SignatureVerificationError
+        result.service_failure!(code: "webhook_error", message: "Invalid signature")
+      end
+
+      private
+
+      attr_reader :payload, :signature, :provider
+
+      def webhook_secret
+        provider.webhook_secret
+      end
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -119,6 +119,12 @@ module Clockwork
       .perform_later
   end
 
+  every(1.day, 'schedule:clean_inbound_webhooks', at: '01:10') do
+    Clock::InboundWebhooksCleanupJob
+      .set(sentry: {"slug" => 'lago_clean_inbound_webhooks', "cron" => '5 1 * * *'})
+      .perform_later
+  end
+
   unless ActiveModel::Type::Boolean.new.cast(ENV['LAGO_DISABLE_EVENTS_VALIDATION'])
     every(1.hour, 'schedule:post_validate_events', at: '*:05') do
       Clock::EventsValidationJob

--- a/clock.rb
+++ b/clock.rb
@@ -153,9 +153,9 @@ module Clockwork
       .perform_later
   end
 
-  every(15.minutes, "schedule:retry_failed_inbound_webhooks") do
+  every(15.minutes, "schedule:retry_inbound_webhooks") do
     Clock::InboundWebhooksRetryJob
-      .set(sentry: {"slug" => "lago_retry_failed_inbound_webhooks", "cron" => '*/15 * * * *'})
+      .set(sentry: {"slug" => "lago_retry_inbound_webhooks", "cron" => '*/15 * * * *'})
       .perform_later
   end
 end

--- a/clock.rb
+++ b/clock.rb
@@ -152,4 +152,10 @@ module Clockwork
       .set(sentry: {"slug" => "lago_retry_failed_invoices", "cron" => '*/15 * * * *'})
       .perform_later
   end
+
+  every(15.minutes, "schedule:retry_failed_inbound_webhooks") do
+    Clock::InboundWebhooksRetryJob
+      .set(sentry: {"slug" => "lago_retry_failed_inbound_webhooks", "cron" => '*/15 * * * *'})
+      .perform_later
+  end
 end

--- a/db/migrate/20241213182343_create_inbound_webhooks.rb
+++ b/db/migrate/20241213182343_create_inbound_webhooks.rb
@@ -2,11 +2,13 @@
 
 class CreateInboundWebhooks < ActiveRecord::Migration[7.1]
   def change
+    create_enum :inbound_webhook_status, %w[pending processing succeeded failed]
+
     create_table :inbound_webhooks, id: :uuid do |t|
       t.string :source, null: false
       t.string :event_type, null: false
       t.jsonb :payload, null: false
-      t.string :status, null: false, default: 'pending'
+      t.enum :status, enum_type: "inbound_webhook_status", null: false, default: 'pending'
       t.belongs_to :organization, null: false, foreign_key: true, type: :uuid, index: true
       t.string :code
       t.string :signature

--- a/db/migrate/20241213182343_create_inbound_webhooks.rb
+++ b/db/migrate/20241213182343_create_inbound_webhooks.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateInboundWebhooks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :inbound_webhooks, id: :uuid do |t|
+      t.string :source, null: false
+      t.string :event_type, null: false
+      t.jsonb :payload, null: false
+      t.string :status, null: false, default: 'pending'
+      t.belongs_to :organization, null: false, foreign_key: true, type: :uuid, index: true
+      t.string :code
+      t.string :signature
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241219122151_add_processing_at_to_inbound_webhooks.rb
+++ b/db/migrate/20241219122151_add_processing_at_to_inbound_webhooks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProcessingAtToInboundWebhooks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :inbound_webhooks, :processing_at, :timestamp, precision: nil
+  end
+end

--- a/db/migrate/20241223154437_add_indices_to_inbound_webhooks.rb
+++ b/db/migrate/20241223154437_add_indices_to_inbound_webhooks.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddIndicesToInboundWebhooks < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :inbound_webhooks,
+      %i[status processing_at],
+      where: "status = 'processing'",
+      algorithm: :concurrently
+
+    add_index :inbound_webhooks,
+      %i[status created_at],
+      where: "status = 'pending'",
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -724,6 +724,19 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_23_144027) do
     t.index ["parent_group_id"], name: "index_groups_on_parent_group_id"
   end
 
+  create_table "inbound_webhooks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "source", null: false
+    t.string "event_type", null: false
+    t.jsonb "payload", null: false
+    t.string "status", default: "pending", null: false
+    t.uuid "organization_id", null: false
+    t.string "code"
+    t.string "signature"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id"], name: "index_inbound_webhooks_on_organization_id"
+  end
+
   create_table "integration_collection_mappings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "integration_id", null: false
     t.integer "mapping_type", null: false
@@ -1415,6 +1428,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_23_144027) do
   add_foreign_key "group_properties", "groups", on_delete: :cascade
   add_foreign_key "groups", "billable_metrics", on_delete: :cascade
   add_foreign_key "groups", "groups", column: "parent_group_id"
+  add_foreign_key "inbound_webhooks", "organizations"
   add_foreign_key "integration_collection_mappings", "integrations"
   add_foreign_key "integration_customers", "customers"
   add_foreign_key "integration_customers", "integrations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_23_144027) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_23_154437) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_23_144027) do
   create_enum "billable_metric_rounding_function", ["round", "floor", "ceil"]
   create_enum "billable_metric_weighted_interval", ["seconds"]
   create_enum "customer_type", ["company", "individual"]
+  create_enum "inbound_webhook_status", ["pending", "processing", "succeeded", "failed"]
   create_enum "payment_payable_payment_status", ["pending", "processing", "succeeded", "failed"]
   create_enum "subscription_invoicing_reason", ["subscription_starting", "subscription_periodic", "subscription_terminating", "in_advance_charge", "in_advance_charge_periodic", "progressive_billing"]
   create_enum "tax_status", ["pending", "succeeded", "failed"]
@@ -728,7 +729,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_23_144027) do
     t.string "source", null: false
     t.string "event_type", null: false
     t.jsonb "payload", null: false
-    t.string "status", default: "pending", null: false
+    t.enum "status", default: "pending", null: false, enum_type: "inbound_webhook_status"
     t.uuid "organization_id", null: false
     t.string "code"
     t.string "signature"
@@ -736,6 +737,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_23_144027) do
     t.datetime "updated_at", null: false
     t.datetime "processing_at", precision: nil
     t.index ["organization_id"], name: "index_inbound_webhooks_on_organization_id"
+    t.index ["status", "created_at"], name: "index_inbound_webhooks_on_status_and_created_at", where: "(status = 'pending'::inbound_webhook_status)"
+    t.index ["status", "processing_at"], name: "index_inbound_webhooks_on_status_and_processing_at", where: "(status = 'processing'::inbound_webhook_status)"
   end
 
   create_table "integration_collection_mappings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -734,6 +734,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_23_144027) do
     t.string "signature"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "processing_at", precision: nil
     t.index ["organization_id"], name: "index_inbound_webhooks_on_organization_id"
   end
 

--- a/spec/clockwork_spec.rb
+++ b/spec/clockwork_spec.rb
@@ -198,4 +198,25 @@ describe Clockwork do
       expect(Clock::InboundWebhooksCleanupJob).to have_been_enqueued
     end
   end
+
+  describe "schedule:retry_failed_inbound_webhooks" do
+    let(:job) { "schedule:retry_failed_inbound_webhooks" }
+    let(:start_time) { Time.zone.parse("1 Apr 2022 00:05:00") }
+    let(:end_time) { Time.zone.parse("1 Apr 2022 00:20:00") }
+
+    it "enqueue a retry failed inbound webhooks job" do
+      Clockwork::Test.run(
+        file: clock_file,
+        start_time:,
+        end_time:,
+        tick_speed: 1.minute
+      )
+
+      expect(Clockwork::Test).to be_ran_job(job)
+      expect(Clockwork::Test.times_run(job)).to eq(1)
+
+      Clockwork::Test.block_for(job).call
+      expect(Clock::InboundWebhooksRetryJob).to have_been_enqueued
+    end
+  end
 end

--- a/spec/clockwork_spec.rb
+++ b/spec/clockwork_spec.rb
@@ -199,12 +199,12 @@ describe Clockwork do
     end
   end
 
-  describe "schedule:retry_failed_inbound_webhooks" do
-    let(:job) { "schedule:retry_failed_inbound_webhooks" }
+  describe "schedule:retry_inbound_webhooks" do
+    let(:job) { "schedule:retry_inbound_webhooks" }
     let(:start_time) { Time.zone.parse("1 Apr 2022 00:05:00") }
     let(:end_time) { Time.zone.parse("1 Apr 2022 00:20:00") }
 
-    it "enqueue a retry failed inbound webhooks job" do
+    it "enqueue a retry inbound webhooks job" do
       Clockwork::Test.run(
         file: clock_file,
         start_time:,

--- a/spec/clockwork_spec.rb
+++ b/spec/clockwork_spec.rb
@@ -177,4 +177,25 @@ describe Clockwork do
       expect(Clock::ProcessDunningCampaignsJob).to have_been_enqueued
     end
   end
+
+  describe "schedule:clean_inbound_webhooks" do
+    let(:job) { "schedule:clean_inbound_webhooks" }
+    let(:start_time) { Time.zone.parse("1 Apr 2022 00:01:00") }
+    let(:end_time) { Time.zone.parse("2 Apr 2022 00:00:00") }
+
+    it "enqueue a clean inbound webhooks job" do
+      Clockwork::Test.run(
+        file: clock_file,
+        start_time:,
+        end_time:,
+        tick_speed: 1.minute
+      )
+
+      expect(Clockwork::Test).to be_ran_job(job)
+      expect(Clockwork::Test.times_run(job)).to eq(1)
+
+      Clockwork::Test.block_for(job).call
+      expect(Clock::InboundWebhooksCleanupJob).to have_been_enqueued
+    end
+  end
 end

--- a/spec/factories/inbound_webhooks.rb
+++ b/spec/factories/inbound_webhooks.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :inbound_webhook do
+    organization
+
+    source { "stripe" }
+    event_type { "payment_intent.succeeded" }
+    status { "pending" }
+    code { "webhook-endpoint-code" }
+    signature { "MySignature" }
+
+    payload do
+      File.read(Rails.root.join('spec/fixtures/stripe/payment_intent_event.json'))
+    end
+  end
+end

--- a/spec/jobs/clock/inbound_webhooks_cleanup_job_spec.rb
+++ b/spec/jobs/clock/inbound_webhooks_cleanup_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Clock::InboundWebhooksCleanupJob, job: true do
+  subject(:inbound_webhooks_cleanup_job) { described_class }
+
+  describe ".perform" do
+    it "removes all old inbound webhooks" do
+      create(:inbound_webhook, updated_at: 90.days.ago)
+
+      expect { inbound_webhooks_cleanup_job.perform_now }
+        .to change(InboundWebhook, :count).to(0)
+    end
+
+    it "does not delete recent inbound webhooks" do
+      create(:inbound_webhook, updated_at: 89.days.ago)
+
+      expect { inbound_webhooks_cleanup_job.perform_now }
+        .not_to change(InboundWebhook, :count)
+    end
+  end
+end

--- a/spec/jobs/clock/inbound_webhooks_retry_job_spec.rb
+++ b/spec/jobs/clock/inbound_webhooks_retry_job_spec.rb
@@ -15,7 +15,7 @@ describe Clock::InboundWebhooksRetryJob, job: true do
 
     context "when inbound webhook is pending" do
       let(:status) { "pending" }
-      let(:updated_at) { 11.hours.ago }
+      let(:updated_at) { 110.minutes.ago }
 
       it "does not queue a job" do
         inbound_webhooks_retry_job.perform_now
@@ -23,8 +23,8 @@ describe Clock::InboundWebhooksRetryJob, job: true do
         expect(InboundWebhooks::ProcessJob).not_to have_been_enqueued
       end
 
-      context "when inbound webhook has not being updated for more than 12 hours" do
-        let(:updated_at) { 12.hours.ago }
+      context "when inbound webhook has not being updated for more than 2 hours" do
+        let(:updated_at) { 2.hours.ago }
 
         it "queues a job to process the failed inbound webhook" do
           inbound_webhooks_retry_job.perform_now
@@ -38,7 +38,7 @@ describe Clock::InboundWebhooksRetryJob, job: true do
 
     context "when inbound webhook is processing" do
       let(:status) { "processing" }
-      let(:updated_at) { 11.hours.ago }
+      let(:updated_at) { 110.minutes.ago }
 
       it "does not queue a job" do
         inbound_webhooks_retry_job.perform_now
@@ -46,8 +46,8 @@ describe Clock::InboundWebhooksRetryJob, job: true do
         expect(InboundWebhooks::ProcessJob).not_to have_been_enqueued
       end
 
-      context "when inbound webhook has not being updated for more than 12 hours" do
-        let(:updated_at) { 12.hours.ago }
+      context "when inbound webhook has not being updated for more than 2 hours" do
+        let(:updated_at) { 2.hours.ago }
 
         it "queues a job to process the failed inbound webhook" do
           inbound_webhooks_retry_job.perform_now

--- a/spec/jobs/clock/inbound_webhooks_retry_job_spec.rb
+++ b/spec/jobs/clock/inbound_webhooks_retry_job_spec.rb
@@ -69,7 +69,7 @@ describe Clock::InboundWebhooksRetryJob, job: true do
 
     context "when inbound webhook is processed" do
       let(:inbound_webhook) { create :inbound_webhook, status: }
-      let(:status) { "processed" }
+      let(:status) { "succeeded" }
 
       it "does not queue a job" do
         inbound_webhooks_retry_job.perform_now

--- a/spec/jobs/clock/inbound_webhooks_retry_job_spec.rb
+++ b/spec/jobs/clock/inbound_webhooks_retry_job_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Clock::InboundWebhooksRetryJob, job: true do
+  subject(:inbound_webhooks_retry_job) { described_class }
+
+  describe '.perform' do
+    let(:pending_inbound_webhook) { create :inbound_webhook, status: "pending" }
+    let(:failed_inbound_webhook) { create :inbound_webhook, status: "failed" }
+    let(:processing_inbound_webhoook) { create :inbound_webhook, status: "processing" }
+    let(:processed_inbound_webhook) { create :inbound_webhook, status: "processed" }
+
+    before do
+      pending_inbound_webhook
+      failed_inbound_webhook
+      processed_inbound_webhook
+      processed_inbound_webhook
+    end
+
+    it "queues a job to process the failed inbound webhook" do
+      inbound_webhooks_retry_job.perform_now
+
+      expect(InboundWebhooks::ProcessJob).to have_been_enqueued.once
+      expect(InboundWebhooks::ProcessJob)
+        .to have_been_enqueued
+        .with(inbound_webhook: failed_inbound_webhook)
+    end
+  end
+end

--- a/spec/jobs/inbound_webhooks/process_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/process_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InboundWebhooks::ProcessJob, type: :job do
+  subject(:process_job) { described_class }
+
+  let(:inbound_webhook) { create :inbound_webhook }
+  let(:result) { BaseService::Result.new }
+
+  before do
+    allow(InboundWebhooks::ProcessService).to receive(:call).and_return(result)
+  end
+
+  it "calls the process webhook service" do
+    process_job.perform_now(inbound_webhook:)
+
+    expect(InboundWebhooks::ProcessService)
+      .to have_received(:call)
+      .with(inbound_webhook:)
+  end
+
+  context "when result is a failure" do
+    let(:result) do
+      BaseService::Result.new.service_failure!(code: "error", message: "error message")
+    end
+
+    it "raises an error" do
+      expect { process_job.perform_now(inbound_webhook:) }
+        .to raise_error(BaseService::FailedResult)
+    end
+  end
+end

--- a/spec/models/inbound_webhook_spec.rb
+++ b/spec/models/inbound_webhook_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InboundWebhook, type: :model do
+  subject(:inbound_webhook) { build(:inbound_webhook) }
+
+  it { is_expected.to belong_to(:organization) }
+
+  it { is_expected.to validate_presence_of(:event_type) }
+  it { is_expected.to validate_presence_of(:payload) }
+  it { is_expected.to validate_presence_of(:source) }
+  it { is_expected.to validate_presence_of(:status) }
+
+  it { is_expected.to be_pending }
+end

--- a/spec/models/inbound_webhook_spec.rb
+++ b/spec/models/inbound_webhook_spec.rb
@@ -13,4 +13,14 @@ RSpec.describe InboundWebhook, type: :model do
   it { is_expected.to validate_presence_of(:status) }
 
   it { is_expected.to be_pending }
+
+  describe "#processing!" do
+    it "updates status and processing_at" do
+      freeze_time do
+        expect { inbound_webhook.processing! }
+          .to change(inbound_webhook, :status).to("processing")
+          .and change(inbound_webhook, :processing_at).to(Time.zone.now)
+      end
+    end
+  end
 end

--- a/spec/services/inbound_webhooks/create_service_spec.rb
+++ b/spec/services/inbound_webhooks/create_service_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InboundWebhooks::CreateService, type: :service do
+  subject(:result) do
+    described_class.call(
+      organization_id: organization.id,
+      webhook_source:,
+      code:,
+      payload:,
+      signature:,
+      event_type:
+    )
+  end
+
+  let(:organization) { create :organization }
+  let(:code) { "stripe_1" }
+  let(:webhook_source) { "stripe" }
+  let(:signature) { "signature" }
+  let(:payload) { event.merge(code:).to_json }
+  let(:event_type) { "payment_intent.successful" }
+
+  let(:event) do
+    path = Rails.root.join("spec/fixtures/stripe/payment_intent_event.json")
+    JSON.parse(File.read(path))
+  end
+
+  it "creates an inbound webhook" do
+    expect { result }.to change(InboundWebhook, :count).by(1)
+  end
+
+  it "returns a pending inbound webhook in the result" do
+    expect(result.inbound_webhook).to be_a(InboundWebhook)
+    expect(result.inbound_webhook).to be_pending
+  end
+
+  it "queues an InboundWebhook::ProcessJob job" do
+    result
+
+    expect(InboundWebhooks::ProcessJob)
+      .to have_been_enqueued
+      .with(inbound_webhook: result.inbound_webhook)
+  end
+
+  context "with validation error" do
+    let(:webhook_source) { nil }
+
+    it "returns an error" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+      expect(result.error.messages[:source]).to eq(["value_is_mandatory"])
+    end
+
+    it "does not queue an InboundWebhook::ProcessJob job" do
+      result
+
+      expect(InboundWebhooks::ProcessJob).not_to have_been_enqueued
+    end
+  end
+end

--- a/spec/services/inbound_webhooks/process_service_spec.rb
+++ b/spec/services/inbound_webhooks/process_service_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe InboundWebhooks::ProcessService, type: :service do
     end
   end
 
-  context "when inbound webhook has been processed" do
+  context "when inbound webhook has been succeeded" do
     let(:inbound_webhook) { create :inbound_webhook, source: webhook_source, status: }
-    let(:status) { "processed" }
+    let(:status) { "succeeded" }
 
     it "does not process the webhook" do
       expect(result).to be_success
@@ -105,8 +105,8 @@ RSpec.describe InboundWebhooks::ProcessService, type: :service do
         .with(inbound_webhook:)
     end
 
-    it "updated inbound webhook status to processed" do
-      expect { result }.to change(inbound_webhook, :status).to("processed")
+    it "updated inbound webhook status to succeeded" do
+      expect { result }.to change(inbound_webhook, :status).to("succeeded")
     end
 
     context "when the stripe webhook handling fails" do

--- a/spec/services/inbound_webhooks/process_service_spec.rb
+++ b/spec/services/inbound_webhooks/process_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InboundWebhooks::ProcessService, type: :service do
+  subject(:result) { described_class.call(inbound_webhook:) }
+
+  let(:inbound_webhook) { create :inbound_webhook, source: webhook_source }
+  let(:webhook_source) { "stripe" }
+  let(:handle_incoming_webhook_service_result) { BaseService::Result.new }
+
+  before do
+    allow(PaymentProviders::Stripe::HandleIncomingWebhookService)
+      .to receive(:call)
+      .and_return(handle_incoming_webhook_service_result)
+  end
+
+  it "updateds inbound webhook status to processing" do
+    allow(inbound_webhook).to receive(:processing!)
+
+    result
+    expect(inbound_webhook).to have_received(:processing!).once
+  end
+
+  context "when inbound webhook source is invalid" do
+    let(:webhook_source) { "invalid_source" }
+
+    it "flags inbound webhook as failed and raises an error" do
+      expect { result }
+        .to change(inbound_webhook, :status).to("failed")
+        .and raise_error(
+          NameError,
+          "Invalid inbound webhook source: invalid_source"
+        )
+    end
+  end
+
+  context "when webhook source is Stripe" do
+    let(:webhook_source) { "stripe" }
+
+    before do
+      allow(PaymentProviders::Stripe::HandleIncomingWebhookService)
+        .to receive(:call)
+        .and_return(handle_incoming_webhook_service_result)
+    end
+
+    it "delegates the call to the Stripe webhook hanlder service" do
+      expect(result).to be_success
+      expect(PaymentProviders::Stripe::HandleIncomingWebhookService)
+        .to have_received(:call)
+        .with(inbound_webhook:)
+    end
+
+    it "updated inbound webhook status to processed" do
+      expect { result }.to change(inbound_webhook, :status).to("processed")
+    end
+
+    context "when the stripe webhook handling fails" do
+      before do
+        handle_incoming_webhook_service_result.service_failure!(
+          code: "error", message: "error message"
+        )
+      end
+
+      it "returns the handler results" do
+        expect(result).not_to be_success
+        expect(result).to eq(handle_incoming_webhook_service_result)
+      end
+
+      it "updates inbound webhook status to failed" do
+        expect { result }.to change(inbound_webhook, :status).to("failed")
+      end
+    end
+  end
+end

--- a/spec/services/inbound_webhooks/validate_payload_service_spec.rb
+++ b/spec/services/inbound_webhooks/validate_payload_service_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InboundWebhooks::ValidatePayloadService, type: :service do
+  subject(:result) do
+    described_class.call(
+      organization_id: organization.id,
+      code:,
+      payload:,
+      webhook_source:,
+      signature:
+    )
+  end
+
+  let(:organization) { create(:organization) }
+  let(:code) { "payment_provider_1" }
+  let(:payload) { "webhook_payload" }
+  let(:signature) { "signature" }
+  let(:webhook_source) { "stripe" }
+
+  context "when webhook source is unknown" do
+    let(:webhook_source) { "unknown" }
+
+    it "returns an error" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ServiceFailure)
+      expect(result.error.message).to eq("webhook_error: Invalid webhook source")
+    end
+  end
+
+  context "when payment provider is not found" do
+    it "returns a service failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ServiceFailure)
+      expect(result.error.message).to eq("payment_provider_not_found: Payment provider not found")
+    end
+  end
+
+  context "when webhook source is stripe" do
+    let(:webhook_source) { "stripe" }
+    let(:payload) { "webhook_payload" }
+
+    before do
+      allow(::Stripe::Webhook::Signature).to receive(:verify_header).and_return(true)
+      create(:stripe_provider, organization:, code:)
+    end
+
+    it "validates the payload" do
+      expect(result).to be_success
+    end
+
+    context "when signature is invalid" do
+      before do
+        allow(::Stripe::Webhook::Signature)
+          .to receive(:verify_header)
+          .and_raise(
+            ::Stripe::SignatureVerificationError.new(
+              "Unable to extract timestamp and signatures from header",
+              signature,
+              http_body: payload
+            )
+          )
+      end
+
+      it "returns a service failure" do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.message).to eq("webhook_error: Invalid signature")
+      end
+    end
+  end
+end

--- a/spec/services/payment_providers/stripe/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/handle_incoming_webhook_service_spec.rb
@@ -5,11 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::HandleIncomingWebhookService, type: :service do
   subject(:result) { described_class.call(inbound_webhook:) }
 
-  let(:inbound_webhook) { create :inbound_webhook, organization:, code: }
-  let(:code) { nil }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:stripe_provider) { create(:stripe_provider, organization:) }
+  let(:inbound_webhook) { create :inbound_webhook }
   let(:event_result) { Stripe::Event.construct_from(event) }
 
   let(:event) do
@@ -17,42 +13,20 @@ RSpec.describe PaymentProviders::Stripe::HandleIncomingWebhookService, type: :se
     JSON.parse(File.read(path))
   end
 
-  before { stripe_provider }
-
   it "checks the webhook" do
-    allow(::Stripe::Webhook).to receive(:construct_event)
-      .and_return(event_result)
-
     expect(result).to be_success
     expect(result.event).to eq(event_result)
     expect(PaymentProviders::Stripe::HandleEventJob).to have_been_enqueued
   end
 
   context "when failing to parse payload" do
-    it "returns an error" do
-      allow(::Stripe::Webhook).to receive(:construct_event)
-        .and_raise(JSON::ParserError)
+    let(:event) { "invalid" }
 
+    it "returns an error" do
       expect(result).not_to be_success
       expect(result.error).to be_a(BaseService::ServiceFailure)
       expect(result.error.code).to eq("webhook_error")
       expect(result.error.error_message).to eq("Invalid payload")
-    end
-  end
-
-  context "when failing to validate the signature" do
-    it "returns an error" do
-      allow(::Stripe::Webhook).to receive(:construct_event)
-        .and_raise(
-          ::Stripe::SignatureVerificationError.new(
-            "error", "signature", http_body: event.to_json
-          )
-        )
-
-      expect(result).not_to be_success
-      expect(result.error).to be_a(BaseService::ServiceFailure)
-      expect(result.error.code).to eq("webhook_error")
-      expect(result.error.error_message).to eq("Invalid signature")
     end
   end
 end

--- a/spec/services/payment_providers/stripe/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/handle_incoming_webhook_service_spec.rb
@@ -6,12 +6,8 @@ RSpec.describe PaymentProviders::Stripe::HandleIncomingWebhookService, type: :se
   subject(:result) { described_class.call(inbound_webhook:) }
 
   let(:inbound_webhook) { create :inbound_webhook }
-  let(:event_result) { Stripe::Event.construct_from(event) }
-
-  let(:event) do
-    path = Rails.root.join("spec/fixtures/stripe/payment_intent_event.json")
-    JSON.parse(File.read(path))
-  end
+  let(:webhook_payload) { JSON.parse(inbound_webhook.payload) }
+  let(:event_result) { Stripe::Event.construct_from(webhook_payload) }
 
   it "checks the webhook" do
     expect(result).to be_success
@@ -20,7 +16,7 @@ RSpec.describe PaymentProviders::Stripe::HandleIncomingWebhookService, type: :se
   end
 
   context "when failing to parse payload" do
-    let(:event) { "invalid" }
+    let(:inbound_webhook) { create :inbound_webhook, payload: "invalid" }
 
     it "returns an error" do
       expect(result).not_to be_success

--- a/spec/services/payment_providers/stripe/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/handle_incoming_webhook_service_spec.rb
@@ -3,18 +3,12 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviders::Stripe::HandleIncomingWebhookService, type: :service do
-  subject(:result) do
-    described_class.call(
-      organization_id: organization.id,
-      body: event.to_json,
-      signature: "signature",
-      code:
-    )
-  end
+  subject(:result) { described_class.call(inbound_webhook:) }
 
+  let(:inbound_webhook) { create :inbound_webhook, organization:, code: }
+  let(:code) { nil }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:code) { nil }
   let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:event_result) { Stripe::Event.construct_from(event) }
 

--- a/spec/services/payment_providers/stripe/validate_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/validate_incoming_webhook_service_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Stripe::ValidateIncomingWebhookService, type: :service do
+  subject(:result) do
+    described_class.call(payload:, signature:, payment_provider:)
+  end
+
+  let(:payload) { "webhook_payload" }
+  let(:signature) { "signature" }
+  let(:payment_provider) { create(:stripe_provider, webhook_secret:) }
+  let(:webhook_secret) { "webhook_secret" }
+  let(:payload) { "{stripe incoming webhook JSON payload}" }
+  let(:stripe_default_tolerance) { 300 }
+
+  before do
+    allow(::Stripe::Webhook::Signature).to receive(:verify_header).and_return(true)
+  end
+
+  it "validates the payload" do
+    expect(result).to be_success
+
+    expect(::Stripe::Webhook::Signature)
+      .to have_received(:verify_header)
+      .with(
+        payload,
+        signature,
+        webhook_secret,
+        tolerance: stripe_default_tolerance
+      ).once
+  end
+
+  context "when signature is invalid" do
+    before do
+      allow(::Stripe::Webhook::Signature)
+        .to receive(:verify_header)
+        .and_raise(
+          ::Stripe::SignatureVerificationError.new(
+            "Unable to extract timestamp and signatures from header",
+            signature,
+            http_body: payload
+          )
+        )
+    end
+
+    it "returns a service failure" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ServiceFailure)
+      expect(result.error.message).to eq("webhook_error: Invalid signature")
+    end
+  end
+end

--- a/spec/services/payment_providers/stripe/validate_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/validate_incoming_webhook_service_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe PaymentProviders::Stripe::ValidateIncomingWebhookService, type: :
   let(:signature) { "signature" }
   let(:payment_provider) { create(:stripe_provider, webhook_secret:) }
   let(:webhook_secret) { "webhook_secret" }
-  let(:payload) { "{stripe incoming webhook JSON payload}" }
   let(:stripe_default_tolerance) { 300 }
 
   before do


### PR DESCRIPTION
## Context

Currently, when our application receives webhooks from third-party services (e.g., Stripe, GoCardless, Adyen), their payloads are immediately queued in Sidekiq for background processing. While this approach works in most cases, it introduces a critical reliability issue, especially in self-hosted environments where Sidekiq may lose jobs if workers are abruptly terminated or overloaded.

This unreliability has led to issues like pending transactions that are never resolved despite receiving valid webhooks. For example, a reported issue involved a wallet credit purchase where the payment settled on Stripe, the webhook was received, but the transaction remained pending indefinitely until manually resolved.

To address this, we aim to ensure that no webhook payload is lost and processing remains consistent, even under adverse conditions.


## Description

This PR introduces a robust mechanism for handling inbound webhooks by persisting them in the database before processing. Key changes include:

### Database Persistence:
* Webhooks are now stored in a new `inbound_webhooks` table immediately upon receipt. This ensures all webhook payloads are safely persisted in a reliable system before processing.

### Background Processing:
* A new `InboundWebhooks::CreateService` is introduced to persist the webhook and enqueue it for processing.
* A new `InboundWebhooks::ProcessJob` Sidekiq worker processes the persisted webhooks, invoking the `InboundWebhooks::ProcessService`
* A new `InboundWebhooks::ProcessService` processes the persisted webhooks invoking the appropriate payment provider service.

### Retry Mechanisms:
* Failed webhooks are marked as such and can be retried manually or automatically via a clock job.
* A cleanup job is introduced to remove processed webhook records older than 1 month.

### Controller Update:
* The `WebhooksController` actions (stripe, adyen, and gocardless) now use the InboundWebhooks::CreateService and respond with 200 OK once the webhook is persisted successfully.

### Backward Compatibility:
* No webhooks will be missed during the transition. The change is designed to integrate seamlessly into both cloud and self-hosted environments.

### Key Changes
* Added `InboundWebhook` ActiveRecord model to persist webhook payloads with fields such as `source`, `event_type`, `payload`, `status`.
* Implemented `InboundWebhooks::CreateService` to handle webhook persistence and Sidekiq job enqueueing.
* Added `InboundWebhooks::ProcessJob` to process persisted webhooks from Sidekiq queue.
* Added `InboundWebhooks::ProcessService` to call the respective provider's handle incoming webhook service.
* Updated `PaymentProviders::Stripe::HandleIncomingWebhookService` to process webhooks from the database instead of relying solely on direct Sidekiq queues.
* Updated `WebhooksController#stripe` action to integrate with the new service and workflow.
* Introduced a clock job for:
1. Retrying pending webhooks older than 2 hours.
2. Cleaning up processed webhooks older than 90 days.

### Benefits
**Reliability:** Ensures no webhook is lost, even if Sidekiq workers fail.
**Resilience:** Provides a retry mechanism for failed webhook processing.
**Transparency:** Makes webhook processing traceable with statuses (pending, processing, processed, failed).