### PR TITLE
feat(revshare): missing bits of the feature...

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -12,6 +12,7 @@ module Types
       field :number, String, null: false
       field :sequential_id, ID, null: false
 
+      field :self_billed, Boolean, null: false
       field :version_number, Integer, null: false
 
       field :invoice_type, Types::Invoices::InvoiceTypeEnum, null: false

--- a/app/services/invoices/create_generating_service.rb
+++ b/app/services/invoices/create_generating_service.rb
@@ -15,6 +15,8 @@ module Invoices
     end
 
     def call
+      return result.forbidden_failure! if customer.partner_account? && !organization.revenue_share_enabled?
+
       ActiveRecord::Base.transaction do
         invoice = Invoice.create!(
           id: invoice_id || SecureRandom.uuid,

--- a/schema.graphql
+++ b/schema.graphql
@@ -4521,6 +4521,7 @@ type Invoice {
   prepaidCreditAmountCents: BigInt!
   progressiveBillingCreditAmountCents: BigInt!
   refundableAmountCents: BigInt!
+  selfBilled: Boolean!
   sequentialId: ID!
   status: InvoiceStatusTypeEnum!
   subTotalExcludingTaxesAmountCents: BigInt!

--- a/schema.json
+++ b/schema.json
@@ -21304,6 +21304,22 @@
               "args": []
             },
             {
+              "name": "selfBilled",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "sequentialId",
               "description": null,
               "type": {

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Types::Invoices::Object do
   it { is_expected.to have_field(:number).of_type('String!') }
   it { is_expected.to have_field(:sequential_id).of_type('ID!') }
 
+  it { is_expected.to have_field(:self_billed).of_type('Boolean!') }
   it { is_expected.to have_field(:version_number).of_type('Int!') }
 
   it { is_expected.to have_field(:invoice_type).of_type('InvoiceTypeEnum!') }


### PR DESCRIPTION
 ## Roadmap

👉 https://getlago.canny.io/feature-requests/p/calculate-revenue-share

 ## Context

Current problem: companies with **partners** selling for them cannot have a **revenue share** system in Lago.

We want to propose **self-billing** into Lago, a billing arrangement where the **customer** creates and issues the invoice on **behalf** of the **supplier** for goods or services received.

 ## Description

add `self_billed` to graphql invoice object type.

do not allow invoice generation for self billed (partner account) and organizations without revenue share feature enabled.