### PR TITLE
fix(one-off-invoice): Fix create one off invoice service

### DIFF
--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -102,7 +102,7 @@ module Invoices
     end
 
     def tax_error?(fee_result)
-      !fee_result.success? && fee_result&.error&.code == 'tax_error'
+      !fee_result.success? && fee_result.error.respond_to?(:code) && fee_result&.error&.code == 'tax_error'
     end
   end
 end

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -356,4 +356,48 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
       end
     end
   end
+
+  describe '#tax_error?' do
+    subject(:method_call) { create_service.__send__(:tax_error?, result) }
+
+    let(:result) { BaseService::Result.new }
+
+    context 'when the fee result is successful' do
+      it 'returns false' do
+        expect(subject).to be false
+      end
+    end
+
+    context 'when the fee result is not successful' do
+      context 'when the fee result error code is tax_error' do
+        before do
+          result.service_failure!(code: 'tax_error', message: 'Tax error')
+        end
+
+        it 'returns true' do
+          expect(subject).to be true
+        end
+      end
+
+      context 'when the fee result error does not respond to code' do
+        before do
+          result.validation_failure!(errors: [{message: 'error'}])
+        end
+
+        it 'returns false' do
+          expect(subject).to be false
+        end
+      end
+
+      context 'when the fee result error code is not tax_error' do
+        before do
+          result.service_failure!(code: 'code1', message: 'Code1 error')
+        end
+
+        it 'returns false' do
+          expect(subject).to be false
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

We were getting this error in `Invoices::CreateOneOffService#tax_error?`:
```
NoMethodError undefined method `code' for an instance of BaseService::ValidationFailure (NoMethodError)
```

The reason for that is that some errors (e.g.: `BaseService::ValidationFailure`) don't have `code`.


## Description

This PR fixes `Invoices::CreateOneOffService#tax_error?` by checking if the actual error result responds to `code`.