### PR TITLE
feat(invoice-preview): add logic for applying coupons on preview invoice

### DIFF
--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -32,6 +32,13 @@ class AppliedCoupon < ApplicationRecord
     self.terminated_at ||= timestamp
     terminated!
   end
+
+  def remaining_amount
+    return @remaining_amount if defined?(@remaining_amount)
+
+    already_applied_amount = credits.sum(&:amount_cents)
+    @remaining_amount = amount_cents - already_applied_amount
+  end
 end
 
 # == Schema Information

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -162,6 +162,12 @@ class Fee < ApplicationRecord
     end
   end
 
+  def compute_precise_credit_amount_cents(credit_amount, base_amount_cents)
+    return 0 if base_amount_cents.zero?
+
+    (credit_amount * (amount_cents - precise_coupons_amount_cents)).fdiv(base_amount_cents)
+  end
+
   def sub_total_excluding_taxes_amount_cents
     amount_cents - precise_coupons_amount_cents
   end

--- a/app/services/applied_coupons/amount_service.rb
+++ b/app/services/applied_coupons/amount_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module AppliedCoupons
+  class AmountService < BaseService
+    def initialize(applied_coupon:, base_amount_cents:)
+      @applied_coupon = applied_coupon
+      @base_amount_cents = base_amount_cents
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'applied_coupon') unless applied_coupon
+
+      result.amount = compute_amount
+      result
+    end
+
+    private
+
+    attr_reader :applied_coupon, :base_amount_cents
+
+    def compute_amount
+      if applied_coupon.coupon.percentage?
+        discounted_value = base_amount_cents * applied_coupon.percentage_rate.fdiv(100)
+
+        return (discounted_value >= base_amount_cents) ? base_amount_cents : discounted_value.round
+      end
+
+      if applied_coupon.recurring? || applied_coupon.forever?
+        return base_amount_cents if applied_coupon.amount_cents > base_amount_cents
+
+        applied_coupon.amount_cents
+      else
+        return base_amount_cents if applied_coupon.remaining_amount > base_amount_cents
+
+        applied_coupon.remaining_amount
+      end
+    end
+  end
+end

--- a/app/services/coupons/preview_service.rb
+++ b/app/services/coupons/preview_service.rb
@@ -26,7 +26,6 @@ module Coupons
         base_amount_cents = base_amount_cents(applied_coupon, fees)
         credit = add_credit(applied_coupon, fees, base_amount_cents)
 
-        applied_coupon.credits << credit
         result.credits << credit
         invoice.credits << credit
       end

