### PR TITLE
misc(wallet): Refactor wallet transaction related jobs queuing

### DIFF
--- a/app/jobs/invoices/prepaid_credit_job.rb
+++ b/app/jobs/invoices/prepaid_credit_job.rb
@@ -2,7 +2,7 @@
 
 module Invoices
   class PrepaidCreditJob < ApplicationJob
-    queue_as 'wallets'
+    queue_as 'high_priority'
 
     retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6
     unique :until_executed, on_conflict: :log

--- a/app/jobs/wallet_transactions/create_job.rb
+++ b/app/jobs/wallet_transactions/create_job.rb
@@ -2,7 +2,7 @@
 
 module WalletTransactions
   class CreateJob < ApplicationJob
-    queue_as 'wallets'
+    queue_as 'high_priority'
 
     def perform(organization_id:, params:)
       organization = Organization.find(organization_id)

--- a/app/jobs/wallets/refresh_ongoing_balance_job.rb
+++ b/app/jobs/wallets/refresh_ongoing_balance_job.rb
@@ -2,7 +2,7 @@
 
 module Wallets
   class RefreshOngoingBalanceJob < ApplicationJob
-    queue_as 'wallets'
+    queue_as 'low_priority'
 
     unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
 

--- a/config/sidekiq/sidekiq.yml
+++ b/config/sidekiq/sidekiq.yml
@@ -2,13 +2,14 @@ concurrency: 10
 timeout: 25
 retry: 1
 queues:
+  - high_priority
   - default
   - mailers
   - clock
   - providers
   - webhook
   - invoices
-  - wallets
+  - wallets # Remove as all wallet jobs have moved to other queues
   - integrations
   - low_priority
 

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -160,6 +160,7 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
         create(
           :fee,
           :succeeded,
+          succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days,
           invoice_id: nil,
           subscription: subscription_2,
           amount_cents: 999,


### PR DESCRIPTION
## Context
Queuing of wallet transaction related jobs is ideal as jobs as a low priority, meaning that under heavy load, they are a huge delay might happen between enqueue and  processing. Since it is user facing, we need to improve it.


## Description

This PR:
- Adds a new `high_priority` queue that should be used for all jobs requiring an "immediate" processing
- Moves the `Invoices::PrepaidCreditJob` from the `wallet` to the new `high_priority` queue
- Moves the `WalletTransactions::CreateJob` from the `wallet` to the new `high_priority` queue
- Moves `Wallets::RefreshOngoingBalanceJob` into the low priority queue

Note no more jobs will relies on the `wallet` queue, but this queue is kept fro now in the config to avoid issue with existing enqueued jobs.