### PR TITLE
feat(invoice): Avoid generating 0 amount charge fees

### DIFF
--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -2,14 +2,15 @@
 
 module Fees
   class ChargeService < BaseService
-    def initialize(invoice:, charge:, subscription:, boundaries:, current_usage: false, cache_middleware: nil, bypass_aggregation: false)
+    def initialize(invoice:, charge:, subscription:, boundaries:, context: nil, cache_middleware: nil, bypass_aggregation: false)
       @invoice = invoice
       @charge = charge
       @subscription = subscription
       @boundaries = OpenStruct.new(boundaries)
       @currency = subscription.plan.amount.currency
 
-      @current_usage = current_usage
+      @context = context
+      @current_usage = context == :current_usage
       @cache_middleware = cache_middleware || Subscriptions::ChargeCacheMiddleware.new(
         subscription:, charge:, to_datetime: boundaries[:charges_to_datetime], cache: false
       )
@@ -28,7 +29,7 @@ module Fees
 
       if invoice.nil? || !invoice.progressive_billing?
         init_true_up_fee(
-          fee: result.fees.first,
+          fee: result.fees.find { |f| f.charge_filter_id.nil? },
           amount_cents: result.fees.sum(&:amount_cents),
           precise_amount_cents: result.fees.sum(&:precise_amount_cents)
         )
@@ -36,6 +37,8 @@ module Fees
       return result unless result.success?
 
       ActiveRecord::Base.transaction do
+        result.fees.reject! { |f| !should_persit_fee?(f, result.fees) }
+
         result.fees.each do |fee|
           fee.save!
 
@@ -55,7 +58,7 @@ module Fees
 
     private
 
-    attr_accessor :invoice, :charge, :subscription, :boundaries, :current_usage, :currency, :cache_middleware, :bypass_aggregation
+    attr_accessor :invoice, :charge, :subscription, :boundaries, :context, :current_usage, :currency, :cache_middleware, :bypass_aggregation
 
     delegate :billable_metric, to: :charge
     delegate :organization, to: :subscription
@@ -165,6 +168,15 @@ module Fees
       end
 
       new_fee
+    end
+
+    def should_persit_fee?(fee, fees)
+      return true if context == :recurring
+      return true if fee.units != 0 || fee.amount_cents != 0 || fee.events_count != 0
+      return true if adjusted_fee(charge_filter: fee.charge_filter, grouped_by: fee.grouped_by).present?
+      return true if fee.true_up_parent_fee.present?
+
+      fees.any? { |f| f.true_up_parent_fee == fee }
     end
 
     def adjusted_fee(charge_filter:, grouped_by:)

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -117,7 +117,7 @@ module Invoices
           next if should_not_create_charge_fee?(charge, subscription)
 
           bypass_aggregation = !received_event_codes.include?(charge.billable_metric.code)
-          Fees::ChargeService.call(invoice:, charge:, subscription:, boundaries:, bypass_aggregation:).raise_if_error!
+          Fees::ChargeService.call(invoice:, charge:, subscription:, boundaries:, context:, bypass_aggregation:).raise_if_error!
         end
     end
 
@@ -184,7 +184,7 @@ module Invoices
         .find_each do |charge|
         next if should_not_create_charge_fee?(charge, subscription)
 
-        fee_result = Fees::ChargeService.call(invoice: nil, charge:, subscription:, boundaries:).raise_if_error!
+        fee_result = Fees::ChargeService.call(invoice: nil, charge:, subscription:, context: :recurring, boundaries:).raise_if_error!
 
         result.non_invoiceable_fees.concat(fee_result.fees)
       end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -102,7 +102,7 @@ module Invoices
       applied_boundaries = applied_boundaries.merge(charges_to_datetime: max_to_datetime) if max_to_datetime
 
       Fees::ChargeService
