### PR TITLE
Feat manual payments controller

### DIFF
--- a/app/contracts/queries/payments_query_filters_contract.rb
+++ b/app/contracts/queries/payments_query_filters_contract.rb
@@ -2,7 +2,6 @@
 
 module Queries
   class PaymentsQueryFiltersContract < Dry::Validation::Contract
-
     UUID_REGEX = /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/
 
     params do

--- a/app/contracts/queries/payments_query_filters_contract.rb
+++ b/app/contracts/queries/payments_query_filters_contract.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Queries
+  class PaymentsQueryFiltersContract < Dry::Validation::Contract
+    params do
+      required(:filters).hash do
+        optional(:invoice_id).maybe(:string)
+      end
+    end
+
+    rule(filters: :invoice_id) do
+      next if value.blank? # Skip validation for nil or empty values
+      key.failure('must be a valid UUID') unless valid_uuid?(value)
+    end
+
+    private
+
+    def valid_uuid?(uuid)
+      uuid =~ /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/
+    end
+  end
+end

--- a/app/contracts/queries/payments_query_filters_contract.rb
+++ b/app/contracts/queries/payments_query_filters_contract.rb
@@ -5,6 +5,7 @@ module Queries
     params do
       required(:filters).hash do
         optional(:invoice_id).maybe(:string)
+        optional(:external_customer_id).maybe(:string)
       end
     end
 

--- a/app/contracts/queries/payments_query_filters_contract.rb
+++ b/app/contracts/queries/payments_query_filters_contract.rb
@@ -2,22 +2,14 @@
 
 module Queries
   class PaymentsQueryFiltersContract < Dry::Validation::Contract
+
+    UUID_REGEX = /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/
+
     params do
       required(:filters).hash do
-        optional(:invoice_id).maybe(:string)
+        optional(:invoice_id).maybe(:string, format?: UUID_REGEX)
         optional(:external_customer_id).maybe(:string)
       end
-    end
-
-    rule(filters: :invoice_id) do
-      next if value.blank? # Skip validation for nil or empty values
-      key.failure('must be a valid UUID') unless valid_uuid?(value)
-    end
-
-    private
-
-    def valid_uuid?(uuid)
-      uuid =~ /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/
     end
   end
 end

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -56,6 +56,7 @@ module Api
             payment_status: (params[:payment_status] if valid_payment_status?(params[:payment_status])),
             payment_dispute_lost: params[:payment_dispute_lost],
             payment_overdue: (params[:payment_overdue] if %w[true false].include?(params[:payment_overdue])),
+            partially_paid: (params[:partially_paid] if %w[true false].include?(params[:partially_paid])),
             status: (params[:status] if valid_status?(params[:status])),
             currency: params[:currency],
             customer_external_id: params[:external_customer_id],

