### PR TITLE
feat(data): Add usage_date to daily_usages

### DIFF
--- a/app/jobs/clock/compute_all_daily_usages_job.rb
+++ b/app/jobs/clock/compute_all_daily_usages_job.rb
@@ -5,7 +5,7 @@ module Clock
     include SentryCronConcern
 
     queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_CLOCK'])
+      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
         :clock_worker
       else
         :clock
@@ -13,7 +13,7 @@ module Clock
     end
 
     def perform
-      DailyUsages::ComputeAllService.call
+      DailyUsages::ComputeAllService.call(timestamp: Time.current)
     end
   end
 end

--- a/app/jobs/daily_usages/compute_job.rb
+++ b/app/jobs/daily_usages/compute_job.rb
@@ -2,7 +2,7 @@
 
 module DailyUsages
   class ComputeJob < ApplicationJob
-    queue_as 'low_priority'
+    queue_as "low_priority"
 
     def perform(subscription, timestamp:)
       DailyUsages::ComputeService.call(subscription:, timestamp:).raise_if_error!

--- a/app/models/daily_usage.rb
+++ b/app/models/daily_usage.rb
@@ -23,6 +23,7 @@ end
 #  refreshed_at             :datetime         not null
 #  to_datetime              :datetime         not null
 #  usage                    :jsonb            not null
+#  usage_date               :date
 #  usage_diff               :jsonb            not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
@@ -37,6 +38,7 @@ end
 #  index_daily_usages_on_customer_id                           (customer_id)
 #  index_daily_usages_on_organization_id                       (organization_id)
 #  index_daily_usages_on_subscription_id                       (subscription_id)
+#  index_daily_usages_on_usage_date                            (usage_date)
 #
 # Foreign Keys
 #

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -28,7 +28,7 @@ module DailyUsages
         from_datetime: current_usage.from_datetime,
         to_datetime: current_usage.to_datetime,
         refreshed_at: timestamp,
-        usage_date: timestamp.to_date - 1.day
+        usage_date: date_in_timezone - 1.day
       )
 
       daily_usage.usage_diff = diff_usage(daily_usage)
@@ -74,8 +74,6 @@ module DailyUsages
     end
 
     def subscription_billing_day?
-      date_in_timezone = timestamp.in_time_zone(customer.applicable_timezone).to_date
-
       previous_billing_date_in_timezone = Subscriptions::DatesService
         .new_instance(subscription, timestamp, current_usage: true)
         .previous_beginning_of_period
@@ -83,6 +81,10 @@ module DailyUsages
         .to_date
 
       date_in_timezone == previous_billing_date_in_timezone
+    end
+
+    def date_in_timezone
+      @date_in_timezone ||= timestamp.in_time_zone(customer.applicable_timezone).to_date
     end
   end
 end

--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -27,7 +27,8 @@ module DailyUsages
         usage: ::V1::Customers::UsageSerializer.new(current_usage, includes: %i[charges_usage]).serialize,
         from_datetime: current_usage.from_datetime,
         to_datetime: current_usage.to_datetime,
-        refreshed_at: timestamp
+        refreshed_at: timestamp,
+        usage_date: timestamp.to_date - 1.day
       )
 
       daily_usage.usage_diff = diff_usage(daily_usage)

--- a/app/services/daily_usages/fill_from_invoice_service.rb
+++ b/app/services/daily_usages/fill_from_invoice_service.rb
@@ -27,7 +27,8 @@ module DailyUsages
           usage: ::V1::Customers::UsageSerializer.new(usage, includes: %i[charges_usage]).serialize,
           from_datetime: invoice_subscription.from_datetime,
           to_datetime: invoice_subscription.to_datetime,
-          refreshed_at: invoice_subscription.timestamp
+          refreshed_at: invoice_subscription.timestamp,
+          usage_date: invoice_subscription.charges_to_datetime
         )
 
         daily_usage.usage_diff = diff_usage(daily_usage)

--- a/app/services/daily_usages/fill_history_service.rb
+++ b/app/services/daily_usages/fill_history_service.rb
@@ -18,7 +18,7 @@ module DailyUsages
         datetime = date.in_time_zone(subscription.customer.applicable_timezone).beginning_of_day.utc
 
         next if date == Time.zone.today ||
