### PR TITLE
fix: Recurring fee not displayed on invoices after upgrade

### DIFF
--- a/app/jobs/bill_non_invoiceable_fees_job.rb
+++ b/app/jobs/bill_non_invoiceable_fees_job.rb
@@ -12,7 +12,7 @@ class BillNonInvoiceableFeesJob < ApplicationJob
   retry_on Sequenced::SequenceError, ActiveJob::DeserializationError
 
   def perform(subscriptions, billing_at)
-    result = Invoices::AdvanceChargesService.call(subscriptions:, billing_at:)
+    result = Invoices::AdvanceChargesService.call(initial_subscriptions: subscriptions, billing_at:)
     result.raise_if_error!
   end
 end

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -111,10 +111,7 @@ module Subscriptions
           subscription.terminated_at,
           invoicing_reason: :subscription_terminating
         )
-        BillNonInvoiceableFeesJob.set(wait: 2.seconds).perform_later(
-          invoiceable_subscriptions.to_a,
-          subscription.terminated_at
-        )
+        BillNonInvoiceableFeesJob.set(wait: 2.seconds).perform_later([subscription], subscription.terminated_at)
       else
         BillSubscriptionJob.perform_now(
           [subscription],
@@ -122,18 +119,10 @@ module Subscriptions
           invoicing_reason: :subscription_terminating
         )
         BillNonInvoiceableFeesJob.perform_now(
-          invoiceable_subscriptions.to_a,
+          [subscription],
           subscription.terminated_at
         )
       end
-    end
-
-    def invoiceable_subscriptions
-      # Expect all subscriptions belogns to the same organization
-      @invoiceable_subscriptions ||= subscription.organization.subscriptions.where(
-        external_id: subscription.external_id,
-        status: [:active, :terminated]
-      )
     end
 
     # NOTE: If subscription is terminated automatically by setting ending_at, there is a chance that this service will

--- a/spec/graphql/lago_api_schema_spec.rb
+++ b/spec/graphql/lago_api_schema_spec.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe LagoApiSchema do
-  it 'matches the dumped schema' do
-    aggregate_failures do
-      expect(described_class.to_definition.rstrip).to eq(File.read(Rails.root.join('schema.graphql')).rstrip)
-      expect(described_class.to_json.rstrip).to eq(File.read(Rails.root.join('schema.json')).rstrip)
-    end
+  it "matches the dumped graphql schema" do
+    expect(described_class.to_definition.rstrip).to eq(File.read(Rails.root.join("schema.graphql")).rstrip)
+  end
+
+  it "matches the dumped JSON schema" do
+    actual_json_schema = JSON.parse(described_class.to_json)
+    expected_json_schema = JSON.parse(File.read(Rails.root.join("schema.json")))
+
+    expect(actual_json_schema).to eq(expected_json_schema)
   end
 end

--- a/spec/scenarios/invoices/recurring_fees_spec.rb
+++ b/spec/scenarios/invoices/recurring_fees_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Recurring fee invoice inclusion after upgrade", :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: "http://lago.test/wh") }
+  let(:customer) { create(:customer, organization:) }
+  let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
+  let(:original_plan) { create(:plan, organization:) }
+  let(:upgraded_plan) { create(:plan, organization:) }
+  let(:external_subscription_id) { SecureRandom.uuid }
+
+  let(:charge) do
+    create(
+      :charge,
+      plan: original_plan,
+      billable_metric:,
+      prorated: true,
+      pay_in_advance: true,
+      invoiceable: false,
+      regroup_paid_fees: "invoice",
+      properties: {amount: "1"}
+    )
+  end
+
+  before do
+    WebMock
+      .stub_request(:post, "http://lago.test/wh")
+      .to_return(status: 200, body: "", headers: {})
+
+    charge
+  end
+
+  it "includes the recurring fee in the end-of-period invoice after subscription upgrade" do
+    # Step 1: Create a subscription with a start date in the past
+    create_subscription(
+      external_customer_id: customer.external_id,
+      external_id: external_subscription_id,
+      plan_code: original_plan.code,
+      subscription_at: 2.weeks.ago
+    )
+    subscription = customer.subscriptions.first
+
+    # Step 2: Send an event in the past and verify fee creation
+    create_event(
+      transaction_id: SecureRandom.uuid,
+      code: billable_metric.code,
+      external_subscription_id: subscription.external_id,
+      properties: {"item_id" => 1},
+      timestamp: 1.week.ago.to_i
+    )
+
+    fee_from_date = subscription.subscription_at.beginning_of_day.to_time.iso8601
+    fee_to_date = subscription.subscription_at.end_of_month.to_time.iso8601
+
+    expect(
+      a_request(:post, "http://lago.test/wh")
+      .with(
+        body: hash_including(
+          webhook_type: "fee.created", fee: hash_including(
+            {
+              "units" => "1.0",
+              "from_date" => fee_from_date,
+              "to_date" => fee_to_date
+            }
+          )
+        )
+      )
+    ).to have_been_made.once
+
+    fee = Fee.where(subscription:, charge:, created_at: Time.current.to_date..).sole
+    expect(fee).to be_present
+
+    # Step 3: Duplicate the original plan with a higher price
+    upgraded_plan.update!(amount_cents: original_plan.amount_cents + 10_00)
+
+    # Step 4: Upgrade the subscription to the new plan
+    create_subscription(
+      {
+        external_customer_id: customer.external_id,
+        external_id: external_subscription_id,
+        plan_code: upgraded_plan.code
+      }
+    )
+
+    # Step 5: Mark the original fee as succeeded
+    update_fee(fee, {fee: {payment_status: "succeeded"}})
+    expect(fee.reload.payment_status).to eq("succeeded")
+
+    # Step 6: Verify the fee is included in the end-of-period invoice
+    terminate_subscription(subscription)
+
+    fee_invoice = Invoice.order(created_at: :desc).first
+    expect(fee_invoice).to be_present
+    expect(fee_invoice.fees).to include(fee)
+  end
+end

