### PR TITLE
feat(revshare): update customer account_type

### DIFF
--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -7,6 +7,7 @@ module Types
 
       argument :id, ID, required: true
 
+      argument :account_type, Types::Customers::AccountTypeEnum, required: false
       argument :address_line1, String, required: false, permission: 'customers:update'
       argument :address_line2, String, required: false, permission: 'customers:update'
       argument :city, String, required: false, permission: 'customers:update'

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -106,6 +106,11 @@ module Customers
         end
       end
 
+      if customer.partner_account?
+        customer.exclude_from_dunning_campaign = true
+        customer.applied_dunning_campaign = nil
+      end
+
       ActiveRecord::Base.transaction do
         if old_provider_customer && args[:payment_provider].nil? && args[:payment_provider_code].present?
           old_provider_customer.discard!

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -2,6 +2,7 @@
 
 module Customers
   class UpdateService < BaseService
+    extend Forwardable
     include Customers::PaymentProviderFinder
 
     def initialize(customer:, args:)
@@ -90,10 +91,16 @@ module Customers
         Customers::UpdateInvoicePaymentDueDateService.call(customer:, net_payment_term: args[:net_payment_term])
       end
 
-      # NOTE: external_id is not editable if customer is attached to subscriptions
-      customer.external_id = args[:external_id] if customer.editable? && args.key?(:external_id)
+      # NOTE: external_id and account_type are not editable if customer is attached to subscriptions
+      if customer.editable?
+        customer.external_id = args[:external_id] if args.key?(:external_id)
 
-      if customer.organization.auto_dunning_enabled?
+        if organization.revenue_share_enabled?
+          customer.account_type = args[:account_type] if args.key?(:account_type)
+        end
+      end
+
+      if organization.auto_dunning_enabled?
         if args.key?(:applied_dunning_campaign_id)
           customer.applied_dunning_campaign = applied_dunning_campaign
           customer.exclude_from_dunning_campaign = false
@@ -106,6 +113,7 @@ module Customers
         end
       end
 
+      # NOTE: partner accounts are excluded from dunning campaigns
       if customer.partner_account?
         customer.exclude_from_dunning_campaign = true
         customer.applied_dunning_campaign = nil
@@ -130,7 +138,7 @@ module Customers
         customer.save!
         customer.reload
 
-        if customer.organization.eu_tax_management
+        if organization.eu_tax_management
           eu_tax_code = Customers::EuAutoTaxesService.call(customer:)
 
           args[:tax_codes] ||= []
@@ -175,6 +183,7 @@ module Customers
     private
 
     attr_reader :customer, :args
+    def_delegators :customer, :organization
 
     def valid_metadata_count?(metadata:)
       return true if metadata.blank?

