### PR TITLE
feat(anrok): make api calls async in dedicated service

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -19,6 +19,7 @@ module Types
       field :payment_dispute_lost_at, GraphQL::Types::ISO8601DateTime
       field :payment_status, Types::Invoices::PaymentStatusTypeEnum, null: false
       field :status, Types::Invoices::StatusTypeEnum, null: false
+      field :tax_status, Types::Invoices::TaxStatusTypeEnum, null: true
       field :voidable, Boolean, null: false, method: :voidable?
 
       field :currency, Types::CurrencyEnum

--- a/app/graphql/types/invoices/tax_status_type_enum.rb
+++ b/app/graphql/types/invoices/tax_status_type_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Invoices
+    class TaxStatusTypeEnum < Types::BaseEnum
+      graphql_name 'InvoiceTaxStatusTypeEnum'
+
+      Invoice::TAX_STATUSES.keys.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/jobs/bill_subscription_job.rb
+++ b/app/jobs/bill_subscription_job.rb
@@ -20,9 +20,6 @@ class BillSubscriptionJob < ApplicationJob
       skip_charges:
     )
     return if result.success?
-    # NOTE: We don't want a dead job for failed invoice due to the tax reason.
-    #       This invoice should be in failed status and can be retried.
-    return if tax_error?(result)
 
     # If the invoice was passed as an argument, it means the job was already retried (see end of function)
     if invoice || !result.invoice&.generating?
@@ -40,13 +37,5 @@ class BillSubscriptionJob < ApplicationJob
       invoice: result.invoice,
       skip_charges:
     )
-  end
-
-  private
-
-  def tax_error?(result)
-    return false unless result.error.is_a?(BaseService::ValidationFailure)
-
-    result.error&.messages&.dig(:tax_error)&.present?
   end
 end

--- a/app/jobs/fees/create_pay_in_advance_job.rb
+++ b/app/jobs/fees/create_pay_in_advance_job.rb
@@ -2,7 +2,11 @@
 
 module Fees
   class CreatePayInAdvanceJob < ApplicationJob
+    include ConcurrencyThrottlable
+
     queue_as :default
+
+    retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
     unique :until_executed, on_conflict: :log
 

--- a/app/jobs/fees/create_pay_in_advance_job.rb
+++ b/app/jobs/fees/create_pay_in_advance_job.rb
@@ -2,8 +2,6 @@
 
 module Fees
   class CreatePayInAdvanceJob < ApplicationJob
-    include ConcurrencyThrottlable
-
     queue_as :default
 
     retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25

--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -2,8 +2,6 @@
 
 module Invoices
   class CreatePayInAdvanceChargeJob < ApplicationJob
-    include ConcurrencyThrottlable
-
     queue_as do
       if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_BILLING'])
         :billing

--- a/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
+++ b/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
@@ -3,7 +3,11 @@
 module Invoices
   module ProviderTaxes
     class PullTaxesAndApplyJob < ApplicationJob
+      include ConcurrencyThrottlable
+
       queue_as 'integrations'
+
+      retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
       def perform(invoice:)
         Invoices::ProviderTaxes::PullTaxesAndApplyService.call(invoice:)

--- a/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
+++ b/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
@@ -3,8 +3,6 @@
 module Invoices
   module ProviderTaxes
     class PullTaxesAndApplyJob < ApplicationJob
-      include ConcurrencyThrottlable
-
       queue_as 'integrations'
 
       retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25

--- a/app/services/integrations/aggregator/taxes/invoices/create_draft_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_draft_service.rb
@@ -13,6 +13,8 @@ module Integrations
             return result unless integration
             return result unless integration.type == 'Integrations::AnrokIntegration'
 
+            throttle!(:anrok)
+
             response = http_client.post_with_response(payload, headers)
             body = JSON.parse(response.body)
 

--- a/app/services/integrations/aggregator/taxes/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_service.rb
@@ -13,6 +13,8 @@ module Integrations
             return result unless integration
             return result unless integration.type == 'Integrations::AnrokIntegration'
 
+            throttle!(:anrok)
+
             response = http_client.post_with_response(payload, headers)
             body = JSON.parse(response.body)
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -47,23 +47,10 @@ module Invoices
         Credits::ProgressiveBillingService.call(invoice:)
         Credits::AppliedCouponsService.call(invoice:) if should_create_coupon_credit?
 
