### PR TITLE
fix(invoice-filtering): Wrong total count when filter invoices by metadata

### DIFF
--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -113,7 +113,7 @@ class InvoicesQuery < BaseQuery
   end
 
   def with_metadata(scope)
-    base_scope = scope.left_joins(:metadata)
+    base_scope = scope.left_joins(:metadata).limit(nil).offset(nil)
     subquery = base_scope
 
     presence_filters = filters.metadata.select { |_k, v| v.present? }

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -668,7 +668,8 @@ RSpec.describe InvoicesQuery, type: :query do
         }
       end
 
-      let!(:matching_invoices) { create_pair(:invoice, organization:) }
+      let(:pagination) { {page: 1, limit: 2} }
+      let!(:matching_invoices) { create_list(:invoice, 3, organization:) }
 
       before do
         matching_invoices.each do |invoice|
@@ -692,7 +693,8 @@ RSpec.describe InvoicesQuery, type: :query do
 
       it "returns invoices with matching metadata filters" do
         expect(result).to be_success
-        expect(result.invoices.pluck(:id)).to match_array matching_invoices.pluck(:id)
+        expect(result.invoices.pluck(:id)).to match_array matching_invoices[1..].pluck(:id)
+        expect(result.invoices.total_count).to eq matching_invoices.count
       end
     end
   end


### PR DESCRIPTION
## Context

Recently added invoice filtering by metadata incorrectly counts `total_count` in pagination metadata.

## Description

Fix pagination `total_count` when filter invoices by metadata.