-          subscription.daily_usages.where(usage_date: date - 1.day).exists? ||
+          subscription.daily_usages.where(usage_date: datetime.to_date - 1.day).exists? ||
           DailyUsage.refreshed_at_in_timezone(datetime).where(subscription_id: subscription.id).exists?
 
         Timecop.thread_safe = true
@@ -46,7 +46,7 @@ module DailyUsages
             to_datetime: usage.to_datetime,
             refreshed_at: datetime,
             usage_diff: {},
-            usage_date: date - 1.day
+            usage_date: datetime.to_date - 1.day
           )
 
           if date != from

--- a/app/services/daily_usages/fill_history_service.rb
+++ b/app/services/daily_usages/fill_history_service.rb
@@ -18,6 +18,7 @@ module DailyUsages
         datetime = date.in_time_zone(subscription.customer.applicable_timezone).beginning_of_day.utc
 
         next if date == Time.zone.today ||
+          subscription.daily_usages.where(usage_date: date - 1.day).exists? ||
           DailyUsage.refreshed_at_in_timezone(datetime).where(subscription_id: subscription.id).exists?
 
         Timecop.thread_safe = true
@@ -44,7 +45,8 @@ module DailyUsages
             from_datetime: usage.from_datetime,
             to_datetime: usage.to_datetime,
             refreshed_at: datetime,
-            usage_diff: {}
+            usage_diff: {},
+            usage_date: date - 1.day
           )
 
           if date != from

--- a/db/migrate/20241219145642_add_usage_date_to_daily_usages.rb
+++ b/db/migrate/20241219145642_add_usage_date_to_daily_usages.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUsageDateToDailyUsages < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      add_column :daily_usages, :usage_date, :date
+    end
+  end
+end

--- a/db/migrate/20241219152909_add_index_on_usage_date_to_daily_usages.rb
+++ b/db/migrate/20241219152909_add_index_on_usage_date_to_daily_usages.rb
@@ -5,7 +5,6 @@ class AddIndexOnUsageDateToDailyUsages < ActiveRecord::Migration[7.1]
 
   def change
     safety_assured do
-      remove_column :daily_usages, :timezone
       add_index :daily_usages, :usage_date, algorithm: :concurrently
     end
   end

--- a/db/migrate/20241219152909_add_index_on_usage_date_to_daily_usages.rb
+++ b/db/migrate/20241219152909_add_index_on_usage_date_to_daily_usages.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexOnUsageDateToDailyUsages < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      remove_column :daily_usages, :timezone
+      add_index :daily_usages, :usage_date, algorithm: :concurrently
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -513,10 +513,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_20_095049) do
     t.datetime "updated_at", null: false
     t.datetime "refreshed_at", null: false
     t.jsonb "usage_diff", default: "{}", null: false
+    t.date "usage_date"
     t.index ["customer_id"], name: "index_daily_usages_on_customer_id"
     t.index ["organization_id", "external_subscription_id"], name: "idx_on_organization_id_external_subscription_id_df3a30d96d"
     t.index ["organization_id"], name: "index_daily_usages_on_organization_id"
     t.index ["subscription_id"], name: "index_daily_usages_on_subscription_id"
+    t.index ["usage_date"], name: "index_daily_usages_on_usage_date"
   end
 
   create_table "data_export_parts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/jobs/clock/compute_all_daily_usages_job_spec.rb
+++ b/spec/jobs/clock/compute_all_daily_usages_job_spec.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Clock::ComputeAllDailyUsagesJob, type: :job do
   subject(:compute_job) { described_class }
 
-  describe '.perform' do
+  describe ".perform" do
     before { allow(DailyUsages::ComputeAllService).to receive(:call) }
 
-    it 'removes all old webhooks' do
-      compute_job.perform_now
-
-      expect(DailyUsages::ComputeAllService).to have_received(:call)
+    it "calls DailyUsages::ComputeAllService" do
+      freeze_time do
+        compute_job.perform_now
+        expect(DailyUsages::ComputeAllService).to have_received(:call).with(timestamp: Time.current)
+      end
     end
   end
 end

--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe DailyUsages::ComputeService, type: :service do
   subject(:compute_service) { described_class.new(subscription:, timestamp:) }
@@ -12,10 +12,10 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
     create(:subscription, :calendar, customer:, plan:, started_at: 1.year.ago, subscription_at: 1.year.ago)
   end
 