--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class PaymentsController < Api::BaseController
+      def create
+        result = ManualPayments::CreateService.call(
+          organization: current_organization,
+          params: create_params.to_h.deep_symbolize_keys
+        )
+
+        if result.success?
+          render(
+            json: ::V1::PaymentSerializer.new(result.payment, root_name: "payment")
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
+      def index
+        result = PaymentsQuery.call(
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          },
+          filters: index_filters
+        )
+
+        if result.success?
+          render(
+            json: ::CollectionSerializer.new(
+              result.payments,
+              ::V1::PaymentSerializer,
+              collection_name: "payments",
+              meta: pagination_metadata(result.payments)
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
+      def show
+        payment_of_invoice = Payment.of_invoice(organization: current_organization)
+          .find_by(id: params[:id])
+
+        payment_of_payment_request = Payment.of_payment_request(organization: current_organization)
+          .find_by(id: params[:id])
+
+        payment = payment_of_invoice || payment_of_payment_request
+
+        return not_found_error(resource: "payment") unless payment
+
+        render_payment(payment)
+      end
+
+      private
+
+      def create_params
+        params.require(:payment).permit(
+          :invoice_id,
+          :amount_cents,
+          :reference,
+          :paid_at
+        )
+      end
+
+      def index_filters
+        params.permit(:invoice_id)
+      end
+
+      def render_payment(payment)
+        render(
+          json: ::V1::PaymentSerializer.new(
+            payment,
+            root_name: "payment"
+          )
+        )
+      end
+
+      def resource_name
+        'payment'
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -11,7 +11,7 @@ module Api
 
         if result.success?
           render(
-            json: ::V1::PaymentSerializer.new(result.payment, root_name: "payment")
+            json: ::V1::PaymentSerializer.new(result.payment, root_name: resource_name)
           )
         else
           render_error_response(result)
@@ -33,7 +33,7 @@ module Api
             json: ::CollectionSerializer.new(
               result.payments,
               ::V1::PaymentSerializer,
-              collection_name: "payments",
+              collection_name: resource_name.pluralize,
               meta: pagination_metadata(result.payments)
             )
           )
@@ -44,7 +44,7 @@ module Api
 
       def show
         payment = Payment.for_organization(current_organization).find_by(id: params[:id])
-        return not_found_error(resource: "payment") unless payment
+        return not_found_error(resource: resource_name) unless payment
 
         render_payment(payment)
       end
@@ -68,7 +68,7 @@ module Api
         render(
           json: ::V1::PaymentSerializer.new(
             payment,
-            root_name: "payment"
+            root_name: resource_name
           )
         )
       end

--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -20,6 +20,7 @@ module Api
 
       def index
         result = PaymentsQuery.call(
+          organization: current_organization,
           pagination: {
             page: params[:page],
             limit: params[:per_page] || PER_PAGE
@@ -42,14 +43,7 @@ module Api
       end
 
       def show
-        payment_of_invoice = Payment.of_invoice(organization: current_organization)
-          .find_by(id: params[:id])
-
-        payment_of_payment_request = Payment.of_payment_request(organization: current_organization)
-          .find_by(id: params[:id])
-
-        payment = payment_of_invoice || payment_of_payment_request
-
+        payment = Payment.for_organization(current_organization).find_by(id: params[:id])
         return not_found_error(resource: "payment") unless payment
 
         render_payment(payment)

--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -61,7 +61,7 @@ module Api
       end
 
       def index_filters
-        params.permit(:invoice_id)
+        params.permit(:invoice_id, :external_customer_id)
       end
 
       def render_payment(payment)

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -5,7 +5,7 @@ class ApiKey < ApplicationRecord
 
   RESOURCES = %w[
     add_on analytic billable_metric coupon applied_coupon credit_note customer_usage
-    customer event fee invoice organization payment_request plan subscription lifetime_usage
+    customer event fee invoice organization payment payment_request plan subscription lifetime_usage
     tax wallet wallet_transaction webhook_endpoint webhook_jwt_public_key invoice_custom_section
   ].freeze
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -12,7 +12,7 @@ class Payment < ApplicationRecord
   has_many :refunds
   has_many :integration_resources, as: :syncable
 
-  PAYMENT_TYPES = {provider: "provider", manual: "manual"}
+  PAYMENT_TYPES = {provider: 'provider', manual: 'manual'}.freeze
   attribute :payment_type, :string
   enum :payment_type, PAYMENT_TYPES, default: :provider, prefix: :payment_type
   validates :payment_type, presence: true
@@ -25,16 +25,22 @@ class Payment < ApplicationRecord
 
   enum payable_payment_status: PAYABLE_PAYMENT_STATUS.map { |s| [s, s] }.to_h
 
-  scope :for_organization, ->(organization) do
-    invoices_join = ActiveRecord::Base.sanitize_sql_array(
-      ["LEFT JOIN invoices AS i ON i.id = payments.payable_id AND payments.payable_type = 'Invoice' AND i.organization_id = ?", organization.id]
-    )
-    payment_requests_join = ActiveRecord::Base.sanitize_sql_array(
-      ["LEFT JOIN payment_requests AS pr ON pr.id = payments.payable_id AND payments.payable_type = 'PaymentRequest' AND pr.organization_id = ?", organization.id]
-    )
-
-    joins(invoices_join).joins(payment_requests_join).where('i.id IS NOT NULL OR pr.id IS NOT NULL')
-  end
+  scope :for_organization, lambda { |organization|
+    payables_join = ActiveRecord::Base.sanitize_sql_array([
+      <<~SQL,
+        LEFT JOIN invoices
+          ON invoices.id = payments.payable_id
+          AND payments.payable_type = 'Invoice'
+          AND invoices.organization_id = :org_id
+        LEFT JOIN payment_requests
+          ON payment_requests.id = payments.payable_id
+          AND payments.payable_type = 'PaymentRequest'
+          AND payment_requests.organization_id = :org_id
+      SQL
+      {org_id: organization.id}
+    ])
+    joins(payables_join).where('invoices.id IS NOT NULL OR payment_requests.id IS NOT NULL')
+  }
 
   def should_sync_payment?
     return false unless payable.is_a?(Invoice)
@@ -54,9 +60,9 @@ class Payment < ApplicationRecord
   def payment_request_succeeded
     return if !payable.is_a?(Invoice) || payment_type_provider?
 
-    if payable.payment_requests.where(payment_status: 'succeeded').exists?
-      errors.add(:base, :payment_request_is_already_succeeded)
-    end
+    return unless payable.payment_requests.where(payment_status: 'succeeded').exists?
+
+    errors.add(:base, :payment_request_is_already_succeeded)
   end
 end
 

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -20,6 +20,7 @@ class InvoicesQuery < BaseQuery
     invoices = with_payment_overdue(invoices) unless filters.payment_overdue.nil?
     invoices = with_amount_range(invoices) if filters.amount_from.present? || filters.amount_to.present?
     invoices = with_metadata(invoices) if filters.metadata.present?
+    invoices = with_partially_paid(invoices) unless filters.partially_paid.nil?
 
     result.invoices = invoices
     result
@@ -86,6 +87,16 @@ class InvoicesQuery < BaseQuery
 
   def with_payment_overdue(scope)
     scope.where(payment_overdue: filters.payment_overdue)
+  end
+
+  def with_partially_paid(scope)
+    partially_paid = ActiveModel::Type::Boolean.new.cast(filters.partially_paid)
+
+    if partially_paid
+      scope.where("total_amount_cents > total_paid_amount_cents AND total_paid_amount_cents > 0")
+    else
+      scope.where("total_amount_cents = total_paid_amount_cents OR total_paid_amount_cents = 0")
+    end
   end
 
   def with_issuing_date_range(scope)

--- a/app/queries/payments_query.rb
+++ b/app/queries/payments_query.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class PaymentsQuery < BaseQuery
+  def call
+    return result unless validate_filters.success?
+    payments = base_scope
+    payments = paginate(payments)
+    payments = apply_consistent_ordering(payments)
+    payments = filter_by_invoice(payments) if filters.invoice_id.present?
+
+    result.payments = payments
+    result
+  end
+
+  private
+
+  def filters_contract
+    @filters_contract ||= Queries::PaymentsQueryFiltersContract.new
+  end
+
+  def base_scope
+    Payment.for_organization(organization)
+  end
+
+  def filter_by_invoice(scope)
+    invoice_id = filters.invoice_id
+
+    invoices_payment_requests_join = <<~SQL
+      LEFT JOIN invoices_payment_requests ON invoices_payment_requests.payment_request_id = payment_requests.id
+    SQL
+    scope.joins(invoices_payment_requests_join)
+      .where('invoices.id = :invoice_id OR invoices_payment_requests.invoice_id = :invoice_id', invoice_id: invoice_id)
+  end
+end

--- a/app/serializers/v1/payment_serializer.rb
+++ b/app/serializers/v1/payment_serializer.rb
@@ -5,14 +5,12 @@ module V1
     def serialize
       {
         lago_id: model.id,
-        invoice_id: invoice_id,
+        invoice_ids: invoice_id,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,
         payment_status: model.payable_payment_status,
         type: model.payment_type,
         reference: model.reference,
-        payment_provider_id: model.payment_provider_id,
-        payment_provider_customer_id: model.payment_provider_customer_id,
         external_payment_id: model.provider_payment_id,
         created_at: model.created_at.iso8601
       }
@@ -21,7 +19,7 @@ module V1
     private
 
     def invoice_id
-      model.payable.is_a?(Invoice) ? model.payable.id : model.payable.invoice_ids
+      model.payable.is_a?(Invoice) ? [model.payable.id] : model.payable.invoice_ids
     end
   end
 end

--- a/app/services/manual_payments/create_service.rb
+++ b/app/services/manual_payments/create_service.rb
@@ -2,8 +2,8 @@
 
 module ManualPayments
   class CreateService < BaseService
-    def initialize(invoice:, params:)
-      @invoice = invoice
+    def initialize(organization:, params:)
+      @organization = organization
       @params = params
 
       super
@@ -22,7 +22,8 @@ module ManualPayments
           amount_currency: invoice.currency,
           status: 'succeeded',
           payable_payment_status: 'succeeded',
-          payment_type: :manual
+          payment_type: :manual,
+          created_at: params[:paid_at].present? ? Time.iso8601(params[:paid_at]) : nil
         )
 
         invoice.update!(total_paid_amount_cents: invoice.total_paid_amount_cents + amount_cents)
@@ -43,7 +44,11 @@ module ManualPayments
 
     private
 
-    attr_reader :invoice, :params
+    attr_reader :organization, :params
+
+    def invoice
+      @invoice ||= organization.invoices.find_by(id: params[:invoice_id])
+    end
 
     def check_preconditions
       return result.forbidden_failure! unless License.premium?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,7 @@ Rails.application.routes.draw do
         put :sync_salesforce_id, on: :member
       end
       resources :payment_requests, only: %i[create index]
+      resources :payments, only: %i[create index show]
       resources :plans, param: :code, code: /.*/
       resources :taxes, param: :code, code: /.*/
       resources :wallet_transactions, only: :create

--- a/spec/contracts/queries/payments_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/payments_query_filters_contract_spec.rb
@@ -23,14 +23,63 @@ RSpec.describe Queries::PaymentsQueryFiltersContract, type: :contract do
         expect(result.success?).to be(true)
       end
     end
+
+    context "when external_customer_id is valid" do
+      let(:filters) { {external_customer_id: "valid_string"} }
+
+      it "is valid" do
+        expect(result.success?).to be(true)
+      end
+    end
+
+    context "when external_customer_id is blank" do
+      let(:filters) { {external_customer_id: nil} }
+
+      it "is valid" do
+        expect(result.success?).to be(true)
+      end
+    end
+
+    context "when both invoice_id and external_customer_id are valid" do
+      let(:filters) { {invoice_id: "7b199d93-2663-4e68-beca-203aefcd019b", external_customer_id: "valid_string"} }
+
+      it "is valid" do
+        expect(result.success?).to be(true)
+      end
+    end
   end
 
   context "when filters are invalid" do
-    it "is invalid when invoice_id is not a UUID" do
-      filters[:invoice_id] = "invalid_uuid"
+    context "when invoice_id is not a UUID" do
+      let(:filters) { {invoice_id: "invalid_uuid"} }
 
-      expect(result.success?).to be(false)
-      expect(result.errors.to_h).to include(filters: {invoice_id: ["must be a valid UUID"]})
+      it "is invalid" do
+        expect(result.success?).to be(false)
+        expect(result.errors.to_h).to include(filters: {invoice_id: ["must be a valid UUID"]})
+      end
+    end
+
+    context "when external_customer_id is not a string" do
+      let(:filters) { {external_customer_id: 123} }
+
+      it "is invalid" do
+        expect(result.success?).to be(false)
+        expect(result.errors.to_h).to include(filters: {external_customer_id: ["must be a string"]})
+      end
+    end
+
+    context "when both invoice_id and external_customer_id are invalid" do
+      let(:filters) { {invoice_id: "invalid_uuid", external_customer_id: 123} }
+
+      it "is invalid" do
+        expect(result.success?).to be(false)
+        expect(result.errors.to_h).to include(
+          filters: {
+            invoice_id: ["must be a valid UUID"],
+            external_customer_id: ["must be a string"]
+          }
+        )
+      end
     end
   end
 end

--- a/spec/contracts/queries/payments_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/payments_query_filters_contract_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Queries::PaymentsQueryFiltersContract, type: :contract do
+  subject(:result) { described_class.new.call(filters:) }
+
+  let(:filters) { {} }
+
+  context "when filters are valid" do
+    context "when invoice_id is valid" do
+      let(:filters) { {invoice_id: "7b199d93-2663-4e68-beca-203aefcd019b"} }
+
+      it "is valid" do
+        expect(result.success?).to be(true)
+      end
+    end
+
+    context "when invoice_id is blank" do
+      let(:filters) { {invoice_id: nil} }
+
+      it "is valid" do
+        expect(result.success?).to be(true)
+      end
+    end
+  end
+
+  context "when filters are invalid" do
+    it "is invalid when invoice_id is not a UUID" do
+      filters[:invoice_id] = "invalid_uuid"
+
+      expect(result.success?).to be(false)
+      expect(result.errors.to_h).to include(filters: {invoice_id: ["must be a valid UUID"]})
+    end
+  end
+end

--- a/spec/contracts/queries/payments_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/payments_query_filters_contract_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Queries::PaymentsQueryFiltersContract, type: :contract do
 
       it "is invalid" do
         expect(result.success?).to be(false)
-        expect(result.errors.to_h).to include(filters: {invoice_id: ["must be a valid UUID"]})
+        expect(result.errors.to_h).to include(filters: {invoice_id: ["is in invalid format"]})
       end
     end
 
@@ -75,7 +75,7 @@ RSpec.describe Queries::PaymentsQueryFiltersContract, type: :contract do
         expect(result.success?).to be(false)
         expect(result.errors.to_h).to include(
           filters: {
-            invoice_id: ["must be a valid UUID"],
+            invoice_id: ["is in invalid format"],
             external_customer_id: ["must be a string"]
           }
         )

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -306,12 +306,10 @@ RSpec.describe Payment, type: :model do
     it "returns organization's payments" do
       payments = subject
 
-      aggregate_failures do
-        expect(payments).to include(invoice_payment)
-        expect(payments).to include(payment_request_payment)
-        expect(payments).not_to include(other_org_invoice_payment)
-        expect(payments).not_to include(other_org_payment_request_payment)
-      end
+      expect(payments).to include(invoice_payment)
+      expect(payments).to include(payment_request_payment)
+      expect(payments).not_to include(other_org_invoice_payment)
+      expect(payments).not_to include(other_org_payment_request_payment)
     end
   end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -281,4 +281,37 @@ RSpec.describe Payment, type: :model do
       end
     end
   end
+
+  describe ".for_organization" do
+    subject(:result) { described_class.for_organization(organization) }
+
+    let(:organization) { create(:organization) }
+    let(:invoice) { create(:invoice, organization:) }
+    let(:payment_request) { create(:payment_request, organization:) }
+    let(:other_org_payment_request) { create(:payment_request) }
+
+    let(:invoice_payment) { create(:payment, payable: invoice) }
+    let(:payment_request_payment) { create(:payment, payable: payment_request) }
+    let(:other_org_invoice_payment) { create(:payment) }
+    let(:other_org_payment_request_payment) { create(:payment, payable: other_org_payment_request) }
+
+    before do
+      invoice_payment
+      payment_request_payment
+
+      other_org_invoice_payment
+      other_org_payment_request_payment
+    end
+
+    it "returns organization's payments" do
+      payments = subject
+
+      aggregate_failures do
+        expect(payments).to include(invoice_payment)
+        expect(payments).to include(payment_request_payment)
+        expect(payments).not_to include(other_org_invoice_payment)
+        expect(payments).not_to include(other_org_payment_request_payment)
+      end
+    end
+  end
 end

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -243,6 +243,69 @@ RSpec.describe InvoicesQuery, type: :query do
     end
   end
 
+  context 'when filtering by partially_paid' do
+    let(:invoice_first) do
+      create(
+        :invoice,
+        organization:,
+        status: 'finalized',
+        payment_status: 'succeeded',
+        customer: customer_first,
+        number: '1111111111',
+        issuing_date: 1.week.ago,
+        total_amount_cents: 2000,
+        total_paid_amount_cents: 2000
+      )
+    end
+    let(:invoice_second) do
+      create(
+        :invoice,
+        organization:,
+        status: 'finalized',
+        payment_status: 'pending',
+        customer: customer_second,
+        number: '2222222222',
+        issuing_date: 2.weeks.ago,
+        total_amount_cents: 2000,
+        total_paid_amount_cents: 1500
+      )
+    end
+
+    context 'when partially_paid is true' do
+      let(:filters) { {partially_paid: true} }
+
+      it 'returns only partially paid invoices' do
+        aggregate_failures do
+          expect(returned_ids.count).to eq(1)
+          expect(returned_ids).to include(invoice_second.id)
+          expect(returned_ids).not_to include(invoice_first.id)
+        end
+      end
+    end
+
+    context 'when partially_paid is false' do
+      let(:filters) { {partially_paid: false} }
+
+      it 'returns only fully paid and unpaid invoices' do
+        aggregate_failures do
+          expect(returned_ids.count).to eq(5)
+          expect(returned_ids).not_to include(invoice_second.id)
+          expect(returned_ids).to include(invoice_first.id)
+        end
+      end
+    end
+
+    context 'when partially_paid is nil' do
+      let(:filters) { {partially_paid: nil} }
+
+      it 'returns all invoices' do
+        aggregate_failures do
+          expect(returned_ids.count).to eq(6)
+        end
+      end
+    end
+  end
+
   context 'when filtering by credit invoice_type' do
     let(:filters) { {invoice_type: 'credit'} }
 

--- a/spec/queries/payments_query_spec.rb
+++ b/spec/queries/payments_query_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe PaymentsQuery, type: :query do
 
     it "returns a validation error" do
       expect(result).not_to be_success
-      expect(result.error.messages[:filters][:invoice_id]).to include("must be a valid UUID")
+      expect(result.error.messages[:filters][:invoice_id]).to include("is in invalid format")
     end
   end
 

--- a/spec/queries/payments_query_spec.rb
+++ b/spec/queries/payments_query_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentsQuery, type: :query do
+  subject(:result) do
+    described_class.call(organization:, pagination:, filters:)
+  end
+
+  let(:returned_ids) { result.payments.pluck(:id) }
+  let(:pagination) { nil }
+  let(:filters) { nil }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:invoice) { create(:invoice, organization:) }
+  let(:payment_request) { create(:payment_request, organization:) }
+  let(:payment_one) { create(:payment, payable: invoice) }
+  let(:payment_two) { create(:payment, payable: invoice) }
+  let(:payment_three) { create(:payment, payable: payment_request) }
+
+  before do
+    payment_one
+    payment_two
+    payment_three
+  end
+
+  it "returns all payments for the organization" do
+    expect(result).to be_success
+    expect(returned_ids.count).to eq(3)
+    expect(returned_ids).to include(payment_one.id)
+    expect(returned_ids).to include(payment_two.id)
+    expect(returned_ids).to include(payment_three.id)
+  end
+
+  context "with pagination" do
+    let(:pagination) { {page: 2, limit: 2} }
+
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.payments.count).to eq(1)
+      expect(result.payments.current_page).to eq(2)
+      expect(result.payments.prev_page).to eq(1)
+      expect(result.payments.next_page).to be_nil
+      expect(result.payments.total_pages).to eq(2)
+      expect(result.payments.total_count).to eq(3)
+    end
+  end
+
+  context "when filtering by invoice_id" do
+    let(:filters) { {invoice_id: invoice.id} }
+
+    it "returns only payments for the specified invoice" do
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(2)
+      expect(returned_ids).to include(payment_one.id)
+      expect(returned_ids).to include(payment_two.id)
+      expect(returned_ids).not_to include(payment_three.id)
+    end
+  end
+
+  context "when filtering by invoice_id of a payment request" do
+    let(:filters) { {invoice_id: invoice_pr.id} }
+    let(:invoice_pr) { create(:invoice, organization:) }
+
+    before do
+      create(:payment_request_applied_invoice, invoice: invoice_pr, payment_request:)
+    end
+
+    it "returns only payments for the specified invoice" do
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).to include(payment_three.id)
+    end
+  end
+
+  context "when filtering with an invalid invoice_id" do
+    let(:filters) { {invoice_id: "invalid-uuid"} }
+
+    it "returns a validation error" do
+      expect(result).not_to be_success
+      expect(result.error.messages[:filters][:invoice_id]).to include("must be a valid UUID")
+    end
+  end
+
+  context "when no payments exist" do
+    before do
+      Payment.delete_all
+    end
+
+    it "returns an empty result set" do
+      expect(result).to be_success
+      expect(returned_ids).to be_empty
+    end
+  end
+end

