### PR TITLE
misc: Prevent overriding set by test example aggregate_failures flag

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,6 +66,8 @@ RSpec.configure do |config|
   end
 
   config.define_derived_metadata do |meta|
-    meta[:aggregate_failures] = true
+    unless meta.key?(:aggregate_failures)
+      meta[:aggregate_failures] = true
+    end
   end
 end


### PR DESCRIPTION
## Context

Recently we're added by default `aggregate_failures: true` to all test's metadata.
Unfortunately, `aggregate_failures` changes some information on the test example metadata and limits our opportunity to debug randomly failing test more efficiently.

Particularly this overrides `example.exception`. It's needed when we have test that fails from time to time depending on some tricky data combination.

The quickest and easiest known way to me to debug it is to use `after { |example| binding.pry if example.exception }`. That callback will trigger breakpoint only if test failed.

quick debug setup will look like
```ruby
describe "something" do
  after { |example| binding.pry if example.exception }

  1000.times do
  fit "randomly failing test", aggregate_failures: false do
    # ....
  end
  end
end
```

That will run the same test many times and trigger breakpoint only when it's worth to check by us.


## Description

Adjusting metadata setup to respect values set directly on test.