--- a/app/services/coupons/preview_service.rb
+++ b/app/services/coupons/preview_service.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Coupons
+  class PreviewService < BaseService
+    def initialize(invoice:, applied_coupons:)
+      @invoice = invoice
+      @applied_coupons = applied_coupons
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'invoice') unless invoice
+      return result.not_found_failure!(resource: 'applied_coupons') unless applied_coupons
+
+      result.credits = []
+
+      applied_coupons.each do |applied_coupon|
+        break unless invoice.sub_total_excluding_taxes_amount_cents&.positive?
+        next unless invoice.currency == applied_coupon.amount_currency
+
+        fees = fees(applied_coupon)
+
+        next if fees.none?
+
+        base_amount_cents = base_amount_cents(applied_coupon, fees)
+        credit = add_credit(applied_coupon, fees, base_amount_cents)
+
+        applied_coupon.credits << credit
+        result.credits << credit
+        invoice.credits << credit
+      end
+
+      result.invoice = invoice
+      result
+    end
+
+    private
+
+    attr_reader :applied_coupons, :invoice
+
+    def add_credit(applied_coupon, fees, base_amount_cents)
+      credit_amount = AppliedCoupons::AmountService.call(applied_coupon:, base_amount_cents:).amount
+      new_credit = Credit.new(
+        invoice:,
+        applied_coupon:,
+        amount_cents: credit_amount,
+        amount_currency: invoice.currency,
+        before_taxes: true
+      )
+
+      fees.each do |fee|
+        unless base_amount_cents.zero?
+          fee.precise_coupons_amount_cents += fee.compute_precise_credit_amount_cents(credit_amount, base_amount_cents)
+        end
+
+        fee.precise_coupons_amount_cents = fee.amount_cents if fee.amount_cents < fee.precise_coupons_amount_cents
+      end
+
+      invoice.coupons_amount_cents += new_credit.amount_cents
+      invoice.sub_total_excluding_taxes_amount_cents -= new_credit.amount_cents
+
+      new_credit
+    end
+
+    def base_amount_cents(applied_coupon, fees)
+      if applied_coupon.coupon.limited_billable_metrics? || applied_coupon.coupon.limited_plans?
+        fees.sum(&:amount_cents)
+      else
+        invoice.sub_total_excluding_taxes_amount_cents
+      end
+    end
+
+    # TODO: update later when charges will be added to the preview
+    def fees(applied_coupon)
+      if applied_coupon.coupon.limited_billable_metrics?
+        Fee.none
+      elsif applied_coupon.coupon.limited_plans?
+        plan_related_fees(applied_coupon)
+      else
+        invoice.fees
+      end
+    end
+
+    def plan_related_fees(applied_coupon)
+      if applied_coupon.coupon.plans.map(&:id).include?(invoice.subscriptions[0].plan_id)
+        invoice.fees
+      else
+        Fee.none
+      end
+    end
+  end
+end

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -6,4 +6,15 @@ RSpec.describe AppliedCoupon, type: :model do
   subject(:applied_coupon) { build(:applied_coupon) }
 
   it_behaves_like 'paper_trail traceable'
+
+  describe '#remaining_amount' do
+    let(:credit) { build(:credit, applied_coupon:, amount_cents: 10) }
+    let(:applied_coupon) { build(:applied_coupon, amount_cents: 50) }
+
+    it 'returns correct amount' do
+      applied_coupon.credits = [credit]
+
+      expect(applied_coupon.remaining_amount).to eq(40)
+    end
+  end
 end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -403,6 +403,14 @@ RSpec.describe Fee, type: :model do
     end
   end
 
+  describe 'compute_precise_credit_amount_cents' do
+    subject(:fee) { create(:add_on_fee, amount_cents: 500, precise_coupons_amount_cents: 100) }
+
+    it 'returns correct value' do
+      expect(fee.compute_precise_credit_amount_cents(10, 5)).to eq(800)
+    end
+  end
+
   describe '#creditable_amount_cents' do
     let(:fee) { create(:fee, fee_type:, amount_cents:, invoice:) }
     let(:invoice) { create(:invoice, invoice_type: :credit) }

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -409,6 +409,12 @@ RSpec.describe Fee, type: :model do
     it 'returns correct value' do
       expect(fee.compute_precise_credit_amount_cents(10, 5)).to eq(800)
     end
+
+    context 'when base_amount_cents is zero' do
+      it 'returns zero' do
+        expect(fee.compute_precise_credit_amount_cents(10, 0)).to eq(0)
+      end
+    end
   end
 
   describe '#creditable_amount_cents' do

--- a/spec/services/applied_coupons/amount_service_spec.rb
+++ b/spec/services/applied_coupons/amount_service_spec.rb
@@ -17,10 +17,8 @@ RSpec.describe AppliedCoupons::AmountService do
     it 'calculates amount' do
       result = amount_service.call
 
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.amount).to eq(12)
-      end
+      expect(result).to be_success
+      expect(result.amount).to eq(12)
     end
 
     context 'when base_amount_cents is equal to 0' do
@@ -57,10 +55,8 @@ RSpec.describe AppliedCoupons::AmountService do
       it 'applies the remaining amount' do
         result = amount_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.amount).to eq(6)
-        end
+        expect(result).to be_success
+        expect(result.amount).to eq(6)
       end
     end
 