-  let(:timestamp) { Time.zone.parse('2024-10-22 00:05:00') }
+  let(:timestamp) { Time.zone.parse("2024-10-22 00:05:00") }
 
-  describe '#call' do
-    it 'creates a daily usage', aggregate_failures: true do
+  describe "#call" do
+    it "creates a daily usage", aggregate_failures: true do
       travel_to(timestamp) do
         expect { compute_service.call }.to change(DailyUsage, :count).by(1)
 
@@ -26,7 +26,8 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
           subscription_id: subscription.id,
           external_subscription_id: subscription.external_id,
           usage: Hash,
-          usage_diff: Hash
+          usage_diff: Hash,
+          usage_date: timestamp.to_date - 1.day
         )
         expect(daily_usage.refreshed_at).to match_datetime(timestamp)
         expect(daily_usage.from_datetime).to match_datetime(timestamp.beginning_of_month)
@@ -34,28 +35,28 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
       end
     end
 
-    context 'when a daily usage already exists' do
+    context "when a daily usage already exists" do
       let(:existing_daily_usage) do
         create(:daily_usage, subscription:, organization:, customer:, refreshed_at: timestamp)
       end
 
       before { existing_daily_usage }
 
-      it 'returns the existing daily usage', aggregate_failure: true do
+      it "returns the existing daily usage", aggregate_failure: true do
         result = compute_service.call
 
         expect(result).to be_success
         expect(result.daily_usage).to eq(existing_daily_usage)
       end
 
-      context 'when the organization has a timezone' do
-        let(:organization) { create(:organization, timezone: 'America/Sao_Paulo') }
+      context "when the organization has a timezone" do
+        let(:organization) { create(:organization, timezone: "America/Sao_Paulo") }
 
         let(:existing_daily_usage) do
           create(:daily_usage, subscription:, organization:, customer:, refreshed_at: timestamp - 4.hours)
         end
 
-        it 'takes the timezone into account' do
+        it "takes the timezone into account" do
           result = compute_service.call
 
           expect(result).to be_success
@@ -63,14 +64,14 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
         end
       end
 
-      context 'when the customer has a timezone' do
-        let(:customer) { create(:customer, organization:, timezone: 'America/Sao_Paulo') }
+      context "when the customer has a timezone" do
+        let(:customer) { create(:customer, organization:, timezone: "America/Sao_Paulo") }
 
         let(:existing_daily_usage) do
           create(:daily_usage, subscription:, organization:, customer:, refreshed_at: timestamp - 4.hours)
         end
 
-        it 'takes the timezone into account' do
+        it "takes the timezone into account" do
           result = compute_service.call
 
           expect(result).to be_success
@@ -79,26 +80,26 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
       end
     end
 
-    context 'when timestamp is on subscription billing day' do
+    context "when timestamp is on subscription billing day" do
       let(:subscription) do
         create(:subscription, :anniversary, customer:, plan:, started_at: 1.year.ago, subscription_at: 1.year.ago)
       end
 
       let(:timestamp) { subscription.subscription_at + 1.year }
 
-      it 'does not create a daily usage' do
+      it "does not create a daily usage" do
         expect { compute_service.call }.not_to change(DailyUsage, :count)
       end
     end
 
-    context 'when subscription is terminated after the timestamp' do
+    context "when subscription is terminated after the timestamp" do
       let(:subscription) do
         create(:subscription, :terminated, :calendar, customer:, plan:, started_at: 1.year.ago)
       end
 
       let(:timestamp) { subscription.terminated_at - 1.day }
 
-      it 'creates a daily usage', aggregate_failures: true do
+      it "creates a daily usage", aggregate_failures: true do
         result = compute_service.call
 
         expect(result).to be_success
@@ -110,7 +111,8 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
           subscription_id: subscription.id,
           external_subscription_id: subscription.external_id,
           usage: Hash,
-          usage_diff: Hash
+          usage_diff: Hash,
+          usage_date: timestamp.to_date - 1.day
         )
         expect(daily_usage.refreshed_at).to match_datetime(timestamp)
         expect(daily_usage.from_datetime).to match_datetime(timestamp.beginning_of_month)

--- a/spec/services/daily_usages/fill_from_invoice_service_spec.rb
+++ b/spec/services/daily_usages/fill_from_invoice_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DailyUsages::FillFromInvoiceService, type: :service do
 
   let(:subscriptions) { [subscription] }
 
