### PR TITLE
misc(billing): Split billing job per organization

### DIFF
--- a/app/jobs/clock/subscriptions_biller_job.rb
+++ b/app/jobs/clock/subscriptions_biller_job.rb
@@ -5,7 +5,7 @@ module Clock
     include SentryCronConcern
 
     queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_CLOCK'])
+      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
         :clock_worker
       else
         :clock
@@ -13,7 +13,9 @@ module Clock
     end
 
     def perform
-      Subscriptions::BillingService.call
+      Organization.find_each do |organization|
+        Subscriptions::OrganizationBillingJob.perform_later(organization:)
+      end
     end
   end
 end

--- a/app/jobs/subscriptions/organization_billing_job.rb
+++ b/app/jobs/subscriptions/organization_billing_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class OrganizationBillingJob < ApplicationJob
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
+        :clock_worker
+      else
+        :clock
+      end
+    end
+
+    unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
+
+    def perform(organization:)
+      Subscriptions::OrganizationBillingService.call!(organization:)
+    end
+  end
+end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -3,12 +3,12 @@
 FactoryBot.define do
   factory :organization do
     name { Faker::Company.name }
-    default_currency { 'USD' }
+    default_currency { "USD" }
 
     email { Faker::Internet.email }
-    email_settings { ['invoice.finalized', 'credit_note.created'] }
+    email_settings { ["invoice.finalized", "credit_note.created"] }
 
-    api_keys { [association(:api_key)] }
+    api_keys { [association(:api_key, organization: instance)] }
 
     transient do
       webhook_url { Faker::Internet.url }

--- a/spec/jobs/clock/subscriptions_biller_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_biller_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Clock::SubscriptionsBillerJob, type: :job do
+  subject { described_class }
+
+  describe ".perform" do
+    let(:organization1) { create(:organization, api_keys: []) }
+    let(:organization2) { create(:organization, api_keys: []) }
+
+    before do
+      organization1
+      organization2
+    end
+
+    it "enqueues Subscriptions::OrganizationBillingJob for each organization" do
+      expect do
+        described_class.perform_now
+      end.to have_enqueued_job(Subscriptions::OrganizationBillingJob).exactly(2).times
+    end
+  end
+end

--- a/spec/jobs/subscriptions/organization_billing_job_spec.rb
+++ b/spec/jobs/subscriptions/organization_billing_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::OrganizationBillingJob, type: :job do
+  subject { described_class }
+
+  describe ".perform" do
+    let(:organization) { create(:organization, api_keys: []) }
+    let(:result) { BaseService::Result.new }
+
+    it "calls the subscriptions biller service" do
+      allow(Subscriptions::OrganizationBillingService).to receive(:call!)
+        .with(organization:)
+        .and_return(result)
+
+      described_class.perform_now(organization:)
+
+      expect(Subscriptions::OrganizationBillingService).to have_received(:call!)
+    end
+  end
+end

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :request do
+describe "Charge Models - Prorated Graduated Scenarios", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:customer) { create(:customer, organization:, name: 'aaaaaabcd') }
+  let(:customer) { create(:customer, organization:, name: "aaaaaabcd") }
   let(:tax) { create(:tax, organization:, rate: 0) }
 
   let(:plan) { create(:plan, organization:, amount_cents: 0) }
@@ -12,12 +12,12 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
 
   before { tax }
 
-  describe 'with sum_agg' do
-    let(:aggregation_type) { 'sum_agg' }
-    let(:field_name) { 'amount' }
+  describe "with sum_agg" do
+    let(:aggregation_type) { "sum_agg" }
+    let(:field_name) { "amount" }
 
-    describe 'three ranges and one overflow case' do
-      it 'returns the expected invoice and usage amounts' do
+    describe "three ranges and one overflow case" do
+      it "returns the expected invoice and usage amounts" do
         Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
         WebhookEndpoint.destroy_all
 
@@ -41,20 +41,20 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 from_value: 0,
                 to_value: 5,
-                per_unit_amount: '10',
-                flat_amount: '100'
+                per_unit_amount: "10",
+                flat_amount: "100"
               },
               {
                 from_value: 6,
                 to_value: 15,
-                per_unit_amount: '5',
-                flat_amount: '50'
+                per_unit_amount: "5",
+                flat_amount: "50"
               },
               {
                 from_value: 16,
                 to_value: nil,
-                per_unit_amount: '2',
-                flat_amount: '0'
+                per_unit_amount: "2",
+                flat_amount: "0"
               }
             ]
           }
@@ -63,7 +63,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
         fetch_current_usage(customer:)
         expect(json[:customer_usage][:amount_cents].round(2)).to eq(0)
         expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(0)
-        expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.0')
+        expect(json[:customer_usage][:charges_usage][0][:units]).to eq("0.0")
 
         travel_to(DateTime.new(2023, 9, 10)) do
           create_event(
@@ -71,14 +71,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '2'}
+              properties: {amount: "2"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(11_400)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(11_400)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('2.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("2.0")
         end
 
         travel_to(DateTime.new(2023, 9, 16)) do
@@ -87,14 +87,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '5'}
+              properties: {amount: "5"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(18_400)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(18_400)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('7.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("7.0")
         end
 
         travel_to(DateTime.new(2023, 9, 20)) do
@@ -103,14 +103,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '-6'}
+              properties: {amount: "-6"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(16_567)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(16_567)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('1.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("1.0")
         end
 
         travel_to(DateTime.new(2023, 9, 25)) do
@@ -119,14 +119,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '10'}
+              properties: {amount: "10"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(17_967)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(17_967)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('11.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("11.0")
         end
 
         travel_to(DateTime.new(2023, 9, 26)) do
@@ -135,14 +135,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '4'}
+              properties: {amount: "4"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(18_300)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(18_300)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('15.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("15.0")
         end
 
         travel_to(DateTime.new(2023, 9, 30)) do
@@ -151,20 +151,18 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '60'}
+              properties: {amount: "60"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(18_700)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(18_700)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('75.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("75.0")
         end
 
         travel_to(DateTime.new(2023, 10, 1)) do
-          Subscriptions::BillingService.new.call
-
-          perform_all_enqueued_jobs
+          perform_billing
 
           subscription = customer.subscriptions.first
           invoice = subscription.invoices.first
@@ -179,7 +177,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(37_000)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(37_000)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('75.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("75.0")
         end
 
         travel_to(DateTime.new(2023, 10, 17)) do
@@ -188,19 +186,19 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '20'}
+              properties: {amount: "20"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(38_935)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(38_935)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('95.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("95.0")
         end
       end
 
-      context 'when there are old events before first invoice' do
-        it 'returns expected invoice and usage amounts' do
+      context "when there are old events before first invoice" do
+        it "returns expected invoice and usage amounts" do
           Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
           WebhookEndpoint.destroy_all
 
@@ -226,14 +224,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 {
                   from_value: 0,
                   to_value: 5,
-                  per_unit_amount: '0',
-                  flat_amount: '0'
+                  per_unit_amount: "0",
+                  flat_amount: "0"
                 },
                 {
                   from_value: 6,
                   to_value: nil,
-                  per_unit_amount: '12',
-                  flat_amount: '0'
+                  per_unit_amount: "12",
+                  flat_amount: "0"
                 }
               ]
             }
@@ -246,7 +244,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 transaction_id: SecureRandom.uuid,
                 timestamp: 1_699_336_493, ## November 2023
                 external_subscription_id: subscription.external_id,
-                properties: {amount: '5'}
+                properties: {amount: "5"}
               }
             )
 
@@ -256,20 +254,18 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 transaction_id: SecureRandom.uuid,
                 timestamp: 1_699_336_493, ## November 2023
                 external_subscription_id: subscription.external_id,
-                properties: {amount: '5'}
+                properties: {amount: "5"}
               }
             )
 
             fetch_current_usage(customer:)
             expect(json[:customer_usage][:amount_cents].round(2)).to eq(6_000)
             expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(6_000)
-            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('10.0')
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq("10.0")
           end
 
           travel_to(DateTime.new(2024, 1, 1)) do
-            Subscriptions::BillingService.new.call
-
-            perform_all_enqueued_jobs
+            perform_billing
 
             subscription = customer.subscriptions.first
             invoice = subscription.invoices.first
@@ -284,7 +280,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             fetch_current_usage(customer:)
             expect(json[:customer_usage][:amount_cents].round(2)).to eq(6_000)
             expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(6_000)
-            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('10.0')
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq("10.0")
           end
 
           travel_to(DateTime.new(2024, 1, 6)) do
@@ -293,20 +289,20 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: customer.external_id,
-                properties: {amount: '2'}
+                properties: {amount: "2"}
               }
             )
 
             fetch_current_usage(customer:)
             expect(json[:customer_usage][:amount_cents].round(2)).to eq(8_013)
             expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(8_013)
-            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('12.0')
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq("12.0")
           end
         end
       end
 
-      context 'when there are old events before first invoice and subscription is terminated' do
-        it 'returns expected invoice and usage amounts' do
+      context "when there are old events before first invoice and subscription is terminated" do
+        it "returns expected invoice and usage amounts" do
           Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
           WebhookEndpoint.destroy_all
 
@@ -332,14 +328,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 {
                   from_value: 0,
                   to_value: 5,
-                  per_unit_amount: '0',
-                  flat_amount: '0'
+                  per_unit_amount: "0",
+                  flat_amount: "0"
                 },
                 {
                   from_value: 6,
                   to_value: nil,
-                  per_unit_amount: '10',
-                  flat_amount: '0'
+                  per_unit_amount: "10",
+                  flat_amount: "0"
                 }
               ]
             }
@@ -351,7 +347,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: subscription.external_id,
-                properties: {amount: '4'}
+                properties: {amount: "4"}
               }
             )
 
@@ -360,7 +356,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: subscription.external_id,
-                properties: {amount: '3'}
+                properties: {amount: "3"}
               }
             )
           end
@@ -371,7 +367,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: subscription.external_id,
-                properties: {amount: '-1'}
+                properties: {amount: "-1"}
               }
             )
           end
@@ -380,21 +376,21 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             fetch_current_usage(customer:)
             expect(json[:customer_usage][:amount_cents].round(2)).to eq(1_000)
             expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(1_000)
-            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('6.0')
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq("6.0")
 
             create_event(
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: subscription.external_id,
-                properties: {amount: '1'}
+                properties: {amount: "1"}
               }
             )
 
             fetch_current_usage(customer:)
             expect(json[:customer_usage][:amount_cents].round(2)).to eq(1_806)
             expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(1_806)
-            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('7.0')
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq("7.0")
 
             Subscriptions::TerminateService.call(subscription:)
             perform_all_enqueued_jobs
@@ -404,16 +400,16 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               expect(subscription.reload).to be_terminated
               expect(subscription.reload.invoices.count).to eq(1)
               expect(invoice.total_amount_cents).to eq(258)
-              expect(invoice.issuing_date.iso8601).to eq('2023-12-07')
+              expect(invoice.issuing_date.iso8601).to eq("2023-12-07")
             end
           end
         end
       end
 
-      context 'when upgrade is performed' do
+      context "when upgrade is performed" do
         let(:plan_new) { create(:plan, organization:, amount_cents: 100) }
 
-        it 'returns expected invoice and usage amounts' do
+        it "returns expected invoice and usage amounts" do
           Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
           WebhookEndpoint.destroy_all
 
@@ -437,20 +433,20 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 {
                   from_value: 0,
                   to_value: 5,
-                  per_unit_amount: '10',
-                  flat_amount: '100'
+                  per_unit_amount: "10",
+                  flat_amount: "100"
                 },
                 {
                   from_value: 6,
                   to_value: 15,
-                  per_unit_amount: '5',
-                  flat_amount: '50'
+                  per_unit_amount: "5",
+                  flat_amount: "50"
                 },
                 {
                   from_value: 16,
                   to_value: nil,
-                  per_unit_amount: '2',
-                  flat_amount: '0'
+                  per_unit_amount: "2",
+                  flat_amount: "0"
                 }
               ]
             }
@@ -462,7 +458,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: customer.external_id,
-                properties: {amount: '2'}
+                properties: {amount: "2"}
               }
             )
           end
@@ -473,7 +469,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: customer.external_id,
-                properties: {amount: '5'}
+                properties: {amount: "5"}
               }
             )
           end
@@ -484,7 +480,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: customer.external_id,
-                properties: {amount: '-6'}
+                properties: {amount: "-6"}
               }
             )
           end
@@ -495,7 +491,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: customer.external_id,
-                properties: {amount: '10'}
+                properties: {amount: "10"}
               }
             )
           end
@@ -506,7 +502,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: customer.external_id,
-                properties: {amount: '4'}
+                properties: {amount: "4"}
               }
             )
           end
@@ -517,20 +513,18 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: customer.external_id,
-                properties: {amount: '60'}
+                properties: {amount: "60"}
               }
             )
 
             fetch_current_usage(customer:)
             expect(json[:customer_usage][:amount_cents].round(2)).to eq(18_700)
             expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(18_700)
-            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('75.0')
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq("75.0")
           end
 
           travel_to(DateTime.new(2023, 10, 1)) do
-            Subscriptions::BillingService.new.call
-
-            perform_all_enqueued_jobs
+            perform_billing
 
             subscription = customer.subscriptions.first
             invoice = subscription.invoices.first
@@ -545,7 +539,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             fetch_current_usage(customer:)
             expect(json[:customer_usage][:amount_cents].round(2)).to eq(37_000)
             expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(37_000)
-            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('75.0')
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq("75.0")
           end
 
           travel_to(DateTime.new(2023, 10, 17)) do
@@ -554,14 +548,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: customer.external_id,
-                properties: {amount: '20'}
+                properties: {amount: "20"}
               }
             )
 
             fetch_current_usage(customer:)
             expect(json[:customer_usage][:amount_cents].round(2)).to eq(38_935)
             expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(38_935)
-            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('95.0')
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq("95.0")
           end
 
           subscription = customer.subscriptions.first
@@ -577,20 +571,20 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                   {
                     from_value: 0,
                     to_value: 5,
-                    per_unit_amount: '10',
-                    flat_amount: '100'
+                    per_unit_amount: "10",
+                    flat_amount: "100"
                   },
                   {
                     from_value: 6,
                     to_value: 15,
-                    per_unit_amount: '5',
-                    flat_amount: '50'
+                    per_unit_amount: "5",
+                    flat_amount: "50"
                   },
                   {
                     from_value: 16,
                     to_value: nil,
-                    per_unit_amount: '2',
-                    flat_amount: '0'
+                    per_unit_amount: "2",
+                    flat_amount: "0"
                   }
                 ]
               }
@@ -603,7 +597,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                   plan_code: plan_new.code
                 }
               )
-            }.to change { subscription.reload.status }.from('active').to('terminated')
+            }.to change { subscription.reload.status }.from("active").to("terminated")
               .and change { subscription.invoices.count }.from(1).to(2)
 
             invoice = subscription.invoices.order(created_at: :desc).first
@@ -614,9 +608,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
           end
 
           travel_to(DateTime.new(2023, 11, 1)) do
-            Subscriptions::BillingService.new.call
-
-            perform_all_enqueued_jobs
+            perform_billing
 
             subscription = customer.subscriptions.order(created_at: :desc).first
             invoice = subscription.invoices.order(created_at: :desc).first
@@ -633,19 +625,19 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             fetch_current_usage(customer:)
             expect(json[:customer_usage][:amount_cents].round(2)).to eq(41_000)
             expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(41_000)
-            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('95.0')
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq("95.0")
           end
         end
       end
     end
   end
 
-  describe 'with unique_count_agg' do
-    let(:aggregation_type) { 'unique_count_agg' }
-    let(:field_name) { 'amount' }
+  describe "with unique_count_agg" do
+    let(:aggregation_type) { "unique_count_agg" }
+    let(:field_name) { "amount" }
 
-    describe 'two ranges' do
-      it 'returns the expected invoice and usage amounts' do
+    describe "two ranges" do
+      it "returns the expected invoice and usage amounts" do
         Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
         WebhookEndpoint.destroy_all
 
@@ -669,14 +661,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 from_value: 0,
                 to_value: 1,
-                per_unit_amount: '10',
-                flat_amount: '100'
+                per_unit_amount: "10",
+                flat_amount: "100"
               },
               {
                 from_value: 2,
                 to_value: nil,
-                per_unit_amount: '5',
-                flat_amount: '50'
+                per_unit_amount: "5",
+                flat_amount: "50"
               }
             ]
           }
