### PR TITLE
fix(payment): Handle payment and invoice status update

### DIFF
--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -24,10 +24,15 @@ module Invoices
         result.invoice = payment.payable
         return result if payment.payable.payment_succeeded?
 
-        payment.update!(status:)
+        payment.status = status
 
-        invoice_payment_status = payment.payment_provider&.determine_payment_status(status)
-        update_invoice_payment_status(payment_status: invoice_payment_status)
+        payable_payment_status = payment.payment_provider&.determine_payment_status(payment.status)
+        if Payment::PAYABLE_PAYMENT_STATUS.include?(payable_payment_status)
+          payment.payable_payment_status = payable_payment_status
+        end
+        payment.save!
+
+        update_invoice_payment_status(payment_status: payable_payment_status)
 
         result
       rescue BaseService::FailedResult => e

--- a/app/services/invoices/payments/cashfree_service.rb
+++ b/app/services/invoices/payments/cashfree_service.rb
@@ -23,9 +23,15 @@ module Invoices
         result.invoice = payment.payable
         return result if payment.payable.payment_succeeded?
 
-        payment.update!(status:)
-        invoice_payment_status = payment.payment_provider&.determine_payment_status(status)
-        update_invoice_payment_status(payment_status: invoice_payment_status)
+        payment.status = status
+
+        payable_payment_status = payment.payment_provider&.determine_payment_status(payment.status)
+        if Payment::PAYABLE_PAYMENT_STATUS.include?(payable_payment_status)
+          payment.payable_payment_status = payable_payment_status
+        end
+        payment.save!
+
+        update_invoice_payment_status(payment_status: payable_payment_status)
 
         result
       rescue BaseService::FailedResult => e

--- a/app/services/invoices/payments/gocardless_service.rb
+++ b/app/services/invoices/payments/gocardless_service.rb
@@ -19,10 +19,15 @@ module Invoices
         result.invoice = payment.payable
         return result if payment.payable.payment_succeeded?
 
-        payment.update!(status:)
+        payment.status = status
 
-        invoice_payment_status = payment.payment_provider&.determine_payment_status(status)
-        update_invoice_payment_status(payment_status: invoice_payment_status)
+        payable_payment_status = payment.payment_provider&.determine_payment_status(payment.status)
+        if Payment::PAYABLE_PAYMENT_STATUS.include?(payable_payment_status)
+          payment.payable_payment_status = payable_payment_status
+        end
+        payment.save!
+
+        update_invoice_payment_status(payment_status: payable_payment_status)
 
         result
       rescue BaseService::FailedResult => e

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -29,10 +29,16 @@ module Invoices
         result.invoice = payment.payable
         return result if payment.payable.payment_succeeded?
 
-        payment.update!(status:)
+        payment.status = status
+
+        payable_payment_status = payment.payment_provider&.determine_payment_status(payment.status)
+        if Payment::PAYABLE_PAYMENT_STATUS.include?(payable_payment_status)
+          payment.payable_payment_status = payable_payment_status
+        end
+        payment.save!
 
         update_invoice_payment_status(
-          payment_status: payment.payment_provider&.determine_payment_status(status),
+          payment_status: payable_payment_status,
           processing: status == "processing"
         )
 

--- a/app/services/payment_requests/payments/adyen_service.rb
+++ b/app/services/payment_requests/payments/adyen_service.rb
@@ -43,9 +43,14 @@ module PaymentRequests
         result.payable = payment.payable
         return result if payment.payable.payment_succeeded?
 
-        payment.update!(status:)
+        payment.status = status
 
-        payable_payment_status = payment.payment_provider&.determine_payment_status(status)
+        payable_payment_status = payment.payment_provider&.determine_payment_status(payment.status)
+        if Payment::PAYABLE_PAYMENT_STATUS.include?(payable_payment_status)
+          payment.payable_payment_status = payable_payment_status
+        end
+        payment.save!
+
         update_payable_payment_status(payment_status: payable_payment_status)
         update_invoices_payment_status(payment_status: payable_payment_status)
         reset_customer_dunning_campaign_status(payable_payment_status)

--- a/app/services/payment_requests/payments/gocardless_service.rb
+++ b/app/services/payment_requests/payments/gocardless_service.rb
@@ -32,9 +32,14 @@ module PaymentRequests
         result.payable = payment.payable
         return result if payment.payable.payment_succeeded?
 
-        payment.update!(status:)
+        payment.status = status
 
-        payable_payment_status = payment.payment_provider.determine_payment_status(status)
+        payable_payment_status = payment.payment_provider&.determine_payment_status(payment.status)
+        if Payment::PAYABLE_PAYMENT_STATUS.include?(payable_payment_status)
+          payment.payable_payment_status = payable_payment_status
+        end
+        payment.save!
+
         update_payable_payment_status(payment_status: payable_payment_status)
         update_invoices_payment_status(payment_status: payable_payment_status)
         reset_customer_dunning_campaign_status(payable_payment_status)

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -52,10 +52,17 @@ module PaymentRequests
         payment.update!(status:)
 
         processing = status == "processing"
-        payment_status = payment.payment_provider.determine_payment_status(status)
-        update_payable_payment_status(payment_status:, processing:)
-        update_invoices_payment_status(payment_status:, processing:)
-        reset_customer_dunning_campaign_status(payment_status)
+        payment.status = status
+
+        payable_payment_status = payment.payment_provider&.determine_payment_status(payment.status)
+        if Payment::PAYABLE_PAYMENT_STATUS.include?(payable_payment_status)
+          payment.payable_payment_status = payable_payment_status
+        end
+        payment.save!
+
+        update_payable_payment_status(payment_status: payable_payment_status, processing:)
+        update_invoices_payment_status(payment_status: payable_payment_status, processing:)
+        reset_customer_dunning_campaign_status(payable_payment_status)
 
         PaymentRequestMailer.with(payment_request: payment.payable).requested.deliver_later if result.payable.payment_failed?
 

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -22,6 +22,11 @@ FactoryBot.define do
       association :payment_provider_customer, factory: :gocardless_customer
     end
 
+    trait :cashfree_payment do
+      association :payment_provider, factory: :cashfree_provider
+      association :payment_provider_customer, factory: :cashfree_customer
+    end
+
     trait :requires_action do
       status { 'requires_action' }
       provider_payment_data do


### PR DESCRIPTION
# Context

This PR is related to the recent changes introduced by https://github.com/getlago/lago-api/pull/2962 and https://github.com/getlago/lago-api/pull/2986 to rely on payment provider idem-potency logic

A new `payable_payment_status` was added to the Payment model, but this status is not updated when a webhook is received from a payment provider

# Description

This PR makes sure that the payment, payment request or all other payment related statuses are updated accordingly