### PR TITLE
misc(invoice): Add integration_customers to the invoice payload

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -70,7 +70,7 @@ module Api
               ::V1::InvoiceSerializer,
               collection_name: 'invoices',
               meta: pagination_metadata(result.invoices),
-              includes: %i[customer metadata applied_taxes]
+              includes: %i[customer integration_customers metadata applied_taxes]
             )
           )
         else
@@ -241,7 +241,7 @@ module Api
           json: ::V1::InvoiceSerializer.new(
             invoice,
             root_name: 'invoice',
-            includes: %i[customer subscriptions fees credits metadata applied_taxes error_details]
+            includes: %i[customer integration_customers subscriptions fees credits metadata applied_taxes error_details]
           )
         )
       end

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -183,6 +183,16 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       end
     end
 
+    context 'when customer has an integration customer' do
+      let!(:netsuite_customer) { create(:netsuite_customer, customer:) }
+
+      it 'returns an invoice with customer having integration customers' do
+        subject
+
+        expect(json[:invoice][:customer][:integration_customers].first).to include(lago_id: netsuite_customer.id)
+      end
+    end
+
     context 'when invoice does not exist' do
       let(:invoice_id) { SecureRandom.uuid }
 
@@ -276,6 +286,17 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
           payment_status: invoice.payment_status,
           status: invoice.status
         )
+      end
+
+      context 'when customer has an integration customer' do
+        let!(:netsuite_customer) { create(:netsuite_customer, customer:) }
+
+        it 'returns an invoice with customer having integration customers' do
+          subject
+
+          expect(json[:invoices].first[:customer][:integration_customers].first)
+            .to include(lago_id: netsuite_customer.id)
+        end
       end
     end
 


### PR DESCRIPTION
## Context

We were not sending `integration_customers` in the invoice payload in the following endpoints:
```
GET /api/v1/invoices/
GET /api/v1/invoices/:id
```

## Description

This PR adds `integration_customers` to the payload in `InvoicesController#show` and `InvoicesController#index` actions.