-        if customer_provider_taxation?
-          taxes_result = fetch_taxes_for_invoice
+        totals_result = Invoices::ComputeTaxesAndTotalsService.call(invoice:, finalizing: finalizing_invoice?)
+        return totals_result if !totals_result.success? && totals_result.error.is_a?(BaseService::UnknownTaxFailure)
 
-          unless taxes_result.success?
-            create_error_detail(taxes_result.error)
-
-            # only fail invoices that are finalizing
-            invoice.failed! if finalizing_invoice?
-
-            invoice.save!
-            return result.service_failure!(code: 'tax_error', message: taxes_result.error.code)
-          end
-
-          Invoices::ComputeAmountsFromFees.call(invoice:, provider_taxes: taxes_result.fees)
-        else
-          Invoices::ComputeAmountsFromFees.call(invoice:)
-        end
+        totals_result.raise_if_error!
 
         create_credit_note_credit if should_create_credit_note_credit?
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
@@ -335,33 +322,6 @@ module Invoices
       tz = subscription.customer.applicable_timezone
 
       timestamp.in_time_zone(tz).to_date != subscription.trial_end_datetime.in_time_zone(tz).to_date
-    end
-
-    def customer_provider_taxation?
-      @customer_provider_taxation ||= invoice.customer.anrok_customer
-    end
-
-    def create_error_detail(error)
-      error_result = ErrorDetails::CreateService.call(
-        owner: invoice,
-        organization: invoice.organization,
-        params: {
-          error_code: :tax_error,
-          details: {
-            tax_error: error.code
-          }.tap do |details|
-            details[:tax_error_message] = error.error_message if error.code == 'validationError'
-          end
-        }
-      )
-      error_result.raise_if_error!
-    end
-
-    def fetch_taxes_for_invoice
-      if finalizing_invoice?
-        return Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:, fees: invoice.fees)
-      end
-      Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:, fees: invoice.fees)
     end
 
     def finalizing_invoice?

--- a/app/services/invoices/compute_taxes_and_totals_service.rb
+++ b/app/services/invoices/compute_taxes_and_totals_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Invoices
+  class ComputeTaxesAndTotalsService < BaseService
+    def initialize(invoice:, finalizing: true)
+      @invoice = invoice
+      @finalizing = finalizing
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'invoice') unless invoice
+
+      if customer_provider_taxation?
+        invoice.status = 'pending' if finalizing
+        invoice.tax_status = 'pending'
+        invoice.save!
+        after_commit { Invoices::ProviderTaxes::PullTaxesAndApplyJob.perform_later(invoice:) }
+
+        return result.unknown_tax_failure!(code: 'tax_error', message: 'unknown taxes')
+      else
+        Invoices::ComputeAmountsFromFees.call(invoice:)
+      end
+
+      result.invoice = invoice
+      result
+    end
+
+    private
+
+    attr_reader :invoice, :finalizing
+
+    def customer_provider_taxation?
+      @customer_provider_taxation ||= invoice.customer.anrok_customer
+    end
+  end
+end

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -22,19 +22,10 @@ module Invoices
         Credits::ProgressiveBillingService.call(invoice:)
         Credits::AppliedCouponsService.call(invoice:)
 
-        if customer_provider_taxation?
-          taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:, fees: invoice.fees)
+        totals_result = Invoices::ComputeTaxesAndTotalsService.call(invoice:)
+        return totals_result if !totals_result.success? && totals_result.error.is_a?(BaseService::UnknownTaxFailure)
 
-          unless taxes_result.success?
-            create_error_detail(taxes_result.error)
-            invoice.failed!
-
-            return result.service_failure!(code: 'tax_error', message: taxes_result.error.code)
-          end
-          Invoices::ComputeAmountsFromFees.call(invoice:, provider_taxes: taxes_result.fees)
-        else
-          Invoices::ComputeAmountsFromFees.call(invoice:)
-        end
+        totals_result.raise_if_error!
 
         create_credit_note_credit
         create_applied_prepaid_credit
