### PR TITLE
chore: Use enum with positional arguments

### DIFF
--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -13,7 +13,7 @@ class AdjustedFee < ApplicationRecord
     :adjusted_amount
   ].freeze
 
-  enum fee_type: Fee::FEE_TYPES
+  enum :fee_type, Fee::FEE_TYPES
 
   def adjusted_display_name?
     adjusted_units.blank? && adjusted_amount.blank?

--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -20,8 +20,8 @@ class AppliedCoupon < ApplicationRecord
     :forever
   ].freeze
 
-  enum status: STATUSES
-  enum frequency: FREQUENCIES
+  enum :status, STATUSES
+  enum :frequency, FREQUENCIES
 
   monetize :amount_cents, disable_validation: true, allow_nil: true
 

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -31,9 +31,9 @@ class BillableMetric < ApplicationRecord
 
   WEIGHTED_INTERVAL = {seconds: "seconds"}.freeze
 
-  enum aggregation_type: AGGREGATION_TYPES
-  enum rounding_function: ROUNDING_FUNCTIONS
-  enum weighted_interval: WEIGHTED_INTERVAL
+  enum :aggregation_type, AGGREGATION_TYPES
+  enum :rounding_function, ROUNDING_FUNCTIONS
+  enum :weighted_interval, WEIGHTED_INTERVAL
 
   validate :validate_recurring
   validate :validate_expression

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -31,8 +31,8 @@ class Charge < ApplicationRecord
 
   REGROUPING_PAID_FEES_OPTIONS = %i[invoice].freeze
 
-  enum charge_model: CHARGE_MODELS
-  enum regroup_paid_fees: REGROUPING_PAID_FEES_OPTIONS
+  enum :charge_model, CHARGE_MODELS
+  enum :regroup_paid_fees, REGROUPING_PAID_FEES_OPTIONS
 
   validate :validate_amount, if: -> { standard? }
   validate :validate_graduated, if: -> { graduated? }

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -9,7 +9,7 @@ class Commitment < ApplicationRecord
     minimum_commitment: 0
   }.freeze
 
-  enum commitment_type: COMMITMENT_TYPES
+  enum :commitment_type, COMMITMENT_TYPES
 
   monetize :amount_cents, disable_validation: true, allow_nil: true
 

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -35,10 +35,10 @@ class Coupon < ApplicationRecord
     :forever
   ].freeze
 
-  enum status: STATUSES
-  enum expiration: EXPIRATION_TYPES
-  enum coupon_type: COUPON_TYPES
-  enum frequency: FREQUENCIES
+  enum :status, STATUSES
+  enum :expiration, EXPIRATION_TYPES
+  enum :coupon_type, COUPON_TYPES
+  enum :frequency, FREQUENCIES
 
   monetize :amount_cents, disable_validation: true, allow_nil: true
 

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -48,10 +48,10 @@ class CreditNote < ApplicationRecord
   REASON = %i[duplicated_charge product_unsatisfactory order_change order_cancellation fraudulent_charge other].freeze
   STATUS = %i[draft finalized].freeze
 
-  enum credit_status: CREDIT_STATUS
-  enum refund_status: REFUND_STATUS
-  enum reason: REASON
-  enum status: STATUS
+  enum :credit_status, CREDIT_STATUS
+  enum :refund_status, REFUND_STATUS
+  enum :reason, REASON
+  enum :status, STATUS
 
   sequenced scope: ->(credit_note) { CreditNote.where(invoice_id: credit_note.invoice_id) },
     lock_key: ->(credit_note) { credit_note.invoice_id }

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -26,11 +26,11 @@ class Customer < ApplicationRecord
   }.freeze
 
   attribute :finalize_zero_amount_invoice, :integer
-  enum finalize_zero_amount_invoice: FINALIZE_ZERO_AMOUNT_INVOICE_OPTIONS, _prefix: :finalize_zero_amount_invoice
+  enum :finalize_zero_amount_invoice, FINALIZE_ZERO_AMOUNT_INVOICE_OPTIONS, prefix: :finalize_zero_amount_invoice
   attribute :customer_type, :string
-  enum customer_type: CUSTOMER_TYPES, _prefix: :customer_type
+  enum :customer_type, CUSTOMER_TYPES, prefix: :customer_type
   attribute :account_type, :string
