### PR TITLE
feat(manual-payments): Add total paid and total due to pdf templates

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -50,12 +50,14 @@ class Invoice < ApplicationRecord
     :sub_total_excluding_taxes_amount_cents,
     :sub_total_including_taxes_amount_cents,
     :total_amount_cents,
+    :total_paid_amount_cents,
     :taxes_amount_cents,
     with_model_currency: :currency
 
   # NOTE: Readonly fields
   monetize :charge_amount_cents,
     :subscription_amount_cents,
+    :total_due_amount_cents,
     disable_validation: true,
     allow_nil: true,
     with_model_currency: :currency
@@ -255,6 +257,10 @@ class Invoice < ApplicationRecord
       number_of_days:,
       period_duration: date_service.charges_duration_in_days
     }
+  end
+
+  def total_due_amount_cents
+    total_amount_cents - total_paid_amount_cents
   end
 
   # amount cents onto which we can issue a credit note

--- a/app/views/templates/invoices/v3/_credit.slim
+++ b/app/views/templates/invoices/v3/_credit.slim
@@ -14,5 +14,13 @@ table.invoice-resume-table width="100%"
 table.total-table width="100%"
   tr
     td.body-2
-    td.body-1 = I18n.t('invoice.total_due')
+    td.body-1 = I18n.t('invoice.total')
     td.body-1 = MoneyHelper.format(total_amount)
+  tr
+    td.body-2
+    td.body-1 = I18n.t('invoice.total_paid_amount')
+    td.body-1 = MoneyHelper.format(total_paid_amount)
+  tr
+    td.body-2
+    td.body-1 = I18n.t('invoice.total_due_amount')
+    td.body-1 = MoneyHelper.format(total_due_amount)

--- a/app/views/templates/invoices/v3/_subscription_details.slim
+++ b/app/views/templates/invoices/v3/_subscription_details.slim
@@ -186,9 +186,19 @@
               td.body-2 = '-' + MoneyHelper.format(prepaid_credit_amount)
           tr
             td.body-2
-            td.body-1 = I18n.t('invoice.total_due')
+            td.body-1 = I18n.t('invoice.total')
             td.body-1
               = MoneyHelper.format(total_amount)
+          tr
+            td.body-2
+            td.body-1 = I18n.t('invoice.total_paid_amount')
+            td.body-1
+              = MoneyHelper.format(total_paid_amount)
+          tr
+            td.body-2
+            td.body-1 = I18n.t('invoice.total_due_amount')
+            td.body-1
+              = MoneyHelper.format(total_due_amount)
         - else
           tr
             td.body-2

--- a/app/views/templates/invoices/v3/_subscriptions_summary.slim
+++ b/app/views/templates/invoices/v3/_subscriptions_summary.slim
@@ -46,5 +46,13 @@ table.total-table width="100%"
       td.body-2 = '-' + MoneyHelper.format(prepaid_credit_amount)
   tr
     td.body-2
-    td.body-1 = I18n.t('invoice.total_due')
+    td.body-1 = I18n.t('invoice.total')
     td.body-1 = MoneyHelper.format(total_amount)
+  tr
+    td.body-2
+    td.body-1 = I18n.t('invoice.total_paid_amount')
+    td.body-1 = MoneyHelper.format(total_paid_amount)
+  tr
+    td.body-2
+    td.body-1 = I18n.t('invoice.total_due_amount')
+    td.body-1 = MoneyHelper.format(total_due_amount)

--- a/app/views/templates/invoices/v3/one_off.slim
+++ b/app/views/templates/invoices/v3/one_off.slim
@@ -453,10 +453,16 @@ html
             td.body-2 = MoneyHelper.format(sub_total_including_taxes_amount)
           tr
             td.body-2
-            td.body-1 = I18n.t('invoice.total_due')
+            td.body-1 = I18n.t('invoice.total')
             td.body-1 = MoneyHelper.format(total_amount)
