### PR TITLE
feat(revshare): Create customers with partner as account_type

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -100,6 +100,7 @@ module Api
 
       def create_params
         params.require(:customer).permit(
+          :account_type,
           :external_id,
           :name,
           :firstname,

--- a/app/graphql/types/customers/account_type_enum.rb
+++ b/app/graphql/types/customers/account_type_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Customers
+    class AccountTypeEnum < Types::BaseEnum
+      graphql_name "CustomerAccountTypeEnum"
+
+      Customer::ACCOUNT_TYPES.keys.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/customers/create_customer_input.rb
+++ b/app/graphql/types/customers/create_customer_input.rb
@@ -5,6 +5,7 @@ module Types
     class CreateCustomerInput < BaseInputObject
       description 'Create Customer input arguments'
 
+      argument :account_type, Types::Customers::AccountTypeEnum, required: false
       argument :address_line1, String, required: false
       argument :address_line2, String, required: false
       argument :city, String, required: false

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -7,6 +7,7 @@ module Types
 
       field :id, ID, null: false
 
+      field :account_type, Types::Customers::AccountTypeEnum, null: false
       field :customer_type, Types::Customers::CustomerTypeEnum
       field :display_name, String, null: false
       field :external_id, String, null: false

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -20,10 +20,17 @@ class Customer < ApplicationRecord
     individual: 'individual'
   }.freeze
 
+  ACCOUNT_TYPES = {
+    customer: 'customer',
+    partner: 'partner'
+  }.freeze
+
   attribute :finalize_zero_amount_invoice, :integer
   enum finalize_zero_amount_invoice: FINALIZE_ZERO_AMOUNT_INVOICE_OPTIONS, _prefix: :finalize_zero_amount_invoice
   attribute :customer_type, :string
   enum customer_type: CUSTOMER_TYPES, _prefix: :customer_type
+  attribute :account_type, :string
+  enum account_type: ACCOUNT_TYPES, _suffix: :account
 
   before_save :ensure_slug
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -63,7 +63,7 @@ class Organization < ApplicationRecord
   ].freeze
 
   INTEGRATIONS = %w[
-    netsuite okta anrok xero progressive_billing hubspot auto_dunning revenue_analytics salesforce api_permissions
+    netsuite okta anrok xero progressive_billing hubspot auto_dunning revenue_analytics salesforce api_permissions revenue_share
   ].freeze
   PREMIUM_INTEGRATIONS = INTEGRATIONS - %w[anrok]
 
@@ -138,6 +138,10 @@ class Organization < ApplicationRecord
 
   def auto_dunning_enabled?
     License.premium? && premium_integrations.include?("auto_dunning")
+  end
+
+  def revenue_share_enabled?
+    License.premium? && premium_integrations.include?("revenue_share")
   end
 
   def reset_customers_last_dunning_campaign_attempt

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -6,6 +6,7 @@ module V1
       payload = {
         lago_id: model.id,
         external_id: model.external_id,
+        account_type: model.account_type,
         name: model.name,
         firstname: model.firstname,
         lastname: model.lastname,

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -56,6 +56,12 @@ module Customers
         customer.firstname = params[:firstname] if params.key?(:firstname)
         customer.lastname = params[:lastname] if params.key?(:lastname)
         customer.customer_type = params[:customer_type] if params.key?(:customer_type)
+
+        if customer.organization.revenue_share_enabled?
+          customer.account_type = params[:account_type] if params.key?(:account_type)
+          customer.exclude_from_dunning_campaign = customer.partner_account?
+        end
+
         if params.key?(:tax_identification_number)
           customer.tax_identification_number = params[:tax_identification_number]
         end
@@ -168,6 +174,11 @@ module Customers
         lastname: args[:lastname],
         customer_type: args[:customer_type]
       )
+
+      if customer&.organization&.revenue_share_enabled?
+        customer.account_type = args[:account_type] if args.key?(:account_type)
+        customer.exclude_from_dunning_campaign = customer.partner_account?
+      end
 
       if args.key?(:finalize_zero_amount_invoice)
         customer.finalize_zero_amount_invoice = args[:finalize_zero_amount_invoice]

--- a/schema.graphql
+++ b/schema.graphql
@@ -4444,6 +4444,7 @@ enum IntegrationTypeEnum {
   okta
   progressive_billing
   revenue_analytics
+  revenue_share
   salesforce
   xero
 }
