### PR TITLE
Propagate StaleObjectErrors so PayInAdvance jobs retry

### DIFF
--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -59,7 +59,7 @@ module Invoices
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    rescue Sequenced::SequenceError
+    rescue Sequenced::SequenceError, ActiveRecord::StaleObjectError
       raise
     rescue => e
       result.fail_with_error!(e)

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -318,5 +318,27 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
         expect(result.invoice).to be_finalized
       end
     end
+
+    context 'when an error occurs' do
+      context 'with a stale object error' do
+        before { create(:wallet, customer:, balance_cents: 100) }
+
+        it 'propagates the error' do
+          allow_any_instance_of(Credits::AppliedPrepaidCreditService) # rubocop:disable RSpec/AnyInstance
+            .to receive(:call).and_raise(ActiveRecord::StaleObjectError)
+
+          expect { invoice_service.call }.to raise_error(ActiveRecord::StaleObjectError)
+        end
+      end
+
+      context 'with a sequence error' do
+        it 'propagates the error' do
+          allow_any_instance_of(Invoice) # rubocop:disable RSpec/AnyInstance
+            .to receive(:save!).and_raise(Sequenced::SequenceError)
+
+          expect { invoice_service.call }.to raise_error(Sequenced::SequenceError)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Pay in advance jobs do not reliably retry when a StaleObjectError is raised.

## Description

This PR builds on top of [this PR](https://github.com/getlago/lago-api/pull/3027) which will retry the pay in advance job when a StaleObjectError is raised. This error is currently handled by the generic `rescue` block, and instead should be re-raised similarly to how the SequenceError is.

I have tested this in a local docker setup, by sending a large volume of events to Lago over a very short period. Before this fix, some fees fail to generate, after the fix all the fees are successfully generated.