-
-
+          tr
+            td.body-2
+            td.body-1 = I18n.t('invoice.total_paid_amount')
+            td.body-1 = MoneyHelper.format(total_paid_amount)
+          tr
+            td.body-2
+            td.body-1 = I18n.t('invoice.total_due_amount')
+            td.body-1 = MoneyHelper.format(total_due_amount)
 
       - if applied_invoice_custom_sections.present?
         == SlimHelper.render('templates/invoices/v3/_custom_sections', self)

--- a/app/views/templates/invoices/v4/_credit.slim
+++ b/app/views/templates/invoices/v4/_credit.slim
@@ -17,5 +17,13 @@ table.invoice-resume-table width="100%"
 table.total-table width="100%"
   tr
     td.body-2
-    td.body-1 = I18n.t('invoice.total_due')
+    td.body-1 = I18n.t('invoice.total')
     td.body-1 = MoneyHelper.format(total_amount)
+  tr
+    td.body-2
+    td.body-1 = I18n.t('invoice.total_paid_amount')
+    td.body-1 = MoneyHelper.format(total_paid_amount)
+  tr
+    td.body-2
+    td.body-1 = I18n.t('invoice.total_due_amount')
+    td.body-1 = MoneyHelper.format(total_due_amount)

--- a/app/views/templates/invoices/v4/_one_off.slim
+++ b/app/views/templates/invoices/v4/_one_off.slim
@@ -43,5 +43,13 @@ table.total-table width="100%"
     td.body-2 = MoneyHelper.format(sub_total_including_taxes_amount)
   tr
     td.body-2
-    td.body-1 = I18n.t('invoice.total_due')
+    td.body-1 = I18n.t('invoice.total')
     td.body-1 = MoneyHelper.format(total_amount)
+  tr
+    td.body-2
+    td.body-1 = I18n.t('invoice.total_paid_amount')
+    td.body-1 = MoneyHelper.format(total_paid_amount)
+  tr
+    td.body-2
+    td.body-1 = I18n.t('invoice.total_due_amount')
+    td.body-1 = MoneyHelper.format(total_due_amount)

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -183,9 +183,19 @@
               td.body-2 = '-' + MoneyHelper.format(prepaid_credit_amount)
           tr
             td.body-2
-            td.body-1 = I18n.t('invoice.total_due')
+            td.body-1 = I18n.t('invoice.total')
             td.body-1
               = MoneyHelper.format(total_amount)
+          tr
+            td.body-2
+            td.body-1 = I18n.t('invoice.total_paid_amount')
+            td.body-1
+              = MoneyHelper.format(total_paid_amount)
+          tr
+            td.body-2
+            td.body-1 = I18n.t('invoice.total_due_amount')
+            td.body-1
+              = MoneyHelper.format(total_due_amount)
         - else
           - if progressive_billing_credit_amount_cents.positive?
             - credits = progressice_billing_credits(invoice_subscription.subscription).all

--- a/app/views/templates/invoices/v4/_subscriptions_summary.slim
+++ b/app/views/templates/invoices/v4/_subscriptions_summary.slim
@@ -62,5 +62,13 @@ table.total-table width="100%"
       td.body-2 = '-' + MoneyHelper.format(prepaid_credit_amount)
   tr
     td.body-2
-    td.body-1 = I18n.t('invoice.total_due')
+    td.body-1 = I18n.t('invoice.total')
     td.body-1 = MoneyHelper.format(total_amount)
+  tr
+    td.body-2
+    td.body-1 = I18n.t('invoice.total_paid_amount')
+    td.body-1 = MoneyHelper.format(total_paid_amount)
+  tr
+    td.body-2
+    td.body-1 = I18n.t('invoice.total_due_amount')
+    td.body-1 = MoneyHelper.format(total_due_amount)

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -90,7 +90,9 @@ de:
     total_credits: Gesamtguthaben
     total_credits_with_value: 'Gesamtguthaben: %{credit_amount} Credits'
     total_due: Insgesamt fällig
+    total_due_amount: Betrag fällig
     total_events: 'Ereignisse insgesamt: %{count}'
