### PR TITLE
feat(api): Add GET /api/v1/wallet_transactions/:id endpoint

### DIFF
--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -48,6 +48,21 @@ module Api
         )
       end
 
+      def show
+        wallet_transaction = current_organization.wallet_transactions.find_by(
+          id: params[:id]
+        )
+
+        return not_found_error(resource: 'wallet_transaction') unless wallet_transaction
+
+        render(
+          json: ::V1::WalletTransactionSerializer.new(
+            wallet_transaction,
+            root_name: 'wallet_transaction'
+          )
+        )
+      end
+
       private
 
       def input_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,7 @@ Rails.application.routes.draw do
       resources :payments, only: %i[create index show]
       resources :plans, param: :code, code: /.*/
       resources :taxes, param: :code, code: /.*/
-      resources :wallet_transactions, only: :create
+      resources :wallet_transactions, only: %i[create show]
       get '/wallets/:id/wallet_transactions', to: 'wallet_transactions#index'
       resources :wallets, only: %i[create update show index]
       delete '/wallets/:id', to: 'wallets#terminate'


### PR DESCRIPTION
## Context

**Wallets**
```
  POST /wallets
  PUT  /wallets/{lago_id} 
  DEL  /wallets/{lago_id}
  GET  / wallets
  GET  / wallets/{lago_id}
  GET  /wallets/{lago_id}/wallet_transactions
```

**Wallet Transactions**
```diff
  POST /wallets_transactions
+ GET /wallets_transactions/{lago_id}
```

## Description

This new endpoint allows you to retrieve a wallet transaction.

Alternatively, we could have an endpoint nested under wallet, `/wallets/:id/wallet_transactions/:wt_id` but I think it's less consistant with our API.

![CleanShot 2025-01-29 at 17 46 03@2x](https://github.com/user-attachments/assets/40385957-d1f3-4720-b360-094277d8cabf)
![CleanShot 2025-01-29 at 17 46 25@2x](https://github.com/user-attachments/assets/65b83d0b-cddc-4779-a875-bb8c75f6b94f)

