### PR TITLE
fix(migration): Payment status migration

### DIFF
--- a/db/migrate/20241220095049_backfill_payable_payment_status.rb
+++ b/db/migrate/20241220095049_backfill_payable_payment_status.rb
@@ -43,7 +43,7 @@ class BackfillPayablePaymentStatus < ActiveRecord::Migration[7.1]
       provider_class = provider_type.constantize
 
       payments = Payment.joins(:payment_provider)
-        .where(payment_providers: {type: provider_type}, status: provider_class::PENDING_STATUSES)
+        .where(payment_providers: {type: provider_type}, status: provider_class::PROCESSING_STATUSES)
       payments.update_all(payable_payment_status: :pending) # rubocop:disable Rails/SkipsModelValidations
 
       payments = Payment.joins(:payment_provider)


### PR DESCRIPTION
The issue is related to the merge of https://github.com/getlago/lago-api/pull/2986 created before the migration but turning the `PENDING_STATUSES` constants to `PROCESSING_STATUSES`