### PR TITLE
fix: Retry when getting stale wallet error for pay in advance events

### DIFF
--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -12,6 +12,7 @@ module Invoices
 
     retry_on Sequenced::SequenceError
     retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
+    retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6
 
     unique :until_executed, on_conflict: :log
 


### PR DESCRIPTION
Sometimes, we could have issues related to stale wallet updates, when creating pay in advance event.
The goal of this PR is to retry the `Invoices::CreatePayInAdvanceChargeJob` if we had this exception.