@@ -74,10 +70,8 @@ RSpec.describe AppliedCoupons::AmountService do
       it 'calculates amount' do
         result = amount_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.amount).to eq(60)
-        end
+        expect(result).to be_success
+        expect(result.amount).to eq(60)
       end
     end
 
@@ -98,10 +92,8 @@ RSpec.describe AppliedCoupons::AmountService do
       it 'calculates amount' do
         result = amount_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.amount).to eq(12)
-        end
+        expect(result).to be_success
+        expect(result.amount).to eq(12)
       end
 
       context 'when coupon amount is higher than invoice amount' do
@@ -133,10 +125,8 @@ RSpec.describe AppliedCoupons::AmountService do
       it 'calculates amount' do
         result = amount_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.amount).to eq(12)
-        end
+        expect(result).to be_success
+        expect(result.amount).to eq(12)
       end
 
       context 'when coupon amount is higher than invoice amount' do
@@ -170,10 +160,8 @@ RSpec.describe AppliedCoupons::AmountService do
       it 'calculates amount' do
         result = amount_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.amount).to eq(60)
-        end
+        expect(result).to be_success
+        expect(result.amount).to eq(60)
       end
     end
   end

--- a/spec/services/applied_coupons/amount_service_spec.rb
+++ b/spec/services/applied_coupons/amount_service_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AppliedCoupons::AmountService do
+  subject(:amount_service) do
+    described_class.new(applied_coupon: , base_amount_cents:)
+  end
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:base_amount_cents) { 300 }
+  let(:coupon) { create(:coupon, organization:) }
+  let(:applied_coupon) { create(:applied_coupon, amount_cents: 12, coupon:, customer:) }
+
+  describe 'call' do
+    it 'calculates amount' do
+      result = amount_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.amount).to eq(12)
+      end
+    end
+
+    context 'when base_amount_cents is equal to 0' do
+      let(:base_amount_cents) { 0 }
+
+      it 'limits the amount to the invoice amount' do
+        result = amount_service.call
+
+        expect(result).to be_success
+        expect(result.amount).to eq(0)
+      end
+    end
+
+    context 'when coupon amount is higher than invoice amount' do
+      let(:base_amount_cents) { 6 }
+
+      it 'limits the amount to the invoice amount' do
+        result = amount_service.call
+
+        expect(result).to be_success
+        expect(result.amount).to eq(6)
+      end
+    end
+
+    context 'when coupon is partially used' do
+      before do
+        create(
+          :credit,
+          applied_coupon:,
+          amount_cents: 6
+        )
+      end
+
+      it 'applies the remaining amount' do
+        result = amount_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.amount).to eq(6)
+        end
+      end
+    end
+
+    context 'when coupon is percentage' do
+      let(:coupon) { create(:coupon, coupon_type: 'percentage', percentage_rate: 10.00) }
+
+      let(:applied_coupon) do
+        create(:applied_coupon, coupon:, percentage_rate: 20.00)
+      end
+
+      it 'calculates amount' do
+        result = amount_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.amount).to eq(60)
+        end
+      end
+    end
+
+    context 'when coupon is recurring and fixed amount' do
+      let(:coupon) { create(:coupon, frequency: 'recurring', frequency_duration: 3) }
+
+      let(:applied_coupon) do
+        create(
+          :applied_coupon,
+          coupon:,
+          frequency: 'recurring',
+          frequency_duration: 3,
+          frequency_duration_remaining: 3,
+          amount_cents: 12
+        )
+      end
+
+      it 'calculates amount' do
+        result = amount_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.amount).to eq(12)
+        end
+      end
+
+      context 'when coupon amount is higher than invoice amount' do
+        let(:base_amount_cents) { 6 }
+
+        it 'limits the amount to the invoice amount' do
+          result = amount_service.call
+
+          expect(result).to be_success
+          expect(result.amount).to eq(6)
+        end
+      end
+    end
+
+    context 'when coupon is forever and fixed amount' do
+      let(:coupon) { create(:coupon, frequency: 'forever', frequency_duration: 0) }
+
+      let(:applied_coupon) do
+        create(
+          :applied_coupon,
+          coupon:,
+          frequency: 'forever',
+          frequency_duration: 0,
+          frequency_duration_remaining: 0,
+          amount_cents: 12
+        )
+      end
+
+      it 'calculates amount' do
+        result = amount_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.amount).to eq(12)
+        end
+      end
+
+      context 'when coupon amount is higher than invoice amount' do
+        let(:base_amount_cents) { 6 }
+
+        it 'limits the amount to the invoice amount' do
+          result = amount_service.call
+
+          expect(result).to be_success
+          expect(result.amount).to eq(6)
+        end
+      end
+    end
+
+    context 'when coupon is recurring and percentage' do
+      let(:coupon) do
+        create(:coupon, frequency: 'recurring', frequency_duration: 3, coupon_type: 'percentage', percentage_rate: 10)
+      end
+
+      let(:applied_coupon) do
+        create(
+          :applied_coupon,
+          coupon:,
+          frequency: 'recurring',
+          frequency_duration: 3,
+          frequency_duration_remaining: 3,
+          percentage_rate: 20.00
+        )
+      end
+
+      it 'calculates amount' do
+        result = amount_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.amount).to eq(60)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/applied_coupons/amount_service_spec.rb
+++ b/spec/services/applied_coupons/amount_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AppliedCoupons::AmountService do
   subject(:amount_service) do
