### PR TITLE
Chore: delete invoice errors for sequential number generation when finishing invoice generation

### DIFF
--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -82,7 +82,7 @@ module Invoices
 
     def clear_invoice_errors(invoice)
       invoice_error = InvoiceError.where(id: invoice.id)
-      return unless invoice_error.present?
+      return if invoice_error.blank?
 
       delete_generating_sequence_number_error(invoice_error)
     end

--- a/db/migrate/20250122112050_delete_sequence_generation_invoice_error_for_generated_invoices.rb
+++ b/db/migrate/20250122112050_delete_sequence_generation_invoice_error_for_generated_invoices.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DeleteSequenceGenerationInvoiceErrorForGeneratedInvoices < ActiveRecord::Migration[7.1]
+  def change
+    InvoiceError.joins("LEFT JOIN invoices ON invoices.id = invoice_errors.id")
+                .where("invoice_errors.backtrace LIKE ?", "%generate_organization_sequential_id%")
+                .where(invoices: {status: Invoice::GENERATED_INVOICE_STATUSES}).find_each do |ie|
+      ie.delete
+    end
+  end
+end

--- a/db/migrate/20250122112050_delete_sequence_generation_invoice_error_for_generated_invoices.rb
+++ b/db/migrate/20250122112050_delete_sequence_generation_invoice_error_for_generated_invoices.rb
@@ -3,8 +3,8 @@
 class DeleteSequenceGenerationInvoiceErrorForGeneratedInvoices < ActiveRecord::Migration[7.1]
   def change
     InvoiceError.joins("LEFT JOIN invoices ON invoices.id = invoice_errors.id")
-                .where("invoice_errors.backtrace LIKE ?", "%generate_organization_sequential_id%")
-                .where(invoices: {status: Invoice::GENERATED_INVOICE_STATUSES}).find_each do |ie|
+      .where("invoice_errors.backtrace LIKE ?", "%generate_organization_sequential_id%")
+      .where(invoices: {status: Invoice::GENERATED_INVOICE_STATUSES}).find_each do |ie|
       ie.delete
     end
   end

--- a/db/migrate/20250122112050_delete_sequence_generation_invoice_error_for_generated_invoices.rb
+++ b/db/migrate/20250122112050_delete_sequence_generation_invoice_error_for_generated_invoices.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DeleteSequenceGenerationInvoiceErrorForGeneratedInvoices < ActiveRecord::Migration[7.1]
-  GENERATED_INVOICE_STATUSES = %w[finalized closed].freeze
+  GENERATED_INVOICE_STATUSES = [1, 6].freeze
 
   def change
     InvoiceError.joins("LEFT JOIN invoices ON invoices.id = invoice_errors.id")

--- a/db/migrate/20250122112050_delete_sequence_generation_invoice_error_for_generated_invoices.rb
+++ b/db/migrate/20250122112050_delete_sequence_generation_invoice_error_for_generated_invoices.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class DeleteSequenceGenerationInvoiceErrorForGeneratedInvoices < ActiveRecord::Migration[7.1]
+  GENERATED_INVOICE_STATUSES = %w[finalized closed].freeze
+
   def change
     InvoiceError.joins("LEFT JOIN invoices ON invoices.id = invoice_errors.id")
       .where("invoice_errors.backtrace LIKE ?", "%generate_organization_sequential_id%")
-      .where(invoices: {status: Invoice::GENERATED_INVOICE_STATUSES}).find_each do |ie|
+      .where(invoices: {status: GENERATED_INVOICE_STATUSES}).find_each do |ie|
       ie.delete
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_20_151959) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_22_112050) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -271,5 +271,35 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
         expect { finalize_service.call }.not_to change { invoice.reload.status }
       end
     end
+
+    context 'when invoice has invoice_errors' do
+      before do
+        InvoiceError.create(
+          id: invoice.id,
+          backtrace: "[\"/app/app/models/invoice.rb:432:in 'generate_organization_sequential_id'\", \"/app/app/models/invoice.rb:395:in...",
+          error: "\"#\\u003cSequenced::SequenceError: Unable to acquire lock on the database\\u003e\"",
+          invoice: invoice.to_json(except: :file),
+          subscriptions: invoice.subscriptions.to_json
+        )
+      end
+
+      context 'when successfully generated the invoice' do
+        it 'deletes the invoice_errors' do
+          expect { finalize_service.call }.to change(InvoiceError, :count).by(-1)
+          expect(InvoiceError.find_by(id: invoice.id)).to be_nil
+        end
+      end
+
+      context 'when failed to generate the invoice' do
+        before do
+          allow(Invoices::RefreshDraftService).to receive(:call).and_return(BaseService::Result.new.service_failure!(code: 'code', message: 'message'))
+        end
+
+        it 'does not delete the invoice_errors' do
+          expect { finalize_service.call }.to raise_error(BaseService::ServiceFailure)
+          expect(InvoiceError.find_by(id: invoice.id)).to be_present
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

We have invoices that are generated, so they have invoice_number, but the invoice_error storing details of not generated number still exists

## Description

Added migration to delete invoice_errors that are not needed anymore;
Added methods to delete invoice_errors when invoice is successfully generated