-  let(:timestamp) { Time.zone.parse('2025-01-01T01:00:00') }
+  let(:timestamp) { Time.zone.parse("2025-01-01T01:00:00") }
 
   let(:invoice) do
     create(
@@ -28,10 +28,10 @@ RSpec.describe DailyUsages::FillFromInvoiceService, type: :service do
       subscription:,
       invoice:,
       timestamp:,
-      from_datetime: Time.zone.parse('2024-12-01T00:00:00'),
-      to_datetime: Time.zone.parse('2024-12-31T23:59:59'),
-      charges_from_datetime: Time.zone.parse('2024-12-01T00:00:00'),
-      charges_to_datetime: Time.zone.parse('2024-12-31T23:59:59')
+      from_datetime: Time.zone.parse("2024-12-01T00:00:00"),
+      to_datetime: Time.zone.parse("2024-12-31T23:59:59"),
+      charges_from_datetime: Time.zone.parse("2024-12-01T00:00:00"),
+      charges_to_datetime: Time.zone.parse("2024-12-31T23:59:59")
     )
   end
 
@@ -51,7 +51,8 @@ RSpec.describe DailyUsages::FillFromInvoiceService, type: :service do
         from_datetime: invoice_subscription.from_datetime,
         to_datetime: invoice_subscription.to_datetime,
         refreshed_at: invoice_subscription.timestamp,
-        usage_diff: Hash
+        usage_diff: Hash,
+        usage_date: invoice_subscription.charges_to_datetime.to_date
       )
     end
 
@@ -65,7 +66,8 @@ RSpec.describe DailyUsages::FillFromInvoiceService, type: :service do
           external_subscription_id: subscription.external_id,
           from_datetime: invoice_subscription.from_datetime,
           to_datetime: invoice_subscription.to_datetime,
-          refreshed_at: invoice_subscription.timestamp
+          refreshed_at: invoice_subscription.timestamp,
+          usage_date: invoice_subscription.charges_to_datetime.to_date
         )
       end
 
@@ -74,7 +76,7 @@ RSpec.describe DailyUsages::FillFromInvoiceService, type: :service do
       end
     end
 
-    context 'when multiples subscriptions are passed to the service' do
+    context "when multiples subscriptions are passed to the service" do
       let(:subscription2) { create(:subscription, customer:) }
       let(:subscriptions) { [subscription, subscription2] }
 
@@ -84,10 +86,10 @@ RSpec.describe DailyUsages::FillFromInvoiceService, type: :service do
           subscription: subscription2,
           invoice:,
           timestamp:,
-          from_datetime: Time.zone.parse('2024-12-01T00:00:00'),
-          to_datetime: Time.zone.parse('2024-12-31T23:59:59'),
-          charges_from_datetime: Time.zone.parse('2024-12-01T00:00:00'),
-          charges_to_datetime: Time.zone.parse('2024-12-31T23:59:59')
+          from_datetime: Time.zone.parse("2024-12-01T00:00:00"),
+          to_datetime: Time.zone.parse("2024-12-31T23:59:59"),
+          charges_from_datetime: Time.zone.parse("2024-12-01T00:00:00"),
+          charges_to_datetime: Time.zone.parse("2024-12-31T23:59:59")
         )
       end
 
@@ -97,7 +99,7 @@ RSpec.describe DailyUsages::FillFromInvoiceService, type: :service do
         expect { fill_service.call }.to change(DailyUsage, :count).by(2)
       end
 
-      context 'when only one subscription has to be updated' do
+      context "when only one subscription has to be updated" do
         let(:subscriptions) { [subscription] }
 
         it "creates daily usages for the subscriptions" do
@@ -113,7 +115,8 @@ RSpec.describe DailyUsages::FillFromInvoiceService, type: :service do
             from_datetime: invoice_subscription.from_datetime,
             to_datetime: invoice_subscription.to_datetime,
             refreshed_at: invoice_subscription.timestamp,
-            usage_diff: Hash
+            usage_diff: Hash,
+            usage_date: invoice_subscription.charges_to_datetime.to_date
           )
         end
       end


### PR DESCRIPTION
## Description

The goal of this PR is to add `usage_date` column to the `daily_usages` table.
It will help fetching the correct usage for a specific date, without computing the `refreshed_at` values.

Next PR will remove use of `refreshed_at` in favor of `usage_date`.