-    described_class.new(applied_coupon: , base_amount_cents:)
+    described_class.new(applied_coupon:, base_amount_cents:)
   end
 
   let(:organization) { create(:organization) }

--- a/spec/services/coupons/preview_service_spec.rb
+++ b/spec/services/coupons/preview_service_spec.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Coupons::PreviewService do
+  subject(:preview_service) { described_class.new(invoice:, applied_coupons:) }
+
+  let(:invoice) do
+    build(
+      :invoice,
+      fees_amount_cents: 100,
+      sub_total_excluding_taxes_amount_cents: 100,
+      currency: 'EUR',
+      customer: subscription.customer
+    )
+  end
+
+  let(:subscription) do
+    build(
+      :subscription,
+      plan:,
+      billing_time: :calendar,
+      subscription_at: started_at,
+      started_at:,
+      created_at:,
+      status: :active
+    )
+  end
+  let(:started_at) { Time.zone.now - 2.years }
+  let(:created_at) { started_at }
+
+  describe '#call' do
+    let(:timestamp) { Time.zone.now.beginning_of_month }
+    let(:fee) { build(:fee, amount_cents: 100, invoice:, subscription:) }
+    let(:applied_coupon) do
+      build(
+        :applied_coupon,
+        customer: subscription.customer,
+        amount_cents: 10,
+        amount_currency: plan.amount_currency
+      )
+    end
+    let(:coupon_latest) { build(:coupon, coupon_type: 'percentage', percentage_rate: 10.00) }
+    let(:applied_coupon_latest) do
+      build(
+        :applied_coupon,
+        coupon: coupon_latest,
+        customer: subscription.customer,
+        percentage_rate: 20.00
+      )
+    end
+    let(:applied_coupons) do
+      [
+        applied_coupon,
+        applied_coupon_latest
+      ]
+    end
+
+    let(:plan) { create(:plan, interval: 'monthly') }
+
+    before do
+      invoice.subscriptions = [subscription]
+      invoice.fees = [fee]
+      applied_coupon
+      applied_coupon_latest
+    end
+
+    it 'updates the invoice accordingly' do
+      result = preview_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.invoice.coupons_amount_cents).to eq(28)
+        expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(72)
+        expect(result.invoice.credits.length).to eq(2)
+      end
+    end
+
+    context 'when first coupon covers the invoice' do
+      let(:invoice) do
+        build(
+          :invoice,
+          fees_amount_cents: 5,
+          sub_total_excluding_taxes_amount_cents: 5,
+          currency: 'EUR',
+          customer: subscription.customer
+        )
+      end
+
+      before { fee.amount_cents = 5 }
+
+      it 'updates the invoice accordingly and spends only the first coupon' do
+        result = preview_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice.coupons_amount_cents).to eq(5)
+          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(0)
+          expect(result.invoice.credits.length).to eq(1)
+        end
+      end
+    end
+
+    context 'when both coupons are fixed amount' do
+      let(:coupon_latest) { build(:coupon, coupon_type: 'fixed_amount') }
+      let(:applied_coupon_latest) do
+        create(
+          :applied_coupon,
+          coupon: coupon_latest,
+          customer: subscription.customer,
+          amount_cents: 20,
+          amount_currency: plan.amount_currency
+        )
+      end
+
+      it 'updates the invoice accordingly' do
+        result = preview_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice.coupons_amount_cents).to eq(30)
+          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(70)
+          expect(result.invoice.credits.length).to eq(2)
+        end
+      end
+    end
+
+    context 'when both coupons are percentage' do
+      let(:coupon) { build(:coupon, coupon_type: 'percentage', percentage_rate: 10.00) }
+      let(:applied_coupon) do
+        build(
+          :applied_coupon,
+          coupon:,
+          customer: subscription.customer,
+          percentage_rate: 15.00
+        )
+      end
+
+      it 'updates the invoice accordingly' do
+        result = preview_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice.coupons_amount_cents).to eq(32)
+          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(68)
+          expect(result.invoice.credits.length).to eq(2)
+        end
+      end
+    end
+
+    context 'when coupon has a difference currency' do
+      let(:applied_coupons) { [applied_coupon] }
+      let(:applied_coupon) do
+        build(
+          :applied_coupon,
+          customer: subscription.customer,
+          amount_cents: 10,
+          amount_currency: 'NOK'
+        )
+      end
+
+      it 'ignores the coupon' do
+        result = preview_service.call
+
+        expect(result).to be_success
+        expect(result.invoice.credits.length).to be_zero
+      end
+    end
+
+    context 'when both coupons have plan limitations which are not applicable' do
+      let(:coupon) { build(:coupon, coupon_type: 'fixed_amount', limited_plans: true) }
+      let(:coupon_plan) { build(:coupon_plan, coupon:, plan: create(:plan)) }
+      let(:applied_coupon) do
+        build(
+          :applied_coupon,
+          coupon:,
+          customer: subscription.customer,
+          amount_cents: 10,
+          amount_currency: plan.amount_currency
+        )
+      end
+      let(:coupon_latest) { build(:coupon, coupon_type: 'fixed_amount', limited_plans: true) }
+      let(:coupon_plan_latest) { build(:coupon_plan, coupon: coupon_latest, plan: create(:plan)) }
+      let(:applied_coupon_latest) do
+        build(
+          :applied_coupon,
+          coupon: coupon_latest,
+          customer: subscription.customer,
+          amount_cents: 20,
+          amount_currency: plan.amount_currency
+        )
+      end
+
+      before do
+        coupon_plan
+        coupon_plan_latest
+      end
+
+      it 'ignores coupons' do
+        result = preview_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice.coupons_amount_cents).to eq(0)
+          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(100)
+          expect(result.invoice.credits.length).to be_zero
+        end
+      end
+    end
+
+    context 'when only one coupon is applicable due to plan limitations' do
+      let(:coupon) { build(:coupon, coupon_type: 'fixed_amount', limited_plans: true) }
+      let(:coupon_plan) { build(:coupon_plan, coupon:, plan: create(:plan)) }
+      let(:applied_coupon) do
+        build(
+          :applied_coupon,
+          coupon:,
+          customer: subscription.customer,
+          amount_cents: 10,
+          amount_currency: plan.amount_currency
+        )
+      end
+      let(:coupon_latest) { build(:coupon, coupon_type: 'fixed_amount', limited_plans: true) }
+      let(:coupon_plan_latest) { build(:coupon_plan, coupon: coupon_latest, plan:) }
+      let(:applied_coupon_latest) do
+        build(
+          :applied_coupon,
+          coupon: coupon_latest,
+          customer: subscription.customer,
+          amount_cents: 20,
+          amount_currency: plan.amount_currency
+        )
+      end
+
+      before do
+        coupon_plan
+        coupon_plan_latest
+        coupon.plans = []
+        coupon_latest.plans = [plan]
+      end
+
+      it 'ignores only one coupon and applies the other one' do
+        result = preview_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice.coupons_amount_cents).to eq(20)
+          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(80)
+          expect(result.invoice.credits.length).to eq(1)
+        end
+      end
+    end
+
+    context 'when both coupons are applicable due to plan limitations' do
+      let(:coupon) { build(:coupon, coupon_type: 'fixed_amount', limited_plans: true) }
+      let(:coupon_plan) { build(:coupon_plan, coupon:, plan:) }
+      let(:applied_coupon) do
+        build(
+          :applied_coupon,
+          coupon:,
+          customer: subscription.customer,
+          amount_cents: 10,
+          amount_currency: plan.amount_currency
+        )
+      end
+      let(:coupon_latest) { build(:coupon, coupon_type: 'fixed_amount', limited_plans: true) }
+      let(:coupon_plan_latest) { build(:coupon_plan, coupon: coupon_latest, plan:) }
+      let(:applied_coupon_latest) do
+        build(
+          :applied_coupon,
+          coupon: coupon_latest,
+          customer: subscription.customer,
+          amount_cents: 20,
+          amount_currency: plan.amount_currency
+        )
+      end
+
+      before do
+        coupon_plan
+        coupon_plan_latest
+        coupon.plans = [plan]
+        coupon_latest.plans = [plan]
+      end
+
+      it 'applies two coupons' do
+        result = preview_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice.coupons_amount_cents).to eq(30)
+          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(70)
+          expect(result.invoice.credits.length).to eq(2)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/coupons/preview_service_spec.rb
+++ b/spec/services/coupons/preview_service_spec.rb
@@ -68,12 +68,10 @@ RSpec.describe Coupons::PreviewService do
     it 'updates the invoice accordingly' do
       result = preview_service.call
 
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.invoice.coupons_amount_cents).to eq(28)
-        expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(72)
-        expect(result.invoice.credits.length).to eq(2)
-      end
+      expect(result).to be_success
+      expect(result.invoice.coupons_amount_cents).to eq(28)
+      expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(72)
+      expect(result.invoice.credits.length).to eq(2)
     end
 
     context 'when first coupon covers the invoice' do
