### PR TITLE
Feat(revshare): self billed invoices - do not trigger integrations

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -331,7 +331,7 @@ class Invoice < ApplicationRecord
   end
 
   def should_sync_invoice?
-    finalized? && customer.integration_customers.accounting_kind.any? { |c| c.integration.sync_invoices }
+    !self_billed && finalized? && customer.integration_customers.accounting_kind.any? { |c| c.integration.sync_invoices }
   end
 
   def should_sync_hubspot_invoice?
@@ -339,11 +339,11 @@ class Invoice < ApplicationRecord
   end
 
   def should_sync_salesforce_invoice?
-    finalized? && customer.integration_customers.salesforce_kind.any?
+    f!self_billed && inalized? && customer.integration_customers.salesforce_kind.any?
   end
 
   def should_update_hubspot_invoice?
-    customer.integration_customers.hubspot_kind.any? { |c| c.integration.sync_invoices }
+    !self_billed && customer.integration_customers.hubspot_kind.any? { |c| c.integration.sync_invoices }
   end
 
   def document_invoice_name

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -339,7 +339,7 @@ class Invoice < ApplicationRecord
   end
 
   def should_sync_salesforce_invoice?
-    !self_billed && inalized? && customer.integration_customers.salesforce_kind.any?
+    !self_billed && finalized? && customer.integration_customers.salesforce_kind.any?
   end
 
   def should_update_hubspot_invoice?

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -339,7 +339,7 @@ class Invoice < ApplicationRecord
   end
 
   def should_sync_salesforce_invoice?
-    f!self_billed && inalized? && customer.integration_customers.salesforce_kind.any?
+    !self_billed && inalized? && customer.integration_customers.salesforce_kind.any?
   end
 
   def should_update_hubspot_invoice?

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -389,6 +389,7 @@ RSpec.describe Invoice, type: :model do
 
         context 'when invoice is self_billed' do
           let(:invoice) { create(:invoice, customer:, organization:, status:, self_billed: true) }
+          let(:sync_invoices) { true }
 
           it 'returns false' do
             expect(method_call).to eq(false)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -265,6 +265,15 @@ RSpec.describe Invoice, type: :model do
             expect(method_call).to eq(false)
           end
         end
+
+        context 'when the invoice is self_billed' do
+          let(:invoice) { create(:invoice, customer:, organization:, status:, self_billed: true) }
+          let(:sync_invoices) { true }
+
+          it 'returns false' do
+            expect(method_call).to eq(false)
+          end
+        end
       end
     end
   end
@@ -283,6 +292,14 @@ RSpec.describe Invoice, type: :model do
 
       it 'returns true' do
         expect(method_call).to eq(true)
+      end
+
+      context 'when the invoice is self-billed' do
+        let(:invoice) { create(:invoice, customer:, organization:, status: :finalized, self_billed: true) }
+
+        it 'returns false' do
+          expect(method_call).to eq(false)
+        end
       end
     end
 
@@ -369,6 +386,14 @@ RSpec.describe Invoice, type: :model do
             expect(method_call).to eq(false)
           end
         end
+
+        context 'when invoice is self_billed' do
+          let(:invoice) { create(:invoice, customer:, organization:, status:, self_billed: true) }
+
+          it 'returns false' do
+            expect(method_call).to eq(false)
+          end
+        end
       end
     end
   end
@@ -437,6 +462,14 @@ RSpec.describe Invoice, type: :model do
 
           it 'returns true' do
             expect(method_call).to eq(true)
+          end
+
+          context 'when invoice is self_billed' do
+            let(:invoice) { create(:invoice, customer:, organization:, status:, self_billed: true) }
+
+            it 'returns false' do
+              expect(method_call).to eq(false)
+            end
           end
         end
 

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
               message: "error",
               error_code: "code"
             }
-          ).on_queue(:webhook)
+          ).on_queue(:webhook_worker)
       end
 
       context "when payment has a payable_payment_status" do

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
               message: "error",
               error_code: "code"
             }
-          ).on_queue(:webhook_worker)
+          ).on_queue(:webhook)
       end
 
       context "when payment has a payable_payment_status" do


### PR DESCRIPTION
## Canny link
👉 https://getlago.canny.io/feature-requests/p/calculate-revenue-share

## Context

Self-billed invoices should not be reported to Hubspot and Salesforce 

## Description

in definition of methods that return if invoice should be synced, added condition to skip self-billed invoices