@@ -688,14 +680,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '1111', operation_type: 'add'}
+              properties: {amount: "1111", operation_type: "add"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(10_700)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(10_700)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('1.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("1.0")
         end
 
         travel_to(DateTime.new(2023, 9, 12)) do
@@ -704,14 +696,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '1111', operation_type: 'remove'}
+              properties: {amount: "1111", operation_type: "remove"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(10_100)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(10_100)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("0.0")
         end
 
         travel_to(DateTime.new(2023, 9, 14)) do
@@ -720,14 +712,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '1111', operation_type: 'add'}
+              properties: {amount: "1111", operation_type: "add"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(15_383)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(15_383)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('1.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("1.0")
         end
 
         travel_to(DateTime.new(2023, 9, 15)) do
@@ -736,14 +728,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '2222', operation_type: 'add'}
+              properties: {amount: "2222", operation_type: "add"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(15_650)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(15_650)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('2.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("2.0")
         end
 
         travel_to(DateTime.new(2023, 9, 16)) do
@@ -752,14 +744,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '2222', operation_type: 'add'}
+              properties: {amount: "2222", operation_type: "add"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(15_650)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(15_650)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('2.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("2.0")
         end
 
         travel_to(DateTime.new(2023, 9, 20)) do
@@ -768,20 +760,18 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '3333', operation_type: 'add'}
+              properties: {amount: "3333", operation_type: "add"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(15_833)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(15_833)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('3.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("3.0")
         end
 
         travel_to(DateTime.new(2023, 10, 1)) do
-          Subscriptions::BillingService.new.call
-
-          perform_all_enqueued_jobs
+          perform_billing
 
           subscription = customer.subscriptions.first
           invoice = subscription.invoices.first
@@ -796,7 +786,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(17_000) # 100 + 10 + 50 + 5 + 5
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(17_000)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('3.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("3.0")
         end
 
         travel_to(DateTime.new(2023, 10, 17)) do
@@ -805,20 +795,20 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '4444', operation_type: 'add'}
+              properties: {amount: "4444", operation_type: "add"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(17_242)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(17_242)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('4.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("4.0")
         end
       end
     end
 
-    context 'with multiple events on the same day' do
-      it 'returns the expected invoice and usage amounts' do
+    context "with multiple events on the same day" do
+      it "returns the expected invoice and usage amounts" do
         Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
         WebhookEndpoint.destroy_all
 
@@ -842,14 +832,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 from_value: 0,
                 to_value: 5,
-                per_unit_amount: '10',
-                flat_amount: '100'
+                per_unit_amount: "10",
+                flat_amount: "100"
               },
               {
                 from_value: 6,
                 to_value: nil,
-                per_unit_amount: '5',
-                flat_amount: '50'
+                per_unit_amount: "5",
+                flat_amount: "50"
               }
             ]
           }
@@ -861,14 +851,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '1111', operation_type: 'add'}
+              properties: {amount: "1111", operation_type: "add"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(10_710)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(10_710)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('1.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("1.0")
         end
 
         travel_to(DateTime.new(2023, 10, 20)) do
@@ -877,14 +867,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '2222', operation_type: 'add'}
+              properties: {amount: "2222", operation_type: "add"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(11_097)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(11_097)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('2.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("2.0")
         end
 
         travel_to(DateTime.new(2023, 10, 20)) do
@@ -893,14 +883,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '3333', operation_type: 'add'}
+              properties: {amount: "3333", operation_type: "add"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(11_484)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(11_484)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('3.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("3.0")
         end
 
         travel_to(DateTime.new(2023, 10, 20)) do
@@ -909,14 +899,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '4444', operation_type: 'add'}
+              properties: {amount: "4444", operation_type: "add"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(11_871)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(11_871)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('4.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("4.0")
         end
 
         travel_to(DateTime.new(2023, 10, 20)) do
@@ -925,14 +915,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '5555', operation_type: 'add'}
+              properties: {amount: "5555", operation_type: "add"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(12_258)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(12_258)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('5.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("5.0")
         end
 
         travel_to(DateTime.new(2023, 10, 25)) do
@@ -941,20 +931,18 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {amount: '6666', operation_type: 'add'}
+              properties: {amount: "6666", operation_type: "add"}
             }
           )
 
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(17_371)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(17_371)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('6.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("6.0")
         end
 
         travel_to(DateTime.new(2023, 11, 1)) do
-          Subscriptions::BillingService.new.call
-
-          perform_all_enqueued_jobs
+          perform_billing
 
           subscription = customer.subscriptions.first
           invoice = subscription.invoices.first
@@ -969,12 +957,12 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
           fetch_current_usage(customer:)
           expect(json[:customer_usage][:amount_cents].round(2)).to eq(20_500)
           expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(20_500)
-          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('6.0')
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq("6.0")
         end
       end
 
-      context 'when there are old events before first invoice and subscription is terminated' do
-        it 'returns expected invoice and usage amounts' do
+      context "when there are old events before first invoice and subscription is terminated" do
+        it "returns expected invoice and usage amounts" do
           Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
           WebhookEndpoint.destroy_all
 
@@ -1000,14 +988,14 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 {
                   from_value: 0,
                   to_value: 1,
-                  per_unit_amount: '5',
-                  flat_amount: '10'
+                  per_unit_amount: "5",
+                  flat_amount: "10"
                 },
                 {
                   from_value: 2,
                   to_value: nil,
-                  per_unit_amount: '15',
-                  flat_amount: '30'
+                  per_unit_amount: "15",
+                  flat_amount: "30"
                 }
               ]
             }
@@ -1019,7 +1007,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: subscription.external_id,
-                properties: {amount: '1111', operation_type: 'add'}
+                properties: {amount: "1111", operation_type: "add"}
               }
             )
           end
@@ -1028,21 +1016,21 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             fetch_current_usage(customer:)
             expect(json[:customer_usage][:amount_cents].round(2)).to eq(1_500)
             expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(1_500)
-            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('1.0')
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq("1.0")
 
             create_event(
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
                 external_subscription_id: subscription.external_id,
-                properties: {amount: '2222', operation_type: 'add'}
+                properties: {amount: "2222", operation_type: "add"}
               }
             )
 
             fetch_current_usage(customer:)
             expect(json[:customer_usage][:amount_cents].round(2)).to eq(5_710)
             expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(5_710)
-            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('2.0')
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq("2.0")
 
             Subscriptions::TerminateService.call(subscription:)
             perform_all_enqueued_jobs
@@ -1052,7 +1040,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               expect(subscription.reload).to be_terminated
               expect(subscription.reload.invoices.count).to eq(1)
               expect(invoice.total_amount_cents).to eq(4_161)
-              expect(invoice.issuing_date.iso8601).to eq('2023-12-07')
+              expect(invoice.issuing_date.iso8601).to eq("2023-12-07")
             end
           end
         end

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/monthly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Advance',
-      code: 'in_advance',
+      name: "In Advance",
+      code: "in_advance",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -26,10 +26,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -38,10 +38,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'metered_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "metered_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -50,16 +50,16 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'advance_recurring',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "advance_recurring",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'anniversary' }
-  let(:plan_interval) { 'monthly' }
+  let(:billing_time) { "anniversary" }
+  let(:plan_interval) { "monthly" }
   let(:subscription_time) { DateTime.new(2024, 2, 28, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -71,7 +71,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -80,7 +80,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -89,7 +89,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -108,7 +108,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '15'}
+          properties: {total: "15"}
         }
       )
 
@@ -117,7 +117,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '25'}
+          properties: {total: "25"}
         }
       )
 
@@ -126,53 +126,49 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '30'}
+          properties: {total: "30"}
         }
       )
 
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when coupons are not applied' do
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+  context "when coupons are not applied" do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to(subscription_time + 1.month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 1.month) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(983_000)
         end
       end
     end
 
-    context 'when subscription is billed for the third period' do
+    context "when subscription is billed for the third period" do
       before do
         travel_to(subscription_time + 1.month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to(subscription_time + 2.months) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 2.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(988_500)
         end
@@ -180,7 +176,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     end
   end
 
-  context 'when coupon is applied' do
+  context "when coupon is applied" do
     let(:coupon) do
       create(
         :coupon,
@@ -200,43 +196,40 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       )
     end
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to(subscription_time + 1.month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 1.month) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(983_000)
         end
       end
     end
 
-    context 'when subscription is billed for the third period' do
+    context "when subscription is billed for the third period" do
       before do
         travel_to(subscription_time + 1.month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to(subscription_time + 2.months) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 2.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(988_500)
         end

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/quarterly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Advance',
-      code: 'in_advance',
+      name: "In Advance",
+      code: "in_advance",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -26,10 +26,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -38,10 +38,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'metered_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "metered_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -50,16 +50,16 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'advance_recurring',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "advance_recurring",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'anniversary' }
-  let(:plan_interval) { 'quarterly' }
+  let(:billing_time) { "anniversary" }
+  let(:plan_interval) { "quarterly" }
   let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -71,7 +71,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -80,7 +80,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -89,7 +89,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -108,7 +108,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '15'}
+          properties: {total: "15"}
         }
       )
 
@@ -117,7 +117,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '25'}
+          properties: {total: "25"}
         }
       )
 
@@ -126,53 +126,49 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '30'}
+          properties: {total: "30"}
         }
       )
 
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when coupons are not applied' do
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+  context "when coupons are not applied" do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to(subscription_time + 3.months) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 3.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(983_000)
         end
       end
     end
 
-    context 'when subscription is billed for the third period' do
+    context "when subscription is billed for the third period" do
       before do
         travel_to(subscription_time + 3.months) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to(subscription_time + 6.months) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 6.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(988_500)
         end
@@ -180,7 +176,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     end
   end
 
-  context 'when coupon is applied' do
+  context "when coupon is applied" do
     let(:coupon) do
       create(
         :coupon,
@@ -200,43 +196,40 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       )
     end
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to(subscription_time + 3.months) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 3.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(983_000)
         end
       end
     end
 
-    context 'when subscription is billed for the third period' do
+    context "when subscription is billed for the third period" do
       before do
         travel_to(subscription_time + 3.months) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to(subscription_time + 6.months) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 6.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(988_500)
         end

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/weekly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Advance',
-      code: 'in_advance',
+      name: "In Advance",
+      code: "in_advance",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -26,10 +26,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -38,10 +38,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'metered_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "metered_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -50,16 +50,16 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'advance_recurring',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "advance_recurring",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'anniversary' }
-  let(:plan_interval) { 'weekly' }
+  let(:billing_time) { "anniversary" }
+  let(:plan_interval) { "weekly" }
   let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -71,7 +71,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -80,7 +80,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -89,7 +89,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -108,7 +108,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '15'}
+          properties: {total: "15"}
         }
       )
 
@@ -117,7 +117,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '25'}
+          properties: {total: "25"}
         }
       )
 
@@ -126,53 +126,49 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '30'}
+          properties: {total: "30"}
         }
       )
 
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when coupons are not applied' do
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+  context "when coupons are not applied" do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to(subscription_time + 1.week) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 1.week) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(983_000)
         end
       end
     end
 
-    context 'when subscription is billed for the third period' do
+    context "when subscription is billed for the third period" do
       before do
         travel_to(subscription_time + 1.week) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to(subscription_time + 2.weeks) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 2.weeks) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(988_500)
         end
@@ -180,7 +176,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     end
   end
 
-  context 'when coupon is applied' do
+  context "when coupon is applied" do
     let(:coupon) do
       create(
         :coupon,
@@ -200,43 +196,40 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       )
     end
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to(subscription_time + 1.week) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 1.week) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(983_000)
         end
       end
     end
 
-    context 'when subscription is billed for the third period' do
+    context "when subscription is billed for the third period" do
       before do
         travel_to(subscription_time + 1.week) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to(subscription_time + 2.weeks) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 2.weeks) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(988_500)
         end

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/monthly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Advance',
-      code: 'in_advance',
+      name: "In Advance",
+      code: "in_advance",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -26,10 +26,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -38,10 +38,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'metered_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "metered_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -50,16 +50,16 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'advance_recurring',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "advance_recurring",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'calendar' }
-  let(:plan_interval) { 'monthly' }
+  let(:billing_time) { "calendar" }
+  let(:plan_interval) { "monthly" }
   let(:subscription_time) { DateTime.new(2024, 2, 28, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -71,7 +71,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -80,7 +80,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -89,7 +89,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -108,7 +108,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '15'}
+          properties: {total: "15"}
         }
       )
 
@@ -117,7 +117,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '25'}
+          properties: {total: "25"}
         }
       )
 
@@ -126,53 +126,49 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '30'}
+          properties: {total: "30"}
         }
       )
 
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when coupons are not applied' do
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+  context "when coupons are not applied" do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to((subscription_time + 1.month).beginning_of_month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 1.month).beginning_of_month) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(61_276)
         end
       end
     end
 
-    context 'when subscription is billed for the third period' do
+    context "when subscription is billed for the third period" do
       before do
         travel_to((subscription_time + 1.month).beginning_of_month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to((subscription_time + 2.months).beginning_of_month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 2.months).beginning_of_month) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(988_500)
         end
@@ -180,7 +176,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     end
   end
 
-  context 'when coupon is applied' do
+  context "when coupon is applied" do
     let(:coupon) do
       create(
         :coupon,
@@ -200,43 +196,40 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       )
     end
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to((subscription_time + 1.month).beginning_of_month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 1.month).beginning_of_month) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(61_276)
         end
       end
     end
 
-    context 'when subscription is billed for the third period' do
+    context "when subscription is billed for the third period" do
       before do
         travel_to((subscription_time + 1.month).beginning_of_month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to((subscription_time + 2.months).beginning_of_month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 2.months).beginning_of_month) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(988_500)
         end

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/quarterly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Advance',
-      code: 'in_advance',
+      name: "In Advance",
+      code: "in_advance",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -26,10 +26,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -38,10 +38,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'metered_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "metered_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -50,16 +50,16 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'advance_recurring',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "advance_recurring",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'calendar' }
-  let(:plan_interval) { 'quarterly' }
+  let(:billing_time) { "calendar" }
+  let(:plan_interval) { "quarterly" }
   let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -71,7 +71,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -80,7 +80,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -89,7 +89,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -108,7 +108,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '15'}
+          properties: {total: "15"}
         }
       )
 
@@ -117,7 +117,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '25'}
+          properties: {total: "25"}
         }
       )
 
@@ -126,53 +126,49 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '30'}
+          properties: {total: "30"}
         }
       )
 
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when coupons are not applied' do
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+  context "when coupons are not applied" do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to((subscription_time + 3.months).beginning_of_quarter) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 3.months).beginning_of_quarter) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(210_582)
         end
       end
     end
 
-    context 'when subscription is billed for the third period' do
+    context "when subscription is billed for the third period" do
       before do
         travel_to((subscription_time + 3.months).beginning_of_quarter) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to((subscription_time + 6.months).beginning_of_quarter) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 6.months).beginning_of_quarter) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(988_500)
         end
@@ -180,7 +176,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     end
   end
 
-  context 'when coupon is applied' do
+  context "when coupon is applied" do
     let(:coupon) do
       create(
         :coupon,
@@ -200,43 +196,40 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       )
     end
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to((subscription_time + 3.months).beginning_of_quarter) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 3.months).beginning_of_quarter) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(210_582)
         end
       end
     end
 
-    context 'when subscription is billed for the third period' do
+    context "when subscription is billed for the third period" do
       before do
         travel_to((subscription_time + 3.months).beginning_of_quarter) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to((subscription_time + 6.months).beginning_of_quarter) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 6.months).beginning_of_quarter) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(988_500)
         end

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/weekly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Advance',
-      code: 'in_advance',
+      name: "In Advance",
+      code: "in_advance",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -26,10 +26,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -38,10 +38,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'metered_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "metered_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -50,16 +50,16 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'advance_recurring',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "advance_recurring",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'calendar' }
-  let(:plan_interval) { 'weekly' }
+  let(:billing_time) { "calendar" }
+  let(:plan_interval) { "weekly" }
   let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -71,7 +71,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -80,7 +80,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -89,7 +89,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -108,7 +108,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '15'}
+          properties: {total: "15"}
         }
       )
 
@@ -117,7 +117,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '25'}
+          properties: {total: "25"}
         }
       )
 
@@ -126,53 +126,49 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '30'}
+          properties: {total: "30"}
         }
       )
 
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when coupons are not applied' do
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+  context "when coupons are not applied" do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to((subscription_time + 1.week).beginning_of_week) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 1.week).beginning_of_week) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(841_572)
         end
       end
     end
 
-    context 'when subscription is billed for the third period' do
+    context "when subscription is billed for the third period" do
       before do
         travel_to((subscription_time + 1.week).beginning_of_week) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to((subscription_time + 2.weeks).beginning_of_week) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 2.weeks).beginning_of_week) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(988_500)
         end
@@ -180,7 +176,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     end
   end
 
-  context 'when coupon is applied' do
+  context "when coupon is applied" do
     let(:coupon) do
       create(
         :coupon,
@@ -200,43 +196,40 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       )
     end
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to((subscription_time + 1.week).beginning_of_week) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 1.week).beginning_of_week) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(841_572)
         end
       end
     end
 
-    context 'when subscription is billed for the third period' do
+    context "when subscription is billed for the third period" do
       before do
         travel_to((subscription_time + 1.week).beginning_of_week) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to((subscription_time + 2.weeks).beginning_of_week) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 2.weeks).beginning_of_week) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(988_500)
         end

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/yearly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Advance',
-      code: 'in_advance',
+      name: "In Advance",
+      code: "in_advance",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -27,10 +27,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'advance_metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "advance_metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -39,10 +39,10 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -51,16 +51,16 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'recurring_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "recurring_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'calendar' }
-  let(:plan_interval) { 'yearly' }
+  let(:billing_time) { "calendar" }
+  let(:plan_interval) { "yearly" }
   let(:subscription_time) { DateTime.new(2024, 3, 5, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -73,7 +73,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_advance_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -81,7 +81,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -90,7 +90,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -111,7 +111,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '2'}
+          properties: {total: "2"}
         }
       )
 
@@ -120,7 +120,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '1'}
+          properties: {total: "1"}
         }
       )
 
@@ -129,27 +129,26 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '30'}
+          properties: {total: "30"}
         }
       )
 
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when billed monthly' do
+  context "when billed monthly" do
     let(:bill_charges_monthly) { true }
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time + 1.minute) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the last period' do
+    context "when subscription is billed for the last period" do
       before do
         travel_to(subscription_time + 5.months) do
           create_event(
@@ -157,7 +156,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
               code: billable_metric_advance_metered.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {total: '55'}
+              properties: {total: "55"}
             }
           )
         end
@@ -168,23 +167,21 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
               code: billable_metric_metered.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {total: '1'}
+              properties: {total: "1"}
             }
           )
         end
 
         travel_to((subscription_time + 12.months).beginning_of_month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         travel_to((subscription_time + 1.year).beginning_of_year) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 1.year).beginning_of_year) do
           aggregate_failures do
             expect(invoice.fees.commitment.count).to eq(1)

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/monthly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Arrears',
-      code: 'in_arrears',
+      name: "In Arrears",
+      code: "in_arrears",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -26,10 +26,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -38,10 +38,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'metered_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "metered_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -50,16 +50,16 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'advance_recurring',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "advance_recurring",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'anniversary' }
-  let(:plan_interval) { 'monthly' }
+  let(:billing_time) { "anniversary" }
+  let(:plan_interval) { "monthly" }
   let(:subscription_time) { DateTime.new(2024, 2, 28, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -71,7 +71,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -80,7 +80,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -89,7 +89,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -108,7 +108,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
 
@@ -117,7 +117,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
 
@@ -126,35 +126,33 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
     end
 
     travel_to(subscription_time + 1.month) do
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when coupons are not applied' do
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with minimum commitment fee' do
+  context "when coupons are not applied" do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 1.month) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(987_000)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to(subscription_time + 2.months) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 2.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(989_000)
         end
@@ -162,7 +160,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     end
   end
 
-  context 'when coupon is applied' do
+  context "when coupon is applied" do
     let(:coupon) do
       create(
         :coupon,
@@ -182,23 +180,22 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       )
     end
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 1.month) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(987_000)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to(subscription_time + 2.months) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 2.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(989_000)
         end

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/quarterly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Arrears',
-      code: 'in_arrears',
+      name: "In Arrears",
+      code: "in_arrears",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -26,10 +26,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -38,10 +38,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'metered_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "metered_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -50,16 +50,16 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'advance_recurring',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "advance_recurring",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'anniversary' }
-  let(:plan_interval) { 'quarterly' }
+  let(:billing_time) { "anniversary" }
+  let(:plan_interval) { "quarterly" }
   let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -71,7 +71,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -80,7 +80,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -89,7 +89,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -108,7 +108,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
 
@@ -117,7 +117,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
 
@@ -126,35 +126,33 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
     end
 
     travel_to(subscription_time + 3.months) do
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when coupons are not applied' do
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with minimum commitment fee' do
+  context "when coupons are not applied" do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 3.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(987_000)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to(subscription_time + 6.months) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 6.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(989_000)
         end
@@ -162,7 +160,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     end
   end
 
-  context 'when coupon is applied' do
+  context "when coupon is applied" do
     let(:coupon) do
       create(
         :coupon,
@@ -182,23 +180,22 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       )
     end
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 3.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(987_000)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to(subscription_time + 6.months) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 6.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(989_000)
         end

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/weekly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Arrears',
-      code: 'in_arrears',
+      name: "In Arrears",
+      code: "in_arrears",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -26,10 +26,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -38,10 +38,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'metered_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "metered_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -50,16 +50,16 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'advance_recurring',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "advance_recurring",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'anniversary' }
-  let(:plan_interval) { 'weekly' }
+  let(:billing_time) { "anniversary" }
+  let(:plan_interval) { "weekly" }
   let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -71,7 +71,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -80,7 +80,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -89,7 +89,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -108,7 +108,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
 
@@ -117,7 +117,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
 
@@ -126,35 +126,33 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
     end
 
     travel_to(subscription_time + 1.week) do
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when coupons are not applied' do
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with minimum commitment fee' do
+  context "when coupons are not applied" do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 1.week) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(987_000)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to(subscription_time + 2.weeks) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 2.weeks) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(989_000)
         end
@@ -162,7 +160,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     end
   end
 
-  context 'when coupon is applied' do
+  context "when coupon is applied" do
     let(:coupon) do
       create(
         :coupon,
@@ -182,23 +180,22 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       )
     end
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 1.week) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(987_000)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to(subscription_time + 2.weeks) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 2.weeks) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(989_000)
         end

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/yearly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Arrears',
-      code: 'in_arrears',
+      name: "In Arrears",
+      code: "in_arrears",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -27,10 +27,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'advance_metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "advance_metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -39,10 +39,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -51,16 +51,16 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'recurring_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "recurring_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'anniversary' }
-  let(:plan_interval) { 'yearly' }
+  let(:billing_time) { "anniversary" }
+  let(:plan_interval) { "yearly" }
   let(:subscription_time) { DateTime.new(2024, 3, 1, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -73,7 +73,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_advance_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -81,7 +81,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -90,7 +90,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -111,7 +111,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '2'}
+          properties: {total: "2"}
         }
       )
 
@@ -120,7 +120,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '1'}
+          properties: {total: "1"}
         }
       )
 
@@ -129,27 +129,26 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '30'}
+          properties: {total: "30"}
         }
       )
     end
   end
 
-  context 'when billed monthly' do
+  context "when billed monthly" do
     let(:bill_charges_monthly) { true }
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time + 1.month + 1.day) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
 
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the last period' do
+    context "when subscription is billed for the last period" do
       before do
         (1..12).each do |i|
           travel_to(subscription_time + i.month) do
