### PR TITLE
feat(revshare): self billed invoice creation and skip payments

### DIFF
--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -27,6 +27,7 @@ module V1
         prepaid_credit_amount_cents: model.prepaid_credit_amount_cents,
         file_url: model.file_url,
         version_number: model.version_number,
+        self_billed: model.self_billed,
         created_at: model.created_at.iso8601,
         updated_at: model.updated_at.iso8601
       }

--- a/app/services/invoices/create_generating_service.rb
+++ b/app/services/invoices/create_generating_service.rb
@@ -27,7 +27,8 @@ module Invoices
           issuing_date:,
           payment_due_date:,
           net_payment_term: customer.applicable_net_payment_term,
-          skip_charges:
+          skip_charges:,
+          self_billed: customer.partner_account?
         )
         result.invoice = invoice
 

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -97,6 +97,7 @@ module Invoices
       end
 
       def should_process_payment?
+        return false if invoice.self_billed?
         return false if invoice.payment_succeeded? || invoice.voided?
         return false if current_payment_provider.blank?
 

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -56,5 +56,9 @@ FactoryBot.define do
         end
       end
     end
+
+    trait :self_billed do
+      self_billed { true }
+    end
   end
 end

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe ::V1::InvoiceSerializer do
           }
         ],
         "version_number" => 4,
+        "self_billed" => invoice.self_billed,
         "created_at" => invoice.created_at.iso8601,
         "updated_at" => invoice.updated_at.iso8601
       )

--- a/spec/services/invoices/create_generating_service_spec.rb
+++ b/spec/services/invoices/create_generating_service_spec.rb
@@ -118,5 +118,15 @@ RSpec.describe Invoices::CreateGeneratingService, type: :service do
         end
       end
     end
+
+    context "when customer is a partner account" do
+      let(:customer) { create(:customer, account_type: "partner") }
+
+      it "creates an invoice with self billed" do
+        result = create_service.call
+
+        expect(result.invoice.self_billed).to eq(true)
+      end
+    end
   end
 end

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
               message: "error",
               error_code: "code"
             }
-          ).on_queue(:webhook)
+          ).on_queue(:webhook_worker)
       end
 
       context "when payment has a payable_payment_status" do

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
               message: "error",
               error_code: "code"
             }
-          ).on_queue(:webhook_worker)
+          ).on_queue(:webhook)
       end
 
       context "when payment has a payable_payment_status" do

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -97,6 +97,21 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
       end
     end
 
+    context "when invoice is self_billed" do
+      let(:invoice) do
+        create(:invoice, :self_billed, customer:, organization:, total_amount_cents: 100)
+      end
+
+      it "does not creates a payment" do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.invoice).to eq(invoice)
+        expect(result.payment).to be_nil
+        expect(provider_class).not_to have_received(:new)
+      end
+    end
+
     context "when invoice is payment_succeeded" do
       before { invoice.payment_succeeded! }
 


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/calculate-revenue-share

 ## Context

Current problem: companies with **partners** selling for them cannot have a **revenue share** system in Lago.

We want to propose **self-billing** into Lago, a billing arrangement where the **customer** creates and issues the invoice on **behalf** of the **supplier** for goods or services received.

 ## Description

expose self_billed attribute in v1 invoices serializer

create invoice as self_billed when customer is a partner

skip payment creation for self_billed invoices.