### PR TITLE
chore(fees): Add unique index on event transaction id

### DIFF
--- a/.github/workflows/migrations-test.yml
+++ b/.github/workflows/migrations-test.yml
@@ -57,6 +57,10 @@ jobs:
         run: bin/rails db:migrate:primary
       - name: dump schema
         run: LAGO_DISABLE_SCHEMA_DUMP="" bin/rails db:schema:dump:primary
+      - name: Remove dates
+        run: |
+          sed -i 's/[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\} [0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}//g' db/schema.rb
+          sed -i 's/[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\} [0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}//g' db/schema-before-dump.rb
       - name: Ensure no changes to schema.rb
         run: diff db/schema.rb db/schema-before-dump.rb
       - name: Ensure annotations are up to date

--- a/.github/workflows/migrations-test.yml
+++ b/.github/workflows/migrations-test.yml
@@ -57,10 +57,6 @@ jobs:
         run: bin/rails db:migrate:primary
       - name: dump schema
         run: LAGO_DISABLE_SCHEMA_DUMP="" bin/rails db:schema:dump:primary
-      - name: Remove dates
-        run: |
-          sed -i 's/[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\} [0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}//g' db/schema.rb
-          sed -i 's/[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\} [0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}//g' db/schema-before-dump.rb
       - name: Ensure no changes to schema.rb
         run: diff db/schema.rb db/schema-before-dump.rb
       - name: Ensure annotations are up to date

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -257,19 +257,20 @@ end
 #
 # Indexes
 #
-#  index_fees_on_add_on_id                            (add_on_id)
-#  index_fees_on_applied_add_on_id                    (applied_add_on_id)
-#  index_fees_on_charge_filter_id                     (charge_filter_id)
-#  index_fees_on_charge_id                            (charge_id)
-#  index_fees_on_charge_id_and_invoice_id             (charge_id,invoice_id) WHERE (deleted_at IS NULL)
-#  index_fees_on_deleted_at                           (deleted_at)
-#  index_fees_on_group_id                             (group_id)
-#  index_fees_on_invoice_id                           (invoice_id)
-#  index_fees_on_invoiceable                          (invoiceable_type,invoiceable_id)
-#  index_fees_on_organization_id                      (organization_id)
-#  index_fees_on_pay_in_advance_event_transaction_id  (pay_in_advance_event_transaction_id) WHERE (deleted_at IS NULL)
-#  index_fees_on_subscription_id                      (subscription_id)
-#  index_fees_on_true_up_parent_fee_id                (true_up_parent_fee_id)
+#  idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167  (pay_in_advance_event_transaction_id,charge_id,charge_filter_id) UNIQUE WHERE (created_at > '2025-01-20 15:26:22'::timestamp without time zone)
+#  index_fees_on_add_on_id                                         (add_on_id)
+#  index_fees_on_applied_add_on_id                                 (applied_add_on_id)
+#  index_fees_on_charge_filter_id                                  (charge_filter_id)
+#  index_fees_on_charge_id                                         (charge_id)
+#  index_fees_on_charge_id_and_invoice_id                          (charge_id,invoice_id) WHERE (deleted_at IS NULL)
+#  index_fees_on_deleted_at                                        (deleted_at)
+#  index_fees_on_group_id                                          (group_id)
+#  index_fees_on_invoice_id                                        (invoice_id)
+#  index_fees_on_invoiceable                                       (invoiceable_type,invoiceable_id)
+#  index_fees_on_organization_id                                   (organization_id)
+#  index_fees_on_pay_in_advance_event_transaction_id               (pay_in_advance_event_transaction_id) WHERE (deleted_at IS NULL)
+#  index_fees_on_subscription_id                                   (subscription_id)
+#  index_fees_on_true_up_parent_fee_id                             (true_up_parent_fee_id)
 #
 # Foreign Keys
 #

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -257,7 +257,7 @@ end
 #
 # Indexes
 #
-#  idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167  (pay_in_advance_event_transaction_id,charge_id,charge_filter_id) UNIQUE WHERE (created_at > '2025-01-20 15:26:22'::timestamp without time zone)
+#  idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167  (pay_in_advance_event_transaction_id,charge_id,charge_filter_id) UNIQUE WHERE ((created_at > '2025-01-21 15:25:41'::timestamp without time zone) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true))
 #  index_fees_on_add_on_id                                         (add_on_id)
 #  index_fees_on_applied_add_on_id                                 (applied_add_on_id)
 #  index_fees_on_charge_filter_id                                  (charge_filter_id)

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -257,7 +257,7 @@ end
 #
 # Indexes
 #
-#  idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167  (pay_in_advance_event_transaction_id,charge_id,charge_filter_id) UNIQUE WHERE ((created_at > '2025-01-21 15:25:41'::timestamp without time zone) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true))
+#  idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167  (pay_in_advance_event_transaction_id,charge_id,charge_filter_id) UNIQUE WHERE ((created_at > '2025-01-21 00:00:00'::timestamp without time zone) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true))
 #  index_fees_on_add_on_id                                         (add_on_id)
 #  index_fees_on_applied_add_on_id                                 (applied_add_on_id)
 #  index_fees_on_charge_filter_id                                  (charge_filter_id)

