### PR TITLE
fix(current usage): fix current usage taxes

### DIFF
--- a/app/services/integrations/aggregator/taxes/invoices/payload.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payload.rb
@@ -47,7 +47,7 @@ module Integrations
             mapped_item ||= empty_struct
 
             {
-              'item_id' => fee.id,
+              'item_id' => fee.id || fee.item_id,
               'item_code' => mapped_item.external_id,
               'amount_cents' => fee.sub_total_excluding_taxes_amount_cents&.to_i
             }

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -153,8 +153,6 @@ module Invoices
       taxes_result = Rails.cache.read(provider_taxes_cache_key)
 
       unless taxes_result
-        invoice.fees.each { |f| f.id = SecureRandom.uuid }
-
         # Call the service if the cache is empty
         taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:, fees: invoice.fees)
 
@@ -167,7 +165,9 @@ module Invoices
       result.fees_taxes = taxes_result.fees
 
       invoice.fees.each do |fee|
-        fee_taxes = result.fees_taxes.find { |item| item.item_id == fee.id }
+        fee_taxes = result.fees_taxes.find do |item|
+          (item.item_id == fee.item_id) && (item.amount_cents.to_i == fee.sub_total_excluding_taxes_amount_cents&.to_i)
+        end
 
         res = Fees::ApplyProviderTaxesService.call(fee:, fee_taxes:)
         res.raise_if_error!

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -165,7 +165,9 @@ module Invoices
       result.fees_taxes = taxes_result.fees
 
       invoice.fees.each do |fee|
-        fee_taxes = result.fees_taxes.find { |item| item.item_id == fee.id }
+        fee_taxes = result.fees_taxes.find do |item|
+          (item.item_id == fee.item_id) && (item.amount_cents.to_i == fee.sub_total_excluding_taxes_amount_cents&.to_i)
+        end
 
         res = Fees::ApplyProviderTaxesService.call(fee:, fee_taxes:)
         res.raise_if_error!

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -131,14 +131,14 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
       let(:response) { instance_double(Net::HTTPOK) }
       let(:lago_client) { instance_double(LagoHttpClient::Client) }
       let(:endpoint) { 'https://api.nango.dev/v1/anrok/draft_invoices' }
+      let(:fee_id) { '073825ef-9e1d-4694-b01c-991c7e57e0bf' }
       let(:body) do
         p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
         json = File.read(p)
 
         # setting item_id based on the test example
         response = JSON.parse(json)
-        response['succeededInvoices'].first['fees'].last['item_id'] = charge.billable_metric.id
-        response['succeededInvoices'].first['fees'].last['amount_cents'] = 2532
+        response['succeededInvoices'].first['fees'].last['item_id'] = fee_id
 
         response.to_json
       end
@@ -158,6 +158,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
+        allow(SecureRandom).to receive(:uuid).and_return(fee_id)
       end
 
       it 'initializes an invoice' do
@@ -166,6 +167,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
         aggregate_failures do
           expect(result).to be_success
           expect(result.invoice).to be_a(Invoice)
+          expect(result.invoice.fees.first.id).to eq(fee_id)
 
           expect(result.usage).to have_attributes(
             from_datetime: Time.current.beginning_of_month.iso8601,

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -133,7 +133,14 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
       let(:endpoint) { 'https://api.nango.dev/v1/anrok/draft_invoices' }
       let(:body) do
         p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
-        File.read(p)
+        json = File.read(p)
+
+        # setting item_id based on the test example
+        response = JSON.parse(json)
+        response['succeededInvoices'].first['fees'].last['item_id'] = charge.billable_metric.id
+        response['succeededInvoices'].first['fees'].last['amount_cents'] = 2532
+
+        response.to_json
       end
       let(:integration_collection_mapping) do
         create(
@@ -151,7 +158,6 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
-        allow_any_instance_of(Fee).to receive(:id).and_return('lago_fee_id') # rubocop:disable RSpec/AnyInstance
       end
 
       it 'initializes an invoice' do

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -131,14 +131,14 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
       let(:response) { instance_double(Net::HTTPOK) }
       let(:lago_client) { instance_double(LagoHttpClient::Client) }
       let(:endpoint) { 'https://api.nango.dev/v1/anrok/draft_invoices' }
-      let(:fee_id) { '073825ef-9e1d-4694-b01c-991c7e57e0bf' }
       let(:body) do
         p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
         json = File.read(p)
 
         # setting item_id based on the test example
         response = JSON.parse(json)
-        response['succeededInvoices'].first['fees'].last['item_id'] = fee_id
+        response['succeededInvoices'].first['fees'].last['item_id'] = charge.billable_metric.id
+        response['succeededInvoices'].first['fees'].last['amount_cents'] = 2532
 
         response.to_json
       end
@@ -158,7 +158,6 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
         allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
-        allow(SecureRandom).to receive(:uuid).and_return(fee_id)
       end
 
       it 'initializes an invoice' do
@@ -167,7 +166,6 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
         aggregate_failures do
           expect(result).to be_success
           expect(result.invoice).to be_a(Invoice)
-          expect(result.invoice.fees.first.id).to eq(fee_id)
 
           expect(result.usage).to have_attributes(
             from_datetime: Time.current.beginning_of_month.iso8601,


### PR DESCRIPTION
Initially, when fetching taxes from Anrok we used `fee.item_id` (`add_on_id`, `billable_metric_id`, `subscription_id`) as main identifier that helps us map received taxes with certain fee on Lago side.

First version worked well for real invoices, but also for current usage where we don't have ID persisted on fee.

However, there was a case where multiple charges are related to the same billable_metric (especially when one fee amount is zero and another is positive) and we were not able to perform mapping correctly: https://github.com/getlago/lago-api/pull/2842

However, one regression bug was produced with latest changes. Since `fee.id` is nil for current usage, taxes are not applied correctly in some scenarios.

This PR fixes described case