### PR TITLE
feat(revshare): self billed invoice pdf/html template

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -347,6 +347,7 @@ class Invoice < ApplicationRecord
   end
 
   def document_invoice_name
+    return I18n.t('invoice.document_name_self_billed') if self_billed?
     return I18n.t('invoice.prepaid_credit_invoice') if credit?
 
     if %w[AU AE ID NZ].include?(organization.country)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -347,7 +347,7 @@ class Invoice < ApplicationRecord
   end
 
   def document_invoice_name
-    return I18n.t('invoice.document_name_self_billed') if self_billed?
+    return I18n.t("invoice.self_billed.document_name") if self_billed?
     return I18n.t('invoice.prepaid_credit_invoice') if credit?
 
     if %w[AU AE ID NZ].include?(organization.country)

--- a/app/services/invoices/generate_pdf_service.rb
+++ b/app/services/invoices/generate_pdf_service.rb
@@ -45,7 +45,10 @@ module Invoices
     end
 
     def template
-      if invoice.one_off?
+      if invoice.self_billed?
+        "invoices/v#{invoice.version_number}/self_billed"
+
+      elsif invoice.one_off?
         return 'invoices/v3/one_off' if invoice.version_number < 4
 
         "invoices/v#{invoice.version_number}/one_off"

--- a/app/views/templates/invoices/v4/self_billed.slim
+++ b/app/views/templates/invoices/v4/self_billed.slim
@@ -1,0 +1,481 @@
+doctype html
+html
+  head
+    meta charset='UTF-8'
+    meta http-equiv='X-UA-Compatible' content='IE=edge'
+    meta name='viewport' content='width=device-width, initial-scale=1.0'
+    title Self billing invoice
+  body
+    css:
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 100;
+        font-display: swap;
+        src: local("Inter-Thin");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 100;
+        font-display: swap;
+        src: local("Inter-ThinItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 200;
+        font-display: swap;
+        src: local("Inter-ExtraLight");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 200;
+        font-display: swap;
+        src: local("Inter-ExtraLightItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 300;
+        font-display: swap;
+        src: local("Inter-Light");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 300;
+        font-display: swap;
+        src: local("Inter-LightItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 400;
+        font-display: swap;
+        src: local("Inter-Regular");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 400;
+        font-display: swap;
+        src: local("Inter-Italic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 500;
+        font-display: swap;
+        src: local("Inter-Medium");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 500;
+        font-display: swap;
+        src: local("Inter-MediumItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 600;
+        font-display: swap;
+        src: local("Inter-SemiBold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 600;
+        font-display: swap;
+        src: local("Inter-SemiBoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 700;
+        font-display: swap;
+        src: local("Inter-Bold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 700;
+        font-display: swap;
+        src: local("Inter-BoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 800;
+        font-display: swap;
+        src: local("Inter-ExtraBold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 800;
+        font-display: swap;
+        src: local("Inter-ExtraBoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 900;
+        font-display: swap;
+        src: local("Inter-Black");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 900;
+        font-display: swap;
+        src: local("Inter-BlackItalic");
+      }
+
+
+      /* ----------------------- variable ----------------------- */
+      :root {
+        --border-color: #D9DEE7;
+      }
+
+      @font-face {
+        font-family: 'Inter var';
+        font-style: normal;
+        font-weight: 100 900;
+        font-display: swap;
+        src: local('Inter-roman') format('woff2');
+        font-named-instance: 'Regular';
+      }
+
+      @font-face {
+        font-family: 'Inter var';
+        font-style: italic;
+        font-weight: 100 900;
+        font-display: swap;
+        src: local('Inter-italic') format('woff2');
+        font-named-instance: 'Italic';
+      }
+      h1, h2, p { margin: 0; padding: 0; }
+      html { font-family: Inter, sans-serif; }
+      h1 { color: #19212e; font-weight: 700; font-size: 24px; line-height: 32px; }
+      h2 {
+        color: #19212e;
+        font-weight: 700;
+        font-size: 18px;
+        line-height: 24px;
+      }
+      .body-1 {
+        color: #19212e;
+        font-weight: 600;
+        font-size: 10px;
+        line-height: 16px;
+      }
+      .body-2 {
+        color: #19212e;
+        font-weight: 400;
+        font-size: 10px;
+        line-height: 16px;
+      }
+      .body-3 {
+        color: #66758f;
+        font-weight: 400;
+        font-size: 9px;
+        line-height: 16px;
+      }
+
+      .mb-4 {
+        margin-bottom: 4px;
+      }
+      .mb-24 {
+        margin-bottom: 24px;
+      }
+      .mt-24 {
+        margin-top: 24px;
+      }
+
+      .overflow-auto {
+        overflow: auto;
+      }
+      tr {
+        break-inside: avoid;
+      }
+
+      .invoice-title {
+        display: inline;
+      }
+      .header-logo {
+        float: right;
+        max-height: 32px;
+      }
+
+      .invoice-information-column {
+        float: left;
+        width: 50%;
+      }
+      .invoice-information-table tr td:first-child {
+        padding: 0 16px 0 0;
+      }
+      .invoice-information-table tr td:last-child {
+        width: 55%;
+      }
+      .invoice-information-table, tr td{
+        text-wrap: normal;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
+      .invoice-information-table {
+        border-collapse: collapse;
+        table-layout: fixed;
+        width: 100%;
+      }
+
+      .billing-information-column {
+        float: left;
+        width: 50%;
+      }
+
+      .invoice-resume-table tr.first_child td {
+        color: #66758F;
+      }
+      .invoice-resume-table tr {
+        border-bottom: 1px solid var(--border-color);
+      }
+      .invoice-resume-table tr td {
+        padding-top: 8px;
+        padding-bottom: 8px;
+        text-align: right;
+        word-wrap: break-word;
+      }
+      .invoice-resume-table td:first-child {
+        width: 50%;
+        text-align: left;
+      }
+      .invoice-resume-table td:nth-child(2) {
+        width: 12.5%;
+        max-width: 10vw;
+      }
+      .invoice-resume-table td:nth-child(3) {
+        width: 12.5%;
+        max-width: 10vw;
+      }
+      .invoice-resume-table td:nth-child(4) {
+        width: 12.5%;
+      }
+      .invoice-resume-table td:nth-child(5) {
+        width: 12.5%;
+        max-width: 10vw;
+      }
+      .invoice-resume table {
+        border-collapse: collapse;
+      }
+      .invoice-resume .total-table tr td {
+        padding-top: 8px;
+        padding-bottom: 8px;
+        text-align: right;
+      }
+      .invoice-resume .total-table td:first-child {
+        width: 50%;
+      }
+      .invoice-resume .total-table tr:not(:last-child) td:nth-child(2) {
+        border-bottom: 1px solid var(--border-color);
+        text-align: left;
+        width: 35%;
+      }
+      .invoice-resume .total-table tr:not(:last-child) td:nth-child(3) {
+        border-bottom: 1px solid var(--border-color);
+        text-align: right;
+        width: 15%;
+      }
+      .invoice-resume .total-table tr:last-child td:nth-child(2) {
+        text-align: left;
+        width: 25%;
+      }
+      .invoice-resume .total-table tr:last-child td:nth-child(3) {
+        text-align: right;
+        width: 25%;
+      }
+
+      .invoice-details-title {
+        page-break-before: always;
+      }
+
+      .breakdown-details table {
+        border-collapse: collapse;
+      }
+      .breakdown-details {
+        margin-top: -15px;
+      }
+      .breakdown-details-table tr td {
+        padding-bottom: 8px;
+        padding-top: 8px;
+      }
+      .breakdown-details-table tr td:last-child {
+        text-align: right;
+      }
+      .breakdown-details-table tr td {
+        border-bottom: 1px solid var(--border-color);
+      }
+      .breakdown-details-table tr:first-child td {
+        border-top: 1px solid var(--border-color);
+      }
+
+      .powered-by {
+        width: 100%;
+        text-align: right;
+      }
+      .powered-by span {
+        color: #8c95a6;
+      }
+      .powered-by img {
+        width: 37px;
+        height: 11px;
+        vertical-align: middle;
+        margin-top: 2px;
+      }
+      .alert {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        padding: 16px;
+        gap: 16px;
+        background: #F3F4F6;
+        border-radius: 12px;
+      }
+      .invoice-resume-table tr.details, .invoice-resume-table tr.charge-name {
+        border: none;
+      }
+      .invoice-resume-table tr.charge-name td {
+        padding-bottom: 0;
+        color: #19212e;
+      }
+      .invoice-resume-table tr.details td {
+        color: #66758F;
+        padding-top: 4px;
+        padding-bottom: 4px;
+      }
+      .invoice-resume-table tr.details td:first-child {
+        padding-left: 8px;
+      }
+      .invoice-resume-table tr.details.subtotal td {
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--border-color);
+        color: #19212e;
+      }
+
+    .wrapper
+      .mb-24
+        h1.invoice-title = document_invoice_name
+
+      .mb-24.overflow-auto
+        .invoice-information-column
+          table.invoice-information-table
+            tr
+              td.body-1 = I18n.t('invoice.invoice_number')
+              td.body-2 = number
+            tr
+              td.body-1 = I18n.t('invoice.issue_date')
+              td.body-2 = I18n.l(issuing_date, format: :default)
+            tr
+              td.body-1 = I18n.t('invoice.payment_term')
+              td.body-2 = I18n.t('invoice.payment_term_days', net_payment_term:)
+        .invoice-information-column
+          table.invoice-information-table
+            - if customer.metadata.displayable.any?
+              - customer.metadata.displayable.order(created_at: :asc).each do |metadata|
+                tr
+                  td.body-1 = metadata.key
+                  td.body-2 = metadata.value
+
+      .mb-24.overflow-auto
+        // Issuer (partner) information
+        .billing-information-column
+          .body-1 = I18n.t('invoice.bill_from')
+          .body-2 = customer.display_name
+          - if customer.legal_number.present?
+            .body-2 #{customer.legal_number}
+          .body-2 = customer.address_line1
+          .body-2 = customer.address_line2
+          .body-2
+            span
+              = customer.zipcode
+            - if customer.zipcode.present? && customer.city.present?
+              span
+                | , &nbsp;
+            span
+              = customer.city
+          .body-2 = customer.state
+          .body-2 = ISO3166::Country.new(customer.country)&.common_name
+          .body-2 = customer.email&.gsub(/,\s*/, ', ')
+          - if customer.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)
+
+        // Recipient (organization) information
+        .billing-information-column
+          .body-1 = I18n.t('invoice.bill_to')
+          .body-2
+            - if organization.legal_name.present?
+              | #{organization.legal_name}
+            - else
+              | #{organization.name}
+          - if organization.legal_number.present?
+            .body-2 #{organization.legal_number}
+          .body-2 = organization.address_line1
+          .body-2 = organization.address_line2
+          .body-2
+            span
+              = organization.zipcode
+            - if organization.zipcode.present? && organization.city.present?
+              span
+                | , &nbsp;
+            span
+              = organization.city
+          - if organization.state.present?
+            .body-2 = organization.state
+          .body-2 = ISO3166::Country.new(organization.country)&.common_name
+          .body-2 = organization.email
+          - if organization.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
+
+      .mb-24
+        h2.title-2.mb-4 = MoneyHelper.format(total_amount)
+        .body-1 = I18n.t('invoice.due_date', date: I18n.l(payment_due_date, format: :default))
+
+      .invoice-resume.mb-24.overflow-auto
+        - if credit?
+          == SlimHelper.render('templates/invoices/v4/_credit', self)
+        - elsif progressive_billing?
+          == SlimHelper.render('templates/invoices/v4/_progressive_billing_details', self)
+        - elsif subscriptions.count == 1
+          == SlimHelper.render('templates/invoices/v4/_subscription_details', self)
+        - else
+          == SlimHelper.render('templates/invoices/v4/_subscriptions_summary', self)
+
+      == SlimHelper.render('templates/invoices/v4/_eu_tax_management', self)
+
+      - if progressive_billing?
+        p.body-3.mb-24
+          - applied_usage_threshold = applied_usage_thresholds.order(created_at: :asc).last
+          = I18n.t('invoice.reached_usage_threshold', usage_amount: MoneyHelper.format(applied_usage_threshold.lifetime_usage_amount), threshold_amount: MoneyHelper.format(applied_usage_threshold.passed_threshold_amount))
+
+      - if applied_invoice_custom_sections.present?
+        == SlimHelper.render('templates/invoices/v4/_custom_sections', self)
+
+      p.body-3.mb-24 = LineBreakHelper.break_lines(I18n.t("invoice.self_billed.footer"))
+
+      .powered-by
+        span.body-2
+          | #{I18n.t('invoice.powered_by')} &nbsp;
+        img src="#{::SlimHelper::PDF_LOGO_FILENAME}" alt="Lago Logo"
+
+      - if subscriptions.count > 1
+        == SlimHelper.render('templates/invoices/v4/_subscription_details', self)

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -37,6 +37,9 @@ de:
     monthly: Monatlich
     notice_full: Unabhängig davon, wann ein Ereignis empfangen wird, wird die Einheit nicht anteilig berechnet, wir berechnen den vollen Preis.
     notice_prorated: Wenn eine Einheit während des Abrechnungszeitraums hinzugefügt oder entfernt wird, berechnen wir den anteiligen Preis basierend auf dem Verhältnis der verbleibenden oder genutzten Tage zur Gesamtzahl der Tage im Plan. Zum Beispiel, wenn noch 15 Tage im Plan verbleiben, multiplizieren wir den Preis mit 15/%{days_in_month}, und wenn eine Einheit für 10 Tage genutzt wurde, multiplizieren wir den Preis mit 10/%{days_in_month}.
+    self_billed:
+      document_name: Selbstabrechnungsrechnung
+      footer: Selbstabgerechnete Rechnung. Der Partner hat zugestimmt, für diese Transaktion keine eigene Rechnung auszustellen.
     package:
       fee_per_package: Gebühr pro Paket
       fee_per_package_unit_price: "%{amount} pro %{package_size}"

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -37,9 +37,6 @@ de:
     monthly: Monatlich
     notice_full: Unabhängig davon, wann ein Ereignis empfangen wird, wird die Einheit nicht anteilig berechnet, wir berechnen den vollen Preis.
     notice_prorated: Wenn eine Einheit während des Abrechnungszeitraums hinzugefügt oder entfernt wird, berechnen wir den anteiligen Preis basierend auf dem Verhältnis der verbleibenden oder genutzten Tage zur Gesamtzahl der Tage im Plan. Zum Beispiel, wenn noch 15 Tage im Plan verbleiben, multiplizieren wir den Preis mit 15/%{days_in_month}, und wenn eine Einheit für 10 Tage genutzt wurde, multiplizieren wir den Preis mit 10/%{days_in_month}.
-    self_billed:
-      document_name: Selbstabrechnungsrechnung
-      footer: Selbstabgerechnete Rechnung. Der Partner hat zugestimmt, für diese Transaktion keine eigene Rechnung auszustellen.
     package:
       fee_per_package: Gebühr pro Paket
       fee_per_package_unit_price: "%{amount} pro %{package_size}"
@@ -64,6 +61,9 @@ de:
     quarterly: Vierteljährlich
     reached_usage_threshold: Diese progressive Rechnung wird erstellt, da Ihre kumulierte Nutzung %{usage_amount} erreicht hat und den Schwellenwert von %{threshold_amount} überschritten hat.
     see_breakdown: Siehe Aufschlüsselung für Gesamtübersicht
+    self_billed:
+      document_name: Selbstabrechnungsrechnung
+      footer: Selbstabgerechnete Rechnung. Der Partner hat zugestimmt, für diese Transaktion keine eigene Rechnung auszustellen.
     sub_total: Zwischensumme
     sub_total_with_tax: Zwischensumme (inkl. Steuern)
     sub_total_without_tax: Zwischensumme (ohne Steuern)

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -18,6 +18,7 @@ en:
     date_to: to
     details: "%{resource} details"
     document_name: Invoice
+    document_name_self_billed: Self billing invoice
     document_tax_name: Tax invoice
     due_date: Due %{date}
     fee_prorated: The fee is prorated on days of usage, the displayed unit price is an average

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -18,7 +18,6 @@ en:
     date_to: to
     details: "%{resource} details"
     document_name: Invoice
-    document_name_self_billed: Self billing invoice
     document_tax_name: Tax invoice
     due_date: Due %{date}
     fee_prorated: The fee is prorated on days of usage, the displayed unit price is an average
@@ -38,6 +37,9 @@ en:
     monthly: Monthly
     notice_full: Regardless of when an event is received, the unit is not prorated, we charge the full price.
     notice_prorated: If a unit is added or removed during the monthly plan, we calculate the prorated price based on the ratio of days remaining or used to the total number of days in the plan. For instance, if 15 days are left in the plan, we multiply the price by 15/%{days_in_month}, and if a unit was used for 10 days, we multiply the price by 10/%{days_in_month}.
+    self_billed:
+      document_name: Self billing invoice
+      footer: Self-billed invoice. The partner has agreed not to issue their own invoice for this transaction.
     package:
       fee_per_package: Fee per package
       fee_per_package_unit_price: "%{amount} per %{package_size}"

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -37,9 +37,6 @@ en:
     monthly: Monthly
     notice_full: Regardless of when an event is received, the unit is not prorated, we charge the full price.
     notice_prorated: If a unit is added or removed during the monthly plan, we calculate the prorated price based on the ratio of days remaining or used to the total number of days in the plan. For instance, if 15 days are left in the plan, we multiply the price by 15/%{days_in_month}, and if a unit was used for 10 days, we multiply the price by 10/%{days_in_month}.
-    self_billed:
-      document_name: Self billing invoice
-      footer: Self-billed invoice. The partner has agreed not to issue their own invoice for this transaction.
     package:
       fee_per_package: Fee per package
       fee_per_package_unit_price: "%{amount} per %{package_size}"
@@ -64,6 +61,9 @@ en:
     quarterly: Quarterly
     reached_usage_threshold: This progressive billing is generated because your cumulative usage has reached %{usage_amount}, exceeding the %{threshold_amount} threshold.
     see_breakdown: See breakdown for total unit
+    self_billed:
+      document_name: Self billing invoice
+      footer: Self-billed invoice. The partner has agreed not to issue their own invoice for this transaction.
     sub_total: Subtotal
     sub_total_with_tax: Subtotal (incl. tax)
     sub_total_without_tax: Subtotal (excl. tax)

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -36,9 +36,6 @@ es:
     monthly: Mensual
     notice_full: Independientemente de cuándo se reciba un evento, la unidad no se prorratea, cobramos el precio completo.
     notice_prorated: Si se agrega o se elimina una unidad durante el plan mensual, calculamos el precio prorrateado en función de la proporción de días restantes o utilizados con respecto al número total de días en el plan. Por ejemplo, si quedan 15 días en el plan, multiplicamos el precio por 15/%{days_in_month}, y si una unidad se usó durante 10 días, multiplicamos el precio por 10/%{days_in_month}.
-    self_billed:
-      document_name: Factura de autofacturación
-      footer: Factura autofacturada. El socio ha aceptado no emitir su propia factura para esta transacción.
     package:
       fee_per_package: Tarifa por paquete
       fee_per_package_unit_price: "%{amount} por %{package_size}"
@@ -63,6 +60,9 @@ es:
     quarterly: Trimestral
     reached_usage_threshold: Esta facturación progresiva se genera porque su uso acumulado ha alcanzado los %{usage_amount}, superando el umbral de %{threshold_amount}.
     see_breakdown: Consulte el desglose a continuación
+    self_billed:
+      document_name: Factura de autofacturación
+      footer: Factura autofacturada. El socio ha aceptado no emitir su propia factura para esta transacción.
     sub_total: Subtotal
     sub_total_with_tax: Subtotal (impuestos incl.)
     sub_total_without_tax: Subtotal (impuestos excl.)

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -36,6 +36,9 @@ es:
     monthly: Mensual
     notice_full: Independientemente de cuándo se reciba un evento, la unidad no se prorratea, cobramos el precio completo.
     notice_prorated: Si se agrega o se elimina una unidad durante el plan mensual, calculamos el precio prorrateado en función de la proporción de días restantes o utilizados con respecto al número total de días en el plan. Por ejemplo, si quedan 15 días en el plan, multiplicamos el precio por 15/%{days_in_month}, y si una unidad se usó durante 10 días, multiplicamos el precio por 10/%{days_in_month}.
+    self_billed:
+      document_name: Factura de autofacturación
+      footer: Factura autofacturada. El socio ha aceptado no emitir su propia factura para esta transacción.
     package:
       fee_per_package: Tarifa por paquete
       fee_per_package_unit_price: "%{amount} por %{package_size}"

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -37,6 +37,9 @@ fr:
     monthly: mensuel
     notice_full: Peu importe quand l’évènement de consommation est reçu, l'unité n'est pas proratisée et nous facturons le prix complet.
     notice_prorated: Si une unité est ajoutée ou supprimée pendant la période de facturation, nous calculons le prix au prorata en fonction du ratio des jours restants ou utilisés. Par exemple, s'il reste 15 jours dans le plan, nous multiplions le prix par 15/%{days_in_month}, et si une unité a été utilisée pendant 10 jours, nous multiplions le prix par 10/%{days_in_month}.
+    self_billed:
+      document_name: Facture d'autofacturation
+      footer: Facture autofacturée. Le partenaire a accepté de ne pas émettre sa propre facture pour cette transaction.
     package:
       fee_per_package: Frais par tranche
       fee_per_package_unit_price: "%{amount} par tranche de %{package_size}"

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -37,9 +37,6 @@ fr:
     monthly: mensuel
     notice_full: Peu importe quand l’évènement de consommation est reçu, l'unité n'est pas proratisée et nous facturons le prix complet.
     notice_prorated: Si une unité est ajoutée ou supprimée pendant la période de facturation, nous calculons le prix au prorata en fonction du ratio des jours restants ou utilisés. Par exemple, s'il reste 15 jours dans le plan, nous multiplions le prix par 15/%{days_in_month}, et si une unité a été utilisée pendant 10 jours, nous multiplions le prix par 10/%{days_in_month}.
-    self_billed:
-      document_name: Facture d'autofacturation
-      footer: Facture autofacturée. Le partenaire a accepté de ne pas émettre sa propre facture pour cette transaction.
     package:
       fee_per_package: Frais par tranche
       fee_per_package_unit_price: "%{amount} par tranche de %{package_size}"
@@ -64,6 +61,9 @@ fr:
     quarterly: trimestriellement
     reached_usage_threshold: Cette facturation progressive est générée car votre usage cumulé a atteint %{usage_amount}, dépassant le seuil de %{threshold_amount}.
     see_breakdown: Consultez le détail ci-après
+    self_billed:
+      document_name: Facture d'autofacturation
+      footer: Facture autofacturée. Le partenaire a accepté de ne pas émettre sa propre facture pour cette transaction.
     sub_total: Sous total
     sub_total_with_tax: Sous total (TTC)
     sub_total_without_tax: Sous total (HT)

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -37,6 +37,9 @@ it:
     monthly: Mensile
     notice_full: Indipendentemente da quando un evento viene ricevuto, l'unità non è prorata, addebitiamo il prezzo intero.
     notice_prorated: Se un'unità viene aggiunta o rimossa durante il piano mensile, calcoliamo il prezzo proporzionato in base al rapporto tra i giorni rimanenti o utilizzati e il numero totale di giorni nel piano. Ad esempio, se restano 15 giorni nel piano, moltiplichiamo il prezzo per 15/%{days_in_month}, e se un'unità è stata utilizzata per 10 giorni, moltiplichiamo il prezzo per 10/%{days_in_month}.
+    self_billed:
+      document_name: Fattura di autofatturazione
+      footer: Fattura autofatturata. Il partner ha accettato di non emettere la propria fattura per questa transazione.
     package:
       fee_per_package: Tassa per pacchetto
       fee_per_package_unit_price: "%{amount} per %{package_size}"

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -37,9 +37,6 @@ it:
     monthly: Mensile
     notice_full: Indipendentemente da quando un evento viene ricevuto, l'unità non è prorata, addebitiamo il prezzo intero.
     notice_prorated: Se un'unità viene aggiunta o rimossa durante il piano mensile, calcoliamo il prezzo proporzionato in base al rapporto tra i giorni rimanenti o utilizzati e il numero totale di giorni nel piano. Ad esempio, se restano 15 giorni nel piano, moltiplichiamo il prezzo per 15/%{days_in_month}, e se un'unità è stata utilizzata per 10 giorni, moltiplichiamo il prezzo per 10/%{days_in_month}.
-    self_billed:
-      document_name: Fattura di autofatturazione
-      footer: Fattura autofatturata. Il partner ha accettato di non emettere la propria fattura per questa transazione.
     package:
       fee_per_package: Tassa per pacchetto
       fee_per_package_unit_price: "%{amount} per %{package_size}"
@@ -64,6 +61,9 @@ it:
     quarterly: Trimestrale
     reached_usage_threshold: Questa fatturazione progressiva è generata poiché il tuo utilizzo cumulato ha raggiunto %{usage_amount}, superando la soglia di %{threshold_amount}.
     see_breakdown: Vedere la ripartizione per l'unità totale
+    self_billed:
+      document_name: Fattura di autofatturazione
+      footer: Fattura autofatturata. Il partner ha accettato di non emettere la propria fattura per questa transazione.
     sub_total: Subtotale
     sub_total_with_tax: Subtotale (incl. tasse)
     sub_total_without_tax: Subtotale (escl. tasse)

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -37,6 +37,9 @@ nb:
     monthly: Månedlig
     notice_full: Uavhengig av når en hendelse mottas, blir enheten ikke forholdsmessig priset, vi belaster full pris.
     notice_prorated: Hvis en enhet legges til eller fjernes i løpet av faktureringsperioden, beregner vi den proporsjonale prisen basert på forholdet mellom gjenværende eller brukte dager og det totale antallet dager i planen. For eksempel, hvis det er 15 dager igjen i planen, multipliserer vi prisen med 15/%{days_in_month}, og hvis en enhet ble brukt i 10 dager, multipliserer vi prisen med 10/%{days_in_month}.
+    self_billed:
+      document_name: Selvfakturering
+      footer: Selvfakturert faktura. Partneren har gått med på å ikke utstede sin egen faktura for denne transaksjonen.
     package:
       fee_per_package: Gebyr per pakke
       fee_per_package_unit_price: "%{amount} per %{package_size}"

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -37,9 +37,6 @@ nb:
     monthly: Månedlig
     notice_full: Uavhengig av når en hendelse mottas, blir enheten ikke forholdsmessig priset, vi belaster full pris.
     notice_prorated: Hvis en enhet legges til eller fjernes i løpet av faktureringsperioden, beregner vi den proporsjonale prisen basert på forholdet mellom gjenværende eller brukte dager og det totale antallet dager i planen. For eksempel, hvis det er 15 dager igjen i planen, multipliserer vi prisen med 15/%{days_in_month}, og hvis en enhet ble brukt i 10 dager, multipliserer vi prisen med 10/%{days_in_month}.
-    self_billed:
-      document_name: Selvfakturering
-      footer: Selvfakturert faktura. Partneren har gått med på å ikke utstede sin egen faktura for denne transaksjonen.
     package:
       fee_per_package: Gebyr per pakke
       fee_per_package_unit_price: "%{amount} per %{package_size}"
@@ -64,6 +61,9 @@ nb:
     quarterly: Kvartalsvis
     reached_usage_threshold: Denne progressive faktureringen er generert fordi din akkumulerte bruk har nådd %{usage_amount}, og overskredet terskelen på %{threshold_amount}.
     see_breakdown: Se oversikt for antall enheter
+    self_billed:
+      document_name: Selvfakturering
+      footer: Selvfakturert faktura. Partneren har gått med på å ikke utstede sin egen faktura for denne transaksjonen.
     sub_total: Sub total
     sub_total_with_tax: Sub total (inkl. MVA)
     sub_total_without_tax: Sub total (ekskl. MVA)

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -36,6 +36,9 @@ sv:
     monthly: Månadsvis
     notice_full: Oavsett när en händelse tas emot är enheten inte proportionell, fullt pris debiteras fullt pris.
     notice_prorated: Skulle en produkt läggas till eller tas bort under månadsperioden beräknar vi det justerade priset baserat på förhållandet mellan kvarvarande eller använda dagar till det totala antalet dagar i perioden. Skulle det till exempel vara 15 dagar kvar i perioden, multipliceras priset med 15/%{days_in_month}, om en produkt nyttjas i 10 dagar, multipliceras priset med 10/%{days_in_month}.
+    self_billed:
+      document_name: Självfaktura
+      footer: Självfakturerad faktura. Partnern har gått med på att inte utfärda sin egen faktura för denna transaktion.
     package:
       fee_per_package: Avgift per paket
       fee_per_package_unit_price: "%{amount} per %{package_size}"

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -36,9 +36,6 @@ sv:
     monthly: Månadsvis
     notice_full: Oavsett när en händelse tas emot är enheten inte proportionell, fullt pris debiteras fullt pris.
     notice_prorated: Skulle en produkt läggas till eller tas bort under månadsperioden beräknar vi det justerade priset baserat på förhållandet mellan kvarvarande eller använda dagar till det totala antalet dagar i perioden. Skulle det till exempel vara 15 dagar kvar i perioden, multipliceras priset med 15/%{days_in_month}, om en produkt nyttjas i 10 dagar, multipliceras priset med 10/%{days_in_month}.
-    self_billed:
-      document_name: Självfaktura
-      footer: Självfakturerad faktura. Partnern har gått med på att inte utfärda sin egen faktura för denna transaktion.
     package:
       fee_per_package: Avgift per paket
       fee_per_package_unit_price: "%{amount} per %{package_size}"
@@ -63,6 +60,9 @@ sv:
     quarterly: Kvartalsvis
     reached_usage_threshold: Denna progressiva fakturering skapas eftersom din ackumulerade användning har nått %{usage_amount} och överstiger %{threshold_amount} tröskeln.
     see_breakdown: Se uppdelning nedan
+    self_billed:
+      document_name: Självfaktura
+      footer: Självfakturerad faktura. Partnern har gått med på att inte utfärda sin egen faktura för denna transaktion.
     sub_total: Delsumma
     sub_total_with_tax: Delsumma (inkl. moms)
     sub_total_without_tax: Delsumma (exkl. moms)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -779,6 +779,14 @@ RSpec.describe Invoice, type: :model do
       expect(invoice.document_invoice_name).to eq('Invoice')
     end
 
+    context "when invoice is self billed" do
+      let(:invoice) { create(:invoice, :self_billed, customer:, organization:) }
+
+      it 'returns the correct name for EU country' do
+        expect(invoice.document_invoice_name).to eq("Self billing invoice")
+      end
+    end
+
     context 'when organization country is Australia' do
       let(:organization) { create(:organization, name: 'LAGO', country: 'AU') }
 

--- a/spec/services/invoices/generate_pdf_service_spec.rb
+++ b/spec/services/invoices/generate_pdf_service_spec.rb
@@ -113,6 +113,30 @@ RSpec.describe Invoices::GeneratePdfService, type: :service do
       end
     end
 
+    context "when invoice is self billed" do
+      let(:invoice) do
+        create(:invoice, :self_billed, customer:, status: :finalized, organization:)
+      end
+
+      let(:pdf_generator) { instance_double(Utils::PdfGenerator, call: pdf_response) }
+
+      let(:pdf_response) do
+        BaseService::Result.new.tap { |r| r.io = StringIO.new(pdf_content) }
+      end
+
+      let(:pdf_content) { File.read(Rails.root.join('spec/fixtures/blank.pdf')) }
+
+      before do
+        allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+      end
+
+      it "calls the self billed template" do
+        invoice_generate_service.call
+
+        expect(Utils::PdfGenerator).to have_received(:new).with(template: 'invoices/v4/self_billed', context: invoice)
+      end
+    end
+
     context 'when in API context' do
       let(:context) { 'api' }
 


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/calculate-revenue-share

 ## Context

Current problem: companies with **partners** selling for them cannot have a **revenue share** system in Lago.

We want to propose **self-billing** into Lago, a billing arrangement where the **customer** creates and issues the invoice on **behalf** of the **supplier** for goods or services received.

 ## Description

add self_billed invoice template

generate self_billed invoices with the right template

custom sections feature is the only one excluded from v4 normal invoices template, all other features like progressive billing, coupons, etc should be available.