### PR TITLE
Chore: add validation on credit note creation and estimate to have items as an array

### DIFF
--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -117,6 +117,8 @@ module CreditNotes
     end
 
     def create_items
+      return result.validation_failure!(errors: {items: ['must_be_an_array']}) unless items_attr.is_a?(Array)
+
       items_attr.each do |item_attr|
         amount_cents = item_attr[:amount_cents] || 0
 

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -43,6 +43,8 @@ module CreditNotes
     end
 
     def validate_items
+      return result.validation_failure!(errors: {items: ['must_be_an_array']}) unless items.is_a?(Array)
+
       items.each do |item_attr|
         amount_cents = item_attr[:amount_cents]&.to_i || 0
 

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -190,6 +190,23 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       end
     end
 
+    context 'when items are missing' do
+      let(:items) {}
+
+      it 'returns a failed result' do
+        result = create_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages.keys).to include(:items)
+        expect(result.error.messages[:items]).to eq(
+          %w[
+            must_be_an_array
+          ]
+        )
+      end
+    end
+
     context 'with a refund, a payment and a succeeded invoice' do
       let(:payment) { create(:payment, payable: invoice) }
 

--- a/spec/services/credit_notes/estimate_service_spec.rb
+++ b/spec/services/credit_notes/estimate_service_spec.rb
@@ -123,6 +123,23 @@ RSpec.describe CreditNotes::EstimateService, type: :service do
     end
   end
 
+  context 'with missing items' do
+    let(:items) {}
+
+    it 'returns a failed result' do
+      result = estimate_service.call
+
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ValidationFailure)
+      expect(result.error.messages.keys).to include(:items)
+      expect(result.error.messages[:items]).to eq(
+        %w[
+          must_be_an_array
+        ]
+      )
+    end
+  end
+
   context 'when invoice is not found' do
     let(:invoice) { nil }
     let(:items) { [] }


### PR DESCRIPTION
## Context

When receiving a request to estimate/create a credit note with missing items, now we simply fail with server error, instead we want to return a validation error

## Description

Added validation to credit_notes/create_service and credit_notes/estimate_service to check if the received items is an array
