### PR TITLE
Feat/terminate orga add orga id credit notes

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -192,15 +192,18 @@ end
 #  updated_at                              :datetime         not null
 #  customer_id                             :uuid             not null
 #  invoice_id                              :uuid             not null
+#  organization_id                         :uuid
 #  sequential_id                           :integer          not null
 #
 # Indexes
 #
-#  index_credit_notes_on_customer_id  (customer_id)
-#  index_credit_notes_on_invoice_id   (invoice_id)
+#  index_credit_notes_on_customer_id      (customer_id)
+#  index_credit_notes_on_invoice_id       (invoice_id)
+#  index_credit_notes_on_organization_id  (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -23,6 +23,7 @@ module CreditNotes
 
       ActiveRecord::Base.transaction do
         result.credit_note = CreditNote.create!(
+          organization_id: invoice.organization_id,
           customer: invoice.customer,
           invoice:,
           issuing_date:,
@@ -155,7 +156,7 @@ module CreditNotes
         membership_id: CurrentContext.membership,
         event: 'credit_note_issued',
         properties: {
-          organization_id: credit_note.organization.id,
+          organization_id: credit_note.organization_id,
           credit_note_id: credit_note.id,
           invoice_id: credit_note.invoice_id,
           credit_note_method: types

--- a/db/migrate/20250130101122_add_organization_id_to_credit_notes.rb
+++ b/db/migrate/20250130101122_add_organization_id_to_credit_notes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToCreditNotes < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :credit_notes, :organization, type: :uuid, index: {algorithm: :concurrently}
+
+    add_foreign_key :credit_notes, :organizations, validate: false
+    validate_foreign_key :credit_notes, :organizations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_22_112050) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_30_101122) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -392,8 +392,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_22_112050) do
     t.decimal "precise_coupons_adjustment_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "precise_taxes_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
     t.float "taxes_rate", default: 0.0, null: false
+    t.uuid "organization_id"
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
+    t.index ["organization_id"], name: "index_credit_notes_on_organization_id"
   end
 
   create_table "credit_notes_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1409,6 +1411,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_22_112050) do
   add_foreign_key "credit_note_items", "fees"
   add_foreign_key "credit_notes", "customers"
   add_foreign_key "credit_notes", "invoices"
+  add_foreign_key "credit_notes", "organizations"
   add_foreign_key "credit_notes_taxes", "credit_notes"
   add_foreign_key "credit_notes_taxes", "taxes"
   add_foreign_key "credits", "applied_coupons"

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
         expect(result).to be_success
 
         credit_note = result.credit_note
+        expect(credit_note.organization_id).to eq(organization.id)
         expect(credit_note.invoice).to eq(invoice)
         expect(credit_note.customer).to eq(invoice.customer)
         expect(credit_note.issuing_date.to_s).to eq(Time.zone.today.to_s)
@@ -110,7 +111,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
         membership_id: CurrentContext.membership,
         event: 'credit_note_issued',
         properties: {
-          organization_id: credit_note.organization.id,
+          organization_id: organization.id,
           credit_note_id: credit_note.id,
           invoice_id: credit_note.invoice_id,
           credit_note_method: 'both'


### PR DESCRIPTION
## Context

This change makes it easier and more feasible to implement a mechanism for terminating an organization and deleting all its data. By explicitly associating `CreditNote` records with `Organization`, we improve data consistency and simplify tenant-scoped deletions.  

Beyond the primary goal, this change also benefits the multi-tenant application in several ways:  
- Improves data integrity by making the organization-tenant relationship explicit.  
- Enables more efficient queries and filtering at the organization level.  
- Aligns `CreditNote` with other models that are already explicitly tied to `Organization`.  

## Description
- Added an `organization_id` column to `credit_notes`, with an index and foreign key constraint.  
- Updated `CreditNotes::CreateService` to set `organization_id` when creating a `CreditNote`.
- Refactored event tracking to reference `credit_note.organization_id` directly.  
- Updated specs to assert the presence of `organization_id`.  

### Impact
- Existing `CreditNote` records will need backfilling (handled separately if needed).  
- Queries can now leverage `organization_id` for better performance.  
- Future work on organization deletion is now more straightforward.  

### Next up: 
- backfilling
- marking the column `not_null`