### PR TITLE
feat (anrok integration): add pull taxes service that is used in async mode

### DIFF
--- a/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
+++ b/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Invoices
+  module ProviderTaxes
+    class PullTaxesAndApplyJob < ApplicationJob
+      queue_as 'integrations'
+
+      def perform(invoice:)
+        return unless invoice.customer.anrok_customer
+
+        Invoices::ProviderTaxes::PullTaxesAndApplyService.call(invoice:)
+      end
+    end
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -446,7 +446,8 @@ class Invoice < ApplicationRecord
     status_changed?(from: 'draft', to: 'finalized') ||
       status_changed?(from: 'generating', to: 'finalized') ||
       status_changed?(from: 'open', to: 'finalized') ||
-      status_changed?(from: 'failed', to: 'finalized')
+      status_changed?(from: 'failed', to: 'finalized') ||
+      status_changed?(from: 'pending', to: 'finalized')
   end
 end
 

--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -60,7 +60,7 @@ module Invoices
     end
 
     def should_apply_fee_taxes?
-      return false if invoice.one_off? && !invoice.failed?
+      return false if invoice.one_off? && !(invoice.failed? || invoice.pending?)
       return false if invoice.advance_charges?
 
       true

--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module Invoices
+  module ProviderTaxes
+    class PullTaxesAndApplyService < BaseService
+      def initialize(invoice:)
+        @invoice = invoice
+
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: 'invoice') unless invoice
+        unless (invoice.pending? || invoice.draft?) && invoice.tax_pending?
+          return result.not_allowed_failure!(code: 'invalid_status')
+        end
+
+        invoice.error_details.tax_error.discard_all
+        taxes_result = if invoice.draft?
+          Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:, fees: invoice.fees)
+        else
+          Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:, fees: invoice.fees)
+        end
+
+        unless taxes_result.success?
+          create_error_detail(taxes_result.error)
+          invoice.tax_status = 'failed'
+          invoice.status = 'failed' unless invoice.draft?
+          invoice.save!
+
+          return result.validation_failure!(errors: {tax_error: [taxes_result.error.code]})
+        end
+
+        provider_taxes = taxes_result.fees
+
+        ActiveRecord::Base.transaction do
+          Invoices::ComputeAmountsFromFees.call(invoice:, provider_taxes:)
+
+          create_credit_note_credit if should_create_credit_note_credit?
+          create_applied_prepaid_credit if should_create_applied_prepaid_credit?
+
+          invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
+          if invoice.draft?
+            invoice.status = :draft
+          else
+            Invoices::TransitionToFinalStatusService.call(invoice:)
+          end
+
+          invoice.save!
+          invoice.reload
+
+          result.invoice = invoice
+        end
+
+        if invoice.finalized?
+          SendWebhookJob.perform_later('invoice.created', invoice)
+          GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
+          Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
+          Integrations::Aggregator::Invoices::Hubspot::CreateJob.perform_later(invoice:) if invoice.should_sync_hubspot_invoice?
+          Invoices::Payments::CreateService.call_async(invoice:)
+          Utils::SegmentTrack.invoice_created(invoice)
+        end
+
+        result
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
+      rescue BaseService::FailedResult => e
+        e.result
+      rescue => e
+        result.fail_with_error!(e)
+      end
+
+      private
+
+      attr_accessor :invoice
+
+      def should_deliver_email?
+        License.premium? &&
+          invoice.organization.email_settings.include?('invoice.finalized')
+      end
+
+      def wallet
+        return @wallet if @wallet
+
+        @wallet = customer.wallets.active.first
+      end
+
+      def should_create_credit_note_credit?
+        return false if invoice.draft?
+
+        !invoice.one_off?
+      end
+
+      def should_create_applied_prepaid_credit?
+        return false if invoice.draft?
+        return false if invoice.one_off?
+        return false unless wallet&.active?
+        return false unless invoice.total_amount_cents&.positive?
+
+        wallet.balance.positive?
+      end
+
+      def create_credit_note_credit
+        credit_result = Credits::CreditNoteService.new(invoice:).call
+        credit_result.raise_if_error!
+
+        invoice.total_amount_cents -= credit_result.credits.sum(&:amount_cents) if credit_result.credits
+      end
+
+      def create_applied_prepaid_credit
+        prepaid_credit_result = Credits::AppliedPrepaidCreditService.call(invoice:, wallet:)
+        prepaid_credit_result.raise_if_error!
+
+        invoice.total_amount_cents -= prepaid_credit_result.prepaid_credit_amount_cents
+      end
+
+      def customer
+        @customer ||= invoice.customer
+      end
+
+      def create_error_detail(error)
+        error_result = ErrorDetails::CreateService.call(
+          owner: invoice,
+          organization: invoice.organization,
+          params: {
+            error_code: :tax_error,
+            details: {
+              tax_error: error.code
+            }.tap do |details|
+              details[:tax_error_message] = error.error_message if error.code == 'validationError'
+            end
+          }
+        )
+        error_result.raise_if_error!
+      end
+    end
+  end
+end

