### PR TITLE
feat(stripe): Save Payment Method in Customer when paying invoice with checkout url

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -136,6 +136,7 @@ module Invoices
           payment_method_types: customer.stripe_customer.provider_payment_methods,
           payment_intent_data: {
             description:,
+            setup_future_usage: off_session? ? "off_session" : nil, # save payment method for future use
             metadata: {
               lago_customer_id: customer.id,
               lago_invoice_id: invoice.id,

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
           payment_method_types: customer.stripe_customer.provider_payment_methods,
           payment_intent_data: {
             description: stripe_service.__send__(:description),
+            setup_future_usage: "off_session",
             metadata: {
               lago_customer_id: customer.id,
               lago_invoice_id: invoice.id,


### PR DESCRIPTION
## Context

Recently we added the possibility to pay an invoice with a stripe checkout url. The payment method used wasn't saved in stripe. This change will allow the customer to reuse this method next time.


## Description

When using the `/customers/:external_customer_id/checkout_url` you setup a payment method so the payment method is associated with the customer in Stripe.

When using `/invoices/:lago_id/payment_url` the payment method is used but not associated. This PR makes sure the payment method used is savec with the customer.

Related docs: https://docs.stripe.com/api/checkout/sessions/create#create_checkout_session-payment_intent_data-setup_future_usage

For now, we don't support offsession paiement in India so we don't et this parameter in case the customer is in India.

Note that **it's different** from saving your card with Link (as shown below).

![CleanShot 2025-01-27 at 15 12 32@2x](https://github.com/user-attachments/assets/1469f261-cd3f-43c3-9ca8-451c4a77d993)
