### PR TITLE
misc(Github) - Do not use secrets when hardcoded values suffice

### DIFF
--- a/.github/workflows/migrations-test.yml
+++ b/.github/workflows/migrations-test.yml
@@ -2,7 +2,7 @@ name: Run rails migrations
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
@@ -13,29 +13,28 @@ jobs:
       postgres:
         image: postgres:14-alpine
         ports:
-          - '5432:5432'
+          - "5432:5432"
         env:
           POSTGRES_DB: lago
           POSTGRES_USER: lago
           POSTGRES_PASSWORD: lago
     env:
       RAILS_ENV: test
-      DATABASE_URL: 'postgres://lago:lago@localhost:5432/lago'
-      RAILS_MASTER_KEY: ${{ secrets.RAILS_TEST_KEY }}
-      SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+      DATABASE_URL: "postgres://lago:lago@localhost:5432/lago"
+      RAILS_MASTER_KEY: N+XcWoGDzKjuoxrU8BIPN5D0/GSuqx9s
+      SECRET_KEY_BASE: cvIAI6ycC0OnVDRAjT5hmbRxnjCxl4YB
       ENCRYPTION_PRIMARY_KEY: 5I9mjfzry2P787x4S5ZuDdJwXNgYEwqo
       ENCRYPTION_DETERMINISTIC_KEY: SGiZzmh18EjBF9gSW8LCNk7pelauWVr4
       ENCRYPTION_KEY_DERIVATION_SALT: q3pkMw34ZkRPFSf2LmtWe705yw532Pf7
       LAGO_API_URL: https://api.lago.dev
       LAGO_PDF_URL: https://pdf.lago.dev
-      SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
       LAGO_FROM_EMAIL: noreply@getlago.com
       LAGO_CLICKHOUSE_ENABLED: true
       LAGO_CLICKHOUSE_MIGRATIONS_ENABLED: true
       LAGO_CLICKHOUSE_HOST: localhost
       LAGO_CLICKHOUSE_DATABASE: default
-      LAGO_CLICKHOUSE_USERNAME: ''
-      LAGO_CLICKHOUSE_PASSWORD: ''
+      LAGO_CLICKHOUSE_USERNAME: ""
+      LAGO_CLICKHOUSE_PASSWORD: ""
       LAGO_DISABLE_SCHEMA_DUMP: true
       ANNOTATE_SKIP_ON_DB_MIGRATE: 1
     steps:
@@ -44,7 +43,7 @@ jobs:
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3.6'
+          ruby-version: "3.3.6"
           bundler-cache: true
       - name: Start Clickhouse database
         run: |

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -2,7 +2,7 @@ name: Run Spec
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
@@ -13,7 +13,7 @@ jobs:
       postgres:
         image: postgres:14-alpine
         ports:
-          - '5432:5432'
+          - "5432:5432"
         env:
           POSTGRES_DB: lago
           POSTGRES_USER: lago
@@ -30,20 +30,19 @@ jobs:
 
     env:
       RAILS_ENV: test
-      DATABASE_URL: 'postgres://lago:lago@localhost:5432/lago'
-      LAGO_REDIS_CACHE_URL: 'redis://localhost:6379'
-      RAILS_MASTER_KEY: ${{ secrets.RAILS_TEST_KEY }}
-      SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+      DATABASE_URL: "postgres://lago:lago@localhost:5432/lago"
+      LAGO_REDIS_CACHE_URL: "redis://localhost:6379"
+      RAILS_MASTER_KEY: N+XcWoGDzKjuoxrU8BIPN5D0/GSuqx9s
+      SECRET_KEY_BASE: cvIAI6ycC0OnVDRAjT5hmbRxnjCxl4YB
       LAGO_API_URL: https://api.lago.dev
       LAGO_PDF_URL: https://pdf.lago.dev
-      SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
       LAGO_FROM_EMAIL: noreply@getlago.com
       LAGO_CLICKHOUSE_ENABLED: true
       LAGO_CLICKHOUSE_MIGRATIONS_ENABLED: true
       LAGO_CLICKHOUSE_HOST: localhost
       LAGO_CLICKHOUSE_DATABASE: default
-      LAGO_CLICKHOUSE_USERNAME: ''
-      LAGO_CLICKHOUSE_PASSWORD: ''
+      LAGO_CLICKHOUSE_USERNAME: ""
+      LAGO_CLICKHOUSE_PASSWORD: ""
 
     steps:
       - name: Checkout code
@@ -51,7 +50,7 @@ jobs:
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3.6'
+          ruby-version: "3.3.6"
           bundler-cache: true
       - name: Start Clickhouse database
         run: |


### PR DESCRIPTION
## Description

To support external contributions, we can't use secrets in GitHub workflows that need to run. This PR addresses that by hardcoding the values for specs and migration tests.