### PR TITLE
fix(invoice): Fix updating invoice payment status from succeeded

### DIFF
--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -35,6 +35,10 @@ module Invoices
         return result.not_allowed_failure!(code: 'payment_status_update_on_draft_invoice')
       end
 
+      if old_payment_status.to_s == 'succeeded' && params.key?(:payment_status) && params[:payment_status].to_s != 'succeeded'
+        return result.not_allowed_failure!(code: 'payment_status_update_on_succeeded_invoice')
+      end
+
       if params.key?(:ready_for_payment_processing) && !invoice.voided?
         invoice.ready_for_payment_processing = params[:ready_for_payment_processing]
       end

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -111,6 +111,22 @@ RSpec.describe Invoices::UpdateService do
           end
         end
       end
+
+      context 'when invoice has succeded payment status' do
+        let(:invoice) { create(:invoice, payment_status: :succeeded) }
+
+        let(:update_args) do
+          {
+            payment_status: 'failed'
+          }
+        end
+
+        it 'raises an error' do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(result.error.code).to eq('payment_status_update_on_succeeded_invoice')
+        end
+      end
     end
 
     context 'with attached fees' do


### PR DESCRIPTION
## Context

Currently there is a possibility to update invoice payment status from succeeded to other status.

## Description

This PR fixes `Invoices::UpdateService` that raises an error when attempting to change invoice's `succeeded` payment status.