@@ -159,7 +158,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
                   code: billable_metric_advance_metered.code,
                   transaction_id: SecureRandom.uuid,
                   external_subscription_id: customer.external_id,
-                  properties: {total: '55'}
+                  properties: {total: "55"}
                 }
               )
             end
@@ -170,18 +169,17 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
                   code: billable_metric_metered.code,
                   transaction_id: SecureRandom.uuid,
                   external_subscription_id: customer.external_id,
-                  properties: {total: '1'}
+                  properties: {total: "1"}
                 }
               )
             end
 
-            Subscriptions::BillingService.new.call
-            perform_all_enqueued_jobs
+            perform_billing
           end
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 1.year + 1.month) do
           aggregate_failures do
             expect(invoice.fees.commitment.count).to eq(1)

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/monthly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Arrears',
-      code: 'in_arrears',
+      name: "In Arrears",
+      code: "in_arrears",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -26,10 +26,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -38,10 +38,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'metered_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "metered_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -50,16 +50,16 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'advance_recurring',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "advance_recurring",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'calendar' }
-  let(:plan_interval) { 'monthly' }
+  let(:billing_time) { "calendar" }
+  let(:plan_interval) { "monthly" }
   let(:subscription_time) { DateTime.new(2024, 2, 28, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -71,7 +71,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -80,7 +80,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -89,7 +89,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -108,7 +108,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
 
@@ -117,7 +117,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
 
@@ -126,35 +126,33 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
     end
 
     travel_to((subscription_time + 1.month).beginning_of_month) do
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when coupons are not applied' do
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with minimum commitment fee' do
+  context "when coupons are not applied" do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 1.month).beginning_of_month) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(65_276)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to((subscription_time + 2.months).beginning_of_month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 2.months).beginning_of_month) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(989_000)
         end
@@ -162,7 +160,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     end
   end
 
-  context 'when coupon is applied' do
+  context "when coupon is applied" do
     let(:coupon) do
       create(
         :coupon,
@@ -182,28 +180,26 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       )
 
       travel_to((subscription_time + 1.month).beginning_of_month) do
-        Subscriptions::BillingService.new.call
-        perform_all_enqueued_jobs
+        perform_billing
       end
     end
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 1.month).beginning_of_month) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(65_276)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to((subscription_time + 2.months).beginning_of_month) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 2.months).beginning_of_month) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(989_000)
         end

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/quarterly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Arrears',
-      code: 'in_arrears',
+      name: "In Arrears",
+      code: "in_arrears",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -26,10 +26,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -38,10 +38,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'metered_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "metered_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -50,16 +50,16 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'advance_recurring',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "advance_recurring",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'calendar' }
-  let(:plan_interval) { 'quarterly' }
+  let(:billing_time) { "calendar" }
+  let(:plan_interval) { "quarterly" }
   let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -71,7 +71,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -80,7 +80,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -89,7 +89,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -108,7 +108,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
 
@@ -117,7 +117,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
 
@@ -126,35 +126,33 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
     end
 
     travel_to((subscription_time + 3.months).beginning_of_quarter) do
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when coupons are not applied' do
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with minimum commitment fee' do
+  context "when coupons are not applied" do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 3.months).beginning_of_quarter) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(214_582)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to((subscription_time + 6.months).beginning_of_quarter) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 6.months).beginning_of_quarter) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(989_000)
         end
@@ -162,7 +160,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     end
   end
 
-  context 'when coupon is applied' do
+  context "when coupon is applied" do
     let(:coupon) do
       create(
         :coupon,
@@ -182,28 +180,26 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       )
 
       travel_to((subscription_time + 3.months).beginning_of_quarter) do
-        Subscriptions::BillingService.new.call
-        perform_all_enqueued_jobs
+        perform_billing
       end
     end
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with minimum commitment fee" do
         travel_to(subscription_time + 3.months) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(214_582)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to((subscription_time + 6.months).beginning_of_quarter) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 6.months).beginning_of_quarter) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(989_000)
         end

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/weekly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Arrears',
-      code: 'in_arrears',
+      name: "In Arrears",
+      code: "in_arrears",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -26,10 +26,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -38,10 +38,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'metered_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "metered_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -50,16 +50,16 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'advance_recurring',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "advance_recurring",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'calendar' }
-  let(:plan_interval) { 'weekly' }
+  let(:billing_time) { "calendar" }
+  let(:plan_interval) { "weekly" }
   let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -71,7 +71,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -80,7 +80,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -89,7 +89,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -108,7 +108,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
 
@@ -117,7 +117,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
 
@@ -126,35 +126,33 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '10'}
+          properties: {total: "10"}
         }
       )
     end
 
     travel_to((subscription_time + 1.week).beginning_of_week) do
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when coupons are not applied' do
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with minimum commitment fee' do
+  context "when coupons are not applied" do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 1.week).beginning_of_week) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(845_572)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to((subscription_time + 2.weeks).beginning_of_week) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 2.weeks).beginning_of_week) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(989_000)
         end
@@ -162,7 +160,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     end
   end
 
-  context 'when coupon is applied' do
+  context "when coupon is applied" do
     let(:coupon) do
       create(
         :coupon,
@@ -182,28 +180,26 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       )
 
       travel_to((subscription_time + 1.week).beginning_of_week) do
-        Subscriptions::BillingService.new.call
-        perform_all_enqueued_jobs
+        perform_billing
       end
     end
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 1.week).beginning_of_week) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(845_572)
         end
       end
     end
 
-    context 'when subscription is billed for the second period' do
+    context "when subscription is billed for the second period" do
       before do
         travel_to((subscription_time + 2.weeks).beginning_of_week) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 2.weeks).beginning_of_week) do
           expect(invoice.fees.commitment.first.amount_cents).to eq(989_000)
         end

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/yearly_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
+  let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
-      name: 'In Arrears',
-      code: 'in_arrears',
+      name: "In Arrears",
+      code: "in_arrears",
       organization:,
       amount_cents: 10_000,
       interval: plan_interval,
@@ -27,10 +27,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in advance',
-      code: 'advance_metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in advance",
+      code: "advance_metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -39,10 +39,10 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'Metered in arrears',
-      code: 'metered',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "Metered in arrears",
+      code: "metered",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: false
     )
   end
@@ -51,16 +51,16 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
     create(
       :billable_metric,
       organization:,
-      name: 'In advance recurring',
-      code: 'recurring_advance',
-      aggregation_type: 'sum_agg',
-      field_name: 'total',
+      name: "In advance recurring",
+      code: "recurring_advance",
+      aggregation_type: "sum_agg",
+      field_name: "total",
       recurring: true
     )
   end
 
-  let(:billing_time) { 'calendar' }
-  let(:plan_interval) { 'yearly' }
+  let(:billing_time) { "calendar" }
+  let(:plan_interval) { "yearly" }
   let(:subscription_time) { DateTime.new(2024, 3, 5, 10) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
@@ -73,7 +73,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_advance_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -81,7 +81,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_metered,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     create(
@@ -90,7 +90,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
       billable_metric: billable_metric_recurring_advance,
       invoiceable: true,
       plan:,
-      properties: {amount: '1'}
+      properties: {amount: "1"}
     )
 
     # Create the subscription
@@ -111,7 +111,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '2'}
+          properties: {total: "2"}
         }
       )
 
@@ -120,7 +120,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '1'}
+          properties: {total: "1"}
         }
       )
 
@@ -129,29 +129,28 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: customer.external_id,
-          properties: {total: '30'}
+          properties: {total: "30"}
         }
       )
     end
 
     travel_to((subscription_time + 1.month).beginning_of_month) do
-      Subscriptions::BillingService.new.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
   end
 
-  context 'when billed monthly' do
+  context "when billed monthly" do
     let(:bill_charges_monthly) { true }
 
-    context 'when subscription is billed for the first period' do
-      it 'creates an invoice with no minimum commitment fee' do
+    context "when subscription is billed for the first period" do
+      it "creates an invoice with no minimum commitment fee" do
         travel_to(subscription_time + 1.minute) do
           expect(invoice.fees.commitment.count).to eq(0)
         end
       end
     end
 
-    context 'when subscription is billed for the last period' do
+    context "when subscription is billed for the last period" do
       before do
         travel_to(subscription_time + 5.months) do
           create_event(
@@ -159,7 +158,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
               code: billable_metric_advance_metered.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {total: '55'}
+              properties: {total: "55"}
             }
           )
         end
@@ -170,18 +169,17 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
               code: billable_metric_metered.code,
               transaction_id: SecureRandom.uuid,
               external_subscription_id: customer.external_id,
-              properties: {total: '1'}
+              properties: {total: "1"}
             }
           )
         end
 
         travel_to((subscription_time + 1.year).beginning_of_year) do
-          Subscriptions::BillingService.new.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
       end
 
-      it 'creates an invoice with minimum commitment fee' do
+      it "creates an invoice with minimum commitment fee" do
         travel_to((subscription_time + 1.year).beginning_of_year) do
           aggregate_failures do
             expect(invoice.fees.commitment.count).to eq(1)

--- a/spec/scenarios/commitments/minimum/in_arrears_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
-  let(:timezone) { 'UTC' }
-  let(:customer) { create(:customer, organization:, timezone:, currency: 'EUR') }
+  let(:timezone) { "UTC" }
+  let(:customer) { create(:customer, organization:, timezone:, currency: "EUR") }
 
   let(:plan) do
     create(
       :plan,
       organization:,
       amount_cents: 100_000,
-      amount_currency: 'EUR',
+      amount_currency: "EUR",
       interval: plan_interval,
       pay_in_advance: false,
       bill_charges_monthly:
@@ -40,138 +40,137 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
 
     billing_times.each do |time|
       travel_to(time) do
-        Subscriptions::BillingService.new.call
-        perform_all_enqueued_jobs
+        perform_billing
       end
     end
   end
 
-  shared_examples 'a subscription billing' do
-    context 'when plan has no minimum commitment' do
+  shared_examples "a subscription billing" do
+    context "when plan has no minimum commitment" do
       let(:minimum_commitment) { nil }
 
-      it 'creates an invoice without minimum commitment fee' do
+      it "creates an invoice without minimum commitment fee" do
         expect(invoice.fees.commitment.count).to eq(0)
       end
     end
 
-    context 'when minimum commitment amount is reached' do
+    context "when minimum commitment amount is reached" do
       let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
 
-      it 'creates an invoice without minimum commitment fee' do
+      it "creates an invoice without minimum commitment fee" do
         expect(invoice.fees.commitment.count).to eq(0)
       end
     end
 
-    context 'when minimum commitment amount is not reached' do
+    context "when minimum commitment amount is not reached" do
       let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
-      it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+      it "creates an invoice with minimum commitment fee", :aggregate_failures do
         expect(invoice.fees.commitment.count).to eq(1)
         expect(invoice.fees.commitment.first.amount_cents).to eq(commitment_fee_amount_cents)
       end
     end
   end
 
-  context 'when plan is billed in arrears' do
-    context 'with weekly plan' do
-      let(:plan_interval) { 'weekly' }
+  context "when plan is billed in arrears" do
+    context "with weekly plan" do
+      let(:plan_interval) { "weekly" }
 
-      context 'with calendar billing' do
-        let(:billing_time) { 'calendar' }
+      context "with calendar billing" do
+        let(:billing_time) { "calendar" }
         let(:subscription_time) { DateTime.new(2023, 2, 1) }
         let(:billing_times) { [DateTime.new(2023, 2, 6, 1), DateTime.new(2023, 2, 6, 2)] }
         let(:commitment_fee_amount_cents) { 642_857 }
 
-        it_behaves_like 'a subscription billing'
+        it_behaves_like "a subscription billing"
       end
 
-      context 'with anniversary billing' do
-        let(:billing_time) { 'anniversary' }
+      context "with anniversary billing" do
+        let(:billing_time) { "anniversary" }
         let(:subscription_time) { DateTime.new(2023, 2, 1) }
         let(:billing_times) { [DateTime.new(2023, 2, 15, 1), DateTime.new(2023, 2, 15, 2)] }
         let(:commitment_fee_amount_cents) { 900_000 }
 
-        it_behaves_like 'a subscription billing'
+        it_behaves_like "a subscription billing"
       end
     end
 
-    context 'with monthly plan' do
-      let(:plan_interval) { 'monthly' }
+    context "with monthly plan" do
+      let(:plan_interval) { "monthly" }
 
-      context 'with calendar billing' do
-        let(:billing_time) { 'calendar' }
+      context "with calendar billing" do
+        let(:billing_time) { "calendar" }
         let(:subscription_time) { DateTime.new(2023, 2, 4) }
         let(:billing_times) { [DateTime.new(2023, 3, 1, 1), DateTime.new(2023, 3, 1, 2)] }
         let(:commitment_fee_amount_cents) { 803_571 }
 
-        it_behaves_like 'a subscription billing'
+        it_behaves_like "a subscription billing"
       end
 
-      context 'with anniversary billing' do
-        let(:billing_time) { 'anniversary' }
+      context "with anniversary billing" do
+        let(:billing_time) { "anniversary" }
         let(:subscription_time) { DateTime.new(2023, 2, 4) }
         let(:billing_times) { [DateTime.new(2023, 3, 4, 1), DateTime.new(2023, 3, 4, 2)] }
         let(:commitment_fee_amount_cents) { 900_000 }
 
-        it_behaves_like 'a subscription billing'
+        it_behaves_like "a subscription billing"
       end
     end
 
-    context 'with quarterly plan' do
-      let(:plan_interval) { 'quarterly' }
+    context "with quarterly plan" do
+      let(:plan_interval) { "quarterly" }
 
-      context 'with calendar billing' do
-        let(:billing_time) { 'calendar' }
+      context "with calendar billing" do
+        let(:billing_time) { "calendar" }
         let(:subscription_time) { DateTime.new(2023, 2, 4) }
         let(:billing_times) { [DateTime.new(2023, 4, 1, 1), DateTime.new(2023, 4, 1, 2)] }
         let(:commitment_fee_amount_cents) { 560_000 }
 
-        it_behaves_like 'a subscription billing'
+        it_behaves_like "a subscription billing"
       end
 
-      context 'with anniversary billing' do
-        let(:billing_time) { 'anniversary' }
+      context "with anniversary billing" do
+        let(:billing_time) { "anniversary" }
         let(:subscription_time) { DateTime.new(2023, 2, 4) }
         let(:billing_times) { [DateTime.new(2023, 5, 4, 1), DateTime.new(2023, 5, 4, 2)] }
         let(:commitment_fee_amount_cents) { 900_000 }
 
-        it_behaves_like 'a subscription billing'
+        it_behaves_like "a subscription billing"
       end
     end
 
-    context 'with yearly plan and yearly charge' do
-      let(:plan_interval) { 'yearly' }
+    context "with yearly plan and yearly charge" do
+      let(:plan_interval) { "yearly" }
 
-      context 'with calendar billing' do
-        let(:billing_time) { 'calendar' }
+      context "with calendar billing" do
+        let(:billing_time) { "calendar" }
         let(:subscription_time) { DateTime.new(2022, 2, 1) }
         let(:billing_times) { [DateTime.new(2023, 1, 1, 1), DateTime.new(2023, 1, 1, 2)] }
         let(:commitment_fee_amount_cents) { 823_561 }
 
-        it_behaves_like 'a subscription billing'
+        it_behaves_like "a subscription billing"
 
-        context 'when plan is charged monthly' do
+        context "when plan is charged monthly" do
           let(:bill_charges_monthly) { false }
 
-          it_behaves_like 'a subscription billing'
+          it_behaves_like "a subscription billing"
         end
       end
 
-      context 'with anniversary billing' do
-        let(:billing_time) { 'anniversary' }
+      context "with anniversary billing" do
+        let(:billing_time) { "anniversary" }
         let(:subscription_time) { DateTime.new(2022, 2, 4) }
         let(:billing_times) { [DateTime.new(2023, 2, 4, 1), DateTime.new(2023, 2, 4, 2)] }
         let(:commitment_fee_amount_cents) { 900_000 }
 
-        context 'when plan is charged yearly' do
-          it_behaves_like 'a subscription billing'
+        context "when plan is charged yearly" do
+          it_behaves_like "a subscription billing"
         end
 
-        context 'when plan is charged monthly' do
+        context "when plan is charged monthly" do
           let(:bill_charges_monthly) { false }
 
-          it_behaves_like 'a subscription billing'
+          it_behaves_like "a subscription billing"
         end
       end
     end

--- a/spec/scenarios/credit_note_spec.rb
+++ b/spec/scenarios/credit_note_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Create credit note Scenarios', :scenarios, type: :request do
+describe "Create credit note Scenarios", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
   let(:customer) { create(:customer, organization:) }
 
@@ -44,7 +44,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
     create(:coupon_plan, coupon:, plan: plan2)
   end
 
-  let(:plan_tax) { create(:tax, organization:, name: 'Plan Tax', rate: 10, applied_to_organization: false) }
+  let(:plan_tax) { create(:tax, organization:, name: "Plan Tax", rate: 10, applied_to_organization: false) }
   let(:plan_applied_tax) { create(:plan_applied_tax, plan: plan2, tax: plan_tax) }
   let(:plan_applied_tax2) { create(:plan_applied_tax, plan: plan2, tax:) }
 
@@ -56,7 +56,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
     plan_applied_tax2
   end
 
-  it 'Allows creation of partial credit note' do
+  it "Allows creation of partial credit note" do
     # Creates two subscriptions
     travel_to(DateTime.new(2022, 12, 19, 12)) do
       create_subscription(
@@ -85,8 +85,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
 
     # Bill subscription on an anniversary date
     travel_to(DateTime.new(2023, 10, 19)) do
-      Subscriptions::BillingService.call
-      perform_all_enqueued_jobs
+      perform_billing
     end
 
     invoice = customer.invoices.order(created_at: :desc).first
@@ -168,7 +167,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
     expect(credit_note.coupons_adjustment_amount_cents).to eq(16_454)
   end
 
-  context 'when applying multiple time the same coupon' do
+  context "when applying multiple time the same coupon" do
     let(:plan) do
       create(
         :plan,
@@ -240,7 +239,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
       charge5
     end
 
-    it 'Allows creation of partial credit note' do
+    it "Allows creation of partial credit note" do
       # Creates two subscriptions
       travel_to(DateTime.new(2022, 12, 19, 12)) do
         create_subscription(
@@ -268,8 +267,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
 
       # Bill subscription on an anniversary date
       travel_to(DateTime.new(2023, 10, 19)) do
-        Subscriptions::BillingService.call
-        perform_all_enqueued_jobs
+        perform_billing
       end
 
       invoice = customer.invoices.order(created_at: :desc).first
@@ -337,14 +335,14 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when creating credit note with possible rounding issues' do
-    context 'when creating credit notes for small items with taxes, so sum of items with their taxes is bigger than invoice total amount' do
+  context "when creating credit note with possible rounding issues" do
+    context "when creating credit notes for small items with taxes, so sum of items with their taxes is bigger than invoice total amount" do
       let(:tax) { create(:tax, organization:, rate: 20) }
 
-      context 'when two similar items are refunded separately' do
+      context "when two similar items are refunded separately" do
         let(:add_ons) { create_list(:add_on, 2, organization:, amount_cents: 68_33) }
 
-        it 'solves the rounding issue' do
+        it "solves the rounding issue" do
           #  create a one off invoice with two addons and small amounts as feed
           create_one_off_invoice(customer, add_ons)
           # invoice amount should be with taxes calculated on items sum:
@@ -352,7 +350,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
           expect(invoice.total_amount_cents).to eq(163_99)
           expect(invoice.taxes_amount_cents).to eq(27_33)
           fees = invoice.fees
-          invoice.update(payment_status: 'succeeded')
+          invoice.update(payment_status: "succeeded")
 
           # estimate and create credit notes for first item - full refund; the taxes are rounded to higher number
           estimate_credit_note(
@@ -447,10 +445,10 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
         end
       end
 
-      context 'when four items are refunded separately, some whole, some in parts' do
+      context "when four items are refunded separately, some whole, some in parts" do
         let(:add_ons) { create_list(:add_on, 4, organization:, amount_cents: 68_33) }
 
-        it 'solves the rounding issue' do
+        it "solves the rounding issue" do
           #  create a one off invoice with two addons and small amounts as feed
           create_one_off_invoice(customer, add_ons)
           # invoice amount should be with taxes calculated on items sum:
@@ -458,7 +456,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
           expect(invoice.total_amount_cents).to eq(327_98)
           expect(invoice.taxes_amount_cents).to eq(54_66)
           fees = invoice.fees
-          invoice.update(payment_status: 'succeeded')
+          invoice.update(payment_status: "succeeded")
 
           # estimate and create credit notes for first three items - full refund; the taxes are rounded to higher number
           3.times do |i|
@@ -659,9 +657,9 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
       end
     end
 
-    context 'when creating credit note with small items and applied coupons' do
+    context "when creating credit note with small items and applied coupons" do
       let(:tax) { create(:tax, organization:, rate: 20) }
-      let(:plan_tax) { create(:tax, organization:, name: 'Plan Tax', rate: 20, applied_to_organization: false) }
+      let(:plan_tax) { create(:tax, organization:, name: "Plan Tax", rate: 20, applied_to_organization: false) }
       let(:plan) do
         create(
           :plan,
@@ -706,7 +704,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
         charge2
       end
 
-      it 'calculates all roundings' do
+      it "calculates all roundings" do
         # Creates two subscriptions
         travel_to(DateTime.new(2022, 12, 19, 12)) do
           create_subscription(
@@ -728,8 +726,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
 
         # Bill subscription on an anniversary date
         travel_to(DateTime.new(2023, 10, 19)) do
-          Subscriptions::BillingService.call
-          perform_all_enqueued_jobs
+          perform_billing
         end
 
         invoice = customer.invoices.order(created_at: :desc).first
@@ -880,30 +877,30 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when invoice is prepaid credit' do
-    it 'behaves differently depending on the invoice payment status, wallet balance and wallet status' do
+  context "when invoice is prepaid credit" do
+    it "behaves differently depending on the invoice payment status, wallet balance and wallet status" do
       # Create a prepaid credit invoice for 15 credits
       create_wallet({
         external_customer_id: customer.external_id,
-        rate_amount: '1',
-        name: 'Wallet1',
-        currency: 'EUR',
+        rate_amount: "1",
+        name: "Wallet1",
+        currency: "EUR",
         invoice_requires_successful_payment: false # default
       })
       wallet = customer.wallets.sole
 
       create_wallet_transaction({
         wallet_id: wallet.id,
-        paid_credits: '15'
+        paid_credits: "15"
       })
       wt = WalletTransaction.find json[:wallet_transactions].first[:lago_id]
 
-      expect(wt.status).to eq 'pending'
-      expect(wt.transaction_status).to eq 'purchased'
+      expect(wt.status).to eq "pending"
+      expect(wt.transaction_status).to eq "purchased"
 
       # Customer does not have a payment_provider set yet
       invoice = customer.invoices.credit.sole
-      expect(invoice.status).to eq 'finalized'
+      expect(invoice.status).to eq "finalized"
 
       # it does not allow to create credit notes on invoices with payment status pending
       expect(invoice.creditable_amount_cents).to eq 0
@@ -975,8 +972,8 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
       expect(credit_note.refund_amount_cents).to eq(500)
       expect(credit_note.total_amount_cents).to eq(500)
       wallet_transaction = wallet.wallet_transactions.order(:created_at).last
-      expect(wallet_transaction.status).to eq('settled')
-      expect(wallet_transaction.transaction_status).to eq('voided')
+      expect(wallet_transaction.status).to eq("settled")
+      expect(wallet_transaction.transaction_status).to eq("voided")
       expect(wallet_transaction.credit_note_id).to eq(credit_note.id)
       expect(wallet.reload.balance_cents).to eq(1000)
 
@@ -992,7 +989,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
         ]
       )
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include('higher_than_wallet_balance')
+      expect(response.body).to include("higher_than_wallet_balance")
 
       # when creating a credit note with amount higher than remaining balance, it throws an error
       create_credit_note(
@@ -1007,7 +1004,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
         ]
       )
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include('higher_than_wallet_balance')
+      expect(response.body).to include("higher_than_wallet_balance")
 
       expect(wallet.reload.balance_cents).to eq(5)
 
@@ -1024,7 +1021,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
         ]
       )
       expect(response).to have_http_status(:method_not_allowed)
-      expect(response.body).to include('invalid_type_or_status')
+      expect(response.body).to include("invalid_type_or_status")
 
       create_credit_note(
         invoice_id: invoice.id,
@@ -1038,7 +1035,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
         ]
       )
       expect(response).to have_http_status(:method_not_allowed)
-      expect(response.body).to include('invalid_type_or_status')
+      expect(response.body).to include("invalid_type_or_status")
     end
   end
 end

--- a/spec/scenarios/invoices/adjusted_charge_fees_spec.rb
+++ b/spec/scenarios/invoices/adjusted_charge_fees_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transaction: false do
-  let(:organization) { create(:organization, webhook_url: nil, email_settings: '') }
+describe "Adjusted Charge Fees Scenario", :scenarios, type: :request, transaction: false do
+  let(:organization) { create(:organization, webhook_url: nil, email_settings: "") }
 
   let(:customer) { create(:customer, organization:, invoice_grace_period: 5) }
   let(:subscription_at) { DateTime.new(2022, 7, 19, 12, 12) }
-  let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: 'sum_agg', field_name: 'custom') }
+  let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "custom") }
   let(:unit_precise_amount) { nil }
 
   let(:adjusted_fee_params) do
     {
-      invoice_display_name: 'test-name-25',
+      invoice_display_name: "test-name-25",
       unit_precise_amount:,
       units: 3
     }
