### PR TITLE
fix(fee): Charge pay in advance interval without any day-shift

### DIFF
--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -26,7 +26,7 @@ module Subscriptions
     def self.charge_pay_in_advance_interval(timestamp, subscription)
       date_service = new_instance(
         subscription,
-        Time.zone.at(timestamp) + 1.day,
+        Time.zone.at(timestamp),
         current_usage: true
       )
 


### PR DESCRIPTION
At present, it is possible to obtain fees with errors within boundaries.

In fact, when the fee is of the charge type, paid in advance and the charge non-invoiceable, on the last day of the billing period there is a boundary shift.

`from_date` and `to_date` correspond to the next billing period.