### PR TITLE
fix(payment): Handling of amount_too_small - stripe webhooks

### DIFF
--- a/app/services/payment_provider_customers/stripe/update_payment_method_service.rb
+++ b/app/services/payment_provider_customers/stripe/update_payment_method_service.rb
@@ -35,7 +35,7 @@ module PaymentProviderCustomers
           .where(status: 'finalized')
 
         invoices.find_each do |invoice|
-          Invoices::Payments::StripeCreateJob.perform_later(invoice)
+          Invoices::Payments::CreateJob.perform_later(invoice:, payment_provider: :stripe)
         end
       end
     end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -85,8 +85,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
     invoice_subscriptions
 
     allow(SegmentTrackJob).to receive(:perform_later)
-    allow(Invoices::Payments::StripeCreateJob).to receive(:perform_later).and_call_original
-    allow(Invoices::Payments::GocardlessCreateJob).to receive(:perform_later).and_call_original
+    allow(Invoices::Payments::CreateService).to receive(:call_async).and_call_original
     allow(Credits::ProgressiveBillingService).to receive(:call).and_call_original
   end
 

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -43,8 +43,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
       standard_charge
 
       allow(SegmentTrackJob).to receive(:perform_later)
-      allow(Invoices::Payments::StripeCreateJob).to receive(:perform_later).and_call_original
-      allow(Invoices::Payments::GocardlessCreateJob).to receive(:perform_later).and_call_original
+      allow(Invoices::Payments::CreateService).to receive(:call_async).and_call_original
       allow(Invoices::TransitionToFinalStatusService).to receive(:call).and_call_original
     end
 

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -89,8 +89,7 @@ RSpec.describe Invoices::RetryService, type: :service do
       fee_charge
 
       allow(SegmentTrackJob).to receive(:perform_later)
-      allow(Invoices::Payments::StripeCreateJob).to receive(:perform_later).and_call_original
-      allow(Invoices::Payments::GocardlessCreateJob).to receive(:perform_later).and_call_original
+      allow(Invoices::Payments::CreateService).to receive(:call_async).and_call_original
 
       integration_customer
 

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
       lifetime_usage
 
       allow(SegmentTrackJob).to receive(:perform_later)
-      allow(Invoices::Payments::StripeCreateJob).to receive(:perform_later).and_call_original
-      allow(Invoices::Payments::GocardlessCreateJob).to receive(:perform_later).and_call_original
+      allow(Invoices::Payments::CreateService).to receive(:call_async).and_call_original
       allow(Invoices::TransitionToFinalStatusService).to receive(:call).and_call_original
     end
 
@@ -267,8 +266,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
 
       it "does not create any payment" do
         invoice_service.call
-        expect(Invoices::Payments::StripeCreateJob).not_to have_received(:perform_later)
-        expect(Invoices::Payments::GocardlessCreateJob).not_to have_received(:perform_later)
+        expect(Invoices::Payments::CreateService).not_to have_received(:call_async)
       end
 
       it "creates an invoice as draft" do

--- a/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe PaymentProviderCustomers::Stripe::UpdatePaymentMethodService, typ
         result = update_service.call
 
         expect(result).to be_success
-        expect(Invoices::Payments::StripeCreateJob).to have_been_enqueued
-          .with(invoice)
+        expect(Invoices::Payments::CreateJob).to have_been_enqueued
+          .with(invoice:, payment_provider: :stripe)
       end
 
       context 'when invoices are not finalized' do
@@ -51,8 +51,7 @@ RSpec.describe PaymentProviderCustomers::Stripe::UpdatePaymentMethodService, typ
           result = update_service.call
 
           expect(result).to be_success
-          expect(Invoices::Payments::StripeCreateJob).not_to have_been_enqueued
-            .with(invoice)
+          expect(Invoices::Payments::CreateJob).not_to have_been_enqueued
         end
       end
 
@@ -63,8 +62,7 @@ RSpec.describe PaymentProviderCustomers::Stripe::UpdatePaymentMethodService, typ
           result = update_service.call
 
           expect(result).to be_success
-          expect(Invoices::Payments::StripeCreateJob).not_to have_been_enqueued
-            .with(invoice)
+          expect(Invoices::Payments::CreateJob).not_to have_been_enqueued
         end
       end
     end

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -226,7 +226,15 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service
       it "returns an empty result" do
         result = create_service.call
 
-        expect(result).to be_success
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code).to eq("stripe_error")
+        expect(result.error.error_message).to eq("amount_too_small")
+
+        expect(result.error_message).to eq("amount_too_small")
+        expect(result.error_code).to eq("amount_too_small")
+        expect(result.payment.status).to eq("failed")
+        expect(result.payment.payable_payment_status).to eq("pending")
       end
     end
 


### PR DESCRIPTION
## Description

This pull requests fixes two issues related to the recent refactoring of the payment handling on payment providers:
- It makes sure that `amount_too_small` raised by stripe are correctly handled, by failing the `Payment` record and by setting the `invoice.payment_status` back to `pending`
- I fixes some issues related to missing payment found/created on the fly when receiving Stripe webhooks for payment_intend