### PR TITLE
fix (tax-integrations): change queue for the job that apply taxes on pending invoice

### DIFF
--- a/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
+++ b/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
@@ -3,7 +3,7 @@
 module Invoices
   module ProviderTaxes
     class PullTaxesAndApplyJob < ApplicationJob
-      queue_as 'integrations'
+      queue_as 'providers'
 
       retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 


### PR DESCRIPTION
## Context

Currently Anrok calls are sync and performed during invoice generation

## Description

The goal of this improvement is to make calls to Anrok in dedicated job so that we can implement throttling for rate limit issues.

This PR changes queue for described job. Previous 'integrations' queue was intended mostly for syncs when invoice is already finalized.

Queue for this job needs to have higher priority so that invoice can be moved from `pending` as soon as possible.