### PR TITLE
misc(BillingWorker) - Move Invoices::RefreshDraftJob to billing queue

### DIFF
--- a/app/jobs/invoices/refresh_draft_job.rb
+++ b/app/jobs/invoices/refresh_draft_job.rb
@@ -2,7 +2,13 @@
 
 module Invoices
   class RefreshDraftJob < ApplicationJob
-    queue_as 'invoices'
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_BILLING'])
+        :billing
+      else
+        :invoices
+      end
+    end
 
     unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
 


### PR DESCRIPTION
## Description

As the RefreshDraftJob can be enqueued for lots of invoices, this should be handled by the billing worker as well, avoiding large backlogs on other queues.

