### PR TITLE
Fix: add validation on transaction_metadata type for recurring transaction rules

### DIFF
--- a/app/services/validators/metadata_validator.rb
+++ b/app/services/validators/metadata_validator.rb
@@ -17,7 +17,8 @@ module Validators
     end
 
     def valid?
-      return true if metadata.empty?
+      validate_type
+      return true if metadata.empty? && errors.empty?
 
       validate_size
       metadata.each { |item| validate_item(item) }
@@ -26,6 +27,10 @@ module Validators
     end
 
     private
+
+    def validate_type
+      errors[:metadata] = 'invalid_type' unless metadata.is_a?(Array)
+    end
 
     def validate_size
       errors[:metadata] = 'too_many_keys' if metadata.size > config[:max_keys]

--- a/app/services/wallets/recurring_transaction_rules/validate_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/validate_service.rb
@@ -59,7 +59,7 @@ module Wallets
       end
 
       def valid_metadata?
-        ::Validators::MetadataValidator.new(params[:metadata]).valid?
+        ::Validators::MetadataValidator.new(params[:transaction_metadata]).valid?
       end
     end
   end

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -76,6 +76,27 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           )
         )
       end
+
+      context 'when transaction metadata is a hash' do
+        let(:create_params) do
+          {
+            external_customer_id: customer.external_id,
+            rate_amount: '1',
+            name: 'Wallet1',
+            currency: 'EUR',
+            paid_credits: '10',
+            granted_credits: '10',
+            expiration_at:,
+            invoice_requires_successful_payment: true,
+            transaction_metadata: {}
+          }
+        end
+
+        it 'returns a validation error' do
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(json[:error_details][:metadata]).to include('invalid_type')
+        end
+      end
     end
 
     context 'with recurring transaction rules' do
@@ -215,6 +236,16 @@ RSpec.describe Api::V1::WalletsController, type: :request do
             expect(response).to have_http_status(:success)
             expect(recurring_rules).to be_present
             expect(recurring_rules.first[:transaction_metadata]).to eq(transaction_metadata)
+          end
+        end
+
+        context 'when transaction metadata is a hash' do
+          let(:transaction_metadata) { {key: 'valid_value', value: 'also_valid'} }
+
+          it 'returns a validation error' do
+            subject
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(json[:error_details][:recurring_transaction_rules]).to include('invalid_recurring_rule')
           end
         end
       end

--- a/spec/services/validators/metadata_validator_spec.rb
+++ b/spec/services/validators/metadata_validator_spec.rb
@@ -85,5 +85,14 @@ RSpec.describe Validators::MetadataValidator, type: :validator do
         expect(metadata_validator).to be_valid
       end
     end
+
+    context 'when metadata is an empty hash' do
+      let(:metadata) { {} }
+
+      it 'returns false' do
+        expect(metadata_validator).not_to be_valid
+        expect(metadata_validator.errors[:metadata]).to include('invalid_type')
+      end
+    end
   end
 end

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -103,18 +103,6 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
           expect(rule.transaction_metadata).to eq(transaction_metadata)
         end
       end
-
-      context 'when transaction_metadata is invalid' do
-        let(:transaction_metadata) { {'key' => 'key', 'value' => 'value'} }
-
-        it 'returns a validation error' do
-          result = update_service.call
-
-          expect(result).to be_failure
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages).to eq(['invalid_recurring_transaction_rule'])
-        end
-      end
     end
   end
 end

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -15,10 +15,12 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
         interval: "weekly",
         paid_credits: "105",
         granted_credits: "105",
-        started_at: "2024-05-30T12:48:26Z"
+        started_at: "2024-05-30T12:48:26Z",
+        transaction_metadata:
       }
     ]
   end
+  let(:transaction_metadata) { [] }
 
   describe "#call" do
     before { recurring_transaction_rule }
@@ -87,6 +89,31 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
         result = update_service.call
 
         expect(result.wallet.reload.recurring_transaction_rules.count).to eq(0)
+      end
+    end
+
+    context 'when sending transaction_metadata' do
+      context 'when transaction_metadata is valid' do
+        let(:transaction_metadata) { [{'key' => 'key'}, {'value' => 'value'}] }
+
+        it 'updates existing recurring transaction rule with new transaction_metadata' do
+          result = update_service.call
+
+          rule = result.wallet.reload.recurring_transaction_rules.first
+          expect(rule.transaction_metadata).to eq(transaction_metadata)
+        end
+      end
+
+      context 'when transaction_metadata is invalid' do
+        let(:transaction_metadata) { {'key' => 'key', 'value' => 'value'} }
+
+        it 'returns a validation error' do
+          result = update_service.call
+
+          expect(result).to be_failure
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq(['invalid_recurring_transaction_rule'])
+        end
       end
     end
   end

--- a/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
@@ -58,12 +58,26 @@ RSpec.describe Wallets::RecurringTransactionRules::ValidateService do
       end
     end
 
-    context "when invalid metadata" do
+    context "when valid transaction_metadata" do
       let(:params) do
         {
           trigger: "interval",
           interval: "weekly",
-          metadata: [{'key' => 'valid_key', 'value_1' => 'invalid_value'}]
+          transaction_metadata: [{'key' => 'valid_key', 'value' => 'invalid_value'}]
+        }
+      end
+
+      it "returns true" do
+        expect(validate_service.call).to eq true
+      end
+    end
+
+    context "when invalid transaction_metadata" do
+      let(:params) do
+        {
+          trigger: "interval",
+          interval: "weekly",
+          transaction_metadata: {'key' => 'valid_key', 'value' => 'invalid_value'}
         }
       end
 

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -94,13 +94,15 @@ RSpec.describe Wallets::UpdateService, type: :service do
       around { |test| lago_premium!(&test) }
 
       let(:recurring_transaction_rule) { create(:recurring_transaction_rule, wallet:) }
+      let(:transaction_metadata) { [] }
       let(:rules) do
         [
           {
             trigger: 'interval',
             interval: 'weekly',
             paid_credits: '105',
-            granted_credits: '105'
+            granted_credits: '105',
+            transaction_metadata:
           }
         ]
       end
@@ -269,6 +271,17 @@ RSpec.describe Wallets::UpdateService, type: :service do
             }
           ]
         end
+
+        it 'returns an error' do
+          result = update_service.call
+
+          expect(result).not_to be_success
+          expect(result.error.messages[:recurring_transaction_rules]).to eq(['invalid_recurring_rule'])
+        end
+      end
+
+      context 'when transaction_rule.transaction_metadata is hash' do
+        let(:transaction_metadata) { {} }
 
         it 'returns an error' do
           result = update_service.call


### PR DESCRIPTION
## Context

We expect transaction_metadata for recurring_transaction_rules to be an array, but we do not validate that what we received via API as an array and not an empty hash

## Description

Added validation of type for metadata - both, wallet and recurring_transaction_rule to be of type Array