@@ -92,12 +90,10 @@ RSpec.describe Coupons::PreviewService do
       it 'updates the invoice accordingly and spends only the first coupon' do
         result = preview_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.invoice.coupons_amount_cents).to eq(5)
-          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(0)
-          expect(result.invoice.credits.length).to eq(1)
-        end
+        expect(result).to be_success
+        expect(result.invoice.coupons_amount_cents).to eq(5)
+        expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(0)
+        expect(result.invoice.credits.length).to eq(1)
       end
     end
 
@@ -116,12 +112,10 @@ RSpec.describe Coupons::PreviewService do
       it 'updates the invoice accordingly' do
         result = preview_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.invoice.coupons_amount_cents).to eq(30)
-          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(70)
-          expect(result.invoice.credits.length).to eq(2)
-        end
+        expect(result).to be_success
+        expect(result.invoice.coupons_amount_cents).to eq(30)
+        expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(70)
+        expect(result.invoice.credits.length).to eq(2)
       end
     end
 
@@ -139,12 +133,10 @@ RSpec.describe Coupons::PreviewService do
       it 'updates the invoice accordingly' do
         result = preview_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.invoice.coupons_amount_cents).to eq(32)
-          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(68)
-          expect(result.invoice.credits.length).to eq(2)
-        end
+        expect(result).to be_success
+        expect(result.invoice.coupons_amount_cents).to eq(32)
+        expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(68)
+        expect(result.invoice.credits.length).to eq(2)
       end
     end
 
