### PR TITLE
misc(payment): Avoid error webhooks on small amount failure

### DIFF
--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -34,11 +34,11 @@ module Invoices
           payment_provider_id: current_payment_provider.id,
           payment_provider_customer_id: current_payment_provider_customer.id,
           amount_cents: invoice.total_amount_cents,
-          amount_currency: invoice.currency
+          amount_currency: invoice.currency,
+          status: "pending"
         ).find_or_create_by!(
           payable: invoice,
-          payable_payment_status: "pending",
-          status: "pending"
+          payable_payment_status: "pending"
         )
 
         result.payment = payment
@@ -56,9 +56,9 @@ module Invoices
         result
       rescue BaseService::ServiceFailure => e
         result.payment = e.result.payment
-        deliver_error_webhook(e.result)
 
         if e.result.payment.payable_payment_status&.to_sym != :pending
+          deliver_error_webhook(e.result)
           update_invoice_payment_status(payment_status: e.result.payment.payable_payment_status)
         end
 

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
           end
         end
 
-        it "re-reaise the error and delivers an error webhook" do
+        it "updates the invoice payment status and does not delivers an error webhook" do
           result = create_service.call
 
           expect(result).to be_success
@@ -262,6 +262,8 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
 
           expect(provider_class).to have_received(:new)
           expect(provider_service).to have_received(:call!)
+
+          expect(SendWebhookJob).not_to have_been_enqueued
         end
       end
     end


### PR DESCRIPTION
## Description
This PR is part of the recent payment handling refactoring.

It makes sure that failed payment attempts with an `amount_too_small` error does not lead to an error webhook but only keeps the payment with a `failed` `status` and `pending` `payable_payment_status`. allowing reprocessing of the payment or grouping in  a payment request, without spamming the organization owner
