### PR TITLE
fix(Fee) - make sure organization_id is stored

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -7,7 +7,6 @@ class Fee < ApplicationRecord
   default_scope -> { kept }
 
   belongs_to :invoice, optional: true
-  belongs_to :organization, optional: true, autosave: false
   belongs_to :charge, -> { with_discarded }, optional: true
   belongs_to :add_on, -> { with_discarded }, optional: true
   belongs_to :applied_add_on, optional: true

--- a/app/services/fees/add_on_service.rb
+++ b/app/services/fees/add_on_service.rb
@@ -15,7 +15,7 @@ module Fees
 
       new_fee = Fee.new(
         invoice:,
-        organization:,
+        organization_id: organization.id,
         applied_add_on:,
         amount_cents:,
         precise_amount_cents: amount_cents.to_d,

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -134,7 +134,7 @@ module Fees
 
       new_fee = Fee.new(
         invoice:,
-        organization:,
+        organization_id: organization.id,
         subscription:,
         charge:,
         amount_cents:,

--- a/app/services/fees/commitments/minimum/create_service.rb
+++ b/app/services/fees/commitments/minimum/create_service.rb
@@ -22,7 +22,7 @@ module Fees
 
           new_fee = Fee.new(
             invoice:,
-            organization:,
+            organization_id: organization.id,
             subscription:,
             fee_type: :commitment,
             invoiceable_type: 'Commitment',

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -64,7 +64,7 @@ module Fees
         fee = Fee.new(
           subscription:,
           charge:,
-          organization:,
+          organization_id: organization.id,
           amount_cents: result.amount,
           precise_amount_cents: result.precise_amount,
           amount_currency: subscription.plan.amount_currency,

--- a/app/services/fees/init_from_adjusted_charge_fee_service.rb
+++ b/app/services/fees/init_from_adjusted_charge_fee_service.rb
@@ -63,7 +63,7 @@ module Fees
 
       Fee.new(
         invoice:,
-        organization:,
+        organization_id: organization.id,
         subscription:,
         charge:,
         amount_cents:,

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -24,7 +24,7 @@ module Fees
 
           fee = Fee.new(
             invoice:,
-            organization:,
+            organization_id: organization.id,
             add_on:,
             invoice_display_name: fee[:invoice_display_name].presence,
             description: fee[:description] || add_on.description,

--- a/app/services/fees/paid_credit_service.rb
+++ b/app/services/fees/paid_credit_service.rb
@@ -20,7 +20,7 @@ module Fees
 
       new_fee = Fee.new(
         invoice:,
-        organization:,
+        organization_id: organization.id,
         fee_type: :credit,
         invoiceable_type: 'WalletTransaction',
         invoiceable: wallet_transaction,

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -41,7 +41,7 @@ module Fees
     def initialize_fee(new_amount_cents, new_precise_amount_cents)
       base_fee = Fee.new(
         invoice:,
-        organization:,
+        organization_id: organization.id,
         subscription:,
         amount_cents: new_amount_cents,
         precise_amount_cents: new_precise_amount_cents.to_d,

--- a/spec/services/fees/add_on_service_spec.rb
+++ b/spec/services/fees/add_on_service_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Fees::AddOnService do
       aggregate_failures do
         expect(created_fee.id).not_to be_nil
         expect(created_fee.invoice_id).to eq(invoice.id)
+        expect(created_fee.organization_id).to eq(organization.id)
         expect(created_fee.applied_add_on_id).to eq(applied_add_on.id)
         expect(created_fee.amount_cents).to eq(200)
         expect(created_fee.precise_amount_cents).to eq(200.0)

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Fees::ChargeService do
         expect(result).to be_success
         expect(result.fees.first).to have_attributes(
           id: String,
+          organization_id: organization.id,
           invoice_id: invoice.id,
           charge_id: charge.id,
           amount_cents: 0,

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
         expect(result.fees.count).to eq(1)
         expect(result.fees.first).to have_attributes(
           subscription:,
+          organization_id: organization.id,
           charge:,
           amount_cents: 10,
           precise_amount_cents: 10.0,

--- a/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
+++ b/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService, type: :service do
       started_at: DateTime.parse('2022-03-15')
     )
   end
-
+  let(:organization) { invoice.organization }
   let(:invoice) { create(:invoice, status: :draft) }
   let(:invoice_subscription) { create(:invoice_subscription, invoice:, subscription:) }
 
@@ -63,6 +63,7 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService, type: :service do
       expect(result.fee).to be_a(Fee)
       expect(result.fee).to have_attributes(
         id: nil,
+        organization_id: organization.id,
         invoice:,
         subscription:,
         charge:,

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Fees::OneOffService do
       aggregate_failures do
         expect(first_fee).to have_attributes(
           id: String,
+          organization_id: organization.id,
           invoice_id: invoice.id,
           add_on_id: add_on_first.id,
           description: 'desc-123',
@@ -61,6 +62,7 @@ RSpec.describe Fees::OneOffService do
 
         expect(second_fee).to have_attributes(
           id: String,
+          organization_id: organization.id,
           invoice_id: invoice.id,
           add_on_id: add_on_second.id,
           description: add_on_second.description,

--- a/spec/services/fees/paid_credit_service_spec.rb
+++ b/spec/services/fees/paid_credit_service_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Fees::PaidCreditService do
   end
 
   let(:customer) { create(:customer) }
-  let(:invoice) { create(:invoice, organization: customer.organization) }
+  let(:organization) { customer.organization }
+  let(:invoice) { create(:invoice, organization:) }
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:, rate_amount: '1.00') }
   let(:wallet_transaction) do
@@ -25,6 +26,7 @@ RSpec.describe Fees::PaidCreditService do
       expect(result.fee).to have_attributes(
         id: String,
         fee_type: 'credit',
+        organization_id: organization.id,
         invoice_id: invoice.id,
         invoiceable_type: 'WalletTransaction',
         invoiceable_id: wallet_transaction.id,

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Fees::SubscriptionService do
 
       expect(result.fee).to have_attributes(
         id: String,
+        organization_id: organization.id,
         invoice_id: invoice.id,
         amount_cents: 100,
         precise_amount_cents: 100.0,


### PR DESCRIPTION
## Description

When adding the column back in https://github.com/getlago/lago-api/pull/2858 I did not add specs for the saving of the organization_id. Because of Rails and how relationships were setup, this was not caught and did not result in errors. (just in not-filled-in column, which is not a big deal as the backfill is still to happen).