--- a/db/migrate/20250120151959_add_unique_event_index_on_fees.rb
+++ b/db/migrate/20250120151959_add_unique_event_index_on_fees.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddUniqueEventIndexOnFees < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :fees, %i[pay_in_advance_event_transaction_id charge_id charge_filter_id], unique: true,
+      where: "created_at > '#{Time.current}'", algorithm: :concurrently
+  end
+end

--- a/db/migrate/20250120151959_add_unique_event_index_on_fees.rb
+++ b/db/migrate/20250120151959_add_unique_event_index_on_fees.rb
@@ -7,7 +7,7 @@ class AddUniqueEventIndexOnFees < ActiveRecord::Migration[7.1]
     add_index :fees,
       %i[pay_in_advance_event_transaction_id charge_id charge_filter_id],
       unique: true,
-      where: "created_at > '#{Time.current}' AND pay_in_advance_event_transaction_id IS NOT NULL AND pay_in_advance = true",
+      where: "created_at > '2025-01-21T00:00:00' AND pay_in_advance_event_transaction_id IS NOT NULL AND pay_in_advance = true",
       algorithm: :concurrently
   end
 end

--- a/db/migrate/20250120151959_add_unique_event_index_on_fees.rb
+++ b/db/migrate/20250120151959_add_unique_event_index_on_fees.rb
@@ -4,7 +4,10 @@ class AddUniqueEventIndexOnFees < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def change
-    add_index :fees, %i[pay_in_advance_event_transaction_id charge_id charge_filter_id], unique: true,
-      where: "created_at > '#{Time.current}'", algorithm: :concurrently
+    add_index :fees,
+      %i[pay_in_advance_event_transaction_id charge_id charge_filter_id],
+      unique: true,
+      where: "created_at > '#{Time.current}' AND pay_in_advance_event_transaction_id IS NOT NULL AND pay_in_advance = true",
+      algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -679,7 +679,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_20_151959) do
     t.index ["invoice_id"], name: "index_fees_on_invoice_id"
     t.index ["invoiceable_type", "invoiceable_id"], name: "index_fees_on_invoiceable"
     t.index ["organization_id"], name: "index_fees_on_organization_id"
-    t.index ["pay_in_advance_event_transaction_id", "charge_id", "charge_filter_id"], name: "idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167", unique: true, where: "((created_at > '2025-01-21 15:25:41'::timestamp without time zone) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true))"
+    t.index ["pay_in_advance_event_transaction_id", "charge_id", "charge_filter_id"], name: "idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167", unique: true, where: "((created_at > '2025-01-21 00:00:00'::timestamp without time zone) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true))"
     t.index ["pay_in_advance_event_transaction_id"], name: "index_fees_on_pay_in_advance_event_transaction_id", where: "(deleted_at IS NULL)"
     t.index ["subscription_id"], name: "index_fees_on_subscription_id"
     t.index ["true_up_parent_fee_id"], name: "index_fees_on_true_up_parent_fee_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_14_172823) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_20_151959) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -679,6 +679,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_14_172823) do
     t.index ["invoice_id"], name: "index_fees_on_invoice_id"
     t.index ["invoiceable_type", "invoiceable_id"], name: "index_fees_on_invoiceable"
     t.index ["organization_id"], name: "index_fees_on_organization_id"
+    t.index ["pay_in_advance_event_transaction_id", "charge_id", "charge_filter_id"], name: "idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167", unique: true, where: "(created_at > '2025-01-20 15:26:22'::timestamp without time zone)"
     t.index ["pay_in_advance_event_transaction_id"], name: "index_fees_on_pay_in_advance_event_transaction_id", where: "(deleted_at IS NULL)"
     t.index ["subscription_id"], name: "index_fees_on_subscription_id"
     t.index ["true_up_parent_fee_id"], name: "index_fees_on_true_up_parent_fee_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -679,7 +679,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_20_151959) do
     t.index ["invoice_id"], name: "index_fees_on_invoice_id"
     t.index ["invoiceable_type", "invoiceable_id"], name: "index_fees_on_invoiceable"
     t.index ["organization_id"], name: "index_fees_on_organization_id"
-    t.index ["pay_in_advance_event_transaction_id", "charge_id", "charge_filter_id"], name: "idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167", unique: true, where: "(created_at > '2025-01-20 15:26:22'::timestamp without time zone)"
+    t.index ["pay_in_advance_event_transaction_id", "charge_id", "charge_filter_id"], name: "idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167", unique: true, where: "((created_at > '2025-01-21 15:25:41'::timestamp without time zone) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true))"
     t.index ["pay_in_advance_event_transaction_id"], name: "index_fees_on_pay_in_advance_event_transaction_id", where: "(deleted_at IS NULL)"
     t.index ["subscription_id"], name: "index_fees_on_subscription_id"
     t.index ["true_up_parent_fee_id"], name: "index_fees_on_true_up_parent_fee_id"


### PR DESCRIPTION
- To prevent duplicate invoicing for in advance charges, we add a unique index based on the `transaction_id` from the event