### PR TITLE
misc: Introduce BaseResult to get rid of OpenStruct

### DIFF
--- a/app/services/add_ons/apply_taxes_service.rb
+++ b/app/services/add_ons/apply_taxes_service.rb
@@ -2,6 +2,8 @@
 
 module AddOns
   class ApplyTaxesService < BaseService
+    Result = BaseResult[:applied_taxes]
+
     def initialize(add_on:, tax_codes:)
       @add_on = add_on
       @tax_codes = tax_codes

--- a/app/services/add_ons/create_service.rb
+++ b/app/services/add_ons/create_service.rb
@@ -2,6 +2,8 @@
 
 module AddOns
   class CreateService < BaseService
+    Result = BaseResult[:add_on]
+
     def initialize(args)
       @args = args
       super

--- a/app/services/add_ons/destroy_service.rb
+++ b/app/services/add_ons/destroy_service.rb
@@ -2,6 +2,8 @@
 
 module AddOns
   class DestroyService < BaseService
+    Result = BaseResult[:add_on]
+
     def initialize(add_on:)
       @add_on = add_on
       super

--- a/app/services/add_ons/update_service.rb
+++ b/app/services/add_ons/update_service.rb
@@ -2,6 +2,8 @@
 
 module AddOns
   class UpdateService < BaseService
+    Result = BaseResult[:add_on]
+
     def initialize(add_on:, params:)
       @add_on = add_on
       @params = params

--- a/app/services/base_result.rb
+++ b/app/services/base_result.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class BaseResult
+  def self.[](*attributes)
+    Class.new(BaseResult) { attr_accessor(*attributes) }
+  end
+
+  attr_reader :error
+
+  def initialize
+    @failure = false
+    @error = nil
+  end
+
+  def failure?
+    failure
+  end
+
+  def success?
+    !failure
+  end
+
+  def fail_with_error!(error)
+    @failure = true
+    @error = error
+
+    self
+  end
+
+  def not_found_failure!(resource:)
+    fail_with_error!(BaseService::NotFoundFailure.new(self, resource:))
+  end
+
+  def not_allowed_failure!(code:)
+    fail_with_error!(BaseService::MethodNotAllowedFailure.new(self, code:))
+  end
+
+  def record_validation_failure!(record:)
+    validation_failure!(errors: record.errors.messages)
+  end
+
+  def validation_failure!(errors:)
+    fail_with_error!(BaseService::ValidationFailure.new(self, messages: errors))
+  end
+
+  def single_validation_failure!(error_code:, field: :base)
+    validation_failure!(errors: {field.to_sym => [error_code]})
+  end
+
+  def service_failure!(code:, message:)
+    fail_with_error!(BaseService::ServiceFailure.new(self, code:, error_message: message))
+  end
+
+  def unknown_tax_failure!(code:, message:)
+    fail_with_error!(BaseService::UnknownTaxFailure.new(self, code:, error_message: message))
+  end
+
+  def forbidden_failure!(code: "feature_unavailable")
+    fail_with_error!(BaseService::ForbiddenFailure.new(self, code:))
+  end
+
+  def unauthorized_failure!(message: "unauthorized")
+    fail_with_error!(BaseService::UnauthorizedFailure.new(self, message:))
+  end
+
+  def third_party_failure!(third_party:, error_message:)
+    fail_with_error!(BaseService::ThirdPartyFailure.new(self, third_party:, error_message:))
+  end
+
+  def raise_if_error!
+    return self if success?
+
+    raise(error)
+  end
+
+  private
+
+  attr_accessor :failure
+end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -51,7 +51,7 @@ class BaseService
     private
 
     def format_messages
-      "Validation errors: #{[messages].flatten.join(", ")}"
+      "Validation errors: #{messages.to_json}"
     end
   end
 
@@ -104,7 +104,9 @@ class BaseService
     end
   end
 
-  class Result < OpenStruct
+  # DEPRECATED: This is a legacy result class that should
+  #             be replaced be defining a Result in every service, using the BaseResult
+  class LegacyResult < OpenStruct
     attr_reader :error
 
     def initialize
@@ -176,6 +178,8 @@ class BaseService
     attr_accessor :failure
   end
 
+  Result = LegacyResult
+
   def self.call(*, **, &)
     LagoTracer.in_span("#{name}#call") do
       new(*, **).call(&)
