### PR TITLE
fix: Update provider taxes rescue logic

### DIFF
--- a/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
+++ b/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
@@ -8,7 +8,7 @@ module Invoices
       retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 
       def perform(invoice:)
-        Invoices::ProviderTaxes::PullTaxesAndApplyService.call!(invoice:)
+        Invoices::ProviderTaxes::PullTaxesAndApplyService.call(invoice:)
       end
     end
   end

--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -68,8 +68,6 @@ module Invoices
         result.record_validation_failure!(record: e.record)
       rescue BaseService::FailedResult => e
         e.result
-      rescue => e
-        result.fail_with_error!(e)
       end
 
       private

--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -64,10 +64,6 @@ module Invoices
         end
 
         result
-      rescue ActiveRecord::RecordInvalid => e
-        result.record_validation_failure!(record: e.record)
-      rescue BaseService::FailedResult => e
-        e.result
       end
 
       private


### PR DESCRIPTION
For provider taxes, we do not want to create dead job for all errors related to Anrok configuration. For everything else it is fine to have dead job