@@ -199,12 +191,10 @@ RSpec.describe Coupons::PreviewService do
       it 'ignores coupons' do
         result = preview_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.invoice.coupons_amount_cents).to eq(0)
-          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(100)
-          expect(result.invoice.credits.length).to be_zero
-        end
+        expect(result).to be_success
+        expect(result.invoice.coupons_amount_cents).to eq(0)
+        expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(100)
+        expect(result.invoice.credits.length).to be_zero
       end
     end
 
@@ -242,12 +232,10 @@ RSpec.describe Coupons::PreviewService do
       it 'ignores only one coupon and applies the other one' do
         result = preview_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.invoice.coupons_amount_cents).to eq(20)
-          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(80)
-          expect(result.invoice.credits.length).to eq(1)
-        end
+        expect(result).to be_success
+        expect(result.invoice.coupons_amount_cents).to eq(20)
+        expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(80)
+        expect(result.invoice.credits.length).to eq(1)
       end
     end
 
@@ -285,12 +273,10 @@ RSpec.describe Coupons::PreviewService do
       it 'applies two coupons' do
         result = preview_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.invoice.coupons_amount_cents).to eq(30)
-          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(70)
-          expect(result.invoice.credits.length).to eq(2)
-        end
+        expect(result).to be_success
+        expect(result.invoice.coupons_amount_cents).to eq(30)
+        expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(70)
+        expect(result.invoice.credits.length).to eq(2)
       end
     end
   end

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -51,19 +51,16 @@ RSpec.describe Invoices::PreviewService, type: :service do
         travel_to(timestamp) do
           result = preview_service.call
 