@@ -22,7 +22,7 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
     create(
       :plan,
       organization:,
-      interval: 'monthly',
+      interval: "monthly",
       amount_cents: 12_900,
       pay_in_advance: false
     )
@@ -30,15 +30,15 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
 
   around { |test| lago_premium!(&test) }
 
-  context 'with adjusted units' do
-    it 'creates invoices correctly' do
+  context "with adjusted units" do
+    it "creates invoices correctly" do
       # NOTE: Jul 19th: create the subscription
       travel_to(subscription_at) do
         create(
           :standard_charge,
           plan: monthly_plan,
           billable_metric:,
-          properties: {amount: '5'}
+          properties: {amount: "5"}
         )
 
         create_subscription(
@@ -46,7 +46,7 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: monthly_plan.code,
-            billing_time: 'anniversary',
+            billing_time: "anniversary",
             subscription_at: subscription_at.iso8601
           }
         )
@@ -66,19 +66,18 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
 
       # NOTE: August 19th: Bill subscription
       travel_to(Time.zone.parse("2023-08-19T12:12")) do
-        Subscriptions::BillingService.call
-        perform_all_enqueued_jobs
+        perform_billing
 
         invoice = customer.invoices.order(created_at: :desc).first
         fee = Fee.charge.where(invoice:).first
 
-        expect(invoice.status).to eq('draft')
+        expect(invoice.status).to eq("draft")
         expect(invoice.total_amount_cents).to eq(12_900)
 
         AdjustedFees::CreateService.call(invoice:, params: adjusted_fee_params.merge(fee_id: fee.id))
         perform_all_enqueued_jobs
 
-        expect(invoice.reload.status).to eq('draft')
+        expect(invoice.reload.status).to eq("draft")
         expect(invoice.reload.total_amount_cents).to eq(12_900 + 1_500)
       end
 
@@ -89,29 +88,29 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
         Invoices::RefreshDraftJob.perform_later(invoice)
         perform_all_enqueued_jobs
 
-        expect(invoice.reload.status).to eq('draft')
+        expect(invoice.reload.status).to eq("draft")
         expect(invoice.reload.total_amount_cents).to eq(12_900 + 1_500)
 
         Invoices::FinalizeJob.perform_later(invoice)
         perform_all_enqueued_jobs
 
-        expect(invoice.reload.status).to eq('finalized')
+        expect(invoice.reload.status).to eq("finalized")
         expect(invoice.reload.total_amount_cents).to eq(12_900 + 1_500)
       end
     end
   end
 
-  context 'with adjusted amount' do
-    let(:unit_precise_amount) { '150.00' }
+  context "with adjusted amount" do
+    let(:unit_precise_amount) { "150.00" }
 
-    it 'creates invoices correctly' do
+    it "creates invoices correctly" do
       # NOTE: Jul 19th: create the subscription
       travel_to(subscription_at) do
         create(
           :standard_charge,
           plan: monthly_plan,
           billable_metric:,
-          properties: {amount: '10'}
+          properties: {amount: "10"}
         )
 
         create_subscription(
@@ -119,7 +118,7 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: monthly_plan.code,
-            billing_time: 'anniversary',
+            billing_time: "anniversary",
             subscription_at: subscription_at.iso8601
           }
         )
@@ -139,19 +138,18 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
 
       # NOTE: August 19th: Bill subscription
       travel_to(Time.zone.parse("2023-08-19T12:12")) do
-        Subscriptions::BillingService.call
-        perform_all_enqueued_jobs
+        perform_billing
 
         invoice = customer.invoices.order(created_at: :desc).first
         fee = Fee.charge.where(invoice:).first
 
-        expect(invoice.status).to eq('draft')
+        expect(invoice.status).to eq("draft")
         expect(invoice.total_amount_cents).to eq(12_900)
 
         AdjustedFees::CreateService.call(invoice:, params: adjusted_fee_params.merge(fee_id: fee.id))
         perform_all_enqueued_jobs
 
-        expect(invoice.reload.status).to eq('draft')
+        expect(invoice.reload.status).to eq("draft")
         expect(invoice.reload.total_amount_cents).to eq(12_900 + 45_000)
       end
 
@@ -162,13 +160,13 @@ describe 'Adjusted Charge Fees Scenario', :scenarios, type: :request, transactio
         Invoices::RefreshDraftJob.perform_later(invoice)
         perform_all_enqueued_jobs
 
-        expect(invoice.reload.status).to eq('draft')
+        expect(invoice.reload.status).to eq("draft")
         expect(invoice.reload.total_amount_cents).to eq(12_900 + 45_000)
 
         Invoices::FinalizeJob.perform_later(invoice)
         perform_all_enqueued_jobs
 
-        expect(invoice.reload.status).to eq('finalized')
+        expect(invoice.reload.status).to eq("finalized")
         expect(invoice.reload.total_amount_cents).to eq(12_900 + 45_000)
       end
     end

--- a/spec/scenarios/invoices/adjusted_subscription_fees_spec.rb
+++ b/spec/scenarios/invoices/adjusted_subscription_fees_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, transaction: false do
-  let(:organization) { create(:organization, webhook_url: nil, email_settings: '') }
+describe "Adjusted Subscription Fees Scenario", :scenarios, type: :request, transaction: false do
+  let(:organization) { create(:organization, webhook_url: nil, email_settings: "") }
 
   let(:customer) { create(:customer, organization:, invoice_grace_period: 5) }
   let(:subscription_at) { DateTime.new(2023, 7, 19, 12, 12) }
@@ -11,7 +11,7 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
 
   let(:adjusted_fee_params) do
     {
-      invoice_display_name: 'test-name-25',
+      invoice_display_name: "test-name-25",
       unit_precise_amount:,
       units: 3
     }
@@ -21,7 +21,7 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
     create(
       :plan,
       organization:,
-      interval: 'monthly',
+      interval: "monthly",
       amount_cents: 12_900,
       pay_in_advance: false
     )
@@ -29,8 +29,8 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
 
   around { |test| lago_premium!(&test) }
 
-  context 'with adjusted units' do
-    it 'creates invoices correctly' do
+  context "with adjusted units" do
+    it "creates invoices correctly" do
       # NOTE: Jul 19th: create the subscription
       travel_to(subscription_at) do
         create_subscription(
@@ -38,7 +38,7 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: monthly_plan.code,
-            billing_time: 'anniversary',
+            billing_time: "anniversary",
             subscription_at: subscription_at.iso8601
           }
         )
@@ -46,19 +46,18 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
 
       # NOTE: August 19th: Bill subscription
       travel_to(DateTime.new(2023, 8, 19, 12, 12)) do
-        Subscriptions::BillingService.call
-        perform_all_enqueued_jobs
+        perform_billing
 
         invoice = customer.invoices.order(created_at: :desc).first
         fee = invoice.fees.first
 
-        expect(invoice.status).to eq('draft')
+        expect(invoice.status).to eq("draft")
         expect(invoice.total_amount_cents).to eq(12_900)
 
         AdjustedFees::CreateService.call(invoice:, params: adjusted_fee_params.merge(fee_id: fee.id))
         perform_all_enqueued_jobs
 
-        expect(invoice.reload.status).to eq('draft')
+        expect(invoice.reload.status).to eq("draft")
         expect(invoice.reload.total_amount_cents).to eq(38_700)
       end
 
@@ -69,22 +68,22 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
         Invoices::RefreshDraftJob.perform_later(invoice)
         perform_all_enqueued_jobs
 
-        expect(invoice.reload.status).to eq('draft')
+        expect(invoice.reload.status).to eq("draft")
         expect(invoice.reload.total_amount_cents).to eq(38_700)
 
         Invoices::FinalizeJob.perform_later(invoice)
         perform_all_enqueued_jobs
 
-        expect(invoice.reload.status).to eq('finalized')
+        expect(invoice.reload.status).to eq("finalized")
         expect(invoice.reload.total_amount_cents).to eq(38_700)
       end
     end
   end
 
-  context 'with adjusted amount' do
-    let(:unit_precise_amount) { '150.00' }
+  context "with adjusted amount" do
+    let(:unit_precise_amount) { "150.00" }
 
-    it 'creates invoices correctly' do
+    it "creates invoices correctly" do
       # NOTE: Jul 19th: create the subscription
       travel_to(subscription_at) do
         create_subscription(
@@ -92,7 +91,7 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: monthly_plan.code,
-            billing_time: 'anniversary',
+            billing_time: "anniversary",
             subscription_at: subscription_at.iso8601
           }
         )
@@ -100,19 +99,18 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
 
       # NOTE: August 19th: Bill subscription
       travel_to(DateTime.new(2023, 8, 19, 12, 12)) do
-        Subscriptions::BillingService.call
-        perform_all_enqueued_jobs
+        perform_billing
 
         invoice = customer.invoices.order(created_at: :desc).first
         fee = invoice.fees.first
 
-        expect(invoice.status).to eq('draft')
+        expect(invoice.status).to eq("draft")
         expect(invoice.total_amount_cents).to eq(12_900)
 
         AdjustedFees::CreateService.call(invoice:, params: adjusted_fee_params.merge(fee_id: fee.id))
         perform_all_enqueued_jobs
 
-        expect(invoice.reload.status).to eq('draft')
+        expect(invoice.reload.status).to eq("draft")
         expect(invoice.reload.total_amount_cents).to eq(45_000)
       end
 
@@ -123,13 +121,13 @@ describe 'Adjusted Subscription Fees Scenario', :scenarios, type: :request, tran
         Invoices::RefreshDraftJob.perform_later(invoice)
         perform_all_enqueued_jobs
 
-        expect(invoice.reload.status).to eq('draft')
+        expect(invoice.reload.status).to eq("draft")
         expect(invoice.reload.total_amount_cents).to eq(45_000)
 
         Invoices::FinalizeJob.perform_later(invoice)
         perform_all_enqueued_jobs
 
-        expect(invoice.reload.status).to eq('finalized')
+        expect(invoice.reload.status).to eq("finalized")
         expect(invoice.reload.total_amount_cents).to eq(45_000)
       end
     end

--- a/spec/scenarios/invoices/filters_and_grouped_by_spec.rb
+++ b/spec/scenarios/invoices/filters_and_grouped_by_spec.rb
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Invoices for charges with filters and grouped by', :scenarios, type: :request do
+RSpec.describe "Invoices for charges with filters and grouped by", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
 
   let(:customer) { create(:customer, organization:) }
 
-  let(:billable_metric) { create(:sum_billable_metric, organization:, field_name: 'value') }
+  let(:billable_metric) { create(:sum_billable_metric, organization:, field_name: "value") }
   let(:billable_metric_filter1) do
-    create(:billable_metric_filter, billable_metric:, key: 'cloud', values: %w[aws gcp azure])
+    create(:billable_metric_filter, billable_metric:, key: "cloud", values: %w[aws gcp azure])
   end
   let(:billable_metric_filter2) do
-    create(:billable_metric_filter, billable_metric:, key: 'region', values: %w[us europe asia])
+    create(:billable_metric_filter, billable_metric:, key: "region", values: %w[us europe asia])
   end
 
-  let(:plan) { create(:plan, organization:, amount_cents: 0, interval: 'monthly', pay_in_advance: false) }
+  let(:plan) { create(:plan, organization:, amount_cents: 0, interval: "monthly", pay_in_advance: false) }
   let(:charge) do
-    create(:standard_charge, plan:, billable_metric:, properties: {amount: '10'})
+    create(:standard_charge, plan:, billable_metric:, properties: {amount: "10"})
   end
 
-  let(:charge_filter) { create(:charge_filter, charge:, properties: {amount: '12', grouped_by: %w[country]}) }
+  let(:charge_filter) { create(:charge_filter, charge:, properties: {amount: "12", grouped_by: %w[country]}) }
   let(:charge_filter_value1) do
     create(:charge_filter_value, charge_filter:, billable_metric_filter: billable_metric_filter1, values: %w[aws])
   end
@@ -38,15 +38,15 @@ RSpec.describe 'Invoices for charges with filters and grouped by', :scenarios, t
     charge_filter_value2
   end
 
-  it 'creates a new invoice for charges with filters and grouped by' do
+  it "creates a new invoice for charges with filters and grouped by" do
     # Create a subscription
-    travel_to(Time.zone.parse('2024-02-25T10:00:00')) do
+    travel_to(Time.zone.parse("2024-02-25T10:00:00")) do
       create_subscription(
         {
           external_customer_id: customer.external_id,
           external_id: customer.external_id,
           plan_code: plan.code,
-          billing_time: 'anniversary'
+          billing_time: "anniversary"
         }
       )
     end
@@ -54,77 +54,77 @@ RSpec.describe 'Invoices for charges with filters and grouped by', :scenarios, t
     subscription = customer.subscriptions.first
 
     # Send an event matching a filter and a group
-    travel_to(Time.zone.parse('2024-02-28T10:00:00')) do
+    travel_to(Time.zone.parse("2024-02-28T10:00:00")) do
       create_event(
         {
           code: billable_metric.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: subscription.external_id,
-          properties: {cloud: 'aws', region: 'us', country: 'us', value: 10}
+          properties: {cloud: "aws", region: "us", country: "us", value: 10}
         }
       )
     end
 
-    travel_to(Time.zone.parse('2024-03-01T10:00:00')) do
+    travel_to(Time.zone.parse("2024-03-01T10:00:00")) do
       create_event(
         {
           code: billable_metric.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: subscription.external_id,
-          properties: {cloud: 'aws', region: 'europe', country: 'france', value: 10}
+          properties: {cloud: "aws", region: "europe", country: "france", value: 10}
         }
       )
     end
 
-    travel_to(Time.zone.parse('2024-03-02T10:00:00')) do
+    travel_to(Time.zone.parse("2024-03-02T10:00:00")) do
       create_event(
         {
           code: billable_metric.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: subscription.external_id,
-          properties: {cloud: 'aws', region: 'asia', value: 10}
+          properties: {cloud: "aws", region: "asia", value: 10}
         }
       )
     end
 
-    travel_to(Time.zone.parse('2024-03-03T10:00:00')) do
+    travel_to(Time.zone.parse("2024-03-03T10:00:00")) do
       create_event(
         {
           code: billable_metric.code,
           transaction_id: SecureRandom.uuid,
           external_subscription_id: subscription.external_id,
-          properties: {cloud: 'gcp', region: 'asia', country: 'china', value: 10}
+          properties: {cloud: "gcp", region: "asia", country: "china", value: 10}
         }
       )
     end
 
     # Fetch the current usage