+    total_paid_amount: Betrag bezahlt
     total_unit: 'Gesamte Einheiten: %{units}'
     total_unit_interval: 'Gesamte Einheiten: %{events_count} Ereignisse für %{units}'
     true_up_details: Mindestausgabe von %{min_amount} anteilig an den Nutzungstagen

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -90,7 +90,9 @@ en:
     total_credits: Total credits
     total_credits_with_value: 'Total credits: %{credit_amount} credits'
     total_due: Total due
+    total_due_amount: Amount due
     total_events: 'Total events: %{count}'
+    total_paid_amount: Amount paid
     total_unit: 'Total unit: %{units}'
     total_unit_interval: 'Total unit: %{events_count} events for %{units}'
     true_up_details: Minimum spend of %{min_amount} prorated on days of usage

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -88,7 +88,9 @@ es:
     total: Total
     total_credits_with_value: 'Total de créditos con valor: %{credit_amount} créditos'
     total_due: Total debido
-    total_event: Eventos totales
+    total_due_amount: Monto debido
+    total_events: 'Eventos totales: %{count}'
+    total_paid_amount: Monto pagado
     total_unit: 'Total de unidades: %{units}'
     total_unit_interval: 'Total de unidades: %{events_count} evento(s) para %{units}'
     true_up_details: Gasto mínimo de %{min_amount} prorrateado en días de uso

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -90,7 +90,9 @@ fr:
     total_credits: Total crédits
     total_credits_with_value: 'Nombre total de crédits: %{credit_amount} crédits'
     total_due: Total dû
+    total_due_amount: Montant dû
     total_events: 'Nombre total d''événements: %{count}'
+    total_paid_amount: Montant payé
     total_unit: 'Nombre total d''unités: %{units}'
     total_unit_interval: 'Nombre total d''unités: %{events_count} événement(s) pour %{units}'
     true_up_details: Dépense minimale de %{min_amount} au prorata des jours d'utilisation

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -90,7 +90,9 @@ it:
     total_credits: Crediti totali
     total_credits_with_value: 'Crediti totali: %{credit_amount} crediti'
     total_due: Totale dovuto
+    total_due_amount: Importo dovuto
     total_events: 'Eventi totali: %{count}'
+    total_paid_amount: Importo pagato
     total_unit: 'Unità totale: %{units}'
     total_unit_interval: 'Unità totale: %{events_count} eventi per %{units}'
     true_up_details: Spesa minima di %{min_amount} proporzionata sui giorni di utilizzo

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -90,7 +90,9 @@ nb:
     total_credits: Antall kreditter
     total_credits_with_value: 'Antall kreditter: %{credit_amount} kreditter'
     total_due: Å betale
+    total_due_amount: Skyldig beløp
     total_events: 'Totalt antall hendelser: %{count}'
+    total_paid_amount: Betalt beløp
     total_unit: 'Antall enheter: %{units}'
     total_unit_interval: 'Antall enheter: %{events_count} hendelser for %{units}'
     true_up_details: Minimumsutgift på %{min_amount} beregnet etter antall brukte dager

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -88,7 +88,9 @@ sv:
     total: Total
     total_credits_with_value: 'Totalt antal krediter med värde: %{credit_amount} krediter'
     total_due: Att betala
-    total_event: Totala händelser
+    total_due_amount: Att betala belopp
+    total_events: 'Totala händelser: %{count}'
+    total_paid_amount: Betalt belopp
     total_unit: 'Totalt antal enheter: %{units}'
     total_unit_interval: 'Totalt antal enheter: %{events_count} händelse(r) för %{units}'
     true_up_details: Minsta utgift på %{min_amount} fördelat på användningsdagar


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/log-partial-payments

## Context

After we add partial/manual payments we need to show the paid and due amount in the pdf invoices.

## Description

This PR adds:
 - Total paid amount and total due amount to pdf invoice templates.
 - Translations for these news fields.
 - `Invoice#total_due_amount_cents`
 
 
 