-  enum account_type: ACCOUNT_TYPES, _suffix: :account
+  enum :account_type, ACCOUNT_TYPES, suffix: :account
 
   before_save :ensure_slug
 

--- a/app/models/error_detail.rb
+++ b/app/models/error_detail.rb
@@ -9,7 +9,7 @@ class ErrorDetail < ApplicationRecord
   belongs_to :organization
 
   ERROR_CODES = %w[not_provided tax_error tax_voiding_error]
-  enum error_code: ERROR_CODES
+  enum :error_code, ERROR_CODES
 end
 
 # == Schema Information

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -41,8 +41,8 @@ class Fee < ApplicationRecord
   FEE_TYPES = %i[charge add_on subscription credit commitment].freeze
   PAYMENT_STATUS = %i[pending succeeded failed refunded].freeze
 
-  enum fee_type: FEE_TYPES
-  enum payment_status: PAYMENT_STATUS, _prefix: :payment
+  enum :fee_type, FEE_TYPES
+  enum :payment_status, PAYMENT_STATUS, prefix: :payment
 
   validates :amount_currency, inclusion: {in: currency_list}
   validates :units, numericality: {greater_than_or_equal_to: 0}

--- a/app/models/integration_collection_mappings/base_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/base_collection_mapping.rb
@@ -13,7 +13,7 @@ module IntegrationCollectionMappings
       fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit credit_note account
     ].freeze
 
-    enum mapping_type: MAPPING_TYPES
+    enum :mapping_type, MAPPING_TYPES
 
     validates :mapping_type, uniqueness: {scope: :integration_id}
 

--- a/app/models/integration_item.rb
+++ b/app/models/integration_item.rb
@@ -11,7 +11,7 @@ class IntegrationItem < ApplicationRecord
     :account
   ].freeze
 
-  enum item_type: ITEM_TYPES
+  enum :item_type, ITEM_TYPES
 
   validates :external_id, presence: true, uniqueness: {scope: %i[integration_id item_type]}
 

--- a/app/models/integration_resource.rb
+++ b/app/models/integration_resource.rb
@@ -8,7 +8,7 @@ class IntegrationResource < ApplicationRecord
 
   RESOURCE_TYPES = %i[invoice sales_order_deprecated payment credit_note subscription].freeze
 
-  enum resource_type: RESOURCE_TYPES
+  enum :resource_type, RESOURCE_TYPES
 end
 
 # == Schema Information

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -12,8 +12,8 @@ class Invite < ApplicationRecord
     revoked
   ].freeze
 
-  enum status: INVITE_STATUS
-  enum role: Membership::ROLES
+  enum :status, INVITE_STATUS
+  enum :role, Membership::ROLES
 
   validates :email, email: true
   validates :token, uniqueness: true

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -73,12 +73,12 @@ class Invoice < ApplicationRecord
   STATUS = VISIBLE_STATUS.merge(INVISIBLE_STATUS).freeze
   GENERATED_INVOICE_STATUSES = %w[finalized closed].freeze
 
-  enum invoice_type: INVOICE_TYPES
-  enum payment_status: PAYMENT_STATUS, _prefix: :payment
-  enum status: STATUS
+  enum :invoice_type, INVOICE_TYPES
+  enum :payment_status, PAYMENT_STATUS, prefix: :payment
+  enum :status, STATUS
 
   attribute :tax_status, :string
-  enum tax_status: TAX_STATUSES, _prefix: :tax
+  enum :tax_status, TAX_STATUSES, prefix: :tax
 
   aasm column: 'status', timestamps: true do
     state :generating

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -22,7 +22,7 @@ class InvoiceSubscription < ApplicationRecord
     progressive_billing: 'progressive_billing'
   }.freeze
 
-  enum invoicing_reason: INVOICING_REASONS
+  enum :invoicing_reason, INVOICING_REASONS
 
   scope :order_by_charges_to_datetime,
     lambda {

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -19,8 +19,8 @@ class Membership < ApplicationRecord
     finance: 2
   }.freeze
 