-    travel_to(Time.zone.parse('2024-03-04T10:00:00')) do
+    travel_to(Time.zone.parse("2024-03-04T10:00:00")) do
       fetch_current_usage(customer:)
 
       expect(json[:customer_usage][:total_amount_cents]).to eq(46_000)
 
       expect(json[:customer_usage][:charges_usage].count).to eq(1)
       charge_usage = json[:customer_usage][:charges_usage].first
-      expect(charge_usage[:units]).to eq('40.0')
+      expect(charge_usage[:units]).to eq("40.0")
       expect(charge_usage[:events_count]).to eq(4)
       expect(charge_usage[:amount_cents]).to eq(46_000)
 
       expect(charge_usage[:grouped_usage].count).to eq(4)
-      us_group = charge_usage[:grouped_usage].find { |group| group[:grouped_by][:country] == 'us' }
+      us_group = charge_usage[:grouped_usage].find { |group| group[:grouped_by][:country] == "us" }
       expect(us_group[:amount_cents]).to eq(12_000)
       expect(us_group[:events_count]).to eq(1)
-      expect(us_group[:units]).to eq('10.0')
+      expect(us_group[:units]).to eq("10.0")
       expect(us_group[:filters].count).to eq(1)
-      expect(us_group[:filters].first[:units]).to eq('10.0')
+      expect(us_group[:filters].first[:units]).to eq("10.0")
       expect(us_group[:filters].first[:values]).to eq(cloud: %w[aws], region: [ChargeFilterValue::ALL_FILTER_VALUES])
 
-      france_group = charge_usage[:grouped_usage].find { |group| group[:grouped_by][:country] == 'france' }
+      france_group = charge_usage[:grouped_usage].find { |group| group[:grouped_by][:country] == "france" }
       expect(france_group[:amount_cents]).to eq(12_000)
       expect(france_group[:events_count]).to eq(1)
-      expect(france_group[:units]).to eq('10.0')
+      expect(france_group[:units]).to eq("10.0")
       expect(france_group[:filters].count).to eq(1)
-      expect(france_group[:filters].first[:units]).to eq('10.0')
+      expect(france_group[:filters].first[:units]).to eq("10.0")
       expect(france_group[:filters].first[:values]).to eq(
         cloud: %w[aws],
         region: [ChargeFilterValue::ALL_FILTER_VALUES]
@@ -133,44 +133,43 @@ RSpec.describe 'Invoices for charges with filters and grouped by', :scenarios, t
       empty_group = charge_usage[:grouped_usage].find { |group| group[:grouped_by][:country].nil? }
       expect(empty_group[:amount_cents]).to eq(12_000)
       expect(empty_group[:events_count]).to eq(1)
-      expect(empty_group[:units]).to eq('10.0')
+      expect(empty_group[:units]).to eq("10.0")
       expect(empty_group[:filters].count).to eq(1)
 
       aws_filter = empty_group[:filters].find do |filter|
-        filter[:values] == {cloud: ['aws'], region: [ChargeFilterValue::ALL_FILTER_VALUES]}
+        filter[:values] == {cloud: ["aws"], region: [ChargeFilterValue::ALL_FILTER_VALUES]}
       end
-      expect(aws_filter[:units]).to eq('10.0')
+      expect(aws_filter[:units]).to eq("10.0")
       expect(aws_filter[:values]).to eq(cloud: %w[aws], region: [ChargeFilterValue::ALL_FILTER_VALUES])
 
       empty_filter = charge_usage[:filters].find { |filter| filter[:values].nil? }
       expect(empty_filter[:amount_cents]).to eq(10_000)
       expect(empty_filter[:events_count]).to eq(1)
-      expect(empty_filter[:units]).to eq('10.0')
+      expect(empty_filter[:units]).to eq("10.0")
       expect(empty_filter[:values]).to be_nil
     end
 
     # Run the billing job
-    travel_to(Time.zone.parse('2024-03-25T10:00:00')) do
-      Subscriptions::BillingService.new.call
-      expect { perform_all_enqueued_jobs }.to change { subscription.reload.invoices.count }.by(1)
+    travel_to(Time.zone.parse("2024-03-25T10:00:00")) do
+      expect { perform_billing }.to change { subscription.reload.invoices.count }.by(1)
 
       invoice = subscription.invoices.last
       expect(invoice.total_amount_cents).to eq(46_000)
 
       expect(invoice.fees.charge.count).to eq(4)
-      us_fee = invoice.fees.charge.find { |fee| fee.grouped_by['country'] == 'us' }
+      us_fee = invoice.fees.charge.find { |fee| fee.grouped_by["country"] == "us" }
       expect(us_fee.amount_cents).to eq(12_000)
       expect(us_fee.events_count).to eq(1)
       expect(us_fee.units).to eq(10.0)
       expect(us_fee.charge_filter).to eq(charge_filter)
 
-      france_fee = invoice.fees.charge.find { |fee| fee.grouped_by['country'] == 'france' }
+      france_fee = invoice.fees.charge.find { |fee| fee.grouped_by["country"] == "france" }
       expect(france_fee.amount_cents).to eq(12_000)
       expect(france_fee.events_count).to eq(1)
       expect(france_fee.units).to eq(10.0)
       expect(france_fee.charge_filter).to eq(charge_filter)
 
-      ungrouped_fee = invoice.fees.charge.find { |fee| fee.grouped_by['country'].nil? }
+      ungrouped_fee = invoice.fees.charge.find { |fee| fee.grouped_by["country"].nil? }
       expect(ungrouped_fee.amount_cents).to eq(12_000)
       expect(ungrouped_fee.events_count).to eq(1)
       expect(ungrouped_fee.units).to eq(10.0)

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Invoices Scenarios', :scenarios, type: :request do
+describe "Invoices Scenarios", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
   let(:tax) { create(:tax, organization:, rate: 20) }
 
   before { tax }
 
-  context 'when pay in advance subscription with free trial used on several subscriptions' do
+  context "when pay in advance subscription with free trial used on several subscriptions" do
     let(:organization) { create(:organization, webhook_url: nil) }
     let(:tax) { create(:tax, organization:, rate: 0) }
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 3500, pay_in_advance: true, trial_period: 7) }
 
-    it 'creates an invoice for the expected period' do
-      travel_to(Time.zone.parse('2024-03-04T21:00:00')) do
+    it "creates an invoice for the expected period" do
+      travel_to(Time.zone.parse("2024-03-04T21:00:00")) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -28,14 +28,14 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
       expect(subscription.invoices.count).to eq(0)
 
-      travel_to(Time.zone.parse('2024-03-11T22:00:00')) do
+      travel_to(Time.zone.parse("2024-03-11T22:00:00")) do
         perform_billing
       end
 
       invoice = subscription.invoices.first
       expect(invoice.total_amount_cents).to eq(2371) # (31 - 3 - 7) * 35 / 31
 
-      travel_to(Time.zone.parse('2024-03-11T23:00:00')) do
+      travel_to(Time.zone.parse("2024-03-11T23:00:00")) do
         terminate_subscription(subscription)
       end
 
@@ -45,7 +45,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       expect(invoice.reload.credit_notes.count).to eq(1)
       expect(invoice.credit_notes.first.total_amount_cents).to eq(2371)
 
-      travel_to(Time.zone.parse('2024-03-11T23:05:00')) do
+      travel_to(Time.zone.parse("2024-03-11T23:05:00")) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -61,14 +61,14 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when timezone is negative and not the same day as UTC' do
+  context "when timezone is negative and not the same day as UTC" do
     let(:organization) { create(:organization, webhook_url: nil) }
     let(:tax) { create(:tax, organization:, rate: 0) }
-    let(:customer) { create(:customer, organization:, timezone: 'America/Denver') } # UTC-6
-    let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: 'weekly') }
+    let(:customer) { create(:customer, organization:, timezone: "America/Denver") } # UTC-6
+    let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: "weekly") }
 
-    it 'creates an invoice for the expected period' do
-      travel_to(Time.zone.parse('2023-06-16T05:00:00')) do
+    it "creates an invoice for the expected period" do
+      travel_to(Time.zone.parse("2023-06-16T05:00:00")) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -84,14 +84,14 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when timezone is negative but same day as UTC' do
+  context "when timezone is negative but same day as UTC" do
     let(:organization) { create(:organization, webhook_url: nil) }
     let(:tax) { create(:tax, organization:, rate: 0) }
-    let(:customer) { create(:customer, organization:, timezone: 'America/Halifax') } # UTC-3
-    let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: 'weekly') }
+    let(:customer) { create(:customer, organization:, timezone: "America/Halifax") } # UTC-3
+    let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: "weekly") }
 
-    it 'creates an invoice for the expected period' do
-      travel_to(Time.zone.parse('2023-06-16T05:00:00')) do
+    it "creates an invoice for the expected period" do
+      travel_to(Time.zone.parse("2023-06-16T05:00:00")) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -107,14 +107,14 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when timezone is positive but same day as UTC' do
+  context "when timezone is positive but same day as UTC" do
     let(:organization) { create(:organization, webhook_url: nil) }
     let(:tax) { create(:tax, organization:, rate: 0) }
-    let(:customer) { create(:customer, organization:, timezone: 'Europe/Paris') } # UTC+2
-    let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: 'weekly') }
+    let(:customer) { create(:customer, organization:, timezone: "Europe/Paris") } # UTC+2
+    let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: "weekly") }
 
-    it 'creates an invoice for the expected period' do
-      travel_to(Time.zone.parse('2023-06-16T20:00:00')) do
+    it "creates an invoice for the expected period" do
+      travel_to(Time.zone.parse("2023-06-16T20:00:00")) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -130,14 +130,14 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when timezone is positive and not the same day as UTC' do
+  context "when timezone is positive and not the same day as UTC" do
     let(:organization) { create(:organization, webhook_url: nil) }
     let(:tax) { create(:tax, organization:, rate: 0) }
-    let(:customer) { create(:customer, organization:, timezone: 'Asia/Karachi') } # UTC+5
-    let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: 'weekly') }
+    let(:customer) { create(:customer, organization:, timezone: "Asia/Karachi") } # UTC+5
+    let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: "weekly") }
 
-    it 'creates an invoice for the expected period' do
-      travel_to(Time.zone.parse('2023-06-16T20:00:00')) do
+    it "creates an invoice for the expected period" do
+      travel_to(Time.zone.parse("2023-06-16T20:00:00")) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -153,52 +153,51 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when invoice boundaries should cover leap month february' do
+  context "when invoice boundaries should cover leap month february" do
     let(:organization) { create(:organization, webhook_url: nil) }
     let(:tax) { create(:tax, organization:, rate: 0) }
     let(:customer) { create(:customer, organization:) }
-    let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: 'monthly') }
+    let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: "monthly") }
 
-    it 'creates an invoice for the expected period' do
-      travel_to(Time.zone.parse('2023-06-16T05:00:00')) do
+    it "creates an invoice for the expected period" do
+      travel_to(Time.zone.parse("2023-06-16T05:00:00")) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: plan.code,
-            billing_time: 'calendar'
+            billing_time: "calendar"
           }
         )
       end
 
       subscription = customer.subscriptions.first
 
-      travel_to(Time.zone.parse('2024-02-01T12:12:00')) do
-        Subscriptions::BillingService.call
-        perform_all_enqueued_jobs
+      travel_to(Time.zone.parse("2024-02-01T12:12:00")) do
+        perform_billing
 
         invoice = subscription.invoices.order(created_at: :desc).first
         invoice_subscription = invoice.invoice_subscriptions.first
 
-        expect(invoice_subscription.from_datetime.iso8601).to eq('2024-02-01T00:00:00Z')
-        expect(invoice_subscription.to_datetime.iso8601).to eq('2024-02-29T23:59:59Z')
-        expect(invoice_subscription.charges_from_datetime.iso8601).to eq('2024-01-01T00:00:00Z')
-        expect(invoice_subscription.charges_to_datetime.iso8601).to eq('2024-01-31T23:59:59Z')
+        expect(invoice_subscription.from_datetime.iso8601).to eq("2024-02-01T00:00:00Z")
+        expect(invoice_subscription.to_datetime.iso8601).to eq("2024-02-29T23:59:59Z")
+        expect(invoice_subscription.charges_from_datetime.iso8601).to eq("2024-01-01T00:00:00Z")
+        expect(invoice_subscription.charges_to_datetime.iso8601).to eq("2024-01-31T23:59:59Z")
 
         expect(invoice.total_amount_cents).to eq(700)
       end
     end
   end
 
-  context 'when subscription is upgraded without grace period' do
+  context "when subscription is upgraded without grace period" do
     let(:customer) { create(:customer, organization:, invoice_grace_period: 0) }
     let(:plan) { create(:plan, organization:, amount_cents: 0) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 2000) }
     let(:metric) { create(:latest_billable_metric, organization:) }
 
-    it 'creates invoices with correctly attached amounts and reasons' do
+    it "creates invoices with correctly attached amounts and reasons" do
       ### 24 Apr: Create subscription + charge.
-      apr24_10 = Time.zone.parse('2024-04-24T10:00:00')
+      apr24_10 = Time.zone.parse("2024-04-24T10:00:00")
 
       travel_to(apr24_10) do
         create(
@@ -209,7 +208,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           prorated: false,
           invoiceable: true,
           properties: {
-            amount: '2',
+            amount: "2",
             free_units: 1000,
             package_size: 1000
           }
@@ -227,7 +226,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.active.first
 
       ### 24 Apr: Upgrade subscription
-      apr24_11 = Time.zone.parse('2024-04-24T11:00:00')
+      apr24_11 = Time.zone.parse("2024-04-24T11:00:00")
 
       travel_to(apr24_11) do
         expect {
@@ -238,54 +237,54 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
               plan_code: plan_new.code
             }
           )
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { subscription.invoices.count }.from(0).to(1)
 
         invoice = subscription.invoices.first
         invoice_subscription = invoice.invoice_subscriptions.first
 
-        expect(invoice.status).to eq('finalized')
+        expect(invoice.status).to eq("finalized")
         expect(invoice.total_amount_cents).to eq(0)
-        expect(invoice_subscription.invoicing_reason).to eq('subscription_terminating')
-        expect(invoice_subscription.from_datetime.iso8601).to eq('2024-04-24T00:00:00Z')
-        expect(invoice_subscription.to_datetime.iso8601).to eq('2024-04-24T11:00:00Z')
-        expect(invoice_subscription.charges_from_datetime.iso8601).to eq('2024-04-24T10:00:00Z')
-        expect(invoice_subscription.charges_to_datetime.iso8601).to eq('2024-04-24T11:00:00Z')
+        expect(invoice_subscription.invoicing_reason).to eq("subscription_terminating")
+        expect(invoice_subscription.from_datetime.iso8601).to eq("2024-04-24T00:00:00Z")
+        expect(invoice_subscription.to_datetime.iso8601).to eq("2024-04-24T11:00:00Z")
+        expect(invoice_subscription.charges_from_datetime.iso8601).to eq("2024-04-24T10:00:00Z")
+        expect(invoice_subscription.charges_to_datetime.iso8601).to eq("2024-04-24T11:00:00Z")
       end
 
       latest_subscription = customer.subscriptions.active.order(created_at: :desc).first
 
       ### 26 Apr: Terminate subscription
-      apr26_11 = Time.zone.parse('2024-04-26T11:00:00')
+      apr26_11 = Time.zone.parse("2024-04-26T11:00:00")
 
       travel_to(apr26_11) do
         expect {
           terminate_subscription(latest_subscription)
-        }.to change { latest_subscription.reload.status }.from('active').to('terminated')
+        }.to change { latest_subscription.reload.status }.from("active").to("terminated")
           .and change { latest_subscription.invoices.count }.from(0).to(1)
 
         invoice = latest_subscription.invoices.first
         invoice_subscription = invoice.invoice_subscriptions.first
 
-        expect(invoice.status).to eq('finalized')
+        expect(invoice.status).to eq("finalized")
         expect(invoice.total_amount_cents).to eq(240) # (2000/30) x 3 + tax
-        expect(invoice_subscription.invoicing_reason).to eq('subscription_terminating')
-        expect(invoice_subscription.from_datetime.iso8601).to eq('2024-04-24T00:00:00Z')
-        expect(invoice_subscription.to_datetime.iso8601).to eq('2024-04-26T11:00:00Z')
-        expect(invoice_subscription.charges_from_datetime.iso8601).to eq('2024-04-24T11:00:00Z')
-        expect(invoice_subscription.charges_to_datetime.iso8601).to eq('2024-04-26T11:00:00Z')
+        expect(invoice_subscription.invoicing_reason).to eq("subscription_terminating")
+        expect(invoice_subscription.from_datetime.iso8601).to eq("2024-04-24T00:00:00Z")
+        expect(invoice_subscription.to_datetime.iso8601).to eq("2024-04-26T11:00:00Z")
+        expect(invoice_subscription.charges_from_datetime.iso8601).to eq("2024-04-24T11:00:00Z")
+        expect(invoice_subscription.charges_to_datetime.iso8601).to eq("2024-04-26T11:00:00Z")
       end
     end
   end
 
-  context 'when subscription is terminated with a grace period' do
+  context "when subscription is terminated with a grace period" do
     let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
     let(:plan) { create(:plan, organization:, amount_cents: 1000) }
     let(:metric) { create(:billable_metric, organization:) }
 
-    it 'does not update the invoice amount on refresh' do
+    it "does not update the invoice amount on refresh" do
       ### 15 Dec: Create subscription + charge.
-      dec15 = Time.zone.parse('2022-12-15')
+      dec15 = Time.zone.parse("2022-12-15")
 
       travel_to(dec15) do
         create_subscription(
@@ -296,18 +295,18 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           }
         )
 
-        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: '3'})
+        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: "3"})
       end
 
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = Time.zone.parse('2022-12-20T06:00:00')
+      dec20 = Time.zone.parse("2022-12-20T06:00:00")
 
       travel_to(dec20) do
         expect {
           terminate_subscription(subscription)
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { subscription.invoices.count }.from(0).to(1)
 
         invoice = subscription.invoices.first
@@ -321,16 +320,16 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when pay in arrear subscription with recurring charges is terminated' do
+  context "when pay in arrear subscription with recurring charges is terminated" do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 1000) }
     let(:metric) do
-      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+      create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
 
-    it 'does bill the charges' do
+    it "does bill the charges" do
       ### 15 Dec: Create subscription + charge.
-      dec15 = Time.zone.parse('2022-12-15')
+      dec15 = Time.zone.parse("2022-12-15")
 
       travel_to(dec15) do
         create(
@@ -339,7 +338,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           billable_metric: metric,
           pay_in_advance: false,
           prorated: false,
-          properties: {amount: '3'}
+          properties: {amount: "3"}
         )
 
         create_subscription(
@@ -366,12 +365,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = Time.zone.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse("2022-12-20 06:00:00")
 
       travel_to(dec20) do
         expect {
           terminate_subscription(subscription)
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { subscription.invoices.count }.from(0).to(1)
 
         invoice = subscription.invoices.first
@@ -380,16 +379,16 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when pay in arrear subscription with recurring and prorated charges is terminated' do
+  context "when pay in arrear subscription with recurring and prorated charges is terminated" do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 1000) }
     let(:metric) do
-      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+      create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
 
-    it 'does bill the charges' do
+    it "does bill the charges" do
       ### 15 Dec: Create subscription + charge.
