### PR TITLE
feat(revshare): Add db columns for partners and self_billed invoices

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -230,6 +230,7 @@ end
 # Table name: customers
 #
 #  id                               :uuid             not null, primary key
+#  account_type                     :enum             default("customer"), not null
 #  address_line1                    :string
 #  address_line2                    :string
 #  city                             :string
@@ -278,6 +279,7 @@ end
 #
 # Indexes
 #
+#  index_customers_on_account_type                     (account_type)
 #  index_customers_on_applied_dunning_campaign_id      (applied_dunning_campaign_id)
 #  index_customers_on_deleted_at                       (deleted_at)
 #  index_customers_on_external_id_and_organization_id  (external_id,organization_id) UNIQUE WHERE (deleted_at IS NULL)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -474,6 +474,7 @@ end
 #  progressive_billing_credit_amount_cents :bigint           default(0), not null
 #  ready_for_payment_processing            :boolean          default(TRUE), not null
 #  ready_to_be_refreshed                   :boolean          default(FALSE), not null
+#  self_billed                             :boolean          default(FALSE), not null
 #  skip_charges                            :boolean          default(FALSE), not null
 #  status                                  :integer          default("finalized"), not null
 #  sub_total_excluding_taxes_amount_cents  :bigint           default(0), not null
@@ -502,6 +503,7 @@ end
 #  index_invoices_on_organization_id                (organization_id)
 #  index_invoices_on_payment_overdue                (payment_overdue)
 #  index_invoices_on_ready_to_be_refreshed          (ready_to_be_refreshed) WHERE (ready_to_be_refreshed = true)
+#  index_invoices_on_self_billed                    (self_billed)
 #  index_invoices_on_sequential_id                  (sequential_id)
 #  index_invoices_on_status                         (status)
 #

--- a/db/migrate/20250114163522_add_account_type_to_customers.rb
+++ b/db/migrate/20250114163522_add_account_type_to_customers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddAccountTypeToCustomers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    create_enum :customer_account_type, %w[customer partner]
+    add_column :customers, :account_type, :enum, enum_type: "customer_account_type", default: "customer", null: false
+
+    add_index :customers, :account_type, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20250114172823_add_self_billed_to_invoices.rb
+++ b/db/migrate/20250114172823_add_self_billed_to_invoices.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddSelfBilledToInvoices < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :invoices, :self_billed, :boolean, default: false, null: false
+    add_index :invoices, :self_billed, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_27_161927) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_14_172823) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_27_161927) do
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "billable_metric_rounding_function", ["round", "floor", "ceil"]
   create_enum "billable_metric_weighted_interval", ["seconds"]
+  create_enum "customer_account_type", ["customer", "partner"]
   create_enum "customer_type", ["company", "individual"]
   create_enum "inbound_webhook_status", ["pending", "processing", "succeeded", "failed"]
   create_enum "payment_payable_payment_status", ["pending", "processing", "succeeded", "failed"]
@@ -486,6 +487,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_27_161927) do
     t.integer "last_dunning_campaign_attempt", default: 0, null: false
     t.datetime "last_dunning_campaign_attempt_at", precision: nil
     t.boolean "skip_invoice_custom_sections", default: false, null: false
+    t.enum "account_type", default: "customer", null: false, enum_type: "customer_account_type"
+    t.index ["account_type"], name: "index_customers_on_account_type"
     t.index ["applied_dunning_campaign_id"], name: "index_customers_on_applied_dunning_campaign_id"
     t.index ["deleted_at"], name: "index_customers_on_deleted_at"
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true, where: "(deleted_at IS NULL)"
@@ -936,6 +939,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_27_161927) do
     t.bigint "progressive_billing_credit_amount_cents", default: 0, null: false
     t.enum "tax_status", enum_type: "tax_status"
     t.bigint "total_paid_amount_cents", default: 0, null: false
+    t.boolean "self_billed", default: false, null: false
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["issuing_date"], name: "index_invoices_on_issuing_date"
@@ -943,6 +947,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_27_161927) do
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
     t.index ["payment_overdue"], name: "index_invoices_on_payment_overdue"
     t.index ["ready_to_be_refreshed"], name: "index_invoices_on_ready_to_be_refreshed", where: "(ready_to_be_refreshed = true)"
+    t.index ["self_billed"], name: "index_invoices_on_self_billed"
     t.index ["sequential_id"], name: "index_invoices_on_sequential_id"
     t.index ["status"], name: "index_invoices_on_status"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/calculate-revenue-share

 ## Context

Current problem: companies with **partners** selling for them cannot have a **revenue share** system in Lago.

We want to propose **self-billing** into Lago, a billing arrangement where the **customer** creates and issues the invoice on **behalf** of the **supplier** for goods or services received.

 ## Description

Add `account_type` enum to customers.

Add `self_billed` flag to invoices