### PR TITLE
fix(webhook): Fix specs when webhook worker is enabled

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,6 +60,7 @@ RSpec.configure do |config|
   config.include ScenariosHelper
   config.include LicenseHelper
   config.include PdfHelper
+  config.include QueuesHelper
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ActiveStorageValidations::Matchers
 

--- a/spec/services/integrations/aggregator/companies/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/companies/create_service_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
             .with(
               'customer.crm_provider_created',
               customer
-            ).on_queue(:webhook)
+            ).on_queue(webhook_queue)
         end
 
         it_behaves_like 'throttles!', :hubspot
@@ -139,7 +139,7 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
               .with(
                 'customer.crm_provider_created',
                 customer
-              ).on_queue(:webhook)
+              ).on_queue(webhook_queue)
           end
 
           it_behaves_like 'throttles!', :hubspot

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
             .with(
               'customer.accounting_provider_created',
               customer
-            ).on_queue(:webhook)
+            ).on_queue(webhook_queue)
         end
 
         it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero
@@ -150,7 +150,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
               .with(
                 'customer.accounting_provider_created',
                 customer
-              ).on_queue(:webhook)
+              ).on_queue(webhook_queue)
           end
 
           it_behaves_like 'throttles!', :anrok, :hubspot, :netsuite, :xero

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
               message: "error",
               error_code: "code"
             }
-          ).on_queue(:webhook)
+          ).on_queue(webhook_queue)
       end
 
       context "when payment has a payable_payment_status" do

--- a/spec/services/lifetime_usages/recalculate_and_check_service_spec.rb
+++ b/spec/services/lifetime_usages/recalculate_and_check_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe LifetimeUsages::RecalculateAndCheckService, type: :service do
           'subscription.usage_threshold_reached',
           subscription,
           usage_threshold:
-        ).on_queue(:webhook)
+        ).on_queue(webhook_queue)
     end
 
     it "creates an invoice for the usage_threshold" do
@@ -105,7 +105,7 @@ RSpec.describe LifetimeUsages::RecalculateAndCheckService, type: :service do
           'subscription.usage_threshold_reached',
           subscription,
           usage_threshold:
-        ).on_queue(:webhook)
+        ).on_queue(webhook_queue)
     end
 
     it "sends a webhook for the last threshold" do
@@ -114,7 +114,7 @@ RSpec.describe LifetimeUsages::RecalculateAndCheckService, type: :service do
           'subscription.usage_threshold_reached',
           subscription,
           usage_threshold: usage_threshold2
-        ).on_queue(:webhook)
+        ).on_queue(webhook_queue)
     end
 
     it "creates an invoice for the current usage" do
@@ -160,7 +160,7 @@ RSpec.describe LifetimeUsages::RecalculateAndCheckService, type: :service do
           'subscription.usage_threshold_reached',
           subscription,
           usage_threshold: usage_threshold2
-        ).on_queue(:webhook)
+        ).on_queue(webhook_queue)
     end
 
     it "creates an invoice for the current usage" do

--- a/spec/services/payment_provider_customers/adyen_service_spec.rb
+++ b/spec/services/payment_provider_customers/adyen_service_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe PaymentProviderCustomers::AdyenService, type: :service do
             customer,
             checkout_url: 'https://test.adyen.link/test'
           )
-          .on_queue(:webhook)
+          .on_queue(webhook_queue)
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe PaymentProviderCustomers::AdyenService, type: :service do
               message: 'There are no payment methods available for the given parameters.',
               error_code: 'validation'
             }
-          ).on_queue(:webhook)
+          ).on_queue(webhook_queue)
       end
     end
 
@@ -174,7 +174,7 @@ RSpec.describe PaymentProviderCustomers::AdyenService, type: :service do
             customer,
             checkout_url: 'https://test.adyen.link/test'
           )
-          .on_queue(:webhook)
+          .on_queue(webhook_queue)
       end
     end
   end

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
               message: 'API key invalid.',
               error_code: nil
             }
-          ).on_queue(:webhook)
+          ).on_queue(webhook_queue)
       end
     end
 
@@ -204,7 +204,7 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
                   message: 'Invalid request',
                   error_code: nil
                 }
-              ).on_queue(:webhook)
+              ).on_queue(webhook_queue)
           end
         end
 
@@ -231,7 +231,7 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
                   message: 'Permission error',
                   error_code: nil
                 }
-              ).on_queue(:webhook)
+              ).on_queue(webhook_queue)
           end
         end
 
@@ -257,7 +257,7 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
                   message: 'Invalid username.',
                   error_code: nil
                 }
-              ).on_queue(:webhook)
+              ).on_queue(webhook_queue)
           end
         end
       end
@@ -554,7 +554,7 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
               message: 'Expired API Key provided',
               error_code: nil
             }
-          ).on_queue(:webhook)
+          ).on_queue(webhook_queue)
       end
     end
   end

--- a/spec/services/payment_requests/payments/create_service_spec.rb
+++ b/spec/services/payment_requests/payments/create_service_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
               message: "error",
               error_code: "code"
             }
-          ).on_queue(:webhook)
+          ).on_queue(webhook_queue)
       end
 
       context "when payment has a payable_payment_status" do

--- a/spec/support/queues_helper.rb
+++ b/spec/support/queues_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module QueuesHelper
+  def webhook_queue
+    if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_WEBHOOK'])
+      :webhook_worker
+    else
+      :webhook
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR makes sure that specs involving the `on_queue` matcher keeps passing when the webhook worker is configured