### PR TITLE
fix(customer): avoid duplicated fields in customer response

### DIFF
--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -67,13 +67,13 @@ module V1
       when :stripe
         configuration[:provider_customer_id] = model.stripe_customer&.provider_customer_id
         configuration[:provider_payment_methods] = model.stripe_customer&.provider_payment_methods
-        configuration.merge!(model.stripe_customer&.settings || {})
+        configuration.merge!(model.stripe_customer&.settings&.symbolize_keys || {})
       when :gocardless
         configuration[:provider_customer_id] = model.gocardless_customer&.provider_customer_id
-        configuration.merge!(model.gocardless_customer&.settings || {})
+        configuration.merge!(model.gocardless_customer&.settings&.symbolize_keys || {})
       when :adyen
         configuration[:provider_customer_id] = model.adyen_customer&.provider_customer_id
-        configuration.merge!(model.adyen_customer&.settings || {})
+        configuration.merge!(model.adyen_customer&.settings&.symbolize_keys || {})
       end
 
       configuration

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -65,4 +65,19 @@ RSpec.describe ::V1::CustomerSerializer do
       expect(result['customer']['integration_customers'].count).to eq(1)
     end
   end
+
+  context 'with a stripe customer' do
+    let(:stripe_customer) { create(:stripe_customer, customer:) }
+
+    before do
+      stripe_customer
+      customer.update!(payment_provider: 'stripe')
+    end
+
+    it 'serializes the object' do
+      result = JSON.parse(serializer.to_json)
+      expect(result['customer']['billing_configuration']['provider_customer_id']).to eq(stripe_customer.provider_customer_id)
+      expect(result['customer']['billing_configuration']['provider_payment_methods']).to eq(stripe_customer.provider_payment_methods)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Fixes https://github.com/getlago/lago/issues/442

## Description

Avoid duplicated payment provider settings in customer serializer