@@ -148,26 +139,6 @@ module Invoices
       prepaid_credit_result = Credits::AppliedPrepaidCreditService.call(invoice:, wallet:).raise_if_error!
 
       invoice.total_amount_cents -= prepaid_credit_result.prepaid_credit_amount_cents
-    end
-
-    def customer_provider_taxation?
-      @customer_provider_taxation ||= invoice.customer.anrok_customer
-    end
-
-    def create_error_detail(error)
-      error_result = ErrorDetails::CreateService.call(
-        owner: invoice,
-        organization: invoice.organization,
-        params: {
-          error_code: :tax_error,
-          details: {
-            tax_error: error.code
-          }.tap do |details|
-            details[:tax_error_message] = error.error_message if error.code == 'validationError'
-          end
-        }
-      )
-      error_result.raise_if_error!
     end
   end
 end

--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -78,11 +78,5 @@ module Invoices
       License.premium? &&
         invoice.organization.email_settings.include?('invoice.finalized')
     end
-
-    def tax_error?(error)
-      return false unless error.is_a?(BaseService::ValidationFailure)
-
-      error&.messages&.dig(:tax_error).present?
-    end
   end
 end

--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -15,7 +15,7 @@ module Invoices
       ActiveRecord::Base.transaction do
         invoice.issuing_date = issuing_date
         refresh_result = Invoices::RefreshDraftService.call(invoice:, context: :finalize)
-        if tax_error?(refresh_result.error)
+        if invoice.tax_pending?
           invoice.update!(issuing_date: drafted_issuing_date)
           return refresh_result
         end

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -109,7 +109,7 @@ module Invoices
     end
 
     def tax_error?(error)
-      error && error.is_a?(BaseService::UnknownTaxFailure)
+      error&.is_a?(BaseService::UnknownTaxFailure)
     end
 
     def reset_invoice_values

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -63,10 +63,7 @@ module Invoices
           CreditNotes::RefreshDraftService.call(credit_note:, fee:, old_fee_values:)
         end
 
-        if tax_error?(calculate_result.error)
-          return result.validation_failure!(errors: {tax_error: [calculate_result.error.error_message]})
-        end
-        calculate_result.raise_if_error!
+        calculate_result.raise_if_error! unless tax_error?(calculate_result.error)
 
         if old_total_amount_cents != invoice.total_amount_cents
           flag_lifetime_usage_for_refresh
@@ -75,6 +72,8 @@ module Invoices
 
         # NOTE: In case of a refresh the same day of the termination.
         invoice.fees.update_all(created_at: invoice.created_at) # rubocop:disable Rails/SkipsModelValidations
+
+        return result if tax_error?(calculate_result.error)
 
         if invoice.should_update_hubspot_invoice?
           Integrations::Aggregator::Invoices::Hubspot::UpdateJob.perform_later(invoice: invoice.reload)
@@ -110,9 +109,7 @@ module Invoices
     end
 
     def tax_error?(error)
-      return false unless error.is_a?(BaseService::ServiceFailure)
-
-      error&.code == 'tax_error'
+      error && error.is_a?(BaseService::UnknownTaxFailure)
     end
 
     def reset_invoice_values

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -12,117 +12,18 @@ module Invoices
       return result.not_found_failure!(resource: 'invoice') unless invoice
       return result.not_allowed_failure!(code: 'invalid_status') unless invoice.failed?
 
-      invoice.error_details.tax_error.discard_all
-      taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:, fees: invoice.fees)
+      invoice.status = 'pending'
+      invoice.tax_status = 'pending'
+      invoice.save!
 
-      unless taxes_result.success?
-        create_error_detail(taxes_result.error)
-        return result.validation_failure!(errors: {tax_error: [taxes_result.error.code]})
-      end
+      Invoices::ProviderTaxes::PullTaxesAndApplyJob.perform_later(invoice:)
 
