### PR TITLE
Fix invoice grace period saving with null values

### DIFF
--- a/app/services/customers/update_invoice_grace_period_service.rb
+++ b/app/services/customers/update_invoice_grace_period_service.rb
@@ -4,12 +4,12 @@ module Customers
   class UpdateInvoiceGracePeriodService < BaseService
     def initialize(customer:, grace_period:)
       @customer = customer
-      @grace_period = grace_period.to_i
+      @grace_period = grace_period
       super
     end
 
     def call
-      old_grace_period = customer.invoice_grace_period.to_i
+      old_grace_period = customer.invoice_grace_period
       old_applicable_grace_period = customer.applicable_invoice_grace_period.to_i
 
       if grace_period != old_grace_period

--- a/app/services/customers/update_invoice_grace_period_service.rb
+++ b/app/services/customers/update_invoice_grace_period_service.rb
@@ -25,9 +25,8 @@ module Customers
           invoice.save!
         end
 
-        # NOTE: Finalize related draft invoices.
         customer.invoices.ready_to_be_finalized.find_each do |invoice|
-          Invoices::RefreshDraftAndFinalizeService.call(invoice:)
+          Invoices::FinalizeJob.perform_later(invoice)
         end
       end
 

--- a/app/services/organizations/update_invoice_grace_period_service.rb
+++ b/app/services/organizations/update_invoice_grace_period_service.rb
@@ -24,11 +24,6 @@ module Organizations
           invoice.payment_due_date = grace_period_payment_due_date(invoice)
           invoice.save!
         end
-
-        # NOTE: Finalize related draft invoices.
-        organization.invoices.ready_to_be_finalized.find_each do |invoice|
-          Invoices::RefreshDraftAndFinalizeService.call(invoice:)
-        end
       end
 
       result.organization = organization

--- a/app/services/organizations/update_invoice_grace_period_service.rb
+++ b/app/services/organizations/update_invoice_grace_period_service.rb
@@ -24,6 +24,10 @@ module Organizations
           invoice.payment_due_date = grace_period_payment_due_date(invoice)
           invoice.save!
         end
+
+        organization.invoices.ready_to_be_finalized.find_each do |invoice|
+          Invoices::FinalizeJob.perform_later(invoice)
+        end
       end
 
       result.organization = organization

--- a/spec/services/organizations/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/organizations/update_invoice_grace_period_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Organizations::UpdateInvoiceGracePeriodService, type: :service do
     before do
       invoice_to_be_finalized
       invoice_to_not_be_finalized
-      allow(Invoices::RefreshDraftAndFinalizeService).to receive(:call)
+      allow(Invoices::FinalizeJob).to receive(:perform_later)
     end
 
     it 'updates invoice grace period on organization' do
@@ -36,8 +36,8 @@ RSpec.describe Organizations::UpdateInvoiceGracePeriodService, type: :service do
         result = update_service.call
 
         expect(result.organization.invoice_grace_period).to eq(2)
-        expect(Invoices::RefreshDraftAndFinalizeService).not_to have_received(:call).with(invoice: invoice_to_not_be_finalized)
-        expect(Invoices::RefreshDraftAndFinalizeService).to have_received(:call).with(invoice: invoice_to_be_finalized)
+        expect(Invoices::FinalizeJob).not_to have_received(:perform_later).with(invoice_to_not_be_finalized)
+        expect(Invoices::FinalizeJob).to have_received(:perform_later).with(invoice_to_be_finalized)
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Organizations::UpdateInvoiceGracePeriodService, type: :service do
         travel_to(current_date) do
           update_service.call
 
-          expect(Invoices::RefreshDraftAndFinalizeService).not_to have_received(:call)
+          expect(Invoices::FinalizeJob).not_to have_received(:perform_later)
         end
       end
 

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Organizations::UpdateService do
         before do
           invoice_to_be_finalized
           invoice_to_not_be_finalized
-          allow(Invoices::RefreshDraftAndFinalizeService).to receive(:call)
+          allow(Invoices::FinalizeJob).to receive(:perform_later)
         end
 
         it 'finalizes corresponding draft invoices' do
@@ -137,8 +137,8 @@ RSpec.describe Organizations::UpdateService do
 
             aggregate_failures do
               expect(result.organization.invoice_grace_period).to eq(2)
-              expect(Invoices::RefreshDraftAndFinalizeService).not_to have_received(:call).with(invoice: invoice_to_not_be_finalized)
-              expect(Invoices::RefreshDraftAndFinalizeService).to have_received(:call).with(invoice: invoice_to_be_finalized)
+              expect(Invoices::FinalizeJob).not_to have_received(:perform_later).with(invoice_to_not_be_finalized)
+              expect(Invoices::FinalizeJob).to have_received(:perform_later).with(invoice_to_be_finalized)
             end
           end
         end


### PR DESCRIPTION
## Description

We incorrectly converted nil to zero in the invoice grace period update service. This means we cannot clear the value.