### PR TITLE
fix(cashfree): Fix webhook and payment flow

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -21,8 +21,8 @@ class WebhooksController < ApplicationController
       organization_id: params[:organization_id],
       code: params[:code].presence,
       body: request.body.read,
-      timestamp: request.headers['X-Cashfree-Timestamp'],
-      signature: request.headers['X-Cashfree-Signature']
+      timestamp: request.headers['X-Cashfree-Timestamp'] || request.headers['X-Webhook-Timestamp'],
+      signature: request.headers['X-Cashfree-Signature'] || request.headers['X-Webhook-Signature']
     )
 
     unless result.success?

--- a/app/services/invoices/payments/cashfree_service.rb
+++ b/app/services/invoices/payments/cashfree_service.rb
@@ -123,7 +123,8 @@ module Invoices
           link_notes: {
             lago_customer_id: customer.id,
             lago_invoice_id: invoice.id,
-            invoice_issuing_date: invoice.issuing_date.iso8601
+            invoice_issuing_date: invoice.issuing_date.iso8601,
+            payment_type: "one-time"
           },
           link_id: "#{SecureRandom.uuid}.#{invoice.payment_attempts}",
           link_amount: invoice.total_amount_cents / 100.to_f,


### PR DESCRIPTION
## Description

Updated the Cashfree webhook integration to handle both sets of headers. Additionally, added `payment_type: "one-time"` to the link parameters to ensure the payment is created upon receiving the webhook.

## Additional Context
I tested the flow with these changes in the actual Cashfree Test Environment, and everything is now functioning as expected.

fixes #3105