### PR TITLE
feat(preview-invoice): add route and controller action

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -219,19 +219,8 @@ module Api
             json: ::V1::InvoiceSerializer.new(
               result.invoice,
               root_name: 'invoice',
-              includes: %i[customer integration_customers credits applied_taxes]
-            ).serialize.tap do |p|
-              p[:subscriptions] = [
-                ::V1::SubscriptionSerializer.new(result.subscription).serialize
-              ]
-              p.merge!(
-                ::CollectionSerializer.new(
-                  result.invoice.fees,
-                  ::V1::FeeSerializer,
-                  collection_name: 'fees'
-                ).serialize
-              )
-            end
+              includes: %i[customer integration_customers credits applied_taxes preview_subscriptions preview_fees]
+            )
           )
         else
           render_error_response(result)

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -42,6 +42,8 @@ module V1
       payload.merge!(error_details) if include?(:error_details)
       payload.merge!(applied_usage_thresholds) if model.progressive_billing?
       payload.merge!(applied_invoice_custom_sections) if include?(:applied_invoice_custom_sections)
+      payload.merge!(preview_subscriptions) if include?(:preview_subscriptions)
+      payload.merge!(preview_fees) if include?(:preview_fees)
 
       payload
     end
@@ -63,6 +65,12 @@ module V1
       ).serialize
     end
 
+    def preview_subscriptions
+      ::CollectionSerializer.new(
+        model.subscriptions, ::V1::SubscriptionSerializer, collection_name: 'subscriptions'
+      ).serialize
+    end
+
     def fees
       ::CollectionSerializer.new(
         model.fees.includes(
@@ -77,6 +85,12 @@ module V1
         ),
         ::V1::FeeSerializer,
         collection_name: 'fees'
+      ).serialize
+    end
+
+    def preview_fees
+      ::CollectionSerializer.new(
+        model.fees, ::V1::FeeSerializer, collection_name: 'fees'
       ).serialize
     end
 

--- a/app/serializers/v1/invoices/applied_tax_serializer.rb
+++ b/app/serializers/v1/invoices/applied_tax_serializer.rb
@@ -15,7 +15,7 @@ module V1
           amount_cents: model.amount_cents,
           amount_currency: model.amount_currency,
           fees_amount_cents: model.fees_amount_cents,
-          created_at: model.created_at.iso8601
+          created_at: model&.created_at&.iso8601
         }
       end
     end

--- a/app/services/coupons/preview_service.rb
+++ b/app/services/coupons/preview_service.rb
@@ -17,7 +17,7 @@ module Coupons
 
       applied_coupons.each do |applied_coupon|
         break unless invoice.sub_total_excluding_taxes_amount_cents&.positive?
-        next unless invoice.currency == applied_coupon.amount_currency
+        next if applied_coupon.coupon.fixed_amount? && invoice.currency != applied_coupon.amount_currency
 
         fees = fees(applied_coupon)
 

--- a/app/services/invoices/preview_context_service.rb
+++ b/app/services/invoices/preview_context_service.rb
@@ -34,6 +34,7 @@ module Invoices
           organization: organization,
           tax_identification_number: customer_params[:tax_identification_number],
           currency: customer_params[:currency],
+          timezone: customer_params[:timezone],
           shipping_address_line1: customer_params.dig(:shipping_address, :address_line1),
           shipping_address_line2: customer_params.dig(:shipping_address, :address_line2),
           shipping_city: customer_params.dig(:shipping_address, :city),
@@ -94,6 +95,7 @@ module Invoices
         coupon || Coupon.new(coupon_attr)
       end.map do |coupon|
         AppliedCoupon.new(
+          id: SecureRandom.uuid,
           coupon:,
           customer: result.customer,
           amount_cents: coupon.amount_cents,

--- a/app/services/invoices/preview_context_service.rb
+++ b/app/services/invoices/preview_context_service.rb
@@ -74,7 +74,7 @@ module Invoices
         subscription_at: params[:subscription_at].presence || Time.current,
         started_at: params[:subscription_at].presence || Time.current,
         billing_time:,
-        created_at: Time.current,
+        created_at: params[:subscription_at].presence || Time.current,
         updated_at: Time.current
       )
     end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -57,8 +57,9 @@ module Invoices
 
     def billing_time
       return @billing_time if defined? @billing_time
+      return subscription.subscription_at if subscription.plan.pay_in_advance?
 
-      ds = Subscriptions::DatesService.new_instance(subscription, Time.current, current_usage: true)
+      ds = Subscriptions::DatesService.new_instance(subscription, subscription.subscription_at, current_usage: true)
 
       @billing_time = ds.end_of_period + 1.day
     end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -33,6 +33,7 @@ module Invoices
       compute_tax_and_totals
 
       result.invoice = invoice
+      result.subscription = subscription
       result
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
         post :retry, on: :member
         post :retry_payment, on: :member
         post :payment_url, on: :member
+        post :preview, on: :collection
         put :refresh, on: :member
         put :finalize, on: :member
         put :sync_salesforce_id, on: :member

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -1009,7 +1009,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
   end
 
-  describe 'POST /api/v1/invoices' do
+  describe 'POST /api/v1/invoices/preview' do
     subject { post_with_token(organization, '/api/v1/invoices/preview', preview_params) }
 
     let(:plan) { create(:plan, organization:) }
@@ -1018,7 +1018,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         customer: {
           name: 'test 1',
           currency: 'EUR',
-          tax_identification_number: '123456789',
+          tax_identification_number: '123456789'
         },
         plan_code: plan.code,
         billing_time: 'anniversary'


### PR DESCRIPTION
## Context

Preview feature enables fetching first Lago invoice. This invoice is not persisted and is calculated on the fly.

## Description

This PR is the last one for the feature. It adds route, controller action and includes few fixes based on QA returns