-        .call(invoice:, charge:, subscription:, boundaries: applied_boundaries, current_usage: true, cache_middleware:)
+        .call(invoice:, charge:, subscription:, boundaries: applied_boundaries, context: :current_usage, cache_middleware:)
         .raise_if_error!
         .fees
     end

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -78,7 +78,7 @@ module Invoices
 
     def create_fees
       charges.find_each do |charge|
-        Fees::ChargeService.call(invoice:, charge:, subscription:, boundaries:).raise_if_error!
+        Fees::ChargeService.call(invoice:, charge:, subscription:, context: :finalize, boundaries:).raise_if_error!
       end
     end
 

--- a/spec/scenarios/invoices/adjusted_charge_fees_spec.rb
+++ b/spec/scenarios/invoices/adjusted_charge_fees_spec.rb
@@ -6,7 +6,7 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
   let(:organization) { create(:organization, webhook_url: nil, email_settings: '') }
 
   let(:customer) { create(:customer, organization:, invoice_grace_period: 5) }
-  let(:subscription_at) { DateTime.new(2023, 7, 19, 12, 12) }
+  let(:subscription_at) { DateTime.new(2022, 7, 19, 12, 12) }
   let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: 'sum_agg', field_name: 'custom') }
   let(:unit_precise_amount) { nil }
 
@@ -52,8 +52,20 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
         )
       end
 
+      travel_to(Time.zone.parse("2023-07-23T10:12")) do
+        create_event(
+          {
+            external_subscription_id: customer.external_id,
+            transaction_id: SecureRandom.uuid,
+            code: billable_metric.code,
+            timestamp: Time.current.to_i,
+            properties: {billable_metric.field_name => 0}
+          }
+        )
+      end
+
       # NOTE: August 19th: Bill subscription
-      travel_to(DateTime.new(2023, 8, 19, 12, 12)) do
+      travel_to(Time.zone.parse("2023-08-19T12:12")) do
         Subscriptions::BillingService.call
         perform_all_enqueued_jobs
 
@@ -71,7 +83,7 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
       end
 
       # NOTE: August 20th: Refresh and finalize invoice
-      travel_to(DateTime.new(2023, 8, 20, 12, 12)) do
+      travel_to(Time.zone.parse("2023-08-20T12:12")) do
         invoice = customer.invoices.order(created_at: :desc).first
 
         Invoices::RefreshDraftJob.perform_later(invoice)
@@ -113,8 +125,20 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
         )
       end
 
+      travel_to(Time.zone.parse("2023-07-23T10:12")) do
+        create_event(
+          {
+            external_subscription_id: customer.external_id,
+            transaction_id: SecureRandom.uuid,
+            code: billable_metric.code,
+            timestamp: Time.current.to_i,
+            properties: {billable_metric.field_name => 0}
+          }
+        )
+      end
+
       # NOTE: August 19th: Bill subscription
-      travel_to(DateTime.new(2023, 8, 19, 12, 12)) do
+      travel_to(Time.zone.parse("2023-08-19T12:12")) do
         Subscriptions::BillingService.call
         perform_all_enqueued_jobs
 
@@ -132,7 +156,7 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
       end
 
       # NOTE: August 20th: Refresh and finalize invoice
-      travel_to(DateTime.new(2023, 8, 20, 12, 12)) do
+      travel_to(Time.zone.parse("2023-08-20T12:12")) do
         invoice = customer.invoices.order(created_at: :desc).first
 
         Invoices::RefreshDraftJob.perform_later(invoice)

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -351,6 +351,18 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         )
       end
 
+      travel_to(Time.zone.parse("2022-12-16T10:12")) do
+        create_event(
+          {
+            external_subscription_id: customer.external_id,
+            transaction_id: SecureRandom.uuid,
+            code: metric.code,
+            timestamp: Time.current.to_i,
+            properties: {metric.field_name => 0}
+          }
+        )
+      end
+
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Terminate subscription + refresh.
@@ -399,6 +411,18 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       subscription = customer.subscriptions.first
+
+      travel_to(Time.zone.parse("2022-12-16T10:12")) do
+        create_event(
+          {
+            external_subscription_id: customer.external_id,
+            transaction_id: SecureRandom.uuid,
+            code: metric.code,
+            timestamp: Time.current.to_i,
+            properties: {metric.field_name => 0}
+          }
+        )
+      end
 
       ### 20 Dec: Terminate subscription + refresh.
       dec20 = Time.zone.parse('2022-12-20 06:00:00')