-  enum status: STATUSES
-  enum role: ROLES
+  enum :status, STATUSES
+  enum :role, ROLES
 
   validates :user_id, uniqueness: {conditions: -> { where(revoked_at: nil) }, scope: :organization_id}
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -67,7 +67,7 @@ class Organization < ApplicationRecord
   ].freeze
   PREMIUM_INTEGRATIONS = INTEGRATIONS - %w[anrok]
 
-  enum document_numbering: DOCUMENT_NUMBERINGS
+  enum :document_numbering, DOCUMENT_NUMBERINGS
 
   validates :country, country_code: true, unless: -> { country.nil? }
   validates :default_currency, inclusion: {in: currency_list}

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -23,7 +23,7 @@ class Payment < ApplicationRecord
 
   delegate :customer, to: :payable
 
-  enum payable_payment_status: PAYABLE_PAYMENT_STATUS.map { |s| [s, s] }.to_h
+  enum :payable_payment_status, PAYABLE_PAYMENT_STATUS.map { |s| [s, s] }.to_h
 
   scope :for_organization, lambda { |organization|
     payables_join = ActiveRecord::Base.sanitize_sql_array([

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -16,7 +16,7 @@ class PaymentRequest < ApplicationRecord
 
   PAYMENT_STATUS = %i[pending succeeded failed].freeze
 
-  enum payment_status: PAYMENT_STATUS, _prefix: :payment
+  enum :payment_status, PAYMENT_STATUS, prefix: :payment
 
   alias_attribute :total_amount_cents, :amount_cents
   alias_attribute :currency, :amount_currency

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -32,7 +32,7 @@ class Plan < ApplicationRecord
     quarterly
   ].freeze
 
-  enum interval: INTERVALS
+  enum :interval, INTERVALS
 
   monetize :amount_cents
 

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -22,9 +22,9 @@ class RecurringTransactionRule < ApplicationRecord
     :threshold
   ].freeze
 
-  enum interval: INTERVALS
-  enum method: METHODS
-  enum trigger: TRIGGERS
+  enum :interval, INTERVALS
+  enum :method, METHODS
+  enum :trigger, TRIGGERS
 end
 
 # == Schema Information

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -32,8 +32,8 @@ class Subscription < ApplicationRecord
     anniversary
   ].freeze
 
-  enum status: STATUSES
-  enum billing_time: BILLING_TIME
+  enum :status, STATUSES
+  enum :billing_time, BILLING_TIME
 
   scope :starting_in_the_future, -> { pending.where(previous_subscription: nil) }
 

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -23,7 +23,7 @@ class Wallet < ApplicationRecord
     :terminated
   ].freeze
 
-  enum status: STATUSES
+  enum :status, STATUSES
 
   def mark_as_terminated!(timestamp = Time.zone.now)
     self.terminated_at ||= timestamp

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -32,10 +32,10 @@ class WalletTransaction < ApplicationRecord
     :threshold
   ].freeze
 
-  enum status: STATUSES
-  enum transaction_status: TRANSACTION_STATUSES
-  enum transaction_type: TRANSACTION_TYPES
-  enum source: SOURCES
+  enum :status, STATUSES
+  enum :transaction_status, TRANSACTION_STATUSES
+  enum :transaction_type, TRANSACTION_TYPES
+  enum :source, SOURCES
 
   scope :pending, -> { where(status: :pending) }
 end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -10,7 +10,7 @@ class Webhook < ApplicationRecord
 
   has_one :organization, through: :webhook_endpoint
 
-  enum status: STATUS
+  enum :status, STATUS
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[id webhook_type]

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -15,7 +15,7 @@ class WebhookEndpoint < ApplicationRecord
   validates :webhook_url, uniqueness: {scope: :organization_id}
   validate :max_webhook_endpoints, on: :create
 
-  enum signature_algo: SIGNATURE_ALGOS
+  enum :signature_algo, SIGNATURE_ALGOS
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[webhook_url]


### PR DESCRIPTION
## Context

Let's get ready for Rails 7.2

## Description

I was looking at [Ancor's PR](https://github.com/getlago/lago-api/pull/2894) to upgrade to Rails 7.2 and I thought we could extracted the enum changes to a separate PR since the syntax is already available.

Rails 7.2 will show a warning if we keep using the previous syntax (with a hash) and 8.0 will remove it entirely.

https://blog.saeloun.com/2021/02/26/rails-introduces-new-syntax-for-enum/