### PR TITLE
fix(invoice): Use BigDecimal rather than float for amount details

### DIFF
--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -178,7 +178,7 @@ module Charges
       def min_max_adjustment_total_amount
         return BigDecimal(0) unless should_apply_min_max?
 
-        compute_amount_with_transaction_min_max - compute_percentage_amount - compute_fixed_amount
+        BigDecimal(compute_amount_with_transaction_min_max - compute_percentage_amount - compute_fixed_amount)
       end
     end
   end


### PR DESCRIPTION
## Context

Some invoices failed to generate because some values stored in the fee#amount_details were failing to render as amount. The reason was that they were computed as `float` and converted to string. 

## Description

Since float is not a reliable data type, we should use `BigDecimal` to handle the amount detail values