### PR TITLE
fix(validations): Fix subscriptions validate service

### DIFF
--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -60,7 +60,9 @@ module Subscriptions
 
     def ending_at
       @ending_at ||= if args[:ending_at].is_a?(String)
-        DateTime.strptime(args[:ending_at])
+        args[:ending_at].include?('.') ?
+          DateTime.strptime(args[:ending_at], '%Y-%m-%dT%H:%M:%S.%LZ') :
+          DateTime.strptime(args[:ending_at])
       else
         args[:ending_at]
       end
@@ -68,7 +70,9 @@ module Subscriptions
 
     def subscription_at
       @subscription_at ||= if args[:subscription_at].is_a?(String)
-        DateTime.strptime(args[:subscription_at])
+        args[:subscription_at].include?('.') ?
+          DateTime.strptime(args[:subscription_at], '%Y-%m-%dT%H:%M:%S.%LZ') :
+          DateTime.strptime(args[:subscription_at])
       else
         args[:subscription_at]
       end

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -22,6 +22,46 @@ RSpec.describe Subscriptions::ValidateService, type: :service do
     }
   end
 
+  describe '#ending_at' do
+    subject(:method_call) { validate_service.__send__(:ending_at) }
+
+    context 'when date contains milliseconds' do
+      let(:ending_at) { '2020-01-01T00:00:00.000Z' }
+
+      it 'returns the date' do
+        expect(subject).to eq(DateTime.strptime(ending_at, '%Y-%m-%dT%H:%M:%S.%LZ'))
+      end
+    end
+
+    context 'when date does not contain milliseconds' do
+      let(:ending_at) { '2020-01-01T00:00:00Z' }
+
+      it 'returns the date' do
+        expect(subject).to eq(DateTime.strptime(ending_at))
+      end
+    end
+  end
+
+  describe '#subscription_at' do
+    subject(:method_call) { validate_service.__send__(:subscription_at) }
+
+    context 'when date contains milliseconds' do
+      let(:subscription_at) { '2021-02-01T00:00:00.00Z' }
+
+      it 'returns the date' do
+        expect(subject).to eq(DateTime.strptime(subscription_at, '%Y-%m-%dT%H:%M:%S.%LZ'))
+      end
+    end
+
+    context 'when date does not contain milliseconds' do
+      let(:subscription_at) { '2020-01-01T00:00:00Z' }
+
+      it 'returns the date' do
+        expect(subject).to eq(DateTime.strptime(subscription_at))
+      end
+    end
+  end
+
   describe '.valid?' do
     it 'returns true' do
       expect(validate_service).to be_valid


### PR DESCRIPTION
## Context

When updating the subscription with `subscription_at` or `ending_at` fields, they should accepts milliseconds e.g.: `2025-01-10T00:00:00.000Z`

## Description

This PR updates `Subscriptions::ValidateService#subscription_at` and `Subscriptions::ValidateService#ending_at` so that they can parse datetimes containing milliseconds.