### PR TITLE
Add support for filtering invoices by partially paid

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -56,6 +56,7 @@ module Api
             payment_status: (params[:payment_status] if valid_payment_status?(params[:payment_status])),
             payment_dispute_lost: params[:payment_dispute_lost],
             payment_overdue: (params[:payment_overdue] if %w[true false].include?(params[:payment_overdue])),
+            partially_paid: (params[:partially_paid] if %w[true false].include?(params[:partially_paid])),
             status: (params[:status] if valid_status?(params[:status])),
             currency: params[:currency],
             customer_external_id: params[:external_customer_id],

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -94,10 +94,8 @@ class InvoicesQuery < BaseQuery
 
     if partially_paid
       scope.where("total_amount_cents > total_paid_amount_cents AND total_paid_amount_cents > 0")
-    elsif partially_paid == false
-      scope.where("total_amount_cents = total_paid_amount_cents OR total_paid_amount_cents = 0")
     else
-      scope
+      scope.where("total_amount_cents = total_paid_amount_cents OR total_paid_amount_cents = 0")
     end
   end
 

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -20,6 +20,7 @@ class InvoicesQuery < BaseQuery
     invoices = with_payment_overdue(invoices) unless filters.payment_overdue.nil?
     invoices = with_amount_range(invoices) if filters.amount_from.present? || filters.amount_to.present?
     invoices = with_metadata(invoices) if filters.metadata.present?
+    invoices = with_partially_paid(invoices) unless filters.partially_paid.nil?
 
     result.invoices = invoices
     result
@@ -86,6 +87,13 @@ class InvoicesQuery < BaseQuery
 
   def with_payment_overdue(scope)
     scope.where(payment_overdue: filters.payment_overdue)
+  end
+
+  def with_partially_paid(scope)
+    partially_paid = ActiveModel::Type::Boolean.new.cast(filters.partially_paid)
+    return scope unless partially_paid
+
+    scope.where("total_amount_cents > total_paid_amount_cents AND total_paid_amount_cents > 0")
   end
 
   def with_issuing_date_range(scope)

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -91,9 +91,14 @@ class InvoicesQuery < BaseQuery
 
   def with_partially_paid(scope)
     partially_paid = ActiveModel::Type::Boolean.new.cast(filters.partially_paid)
-    return scope unless partially_paid
 
-    scope.where("total_amount_cents > total_paid_amount_cents AND total_paid_amount_cents > 0")
+    if partially_paid
+      scope.where("total_amount_cents > total_paid_amount_cents AND total_paid_amount_cents > 0")
+    elsif partially_paid == false
+      scope.where("total_amount_cents = total_paid_amount_cents OR total_paid_amount_cents = 0")
+    else
+      scope
+    end
   end
 
   def with_issuing_date_range(scope)

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -243,6 +243,70 @@ RSpec.describe InvoicesQuery, type: :query do
     end
   end
 
+  context 'when filtering by partially_paid' do
+
+    let(:invoice_first) do
+      create(
+        :invoice,
+        organization:,
+        status: 'finalized',
+        payment_status: 'succeeded',
+        customer: customer_first,
+        number: '1111111111',
+        issuing_date: 1.week.ago,
+        total_amount_cents: 2000,
+        total_paid_amount_cents: 2000
+      )
+    end
+    let(:invoice_second) do
+      create(
+        :invoice,
+        organization:,
+        status: 'finalized',
+        payment_status: 'pending',
+        customer: customer_second,
+        number: '2222222222',
+        issuing_date: 2.weeks.ago,
+        total_amount_cents: 2000,
+        total_paid_amount_cents: 1500
+      )
+    end
+
+    context 'when partially_paid is true' do
+      let(:filters) { {partially_paid: true} }
+
+      it 'returns only partially paid invoices' do
+        aggregate_failures do
+          expect(returned_ids.count).to eq(1)
+          expect(returned_ids).to include(invoice_second.id)
+          expect(returned_ids).not_to include(invoice_first.id)
+        end
+      end
+    end
+
+    context 'when partially_paid is false' do
+      let(:filters) { {partially_paid: false} }
+
+      it 'returns only fully paid and unpaid invoices' do
+        aggregate_failures do
+          expect(returned_ids.count).to eq(5)
+          expect(returned_ids).not_to include(invoice_second.id)
+          expect(returned_ids).to include(invoice_first.id)
+        end
+      end
+    end
+
+    context 'when partially_paid is nil' do
+      let(:filters) { {partially_paid: nil} }
+
+      it 'returns all invoices' do
+        aggregate_failures do
+          expect(returned_ids.count).to eq(6)
+        end
+      end
+    end
+  end
+
   context 'when filtering by credit invoice_type' do
     let(:filters) { {invoice_type: 'credit'} }
 

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -244,7 +244,6 @@ RSpec.describe InvoicesQuery, type: :query do
   end
 
   context 'when filtering by partially_paid' do
-
     let(:invoice_first) do
       create(
         :invoice,


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/log-partial-payments

## Context

This feature introduces the ability to filter invoices for partially paid invoices. It provides additional flexibility for users who need to identify partially paid or unpaid invoices. This enhancement aligns with the requirements outlined in the linked roadmap task.

## Description

The changes include:
- Implementation of the with_partially_paid method to filter invoices based on partially_paid values (true, false, or nil).
- Updated the InvoicesQuery class to apply the filter when the partially_paid parameter is provided.