### PR TITLE
misc(adjusted_fee): Allow fee adjustement without pre-existing fee

### DIFF
--- a/app/graphql/mutations/adjusted_fees/create.rb
+++ b/app/graphql/mutations/adjusted_fees/create.rb
@@ -16,14 +16,9 @@ module Mutations
       type Types::Fees::Object
 
       def resolve(**args)
-        fee = Fee.find_by(id: args[:fee_id])
+        invoice = current_organization.invoices.find_by(id: args[:invoice_id])
 
-        result = ::AdjustedFees::CreateService.call(
-          organization: current_organization,
-          fee:,
-          params: args
-        )
-
+        result = ::AdjustedFees::CreateService.call(invoice:, params: args)
         result.success? ? result.fee : result_error(result)
       end
     end

--- a/app/graphql/types/adjusted_fees/create_input.rb
+++ b/app/graphql/types/adjusted_fees/create_input.rb
@@ -5,7 +5,16 @@ module Types
     class CreateInput < Types::BaseInputObject
       description 'Create Adjusted Fee Input'
 
-      argument :fee_id, ID, required: true
+      argument :invoice_id, ID, required: true
+
+      # NOTE: adjust an existing fee
+      argument :fee_id, ID, required: false
+
+      # NOTE: adjust a empty charge fee
+      argument :charge_id, ID, required: false
+      argument :charge_filter_id, ID, required: false
+      argument :subscription_id, ID, required: false
+
       argument :invoice_display_name, String, required: false
       argument :unit_precise_amount, String, required: false
       argument :units, GraphQL::Types::Float, required: false

--- a/app/graphql/types/adjusted_fees/create_input.rb
+++ b/app/graphql/types/adjusted_fees/create_input.rb
@@ -11,8 +11,8 @@ module Types
       argument :fee_id, ID, required: false
 
       # NOTE: adjust a empty charge fee
-      argument :charge_id, ID, required: false
       argument :charge_filter_id, ID, required: false
+      argument :charge_id, ID, required: false
       argument :subscription_id, ID, required: false
 
       argument :invoice_display_name, String, required: false

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -41,6 +41,8 @@ module Types
       field :payment_due_date, GraphQL::Types::ISO8601Date, null: false
       field :payment_overdue, Boolean, null: false
 
+      field :all_charges_have_fees, Boolean, null: false, method: :all_charges_have_fees?
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 

--- a/app/services/adjusted_fees/create_service.rb
+++ b/app/services/adjusted_fees/create_service.rb
@@ -65,8 +65,12 @@ module AdjustedFees
 
     def find_existing_fee
       fee = invoice.fees.find_by(id: params[:fee_id])
-      result.not_found_failure!(resource: 'fee') if fee.blank?
-      return fee
+      if fee.blank?
+        result.not_found_failure!(resource: 'fee')
+        return
+      end
+
+      fee
     end
 
     def create_empty_fee
@@ -102,12 +106,16 @@ module AdjustedFees
     def create_fee(subscription, charge)
       invoice_subscription = invoice.invoice_subscriptions.find_by(subscription_id: subscription.id)
 
-      # TODO: fee in advance & boundaries? + amount details
+      boundaries = {
+        timestamp: invoice_subscription.timestamp,
+        charges_from_datetime: invoice_subscription.charges_from_datetime,
+        charges_to_datetime: invoice_subscription.charges_to_datetime
+      }
 
-      Fee.create(
+      Fee.create!(
         organization:,
-        invoice: ,
-        subscription: ,
+        invoice:,
+        subscription:,
         invoiceable: charge,
         charge:,
         charge_filter_id: params[:charge_filter_id],
@@ -124,7 +132,7 @@ module AdjustedFees
         taxes_precise_amount_cents: 0.to_d,
         units: 0,
         total_aggregated_units: 0,
-        properties: {}
+        properties: boundaries
       )
     end
 

--- a/app/services/adjusted_fees/create_service.rb
+++ b/app/services/adjusted_fees/create_service.rb
@@ -2,16 +2,19 @@
 
 module AdjustedFees
   class CreateService < BaseService
-    def initialize(organization:, fee:, params:)
-      @organization = organization
-      @fee = fee
+    def initialize(invoice:, params:)
+      @invoice = invoice
+      @organization = invoice.organization
       @params = params
 
       super
     end
 
     def call
-      return result.forbidden_failure! if !License.premium? || !fee.invoice.draft?
+      return result.forbidden_failure! if !License.premium? || !invoice.draft?
+
+      fee = find_or_create_fee
+      return result unless result.success?
       return result.validation_failure!(errors: {adjusted_fee: ['already_exists']}) if fee.adjusted_fee
 
       charge = fee.charge
@@ -36,11 +39,15 @@ module AdjustedFees
       )
       adjusted_fee.save!
 
-      refresh_result = Invoices::RefreshDraftService.call(invoice: fee.invoice)
+      subscription_id = fee.subscription_id
+      charge_id = fee.charge_id
+      charge_filter_id = fee.charge_filter_id
+
+      refresh_result = Invoices::RefreshDraftService.call(invoice: invoice)
       refresh_result.raise_if_error!
 
-      result.adjusted_fee = adjusted_fee
-      result.fee = fee
+      result.adjusted_fee = adjusted_fee.reload
+      result.fee = invoice.fees.find_by(subscription_id:, charge_id:, charge_filter_id:)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
@@ -48,7 +55,78 @@ module AdjustedFees
 
     private
 