--- a/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
+++ b/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyJob, type: :job do
+  let(:organization) { create(:organization) }
+  let(:invoice) { create(:invoice, customer:) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:result) { BaseService::Result.new }
+
+  before do
+    allow(Invoices::ProviderTaxes::PullTaxesService).to receive(:call)
+      .with(invoice:)
+      .and_return(result)
+  end
+
+  context 'when there is anrok customer' do
+    let(:integration) { create(:anrok_integration, organization:) }
+    let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+
+    before { integration_customer }
+
+    it 'calls successfully the service' do
+      described_class.perform_now(invoice:)
+
+      expect(Invoices::ProviderTaxes::PullTaxesService).to have_received(:call)
+    end
+  end
+
+  context 'when there is NOT anrok customer' do
+    it 'does not call the service' do
+      described_class.perform_now(invoice:)
+
+      expect(Invoices::ProviderTaxes::PullTaxesService).not_to have_received(:call)
+    end
+  end
+end

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -1,0 +1,415 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service do
+  subject(:pull_taxes_service) { described_class.new(invoice:) }
+
+  describe '#call' do
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+
+    let(:invoice) do
+      create(
+        :invoice,
+        :pending,
+        :with_tax_error,
+        customer:,
+        organization:,
+        subscriptions: [subscription],
+        currency: 'EUR',
+        tax_status: 'pending',
+        issuing_date: Time.zone.at(timestamp).to_date
+      )
+    end
+
+    let(:subscription) do
+      create(
+        :subscription,
+        plan:,
+        subscription_at: started_at,
+        started_at:,
+        created_at: started_at
+      )
+    end
+
+    let(:timestamp) { Time.zone.now - 1.year }
+    let(:started_at) { Time.zone.now - 2.years }
+    let(:plan) { create(:plan, organization:, interval: 'monthly') }
+    let(:billable_metric) { create(:billable_metric, aggregation_type: 'count_agg') }
+    let(:charge) { create(:standard_charge, plan: subscription.plan, charge_model: 'standard', billable_metric:) }
+
+    let(:fee_subscription) do
+      create(
+        :fee,
+        invoice:,
+        subscription:,
+        fee_type: :subscription,
+        amount_cents: 2_000
+      )
+    end
+    let(:fee_charge) do
+      create(
+        :fee,
+        invoice:,
+        charge:,
+        fee_type: :charge,
+        total_aggregated_units: 100,
+        amount_cents: 1_000
+      )
+    end
+
+    let(:integration) { create(:anrok_integration, organization:) }
+    let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+    let(:response) { instance_double(Net::HTTPOK) }
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+    let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+    let(:endpoint_draft) { 'https://api.nango.dev/v1/anrok/draft_invoices' }
+    let(:body) do
+      path = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response_multiple_fees.json')
+      json = File.read(path)
+
+      # setting item_id based on the test example
+      response = JSON.parse(json)
+      response['succeededInvoices'].first['fees'].first['item_id'] = fee_subscription.id
+      response['succeededInvoices'].first['fees'].last['item_id'] = fee_charge.id
+
+      response.to_json
+    end
+    let(:integration_collection_mapping) do
+      create(
+        :netsuite_collection_mapping,
+        integration:,
+        mapping_type: :fallback_item,
+        settings: {external_id: '1', external_account_code: '11', external_name: ''}
+      )
+    end
+
+    before do
+      integration_collection_mapping
+      fee_subscription
+      fee_charge
+
+      allow(SegmentTrackJob).to receive(:perform_later)
+      allow(Invoices::Payments::StripeCreateJob).to receive(:perform_later).and_call_original
+      allow(Invoices::Payments::GocardlessCreateJob).to receive(:perform_later).and_call_original
+
+      integration_customer
+
+      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(LagoHttpClient::Client).to receive(:new).with(endpoint_draft).and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response).and_return(response)
+      allow(response).to receive(:body).and_return(body)
+    end
+
+    context 'when invoice does not exist' do
+      it 'returns an error' do
+        result = described_class.new(invoice: nil).call
+
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq('invoice_not_found')
+      end
+    end
+
+    context 'when invoice is not pending' do
+      before do
+        invoice.update(status: %i[finalized voided generating].sample)
+      end
+
+      it 'returns an error' do
+        result = pull_taxes_service.call
+
+        expect(result).not_to be_success
+        expect(result.error.code).to eq('invalid_status')
+      end
+    end
+
+    context 'when taxes are fetched successfully' do
+      it 'marks the invoice as finalized' do
+        expect { pull_taxes_service.call }
+          .to change(invoice, :status).from('pending').to('finalized')
+      end
+
+      it 'discards previous tax errors' do
+        expect { pull_taxes_service.call }
+          .to change(invoice.error_details.tax_error, :count).from(1).to(0)
+      end
+
+      it 'generates invoice number' do
+        customer_slug = "#{organization.document_number_prefix}-#{format("%03d", customer.sequential_id)}"
+        sequential_id = customer.invoices.where.not(id: invoice.id).order(created_at: :desc).first&.sequential_id || 0
+
+        expect { pull_taxes_service.call }
+          .to change { invoice.reload.number }
+          .from("#{organization.document_number_prefix}-DRAFT")
+          .to("#{customer_slug}-#{format("%03d", sequential_id + 1)}")
+      end
+
+      it 'generates expected invoice totals' do
+        result = pull_taxes_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice.fees.charge.count).to eq(1)
+          expect(result.invoice.fees.subscription.count).to eq(1)
+
+          expect(result.invoice.currency).to eq('EUR')
+          expect(result.invoice.fees_amount_cents).to eq(3_000)
+
+          expect(result.invoice.taxes_amount_cents).to eq(350)
+          expect(result.invoice.taxes_rate.round(2)).to eq(11.67) # (0.667 * 10) + (0.333 * 15)
+          expect(result.invoice.applied_taxes.count).to eq(2)
+
+          expect(result.invoice.total_amount_cents).to eq(3_350)
+        end
+      end
+
+      it_behaves_like 'syncs invoice' do
+        let(:service_call) { pull_taxes_service.call }
+      end
+
+      it 'enqueues a SendWebhookJob' do
+        expect do
+          pull_taxes_service.call
+        end.to have_enqueued_job(SendWebhookJob).with('invoice.created', Invoice)
+      end
+
+      it 'enqueues GeneratePdfAndNotifyJob with email false' do
+        expect do
+          pull_taxes_service.call
+        end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
+      end
+
+      context 'with lago_premium' do
+        around { |test| lago_premium!(&test) }
+
+        it 'enqueues GeneratePdfAndNotifyJob with email true' do
+          expect do
+            pull_taxes_service.call
+          end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: true))
+        end
+
+        context 'when organization does not have right email settings' do
+          before { invoice.organization.update!(email_settings: []) }
+
+          it 'enqueues GeneratePdfAndNotifyJob with email false' do
+            expect do
+              pull_taxes_service.call
+            end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
+          end
+        end
+      end
+
+      it 'calls SegmentTrackJob' do
+        invoice = pull_taxes_service.call.invoice
+
+        expect(SegmentTrackJob).to have_received(:perform_later).with(
+          membership_id: CurrentContext.membership,
+          event: 'invoice_created',
+          properties: {
+            organization_id: invoice.organization.id,
+            invoice_id: invoice.id,
+            invoice_type: invoice.invoice_type
+          }
+        )
+      end
+
+      it 'creates a payment' do
+        allow(Invoices::Payments::CreateService).to receive(:call_async)
+
+        pull_taxes_service.call
+        expect(Invoices::Payments::CreateService).to have_received(:call_async)
+      end
+
+      context 'with credit notes' do
+        let(:credit_note) do
+          create(
+            :credit_note,
+            customer:,
+            total_amount_cents: 10,
+            total_amount_currency: 'EUR',
+            balance_amount_cents: 10,
+            balance_amount_currency: 'EUR',
+            credit_amount_cents: 10,
+            credit_amount_currency: 'EUR'
+          )
+        end
+
+        before { credit_note }
+
+        it 'updates the invoice accordingly' do
+          result = pull_taxes_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.invoice.fees_amount_cents).to eq(3_000)
+            expect(result.invoice.taxes_amount_cents).to eq(350)
+            expect(result.invoice.total_amount_cents).to eq(3_340)
+            expect(result.invoice.credits.count).to eq(1)
+
+            credit = result.invoice.credits.first
+            expect(credit.credit_note).to eq(credit_note)
+            expect(credit.amount_cents).to eq(10)
+          end
+        end
+
+        context 'when invoice type is one_off' do
+          before do
+            invoice.update!(invoice_type: :one_off)
+          end
+
+          it 'does not apply credit note' do
+            result = pull_taxes_service.call
+
+            aggregate_failures do
+              expect(result).to be_success
+              expect(result.invoice.fees_amount_cents).to eq(3_000)
+              expect(result.invoice.taxes_amount_cents).to eq(350)
+              expect(result.invoice.total_amount_cents).to eq(3_350)
+              expect(result.invoice.credits.count).to eq(0)
+            end
+          end
+        end
+      end
+
+      context 'when status is draft' do
+        before do
+          invoice.update!(status: :draft)
+        end
+
+        it 'marks the invoice as draft' do
+          expect { pull_taxes_service.call }
+            .not_to change(invoice, :status).from('draft')
+        end
+
+        it 'discards previous tax errors' do
+          expect { pull_taxes_service.call }
+            .to change(invoice.error_details.tax_error, :count).from(1).to(0)
+        end
+
+        it 'does not generate invoice number' do
+          expect { pull_taxes_service.call }
+            .not_to change { invoice.reload.number }
+            .from("#{organization.document_number_prefix}-DRAFT")
+        end
+
+        it 'generates expected invoice totals' do
+          result = pull_taxes_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.invoice.fees.charge.count).to eq(1)
+            expect(result.invoice.fees.subscription.count).to eq(1)
+
+            expect(result.invoice.currency).to eq('EUR')
+            expect(result.invoice.fees_amount_cents).to eq(3_000)
+
+            expect(result.invoice.taxes_amount_cents).to eq(350)
+            expect(result.invoice.taxes_rate.round(2)).to eq(11.67) # (0.667 * 10) + (0.333 * 15)
+            expect(result.invoice.applied_taxes.count).to eq(2)
+
+            expect(result.invoice.total_amount_cents).to eq(3_350)
+          end
+        end
+
+        it 'does not enqueue a SendWebhookJob' do
+          expect do
+            pull_taxes_service.call
+          end.not_to have_enqueued_job(SendWebhookJob).with('invoice.created', Invoice)
+        end
+
+        it 'does not create a payment' do
+          allow(Invoices::Payments::CreateService).to receive(:call_async)
+
+          pull_taxes_service.call
+          expect(Invoices::Payments::CreateService).not_to have_received(:call_async)
+        end
+
+        context 'with credit notes' do
+          let(:credit_note) do
+            create(
+              :credit_note,
+              customer:,
+              total_amount_cents: 10,
+              total_amount_currency: 'EUR',
+              balance_amount_cents: 10,
+              balance_amount_currency: 'EUR',
+              credit_amount_cents: 10,
+              credit_amount_currency: 'EUR'
+            )
+          end
+
+          before { credit_note }
+
+          it 'does not apply credit note' do
+            result = pull_taxes_service.call
+
+            aggregate_failures do
+              expect(result).to be_success
+              expect(result.invoice.fees_amount_cents).to eq(3_000)
+              expect(result.invoice.taxes_amount_cents).to eq(350)
+              expect(result.invoice.total_amount_cents).to eq(3_350)
+              expect(result.invoice.credits.count).to eq(0)
+            end
+          end
+        end
+      end
+    end
+
+    context 'when failed to fetch taxes' do
+      let(:body) do
+        path = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+        File.read(path)
+      end
+
+      it 'puts invoice in failed status' do
+        result = pull_taxes_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(invoice.reload.status).to eq('failed')
+      end
+
+      it 'resolves old tax error and creates new one' do
+        old_error_id = invoice.reload.error_details.last.id
+        pull_taxes_service.call
+        aggregate_failures do
+          expect(invoice.error_details.tax_error.last.id).not_to eql(old_error_id)
+          expect(invoice.error_details.tax_error.count).to be(1)
+          expect(invoice.error_details.tax_error.order(created_at: :asc).last.discarded?).to be(false)
+        end
+      end
+
+      context 'with api limit error' do
+        let(:body) do
+          p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/api_limit_response.json')
+          File.read(p)
+        end
+
+        it 'puts invoice in failed status' do
+          result = pull_taxes_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(invoice.reload.status).to eq('failed')
+        end
+
+        it 'resolves old tax error and creates new one' do
+          old_error_id = invoice.reload.error_details.last.id
+
+          pull_taxes_service.call
+
+          aggregate_failures do
+            expect(invoice.error_details.tax_error.last.id).not_to eql(old_error_id)
+            expect(invoice.error_details.tax_error.count).to be(1)
+            expect(invoice.error_details.tax_error.order(created_at: :asc).last.discarded?).to be(false)
+            expect(invoice.error_details.tax_error.order(created_at: :asc).last.details['tax_error'])
+              .to eq('validationError')
+            expect(invoice.error_details.tax_error.order(created_at: :asc).last.details['tax_error_message'])
+              .to eq("You've exceeded your API limit of 10 per second")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently Anrok calls are sync and performed during invoice generation

## Description

The goal of this improvement is to make calls to Anrok in dedicated job so that we can implement throttling for rate limit issues.

This PR adds job and service that will be called in async mode. The main goal of the service is to fetch taxes and finalize the invoice. Service for retrying failed invoices is basically subset of the new service, so the new service will be also used there.

The next step is to adjust:
- retry service
- calculate_fees_service
- refresh service
- finalize service

As part of adjustment in the places where taxes are fetched in the synchronous way, we will call `Invoice::ProviderTaxes::PullTaxesAndApplyJob` and return `TaxUnknownError`