@@ -482,6 +506,18 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       subscription = customer.subscriptions.first
+
+      travel_to(Time.zone.parse("2022-12-16T10:12")) do
+        create_event(
+          {
+            external_subscription_id: customer.external_id,
+            transaction_id: SecureRandom.uuid,
+            code: metric.code,
+            timestamp: Time.current.to_i,
+            properties: {metric.field_name => 0}
+          }
+        )
+      end
 
       ### 20 Dec: Upgrade subscription
       dec20 = Time.zone.parse('2022-12-20 06:00:00')

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -4,18 +4,18 @@ require "rails_helper"
 
 RSpec.describe Fees::ChargeService do
   subject(:charge_subscription_service) do
-    described_class.new(invoice:, charge:, subscription:, boundaries:, current_usage:)
+    described_class.new(invoice:, charge:, subscription:, boundaries:, context:)
   end
 
   let(:customer) { create(:customer) }
   let(:organization) { customer.organization }
-  let(:current_usage) { false }
+  let(:context) { :finalize }
 
   let(:subscription) do
     create(
       :subscription,
       status: :active,
-      started_at: DateTime.parse("2022-03-15"),
+      started_at: Time.zone.parse("2022-03-15"),
       customer:
     )
   end
@@ -54,20 +54,40 @@ RSpec.describe Fees::ChargeService do
       it "creates a fee" do
         result = charge_subscription_service.call
         expect(result).to be_success
-        expect(result.fees.first).to have_attributes(
-          id: String,
-          invoice_id: invoice.id,
-          charge_id: charge.id,
-          amount_cents: 0,
-          precise_amount_cents: 0.0,
-          taxes_precise_amount_cents: 0.0,
-          amount_currency: "EUR",
-          units: 0,
-          unit_amount_cents: 0,
-          precise_unit_amount: 0,
-          events_count: 0,
-          payment_status: "pending"
-        )
+        expect(result.fees.count).to be_zero
+      end
+
+      context 'with an event' do
+        let(:event) do
+          create(
+            :event,
+            organization: subscription.organization,
+            subscription:,
+            code: billable_metric.code,
+            timestamp: boundaries[:charges_to_datetime] - 2.days
+          )
+        end
+
+        before { event }
+
+        it "creates a fee" do
+          result = charge_subscription_service.call
+          expect(result).to be_success
+          expect(result.fees.first).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            charge_id: charge.id,
+            amount_cents: 2000,
+            precise_amount_cents: 2000.0,
+            taxes_precise_amount_cents: 0.0,
+            amount_currency: "EUR",
+            units: 1,
+            unit_amount_cents: 2000,
+            precise_unit_amount: 20,
+            events_count: 1,
+            payment_status: "pending"
+          )
+        end
       end
 
       context "with grouped standard charge" do
@@ -88,23 +108,10 @@ RSpec.describe Fees::ChargeService do
         end
 
         context "without events" do
-          it "creates an empty fee" do
+          it "does not create a fee" do
             result = charge_subscription_service.call
             expect(result).to be_success
-            expect(result.fees.count).to eq(1)
-
-            fee = result.fees.first
-            expect(fee).to have_attributes(
-              id: String,
-              invoice_id: invoice.id,
-              charge_id: charge.id,
-              amount_cents: 0,
-              amount_currency: "EUR",
-              units: 0,
-              unit_amount_cents: 0,
-              precise_unit_amount: 0,
-              grouped_by: {"cloud" => nil}
-            )
+            expect(result.fees.count).to eq(0)
           end
         end
 
