### PR TITLE
fix(stripe): Payment failing with requires_payment_method should be marked as failed

### DIFF
--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -23,10 +23,9 @@ module PaymentProviders
       requires_capture
       requires_action
       requires_confirmation
-      requires_payment_method
     ].freeze
     SUCCESS_STATUSES = %w[succeeded].freeze
-    FAILED_STATUSES = %w[canceled].freeze
+    FAILED_STATUSES = %w[canceled requires_payment_method].freeze
 
     validates :secret_key, presence: true
     validates :success_redirect_url, url: true, allow_nil: true, length: {maximum: 1024}

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -36,7 +36,7 @@ module PaymentProviders
         # TODO: global refactor of the error handling
         # identified processing errors should mark it as failed to allow reprocess via a new payment
         # other should be reprocessed
-        rescue ::Stripe::AuthenticationError, ::Stripe::CardError, ::Stripe::InvalidRequestError, ::Stripe::PermissionError => e
+        rescue ::Stripe::AuthenticationError, ::Stripe::CardError, ::Stripe::InvalidRequestError, ::Stripe::PermissionError, ::Stripe::IdempotencyError => e
           # NOTE: Do not mark the invoice as failed if the amount is too small for Stripe
           #       For now we keep it as pending, the user can still update it manually
           if e.code == "amount_too_small"


### PR DESCRIPTION
## Context

Some recent refactors were made on the payment processing implementation with stripe.

When a payment intent creation was failing with the `requires_payment_method` status, the lago payment is kept `processing` preventing it from being retried because of the idem-potency key (the new attempt will have a different payload if the payment method is updated).

## Description

This PR changes the behavior for `requires_payment_method` ensuring that the payment is marked as failed, allowing a retry after fixing the cause of the failure (missing or expired payment method)