-    attr_reader :organization, :fee, :params
+    attr_reader :organization, :invoice, :params
+
+    def find_or_create_fee
+      return find_existing_fee if params.key?(:fee_id)
+
+      create_empty_fee
+    end
+
+    def find_existing_fee
+      fee = invoice.fees.find_by(id: params[:fee_id])
+      result.not_found_failure!(resource: 'fee') if fee.blank?
+      return fee
+    end
+
+    def create_empty_fee
+      subscription = invoice.subscriptions.includes(plan: {charges: :filters}).find_by(id: params[:subscription_id])
+      unless subscription
+        result.not_found_failure!(resource: 'subscription')
+        return
+      end
+
+      charge = subscription.plan.charges.find { |c| c.id == params[:charge_id] }
+      unless charge
+        result.not_found_failure!(resource: 'charge')
+        return
+      end
+
+      if params[:charge_filter_id].present?
+        charge_filter = charge.filters.find_by(id: params[:charge_filter_id])
+
+        unless charge_filter
+          result.not_found_failure!(resource: 'charge_filter')
+          return
+        end
+      end
+
+      fee = invoice.fees.find_by(
+        subscription_id: subscription.id,
+        charge_id: charge.id,
+        charge_filter_id: params[:charge_filter_id]
+      )
+      fee || create_fee(subscription, charge)
+    end
+
+    def create_fee(subscription, charge)
+      invoice_subscription = invoice.invoice_subscriptions.find_by(subscription_id: subscription.id)
+
+      # TODO: fee in advance & boundaries? + amount details
+
+      Fee.create(
+        organization:,
+        invoice: ,
+        subscription: ,
+        invoiceable: charge,
+        charge:,
+        charge_filter_id: params[:charge_filter_id],
+        grouped_by: {},
+        fee_type: :charge,
+        payment_status: :pending,
+        events_count: 0,
+        amount_currency: invoice.currency,
+        amount_cents: 0,
+        precise_amount_cents: 0.to_d,
+        unit_amount_cents: 0,
+        precise_unit_amount: 0.to_d,
+        taxes_amount_cents: 0,
+        taxes_precise_amount_cents: 0.to_d,
+        units: 0,
+        total_aggregated_units: 0,
+        properties: {}
+      )
+    end
 
     def disabled_charge_model?(charge)
       unit_adjustment = params[:units].present? && params[:unit_precise_amount].blank?

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -131,6 +131,7 @@ module BillableMetrics
         result.count = 0
         result.current_usage_units = 0
         result.options = {running_total: []}
+        result
       end
 
       def empty_results

--- a/app/services/fees/init_from_adjusted_charge_fee_service.rb
+++ b/app/services/fees/init_from_adjusted_charge_fee_service.rb
@@ -34,6 +34,10 @@ module Fees
       adjusted_fee_result.full_units_number = adjusted_fee.units
       adjusted_fee_result.count = 0
 