-      provider_taxes = taxes_result.fees
-
-      ActiveRecord::Base.transaction do
-        invoice.issuing_date = issuing_date
-        invoice.payment_due_date = payment_due_date
-
-        Invoices::ComputeAmountsFromFees.call(invoice:, provider_taxes:)
-
-        create_credit_note_credit if should_create_credit_note_credit?
-        create_applied_prepaid_credit if should_create_applied_prepaid_credit?
-
-        invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
-        invoice.status = :finalized
-        invoice.save!
-
-        invoice.reload
-
-        result.invoice = invoice
-      end
-
-      SendWebhookJob.perform_later('invoice.created', invoice)
-      GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
-      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-      Integrations::Aggregator::Invoices::Hubspot::CreateJob.perform_later(invoice:) if invoice.should_sync_hubspot_invoice?
-      Invoices::Payments::CreateService.call_async(invoice:)
-      Utils::SegmentTrack.invoice_created(invoice)
-
+      result.invoice = invoice
       result
-    rescue ActiveRecord::RecordInvalid => e
-      result.record_validation_failure!(record: e.record)
-    rescue BaseService::FailedResult => e
-      e.result
-    rescue => e
-      result.fail_with_error!(e)
     end
 
     private
 
     attr_accessor :invoice
-
-    def should_deliver_email?
-      License.premium? &&
-        invoice.organization.email_settings.include?('invoice.finalized')
-    end
-
-    def wallet
-      return @wallet if @wallet
-
-      @wallet = customer.wallets.active.first
-    end
-
-    def should_create_credit_note_credit?
-      !invoice.one_off?
-    end
-
-    def should_create_applied_prepaid_credit?
-      return false if invoice.one_off?
-      return false unless wallet&.active?
-      return false unless invoice.total_amount_cents&.positive?
-
-      wallet.balance.positive?
-    end
-
-    def create_credit_note_credit
-      credit_result = Credits::CreditNoteService.new(invoice:).call
-      credit_result.raise_if_error!
-
-      invoice.total_amount_cents -= credit_result.credits.sum(&:amount_cents) if credit_result.credits
-    end
-
-    def create_applied_prepaid_credit
-      prepaid_credit_result = Credits::AppliedPrepaidCreditService.call(invoice:, wallet:)
-      prepaid_credit_result.raise_if_error!
-
-      invoice.total_amount_cents -= prepaid_credit_result.prepaid_credit_amount_cents
-    end
-
-    def issuing_date
-      @issuing_date ||= Time.current.in_time_zone(customer.applicable_timezone).to_date
-    end
-
-    def payment_due_date
-      @payment_due_date ||= issuing_date + customer.applicable_net_payment_term.days
-    end
-
-    def customer
-      @customer ||= invoice.customer
-    end
-
-    def create_error_detail(error)
-      error_result = ErrorDetails::CreateService.call(
-        owner: invoice,
-        organization: invoice.organization,
-        params: {
-          error_code: :tax_error,
-          details: {
-            tax_error: error.code
-          }.tap do |details|
-            details[:tax_error_message] = error.error_message if error.code == 'validationError'
-          end
-        }
-      )
-      error_result.raise_if_error!
-    end
   end
 end

--- a/app/services/lifetime_usages/recalculate_and_check_service.rb
+++ b/app/services/lifetime_usages/recalculate_and_check_service.rb
@@ -35,9 +35,9 @@ module LifetimeUsages
     end
 
     def tax_error?(result)
-      return false unless result.error.is_a?(BaseService::ServiceFailure)
+      return false if result.success?
 
-      !result.success? && result.error&.code == 'tax_error'
+      result.error.is_a?(BaseService::UnknownTaxFailure)
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4475,6 +4475,7 @@ type Invoice {
   subTotalIncludingTaxesAmountCents: BigInt!
   subscriptions: [Subscription!]
   taxProviderVoidable: Boolean!
+  taxStatus: InvoiceTaxStatusTypeEnum
   taxesAmountCents: BigInt!
   taxesRate: Float!
   totalAmountCents: BigInt!
@@ -4619,6 +4620,12 @@ type InvoiceSubscription {
   subscriptionAmountCents: BigInt!
   toDatetime: ISO8601DateTime
   totalAmountCents: BigInt!
+}
+
+enum InvoiceTaxStatusTypeEnum {
+  failed
+  pending
+  succeeded
 }
 
 enum InvoiceTypeEnum {

--- a/schema.json
+++ b/schema.json
@@ -21065,6 +21065,18 @@
               "args": []
             },
             {
+              "name": "taxStatus",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "InvoiceTaxStatusTypeEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "taxesAmountCents",
               "description": null,
               "type": {
@@ -22239,6 +22251,35 @@
           ],
           "inputFields": null,
           "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "InvoiceTaxStatusTypeEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "pending",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "succeeded",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "failed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
         },
         {
           "kind": "ENUM",

--- a/spec/graphql/mutations/invoices/finalize_spec.rb
+++ b/spec/graphql/mutations/invoices/finalize_spec.rb
@@ -26,23 +26,21 @@ RSpec.describe Mutations::Invoices::Finalize, type: :graphql do
   it_behaves_like 'requires permission', 'invoices:update'
 
   it 'finalizes the given invoice' do
-    freeze_time do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {id: invoice.id}
-        }
-      )
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query: mutation,
+      variables: {
+        input: {id: invoice.id}
+      }
+    )
 