@@ -6426,6 +6427,7 @@ enum PremiumIntegrationTypeEnum {
   okta
   progressive_billing
   revenue_analytics
+  revenue_share
   salesforce
   xero
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -1951,6 +1951,7 @@ input CreateCreditNoteInput {
 Create Customer input arguments
 """
 input CreateCustomerInput {
+  accountType: CustomerAccountTypeEnum
   addressLine1: String
   addressLine2: String
   billingConfiguration: CustomerBillingConfigurationInput
@@ -3207,6 +3208,8 @@ type CurrentVersion {
 }
 
 type Customer {
+  accountType: CustomerAccountTypeEnum!
+
   """
   Number of active subscriptions per customer
   """
@@ -3322,6 +3325,11 @@ type Customer {
   url: String
   xeroCustomer: XeroCustomer
   zipcode: String
+}
+
+enum CustomerAccountTypeEnum {
+  customer
+  partner
 }
 
 type CustomerAddress {

--- a/schema.json
+++ b/schema.json
@@ -7066,6 +7066,18 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "accountType",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "CustomerAccountTypeEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "addressLine1",
               "description": null,
               "type": {
@@ -12474,6 +12486,22 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "accountType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CustomerAccountTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "activeSubscriptionsCount",
               "description": "Number of active subscriptions per customer",
               "type": {
@@ -13389,6 +13417,29 @@
           ],
           "inputFields": null,
           "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "CustomerAccountTypeEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "customer",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "partner",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
         },
         {
           "kind": "OBJECT",

--- a/schema.json
+++ b/schema.json
@@ -20492,6 +20492,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "revenue_share",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -30487,6 +30493,12 @@
             },
             {
               "name": "api_permissions",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "revenue_share",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/types/customers/account_type_enum_spec.rb
+++ b/spec/graphql/types/customers/account_type_enum_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Customers::AccountTypeEnum do
+  it "enumerizes the correct values" do
+    expect(described_class.values.keys).to match_array(%w[customer partner])
+  end
+end

--- a/spec/graphql/types/customers/create_customer_input_spec.rb
+++ b/spec/graphql/types/customers/create_customer_input_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Types::Customers::CreateCustomerInput do
   subject { described_class }
 
+  it { is_expected.to accept_argument(:account_type).of_type(Types::Customers::AccountTypeEnum) }
   it { is_expected.to accept_argument(:address_line1).of_type('String') }
   it { is_expected.to accept_argument(:address_line2).of_type('String') }
   it { is_expected.to accept_argument(:city).of_type('String') }

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Types::Customers::Object do
 
   it { is_expected.to have_field(:id).of_type('ID!') }
 
+  it { is_expected.to have_field(:account_type).of_type("CustomerAccountTypeEnum!") }
   it { is_expected.to have_field(:customer_type).of_type(Types::Customers::CustomerTypeEnum) }
   it { is_expected.to have_field(:display_name).of_type('String!') }
   it { is_expected.to have_field(:external_id).of_type('String!') }

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -236,6 +236,36 @@ RSpec.describe Customer, type: :model do
     end
   end
 
+  describe "account_type enum" do
+    subject(:customer) { build_stubbed(:customer, account_type:) }
+
+    context "when account_type is customer" do
+      let(:account_type) { "customer" }
+
+      it "identifies the customer as a customer" do
+        expect(customer.account_type).to eq("customer")
+        expect(customer).to be_customer_account
+      end
+    end
+
+    context "when account_type is partner" do
+      let(:account_type) { "partner" }
+
+      it "identifies the customer as partner" do
+        expect(customer.account_type).to eq("partner")
+        expect(customer).to be_partner_account
+      end
+    end
+
+    context "when account_type is nil" do
+      subject(:customer) { build(:customer) }
+
+      it "defaults to customer for existing customers" do
+        expect(customer.account_type).to eq "customer"
+      end
+    end
+  end
+
   describe 'preferred_document_locale' do
     subject(:customer) do
       described_class.new(

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -222,23 +222,11 @@ RSpec.describe Organization, type: :model do
   end
 
   describe "#auto_dunning_enabled?" do
-    subject(:auto_dunning_enabled?) { organization.auto_dunning_enabled? }
+    it_behaves_like "organization premium feature", "auto_dunning"
+  end
 
-    it { is_expected.to eq(false) }
-
-    context "when premium features are enabled" do
-      around { |test| lago_premium!(&test) }
-
-      it { is_expected.to eq(false) }
-
-      context "with auto_dunning integration is enabled" do
-        let(:organization) do
-          described_class.new(premium_integrations: ["auto_dunning"])
-        end
-
-        it { is_expected.to eq(true) }
-      end
-    end
+  describe "#revenue_share_enabled?" do
+    it_behaves_like "organization premium feature", "revenue_share"
   end
 
   describe "#reset_customers_last_dunning_campaign_attempt" do

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -28,17 +28,16 @@ RSpec.describe Api::V1::CustomersController, type: :request do
 
       expect(response).to have_http_status(:success)
 
-      aggregate_failures do
-        expect(json[:customer][:lago_id]).to be_present
-        expect(json[:customer][:external_id]).to eq(create_params[:external_id])
-        expect(json[:customer][:name]).to eq(create_params[:name])
-        expect(json[:customer][:firstname]).to eq(create_params[:firstname])
-        expect(json[:customer][:lastname]).to eq(create_params[:lastname])
-        expect(json[:customer][:customer_type]).to eq(create_params[:customer_type])
-        expect(json[:customer][:created_at]).to be_present
-        expect(json[:customer][:currency]).to eq(create_params[:currency])
-        expect(json[:customer][:external_salesforce_id]).to eq(create_params[:external_salesforce_id])
-      end
+      expect(json[:customer][:lago_id]).to be_present
+      expect(json[:customer][:external_id]).to eq(create_params[:external_id])
+      expect(json[:customer][:name]).to eq(create_params[:name])
+      expect(json[:customer][:firstname]).to eq(create_params[:firstname])
+      expect(json[:customer][:lastname]).to eq(create_params[:lastname])
+      expect(json[:customer][:customer_type]).to eq(create_params[:customer_type])
+      expect(json[:customer][:created_at]).to be_present
+      expect(json[:customer][:currency]).to eq(create_params[:currency])
+      expect(json[:customer][:external_salesforce_id]).to eq(create_params[:external_salesforce_id])
+      expect(json[:customer][:account_type]).to eq("customer")
     end
 
     context 'with premium features' do
@@ -190,6 +189,29 @@ RSpec.describe Api::V1::CustomersController, type: :request do
             expect(billing[:provider_payment_methods]).to eq(%w[sepa_debit])
           end
         end
+      end
+    end
+
+    context "with account_type partner" do
+      let(:organization) { create(:organization, premium_integrations: ["revenue_share"]) }
+
+      let(:create_params) do
+        {
+          external_id: SecureRandom.uuid,
+          name: "Foo Bar",
+          account_type: "partner"
+        }
+      end
+
+      around { |test| lago_premium!(&test) }
+
+      it 'returns a success' do
+        subject
+        expect(response).to have_http_status(:success)
+
+        expect(json[:customer][:lago_id]).to be_present
+        expect(json[:customer][:external_id]).to eq(create_params[:external_id])
+        expect(json[:customer][:account_type]).to eq(create_params[:account_type])
       end
     end
 

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe ::V1::CustomerSerializer do
     aggregate_failures do
       expect(result['customer']['lago_id']).to eq(customer.id)
       expect(result['customer']['external_id']).to eq(customer.external_id)
+      expect(result['customer']['account_type']).to eq(customer.account_type)
       expect(result['customer']['name']).to eq(customer.name)
       expect(result['customer']['firstname']).to eq(customer.firstname)
       expect(result['customer']['lastname']).to eq(customer.lastname)

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Customers::CreateService, type: :service do
   let(:user) { nil }
 
   let(:membership) { create(:membership, organization:) }
-  let(:organization) { create(:organization)}
+  let(:organization) { create(:organization) }
   let(:external_id) { SecureRandom.uuid }
 
   describe 'create_from_api' do

--- a/spec/support/shared_examples/organization_feature_spec.rb
+++ b/spec/support/shared_examples/organization_feature_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "organization premium feature" do |feature_name|
+  subject { organization.public_send("#{feature_name}_enabled?") }
+
+  it { is_expected.to eq(false) }
+
+  context "when premium features are enabled" do
+    around { |test| lago_premium!(&test) }
+
+    it { is_expected.to eq(false) }
+
+    context "with #{feature_name} integration enabled" do
+      let(:organization) do
+        described_class.new(premium_integrations: [feature_name])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+  end
+end


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/calculate-revenue-share

 ## Context

Current problem: companies with **partners** selling for them cannot have a **revenue share** system in Lago.

We want to propose **self-billing** into Lago, a billing arrangement where the **customer** creates and issues the invoice on **behalf** of the **supplier** for goods or services received.

 ## Description

define `revenue_share` premium integration for organizations

Create customers with account_type partner when revenue share premium integration is enabled.

GraphQL and API v1 accepts and returns customer account_type.