-          aggregate_failures do
-            expect(result).to be_success
-
-            expect(result.invoice.subscriptions.first).to eq(subscription)
-            expect(result.invoice.fees.length).to eq(1)
-            expect(result.invoice.invoice_type).to eq('subscription')
-            expect(result.invoice.issuing_date.to_s).to eq('2024-04-01')
-            expect(result.invoice.fees_amount_cents).to eq(6)
-            expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(6)
-            expect(result.invoice.taxes_amount_cents).to eq(3)
-            expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(9)
-            expect(result.invoice.total_amount_cents).to eq(9)
-          end
+          expect(result).to be_success
+          expect(result.invoice.subscriptions.first).to eq(subscription)
+          expect(result.invoice.fees.length).to eq(1)
+          expect(result.invoice.invoice_type).to eq('subscription')
+          expect(result.invoice.issuing_date.to_s).to eq('2024-04-01')
+          expect(result.invoice.fees_amount_cents).to eq(6)
+          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(6)
+          expect(result.invoice.taxes_amount_cents).to eq(3)
+          expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(9)
+          expect(result.invoice.total_amount_cents).to eq(9)
         end
       end
 
@@ -81,21 +78,18 @@ RSpec.describe Invoices::PreviewService, type: :service do
           travel_to(timestamp) do
             result = described_class.new(customer:, subscription:, applied_coupons: [applied_coupon]).call
 