@@ -193,7 +197,7 @@ class BaseService
   end
 
   def initialize(args = nil)
-    @result = Result.new
+    @result = self.class::Result.new
     @source = CurrentContext&.source
   end
 

--- a/spec/services/base_result_spec.rb
+++ b/spec/services/base_result_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BaseResult do
+  subject(:result) { described_class.new }
+
+  it { expect(result).to be_success }
+  it { expect(result).not_to be_failure }
+  it { expect(result.error).to be_nil }
+
+  it { expect(result.raise_if_error!).to eq(result) }
+
+  describe ".fail_with_error!" do
+    let(:error) { StandardError.new("custom_error") }
+
+    it "assign the error the result", :aggregate_failures do
+      failure = result.fail_with_error!(error)
+
+      expect(failure).to eq(result)
+      expect(result).not_to be_success
+      expect(result).to be_failure
+      expect(result.error).to eq(error)
+    end
+  end
+
+  describe ".forbidden_failure!" do
+    before { result.forbidden_failure! }
+
+    it { expect(result).not_to be_success }
+    it { expect(result).to be_failure }
+    it { expect(result.error).to be_a(BaseService::ForbiddenFailure) }
+    it { expect(result.error.code).to eq("feature_unavailable") }
+
+    it { expect { result.raise_if_error! }.to raise_error(BaseService::ForbiddenFailure) }
+
+    context "when passing a code to the failure" do
+      before { result.forbidden_failure!(code: "custom_code") }
+
+      it { expect(result.error.code).to eq("custom_code") }
+    end
+  end
+
+  describe ".not_allowed_failure!" do
+    before { result.not_allowed_failure!(code: "custom_code") }
+
+    it { expect(result).not_to be_success }
+    it { expect(result).to be_failure }
+    it { expect(result.error).to be_a(BaseService::MethodNotAllowedFailure) }
+    it { expect(result.error.code).to eq("custom_code") }
+
+    it { expect { result.raise_if_error! }.to raise_error(BaseService::MethodNotAllowedFailure) }
+  end
+
+  describe ".not_found_failure!" do
+    before { result.not_found_failure!(resource: "custom_resource") }
+
+    it { expect(result).not_to be_success }
+    it { expect(result).to be_failure }
+    it { expect(result.error).to be_a(BaseService::NotFoundFailure) }
+    it { expect(result.error.error_code).to eq("custom_resource_not_found") }
+
+    it { expect { result.raise_if_error! }.to raise_error(BaseService::NotFoundFailure) }
+  end
+
+  describe ".service_failure!" do
+    before { result.service_failure!(code: "custom_code", message: "custom_message") }
+
+    it { expect(result).not_to be_success }
+    it { expect(result).to be_failure }
+    it { expect(result.error).to be_a(BaseService::ServiceFailure) }
+    it { expect(result.error.code).to eq("custom_code") }
+    it { expect(result.error.message).to eq("custom_code: custom_message") }
+
+    it { expect { result.raise_if_error! }.to raise_error(BaseService::ServiceFailure) }
+  end
+
+  describe ".unauthorized_failure!" do
+    before { result.unauthorized_failure! }
+
+    it { expect(result).not_to be_success }
+    it { expect(result).to be_failure }
+    it { expect(result.error).to be_a(BaseService::UnauthorizedFailure) }
+    it { expect(result.error.message).to eq("unauthorized") }
+
+    it { expect { result.raise_if_error! }.to raise_error(BaseService::UnauthorizedFailure) }
+
+    context "when passing a code to the failure" do
+      before { result.unauthorized_failure!(message: "custom_code") }
+
+      it { expect(result.error.message).to eq("custom_code") }
+    end
+  end
+
+  describe ".validation_failure!" do
+    before { result.validation_failure!(errors: {field: ["error"]}) }
+
+    it { expect(result).not_to be_success }
+    it { expect(result).to be_failure }
+    it { expect(result.error).to be_a(BaseService::ValidationFailure) }
+    it { expect(result.error.messages).to eq({field: ["error"]}) }
+    it { expect(result.error.message).to eq('Validation errors: {"field":["error"]}') }
+
+    it { expect { result.raise_if_error! }.to raise_error(BaseService::ValidationFailure) }
+  end
+
+  describe ".record_validation_failure!" do
+    let(:record) { Customer.new.tap(&:valid?) }
+
+    before { result.record_validation_failure!(record:) }
+
+    it { expect(result).not_to be_success }
+    it { expect(result).to be_failure }
+    it { expect(result.error).to be_a(BaseService::ValidationFailure) }
+    it { expect(result.error.messages.keys).to match_array(%i[external_id organization]) }
+    it { expect(result.error.message).to eq("Validation errors: #{result.error.messages.to_json}") }
+
+    it { expect { result.raise_if_error! }.to raise_error(BaseService::ValidationFailure) }
+  end
+
+  describe ".single_validation_failure!" do
+    before { result.single_validation_failure!(error_code: "error_code") }
+
+    it { expect(result).not_to be_success }
+    it { expect(result).to be_failure }
+    it { expect(result.error).to be_a(BaseService::ValidationFailure) }
+    it { expect(result.error.messages).to eq({base: ["error_code"]}) }
+    it { expect(result.error.message).to eq('Validation errors: {"base":["error_code"]}') }
+
+    it { expect { result.raise_if_error! }.to raise_error(BaseService::ValidationFailure) }
+
+    context "when passing a field to the failure" do
+      before { result.single_validation_failure!(error_code: "error", field: "field") }
+
+      it { expect(result.error.messages).to eq({field: ["error"]}) }
+      it { expect(result.error.message).to eq('Validation errors: {"field":["error"]}') }
+    end
+  end
+
+  describe ".unknown_tax_failure!" do
+    before { result.unknown_tax_failure!(code: "custom_code", message: "custom_message") }
+
+    it { expect(result).not_to be_success }
+    it { expect(result).to be_failure }
+    it { expect(result.error).to be_a(BaseService::UnknownTaxFailure) }
+    it { expect(result.error.code).to eq("custom_code") }
+    it { expect(result.error.message).to eq("custom_code: custom_message") }
+
+    it { expect { result.raise_if_error! }.to raise_error(BaseService::UnknownTaxFailure) }
+  end
+
+  describe ".third_party_failure!" do
+    before { result.third_party_failure!(third_party: "stripe", error_message: "custom_message") }
+
+    it { expect(result).not_to be_success }
+    it { expect(result).to be_failure }
+    it { expect(result.error).to be_a(BaseService::ThirdPartyFailure) }
+    it { expect(result.error.third_party).to eq("stripe") }
+    it { expect(result.error.message).to eq("stripe: custom_message") }
+
+    it { expect { result.raise_if_error! }.to raise_error(BaseService::ThirdPartyFailure) }
+  end
+
+  describe ".raise_if_error!" do
+    context "when the result is a failure" do
+      before { result.fail_with_error!(StandardError.new) }
+
+      it { expect { result.raise_if_error! }.to raise_error(StandardError) }
+    end
+
+    context "when the result is a success" do
+      it { expect(result.raise_if_error!).to eq(result) }
+    end
+  end
+
+  describe "#[]" do
+    let(:result_class) { described_class[:property] }
+
+    it { expect(result_class.new).to be_kind_of(described_class) }
+
+    it "defines the attributes" do
+      expect(result_class.new).to respond_to(:property)
+      expect(result_class.new).to respond_to(:property=)
+    end
+
+    context 'with multiple properties' do
+      let(:result_class) { described_class[:property, :another_property] }
+
+      it "defines the attributes" do
+        expect(result_class.new).to respond_to(:property)
+        expect(result_class.new).to respond_to(:property=)
+        expect(result_class.new).to respond_to(:another_property)
+        expect(result_class.new).to respond_to(:another_property=)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

As a requirement to enable YJIT compiler for Ruby, we need to get rid of OpenStruct as it leads to a huge memory consumption.

At the same time, we are lacking visibility on what properties are attached to result objects returned by services.

## Description

This PR introduces a new `BaseResult` result object, that should be used a a base in every services to define the attributes of a Result:
```ruby
module SomeModule
  class SomeService < BaseService
    Result = BaseResult[:attr_name1, :attr_name2]
```

To keep compatibility until all services are migrated to this approach, the `BaseService` is still relying on a `LegacyResult` using OpenStruct as a parent class.