--- a/spec/queries/payments_query_spec.rb
+++ b/spec/queries/payments_query_spec.rb
@@ -73,6 +73,32 @@ RSpec.describe PaymentsQuery, type: :query do
     end
   end
 
+  context "when filtering by external_customer_id" do
+    let(:filters) { {external_customer_id: customer.external_id} }
+    let(:customer) { create(:customer) }
+    let(:new_invoice) { create(:invoice, organization:, customer:) }
+    let(:new_payment) { create(:payment, payable: new_invoice) }
+
+    before do
+      new_payment
+    end
+
+    it "returns only payments for the specified external_customer_id" do
+      expect(result).to be_success
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).to include(new_payment.id)
+    end
+  end
+
+  context "when filtering by an invalid external_customer_id" do
+    let(:filters) { {external_customer_id: "invalid-external-id"} }
+
+    it "returns an empty result set" do
+      expect(result).to be_success
+      expect(returned_ids).to be_empty
+    end
+  end
+
   context "when filtering with an invalid invoice_id" do
     let(:filters) { {invoice_id: "invalid-uuid"} }
 

--- a/spec/requests/api/v1/payments_controller_spec.rb
+++ b/spec/requests/api/v1/payments_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Api::V1::PaymentsController, type: :request do
 
       expect(response).to have_http_status(:success)
       expect(json[:payment][:lago_id]).to eq(payment.id)