+      if charge.dynamic?
+        adjusted_fee_result.precise_total_amount_cents = 0
+      end
+
       apply_charge_model_service(adjusted_fee_result)
     end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1830,12 +1830,17 @@ input CreateAddOnInput {
 Create Adjusted Fee Input
 """
 input CreateAdjustedFeeInput {
+  chargeFilterId: ID
+  chargeId: ID
+
   """
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  feeId: ID!
+  feeId: ID
   invoiceDisplayName: String
+  invoiceId: ID!
+  subscriptionId: ID
   unitPreciseAmount: String
   units: Float
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -4493,6 +4493,7 @@ enum InviteStatusTypeEnum {
 Invoice
 """
 type Invoice {
+  allChargesHaveFees: Boolean!
   appliedTaxes: [InvoiceAppliedTax!]
   associatedActiveWalletPresent: Boolean!
   availableToCreditAmountCents: BigInt!

--- a/schema.json
+++ b/schema.json
@@ -6253,7 +6253,7 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "feeId",
+              "name": "invoiceId",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -6263,6 +6263,54 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feeId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "chargeId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "chargeFilterId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -6281,7 +6281,7 @@
               "deprecationReason": null
             },
             {
-              "name": "chargeId",
+              "name": "chargeFilterId",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -6293,7 +6293,7 @@
               "deprecationReason": null
             },
             {
-              "name": "chargeFilterId",
+              "name": "chargeId",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -20813,6 +20813,22 @@
           "interfaces": [],
           "possibleTypes": null,
           "fields": [
+            {
+              "name": "allChargesHaveFees",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
             {
               "name": "appliedTaxes",
               "description": null,

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -52,7 +52,7 @@ FactoryBot.define do
       invoice_type { :subscription }
       after :create do |invoice, evaluator|
         evaluator.subscriptions.each do |subscription|
-          create(:invoice_subscription, invoice:, subscription:)
+          create(:invoice_subscription, :boundaries, invoice:, subscription:)
         end
       end
     end

--- a/spec/graphql/mutations/adjusted_fees/create_spec.rb
+++ b/spec/graphql/mutations/adjusted_fees/create_spec.rb
@@ -6,14 +6,41 @@ RSpec.describe Mutations::AdjustedFees::Create, type: :graphql do
   let(:required_permission) { 'invoices:update' }
   let(:organization) { create(:organization) }
   let(:membership) { create(:membership, organization:) }
-  let(:invoice) { create(:invoice, organization:) }
-
+  let(:invoice) { create(:invoice, invoice_type: :subscription, organization:, customer:) }
   let(:plan) { create(:plan, organization:) }
   let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
   let(:customer) { create(:customer, organization:) }
-  let(:subscription) { create(:subscription, customer:, plan:) }
-  let(:fee) { create(:charge_fee, subscription:, invoice:, charge:) }
+  let(:subscription) { create(:subscription, customer:, plan:, started_at: Time.current - 1.year) }
+
+  let(:invoice_subscription) do
+    create(
+      :invoice_subscription,
+      invoice:,
+      subscription:,
+      timestamp: Time.current,
+      from_datetime: Time.current.beginning_of_month,
+      to_datetime: Time.current.end_of_month,
+      charges_from_datetime: Time.current.beginning_of_month - 1.month,
+      charges_to_datetime: (Time.current - 1.month).end_of_month
+    )
+  end
+
+  let(:fee) do
+    create(
+      :charge_fee,
+      subscription:,
+      invoice:,
+      charge:,
+      properties: {
+        from_datetime: invoice_subscription.from_datetime,
+        to_datetime: invoice_subscription.to_datetime,
+        charges_from_datetime: invoice_subscription.charges_from_datetime,
+        charges_to_datetime: invoice_subscription.charges_to_datetime,
+        timestamp: invoice_subscription.timestamp
+      }
+    )
+  end
 
   let(:input) do
     {
@@ -32,12 +59,13 @@ RSpec.describe Mutations::AdjustedFees::Create, type: :graphql do
           id,
           units,
           invoiceDisplayName
+          adjustedFee
         }
       }
     GQL
   end
 
-  before {  fee.invoice.draft! }
+  before { fee.invoice.draft! }
 
   around { |test| lago_premium!(&test) }
 
@@ -54,7 +82,41 @@ RSpec.describe Mutations::AdjustedFees::Create, type: :graphql do
       variables: {input:}
     )
 
-    expect(result['data']['createAdjustedFee']['id']).to eq(fee.id)
+    expect(result['data']['createAdjustedFee']['id']).to be_present
+    expect(result['data']['createAdjustedFee']['adjustedFee']).to be_truthy
+    expect(result['data']['createAdjustedFee']['units']).to eq(4)
+    expect(result['data']['createAdjustedFee']['invoiceDisplayName']).to eq('Hello')
+  end
+
+  context 'without an existing fee' do
+    let(:billable_metric2) { create(:billable_metric, organization:) }
+    let(:charge2) { create(:standard_charge, plan:, billable_metric: billable_metric2) }
+
+    let(:input) do
+      {
+        invoiceId: invoice.id,
+        chargeId: charge2.id,
+        subscriptionId: subscription.id,
+        units: 4,
+        unitPreciseAmount: '10.00001',
+        invoiceDisplayName: 'Hello'
+      }
+    end
+
+    it 'creates an adjusted fee' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input:}
+      )
+
+      expect(result['data']['createAdjustedFee']['id']).to be_present
+      expect(result['data']['createAdjustedFee']['adjustedFee']).to be_truthy
+      expect(result['data']['createAdjustedFee']['units']).to eq(4)
+      expect(result['data']['createAdjustedFee']['invoiceDisplayName']).to eq('Hello')
+    end
   end
 
   context 'with finalized invoice' do

--- a/spec/graphql/mutations/adjusted_fees/create_spec.rb
+++ b/spec/graphql/mutations/adjusted_fees/create_spec.rb
@@ -4,11 +4,21 @@ require 'rails_helper'
 
 RSpec.describe Mutations::AdjustedFees::Create, type: :graphql do
   let(:required_permission) { 'invoices:update' }
-  let(:membership) { create(:membership) }
-  let(:fee) { create(:charge_fee) }
+  let(:organization) { create(:organization) }
+  let(:membership) { create(:membership, organization:) }
+  let(:invoice) { create(:invoice, organization:) }
+
+  let(:plan) { create(:plan, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:, plan:) }
+  let(:fee) { create(:charge_fee, subscription:, invoice:, charge:) }
+
   let(:input) do
     {
       feeId: fee.id,
+      invoiceId: invoice.id,
       units: 4,
       unitPreciseAmount: '10.00001',
       invoiceDisplayName: 'Hello'
@@ -27,7 +37,7 @@ RSpec.describe Mutations::AdjustedFees::Create, type: :graphql do
     GQL
   end
 
-  before { fee.invoice.draft! }
+  before {  fee.invoice.draft! }
 
   around { |test| lago_premium!(&test) }
 

--- a/spec/graphql/types/adjusted_fees/create_input_spec.rb
+++ b/spec/graphql/types/adjusted_fees/create_input_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::AdjustedFees::CreateInput do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:invoice_id).of_type('ID!') }
+  it { is_expected.to accept_argument(:fee_id).of_type('ID') }
+  it { is_expected.to accept_argument(:charge_id).of_type('ID') }
+  it { is_expected.to accept_argument(:charge_filter_id).of_type('ID') }
+  it { is_expected.to accept_argument(:subscription_id).of_type('ID') }
+  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
+  it { is_expected.to accept_argument(:unit_precise_amount).of_type('String') }
+  it { is_expected.to accept_argument(:units).of_type('Float') }
+end

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -34,9 +34,11 @@ RSpec.describe Types::Invoices::Object do
   it { is_expected.to have_field(:sub_total_including_taxes_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:taxes_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:total_amount_cents).of_type('BigInt!') }
+
   it { is_expected.to have_field(:issuing_date).of_type('ISO8601Date!') }
   it { is_expected.to have_field(:payment_due_date).of_type('ISO8601Date!') }
   it { is_expected.to have_field(:payment_overdue).of_type('Boolean!') }
+  it { is_expected.to have_field(:all_charges_have_fees).of_type('Boolean!') }
 
   it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
   it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1537,4 +1537,43 @@ RSpec.describe Invoice, type: :model do
       end
     end
   end
+
+  describe '#all_charges_have_fees?' do
+    let(:invoice) { create(:invoice, :subscription, subscriptions: [subscription]) }
+    let(:plan) { create(:plan) }
+    let(:subscription) { create(:subscription, plan:) }
+
+    let(:charge1) { create(:standard_charge, plan:) }
+    let(:charge2) { create(:standard_charge, plan:) }
+
+    before do
+      create(:charge_fee, charge: charge1, invoice:)
+      charge2
+    end
+
+    it { expect(invoice).not_to be_all_charges_have_fees }
+
+    context 'when all charges have fees' do
+      before { create(:charge_fee, charge: charge2, invoice:) }
+
+      it { expect(invoice).to be_all_charges_have_fees }
+    end
+
+    context 'with filters' do
+      let(:charge_filter) { create(:charge_filter, charge: charge1) }
+
+      before do
+        create(:charge_fee, charge: charge2, invoice:)
+        charge_filter
+      end
+
+      it { expect(invoice).not_to be_all_charges_have_fees }
+
+      context 'when filters have fees' do
+        before { create(:charge_fee, charge: charge1, charge_filter:, invoice:) }
+
+        it { expect(invoice).to be_all_charges_have_fees }
+      end
+    end
+  end
 end

--- a/spec/scenarios/invoices/adjusted_charge_fees_spec.rb
+++ b/spec/scenarios/invoices/adjusted_charge_fees_spec.rb
@@ -75,7 +75,7 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
         expect(invoice.status).to eq('draft')
         expect(invoice.total_amount_cents).to eq(12_900)
 
-        AdjustedFees::CreateService.call(organization:, fee:, params: adjusted_fee_params)
+        AdjustedFees::CreateService.call(invoice:, params: adjusted_fee_params.merge(fee_id: fee.id))
         perform_all_enqueued_jobs
 
         expect(invoice.reload.status).to eq('draft')
@@ -148,7 +148,7 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
         expect(invoice.status).to eq('draft')
         expect(invoice.total_amount_cents).to eq(12_900)
 
-        AdjustedFees::CreateService.call(organization:, fee:, params: adjusted_fee_params)
+        AdjustedFees::CreateService.call(invoice:, params: adjusted_fee_params.merge(fee_id: fee.id))
         perform_all_enqueued_jobs
 
         expect(invoice.reload.status).to eq('draft')

--- a/spec/scenarios/invoices/adjusted_subscription_fees_spec.rb
+++ b/spec/scenarios/invoices/adjusted_subscription_fees_spec.rb
@@ -55,7 +55,7 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
         expect(invoice.status).to eq('draft')
         expect(invoice.total_amount_cents).to eq(12_900)
 
-        AdjustedFees::CreateService.call(organization:, fee:, params: adjusted_fee_params)
+        AdjustedFees::CreateService.call(invoice:, params: adjusted_fee_params.merge(fee_id: fee.id))
         perform_all_enqueued_jobs
 
         expect(invoice.reload.status).to eq('draft')
@@ -109,7 +109,7 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
         expect(invoice.status).to eq('draft')
         expect(invoice.total_amount_cents).to eq(12_900)
 
-        AdjustedFees::CreateService.call(organization:, fee:, params: adjusted_fee_params)
+        AdjustedFees::CreateService.call(invoice:, params: adjusted_fee_params.merge(fee_id: fee.id))
         perform_all_enqueued_jobs
 
         expect(invoice.reload.status).to eq('draft')

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -1191,7 +1191,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         # In terminated invoice there is only one fee that is charge kind
         fee = terminated_invoice.fees.charge.first
 
-        AdjustedFees::CreateService.call(organization:, fee:, params: adjusted_fee_params)
+        AdjustedFees::CreateService.call(invoice: terminated_invoice, params: adjusted_fee_params.merge(fee_id: fee.id))
         credit_note = credit_note.reload
         terminated_invoice = terminated_invoice.reload
 
@@ -1272,7 +1272,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           # There is only one fee that is subscription kind
           fee = first_invoice.fees.subscription.first
 
-          AdjustedFees::CreateService.call(organization:, fee:, params: adjusted_fee_params)
+          AdjustedFees::CreateService.call(invoice: first_invoice, params: adjusted_fee_params.merge(fee_id: fee.id))
           credit_note = credit_note.reload
           first_invoice = first_invoice.reload
 
@@ -1353,7 +1353,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           # There is only one fee that is subscription kind
           fee = first_invoice.fees.subscription.first
 
-          AdjustedFees::CreateService.call(organization:, fee:, params: adjusted_fee_params)
+          AdjustedFees::CreateService.call(invoice: first_invoice, params: adjusted_fee_params.merge(fee_id: fee.id))
           credit_note = credit_note.reload
           first_invoice = first_invoice.reload
 

--- a/spec/services/adjusted_fees/create_service_spec.rb
+++ b/spec/services/adjusted_fees/create_service_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
             invoice_display_name: 'new-dis-name',
             subscription_id: subscription.id,
             charge_id: charge.id,
-            charge_filter_id: charge_filter.id,
+            charge_filter_id: charge_filter.id
           }
         end
 
@@ -205,8 +205,8 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
             .to be_a(Fee)
             .and have_attributes(
               organization:,
-              invoice: ,
-              subscription: ,
+              invoice:,
+              subscription:,
               invoiceable: charge,
               charge:,
               charge_filter:,
@@ -244,7 +244,7 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
               invoice_display_name: 'new-dis-name',
               subscription_id: subscription.id,
               charge_id: fee.charge_id,
-              charge_filter_id: fee.charge_filter_id,
+              charge_filter_id: fee.charge_filter_id
             }
           end
 
@@ -265,7 +265,7 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
               invoice_display_name: 'new-dis-name',
               subscription_id: 'invalid_id',
               charge_id: fee.charge_id,
-              charge_filter_id: fee.charge_filter_id,
+              charge_filter_id: fee.charge_filter_id
             }
           end
 
@@ -289,7 +289,7 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
               invoice_display_name: 'new-dis-name',
               subscription_id: subscription.id,
               charge_id: 'invalid_id',
-              charge_filter_id: fee.charge_filter_id,
+              charge_filter_id: fee.charge_filter_id
             }
           end
 
@@ -313,7 +313,7 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
               invoice_display_name: 'new-dis-name',
               subscription_id: subscription.id,
               charge_id: charge.id,
-              charge_filter_id: 'invalid_id',
+              charge_filter_id: 'invalid_id'
             }
           end
 

--- a/spec/services/adjusted_fees/create_service_spec.rb
+++ b/spec/services/adjusted_fees/create_service_spec.rb
@@ -3,15 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe AdjustedFees::CreateService, type: :service do
-  subject(:create_service) { described_class.new(organization:, fee:, params:) }
+  subject(:create_service) { described_class.new(invoice:, params:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:fee) { create(:charge_fee) }
+  let(:customer) { create(:customer) }
+  let(:invoice) { create(:invoice, :subscription, :draft, customer:, subscriptions: [subscription], organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, plan:, customer:) }
+  let(:organization) { customer.organization }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:charge) { create(:standard_charge, billable_metric:, plan: subscription.plan) }
+  let(:charge_filter) { create(:charge_filter, charge:) }
+
+  let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, charge_filter:) }
   let(:code) { 'tax_code' }
   let(:refresh_service) { instance_double(Invoices::RefreshDraftService) }
   let(:params) do
     {
+      fee_id: fee.id,
       units: 5,
       unit_precise_amount: 12.002,
       invoice_display_name: 'new-dis-name'
@@ -20,8 +28,7 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
 
   describe '#call' do
     before do
-      fee.invoice.draft!
-      allow(Invoices::RefreshDraftService).to receive(:new).with(invoice: fee.invoice).and_return(refresh_service)
+      allow(Invoices::RefreshDraftService).to receive(:new).with(invoice: invoice).and_return(refresh_service)
       allow(refresh_service).to receive(:call).and_return(BaseService::Result.new)
     end
 
@@ -59,7 +66,7 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
       end
 
       context 'when invoice is NOT in draft status' do
-        before { fee.invoice.finalized! }
+        before { invoice.finalized! }
 
         it 'returns forbidden status' do
           result = create_service.call
@@ -74,8 +81,7 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
 
       context 'when there is invalid charge model but amount is adjusted' do
         let(:percentage_charge) { create(:percentage_charge) }
-
-        before { fee.charge = percentage_charge }
+        let(:fee) { create(:charge_fee, invoice:, subscription:, charge: percentage_charge) }
 
         it 'returns success response' do
           result = create_service.call
@@ -86,13 +92,13 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
 
       context 'when there is invalid charge model and display name is adjusted' do
         let(:percentage_charge) { create(:percentage_charge) }
+        let(:fee) { create(:charge_fee, invoice:, subscription:, charge: percentage_charge) }
         let(:params) do
           {
+            fee_id: fee.id,
             invoice_display_name: 'new-dis-name'
           }
         end
-
-        before { fee.charge = percentage_charge }
 
         it 'returns success response' do
           result = create_service.call
@@ -103,14 +109,14 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
 
       context 'when there is invalid charge model and units are adjusted' do
         let(:percentage_charge) { create(:percentage_charge) }
+        let(:fee) { create(:charge_fee, invoice:, subscription:, charge: percentage_charge) }
         let(:params) do
           {
+            fee_id: fee.id,
             units: 5,
             invoice_display_name: 'new-dis-name'
           }
         end
-
-        before { fee.charge = percentage_charge }
 
         it 'returns error' do
           result = create_service.call
@@ -119,6 +125,20 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::ValidationFailure)
             expect(result.error.messages[:charge]).to eq(['invalid_charge_model'])
+          end
+        end
+      end
+
+      context 'when fee belongs to another invoice' do
+        let(:fee) { create(:charge_fee) }
+
+        it 'returns error' do
+          result = create_service.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.message).to eq("fee_not_found")
           end
         end
       end
@@ -135,6 +155,176 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::ValidationFailure)
             expect(result.error.messages[:adjusted_fee]).to eq(['already_exists'])
+          end
+        end
+      end
+
+      context 'when adjusting without fee' do
+        let(:fee) { nil }
+        let(:params) do
+          {
+            units: 5,
+            unit_precise_amount: 12.002,
+            invoice_display_name: 'new-dis-name',
+            subscription_id: subscription.id,
+            charge_id: charge.id,
+            charge_filter_id: charge_filter.id,
+          }
+        end
+
+        it 'creates an adjusted fee and a fee' do
+          expect { create_service.call }
+            .to change(AdjustedFee, :count).by(1)
+            .and change(Fee, :count).by(1)
+        end
+
+        it 'returns adjusted fee in the result' do
+          result = create_service.call
+          expect(result.adjusted_fee)
+            .to be_a(AdjustedFee)
+            .and have_attributes(
+              fee: Fee,
+              invoice:,
+              subscription:,
+              charge:,
+              adjusted_units: false,
+              adjusted_amount: true,
+              invoice_display_name: 'new-dis-name',
+              fee_type: 'charge',
+              units: 5,
+              unit_amount_cents: 1200,
+              unit_precise_amount_cents: 1200.2,
+              grouped_by: {},
+              charge_filter:
+            )
+        end
+
+        it 'returns fee in the result' do
+          result = create_service.call
+          expect(result.fee)
+            .to be_a(Fee)
+            .and have_attributes(
+              organization:,
+              invoice: ,
+              subscription: ,
+              invoiceable: charge,
+              charge:,
+              charge_filter:,
+              grouped_by: {},
+              fee_type: "charge",
+              payment_status: "pending",
+              events_count: 0,
+              amount_currency: invoice.currency,
+              amount_cents: 0,
+              precise_amount_cents: 0.to_d,
+              unit_amount_cents: 0,
+              precise_unit_amount: 0.to_d,
+              taxes_amount_cents: 0,
+              taxes_precise_amount_cents: 0.to_d,
+              units: 0,
+              total_aggregated_units: 0,
+              properties: Hash,
+              amount_details: {}
+            )
+        end
+
+        it 'calls the RefreshDraft service' do
+          create_service.call
+
+          expect(Invoices::RefreshDraftService).to have_received(:new)
+          expect(refresh_service).to have_received(:call)
+        end
+
+        context 'when a fee exists with the attributes' do
+          let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, charge_filter:) }
+          let(:params) do
+            {
+              units: 5,
+              unit_precise_amount: 12.002,
+              invoice_display_name: 'new-dis-name',
+              subscription_id: subscription.id,
+              charge_id: fee.charge_id,
+              charge_filter_id: fee.charge_filter_id,
+            }
+          end
+
+          it 'creates an adjusted fee for the fee' do
+            result = create_service.call
+            expect(result.adjusted_fee)
+              .to be_a(AdjustedFee)
+              .and have_attributes(fee:)
+          end
+        end
+
+        context 'when subscription_id does not belongs to the invoice' do
+          let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, charge_filter:) }
+          let(:params) do
+            {
+              units: 5,
+              unit_precise_amount: 12.002,
+              invoice_display_name: 'new-dis-name',
+              subscription_id: 'invalid_id',
+              charge_id: fee.charge_id,
+              charge_filter_id: fee.charge_filter_id,
+            }
+          end
+
+          it 'returns a not found error' do
+            result = create_service.call
+
+            aggregate_failures do
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::NotFoundFailure)
+              expect(result.error.message).to eq("subscription_not_found")
+            end
+          end
+        end
+
+        context 'when charge_id does not belongs to the invoice' do
+          let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, charge_filter:) }
+          let(:params) do
+            {
+              units: 5,
+              unit_precise_amount: 12.002,
+              invoice_display_name: 'new-dis-name',
+              subscription_id: subscription.id,
+              charge_id: 'invalid_id',
+              charge_filter_id: fee.charge_filter_id,
+            }
+          end
+
+          it 'returns a not found error' do
+            result = create_service.call
+
+            aggregate_failures do
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::NotFoundFailure)
+              expect(result.error.message).to eq("charge_not_found")
+            end
+          end
+        end
+
+        context 'when charge_filter_id does not belongs to the invoice' do
+          let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, charge_filter:) }
+          let(:params) do
+            {
+              units: 5,
+              unit_precise_amount: 12.002,
+              invoice_display_name: 'new-dis-name',
+              subscription_id: subscription.id,
+              charge_id: charge.id,
+              charge_filter_id: 'invalid_id',
+            }
+          end
+
+          it 'returns a not found error' do
+            result = create_service.call
+
+            aggregate_failures do
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::NotFoundFailure)
+              expect(result.error.message).to eq("charge_filter_not_found")
+            end
           end
         end
       end

--- a/spec/services/adjusted_fees/create_service_spec.rb
+++ b/spec/services/adjusted_fees/create_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe AdjustedFees::CreateService, type: :service do
   subject(:create_service) { described_class.new(invoice:, params:) }
@@ -15,48 +15,48 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
   let(:charge_filter) { create(:charge_filter, charge:) }
 
   let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, charge_filter:) }
-  let(:code) { 'tax_code' }
+  let(:code) { "tax_code" }
   let(:refresh_service) { instance_double(Invoices::RefreshDraftService) }
   let(:params) do
     {
       fee_id: fee.id,
       units: 5,
       unit_precise_amount: 12.002,
-      invoice_display_name: 'new-dis-name'
+      invoice_display_name: "new-dis-name"
     }
   end
 
-  describe '#call' do
+  describe "#call" do
     before do
       allow(Invoices::RefreshDraftService).to receive(:new).with(invoice: invoice).and_return(refresh_service)
       allow(refresh_service).to receive(:call).and_return(BaseService::Result.new)
     end
 
-    context 'when license is premium' do
+    context "when license is premium" do
       around { |test| lago_premium!(&test) }
 
-      it 'creates an adjusted fee' do
+      it "creates an adjusted fee" do
         expect { create_service.call }.to change(AdjustedFee, :count).by(1)
       end
 
-      it 'returns adjusted fee in the result' do
+      it "returns adjusted fee in the result" do
         result = create_service.call
         expect(result.adjusted_fee).to be_a(AdjustedFee)
       end
 
-      it 'returns fee in the result' do
+      it "returns fee in the result" do
         result = create_service.call
         expect(result.fee).to be_a(Fee)
       end
 
-      it 'calls the RefreshDraft service' do
+      it "calls the RefreshDraft service" do
         create_service.call
 
         expect(Invoices::RefreshDraftService).to have_received(:new)
         expect(refresh_service).to have_received(:call)
       end
 
-      it 'populates precise and not precise values for the created adjusted fee' do
+      it "populates precise and not precise values for the created adjusted fee" do
         result = create_service.call
         expect(result.adjusted_fee).to have_attributes(
           units: 5,
@@ -65,74 +65,74 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
         )
       end
 
-      context 'when invoice is NOT in draft status' do
+      context "when invoice is NOT in draft status" do
         before { invoice.finalized! }
 
-        it 'returns forbidden status' do
+        it "returns forbidden status" do
           result = create_service.call
 
           aggregate_failures do
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::ForbiddenFailure)
-            expect(result.error.code).to eq('feature_unavailable')
+            expect(result.error.code).to eq("feature_unavailable")
           end
         end
       end
 
-      context 'when there is invalid charge model but amount is adjusted' do
+      context "when there is invalid charge model but amount is adjusted" do
         let(:percentage_charge) { create(:percentage_charge) }
         let(:fee) { create(:charge_fee, invoice:, subscription:, charge: percentage_charge) }
 
-        it 'returns success response' do
+        it "returns success response" do
           result = create_service.call
 
           expect(result).to be_success
         end
       end
 
-      context 'when there is invalid charge model and display name is adjusted' do
+      context "when there is invalid charge model and display name is adjusted" do
         let(:percentage_charge) { create(:percentage_charge) }
         let(:fee) { create(:charge_fee, invoice:, subscription:, charge: percentage_charge) }
         let(:params) do
           {
             fee_id: fee.id,
-            invoice_display_name: 'new-dis-name'
+            invoice_display_name: "new-dis-name"
           }
         end
 
-        it 'returns success response' do
+        it "returns success response" do
           result = create_service.call
 
           expect(result).to be_success
         end
       end
 
-      context 'when there is invalid charge model and units are adjusted' do
+      context "when there is invalid charge model and units are adjusted" do
         let(:percentage_charge) { create(:percentage_charge) }
         let(:fee) { create(:charge_fee, invoice:, subscription:, charge: percentage_charge) }
         let(:params) do
           {
             fee_id: fee.id,
             units: 5,
-            invoice_display_name: 'new-dis-name'
+            invoice_display_name: "new-dis-name"
           }
         end
 
-        it 'returns error' do
+        it "returns error" do
           result = create_service.call
 
           aggregate_failures do
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages[:charge]).to eq(['invalid_charge_model'])
+            expect(result.error.messages[:charge]).to eq(["invalid_charge_model"])
           end
         end
       end
 
-      context 'when fee belongs to another invoice' do
+      context "when fee belongs to another invoice" do
         let(:fee) { create(:charge_fee) }
 
-        it 'returns error' do
+        it "returns error" do
           result = create_service.call
 
           aggregate_failures do
@@ -143,42 +143,42 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
         end
       end
 
-      context 'when adjusted fee already exists' do
+      context "when adjusted fee already exists" do
         let(:adjusted_fee) { create(:adjusted_fee, fee:) }
 
         before { adjusted_fee }
 
-        it 'returns validation error' do
+        it "returns validation error" do
           result = create_service.call
 
           aggregate_failures do
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages[:adjusted_fee]).to eq(['already_exists'])
+            expect(result.error.messages[:adjusted_fee]).to eq(["already_exists"])
           end
         end
       end
 
-      context 'when adjusting without fee' do
+      context "when adjusting without fee" do
         let(:fee) { nil }
         let(:params) do
           {
             units: 5,
             unit_precise_amount: 12.002,
-            invoice_display_name: 'new-dis-name',
+            invoice_display_name: "new-dis-name",
             subscription_id: subscription.id,
             charge_id: charge.id,
             charge_filter_id: charge_filter.id
           }
         end
 
-        it 'creates an adjusted fee and a fee' do
+        it "creates an adjusted fee and a fee" do
           expect { create_service.call }
             .to change(AdjustedFee, :count).by(1)
             .and change(Fee, :count).by(1)
         end
 
-        it 'returns adjusted fee in the result' do
+        it "returns adjusted fee in the result" do
           result = create_service.call
           expect(result.adjusted_fee)
             .to be_a(AdjustedFee)
@@ -189,8 +189,8 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
               charge:,
               adjusted_units: false,
               adjusted_amount: true,
-              invoice_display_name: 'new-dis-name',
-              fee_type: 'charge',
+              invoice_display_name: "new-dis-name",
+              fee_type: "charge",
               units: 5,
               unit_amount_cents: 1200,
               unit_precise_amount_cents: 1200.2,
@@ -199,7 +199,7 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
             )
         end
 
-        it 'returns fee in the result' do
+        it "returns fee in the result" do
           result = create_service.call
           expect(result.fee)
             .to be_a(Fee)
@@ -228,27 +228,38 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
             )
         end
 
-        it 'calls the RefreshDraft service' do
+        it "calls the RefreshDraft service" do
           create_service.call
 
           expect(Invoices::RefreshDraftService).to have_received(:new)
           expect(refresh_service).to have_received(:call)
         end
 
-        context 'when a fee exists with the attributes' do
+        context "when adjusting a dynamic charge" do
+          let(:billable_metric) { create(:sum_billable_metric, organization:) }
+          let(:charge) { create(:dynamic_charge, billable_metric:, plan: subscription.plan) }
+
+          it "creates an adjusted fee and a fee" do
+            expect { create_service.call }
+              .to change(AdjustedFee, :count).by(1)
+              .and change(Fee, :count).by(1)
+          end
+        end
+
+        context "when a fee exists with the attributes" do
           let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, charge_filter:) }
           let(:params) do
             {
               units: 5,
               unit_precise_amount: 12.002,
-              invoice_display_name: 'new-dis-name',
+              invoice_display_name: "new-dis-name",
               subscription_id: subscription.id,
               charge_id: fee.charge_id,
               charge_filter_id: fee.charge_filter_id
             }
           end
 
-          it 'creates an adjusted fee for the fee' do
+          it "creates an adjusted fee for the fee" do
             result = create_service.call
             expect(result.adjusted_fee)
               .to be_a(AdjustedFee)
@@ -256,20 +267,20 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
           end
         end
 
-        context 'when subscription_id does not belongs to the invoice' do
+        context "when subscription_id does not belongs to the invoice" do
           let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, charge_filter:) }
           let(:params) do
             {
               units: 5,
               unit_precise_amount: 12.002,
-              invoice_display_name: 'new-dis-name',
-              subscription_id: 'invalid_id',
+              invoice_display_name: "new-dis-name",
+              subscription_id: "invalid_id",
               charge_id: fee.charge_id,
               charge_filter_id: fee.charge_filter_id
             }
           end
 
-          it 'returns a not found error' do
+          it "returns a not found error" do
             result = create_service.call
 
             aggregate_failures do
@@ -280,20 +291,20 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
           end
         end
 
-        context 'when charge_id does not belongs to the invoice' do
+        context "when charge_id does not belongs to the invoice" do
           let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, charge_filter:) }
           let(:params) do
             {
               units: 5,
               unit_precise_amount: 12.002,
-              invoice_display_name: 'new-dis-name',
+              invoice_display_name: "new-dis-name",
               subscription_id: subscription.id,
-              charge_id: 'invalid_id',
+              charge_id: "invalid_id",
               charge_filter_id: fee.charge_filter_id
             }
           end
 
-          it 'returns a not found error' do
+          it "returns a not found error" do
             result = create_service.call
 
             aggregate_failures do
@@ -304,20 +315,20 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
           end
         end
 
-        context 'when charge_filter_id does not belongs to the invoice' do
+        context "when charge_filter_id does not belongs to the invoice" do
           let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, charge_filter:) }
           let(:params) do
             {
               units: 5,
               unit_precise_amount: 12.002,
-              invoice_display_name: 'new-dis-name',
+              invoice_display_name: "new-dis-name",
               subscription_id: subscription.id,
               charge_id: charge.id,
-              charge_filter_id: 'invalid_id'
+              charge_filter_id: "invalid_id"
             }
           end
 
-          it 'returns a not found error' do
+          it "returns a not found error" do
             result = create_service.call
 
             aggregate_failures do
@@ -330,14 +341,14 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
       end
     end
 
-    context 'when license is not premium' do
-      it 'returns forbidden status' do
+    context "when license is not premium" do
+      it "returns forbidden status" do
         result = create_service.call
 
         aggregate_failures do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ForbiddenFailure)
-          expect(result.error.code).to eq('feature_unavailable')
+          expect(result.error.code).to eq("feature_unavailable")
         end
       end
     end


### PR DESCRIPTION
## Context

As a consequence of the removal of the 0 units fees removal from both DB and invoicing logic, we lost the ability to adjust fees without amount / units as the feature was expecting a fee to be present. This feature is a new approach to bring this functionality back.

## Description

This features refactors the `AdjustedFees::CreateService` and the `Mutations::AdjustedFees::Create` mutation to allow the creation of adjusted fees without pre-existing fees via the GraphQL API
