### PR TITLE
feat(invoice-preview): add preview support for wallet and credit note credits

### DIFF
--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -116,12 +116,12 @@ module Invoices
       credit_result = Credits::CreditNoteService.call(invoice:, context: :preview)
       credit_result.raise_if_error!
 
-      refresh_amounts(credit_amount_cents: credit_result.credits.sum(&:amount_cents)) if credit_result.credits
+      invoice.total_amount_cents -= credit_result.credits.sum(&:amount_cents))
     end
 
     def create_applied_prepaid_credits
       return unless customer.persisted?
-      return unless wallet&.active?
+      return unless wallet
       return unless invoice.total_amount_cents&.positive?
       return unless wallet.balance.positive?
 
@@ -131,17 +131,13 @@ module Invoices
         invoice.total_amount_cents
       end
       invoice.prepaid_credit_amount_cents += amount_cents
-      refresh_amounts(credit_amount_cents: amount_cents)
-    end
-
-    def refresh_amounts(credit_amount_cents:)
-      invoice.total_amount_cents -= credit_amount_cents
+      invoice.total_amount_cents -= amount_cents
     end
 
     def wallet
       return @wallet if defined? @wallet
 
-      @wallet = customer.wallets&.active&.first
+      @wallet = customer.wallets.active.first
     end
   end
 end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -116,7 +116,7 @@ module Invoices
       credit_result = Credits::CreditNoteService.call(invoice:, context: :preview)
       credit_result.raise_if_error!
 
-      invoice.total_amount_cents -= credit_result.credits.sum(&:amount_cents))
+      invoice.total_amount_cents -= credit_result.credits.sum(&:amount_cents)
     end
 
     def create_applied_prepaid_credits

--- a/spec/services/credits/credit_note_service_spec.rb
+++ b/spec/services/credits/credit_note_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Credits::CreditNoteService do
-  subject(:credit_service) { described_class.new(invoice:) }
+  subject(:credit_service) { described_class.new(invoice:, context:) }
 
   let(:invoice) do
     create(
@@ -16,6 +16,7 @@ RSpec.describe Credits::CreditNoteService do
 
   let(:amount_cents) { 100 }
   let(:customer) { create(:customer) }
+  let(:context) { nil }
 
   let(:credit_note1) do
     create(
@@ -69,6 +70,18 @@ RSpec.describe Credits::CreditNoteService do
         expect(credit_note1).to be_consumed
 
         expect(invoice.credit_notes_amount_cents).to eq(70)
+      end
+    end
+
+    it 'creates credits in the database' do
+      expect { credit_service.call }.to change(Credit, :count).by(2)
+    end
+
+    context 'when preview mode' do
+      let(:context) { :preview }
+
+      it 'does not create credits in the database' do
+        expect { credit_service.call }.not_to change(Credit, :count)
       end
     end
 

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -93,6 +93,82 @@ RSpec.describe Invoices::PreviewService, type: :service do
           end
         end
       end
+
+      context 'with credit note credits' do
+        let(:credit_note) do
+          create(
+            :credit_note,
+            customer:,
+            total_amount_cents: 2,
+            total_amount_currency: plan.amount_currency,
+            balance_amount_cents: 2,
+            balance_amount_currency: plan.amount_currency,
+            credit_amount_cents: 2,
+            credit_amount_currency: plan.amount_currency
+          )
+        end
+
+        before { credit_note }
+
+        it 'creates preview invoice for 2 days with credits included' do
+          travel_to(timestamp) do
+            result = preview_service.call
+
+            expect(result).to be_success
+            expect(result.invoice.subscriptions.first).to eq(subscription)
+            expect(result.invoice.fees.length).to eq(1)
+            expect(result.invoice.invoice_type).to eq('subscription')
+            expect(result.invoice.issuing_date.to_s).to eq('2024-04-01')
+            expect(result.invoice.fees_amount_cents).to eq(6)
+            expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(6)
+            expect(result.invoice.taxes_amount_cents).to eq(3)
+            expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(9)
+            expect(result.invoice.credit_notes_amount_cents).to eq(2)
+            expect(result.invoice.total_amount_cents).to eq(7)
+          end
+        end
+      end
+
+      context 'with wallet credits' do
+        let(:wallet) { build(:wallet, customer:, balance: '0.03', credits_balance: '0.03') }
+
+        before { wallet }
+
+        context 'with customer that is not persisted' do
+          it 'does not apply credits' do
+            travel_to(timestamp) do
+              result = preview_service.call
+
+              expect(result).to be_success
+              expect(result.invoice.total_amount_cents).to eq(9)
+              expect(result.invoice.prepaid_credit_amount_cents).to eq(0)
+            end
+          end
+        end
+
+        context 'with customer that is persisted' do
+          let(:customer) { create(:customer, organization:) }
+          let(:wallet) { create(:wallet, customer:, balance: '0.03', credits_balance: '0.03') }
+
+          it 'applies credits' do
+            travel_to(timestamp) do
+              result = preview_service.call
+
+              expect(result).to be_success
+              expect(result.invoice.subscriptions.first).to eq(subscription)
+              expect(result.invoice.fees.length).to eq(1)
+              expect(result.invoice.invoice_type).to eq('subscription')
+              expect(result.invoice.issuing_date.to_s).to eq('2024-04-01')
+              expect(result.invoice.fees_amount_cents).to eq(6)
+              expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(6)
+              expect(result.invoice.taxes_amount_cents).to eq(3)
+              expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(9)
+              expect(result.invoice.prepaid_credit_amount_cents).to eq(3)
+              expect(result.invoice.total_amount_cents).to eq(6)
+            end
+          end
+        end
+      end
     end
 
     context 'with anniversary billing' do


### PR DESCRIPTION
## Context

Preview feature enables fetching first Lago invoice. This invoice is not persisted and is calculated on the fly.

## Description

This PR adds logic for applying wallet and credit note credits on preview invoice.