@@ -113,30 +120,27 @@ RSpec.describe Fees::ChargeService do
             create(
               :event,
               organization: subscription.organization,
-              customer: subscription.customer,
               subscription:,
               code: charge.billable_metric.code,
-              timestamp: DateTime.parse("2022-03-16"),
+              timestamp: Time.zone.parse("2022-03-16"),
               properties: {cloud: "aws", value: 10}
             )
 
             create(
               :event,
               organization: subscription.organization,
-              customer: subscription.customer,
               subscription:,
               code: charge.billable_metric.code,
-              timestamp: DateTime.parse("2022-03-16"),
+              timestamp: Time.zone.parse("2022-03-16"),
               properties: {cloud: "aws", value: 5}
             )
 
             create(
               :event,
               organization: subscription.organization,
-              customer: subscription.customer,
               subscription:,
               code: charge.billable_metric.code,
-              timestamp: DateTime.parse("2022-03-16"),
+              timestamp: Time.zone.parse("2022-03-16"),
               properties: {cloud: "gcp", value: 10}
             )
           end
@@ -295,10 +299,9 @@ RSpec.describe Fees::ChargeService do
             :event,
             4,
             organization: subscription.organization,
-            customer: subscription.customer,
             subscription:,
             code: charge.billable_metric.code,
-            timestamp: DateTime.parse("2022-03-16")
+            timestamp: Time.zone.parse("2022-03-16")
           )
         end
 
@@ -341,7 +344,6 @@ RSpec.describe Fees::ChargeService do
           create(
             :event,
             organization: invoice.organization,
-            customer: subscription.customer,
             subscription:,
             code: billable_metric.code,
             timestamp: Time.zone.parse("10 Apr 2022 00:01:00")
@@ -381,13 +383,24 @@ RSpec.describe Fees::ChargeService do
       end
 
       context "with all types of aggregation" do
+        let(:event) do
+          create(
+            :event,
+            code: billable_metric.code,
+            organization: organization,
+            external_subscription_id: subscription.external_id,
+            timestamp: boundaries[:charges_to_datetime] - 2.days,
+            properties: {"foo_bar" => 1}
+          )
+        end
+
         BillableMetric::AGGREGATION_TYPES.keys.each do |aggregation_type|
           before do
             billable_metric.update!(
               aggregation_type:,
-              field_name: "foo_bar",
+              field_name: event.properties.keys.first,
               weighted_interval: "seconds",
-              custom_aggregator: "def aggregate(event, agg, aggregation_properties); agg; end"
+              custom_aggregator: "def aggregate(event, agg, aggregation_properties); { total_units: 1, amount: 1 }; end"
             )
           end
 
@@ -398,13 +411,13 @@ RSpec.describe Fees::ChargeService do
               id: String,
               invoice_id: invoice.id,
               charge_id: charge.id,
-              amount_cents: 0,
-              precise_amount_cents: 0.0,
+              amount_cents: 2000,
+              precise_amount_cents: 2000.0,
               taxes_precise_amount_cents: 0.0,
               amount_currency: "EUR",
-              units: 0,
-              unit_amount_cents: 0,
-              precise_unit_amount: 0
+              units: 1,
+              unit_amount_cents: 2000,
+              precise_unit_amount: 20
             )
           end
         end
@@ -541,37 +554,33 @@ RSpec.describe Fees::ChargeService do
               create(
                 :event,
                 organization: subscription.organization,
-                customer: subscription.customer,
                 subscription:,
                 code: charge.billable_metric.code,
-                timestamp: DateTime.parse("2022-03-16"),
+                timestamp: Time.zone.parse("2022-03-16"),
                 properties: {region: "usa", foo_bar: 12}
               )
               create(
                 :event,
                 organization: subscription.organization,
-                customer: subscription.customer,
                 subscription:,
                 code: charge.billable_metric.code,
-                timestamp: DateTime.parse("2022-03-16"),
+                timestamp: Time.zone.parse("2022-03-16"),
                 properties: {region: "europe", foo_bar: 10}
               )
               create(
                 :event,
                 organization: subscription.organization,
-                customer: subscription.customer,
                 subscription:,
                 code: charge.billable_metric.code,
-                timestamp: DateTime.parse("2022-03-16"),
+                timestamp: Time.zone.parse("2022-03-16"),
                 properties: {region: "europe", foo_bar: 5}
               )
               create(
                 :event,
                 organization: subscription.organization,
-                customer: subscription.customer,
                 subscription:,
                 code: charge.billable_metric.code,
-                timestamp: DateTime.parse("2022-03-16"),
+                timestamp: Time.zone.parse("2022-03-16"),
                 properties: {country: "france", foo_bar: 5}
               )
             end