-      dec15 = Time.zone.parse('2022-12-15')
+      dec15 = Time.zone.parse("2022-12-15")
 
       travel_to(dec15) do
         create(
@@ -398,7 +397,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           billable_metric: metric,
           pay_in_advance: false,
           prorated: true,
-          properties: {amount: '3'}
+          properties: {amount: "3"}
         )
 
         create_subscription(
@@ -425,12 +424,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = Time.zone.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse("2022-12-20 06:00:00")
 
       travel_to(dec20) do
         expect {
           terminate_subscription(subscription)
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { subscription.invoices.count }.from(0).to(1)
 
         invoice = subscription.invoices.first
@@ -439,13 +438,13 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when pay in arrear subscription with no charges is terminated' do
+  context "when pay in arrear subscription with no charges is terminated" do
     let(:customer) { create(:customer, organization:) }
-    let(:plan) { create(:plan, organization:, amount_cents: 1000, interval: 'yearly') }
+    let(:plan) { create(:plan, organization:, amount_cents: 1000, interval: "yearly") }
 
-    it 'creates subscription fee and adds it to the invoice' do
+    it "creates subscription fee and adds it to the invoice" do
       ### 15 Dec: Create subscription + charge.
-      dec15 = Time.zone.parse('2022-12-15')
+      dec15 = Time.zone.parse("2022-12-15")
 
       travel_to(dec15) do
         create_subscription(
@@ -460,12 +459,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = Time.zone.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse("2022-12-20 06:00:00")
 
       travel_to(dec20) do
         expect {
           terminate_subscription(subscription)
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { subscription.invoices.count }.from(0).to(1)
 
         invoice = subscription.invoices.first
@@ -474,17 +473,17 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when pay in arrear subscription with recurring charges is upgraded and new plan does not contain same BM' do
+  context "when pay in arrear subscription with recurring charges is upgraded and new plan does not contain same BM" do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 1000) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 2000) }
     let(:metric) do
-      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+      create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
 
-    it 'does bill the charges' do
+    it "does bill the charges" do
       ### 15 Dec: Create subscription + charge.
-      dec15 = Time.zone.parse('2022-12-15')
+      dec15 = Time.zone.parse("2022-12-15")
 
       travel_to(dec15) do
         create(
@@ -493,7 +492,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           billable_metric: metric,
           pay_in_advance: false,
           prorated: false,
-          properties: {amount: '3'}
+          properties: {amount: "3"}
         )
 
         create_subscription(
@@ -520,7 +519,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       ### 20 Dec: Upgrade subscription
-      dec20 = Time.zone.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse("2022-12-20 06:00:00")
 
       travel_to(dec20) do
         expect {
@@ -531,7 +530,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
               plan_code: plan_new.code
             }
           )
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { subscription.invoices.count }.from(0).to(1)
 
         invoice = subscription.invoices.first
@@ -540,17 +539,17 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when pay in arrear subscription with recurring charges is upgraded and new plan contains same BM' do
+  context "when pay in arrear subscription with recurring charges is upgraded and new plan contains same BM" do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 1000) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 2000) }
     let(:metric) do
-      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+      create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
 
-    it 'does not bill the charges' do
+    it "does not bill the charges" do
       ### 15 Dec: Create subscription + charge.
-      dec15 = Time.zone.parse('2022-12-15')
+      dec15 = Time.zone.parse("2022-12-15")
 
       travel_to(dec15) do
         create(
@@ -559,7 +558,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           billable_metric: metric,
           pay_in_advance: false,
           prorated: false,
-          properties: {amount: '3'}
+          properties: {amount: "3"}
         )
 
         create_subscription(
@@ -574,7 +573,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Upgrade subscription
-      dec20 = Time.zone.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse("2022-12-20 06:00:00")
 
       travel_to(dec20) do
         create(
@@ -583,7 +582,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           billable_metric: metric,
           pay_in_advance: false,
           prorated: false,
-          properties: {amount: '3'}
+          properties: {amount: "3"}
         )
 
         expect {
@@ -594,7 +593,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
               plan_code: plan_new.code
             }
           )
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { subscription.invoices.count }.from(0).to(1)
 
         invoice = subscription.invoices.first
@@ -603,16 +602,16 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when pay in advance subscription with recurring and prorated charges is terminated' do
+  context "when pay in advance subscription with recurring and prorated charges is terminated" do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 1000) }
     let(:metric) do
-      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+      create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
 
-    it 'does not bill the charges' do
+    it "does not bill the charges" do
       ### 15 Dec: Create subscription + charge.
-      dec15 = Time.zone.parse('2022-12-15')
+      dec15 = Time.zone.parse("2022-12-15")
 
       travel_to(dec15) do
         create(
@@ -621,7 +620,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           billable_metric: metric,
           pay_in_advance: true,
           prorated: true,
-          properties: {amount: '3'}
+          properties: {amount: "3"}
         )
 
         create_subscription(
@@ -636,12 +635,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = Time.zone.parse('2022-12-20 06:00:00')
+      dec20 = Time.zone.parse("2022-12-20 06:00:00")
 
       travel_to(dec20) do
         expect {
           terminate_subscription(subscription)
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { subscription.invoices.count }.from(0).to(1)
 
         invoice = subscription.invoices.first
@@ -650,24 +649,24 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when pay in advance subscription is upgraded' do
+  context "when pay in advance subscription is upgraded" do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: true) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 29_000, pay_in_advance: true) }
     let(:tax) { create(:tax, organization:, rate: 0) }
     let(:metric) do
-      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+      create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
 
-    it 'bills fees correctly' do
-      travel_to(Time.zone.parse('2024-01-01T00:00:00')) do
+    it "bills fees correctly" do
+      travel_to(Time.zone.parse("2024-01-01T00:00:00")) do
         create(
           :standard_charge,
           plan:,
           billable_metric: metric,
           pay_in_advance: false,
           prorated: true,
-          properties: {amount: '1'}
+          properties: {amount: "1"}
         )
 
         create(
@@ -676,7 +675,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           billable_metric: metric,
           pay_in_advance: false,
           prorated: true,
-          properties: {amount: '1'}
+          properties: {amount: "1"}
         )
 
         create_subscription(
@@ -684,41 +683,40 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: plan.code,
-            billing_time: 'calendar'
+            billing_time: "calendar"
           }
         )
       end
 
       subscription = customer.subscriptions.first
 
-      travel_to(Time.zone.parse('2024-01-02T00:00:00')) do
+      travel_to(Time.zone.parse("2024-01-02T00:00:00")) do
         create_event(
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
             external_subscription_id: subscription.external_id,
-            properties: {amount: '5'}
+            properties: {amount: "5"}
           }
         )
       end
 
-      travel_to(Time.zone.parse('2024-02-01T00:00:00')) do
-        Subscriptions::BillingService.call
-        perform_all_enqueued_jobs
+      travel_to(Time.zone.parse("2024-02-01T00:00:00")) do
+        perform_billing
       end
 
-      travel_to(Time.zone.parse('2024-02-12T06:00:00')) do
+      travel_to(Time.zone.parse("2024-02-12T06:00:00")) do
         expect {
           create_subscription(
             {
               external_customer_id: customer.external_id,
               external_id: customer.external_id,
               plan_code: plan_new.code,
-              billing_time: 'calendar'
+              billing_time: "calendar"
             }
           )
           perform_all_enqueued_jobs
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { customer.invoices.count }.from(2).to(3)
 
         invoice = customer.subscriptions.active.first.invoices.order(created_at: :desc).first
@@ -728,9 +726,8 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         expect(invoice.total_amount_cents).to eq(18_000 + 190 - 1_800) # 11/29 x 500 = 172
       end
 
-      travel_to(Time.zone.parse('2024-03-01T12:12:00')) do
-        Subscriptions::BillingService.call
-        perform_all_enqueued_jobs
+      travel_to(Time.zone.parse("2024-03-01T12:12:00")) do
+        perform_billing
 
         invoice = customer.subscriptions.active.first.invoices.order(created_at: :desc).first
 
@@ -739,24 +736,24 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when pay in arrear subscription is upgraded' do
+  context "when pay in arrear subscription is upgraded" do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: false) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 29_000, pay_in_advance: false) }
     let(:tax) { create(:tax, organization:, rate: 0) }
     let(:metric) do
-      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+      create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
 
-    it 'bills fees correctly' do
-      travel_to(Time.zone.parse('2024-01-01T00:00:00')) do
+    it "bills fees correctly" do
+      travel_to(Time.zone.parse("2024-01-01T00:00:00")) do
         create(
           :standard_charge,
           plan:,
           billable_metric: metric,
           pay_in_advance: false,
           prorated: true,
-          properties: {amount: '1'}
+          properties: {amount: "1"}
         )
 
         create(
@@ -765,7 +762,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           billable_metric: metric,
           pay_in_advance: false,
           prorated: true,
-          properties: {amount: '1'}
+          properties: {amount: "1"}
         )
 
         create_subscription(
@@ -773,41 +770,40 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: plan.code,
-            billing_time: 'calendar'
+            billing_time: "calendar"
           }
         )
       end
 
       subscription = customer.subscriptions.first
 
-      travel_to(Time.zone.parse('2024-01-02T00:00:00')) do
+      travel_to(Time.zone.parse("2024-01-02T00:00:00")) do
         create_event(
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
             external_subscription_id: subscription.external_id,
-            properties: {amount: '5'}
+            properties: {amount: "5"}
           }
         )
       end
 
-      travel_to(Time.zone.parse('2024-02-01T00:00:00')) do
-        Subscriptions::BillingService.call
-        perform_all_enqueued_jobs
+      travel_to(Time.zone.parse("2024-02-01T00:00:00")) do
+        perform_billing
       end
 
-      travel_to(Time.zone.parse('2024-02-12T06:00:00')) do
+      travel_to(Time.zone.parse("2024-02-12T06:00:00")) do
         expect {
           create_subscription(
             {
               external_customer_id: customer.external_id,
               external_id: customer.external_id,
               plan_code: plan_new.code,
-              billing_time: 'calendar'
+              billing_time: "calendar"
             }
           )
           perform_all_enqueued_jobs
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { customer.invoices.count }.from(1).to(2)
 
         terminated_invoice = subscription.invoices.order(created_at: :desc).first
@@ -815,9 +811,8 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         expect(terminated_invoice.total_amount_cents).to eq((1_100 + (11.fdiv(29) * 500)).round) # 11 + 10/29 x 5
       end
 
-      travel_to(Time.zone.parse('2024-03-01T12:12:00')) do
-        Subscriptions::BillingService.call
-        perform_all_enqueued_jobs
+      travel_to(Time.zone.parse("2024-03-01T12:12:00")) do
+        perform_billing
 
         invoice = customer.subscriptions.active.first.invoices.order(created_at: :desc).first
 
@@ -826,24 +821,24 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when pay in arrear plan events are ingested on the plan change date' do
+  context "when pay in arrear plan events are ingested on the plan change date" do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 0, pay_in_advance: false) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 0, pay_in_advance: false) }
     let(:tax) { create(:tax, organization:, rate: 0) }
     let(:metric) do
-      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: false, field_name: 'amount')
+      create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: false, field_name: "amount")
     end
 
-    it 'bills fees correctly' do
-      travel_to(Time.zone.parse('2024-01-10T06:20:00')) do
+    it "bills fees correctly" do
+      travel_to(Time.zone.parse("2024-01-10T06:20:00")) do
         create(
           :standard_charge,
           plan:,
           billable_metric: metric,
           pay_in_advance: false,
           prorated: false,
-          properties: {amount: '0'}
+          properties: {amount: "0"}
         )
 
         create(
@@ -852,7 +847,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           billable_metric: metric,
           pay_in_advance: false,
           prorated: false,
-          properties: {amount: '1'}
+          properties: {amount: "1"}
         )
 
         create_subscription(
@@ -860,41 +855,41 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: plan.code,
-            billing_time: 'anniversary'
+            billing_time: "anniversary"
           }
         )
       end
 
       subscription = customer.subscriptions.first
 
-      travel_to(Time.zone.parse('2024-01-10T08:20:00')) do
+      travel_to(Time.zone.parse("2024-01-10T08:20:00")) do
         create_event(
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
             external_subscription_id: subscription.external_id,
-            properties: {amount: '10'}
+            properties: {amount: "10"}
           }
         )
 
         fetch_current_usage(customer:, subscription:)
         expect(json[:customer_usage][:amount_cents].round(2)).to eq(0)
         expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(0)
-        expect(json[:customer_usage][:charges_usage][0][:units]).to eq('10.0')
+        expect(json[:customer_usage][:charges_usage][0][:units]).to eq("10.0")
       end
 
-      travel_to(Time.zone.parse('2024-01-10T08:30:00')) do
+      travel_to(Time.zone.parse("2024-01-10T08:30:00")) do
         expect {
           create_subscription(
             {
               external_customer_id: customer.external_id,
               external_id: customer.external_id,
               plan_code: plan_new.code,
-              billing_time: 'anniversary'
+              billing_time: "anniversary"
             }
           )
           perform_all_enqueued_jobs
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { customer.invoices.count }.from(0).to(1)
 
         terminated_invoice = subscription.invoices.order(created_at: :desc).first
@@ -905,39 +900,39 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         fetch_current_usage(customer:, subscription: active_subscription)
         expect(json[:customer_usage][:amount_cents].round(2)).to eq(0)
         expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(0)
-        expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.0')
+        expect(json[:customer_usage][:charges_usage][0][:units]).to eq("0.0")
       end
 
       active_subscription = customer.subscriptions.active.first
 
-      travel_to(Time.zone.parse('2024-01-10T08:35:00')) do
+      travel_to(Time.zone.parse("2024-01-10T08:35:00")) do
         create_event(
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
             external_subscription_id: active_subscription.external_id,
-            properties: {amount: '10000'}
+            properties: {amount: "10000"}
           }
         )
 
         fetch_current_usage(customer:, subscription:)
         expect(json[:customer_usage][:amount_cents].round(2)).to eq(1_000_000)
         expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(1_000_000)
-        expect(json[:customer_usage][:charges_usage][0][:units]).to eq('10000.0')
+        expect(json[:customer_usage][:charges_usage][0][:units]).to eq("10000.0")
       end
 
-      travel_to(Time.zone.parse('2024-01-10T08:40:00')) do
+      travel_to(Time.zone.parse("2024-01-10T08:40:00")) do
         expect {
           create_subscription(
             {
               external_customer_id: customer.external_id,
               external_id: customer.external_id,
               plan_code: plan.code,
-              billing_time: 'anniversary'
+              billing_time: "anniversary"
             }
           )
           perform_all_enqueued_jobs
-        }.to change { active_subscription.reload.status }.from('active').to('terminated')
+        }.to change { active_subscription.reload.status }.from("active").to("terminated")
           .and change { customer.invoices.count }.from(1).to(2)
 
         terminated_invoice = active_subscription.invoices.order(created_at: :desc).first
@@ -948,29 +943,29 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         fetch_current_usage(customer:, subscription: active_subscription)
         expect(json[:customer_usage][:amount_cents].round(2)).to eq(0)
         expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(0)
-        expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.0')
+        expect(json[:customer_usage][:charges_usage][0][:units]).to eq("0.0")
       end
     end
   end
 
-  context 'when pay in advance subscription is terminated' do
+  context "when pay in advance subscription is terminated" do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: true) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 29_000, pay_in_advance: true) }
     let(:tax) { create(:tax, organization:, rate: 0) }
     let(:metric) do
-      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+      create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
 
-    it 'bills fees correctly' do
-      travel_to(Time.zone.parse('2024-01-01T00:00:00')) do
+    it "bills fees correctly" do
+      travel_to(Time.zone.parse("2024-01-01T00:00:00")) do
         create(
           :standard_charge,
           plan:,
           billable_metric: metric,
           pay_in_advance: false,
           prorated: true,
-          properties: {amount: '1'}
+          properties: {amount: "1"}
         )
 
         create(
@@ -979,7 +974,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           billable_metric: metric,
           pay_in_advance: false,
           prorated: true,
-          properties: {amount: '1'}
+          properties: {amount: "1"}
         )
 
         create_subscription(
@@ -987,34 +982,33 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: plan.code,
-            billing_time: 'calendar'
+            billing_time: "calendar"
           }
         )
       end
 
       subscription = customer.subscriptions.first
 
-      travel_to(Time.zone.parse('2024-01-02T00:00:00')) do
+      travel_to(Time.zone.parse("2024-01-02T00:00:00")) do
         create_event(
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
             external_subscription_id: subscription.external_id,
-            properties: {amount: '5'}
+            properties: {amount: "5"}
           }
         )
       end
 
-      travel_to(Time.zone.parse('2024-02-01T00:00:00')) do
-        Subscriptions::BillingService.call
-        perform_all_enqueued_jobs
+      travel_to(Time.zone.parse("2024-02-01T00:00:00")) do
+        perform_billing
       end
 
-      travel_to(Time.zone.parse('2024-02-12T06:00:00')) do
+      travel_to(Time.zone.parse("2024-02-12T06:00:00")) do
         expect {
           terminate_subscription(subscription)
           perform_all_enqueued_jobs
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { customer.invoices.count }.from(2).to(3)
 
         terminated_invoice = subscription.invoices.order(created_at: :desc).first
@@ -1028,20 +1022,20 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when pay in advance subscription is terminated on the same day' do
+  context "when pay in advance subscription is terminated on the same day" do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: true) }
     let(:tax) { create(:tax, organization:, rate: 0) }
     let(:metric) { create(:billable_metric, organization:) }
 
-    it 'bills fees correctly' do
-      travel_to(Time.zone.parse('2024-02-01T03:00:00')) do
+    it "bills fees correctly" do
+      travel_to(Time.zone.parse("2024-02-01T03:00:00")) do
         create_subscription(
           {
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: plan.code,
-            billing_time: 'calendar'
+            billing_time: "calendar"
           }
         )
       end
@@ -1049,11 +1043,11 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
       first_invoice = subscription.invoices.first
 
-      travel_to(Time.zone.parse('2024-02-01T18:00:00')) do
+      travel_to(Time.zone.parse("2024-02-01T18:00:00")) do
         expect {
           terminate_subscription(subscription)
           perform_all_enqueued_jobs
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { customer.invoices.count }.from(1).to(2)
 
         terminated_invoice = subscription.invoices.order(created_at: :desc).first
@@ -1065,24 +1059,24 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
     end
 
-    context 'with usage events' do
-      it 'bills the usage correctly' do
-        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: '12'})
+    context "with usage events" do
+      it "bills the usage correctly" do
+        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: "12"})
 
-        travel_to(Time.zone.parse('2024-02-01 03:00:00')) do
+        travel_to(Time.zone.parse("2024-02-01 03:00:00")) do
           create_subscription(
             {
               external_customer_id: customer.external_id,
               external_id: customer.external_id,
               plan_code: plan.code,
-              billing_time: 'calendar'
+              billing_time: "calendar"
             }
           )
         end
         subscription = customer.subscriptions.first
         first_invoice = subscription.invoices.first
 
-        travel_to(Time.zone.parse('2024-02-01 10:00:00')) do
+        travel_to(Time.zone.parse("2024-02-01 10:00:00")) do
           create_event(
             {
               code: metric.code,
@@ -1093,11 +1087,11 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           )
         end
 
-        travel_to(Time.zone.parse('2024-02-01 18:00:00')) do
+        travel_to(Time.zone.parse("2024-02-01 18:00:00")) do
           expect {
             terminate_subscription(subscription)
             perform_all_enqueued_jobs
-          }.to change { subscription.reload.status }.from('active').to('terminated')
+          }.to change { subscription.reload.status }.from("active").to("terminated")
             .and change { customer.invoices.count }.from(1).to(2)
 
           terminated_invoice = subscription.invoices.order(created_at: :desc).first
@@ -1111,31 +1105,31 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when pay in advance subscription with grace period is terminated' do
+  context "when pay in advance subscription with grace period is terminated" do
     let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
     let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: true) }
     let(:tax) { create(:tax, organization:, rate: 0) }
     let(:metric) do
-      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+      create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
     let(:adjusted_fee_params) do
       {
-        unit_precise_amount: '5.00',
+        unit_precise_amount: "5.00",
         units: 3
       }
     end
 
     around { |test| lago_premium!(&test) }
 
-    it 'bills fees correctly' do
-      travel_to(Time.zone.parse('2024-01-01T00:00:00')) do
+    it "bills fees correctly" do
+      travel_to(Time.zone.parse("2024-01-01T00:00:00")) do
         create(
           :standard_charge,
           plan:,
           billable_metric: metric,
           pay_in_advance: false,
           prorated: true,
-          properties: {amount: '1'}
+          properties: {amount: "1"}
         )
 
         create_subscription(
@@ -1143,7 +1137,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: plan.code,
-            billing_time: 'calendar'
+            billing_time: "calendar"
           }
         )
       end
@@ -1153,29 +1147,28 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       finalize_invoice(first_invoice)
 
