### PR TITLE
feat(salesforce): Sync with provider always true

### DIFF
--- a/app/services/integration_customers/create_service.rb
+++ b/app/services/integration_customers/create_service.rb
@@ -41,12 +41,17 @@ module IntegrationCustomers
     end
 
     def link_customer!
+      sync_with_provider = false
+      if integration&.type&.to_s == 'Integrations::SalesforceIntegration'
+        sync_with_provider = true
+      end
+
       new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
         integration:,
         customer:,
         external_customer_id: params[:external_customer_id],
         type: customer_type,
-        sync_with_provider: false
+        sync_with_provider: sync_with_provider
       )
 
       if integration&.type&.to_s == 'Integrations::NetsuiteIntegration'

--- a/app/services/integration_customers/create_service.rb
+++ b/app/services/integration_customers/create_service.rb
@@ -41,10 +41,7 @@ module IntegrationCustomers
     end
 
     def link_customer!
-      sync_with_provider = false
-      if integration&.type&.to_s == 'Integrations::SalesforceIntegration'
-        sync_with_provider = true
-      end
+      sync_with_provider = integration&.type&.to_s == 'Integrations::SalesforceIntegration'
 
       new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
         integration:,

--- a/spec/services/integration_customers/create_service_spec.rb
+++ b/spec/services/integration_customers/create_service_spec.rb
@@ -7,13 +7,14 @@ RSpec.describe IntegrationCustomers::CreateService, type: :service do
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }
   let(:customer) { create(:customer, organization:) }
+  let(:integration_type) { 'netsuite' }
 
   describe '#call' do
     subject(:service_call) { described_class.call(params:, integration:, customer:) }
 
     let(:params) do
       {
-        integration_type: 'netsuite',
+        integration_type:,
         integration_code:,
         sync_with_provider:,
         external_customer_id:,
@@ -71,6 +72,23 @@ RSpec.describe IntegrationCustomers::CreateService, type: :service do
 
           it 'creates integration customer' do
             expect { service_call }.to change(IntegrationCustomers::BaseCustomer, :count).by(1)
+          end
+
+          context 'when the integration is with salesforce' do
+            let(:integration) { create(:salesforce_integration, organization:) }
+            let(:integration_type) { 'salesforce' }
+
+            it 'returns integration customer with sync_with_provider true' do
+              result = service_call
+
+              aggregate_failures do
+                expect(aggregator_contacts_create_service).not_to have_received(:call)
+                expect(result).to be_success
+                expect(result.integration_customer).to eq(integration_customer)
+                expect(result.integration_customer.external_customer_id).to eq(external_customer_id)
+                expect(result.integration_customer.sync_with_provider).to eq(true)
+              end
+            end
           end
         end
 

--- a/spec/services/integration_customers/create_service_spec.rb
+++ b/spec/services/integration_customers/create_service_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe IntegrationCustomers::CreateService, type: :service do
             expect { service_call }.to change(IntegrationCustomers::BaseCustomer, :count).by(1)
           end
 
-          context 'when the integration is with salesforce' do
+          context 'when the integration type is salesforce' do
             let(:integration) { create(:salesforce_integration, organization:) }
             let(:integration_type) { 'salesforce' }
 


### PR DESCRIPTION
## Context

This PR updates the link_customer! method to ensure that the sync_with_provider attribute is always set to true when the integration type is SalesforceIntegration. Previously, the value for sync_with_provider was hardcoded as false, regardless of the integration type.