--- a/spec/scenarios/invoices/recurring_fees_spec.rb
+++ b/spec/scenarios/invoices/recurring_fees_spec.rb
@@ -32,66 +32,71 @@ describe "Recurring fee invoice inclusion after upgrade", :scenarios, type: :req
   end
 
   it "includes the recurring fee in the end-of-period invoice after subscription upgrade" do
-    # Step 1: Create a subscription with a start date in the past
-    create_subscription(
-      external_customer_id: customer.external_id,
-      external_id: external_subscription_id,
-      plan_code: original_plan.code,
-      subscription_at: 2.weeks.ago
-    )
-    subscription = customer.subscriptions.first
-
-    # Step 2: Send an event in the past and verify fee creation
-    create_event(
-      transaction_id: SecureRandom.uuid,
-      code: billable_metric.code,
-      external_subscription_id: subscription.external_id,
-      properties: {"item_id" => 1},
-      timestamp: 1.week.ago.to_i
-    )
-
-    fee_from_date = subscription.subscription_at.beginning_of_day.to_time.iso8601
-    fee_to_date = subscription.subscription_at.end_of_month.to_time.iso8601
-
-    expect(
-      a_request(:post, "http://lago.test/wh")
-      .with(
-        body: hash_including(
-          webhook_type: "fee.created", fee: hash_including(
-            {
-              "units" => "1.0",
-              "from_date" => fee_from_date,
-              "to_date" => fee_to_date
-            }
-          )
-        )
-      )
-    ).to have_been_made.once
-
-    fee = Fee.where(subscription:, charge:, created_at: Time.current.to_date..).sole
-    expect(fee).to be_present
-
-    # Step 3: Duplicate the original plan with a higher price
-    upgraded_plan.update!(amount_cents: original_plan.amount_cents + 10_00)
-
-    # Step 4: Upgrade the subscription to the new plan
-    create_subscription(
-      {
+    travel_to Time.zone.parse("2024-12-30T03:55:00") do
+      # Step 1: Create a subscription with a start date in the past
+      create_subscription(
         external_customer_id: customer.external_id,
         external_id: external_subscription_id,
-        plan_code: upgraded_plan.code
-      }
-    )
+        plan_code: original_plan.code,
+        subscription_at: 2.weeks.ago
+      )
+      subscription = customer.subscriptions.first
 
-    # Step 5: Mark the original fee as succeeded
-    update_fee(fee, {fee: {payment_status: "succeeded"}})
-    expect(fee.reload.payment_status).to eq("succeeded")
+      WebMock.reset_executed_requests!
 
-    # Step 6: Verify the fee is included in the end-of-period invoice
-    terminate_subscription(subscription)
+      # Step 2: Send an event in the past and verify fee creation
+      create_event(
+        transaction_id: SecureRandom.uuid,
+        code: billable_metric.code,
+        external_subscription_id: subscription.external_id,
+        properties: {"item_id" => 1},
+        timestamp: 1.week.ago.to_i
+      )
 