@@ -583,7 +592,7 @@ RSpec.describe Fees::ChargeService do
               created_fees = result.fees
 
               aggregate_failures do
-                expect(created_fees.count).to eq(4)
+                expect(created_fees.count).to eq(3)
                 expect(created_fees).to all(
                   have_attributes(
                     invoice_id: invoice.id,
@@ -730,7 +739,7 @@ RSpec.describe Fees::ChargeService do
 
       context "with true-up fee" do
         it "creates two fees" do
-          travel_to(DateTime.new(2023, 4, 1)) do
+          travel_to(Time.zone.parse("2023-04-01")) do
             charge.update!(min_amount_cents: 1000)
             result = charge_subscription_service.call
 
@@ -773,10 +782,9 @@ RSpec.describe Fees::ChargeService do
           create(
             :event,
             organization: subscription.organization,
-            customer: subscription.customer,
             subscription:,
             code: billable_metric.code,
-            timestamp: DateTime.parse("2022-03-16"),
+            timestamp: Time.zone.parse("2022-03-16"),
             properties: {item_id: -10}
           )
         end
@@ -856,37 +864,41 @@ RSpec.describe Fees::ChargeService do
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
+          properties: {foo_bar: 12}
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          subscription:,
+          code: charge.billable_metric.code,
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "usa", foo_bar: 12}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "europe", foo_bar: 10}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "europe", foo_bar: 5}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {country: "france", foo_bar: 5}
         )
       end
@@ -1163,37 +1175,41 @@ RSpec.describe Fees::ChargeService do
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
+          properties: {foo_bar: 12}
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          subscription:,
+          code: charge.billable_metric.code,
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "usa", foo_bar: 12}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "europe", foo_bar: 10}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "europe", foo_bar: 5}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {country: "france", foo_bar: 5}
         )
       end
@@ -1315,37 +1331,41 @@ RSpec.describe Fees::ChargeService do
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
+          properties: {foo_bar: 12}
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          subscription:,
+          code: charge.billable_metric.code,
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "usa", foo_bar: 12}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "europe", foo_bar: 10}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "europe", foo_bar: 5}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {country: "france", foo_bar: 5}
         )
       end
@@ -1473,28 +1493,33 @@ RSpec.describe Fees::ChargeService do
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
+          properties: {foo_bar: 12}
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          subscription:,
+          code: charge.billable_metric.code,
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "usa", foo_bar: 12}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "europe", foo_bar: 10}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "europe", foo_bar: 5}
         )
       end
@@ -1597,28 +1622,33 @@ RSpec.describe Fees::ChargeService do
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
+          properties: {foo_bar: 12}
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          subscription:,
+          code: charge.billable_metric.code,
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "usa", foo_bar: 12}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "europe", foo_bar: 10}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "europe", foo_bar: 5}
         )
       end
@@ -1736,28 +1766,33 @@ RSpec.describe Fees::ChargeService do
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
+          properties: {foo_bar: 12}
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          subscription:,
+          code: charge.billable_metric.code,
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "usa", foo_bar: 12}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "europe", foo_bar: 10}
         )
         create(
           :event,
           organization: subscription.organization,
-          customer: subscription.customer,
           subscription:,
           code: charge.billable_metric.code,
-          timestamp: DateTime.parse("2022-03-16"),
+          timestamp: Time.zone.parse("2022-03-16"),
           properties: {region: "europe", foo_bar: 5}
         )
       end