-      travel_to(Time.zone.parse('2024-01-02T00:00:00')) do
+      travel_to(Time.zone.parse("2024-01-02T00:00:00")) do
         create_event(
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
             external_subscription_id: subscription.external_id,
-            properties: {amount: '5'}
+            properties: {amount: "5"}
           }
         )
       end
 
-      travel_to(Time.zone.parse('2024-02-01T00:00:00')) do
-        Subscriptions::BillingService.call
-        perform_all_enqueued_jobs
+      travel_to(Time.zone.parse("2024-02-01T00:00:00")) do
+        perform_billing
 
         finalize_invoice(subscription.invoices.order(created_at: :desc).first)
       end
 
-      travel_to(Time.zone.parse('2024-02-12T06:00:00')) do
+      travel_to(Time.zone.parse("2024-02-12T06:00:00")) do
         expect {
           terminate_subscription(subscription)
           perform_all_enqueued_jobs
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { customer.invoices.count }.from(2).to(3)
 
         terminated_invoice = subscription.invoices.order(created_at: :desc).first
@@ -1214,23 +1207,23 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
     end
 
-    context 'with updated fee with attached credit note' do
+    context "with updated fee with attached credit note" do
       let(:adjusted_fee_params) do
         {
-          unit_precise_amount: '0.50',
+          unit_precise_amount: "0.50",
           units: 18 # 50 x 18 = 900
         }
       end
 
-      it 'bills fees correctly' do
-        travel_to(Time.zone.parse('2024-02-12T06:00:00')) do
+      it "bills fees correctly" do
+        travel_to(Time.zone.parse("2024-02-12T06:00:00")) do
           create(
             :standard_charge,
             plan:,
             billable_metric: metric,
             pay_in_advance: false,
             prorated: true,
-            properties: {amount: '1'}
+            properties: {amount: "1"}
           )
 
           create_subscription(
@@ -1238,7 +1231,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
               external_customer_id: customer.external_id,
               external_id: customer.external_id,
               plan_code: plan.code,
-              billing_time: 'calendar'
+              billing_time: "calendar"
             }
           )
         end
@@ -1251,11 +1244,11 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
         subscription = customer.subscriptions.first
 
-        travel_to(Time.zone.parse('2024-02-12T21:00:00')) do
+        travel_to(Time.zone.parse("2024-02-12T21:00:00")) do
           expect {
             terminate_subscription(subscription)
             perform_all_enqueued_jobs
-          }.to change { subscription.reload.status }.from('active').to('terminated')
+          }.to change { subscription.reload.status }.from("active").to("terminated")
             .and change { customer.invoices.count }.from(1).to(2)
 
           first_invoice = first_invoice.reload
@@ -1295,7 +1288,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
     end
 
-    context 'with updated fee equal to zero' do
+    context "with updated fee equal to zero" do
       let(:adjusted_fee_params) do
         {
           unit_precise_amount: 0,
@@ -1303,15 +1296,15 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         }
       end
 
-      it 'bills fees correctly' do
-        travel_to(Time.zone.parse('2024-02-12 06:00:00')) do
+      it "bills fees correctly" do
+        travel_to(Time.zone.parse("2024-02-12 06:00:00")) do
           create(
             :standard_charge,
             plan:,
             billable_metric: metric,
             pay_in_advance: false,
             prorated: true,
-            properties: {amount: '1'}
+            properties: {amount: "1"}
           )
 
           create_subscription(
@@ -1319,7 +1312,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
               external_customer_id: customer.external_id,
               external_id: customer.external_id,
               plan_code: plan.code,
-              billing_time: 'calendar'
+              billing_time: "calendar"
             }
           )
         end
@@ -1332,11 +1325,11 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
         subscription = customer.subscriptions.first
 
-        travel_to(Time.zone.parse('2024-02-12T21:00:00')) do
+        travel_to(Time.zone.parse("2024-02-12T21:00:00")) do
           expect {
             terminate_subscription(subscription)
             perform_all_enqueued_jobs
-          }.to change { subscription.reload.status }.from('active').to('terminated')
+          }.to change { subscription.reload.status }.from("active").to("terminated")
             .and change { customer.invoices.count }.from(1).to(2)
 
           first_invoice = first_invoice.reload
@@ -1377,24 +1370,24 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when pay in arrear subscription is terminated' do
+  context "when pay in arrear subscription is terminated" do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: false) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 29_000, pay_in_advance: false) }
     let(:tax) { create(:tax, organization:, rate: 0) }
     let(:metric) do
-      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+      create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
 
-    it 'bills fees correctly' do
-      travel_to(Time.zone.parse('2024-01-01T00:00:00')) do
+    it "bills fees correctly" do
+      travel_to(Time.zone.parse("2024-01-01T00:00:00")) do
         create(
           :standard_charge,
           plan:,
           billable_metric: metric,
           pay_in_advance: false,
           prorated: true,
-          properties: {amount: '1'}
+          properties: {amount: "1"}
         )
 
         create(
@@ -1403,7 +1396,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           billable_metric: metric,
           pay_in_advance: false,
           prorated: true,
-          properties: {amount: '1'}
+          properties: {amount: "1"}
         )
 
         create_subscription(
@@ -1411,29 +1404,29 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: plan.code,
-            billing_time: 'calendar'
+            billing_time: "calendar"
           }
         )
       end
 
       subscription = customer.subscriptions.first
 
-      travel_to(Time.zone.parse('2024-01-02T00:00:00')) do
+      travel_to(Time.zone.parse("2024-01-02T00:00:00")) do
         create_event(
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
             external_subscription_id: subscription.external_id,
-            properties: {amount: '5'}
+            properties: {amount: "5"}
           }
         )
       end
 
-      travel_to(Time.zone.parse('2024-02-12T06:00:00')) do
+      travel_to(Time.zone.parse("2024-02-12T06:00:00")) do
         expect {
           terminate_subscription(subscription)
           perform_all_enqueued_jobs
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { customer.invoices.count }.from(0).to(1)
 
         terminated_invoice = subscription.invoices.order(created_at: :desc).first
@@ -1443,14 +1436,14 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     end
   end
 
-  context 'when invoice is paid in advance and grace period' do
+  context "when invoice is paid in advance and grace period" do
     let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
     let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 1000) }
     let(:metric) { create(:billable_metric, organization:) }
 
-    it 'terminates the pay in advance subscription with credit note lesser than amount' do
+    it "terminates the pay in advance subscription with credit note lesser than amount" do
       ### 15 Dec: Create subscription + charge.
-      dec15 = Time.zone.parse('2022-12-15')
+      dec15 = Time.zone.parse("2022-12-15")
 
       travel_to(dec15) do
         create_subscription(
@@ -1461,7 +1454,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           }
         )
 
-        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: '3'})
+        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: "3"})
       end
 
       subscription_invoice = Invoice.draft.first
@@ -1469,7 +1462,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       expect(subscription_invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
 
       ### 17 Dec: Create event + refresh.
-      travel_to(Time.zone.parse('2022-12-17')) do
+      travel_to(Time.zone.parse("2022-12-17")) do
         create(
           :event,
           organization_id: organization.id,
@@ -1489,12 +1482,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = Time.zone.parse('2022-12-20')
+      dec20 = Time.zone.parse("2022-12-20")
 
       travel_to(dec20) do
         expect {
           terminate_subscription(subscription)
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { subscription_invoice.reload.credit_notes.count }.from(0).to(1)
           .and change { subscription.invoices.count }.from(1).to(2)
 
@@ -1527,24 +1520,24 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         # Finalize pay in advance invoice
         expect {
           finalize_invoice(subscription_invoice)
-        }.to change { subscription_invoice.reload.status }.from('draft').to('finalized')
-          .and change { credit_note.reload.status }.from('draft').to('finalized')
+        }.to change { subscription_invoice.reload.status }.from("draft").to("finalized")
+          .and change { credit_note.reload.status }.from("draft").to("finalized")
 
         expect(subscription_invoice.total_amount_cents).to eq(658)
 
         # Finalize termination invoice
         expect {
           finalize_invoice(termination_invoice)
-        }.to change { termination_invoice.reload.status }.from('draft').to('finalized')
+        }.to change { termination_invoice.reload.status }.from("draft").to("finalized")
 
         # Total amount should reflect the credit note 720 - 426
         expect(termination_invoice.total_amount_cents).to eq(294)
       end
     end
 
-    it 'terminates the pay in advance subscription with credit note greater than amount' do
+    it "terminates the pay in advance subscription with credit note greater than amount" do
       ### 15 Dec: Create subscription + charge.
-      dec15 = Time.zone.parse('2022-12-15')
+      dec15 = Time.zone.parse("2022-12-15")
 
       travel_to(dec15) do
         create_subscription(
@@ -1556,7 +1549,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           }
         )
 
-        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: '1'})
+        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: "1"})
       end
 
       subscription_invoice = Invoice.draft.first
@@ -1564,7 +1557,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       expect(subscription_invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
 
       ### 17 Dec: Create event + refresh.
-      travel_to(Time.zone.parse('2022-12-17')) do
+      travel_to(Time.zone.parse("2022-12-17")) do
         create(
           :event,
           organization_id: organization.id,
@@ -1578,12 +1571,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = Time.zone.parse('2022-12-20')
+      dec20 = Time.zone.parse("2022-12-20")
 
       travel_to(dec20) do
         expect {
           terminate_subscription(subscription)
-        }.to change { subscription.reload.status }.from('active').to('terminated')
+        }.to change { subscription.reload.status }.from("active").to("terminated")
           .and change { subscription_invoice.reload.credit_notes.count }.from(0).to(1)
           .and change { subscription.invoices.count }.from(1).to(2)
 
@@ -1614,27 +1607,27 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         # Finalize pay in advance invoice
         expect {
           finalize_invoice(subscription_invoice)
-        }.to change { subscription_invoice.reload.status }.from('draft').to('finalized')
-          .and change { credit_note.reload.status }.from('draft').to('finalized')
+        }.to change { subscription_invoice.reload.status }.from("draft").to("finalized")
+          .and change { credit_note.reload.status }.from("draft").to("finalized")
 
         expect(subscription_invoice.total_amount_cents).to eq(658)
 
         # Finalize termination invoice
         expect {
           finalize_invoice(termination_invoice)
-        }.to change { termination_invoice.reload.status }.from('draft').to('finalized')
+        }.to change { termination_invoice.reload.status }.from("draft").to("finalized")
 
         # Total amount should reflect the credit note (120 - 425)
         expect(termination_invoice.total_amount_cents).to eq(0)
       end
     end
 
-    it 'refreshes and finalizes invoices' do
+    it "refreshes and finalizes invoices" do
       ### 15 Dec: Create subscription + charge.
-      dec15 = Time.zone.parse('2022-12-15')
+      dec15 = Time.zone.parse("2022-12-15")
 
       travel_to(dec15) do
-        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: '1'})
+        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: "1"})
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -1650,7 +1643,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       expect(invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
 
       ### 16 Dec: Create event + refresh.
-      travel_to(Time.zone.parse('2022-12-16')) do
+      travel_to(Time.zone.parse("2022-12-16")) do
         create_event(
           {
             code: metric.code,
@@ -1667,7 +1660,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       ### 17 Dec: Create event + refresh.
-      travel_to(Time.zone.parse('2022-12-17')) do
+      travel_to(Time.zone.parse("2022-12-17")) do
         create_event(
           {
             code: metric.code,
@@ -1684,7 +1677,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       ### 1 Jan: Billing + refresh + finalize.
-      travel_to(Time.zone.parse('2023-01-01')) do
+      travel_to(Time.zone.parse("2023-01-01")) do
         perform_billing
 
         expect(subscription.invoices.count).to eq(2)
@@ -1696,7 +1689,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            timestamp: Time.zone.parse('2022-12-18').to_i,
+            timestamp: Time.zone.parse("2022-12-18").to_i,
             organization_id: organization.id,
             external_subscription_id: subscription.external_id
           }
@@ -1715,22 +1708,22 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         # Finalize invoices.
         expect {
           finalize_invoice(invoice)
-        }.to change { invoice.reload.status }.from('draft').to('finalized')
+        }.to change { invoice.reload.status }.from("draft").to("finalized")
 
         expect {
           finalize_invoice(new_invoice)
-        }.to change { new_invoice.reload.status }.from('draft').to('finalized')
+        }.to change { new_invoice.reload.status }.from("draft").to("finalized")
 
         expect(invoice.total_amount_cents).to eq(658)
         expect(new_invoice.total_amount_cents).to eq(1560)
       end
     end
 
-    context 'when upgrading from pay in arrear to pay in advance plan' do
+    context "when upgrading from pay in arrear to pay in advance plan" do
       let(:pay_in_arrear_plan) { create(:plan, organization:, amount_cents: 1000) }
       let(:pay_in_advance_plan) { create(:plan, organization:, pay_in_advance: true, amount_cents: 1000) }
 
-      it 'creates two draft invoices' do
+      it "creates two draft invoices" do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -1739,7 +1732,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           }
         )
 
-        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: '1'})
+        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: "1"})
 
         # Upgrade to pay in advance plan
         create_subscription(
@@ -1762,13 +1755,13 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
     end
 
-    context 'when invoice grace period is removed' do
+    context "when invoice grace period is removed" do
       let(:organization) { create(:organization, webhook_url: nil, invoice_grace_period: 3) }
       let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 1000) }
 
       around { |test| lago_premium!(&test) }
 
-      it 'finalizes draft invoices' do
+      it "finalizes draft invoices" do
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -1777,7 +1770,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           }
         )
 
-        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: '1'})
+        create(:standard_charge, plan:, billable_metric: metric, properties: {amount: "1"})
 
         invoice = Invoice.draft.first
 
@@ -1789,7 +1782,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         expect {
           create_or_update_customer(params)
         }.to change { customer.reload.invoice_grace_period }.from(3).to(0)
-          .and change { invoice.reload.status }.from('draft').to('finalized')
+          .and change { invoice.reload.status }.from("draft").to("finalized")
       end
     end
   end

--- a/spec/scenarios/subscriptions/downgrade_spec.rb
+++ b/spec/scenarios/subscriptions/downgrade_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Subscription Downgrade Scenario', :scenarios, type: :request, transaction: false do
+describe "Subscription Downgrade Scenario", :scenarios, type: :request, transaction: false do
   let(:organization) { create(:organization, webhook_url: false) }
 
   let(:customer) { create(:customer, organization:) }
@@ -11,7 +11,7 @@ describe 'Subscription Downgrade Scenario', :scenarios, type: :request, transact
     create(
       :plan,
       organization:,
-      interval: 'monthly',
+      interval: "monthly",
       amount_cents: 12_900,
       pay_in_advance: true
     )
@@ -21,7 +21,7 @@ describe 'Subscription Downgrade Scenario', :scenarios, type: :request, transact
     create(
       :plan,
       organization:,
-      interval: 'yearly',
+      interval: "yearly",
       amount_cents: 118_800,
       pay_in_advance: true
     )
@@ -29,7 +29,7 @@ describe 'Subscription Downgrade Scenario', :scenarios, type: :request, transact
 
   let(:subscription_at) { DateTime.new(2023, 7, 19, 12, 12) }
 
-  it 'downgrades and bill subscriptions' do
+  it "downgrades and bill subscriptions" do
     subscription = nil
 
     # NOTE: Jul 19th: create the subscription
@@ -39,7 +39,7 @@ describe 'Subscription Downgrade Scenario', :scenarios, type: :request, transact
           external_customer_id: customer.external_id,
           external_id: customer.external_id,
           plan_code: monthly_plan.code,
-          billing_time: 'anniversary',
+          billing_time: "anniversary",
           subscription_at: subscription_at.iso8601
         }
       )
@@ -50,53 +50,50 @@ describe 'Subscription Downgrade Scenario', :scenarios, type: :request, transact
 
       invoice = subscription.invoices.last
       expect(invoice.fees_amount_cents).to eq(monthly_plan.amount_cents)
-      expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq('2023-07-19T00:00:00Z')
-      expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq('2023-08-18T23:59:59Z')
+      expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq("2023-07-19T00:00:00Z")
+      expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq("2023-08-18T23:59:59Z")
     end
 
     # NOTE: August 19th: Bill subscription
     travel_to(DateTime.new(2023, 8, 19, 12, 12)) do
-      Subscriptions::BillingService.call
-      expect { perform_all_enqueued_jobs }.to change { subscription.reload.invoices.count }
+      expect { perform_billing }.to change { subscription.reload.invoices.count }
 
       expect(subscription.invoices.count).to eq(2)
 
       invoice = subscription.invoices.order(created_at: :asc).last
       expect(invoice.fees_amount_cents).to eq(monthly_plan.amount_cents)
-      expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq('2023-08-19T00:00:00Z')
-      expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq('2023-09-18T23:59:59Z')
-      expect(invoice.invoice_subscriptions.first.charges_from_datetime.iso8601).to eq('2023-07-19T12:12:00Z')
-      expect(invoice.invoice_subscriptions.first.charges_to_datetime.iso8601).to eq('2023-08-18T23:59:59Z')
+      expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq("2023-08-19T00:00:00Z")
+      expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq("2023-09-18T23:59:59Z")
+      expect(invoice.invoice_subscriptions.first.charges_from_datetime.iso8601).to eq("2023-07-19T12:12:00Z")
+      expect(invoice.invoice_subscriptions.first.charges_to_datetime.iso8601).to eq("2023-08-18T23:59:59Z")
     end
 
     # NOTE: September 19th: Bill subscription
     travel_to(DateTime.new(2023, 9, 19, 12, 12)) do
-      Subscriptions::BillingService.call
-      expect { perform_all_enqueued_jobs }.to change { subscription.reload.invoices.count }
+      expect { perform_billing }.to change { subscription.reload.invoices.count }
 
       expect(subscription.invoices.count).to eq(3)
 
       invoice = subscription.invoices.order(created_at: :asc).last
       expect(invoice.fees_amount_cents).to eq(monthly_plan.amount_cents)
-      expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq('2023-09-19T00:00:00Z')
-      expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq('2023-10-18T23:59:59Z')
-      expect(invoice.invoice_subscriptions.first.charges_from_datetime.iso8601).to eq('2023-08-19T00:00:00Z')
-      expect(invoice.invoice_subscriptions.first.charges_to_datetime.iso8601).to eq('2023-09-18T23:59:59Z')
+      expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq("2023-09-19T00:00:00Z")
+      expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq("2023-10-18T23:59:59Z")
+      expect(invoice.invoice_subscriptions.first.charges_from_datetime.iso8601).to eq("2023-08-19T00:00:00Z")
+      expect(invoice.invoice_subscriptions.first.charges_to_datetime.iso8601).to eq("2023-09-18T23:59:59Z")
     end
 
     # NOTE: October 19th: Bill subscription
     travel_to(DateTime.new(2023, 10, 19, 12, 12)) do
-      Subscriptions::BillingService.call
-      expect { perform_all_enqueued_jobs }.to change { subscription.reload.invoices.count }
+      expect { perform_billing }.to change { subscription.reload.invoices.count }
 
       expect(subscription.invoices.count).to eq(4)
 
       invoice = subscription.invoices.order(created_at: :asc).last
       expect(invoice.fees_amount_cents).to eq(monthly_plan.amount_cents)
-      expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq('2023-10-19T00:00:00Z')
-      expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq('2023-11-18T23:59:59Z')
-      expect(invoice.invoice_subscriptions.first.charges_from_datetime.iso8601).to eq('2023-09-19T00:00:00Z')
-      expect(invoice.invoice_subscriptions.first.charges_to_datetime.iso8601).to eq('2023-10-18T23:59:59Z')
+      expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq("2023-10-19T00:00:00Z")
+      expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq("2023-11-18T23:59:59Z")
+      expect(invoice.invoice_subscriptions.first.charges_from_datetime.iso8601).to eq("2023-09-19T00:00:00Z")
+      expect(invoice.invoice_subscriptions.first.charges_to_datetime.iso8601).to eq("2023-10-18T23:59:59Z")
     end
 
     # NOTE: On November 9th: Downgrade to the yearly plan