-      expect(json[:payment][:invoice_ids]).to eq([payment.payable.id])
+      expect(json[:payment][:invoice_ids].first).to eq(payment.payable.id)
     end
   end
 
@@ -100,7 +100,7 @@ RSpec.describe Api::V1::PaymentsController, type: :request do
         subject
         expect(response).to have_http_status(:success)
         expect(json[:payments].map { |r| r[:lago_id] }).to contain_exactly(first_payment.id)
-        expect(json[:payments].first[:invoice_ids]).to eq([invoice.id])
+        expect(json[:payments].first[:invoice_ids].first).to eq(invoice.id)
       end
     end
   end
@@ -121,7 +121,7 @@ RSpec.describe Api::V1::PaymentsController, type: :request do
         subject
         expect(response).to have_http_status(:ok)
         expect(json[:payment][:lago_id]).to eq(payment.id)
-        expect(json[:payment][:invoice_ids]).to eq([invoice.id])
+        expect(json[:payment][:invoice_ids].first).to eq(invoice.id)
       end
     end
 

--- a/spec/requests/api/v1/payments_controller_spec.rb
+++ b/spec/requests/api/v1/payments_controller_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::PaymentsController, type: :request do
+  let(:organization) { create(:organization) }
+
+  describe "POST /api/v1/payments" do
+    subject do
+      post_with_token(
+        organization,
+        "/api/v1/payments",
+        {payment: params}
+      )
+    end
+
+    let(:customer) { create(:customer, organization:) }
+    let(:invoice) { create(:invoice, organization:, customer:) }
+    let(:params) do
+      {
+        invoice_id: invoice.id,
+        amount_cents: 100,
+        reference: 'ref1'
+      }
+    end
+
+    let(:payment) { create(:payment, payable: invoice) }
+
+    before do
+      allow(ManualPayments::CreateService).to receive(:call).and_return(
+        BaseService::Result.new.tap { |r| r.payment = payment }
+      )
+    end
+
+    include_examples 'requires API permission', 'payment', 'write'
+
+    it "delegates to ManualPayments::CreateService", :aggregate_failures do
+      subject
+
+      expect(ManualPayments::CreateService).to have_received(:call).with(organization:, params:)
+
+      expect(response).to have_http_status(:success)
+      expect(json[:payment][:lago_id]).to eq(payment.id)
+      expect(json[:payment][:invoice_id]).to eq(payment.payable.id)
+    end
+  end
+
+  describe "GET /api/v1/payments" do
+    subject { get_with_token(organization, "/api/v1/payments", params) }
+
+    let(:params) { {} }
+
+    include_examples 'requires API permission', 'payment', 'read'
+
+    it "returns organization's payments", :aggregate_failures do
+      invoice = create(:invoice, organization:)
+      first_payment = create(:payment, payable: invoice)
+      second_payment = create(:payment, payable: invoice)
+
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:payments].count).to eq(2)
+      expect(json[:payments].map { |r| r[:lago_id] }).to contain_exactly(
+        first_payment.id,
+        second_payment.id
+      )
+    end
+
+    context "with a not found invoice", :aggregate_failures do
+      let(:params) { {invoice_id: SecureRandom.uuid} }
+
+      before do
+        invoice = create(:invoice, organization:)
+        create(:payment, payable: invoice)
+      end
+
+      it "returns an empty result" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:payments]).to be_empty
+      end
+    end
+
+    context "with invoice" do
+      let(:invoice) { create(:invoice, organization:) }
+      let(:params) { {invoice_id: invoice.id} }
+      let(:first_payment) { create(:payment, payable: invoice) }
+
+      before do
+        first_payment
+        create(:payment)
+      end
+
+      it "returns invoices's payments", :aggregate_failures do
+        subject
+
+        aggregate_failures do
+          expect(response).to have_http_status(:success)
+          expect(json[:payments].map { |r| r[:lago_id] }).to contain_exactly(first_payment.id)
+          expect(json[:payments].first[:invoice_id]).to eq(invoice.id)
+        end
+      end
+    end
+  end
+
+  describe 'GET /api/v1/payments/:id' do
+    subject { get_with_token(organization, "/api/v1/payments/#{id}") }
+
+    let(:customer) { create(:customer, organization:) }
+    let(:invoice) { create(:invoice, customer:, organization:) }
+    let(:payment) { create(:payment, payable: invoice) }
+
+    context 'when payment exists' do
+      let(:id) { payment.id }
+
+      include_examples 'requires API permission', 'payment', 'read'
+
+      it 'returns the payment' do
+        subject
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(json[:payment][:lago_id]).to eq(payment.id)
+        end
+      end
+    end
+
+    context 'when payment does not exist' do
+      let(:id) { SecureRandom.uuid }
+
+      it 'returns a not found error' do
+        subject
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/payments_controller_spec.rb
+++ b/spec/requests/api/v1/payments_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Api::V1::PaymentsController, type: :request do
 
       expect(response).to have_http_status(:success)
       expect(json[:payment][:lago_id]).to eq(payment.id)