-            aggregate_failures do
-              expect(result).to be_success
-
-              expect(result.invoice.subscriptions.first).to eq(subscription)
-              expect(result.invoice.fees.length).to eq(1)
-              expect(result.invoice.invoice_type).to eq('subscription')
-              expect(result.invoice.issuing_date.to_s).to eq('2024-04-01')
-              expect(result.invoice.fees_amount_cents).to eq(6)
-              expect(result.invoice.coupons_amount_cents).to eq(2)
-              expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(4)
-              expect(result.invoice.taxes_amount_cents).to eq(2)
-              expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(6)
-              expect(result.invoice.total_amount_cents).to eq(6)
-              expect(result.invoice.credits.length).to eq(1)
-            end
+            expect(result).to be_success
+            expect(result.invoice.subscriptions.first).to eq(subscription)
+            expect(result.invoice.fees.length).to eq(1)
+            expect(result.invoice.invoice_type).to eq('subscription')
+            expect(result.invoice.issuing_date.to_s).to eq('2024-04-01')
+            expect(result.invoice.fees_amount_cents).to eq(6)
+            expect(result.invoice.coupons_amount_cents).to eq(2)
+            expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(4)
+            expect(result.invoice.taxes_amount_cents).to eq(2)
+            expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(6)
+            expect(result.invoice.total_amount_cents).to eq(6)
+            expect(result.invoice.credits.length).to eq(1)
           end
         end
       end
@@ -108,19 +102,16 @@ RSpec.describe Invoices::PreviewService, type: :service do
         travel_to(timestamp) do
           result = preview_service.call
 
-          aggregate_failures do
-            expect(result).to be_success
-
-            expect(result.invoice.subscriptions.first).to eq(subscription)
-            expect(result.invoice.fees.length).to eq(1)
-            expect(result.invoice.invoice_type).to eq('subscription')
-            expect(result.invoice.issuing_date.to_s).to eq('2024-04-30')
-            expect(result.invoice.fees_amount_cents).to eq(100)
-            expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(100)
-            expect(result.invoice.taxes_amount_cents).to eq(50)
-            expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(150)
-            expect(result.invoice.total_amount_cents).to eq(150)
-          end
+          expect(result).to be_success
+          expect(result.invoice.subscriptions.first).to eq(subscription)
+          expect(result.invoice.fees.length).to eq(1)
+          expect(result.invoice.invoice_type).to eq('subscription')
+          expect(result.invoice.issuing_date.to_s).to eq('2024-04-30')
+          expect(result.invoice.fees_amount_cents).to eq(100)
+          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(100)
+          expect(result.invoice.taxes_amount_cents).to eq(50)
+          expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(150)
+          expect(result.invoice.total_amount_cents).to eq(150)
         end
       end
     end

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -66,6 +66,39 @@ RSpec.describe Invoices::PreviewService, type: :service do
           end
         end
       end
+
+      context 'with applied coupons' do
+        let(:applied_coupon) do
+          build(
+            :applied_coupon,
+            customer: subscription.customer,
+            amount_cents: 2,
+            amount_currency: plan.amount_currency
+          )
+        end
+
+        it 'creates preview invoice for 2 days with applied coupons' do
+          travel_to(timestamp) do
+            result = described_class.new(customer:, subscription:, applied_coupons: [applied_coupon]).call
+
+            aggregate_failures do
+              expect(result).to be_success
+
+              expect(result.invoice.subscriptions.first).to eq(subscription)
+              expect(result.invoice.fees.length).to eq(1)
+              expect(result.invoice.invoice_type).to eq('subscription')
+              expect(result.invoice.issuing_date.to_s).to eq('2024-04-01')
+              expect(result.invoice.fees_amount_cents).to eq(6)
+              expect(result.invoice.coupons_amount_cents).to eq(2)
+              expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(4)
+              expect(result.invoice.taxes_amount_cents).to eq(2)
+              expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(6)
+              expect(result.invoice.total_amount_cents).to eq(6)
+              expect(result.invoice.credits.length).to eq(1)
+            end
+          end
+        end
+      end
     end
 
     context 'with anniversary billing' do


### PR DESCRIPTION
## Context

Preview feature enables fetching first Lago invoice. This invoice is not persisted and is calculated on the fly.

## Description

This PR adds service for applying coupons on preview invoice. The goal was not to affect heavily main service for applying coupons on invoices.

In order not to repeat the code, some common logic is extracted  s that it can be used on both places