@@ -106,7 +103,7 @@ describe 'Subscription Downgrade Scenario', :scenarios, type: :request, transact
           external_customer_id: customer.external_id,
           external_id: customer.external_id,
           plan_code: yearly_plan.code,
-          billing_time: 'anniversary'
+          billing_time: "anniversary"
         }
       )
 
@@ -116,8 +113,7 @@ describe 'Subscription Downgrade Scenario', :scenarios, type: :request, transact
 
     # NOTE: November 19th: Bill subscription. Old subscription is terminated and pending one is activated
     travel_to(DateTime.new(2023, 11, 19, 12, 12)) do
-      Subscriptions::BillingService.call
-      expect { perform_all_enqueued_jobs }.to change { subscription.reload.invoices.count }
+      expect { perform_billing }.to change { subscription.reload.invoices.count }
       expect(subscription.reload).to be_terminated
       expect(subscription.invoices.count).to eq(5)
       expect(customer.invoices.count).to eq(5)
@@ -132,9 +128,9 @@ describe 'Subscription Downgrade Scenario', :scenarios, type: :request, transact
       # Also for old pay in advance plan there are no charges so total amount is zero
       expect(new_sub_invoice.fees_amount_cents).to eq(0 + (yearly_plan.amount_cents.fdiv(366) * 243).round)
       expect(new_subscription.invoice_subscriptions.order(created_at: :desc).first.from_datetime.iso8601)
-        .to eq('2023-11-19T00:00:00Z')
+        .to eq("2023-11-19T00:00:00Z")
       expect(new_subscription.invoice_subscriptions.order(created_at: :desc).first.to_datetime.iso8601)
-        .to eq('2024-07-18T23:59:59Z')
+        .to eq("2024-07-18T23:59:59Z")
     end
   end
 end

--- a/spec/scenarios/subscriptions/free_trial_billing_spec.rb
+++ b/spec/scenarios/subscriptions/free_trial_billing_spec.rb
@@ -430,7 +430,7 @@ describe 'Free Trial Billing Subscriptions Scenario', :scenarios, type: :request
 
       expect(customer.reload.invoices.count).to eq(0)
 
-      # NOTE: Subscriptions::BillingService will bill the subscription because it's billing day
+      # NOTE: Subscriptions::OrganizationBillingService will bill the subscription because it's billing day
       #       Subscriptions::FreeTrialBillingService will ignore it because the trial ends at 12:12:00
       #
       #   Time.current:                         31 Mar 2024 22:01:00 UTC +00:00

--- a/spec/scenarios/subscriptions/terminate_ended_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_spec.rb
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
-  let(:organization) { create(:organization, webhook_url: nil, email_settings: '') }
+describe "Subscriptions Termination Scenario", :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil, email_settings: "") }
 
-  let(:timezone) { 'Europe/Paris' }
+  let(:timezone) { "Europe/Paris" }
   let(:customer) { create(:customer, organization:, timezone:) }
 
   let(:plan) do
     create(
       :plan,
       organization:,
-      interval: 'monthly',
+      interval: "monthly",
       amount_cents: 1000,
       pay_in_advance: false
     )
   end
 
-  let(:creation_time) { Time.zone.parse('2023-09-05T00:00:00') }
-  let(:subscription_at) { Time.zone.parse('2023-09-05T00:00:00') }
-  let(:ending_at) { Time.zone.parse('2023-09-06T00:00:00') }
+  let(:creation_time) { Time.zone.parse("2023-09-05T00:00:00") }
+  let(:subscription_at) { Time.zone.parse("2023-09-05T00:00:00") }
+  let(:ending_at) { Time.zone.parse("2023-09-06T00:00:00") }
 
-  context 'when timezone is Europe/Paris' do
-    it 'terminates the subscription when it reaches its ending date' do
+  context "when timezone is Europe/Paris" do
+    it "terminates the subscription when it reaches its ending date" do
       subscription = nil
 
       travel_to(creation_time) do
@@ -32,7 +32,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: plan.code,
-            billing_time: 'anniversary',
+            billing_time: "anniversary",
             subscription_at: subscription_at.iso8601,
             ending_at: ending_at.iso8601
           }
@@ -53,19 +53,19 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
           expect(subscription.reload).to be_terminated
           expect(subscription.reload.invoices.count).to eq(1)
           expect(invoice.total_amount_cents).to eq(67) # 1000 / 30
-          expect(invoice.issuing_date.iso8601).to eq('2023-09-06')
+          expect(invoice.issuing_date.iso8601).to eq("2023-09-06")
         end
       end
     end
   end
 
-  context 'when timezone is Asia/Bangkok' do
-    let(:timezone) { 'Asia/Bangkok' }
+  context "when timezone is Asia/Bangkok" do
+    let(:timezone) { "Asia/Bangkok" }
     let(:creation_time) { DateTime.new(2023, 9, 5, 0, 0) }
     let(:subscription_at) { DateTime.new(2023, 9, 5, 0, 0) }
     let(:ending_at) { DateTime.new(2023, 9, 6, 0, 0) }
 
-    it 'terminates the subscription when it reaches its ending date' do
+    it "terminates the subscription when it reaches its ending date" do
       subscription = nil
 
       travel_to(creation_time) do
@@ -74,7 +74,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: plan.code,
-            billing_time: 'anniversary',
+            billing_time: "anniversary",
             subscription_at: subscription_at.iso8601,
             ending_at: ending_at.iso8601
           }
@@ -95,16 +95,16 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
           expect(subscription.reload).to be_terminated
           expect(subscription.reload.invoices.count).to eq(1)
           expect(invoice.total_amount_cents).to eq(67) # 1000 / 30
-          expect(invoice.issuing_date.iso8601).to eq('2023-09-06')
+          expect(invoice.issuing_date.iso8601).to eq("2023-09-06")
         end
       end
     end
   end
 
-  context 'when timezone is America/Bogota' do
-    let(:timezone) { 'America/Bogota' }
+  context "when timezone is America/Bogota" do
+    let(:timezone) { "America/Bogota" }
 
-    it 'terminates the subscription when it reaches its ending date' do
+    it "terminates the subscription when it reaches its ending date" do
       subscription = nil
 
       travel_to(creation_time) do
@@ -113,7 +113,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: plan.code,
-            billing_time: 'anniversary',
+            billing_time: "anniversary",
             subscription_at: subscription_at.iso8601,
             ending_at: ending_at.iso8601
           }
@@ -134,16 +134,16 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
           expect(subscription.reload).to be_terminated
           expect(subscription.reload.invoices.count).to eq(1)
           expect(invoice.total_amount_cents).to eq(67) # 1000 / 30
-          expect(invoice.issuing_date.iso8601).to eq('2023-09-05')
+          expect(invoice.issuing_date.iso8601).to eq("2023-09-05")
         end
       end
     end
   end
 
-  context 'when ending at is the same as billing date' do
+  context "when ending at is the same as billing date" do
     let(:ending_at) { DateTime.new(2023, 10, 5, 0, 0) }
 
-    it 'bills correctly previous billing period if it has not been billed yet' do
+    it "bills correctly previous billing period if it has not been billed yet" do
       subscription = nil
 
       travel_to(creation_time) do
@@ -152,7 +152,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
             external_customer_id: customer.external_id,
             external_id: customer.external_id,
             plan_code: plan.code,
-            billing_time: 'anniversary',
+            billing_time: "anniversary",
             subscription_at: subscription_at.iso8601,
             ending_at: ending_at.iso8601
           }
@@ -173,23 +173,23 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
           expect(subscription.reload).to be_terminated
           expect(subscription.reload.invoices.count).to eq(1)
           expect(invoice.total_amount_cents).to eq(1000)
-          expect(invoice.issuing_date.iso8601).to eq('2023-10-05')
+          expect(invoice.issuing_date.iso8601).to eq("2023-10-05")
         end
       end
     end
 
-    context 'when plan is pay in advance' do
+    context "when plan is pay in advance" do
       let(:plan) do
         create(
           :plan,
           organization:,
-          interval: 'monthly',
+          interval: "monthly",
           amount_cents: 1000,
           pay_in_advance: true
         )
       end
 
-      it 'does not issue credit note and does not bill previous period ' do
+      it "does not issue credit note and does not bill previous period " do
         subscription = nil
 
         travel_to(creation_time) do
@@ -198,7 +198,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
               external_customer_id: customer.external_id,
               external_id: customer.external_id,
               plan_code: plan.code,
-              billing_time: 'anniversary',
+              billing_time: "anniversary",
               subscription_at: subscription_at.iso8601,
               ending_at: ending_at.iso8601
             }
@@ -220,14 +220,14 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
             expect(subscription.reload.invoices.count).to eq(2)
             expect(customer.credit_notes.count).to eq(0)
             expect(invoice.total_amount_cents).to eq(0)
-            expect(invoice.issuing_date.iso8601).to eq('2023-10-05')
+            expect(invoice.issuing_date.iso8601).to eq("2023-10-05")
           end
         end
       end
     end
 
-    context 'when ending_at is not set and subscription is terminated on the day of creation' do
-      it 'bills correctly only 1 day' do
+    context "when ending_at is not set and subscription is terminated on the day of creation" do
+      it "bills correctly only 1 day" do
         subscription = nil
 
         travel_to(creation_time) do
@@ -236,7 +236,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
               external_customer_id: customer.external_id,
               external_id: customer.external_id,
               plan_code: plan.code,
-              billing_time: 'anniversary',
+              billing_time: "anniversary",
               subscription_at: subscription_at.iso8601,
               ending_at: nil
             }
@@ -260,16 +260,16 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
             expect(subscription.reload).to be_terminated
             expect(subscription.reload.invoices.count).to eq(1)
             expect(invoice.total_amount_cents).to eq(33)
-            expect(invoice.issuing_date.iso8601).to eq('2023-09-05')
+            expect(invoice.issuing_date.iso8601).to eq("2023-09-05")
           end
         end
       end
     end
 
-    context 'with America/Bogota timezone' do
-      let(:timezone) { 'America/Bogota' }
+    context "with America/Bogota timezone" do
+      let(:timezone) { "America/Bogota" }
 
-      it 'bills correctly previous billing period if it has not been billed yet' do
+      it "bills correctly previous billing period if it has not been billed yet" do
         subscription = nil
 
         travel_to(creation_time) do
@@ -278,7 +278,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
               external_customer_id: customer.external_id,
               external_id: customer.external_id,
               plan_code: plan.code,
-              billing_time: 'anniversary',
+              billing_time: "anniversary",
               subscription_at: subscription_at.iso8601,
               ending_at: ending_at.iso8601
             }
@@ -299,16 +299,16 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
             expect(subscription.reload).to be_terminated
             expect(subscription.reload.invoices.count).to eq(1)
             expect(invoice.total_amount_cents).to eq(1000)
-            expect(invoice.issuing_date.iso8601).to eq('2023-10-04')
+            expect(invoice.issuing_date.iso8601).to eq("2023-10-04")
           end
         end
       end
     end
 
-    context 'with Asia/Bangkok timezone' do
-      let(:timezone) { 'Asia/Bangkok' }
+    context "with Asia/Bangkok timezone" do
+      let(:timezone) { "Asia/Bangkok" }
 
-      it 'bills correctly previous billing period if it has not been billed yet' do
+      it "bills correctly previous billing period if it has not been billed yet" do
         subscription = nil
 
         travel_to(creation_time) do
@@ -317,7 +317,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
               external_customer_id: customer.external_id,
               external_id: customer.external_id,
               plan_code: plan.code,
-              billing_time: 'anniversary',
+              billing_time: "anniversary",
               subscription_at: subscription_at.iso8601,
               ending_at: ending_at.iso8601
             }
@@ -338,18 +338,18 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
             expect(subscription.reload).to be_terminated
             expect(subscription.reload.invoices.count).to eq(1)
             expect(invoice.total_amount_cents).to eq(1000)
-            expect(invoice.issuing_date.iso8601).to eq('2023-10-05')
+            expect(invoice.issuing_date.iso8601).to eq("2023-10-05")
           end
         end
       end
     end
 
-    context 'when billing time is calendar' do
+    context "when billing time is calendar" do
       let(:creation_time) { DateTime.new(2023, 8, 1, 0, 0) }
       let(:subscription_at) { DateTime.new(2023, 8, 1, 0, 0) }
       let(:ending_at) { DateTime.new(2023, 10, 1, 0, 0) }
 
-      it 'bills correctly previous billing period if it has not been billed yet' do
+      it "bills correctly previous billing period if it has not been billed yet" do
         subscription = nil
 
         travel_to(creation_time) do
@@ -358,7 +358,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
               external_customer_id: customer.external_id,
               external_id: customer.external_id,
               plan_code: plan.code,
-              billing_time: 'calendar',
+              billing_time: "calendar",
               subscription_at: subscription_at.iso8601,
               ending_at: ending_at.iso8601
             }
@@ -379,23 +379,23 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
             expect(subscription.reload).to be_terminated
             expect(subscription.reload.invoices.count).to eq(1)
             expect(invoice.total_amount_cents).to eq(1000)
-            expect(invoice.issuing_date.iso8601).to eq('2023-10-01')
+            expect(invoice.issuing_date.iso8601).to eq("2023-10-01")
           end
         end
       end
 
-      context 'when plan is pay in advance' do
+      context "when plan is pay in advance" do
         let(:plan) do
           create(
             :plan,
             organization:,
-            interval: 'monthly',
+            interval: "monthly",
             amount_cents: 1000,
             pay_in_advance: true
           )
         end
 
-        it 'does not issue credit note and does not bill previous period' do
+        it "does not issue credit note and does not bill previous period" do
           subscription = nil
 
           travel_to(creation_time) do
@@ -404,7 +404,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
                 external_customer_id: customer.external_id,
                 external_id: customer.external_id,
                 plan_code: plan.code,
-                billing_time: 'calendar',
+                billing_time: "calendar",
                 subscription_at: subscription_at.iso8601,
                 ending_at: ending_at.iso8601
               }
@@ -415,8 +415,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
           end
 
           travel_to(DateTime.new(2023, 9, 1, 0, 0)) do
-            Subscriptions::BillingService.call
-            perform_all_enqueued_jobs
+            perform_billing
           end
 
           travel_to(ending_at + 15.minutes) do
@@ -431,14 +430,14 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
               expect(subscription.reload.invoices.count).to eq(3)
               expect(customer.credit_notes.count).to eq(0)
               expect(invoice.total_amount_cents).to eq(0)
-              expect(invoice.issuing_date.iso8601).to eq('2023-10-01')
+              expect(invoice.issuing_date.iso8601).to eq("2023-10-01")
             end
           end
         end
       end
 
-      context 'with already triggered subscription job' do
-        it 'bills correctly the previous period since billing job is not performed on ending day' do
+      context "with already triggered subscription job" do
+        it "bills correctly the previous period since billing job is not performed on ending day" do
           subscription = nil
 
           travel_to(creation_time) do
@@ -447,7 +446,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
                 external_customer_id: customer.external_id,
                 external_id: customer.external_id,
                 plan_code: plan.code,
-                billing_time: 'calendar',
+                billing_time: "calendar",
                 subscription_at: subscription_at.iso8601,
                 ending_at: ending_at.iso8601
               }
@@ -461,9 +460,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
           WebhookEndpoint.destroy_all
 
           travel_to(ending_at + 5.minutes) do
-            Subscriptions::BillingService.new.call
-
-            perform_all_enqueued_jobs
+            perform_billing
 
             aggregate_failures do
               expect(subscription.reload).to be_active
@@ -482,14 +479,14 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
               expect(subscription.reload).to be_terminated
               expect(subscription.reload.invoices.count).to eq(1)
               expect(invoice.total_amount_cents).to eq(1000)
-              expect(invoice.issuing_date.iso8601).to eq('2023-10-01')
+              expect(invoice.issuing_date.iso8601).to eq("2023-10-01")
             end
           end
         end
       end
 
-      context 'with already triggered subscription job and if ending_at is not set' do
-        it 'bills correctly only one day for manual termination case' do
+      context "with already triggered subscription job and if ending_at is not set" do
+        it "bills correctly only one day for manual termination case" do
           subscription = nil
 
           travel_to(creation_time) do
@@ -498,7 +495,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
                 external_customer_id: customer.external_id,
                 external_id: customer.external_id,
                 plan_code: plan.code,
-                billing_time: 'calendar',
+                billing_time: "calendar",
                 subscription_at: subscription_at.iso8601,
                 ending_at: nil
               }
@@ -512,9 +509,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
           WebhookEndpoint.destroy_all
 
           travel_to(ending_at + 5.minutes) do
-            Subscriptions::BillingService.new.call
-
-            perform_all_enqueued_jobs
+            perform_billing
 
             invoice = subscription.invoices.order(created_at: :desc).first
 
@@ -522,7 +517,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
               expect(subscription.reload).to be_active
               expect(subscription.reload.invoices.count).to eq(1)
               expect(invoice.total_amount_cents).to eq(1000)
-              expect(invoice.issuing_date.iso8601).to eq('2023-10-01')
+              expect(invoice.issuing_date.iso8601).to eq("2023-10-01")
             end
           end
 
@@ -537,7 +532,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
               expect(subscription.reload).to be_terminated
               expect(subscription.reload.invoices.count).to eq(2)
               expect(invoice.total_amount_cents).to eq(32)
-              expect(invoice.issuing_date.iso8601).to eq('2023-10-01')
+              expect(invoice.issuing_date.iso8601).to eq("2023-10-01")
             end
           end
         end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -1296,8 +1296,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
         context 'when started_at in the past' do
           let(:timestamp) { Time.zone.parse(started_at.to_s).end_of_year + 1.day }
-          let(:started_at) { Time.current - 2.months }
-          let(:created_at) { Time.current }
+          let(:started_at) { created_at - 2.months }
+          let(:created_at) { Time.zone.parse('2025-01-21T00:10:00') }
 
           it 'updates the invoice accordingly' do
             result = invoice_service.call

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -2,19 +2,22 @@
 
 require 'rails_helper'
 
-RSpec.describe Subscriptions::BillingService, type: :service do
-  subject(:billing_service) { described_class.new(billing_at:) }
+RSpec.describe Subscriptions::OrganizationBillingService, type: :service do
+  subject(:billing_service) { described_class.new(organization:, billing_at:) }
 
   describe '.call' do
-    let(:plan) { create(:plan, interval:, bill_charges_monthly:) }
+    let(:organization) { create(:organization) }
+    let(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:) }
     let(:bill_charges_monthly) { false }
     let(:created_at) { DateTime.parse('20 Feb 2020') }
     let(:subscription_at) { DateTime.parse('20 Feb 2021') }
-    let(:customer) { create(:customer) }
+    let(:customer) { create(:customer, organization:) }
+    let(:customer2) { create(:customer, organization:) }
 
     let(:subscription) do
       create(
         :subscription,
+        customer: customer2,
         plan:,
         subscription_at:,
         started_at: current_date - 10.days,
@@ -54,9 +57,12 @@ RSpec.describe Subscriptions::BillingService, type: :service do
         )
       end
 
+      let(:customer3) { create(:customer, organization:) }
+
       let(:subscription3) do
         create(
           :subscription,
+          customer: customer3,
           plan:,
           subscription_at:,
           started_at: current_date - 10.days,
@@ -409,7 +415,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
     end
 
     context 'when downgraded' do
-      let(:customer) { create(:customer, :with_hubspot_integration) }
+      let(:customer) { create(:customer, :with_hubspot_integration, organization:) }
       let(:current_date) { DateTime.parse('20 Feb 2022') }
       let(:subscription) do
         create(


### PR DESCRIPTION
## Description

Today, the `Subscriptions::BillingService`, called by the `Clock::SubscriptionsBillerJob` fetches all subscription that have to be billed at a certain moment of time.

Since the number of subscription to bill is growing quickly, this could lead to a very large number of subscription to load in certain condition (mainly on the first day of each month as most of subscription are billed monthly on a calendar basis)

This PR renames the `Subscriptions::BillingService` into `Subscriptions::OrganizationBillingService` and adds a new `organization` argument, to loop over the billable subscription of an organization instead of all of the application.

The `Clock::SubscriptionsBillerJob` is also updated to perform one job per organization