-    fee_invoice = Invoice.order(created_at: :desc).first
-    expect(fee_invoice).to be_present
-    expect(fee_invoice.fees).to include(fee)
+      fee_from_date = subscription.subscription_at.beginning_of_day.to_time.iso8601
+      fee_to_date = subscription.subscription_at.end_of_month.to_time.iso8601
+
+      expect(
+        a_request(:post, "http://lago.test/wh")
+        .with(
+          body: hash_including(
+            webhook_type: "fee.created", fee: hash_including(
+              {
+                "units" => "1.0",
+                "from_date" => fee_from_date,
+                "to_date" => fee_to_date
+              }
+            )
+          )
+        )
+      ).to have_been_made.once
+
+      fee = Fee.where(subscription:, charge:, created_at: Time.current.to_date..).sole
+      expect(fee).to be_present
+
+      # Step 3: Duplicate the original plan with a higher price
+      upgraded_plan.update!(amount_cents: original_plan.amount_cents + 10_00)
+
+      # Step 4: Upgrade the subscription to the new plan
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: external_subscription_id,
+          plan_code: upgraded_plan.code
+        }
+      )
+
+      # Step 5: Mark the original fee as succeeded
+      update_fee(fee, {fee: {payment_status: "succeeded"}})
+      expect(fee.reload.payment_status).to eq("succeeded")
+
+      # Step 6: Verify the fee is included in the end-of-period invoice
+      terminate_subscription(subscription)
+
+      fee_invoice = customer.invoices.find_by(invoice_type: "advance_charges")
+
+      expect(fee_invoice).to be_present
+      expect(fee_invoice.fees).to include(fee)
+    end
   end
 end

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -191,25 +191,6 @@ RSpec.describe Subscriptions::TerminateService do
         end
       end
     end
-
-    context "when subscription is an upgrade or downgrade" do
-      let(:subscription_2) do
-        create(:subscription, {
-          external_id: subscription.external_id,
-          customer: subscription.customer,
-          status: :terminated
-        })
-      end
-
-      before { subscription_2 }
-
-      it "enqueues a BillNonInvoiceableFeesJob with both subscriptions" do
-        freeze_time do
-          expect { terminate_service.call }.to have_enqueued_job(BillNonInvoiceableFeesJob)
-            .with([subscription_2, subscription], Time.zone.now)
-        end
-      end
-    end
   end
 
   describe '.terminate_and_start_next' do

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Subscriptions::TerminateService do
   subject(:terminate_service) { described_class.new(subscription:) }
 
-  describe '.terminate' do
+  describe '#call' do
     let(:subscription) { create(:subscription) }
 
     it 'terminates a subscription' do
@@ -32,9 +32,14 @@ RSpec.describe Subscriptions::TerminateService do
     end
 
     it 'enqueues a BillSubscriptionJob' do
-      expect do
-        terminate_service.call
-      end.to have_enqueued_job(BillSubscriptionJob).and have_enqueued_job(BillNonInvoiceableFeesJob)
+      expect { terminate_service.call }.to have_enqueued_job(BillSubscriptionJob)
+    end
+
+    it "enqueues a BillNonInvoiceableFeesJob" do
+      freeze_time do
+        expect { terminate_service.call }.to have_enqueued_job(BillNonInvoiceableFeesJob)
+          .with([subscription], Time.zone.now)
+      end
     end
 
     it 'enqueues a SendWebhookJob' do
@@ -183,6 +188,25 @@ RSpec.describe Subscriptions::TerminateService do
           expect do
             terminate_service.call
           end.not_to change(CreditNote, :count)
+        end
+      end
+    end
+
+    context "when subscription is an upgrade or downgrade" do
+      let(:subscription_2) do
+        create(:subscription, {
+          external_id: subscription.external_id,
+          customer: subscription.customer,
+          status: :terminated
+        })
+      end
+
+      before { subscription_2 }
+
+      it "enqueues a BillNonInvoiceableFeesJob with both subscriptions" do
+        freeze_time do
+          expect { terminate_service.call }.to have_enqueued_job(BillNonInvoiceableFeesJob)
+            .with([subscription_2, subscription], Time.zone.now)
         end
       end
     end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -146,6 +146,12 @@ module ScenariosHelper
     customer.update!(payment_provider: 'stripe', payment_provider_code: stripe_provider.code)
   end
 
+  ### Fees
+
+  def update_fee(fee, params)
+    put_with_token(organization, "/api/v1/fees/#{fee.id}", params)
+  end
+
   # This performs any enqueued-jobs, and continues doing so until the queue is empty.
   # Lots of the jobs enqueue other jobs as part of their work, and this ensures that
   # everything that's supposed to happen, happens.


### PR DESCRIPTION
## Context

Steps to reproduce the issue:

1. Create a recurring metric;

2. Create a plan with a charge linked to the recurring metric - the charge should be:
* prorated = true;
* pay_in_advance = true;
* invoiceable = false;
* regroup_paid_fees = invoice;

3. Create a subscription with a start date in the past and send an event in the past (e.g. 1 December) -> you receive a fee.created webhook;

4. Duplicate the original plan and only modify the price of the charge (higher price);

5. Trigger an upgrade of the existing subscription by assigning the new plan;

6. Mark the fee in step 3 as succeeded via POST api/v1/fees/:lago_id

7. Terminate the subscription -> the fee is not included in the end-of-period invoice.

Expected behaviour: the fee should be included in the end-of-period invoice, even if the original Lago subscription to which it belongs is no longer active.

## Description

This change fetches all subscriptions with status active or terminated of a given organization with a matching external id to invoice their paid in advance fees.