### PR TITLE
fix: Ensure Plans::DestroyJob are queued only once

### DIFF
--- a/app/jobs/plans/destroy_job.rb
+++ b/app/jobs/plans/destroy_job.rb
@@ -2,7 +2,9 @@
 
 module Plans
   class DestroyJob < ApplicationJob
-    queue_as 'default'
+    queue_as "default"
+
+    unique :until_executed, on_conflict: :log
 
     def perform(plan)
       plan.children.each do |children_plan|

--- a/spec/jobs/plans/destroy_job_spec.rb
+++ b/spec/jobs/plans/destroy_job_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Plans::DestroyJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:plan) { create(:plan) }
+  let(:child_plan) { create(:plan, parent: plan) }
+  let(:service_result) { BaseService::Result.new }
+
+  before do
+    plan.children << child_plan
+  end
+
+  describe "unique job behavior" do
+    around do |example|
+      ActiveJob::Uniqueness.reset_manager!
+      example.run
+      ActiveJob::Uniqueness.test_mode!
+    end
+
+    it "does not enqueue duplicate jobs" do
+      expect do
+        described_class.perform_later(plan)
+        described_class.perform_later(plan)
+      end.to change { enqueued_jobs.count }.by(1)
+    end
+  end
+
+  describe "#perform" do
+    before do
+      allow(Plans::DestroyService).to receive(:call).and_return(service_result)
+    end
+
+    context "when destroy service succeeds" do
+      let(:service_result) { BaseService::Result.new }
+
+      it "calls the destroy service for child plans first" do
+        described_class.perform_now(plan)
+
+        expect(Plans::DestroyService)
+          .to have_received(:call)
+          .with(plan: child_plan)
+          .ordered
+
+        expect(Plans::DestroyService)
+          .to have_received(:call)
+          .with(plan: plan)
+          .ordered
+      end
+    end
+
+    context "when destroy service fails" do
+      let(:service_result) do
+        BaseService::Result.new.service_failure!(
+          code: "failure",
+          message: "Destroy failed"
+        )
+      end
+
+      it "raises an error when the destroy service fails" do
+        expect { described_class.perform_now(plan) }
+          .to raise_error(BaseService::ServiceFailure, "failure: Destroy failed")
+      end
+    end
+  end
+end
+

--- a/spec/jobs/plans/destroy_job_spec.rb
+++ b/spec/jobs/plans/destroy_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Plans::DestroyJob, type: :job do
       expect do
         described_class.perform_later(plan)
         described_class.perform_later(plan)
-      end.to change { enqueued_jobs.count }.by(1)
+      end.to change(enqueued_jobs, :count).by(1)
     end
   end
 
@@ -66,4 +66,3 @@ RSpec.describe Plans::DestroyJob, type: :job do
     end
   end
 end
-


### PR DESCRIPTION
This change is meant to avoid issues when a user tries to delete a plan more than once. This happens because the plan deletion is performed as a background job and could take some time as all child plans must be deleted, subscriptions terminated, invoices generated and discarded, etc...

The goal of this change is to avoid failed jobs because of race conditions between multiple runs for the same plan producing unique DB index constraints errors or discard! errors as those only produce noise and waste of support time.