### PR TITLE
fix(event): retrieve clickhouse events

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -47,7 +47,7 @@ module Api
       def show
         event_scope = current_organization.clickhouse_events_store? ? Clickhouse::EventsRaw : Event
         event = event_scope.find_by(
-          organization: current_organization,
+          organization_id: current_organization.id,
           transaction_id: params[:id]
         )
 


### PR DESCRIPTION
## Context

This PR fixes `ActiveRecord::ActiveRecordError` raised when calling `GET /api/v1/events/:transaction_id`.
It happen when the `clickhouse_events_store` flag is turned on at organization level.

## Description

The fix is to use `organization_id` rather than `organization` when fetching the event as `Clickhouse::RawEvent` does not define a relation with the organization model