@@ -1847,24 +1882,25 @@ RSpec.describe Fees::ChargeService do
         usa_filter_value
       end
 
-      it "creates three fees" do
-        travel_to(DateTime.new(2023, 4, 1)) do
+      it "creates two fees" do
+        travel_to(Time.zone.parse("2023-04-01")) do
           result = charge_subscription_service.call
 
           aggregate_failures do
             expect(result).to be_success
-            expect(result.fees.count).to eq(4)
+            expect(result.fees.count).to eq(2)
 
             # 548 is 1000 prorated for 17 days.
-            expect(result.fees.pluck(:amount_cents)).to contain_exactly(0, 0, 0, 548)
-            expect(result.fees.pluck(:precise_amount_cents)).to contain_exactly(0, 0, 0, 548.3870967741935)
-            expect(result.fees.pluck(:taxes_precise_amount_cents)).to contain_exactly(0.0, 0.0, 0.0, 0.0)
+            expect(result.fees.pluck(:amount_cents)).to contain_exactly(0, 548)
+            expect(result.fees.pluck(:precise_amount_cents)).to contain_exactly(0, 548.3870967741935)
+            expect(result.fees.pluck(:taxes_precise_amount_cents)).to contain_exactly(0.0, 0.0)
           end
         end
       end
     end
 
     context "with recurring weighted sum aggregation" do
+      let(:context) { :recurring }
       let(:billable_metric) { create(:weighted_sum_billable_metric, :recurring, organization:) }
 
       it "creates a fee and a cached aggregation" do
@@ -1929,7 +1965,7 @@ RSpec.describe Fees::ChargeService do
     end
 
     context "when current usage" do
-      let(:current_usage) { true }
+      let(:context) { :current_usage }
 
       context "with all types of aggregation" do
         BillableMetric::AGGREGATION_TYPES.keys.each do |aggregation_type|
@@ -1991,10 +2027,9 @@ RSpec.describe Fees::ChargeService do
             :event,
             4,
             organization: subscription.organization,
-            customer: subscription.customer,
             subscription:,
             code: charge.billable_metric.code,
-            timestamp: DateTime.parse("2022-03-16")
+            timestamp: Time.zone.parse("2022-03-16")
           )
         end
 

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -77,12 +77,31 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
   let(:interval) { 'monthly' }
   let(:trial_period) { 0 }
 
-  let(:charge) { create(:standard_charge, plan: subscription.plan, charge_model: 'standard') }
+  let(:charge) do
+    create(
+      :standard_charge,
+      plan: subscription.plan,
+      charge_model: 'standard',
+      billable_metric:,
+      properties: {amount: "1"}
+    )
+  end
+
+  let(:event) do
+    create(
+      :event,
+      organization: organization,
+      subscription: subscription,
+      code: billable_metric.code,
+      timestamp: date_service.charges_to_datetime - 2.days
+    )
+  end
 
   before do
     tax
     charge
     invoice_subscriptions
+    event
 
     allow(SegmentTrackJob).to receive(:perform_later)
     allow(Invoices::Payments::CreateService).to receive(:call_async).and_call_original
@@ -139,6 +158,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           create(:charge_fee, amount_cents: 50, invoice: progressive_invoice)
         end
 
+        let(:event) { nil }
+
         before do
           progressive_invoice
           progressive_fee
@@ -175,7 +196,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
             expect(invoice.reload.status).to eq('pending')
             expect(invoice.reload.tax_status).to eq('pending')
-            expect(invoice.reload.fees_amount_cents).to eq(100)
+            expect(invoice.reload.fees_amount_cents).to eq(200)
             expect(invoice.reload.taxes_amount_cents).to eq(0)
             expect(invoice.reload.error_details.count).to eq(0)
           end
@@ -204,7 +225,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
                 expect(invoice.reload.status).to eq('draft')
                 expect(invoice.reload.tax_status).to eq('pending')
