### PR TITLE
feat(revshare): Skip self billed invoices in analytics

### DIFF
--- a/app/models/analytics/gross_revenue.rb
+++ b/app/models/analytics/gross_revenue.rb
@@ -57,6 +57,7 @@ module Analytics
             LEFT JOIN customers c ON i.customer_id = c.id
             LEFT JOIN credit_notes cn ON cn.invoice_id = i.id
             WHERE i.organization_id = :organization_id
+            AND i.self_billed IS FALSE
             AND i.status = 1
             AND i.payment_dispute_lost_at IS NULL
             #{and_external_customer_id_sql}

--- a/app/models/analytics/invoice_collection.rb
+++ b/app/models/analytics/invoice_collection.rb
@@ -56,6 +56,7 @@ module Analytics
             FROM invoices i
             LEFT JOIN customers c ON i.customer_id = c.id
             WHERE i.organization_id = :organization_id
+            AND i.self_billed IS FALSE
             AND i.status = 1
             AND i.payment_dispute_lost_at IS NULL
             #{and_external_customer_id_sql}

--- a/app/models/analytics/invoiced_usage.rb
+++ b/app/models/analytics/invoiced_usage.rb
@@ -49,6 +49,7 @@ module Analytics
             LEFT JOIN customers c ON c.id = s.customer_id
             WHERE f.invoiceable_type = 'Charge'
             AND f.fee_type = 0
+            AND i.self_billed IS FALSE
             AND i.payment_dispute_lost_at IS NULL
             AND c.organization_id = :organization_id
           ),

--- a/app/models/analytics/mrr.rb
+++ b/app/models/analytics/mrr.rb
@@ -63,6 +63,7 @@ module Analytics
             LEFT JOIN plans p ON p.id = s.plan_id
             WHERE fee_type = 2
               AND c.organization_id = :organization_id
+              AND i.self_billed IS FALSE
               AND i.status = 1
               AND i.payment_dispute_lost_at IS NULL
             ORDER BY issuing_date ASC

--- a/app/models/analytics/overdue_balance.rb
+++ b/app/models/analytics/overdue_balance.rb
@@ -54,6 +54,7 @@ module Analytics
             FROM invoices i
             LEFT JOIN customers c ON i.customer_id = c.id
             WHERE i.organization_id = :organization_id
+            AND i.self_billed IS FALSE
             AND i.payment_overdue IS TRUE
             #{and_external_customer_id_sql}
             GROUP BY month, i.currency, total_amount_cents


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/calculate-revenue-share

 ## Context

Current problem: companies with **partners** selling for them cannot have a **revenue share** system in Lago.

We want to propose **self-billing** into Lago, a billing arrangement where the **customer** creates and issues the invoice on **behalf** of the **supplier** for goods or services received.

 ## Description

Ignore self billed invoices in analytics