-      expect(json[:payment][:invoice_id]).to eq(payment.payable.id)
+      expect(json[:payment][:invoice_ids]).to eq([payment.payable.id])
     end
   end
 
@@ -100,7 +100,7 @@ RSpec.describe Api::V1::PaymentsController, type: :request do
         subject
         expect(response).to have_http_status(:success)
         expect(json[:payments].map { |r| r[:lago_id] }).to contain_exactly(first_payment.id)
-        expect(json[:payments].first[:invoice_id]).to eq(invoice.id)
+        expect(json[:payments].first[:invoice_ids]).to eq([invoice.id])
       end
     end
   end
@@ -121,7 +121,7 @@ RSpec.describe Api::V1::PaymentsController, type: :request do
         subject
         expect(response).to have_http_status(:ok)
         expect(json[:payment][:lago_id]).to eq(payment.id)
-        expect(json[:payment][:invoice_id]).to eq(invoice.id)
+        expect(json[:payment][:invoice_ids]).to eq([invoice.id])
       end
     end
 
@@ -140,7 +140,7 @@ RSpec.describe Api::V1::PaymentsController, type: :request do
         subject
         expect(response).to have_http_status(:ok)
         expect(json[:payment][:lago_id]).to eq(payment.id)
-        expect(json[:payment][:invoice_id].first).to eq(invoice.id)
+        expect(json[:payment][:invoice_ids].first).to eq(invoice.id)
       end
     end
 