-                expect(invoice.reload.fees_amount_cents).to eq(100)
+                expect(invoice.reload.fees_amount_cents).to eq(200)
                 expect(invoice.reload.taxes_amount_cents).to eq(0)
                 expect(invoice.reload.error_details.count).to eq(0)
               end
@@ -224,7 +245,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
                 expect(invoice.reload.status).to eq('pending')
                 expect(invoice.reload.tax_status).to eq('pending')
-                expect(invoice.reload.fees_amount_cents).to eq(100)
+                expect(invoice.reload.fees_amount_cents).to eq(200)
                 expect(invoice.reload.taxes_amount_cents).to eq(0)
                 expect(invoice.reload.error_details.count).to eq(0)
               end
@@ -455,7 +476,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             expect(invoice.subscriptions.to_a).to match_array([subscription, subscription2])
             expect(invoice.payment_status).to eq('pending')
             expect(invoice.fees.subscription.count).to eq(2)
-            expect(invoice.fees.charge.count).to eq(2)
+            expect(invoice.fees.charge.count).to eq(1) # 0 amount charge fee is not created for subscription 2
 
             invoice_subscription = invoice.invoice_subscriptions.first
             expect(invoice_subscription).to have_attributes(
@@ -479,7 +500,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             expect(invoice.subscriptions.to_a).to match_array([subscription, subscription2])
             expect(invoice.payment_status).to eq('pending')
             expect(invoice.fees.subscription.count).to eq(2)
-            expect(invoice.fees.charge.count).to eq(2)
+            expect(invoice.fees.charge.count).to eq(1) # 0 amount charge fee is not created for subscription 2
             expect(invoice.fees.commitment.count).to eq(2)
 
             invoice_subscription = invoice.invoice_subscriptions.first
@@ -618,13 +639,15 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             create(:commitment, :minimum_commitment, plan:, amount_cents: 10_000)
           end
 
+          let(:event) { nil }
+
           it 'creates a charge fee and a minimum commitment fee' do
             result = invoice_service.call
 
             aggregate_failures do
               expect(result).to be_success
 
-              expect(invoice.fees.charge.count).to eq(1)
+              expect(invoice).to have_empty_charge_fees
               expect(invoice.fees.commitment.count).to eq(1)
             end
           end
@@ -863,6 +886,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         let(:subscription_at) { started_at }
         let(:billing_time) { :anniversary }
 
+        let(:event) { nil }
+
         context 'when plan has no minimum commitment' do
           it 'creates a subscription fee' do
             result = invoice_service.call
@@ -1018,6 +1043,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       end
 
       context 'when subscription started on creation day' do
+        let(:event) { nil }
+
         it 'does not create any charge fees' do
           result = invoice_service.call
 
@@ -1164,7 +1191,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
               expect(result).to be_success
 
               expect(invoice.fees.subscription.count).to eq(0)
-              expect(invoice.fees.charge.count).to eq(1)
+              expect(invoice).to have_empty_charge_fees
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
@@ -1198,7 +1225,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
                 expect(result).to be_success
 
                 expect(invoice.fees.subscription.count).to eq(0)
-                expect(invoice.fees.charge.count).to eq(1)
+                expect(invoice).to have_empty_charge_fees
 
                 invoice_subscription = invoice.invoice_subscriptions.first
                 expect(invoice_subscription).to have_attributes(
@@ -1250,6 +1277,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         let(:subscription_at) { started_at }
         let(:billing_time) { :anniversary }
 
+        let(:event) { nil }
+
         it 'updates the invoice accordingly' do
           result = invoice_service.call
 
@@ -1258,7 +1287,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
             expect(invoice.subscriptions.first).to eq(subscription)
             expect(invoice.fees.subscription.count).to eq(1)
-            expect(invoice.fees.charge.count).to eq(1)
+            expect(invoice).to have_empty_charge_fees # Because we didn't fake usage events
 
             invoice_subscription = invoice.invoice_subscriptions.first
             expect(invoice_subscription).to have_attributes(
@@ -1506,9 +1535,9 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
         aggregate_failures do
           expect(result).to be_success
-          expect(result.invoice.fees_amount_cents).to eq(100)
-          expect(result.invoice.taxes_amount_cents).to eq(20)
-          expect(result.invoice.total_amount_cents).to eq(110)
+          expect(result.invoice.fees_amount_cents).to eq(200)
+          expect(result.invoice.taxes_amount_cents).to eq(40)
+          expect(result.invoice.total_amount_cents).to eq(230)
           expect(result.invoice.credits.count).to eq(1)
 
           credit = result.invoice.credits.first
@@ -1541,9 +1570,9 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           expect(result.invoice.subscriptions.first).to eq(subscription)
           expect(result.invoice.fees.subscription.count).to eq(1)
           expect(result.invoice.fees.charge.count).to eq(1)
-          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(100)
-          expect(result.invoice.taxes_amount_cents).to eq(20)
-          expect(result.invoice.total_amount_cents).to eq(90)
+          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(200)
+          expect(result.invoice.taxes_amount_cents).to eq(40)
+          expect(result.invoice.total_amount_cents).to eq(210)
           expect(result.invoice.wallet_transactions.count).to eq(1)
         end
       end
@@ -1563,6 +1592,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             amount_currency: plan.amount_currency
           )
         end
+
+        let(:event) { nil }
 
         before { applied_coupon }
 

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -146,8 +146,7 @@ RSpec.describe Invoices::RefreshDraftService, type: :service do
       create(:standard_charge, plan: subscription.plan, charge_model: 'standard')
 
       expect { refresh_service.call }
-        .to change { invoice.reload.fees.count }.from(1).to(2)
-        .and change { invoice.fees.pluck(:id).include?(fee.id) }.from(true).to(false)
+        .to change { invoice.fees.pluck(:id).include?(fee.id) }.from(true).to(false)
         .and change { invoice.fees.pluck(:created_at).uniq }.to([invoice.created_at])
 
       expect(invoice.invoice_subscriptions.first.recurring).to be_truthy
@@ -187,7 +186,7 @@ RSpec.describe Invoices::RefreshDraftService, type: :service do
 
       context 'when taxes are unknown' do
         it 'regenerates fees' do
-          expect { refresh_service.call }.to change { invoice.fees.count }.from(0).to(2)
+          expect { refresh_service.call }.to change { invoice.fees.count }.from(0).to(1)
         end
 
         it 'sets correct tax status' do

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
         expect(result.invoice.invoice_type).to eq("subscription")
         expect(result.invoice.payment_status).to eq("pending")
         expect(result.invoice.fees.subscription.count).to eq(1)
-        expect(result.invoice.fees.charge.count).to eq(1)
+        expect(result.invoice.fees.charge.count).to eq(0)
 
         expect(result.invoice.currency).to eq("EUR")
         expect(result.invoice.fees_amount_cents).to eq(100)
@@ -149,7 +149,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
           expect(result.invoice.invoice_type).to eq("subscription")
           expect(result.invoice.payment_status).to eq("pending")
           expect(result.invoice.fees.subscription.count).to eq(1)
-          expect(result.invoice.fees.charge.count).to eq(1)
+          expect(result.invoice.fees.charge.count).to eq(0)
 
           expect(result.invoice.currency).to eq("EUR")
           expect(result.invoice.fees_amount_cents).to eq(100)


### PR DESCRIPTION
## Description

This PR follow https://github.com/getlago/lago-api/pull/3020 the goal is to stop generating empty fees (0 units, amount and events without adjustments or true up fees).

The reason behind this change is scalability as for now, depending on the plan setups, it appears that 98% of generated fees does not have an amount...

**NOTE:** a new feature will improve the edit fees feature since this PR will prevent creation of adjustment fees from the UI if no event have been received for a specific billable metric on a period. 
