### PR TITLE
fix(terminate-relations): Fix terminate relations service

### DIFF
--- a/app/services/customers/terminate_relations_service.rb
+++ b/app/services/customers/terminate_relations_service.rb
@@ -19,7 +19,7 @@ module Customers
       customer.subscriptions.pending.find_each(&:mark_as_canceled!)
 
       # NOTE: Finalize all draft invoices.
-      customer.invoices.draft.find_each { |invoice| Invoices::RefreshDraftAndFinalizeService.call(invoice:) }
+      customer.invoices.draft.find_each { |invoice| Invoices::FinalizeJob.set(wait: 5.minutes).perform_later(invoice) }
 
       # NOTE: Terminate applied coupons
       customer.applied_coupons.active.find_each do |applied_coupon|

--- a/spec/services/customers/terminate_relations_service_spec.rb
+++ b/spec/services/customers/terminate_relations_service_spec.rb
@@ -44,10 +44,10 @@ RSpec.describe Customers::TerminateRelationsService, type: :service do
       create(:invoice_subscription, invoice: invoices.last, subscription:, invoicing_reason: :subscription_periodic)
     end
 
-    it 'finalizes draft invoices' do
-      terminate_service.call
-
-      invoices.each { |i| expect(i.reload).to be_finalized }
+    it 'enqueues finalize jobs for the invoices' do
+      expect do
+        terminate_service.call
+      end.to have_enqueued_job(Invoices::FinalizeJob).exactly(:twice)
     end
   end
 


### PR DESCRIPTION
## Context

When deleting a customer that has draft invoices in `Customers::TerminateRelationsService`
This job is called twice `PullTaxesAndApplyJob` as a result of calling `TerminateService` and then `Invoices::RefreshDraftAndFinalizeService.call`.

Then the first enqueued `PullTaxesAndApplyJob` raises:
```
ActiveRecord::InvalidForeignKey
PG::ForeignKeyViolation: ERROR:  insert or update on table "fees_taxes" violates foreign key constraint "fk_rails_..." (ActiveRecord::InvalidForeignKey)
DETAIL:  Key (fee_id)=(...) is not present in table "fees".
```

Because the concurrently running second job deleted those fees from the DB in the meantime.

## Description

This PR mitigates the issue by delaying `Invoices::FinalizeJob` by 5 minutes.