-      result_data = result['data']['finalizeInvoice']
+    result_data = result['data']['finalizeInvoice']
 
-      aggregate_failures do
-        expect(result_data['id']).to be_present
-        expect(result_data['status']).to eq('finalized')
-      end
+    aggregate_failures do
+      expect(result_data['id']).to be_present
+      expect(result_data['status']).to eq('finalized')
     end
   end
 
@@ -55,25 +53,21 @@ RSpec.describe Mutations::Invoices::Finalize, type: :graphql do
     end
 
     it 'returns pending invoice' do
-      freeze_time do
-        result = execute_graphql(
-          current_user: membership.user,
-          current_organization: organization,
-          permissions: required_permission,
-          query: mutation,
-          variables: {
-            input: {id: invoice.id}
-          }
-        )
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {id: invoice.id}
+        }
+      )
 
-        result_data = result['data']['finalizeInvoice']
+      result_data = result['data']['finalizeInvoice']
 
-        aggregate_failures do
-          expect(result_data['id']).to be_present
-          expect(result_data['status']).to eq('pending')
-          expect(result_data['taxStatus']).to eq('pending')
-        end
-      end
+      expect(result_data['id']).to be_present
+      expect(result_data['status']).to eq('pending')
+      expect(result_data['taxStatus']).to eq('pending')
     end
   end
 end

--- a/spec/jobs/bill_subscription_job_spec.rb
+++ b/spec/jobs/bill_subscription_job_spec.rb
@@ -37,18 +37,6 @@ RSpec.describe BillSubscriptionJob, type: :job do
       expect(Invoices::SubscriptionService).to have_received(:call)
     end
 
-    context 'when there is tax error' do
-      let(:result) do
-        BaseService::Result.new.validation_failure!(errors: {tax_error: ['invalidMapping']})
-      end
-
-      it 'does not throw an error' do
-        expect do
-          described_class.perform_now(subscriptions, timestamp, invoicing_reason:)
-        end.not_to raise_error
-      end
-    end
-
     context 'with a previously created invoice' do
       let(:invoice) { create(:invoice, :generating) }
 

--- a/spec/services/lifetime_usages/recalculate_and_check_service_spec.rb
+++ b/spec/services/lifetime_usages/recalculate_and_check_service_spec.rb
@@ -68,13 +68,13 @@ RSpec.describe LifetimeUsages::RecalculateAndCheckService, type: :service do
     end
 
     context 'when there is tax provider error' do
-      let(:error_result) { BaseService::Result.new.service_failure!(code: 'tax_error', message: '') }
+      let(:error_result) { BaseService::Result.new.unknown_tax_failure!(code: 'tax_error', message: '') }
 
       before do
         allow(Invoices::ProgressiveBillingService).to receive(:call).and_return(error_result)
       end
 
-      it "creates a failed invoice without raising error" do
+      it "creates a pending invoice without raising error" do
         expect { service.call }.not_to raise_error
       end
     end


### PR DESCRIPTION
## Context

Currently Anrok calls are sync and performed during invoice generation

## Description

The goal of this improvement is to make calls to Anrok in dedicated job so that we can implement throttling for rate limit issues.

This PR changes all places where Anrok in used in sync way. This is the last PR that is extension of:
- https://github.com/getlago/lago-api/pull/2984
- https://github.com/getlago/lago-api/pull/2968
- https://github.com/getlago/lago-api/pull/2964
