### PR TITLE
fix(payment): Avoid creating duplicated Payment record for one time invoices

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -17,10 +17,10 @@ module Invoices
       end
 
       def update_payment_status(organization_id:, status:, stripe_payment:)
-        payment = if stripe_payment.metadata[:payment_type] == "one-time"
-          create_payment(stripe_payment)
-        else
-          Payment.find_by(provider_payment_id: stripe_payment.id)
+        payment = Payment.find_by(provider_payment_id: stripe_payment.id)
+
+        if !payment && stripe_payment.metadata[:payment_type] == "one-time"
+          payment = create_payment(stripe_payment)
         end
 
         unless payment


### PR DESCRIPTION
## Context

In some situation, multiple `PaymentProviders::Stripe::HandleEventJob` are handled for the same `one-time` stripe, payment_intent, leading to a duplicated payment record in the database.

## Description

This PR makes sure that the payment is retrieved correctly from the database if it already exists