--- a/spec/serializers/v1/payment_serializer_spec.rb
+++ b/spec/serializers/v1/payment_serializer_spec.rb
@@ -13,21 +13,17 @@ RSpec.describe ::V1::PaymentSerializer do
     it "serializes the object" do
       result = JSON.parse(serializer.to_json)
 
-      aggregate_failures do
-        expect(result["payment"]).to include(
-          "lago_id" => payment.id,
-          "invoice_id" => payment.payable.id,
-          "amount_cents" => payment.amount_cents,
-          "amount_currency" => payment.amount_currency,
-          "payment_status" => payment.payable_payment_status,
-          "type" => payment.payment_type,
-          "reference" => payment.reference,
-          "payment_provider_id" => payment.payment_provider_id,
-          "payment_provider_customer_id" => payment.payment_provider_customer_id,
-          "external_payment_id" => payment.provider_payment_id,
-          "created_at" => payment.created_at.iso8601
-        )
-      end
+      expect(result["payment"]).to include(
+        "lago_id" => payment.id,
+        "invoice_ids" => [payment.payable.id],
+        "amount_cents" => payment.amount_cents,
+        "amount_currency" => payment.amount_currency,
+        "payment_status" => payment.payable_payment_status,
+        "type" => payment.payment_type,
+        "reference" => payment.reference,
+        "external_payment_id" => payment.provider_payment_id,
+        "created_at" => payment.created_at.iso8601
+      )
     end
   end
 
