### PR TITLE
Add taxes to recreated recurring pay in advance fees

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -189,7 +189,7 @@ module Invoices
           charge:,
           subscription:,
           boundaries:,
-          apply_taxes: !invoice.customer.anrok_customer.present?
+          apply_taxes: invoice.customer.anrok_customer.blank?
         ).raise_if_error!
 
         result.non_invoiceable_fees.concat(fee_result.fees)

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -184,7 +184,13 @@ module Invoices
         .find_each do |charge|
         next if should_not_create_charge_fee?(charge, subscription)
 
-        fee_result = Fees::ChargeService.call(invoice: nil, charge:, subscription:, boundaries:).raise_if_error!
+        fee_result = Fees::ChargeService.call(
+          invoice: nil,
+          charge:,
+          subscription:,
+          boundaries:,
+          apply_taxes: !invoice.customer.anrok_customer.present?
+        ).raise_if_error!
 
         result.non_invoiceable_fees.concat(fee_result.fees)
       end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -321,11 +321,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         it 'creates a charge fee' do
           result = invoice_service.call
 
-          aggregate_failures do
-            expect(result).to be_success
-
-            expect(Fee.charge.where(invoice_id: nil).count).to eq(1)
-          end
+          expect(result).to be_success
+          expect(Fee.charge.where(invoice_id: nil).count).to eq(1)
         end
       end
 


### PR DESCRIPTION
## Context

Currently we had an issue that pay in advance, non-invoiceable and recurring fees are missing taxes when recreated at next billing period for subscription. This PR partially fixes it by applying defined in Lago taxes.
There will be another part addressing taxes via Anrok provider.

## Description

Optionally add Lago-defined taxes for charge fees.
