### PR TITLE
feat: Add Conditional Integration Customers to use on resync webhook

### DIFF
--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -47,7 +47,10 @@ module V1
 
     def customer
       {
-        customer: ::V1::CustomerSerializer.new(model.customer).serialize
+        customer: ::V1::CustomerSerializer.new(
+          model.customer,
+          includes: include?(:integration_customers) ? [:integration_customers] : []
+        ).serialize
       }
     end
 

--- a/app/services/webhooks/invoices/resynced_service.rb
+++ b/app/services/webhooks/invoices/resynced_service.rb
@@ -13,7 +13,7 @@ module Webhooks
         ::V1::InvoiceSerializer.new(
           object,
           root_name: 'invoice',
-          includes: %i[customer subscriptions fees credits applied_taxes]
+          includes: %i[customer integration_customers subscriptions fees credits applied_taxes]
         )
       end
 

--- a/spec/services/webhooks/invoices/resynced_service_spec.rb
+++ b/spec/services/webhooks/invoices/resynced_service_spec.rb
@@ -11,5 +11,19 @@ RSpec.describe Webhooks::Invoices::ResyncedService do
 
   describe '.call' do
     it_behaves_like 'creates webhook', 'invoice.resynced', 'invoice'
+
+    it 'calls the InvoiceSerializer with integration_customers included' do
+      serializer_instance = instance_double(V1::InvoiceSerializer)
+      allow(V1::InvoiceSerializer).to receive(:new).and_return(serializer_instance)
+      allow(serializer_instance).to receive(:serialize).and_return({})
+
+      webhook_service.call
+
+      expect(V1::InvoiceSerializer).to have_received(:new).with(
+        invoice,
+        root_name: 'invoice',
+        includes: array_including(:customer, :integration_customers, :subscriptions, :fees, :credits, :applied_taxes)
+      )
+    end
   end
 end


### PR DESCRIPTION
## Context

The ResyncedService requires the inclusion of integration_customers in the serialized Customer object as part of the webhook payload. However, this inclusion should only happen in specific cases, like in the ResyncedService, and not affect other serializers or services. 

we use this webhook to do the salesforce integration that why we need the customer integration 