@@ -42,21 +38,17 @@ RSpec.describe ::V1::PaymentSerializer do
     it "serializes the object" do
       result = JSON.parse(serializer.to_json)
 
-      aggregate_failures do
-        expect(result["payment"]).to include(
-          "lago_id" => payment.id,
-          "invoice_id" => payment_request.invoice_ids,
-          "amount_cents" => payment.amount_cents,
-          "amount_currency" => payment.amount_currency,
-          "payment_status" => payment.payable_payment_status,
-          "type" => payment.payment_type,
-          "reference" => payment.reference,
-          "payment_provider_id" => payment.payment_provider_id,
-          "payment_provider_customer_id" => payment.payment_provider_customer_id,
-          "external_payment_id" => payment.provider_payment_id,
-          "created_at" => payment.created_at.iso8601
-        )
-      end
+      expect(result["payment"]).to include(
+        "lago_id" => payment.id,
+        "invoice_ids" => payment_request.invoice_ids,
+        "amount_cents" => payment.amount_cents,
+        "amount_currency" => payment.amount_currency,
+        "payment_status" => payment.payable_payment_status,
+        "type" => payment.payment_type,
+        "reference" => payment.reference,
+        "external_payment_id" => payment.provider_payment_id,
+        "created_at" => payment.created_at.iso8601
+      )
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/log-partial-payments

## Context

This PR introduces a new endpoint to list all payments. Additionally, it adds the ability to filter payments by a specific invoice_id, allowing users to narrow down the results to payments associated with a particular invoice. This enhancement improves the flexibility and usability of the payments listing functionality.
It also adds `create` and `show` actions in the PaymentsController.

## Description

**Added Endpoint:**

- Created an endpoint to list, show and create payments.
- Filter by invoice_id:
- Added functionality to filter payments based on the provided invoice_id.
- Included a validation step to ensure the invoice_id is in the correct UUID format before executing the query.

**Query Updates:**

- Refactored PaymentsQuery to handle dynamic filtering by invoice_id.
- Ensured that the query properly joins related tables, such as invoices and payment_requests, to support filtering.