### PR TITLE
fix: Use succeeded_at to select fees for regrouping

### DIFF
--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -50,7 +50,7 @@ module Invoices
         invoice.invoice_subscriptions.each do |is|
           is.subscription.fees
             .where(invoice: nil, payment_status: :succeeded)
-            .where("properties->>'timestamp' <= ?", is.charges_to_datetime)
+            .where("succeeded_at <= ?", is.timestamp)
             .update_all(invoice_id: invoice.id) # rubocop:disable Rails/SkipsModelValidations
         end
 

--- a/spec/scenarios/invoices/advance_charges_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_spec.rb
@@ -53,7 +53,7 @@ describe 'Advance Charges Invoices Scenarios', :scenarios, type: :request do
       expect(subscription.fees.charge.where(invoice_id: nil).count).to eq 5
       subscription.fees.charge.order(created_at: :asc).limit(3).update!(
         payment_status: :succeeded,
-        succeeded_at: Time.current
+        succeeded_at: DateTime.new(2024, 6, 20, 0, 10)
       )
       travel_to(DateTime.new(2024, 7, 1, 0, 10)) do
         perform_billing

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -50,12 +50,23 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
       before do
         tax
         charge = create(:standard_charge, :regroup_paid_fees, plan: subscription.plan)
-        succeeded_fees = create_list(:charge_fee, 3, :succeeded, invoice_id: nil, subscription:, charge:, amount_cents: 100, properties: fee_boundaries)
+        succeeded_fees = create_list(
+          :charge_fee,
+          3,
+          payment_status: :succeeded,
+          succeeded_at: billing_at - 1.month,
+          invoice_id: nil,
+          subscription:,
+          charge:,
+          amount_cents: 100,
+          properties: fee_boundaries
+        )
         create_list(:charge_fee, 2, :failed, invoice_id: nil, subscription:, charge:, amount_cents: 100, properties: fee_boundaries)
 
         create(
           :charge_fee,
-          :succeeded,
+          payment_status: :succeeded,
+          succeeded_at: (billing_at - 1.month).end_of_month + 1.day,
           invoice_id: nil,
           subscription:,
           charge:,
@@ -123,7 +134,16 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
       before do
         tax
         charge = create(:standard_charge, :regroup_paid_fees, plan: subscription.plan)
-        create(:charge_fee, :succeeded, invoice_id: nil, subscription:, charge:, amount_cents: 100, properties: fee_boundaries)
+        create(
+          :charge_fee,
+          payment_status: :succeeded,
+          succeeded_at: billing_at - 1.month,
+          invoice_id: nil,
+          subscription:,
+          charge:,
+          amount_cents: 100,
+          properties: fee_boundaries
+        )
 
         allow_any_instance_of(Invoice).to receive(:should_sync_invoice?).and_return(true) # rubocop:disable RSpec/AnyInstance
       end


### PR DESCRIPTION
This pull request includes changes to improve the handling of succeeded fees based on a new `succeeded_at` timestamp. These changes ensure that fees are correctly associated with invoices based on their success timestamp.