### PR TITLE
Create the unaccent extension if not exist.

### DIFF
--- a/db/migrate/20220705155228_add_unaccent_extension.rb
+++ b/db/migrate/20220705155228_add_unaccent_extension.rb
@@ -2,6 +2,6 @@
 
 class AddUnaccentExtension < ActiveRecord::Migration[7.0]
   def up
-    safety_assured { execute 'CREATE EXTENSION unaccent' }
+    safety_assured { execute 'CREATE EXTENSION IF NOT EXISTS unaccent' }
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/{{FEATURE_SLUG}}

## Context

Include relevant motivation and context.

Support databases with unaccent extension installed before getlogo migration setup process.

## Logs
bin/rails aborted!
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

PG::DuplicateObject: ERROR:  extension "unaccent" already exists
/app/db/migrate/20220705155228_add_unaccent_extension.rb:5:in `block in up'
/app/db/migrate/20220705155228_add_unaccent_extension.rb:5:in `up'

Caused by:
ActiveRecord::StatementInvalid: PG::DuplicateObject: ERROR:  extension "unaccent" already exists (ActiveRecord::StatementInvalid)
/app/db/migrate/20220705155228_add_unaccent_extension.rb:5:in `block in up'
/app/db/migrate/20220705155228_add_unaccent_extension.rb:5:in `up'

Caused by:
PG::DuplicateObject: ERROR:  extension "unaccent" already exists (PG::DuplicateObject)
/app/db/migrate/20220705155228_add_unaccent_extension.rb:5:in `block in up'
/app/db/migrate/20220705155228


## Description
Create the unaccent extension if not exist.

- Postgres
- unaccent