--- a/schema.graphql
+++ b/schema.graphql
@@ -8376,6 +8376,7 @@ input UpdateCreditNoteInput {
 Update Customer input arguments
 """
 input UpdateCustomerInput {
+  accountType: CustomerAccountTypeEnum
   addressLine1: String
   addressLine2: String
   applicableInvoiceCustomSectionIds: [ID!]

--- a/schema.json
+++ b/schema.json
@@ -39152,6 +39152,18 @@
               "deprecationReason": null
             },
             {
+              "name": "accountType",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "CustomerAccountTypeEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "addressLine1",
               "description": null,
               "type": {

--- a/spec/graphql/types/customers/update_customer_input_spec.rb
+++ b/spec/graphql/types/customers/update_customer_input_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Types::Customers::UpdateCustomerInput do
 
   it { is_expected.to accept_argument(:id).of_type('ID!') }
 
+  it { is_expected.to accept_argument(:account_type).of_type(Types::Customers::AccountTypeEnum) }
   it { is_expected.to accept_argument(:address_line1).of_type('String') }
   it { is_expected.to accept_argument(:address_line2).of_type('String') }
   it { is_expected.to accept_argument(:city).of_type('String') }

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Customers::UpdateService, type: :service do
 
       let(:account_type) { "partner" }
 
-      it "updates the customer without changing the account_type" do
+      it "does not change the account_type" do
         result = customers_service.call
 
         updated_customer = result.customer

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -146,7 +146,6 @@ RSpec.describe Customers::UpdateService, type: :service do
             expect(updated_customer).to be_customer_account
           end
         end
-
       end
     end
 

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -50,16 +50,47 @@ RSpec.describe Customers::UpdateService, type: :service do
       end
     end
 
+    context "when updating account_type to partner" do
+      let(:customer) do
+        create(
+          :customer,
+          organization:,
+          exclude_from_dunning_campaign: false,
+          applied_dunning_campaign: dunning_campaign
+        )
+      end
+
+      let(:dunning_campaign) { create(:dunning_campaign) }
+
+      let(:organization) do
+        create(:organization, premium_integrations: ["auto_dunning"])
+      end
+
+      let(:account_type) { "partner" }
+
+      it "updates the customer without changing the account_type" do
+        result = customers_service.call
+
+        updated_customer = result.customer
+        expect(updated_customer.name).to eq(update_args[:name])
+        expect(updated_customer).to be_customer_account
+        expect(updated_customer).not_to be_exclude_from_dunning_campaign
+        expect(updated_customer.applied_dunning_campaign).to eq dunning_campaign
+      end
+    end
+
     context 'with premium features' do
       around { |test| lago_premium!(&test) }
 
       let(:update_args) do
         {
           id: customer.id,
+          name: "Updated customer name",
           timezone: 'Europe/Paris',
           billing_configuration: {
             invoice_grace_period: 3
-          }
+          },
+          account_type:
         }
       end
 
@@ -73,6 +104,49 @@ RSpec.describe Customers::UpdateService, type: :service do
           billing = update_args[:billing_configuration]
           expect(updated_customer.invoice_grace_period).to eq(billing[:invoice_grace_period])
         end
+      end
+
+      context "when revenue_share feature is enabled and updates account_type to partner" do
+        let(:organization) do
+          create(:organization, premium_integrations: %w[revenue_share auto_dunning])
+        end
+
+        let(:customer) do
+          create(
+            :customer,
+            organization:,
+            exclude_from_dunning_campaign: false,
+            applied_dunning_campaign: dunning_campaign
+          )
+        end
+
+        let(:dunning_campaign) { create(:dunning_campaign) }
+
+        let(:account_type) { "partner" }
+
+        it "updates the customer as partner" do
+          result = customers_service.call
+
+          updated_customer = result.customer
+          expect(updated_customer.name).to eq(update_args[:name])
+          expect(updated_customer).to be_partner_account
+          expect(updated_customer).to be_exclude_from_dunning_campaign
+          expect(updated_customer.applied_dunning_campaign).to be_nil
+        end
+
+        context "when customer is attached to a subscription" do
+          before do
+            create(:subscription, customer:)
+          end
+
+          it "does not update the account_type" do
+            result = customers_service.call
+
+            updated_customer = result.customer
+            expect(updated_customer).to be_customer_account
+          end
+        end
+
       end
     end
 
@@ -569,34 +643,6 @@ RSpec.describe Customers::UpdateService, type: :service do
             expect(result.error.error_code).to eq("dunning_campaign_not_found")
           end
         end
-      end
-    end
-
-    context "when updating account_type to partner" do
-      let(:customer) do
-        create(
-          :customer,
-          organization:,
-          exclude_from_dunning_campaign: false,
-          applied_dunning_campaign: dunning_campaign
-        )
-      end
-
-      let(:dunning_campaign) { create(:dunning_campaign) }
-
-      let(:organization) do
-        create(:organization, premium_integrations: ["auto_dunning"])
-      end
-
-      let(:account_type) { "partner" }
-
-      it "updates the customer" do
-        result = customers_service.call
-
-        updated_customer = result.customer
-        expect(updated_customer).to be_partner_account
-        expect(updated_customer).to be_exclude_from_dunning_campaign
-        expect(updated_customer.applied_dunning_campaign).to be_nil
       end
     end
   end


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/calculate-revenue-share

 ## Context

Current problem: companies with **partners** selling for them cannot have a **revenue share** system in Lago.

We want to propose **self-billing** into Lago, a billing arrangement where the **customer** creates and issues the invoice on **behalf** of the **supplier** for goods or services received.

 ## Description

applies customer account_type updates when customer is editable and feature is enabled.

as side effect excludes customer from dunning campaigns (not applicable to partners)