### PR TITLE
feat(invoice-preview): add base preview service

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -91,7 +91,7 @@ module Invoices
     end
 
     def create_subscription_fee(subscription, boundaries)
-      fee_result = Fees::SubscriptionService.new(invoice:, subscription:, boundaries:).create
+      fee_result = Fees::SubscriptionService.call(invoice:, subscription:, boundaries:)
       fee_result.raise_if_error!
     end
 

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Invoices
+  class PreviewService < BaseService
+    def initialize(customer:, subscription:)
+      @customer = customer
+      @subscription = subscription
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'customer') unless customer
+      return result.not_found_failure!(resource: 'subscription') unless subscription
+
+      @invoice = Invoice.new(
+        organization: customer.organization,
+        customer:,
+        invoice_type: :subscription,
+        currency: subscription.plan&.amount_currency,
+        timezone: customer.applicable_timezone,
+        issuing_date:,
+        payment_due_date:,
+        net_payment_term: customer.applicable_net_payment_term,
+        created_at: Time.current,
+        updated_at: Time.current
+      )
+
+      invoice.subscriptions = [subscription]
+
+      add_subscription_fee
+      compute_tax_and_totals
+
+      result.invoice = invoice
+      result
+    end
+
+    private
+
+    attr_accessor :customer, :subscription, :invoice
+
+    def boundaries
+      {
+        from_datetime: date_service.from_datetime,
+        to_datetime: date_service.to_datetime,
+        charges_from_datetime: date_service.charges_from_datetime,
+        charges_to_datetime: date_service.charges_to_datetime,
+        timestamp: billing_time
+      }
+    end
+
+    def date_service
+      Subscriptions::DatesService.new_instance(subscription, billing_time)
+    end
+
+    def billing_time
+      return @billing_time if defined? @billing_time
+
+      ds = Subscriptions::DatesService.new_instance(subscription, Time.current, current_usage: true)
+
+      @billing_time = ds.end_of_period + 1.day
+    end
+
+    def issuing_date
+      billing_time.in_time_zone(customer.applicable_timezone).to_date
+    end
+
+    def payment_due_date
+      (issuing_date + customer.applicable_net_payment_term.days).to_date
+    end
+
+    def add_subscription_fee
+      invoice.fees =
+        [
+          Fees::SubscriptionService.call(
+            invoice:,
+            subscription:,
+            boundaries:,
+            context: :preview
+          ).raise_if_error!.fee
+        ]
+    end
+
+    def compute_tax_and_totals
+      invoice.fees_amount_cents = invoice.fees.sum(&:amount_cents)
+      invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents - invoice.coupons_amount_cents
+
+      invoice.fees.each do |fee|
+        taxes_result = Fees::ApplyTaxesService.call(fee:)
+        taxes_result.raise_if_error!
+      end
+
+      taxes_result = Invoices::ApplyTaxesService.call(invoice:)
+      taxes_result.raise_if_error!
+
+      invoice.sub_total_including_taxes_amount_cents = (
+        invoice.sub_total_excluding_taxes_amount_cents + invoice.taxes_amount_cents
+      )
+
+      invoice.total_amount_cents = (
+        invoice.sub_total_including_taxes_amount_cents - invoice.credit_notes_amount_cents
+      )
+    end
+  end
+end

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::PreviewService, type: :service do
+  subject(:preview_service) { described_class.new(customer:, subscription:) }
+
+  describe '#call' do
+    let(:organization) { create(:organization) }
+    let(:tax) { create(:tax, rate: 50.0, organization:) }
+    let(:customer) { build(:customer, organization:) }
+    let(:timestamp) { Time.zone.parse('30 Mar 2024') }
+    let(:plan) { create(:plan, organization:, interval: 'monthly') }
+    let(:billing_time) { 'calendar' }
+    let(:subscription) do
+      build(
+        :subscription,
+        customer:,
+        plan:,
+        billing_time:,
+        subscription_at: timestamp,
+        started_at: timestamp,
+        created_at: timestamp
+      )
+    end
+
+    before { tax }
+
+    context 'when customer does not exist' do
+      it 'returns an error' do
+        result = described_class.new(customer: nil, subscription:).call
+
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq('customer_not_found')
+      end
+    end
+
+    context 'when subscription does not exist' do
+      it 'returns an error' do
+        result = described_class.new(customer:, subscription: nil).call
+
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq('subscription_not_found')
+      end
+    end
+
+    context 'with calendar billing' do
+      it 'creates preview invoice for 2 days' do
+        # Two days should be billed, Mar 30 and Mar 31
+
+        travel_to(timestamp) do
+          result = preview_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(result.invoice.subscriptions.first).to eq(subscription)
+            expect(result.invoice.fees.length).to eq(1)
+            expect(result.invoice.invoice_type).to eq('subscription')
+            expect(result.invoice.issuing_date.to_s).to eq('2024-04-01')
+            expect(result.invoice.fees_amount_cents).to eq(6)
+            expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(6)
+            expect(result.invoice.taxes_amount_cents).to eq(3)
+            expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(9)
+            expect(result.invoice.total_amount_cents).to eq(9)
+          end
+        end
+      end
+    end
+
+    context 'with anniversary billing' do
+      let(:billing_time) { 'anniversary' }
+
+      it 'creates preview invoice for full month' do
+        travel_to(timestamp) do
+          result = preview_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(result.invoice.subscriptions.first).to eq(subscription)
+            expect(result.invoice.fees.length).to eq(1)
+            expect(result.invoice.invoice_type).to eq('subscription')
+            expect(result.invoice.issuing_date.to_s).to eq('2024-04-30')
+            expect(result.invoice.fees_amount_cents).to eq(100)
+            expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(100)
+            expect(result.invoice.taxes_amount_cents).to eq(50)
+            expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(150)
+            expect(result.invoice.total_amount_cents).to eq(150)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Preview feature enables fetching first Lago invoice. This invoice is not persisted aand is calculated on the fly.

## Description

This PR adds preview service which will be the base for the feature.
It can work for existing subscription and customer, but also for objects that are just created in-memory.

Following PRs will attach credits to the preview invoice and tax provider integration will also be supported.
