### PR TITLE
feat(wallet): New `wallet.created` webhooks

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -55,6 +55,7 @@ class SendWebhookJob < ApplicationJob
     'subscription.termination_alert' => Webhooks::Subscriptions::TerminationAlertService,
     'subscription.trial_ended' => Webhooks::Subscriptions::TrialEndedService,
     'subscription.usage_threshold_reached' => Webhooks::Subscriptions::UsageThresholdsReachedService,
+    'wallet.created' => Webhooks::Wallets::CreatedService,
     'wallet.depleted_ongoing_balance' => Webhooks::Wallets::DepletedOngoingBalanceService,
     'wallet_transaction.created' => Webhooks::WalletTransactions::CreatedService,
     'wallet_transaction.updated' => Webhooks::WalletTransactions::UpdatedService,

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -56,6 +56,7 @@ class SendWebhookJob < ApplicationJob
     'subscription.trial_ended' => Webhooks::Subscriptions::TrialEndedService,
     'subscription.usage_threshold_reached' => Webhooks::Subscriptions::UsageThresholdsReachedService,
     'wallet.created' => Webhooks::Wallets::CreatedService,
+    'wallet.updated' => Webhooks::Wallets::UpdatedService,
     'wallet.terminated' => Webhooks::Wallets::TerminatedService,
     'wallet.depleted_ongoing_balance' => Webhooks::Wallets::DepletedOngoingBalanceService,
     'wallet_transaction.created' => Webhooks::WalletTransactions::CreatedService,

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -56,6 +56,7 @@ class SendWebhookJob < ApplicationJob
     'subscription.trial_ended' => Webhooks::Subscriptions::TrialEndedService,
     'subscription.usage_threshold_reached' => Webhooks::Subscriptions::UsageThresholdsReachedService,
     'wallet.created' => Webhooks::Wallets::CreatedService,
+    'wallet.terminated' => Webhooks::Wallets::TerminatedService,
     'wallet.depleted_ongoing_balance' => Webhooks::Wallets::DepletedOngoingBalanceService,
     'wallet_transaction.created' => Webhooks::WalletTransactions::CreatedService,
     'wallet_transaction.updated' => Webhooks::WalletTransactions::UpdatedService,

--- a/app/jobs/wallet_transactions/create_job.rb
+++ b/app/jobs/wallet_transactions/create_job.rb
@@ -4,9 +4,13 @@ module WalletTransactions
   class CreateJob < ApplicationJob
     queue_as 'high_priority'
 
-    def perform(organization_id:, params:)
+    def perform(organization_id:, params:, new_wallet: false)
       organization = Organization.find(organization_id)
       WalletTransactions::CreateService.call(organization:, params:)
+
+      if new_wallet
+        SendWebhookJob.perform_later('wallet.created', Wallet.find_by(id: params[:wallet_id]))
+      end
     end
   end
 end

--- a/app/services/wallets/balance/decrease_service.rb
+++ b/app/services/wallets/balance/decrease_service.rb
@@ -23,6 +23,7 @@ module Wallets
           last_consumed_credit_at: Time.current
         )
 
+        SendWebhookJob.perform_later('wallet.updated', wallet)
         Wallets::Balance::RefreshOngoingService.call(wallet:)
 
         result.wallet = wallet

--- a/app/services/wallets/balance/increase_service.rb
+++ b/app/services/wallets/balance/increase_service.rb
@@ -27,6 +27,8 @@ module Wallets
         end
 
         wallet.update!(update_params)
+
+        SendWebhookJob.perform_later('wallet.updated', wallet)
         Wallets::Balance::RefreshOngoingService.call(wallet:)
 
         result.wallet = wallet

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -39,6 +39,8 @@ module Wallets
 
       result.wallet = wallet
 
+      # Webhook `wallet.created` is sent after this job
+      # so the wallet balance always include the paid or granted credit.
       WalletTransactions::CreateJob.perform_later(
         organization_id: params[:organization_id],
         params: {
@@ -47,7 +49,8 @@ module Wallets
           granted_credits: params[:granted_credits],
           source: :manual,
           metadata: params[:transaction_metadata]
-        }
+        },
+        new_wallet: true
       )
 
       result

--- a/app/services/wallets/terminate_service.rb
+++ b/app/services/wallets/terminate_service.rb
@@ -10,7 +10,10 @@ module Wallets
     def call
       return result.not_found_failure!(resource: 'wallet') unless wallet
 
-      wallet.mark_as_terminated! if wallet.active?
+      unless wallet.terminated?
+        wallet.mark_as_terminated! if wallet.active?
+        SendWebhookJob.perform_later('wallet.terminated', wallet)
+      end
 
       result.wallet = wallet
       result

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -27,6 +27,8 @@ module Wallets
         wallet.save!
       end
 
+      SendWebhookJob.perform_later('wallet.updated', wallet)
+
       Wallets::Balance::RefreshOngoingService.call(wallet:)
 
       result.wallet = wallet

--- a/app/services/webhooks/wallets/created_service.rb
+++ b/app/services/webhooks/wallets/created_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Wallets
+    class CreatedService < Webhooks::BaseService
+      private
+
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::WalletSerializer.new(object, root_name: 'wallet', includes: %i[recurring_transaction_rules])
+      end
+
+      def webhook_type
+        'wallet.created'
+      end
+
+      def object_type
+        'wallet'
+      end
+    end
+  end
+end

--- a/app/services/webhooks/wallets/terminated_service.rb
+++ b/app/services/webhooks/wallets/terminated_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Wallets
+    class TerminatedService < Webhooks::BaseService
+      private
+
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::WalletSerializer.new(object, root_name: 'wallet', includes: %i[recurring_transaction_rules])
+      end
+
+      def webhook_type
+        'wallet.terminated'
+      end
+
+      def object_type
+        'wallet'
+      end
+    end
+  end
+end

--- a/app/services/webhooks/wallets/updated_service.rb
+++ b/app/services/webhooks/wallets/updated_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Wallets
+    class UpdatedService < Webhooks::BaseService
+      private
+
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::WalletSerializer.new(object, root_name: 'wallet', includes: %i[recurring_transaction_rules])
+      end
+
+      def webhook_type
+        'wallet.updated'
+      end
+
+      def object_type
+        'wallet'
+      end
+    end
+  end
+end

--- a/spec/factories/wallets.rb
+++ b/spec/factories/wallets.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
 
     trait :terminated do
       status { 'terminated' }
+      terminated_at { DateTime.now }
     end
   end
 end

--- a/spec/graphql/mutations/wallets/terminate_spec.rb
+++ b/spec/graphql/mutations/wallets/terminate_spec.rb
@@ -43,5 +43,7 @@ RSpec.describe Mutations::Wallets::Terminate, type: :graphql do
     expect(data['name']).to eq(wallet.name)
     expect(data['status']).to eq('terminated')
     expect(data['terminatedAt']).to be_present
+
+    expect(SendWebhookJob).to have_been_enqueued.with('wallet.terminated', Wallet)
   end
 end

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -97,5 +97,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
       "targetOngoingBalance" => "300.0",
       "invoiceRequiresSuccessfulPayment" => true
     )
+
+    expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
   end
 end

--- a/spec/jobs/wallet_transactions/create_job_spec.rb
+++ b/spec/jobs/wallet_transactions/create_job_spec.rb
@@ -6,29 +6,31 @@ RSpec.describe WalletTransactions::CreateJob, type: :job do
   subject(:create_job) { described_class }
 
   let(:organization) { create(:organization) }
+  let(:wallet) { create(:wallet) }
   let(:wallet_transaction_create_service) { instance_double(WalletTransactions::CreateService) }
+  let(:params) do
+    {
+      wallet_id: wallet.id,
+      paid_credits: '1.00',
+      granted_credits: '1.00',
+      source: 'manual'
+    }
+  end
 
   it 'calls the WalletTransactions::CreateService' do
     allow(WalletTransactions::CreateService).to receive(:call)
 
-    described_class.perform_now(
-      organization_id: organization.id,
-      params: {
-        wallet_id: '123456',
-        paid_credits: '1.00',
-        granted_credits: '1.00',
-        source: 'manual'
-      }
-    )
+    described_class.perform_now(organization_id: organization.id, params:)
 
-    expect(WalletTransactions::CreateService).to have_received(:call).with(
-      organization:,
-      params: {
-        wallet_id: '123456',
-        paid_credits: '1.00',
-        granted_credits: '1.00',
-        source: 'manual'
-      }
-    )
+    expect(WalletTransactions::CreateService).to have_received(:call).with(organization:, params:)
+    expect(SendWebhookJob).not_to have_been_enqueued
+  end
+
+  context 'with new_wallet set to true' do
+    it 'sends a `wallet.created` webhook' do
+      described_class.perform_now(organization_id: organization.id, params:, new_wallet: true)
+
+      expect(SendWebhookJob).to have_been_enqueued.with('wallet.created', Wallet).exactly(:once)
+    end
   end
 end

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -533,6 +533,10 @@ RSpec.describe Api::V1::WalletsController, type: :request do
       expect(json[:wallet][:name]).to eq(wallet.name)
     end
 
+    it 'sends a wallet.terminated webhook' do
+      expect { subject }.to have_enqueued_job(SendWebhookJob).with('wallet.terminated', Wallet)
+    end
+
     context 'when wallet does not exist' do
       let(:id) { SecureRandom.uuid }
 

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -300,6 +300,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
         expect(json[:wallet][:name]).to eq(update_params[:name])
         expect(json[:wallet][:expiration_at]).to eq(expiration_at)
         expect(json[:wallet][:invoice_requires_successful_payment]).to eq(true)
+
+        expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
       end
     end
 
@@ -309,6 +311,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
       it 'returns not_found error' do
         subject
         expect(response).to have_http_status(:not_found)
+        expect(SendWebhookJob).not_to have_been_enqueued.with('wallet.updated', Wallet)
       end
     end
 
@@ -353,6 +356,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           expect(recurring_rules.first[:method]).to eq('target')
           expect(recurring_rules.first[:trigger]).to eq('interval')
           expect(recurring_rules.first[:invoice_requires_successful_payment]).to eq(true)
+
+          expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
         end
       end
 
@@ -385,6 +390,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
             expect(response).to have_http_status(:success)
             expect(recurring_rules).to be_present
             expect(recurring_rules.first[:transaction_metadata]).to eq(update_transaction_metadata)
+
+            expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
           end
         end
       end
@@ -423,6 +430,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
               expect(recurring_rules).to be_present
               expect(recurring_rules.first[:lago_id]).to eq(recurring_transaction_rule.id)
               expect(recurring_rules.first[:invoice_requires_successful_payment]).to eq(false)
+
+              expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
             end
           end
         end
@@ -441,6 +450,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
               expect(json[:wallet][:invoice_requires_successful_payment]).to eq(true)
               expect(recurring_rules).to be_present
               expect(recurring_rules.first[:invoice_requires_successful_payment]).to eq(true)
+
+              expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
             end
           end
         end
@@ -479,6 +490,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
               expect(json[:wallet][:invoice_requires_successful_payment]).to eq(false)
               expect(recurring_rules).to be_present
               expect(recurring_rules.first[:invoice_requires_successful_payment]).to eq(true)
+
+              expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
             end
           end
         end

--- a/spec/serializers/v1/wallet_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_serializer_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe ::V1::WalletSerializer do
   subject(:serializer) { described_class.new(wallet, root_name: 'wallet') }
 
-  let(:wallet) { create(:wallet) }
+  let(:wallet) { create(:wallet, :terminated) }
+
+  before { Timecop.freeze(DateTime.new(2025, 1, 31, 12, 5, 55)) }
 
   it 'serializes the object' do
     result = JSON.parse(serializer.to_json)
@@ -19,11 +21,11 @@ RSpec.describe ::V1::WalletSerializer do
         'currency' => wallet.currency,
         'name' => wallet.name,
         'rate_amount' => wallet.rate_amount.to_s,
-        'created_at' => wallet.created_at.iso8601,
+        'created_at' => "2025-01-31T12:05:55Z",
         'expiration_at' => wallet.expiration_at&.iso8601,
         'last_balance_sync_at' => wallet.last_balance_sync_at&.iso8601,
         'last_consumed_credit_at' => wallet.last_consumed_credit_at&.iso8601,
-        'terminated_at' => wallet.terminated_at,
+        'terminated_at' => "2025-01-31T12:05:55.000Z", # The date isn't iso8601, but it would be a breaking change to change it now
         'credits_balance' => wallet.credits_balance.to_s,
         'balance_cents' => wallet.balance_cents,
         'credits_ongoing_balance' => wallet.credits_ongoing_balance.to_s,

--- a/spec/services/wallets/balance/decrease_service_spec.rb
+++ b/spec/services/wallets/balance/decrease_service_spec.rb
@@ -36,5 +36,10 @@ RSpec.describe Wallets::Balance::DecreaseService, type: :service do
         .to change(wallet.reload, :ongoing_balance_cents).from(800).to(550)
         .and change(wallet, :credits_ongoing_balance).from(8.0).to(5.5)
     end
+
+    it 'sends a `wallet.updated` webhook' do
+      expect { create_service.call }
+        .to have_enqueued_job(SendWebhookJob).with('wallet.updated', Wallet)
+    end
   end
 end

--- a/spec/services/wallets/balance/increase_service_spec.rb
+++ b/spec/services/wallets/balance/increase_service_spec.rb
@@ -30,5 +30,10 @@ RSpec.describe Wallets::Balance::IncreaseService, type: :service do
         .to change(wallet.reload, :ongoing_balance_cents).from(800).to(1450)
         .and change(wallet, :credits_ongoing_balance).from(8.0).to(14.5)
     end
+
+    it 'sends a `wallet.updated` webhook' do
+      expect { create_service.call }
+        .to have_enqueued_job(SendWebhookJob).with('wallet.updated', Wallet)
+    end
   end
 end

--- a/spec/services/wallets/terminate_service_spec.rb
+++ b/spec/services/wallets/terminate_service_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Wallets::TerminateService, type: :service do
       expect(result.wallet).to be_terminated
     end
 
+    it 'sends a `wallet.terminated` webhook' do
+      expect { terminate_service.call }.to have_enqueued_job(SendWebhookJob).with('wallet.terminated', Wallet)
+    end
+
     context 'when wallet is already terminated' do
       before { wallet.mark_as_terminated! }
 
@@ -35,6 +39,10 @@ RSpec.describe Wallets::TerminateService, type: :service do
         expect(result).to be_success
         expect(result.wallet).to be_terminated
         expect(result.wallet.terminated_at).to eq(terminated_at)
+      end
+
+      it 'does not send the `wallet.terminated` webhook' do
+        expect { terminate_service.call }.not_to have_enqueued_job(SendWebhookJob)
       end
     end
   end

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
         expect(result.wallet.name).to eq('new name')
         expect(result.wallet.expiration_at.iso8601).to eq(expiration_at)
         expect(result.wallet.invoice_requires_successful_payment).to eq(true)
+
+        expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
       end
     end
 
@@ -42,6 +44,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
       allow(Wallets::Balance::RefreshOngoingService).to receive(:call)
       update_service.call
       expect(Wallets::Balance::RefreshOngoingService).to have_received(:call).with(wallet:)
+      expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
     end
 
     context 'when wallet is not found' do
@@ -52,6 +55,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('wallet_not_found')
+
+        expect(SendWebhookJob).not_to have_been_enqueued.with('wallet.updated', Wallet)
       end
     end
 
@@ -64,6 +69,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
 
           expect(result).not_to be_success
           expect(result.error.messages[:expiration_at]).to eq(['invalid_date'])
+
+          expect(SendWebhookJob).not_to have_been_enqueued.with('wallet.updated', Wallet)
         end
       end
 
@@ -75,6 +82,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
 
           expect(result).not_to be_success
           expect(result.error.messages[:expiration_at]).to eq(['invalid_date'])
+
+          expect(SendWebhookJob).not_to have_been_enqueued.with('wallet.updated', Wallet)
         end
       end
 
@@ -86,6 +95,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
 
           expect(result).not_to be_success
           expect(result.error.messages[:expiration_at]).to eq(['invalid_date'])
+
+          expect(SendWebhookJob).not_to have_been_enqueued.with('wallet.updated', Wallet)
         end
       end
     end
@@ -132,6 +143,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
           expect(rule.threshold_credits).to eq(0.0)
           expect(rule.paid_credits).to eq(105.0)
           expect(rule.granted_credits).to eq(105.0)
+
+          expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
         end
       end
 
@@ -163,6 +176,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
             expect(rule.threshold_credits).to eq(0.0)
             expect(rule.paid_credits).to eq(105.0)
             expect(rule.granted_credits).to eq(105.0)
+
+            expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
           end
         end
       end
@@ -194,6 +209,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
             expect(rule.threshold_credits).to eq(205.0)
             expect(rule.paid_credits).to eq(105.0)
             expect(rule.granted_credits).to eq(105.0)
+
+            expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
           end
         end
       end
@@ -209,6 +226,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
           aggregate_failures do
             expect(result).to be_success
             expect(result.wallet.reload.recurring_transaction_rules.count).to eq(0)
+
+            expect(SendWebhookJob).to have_been_enqueued.with('wallet.updated', Wallet)
           end
         end
       end
@@ -235,8 +254,9 @@ RSpec.describe Wallets::UpdateService, type: :service do
           result = update_service.call
 
           expect(result).not_to be_success
-          expect(result.error.messages[:recurring_transaction_rules])
-            .to eq(['invalid_number_of_recurring_rules'])
+          expect(result.error.messages[:recurring_transaction_rules]).to eq(['invalid_number_of_recurring_rules'])
+
+          expect(SendWebhookJob).not_to have_been_enqueued.with('wallet.updated', Wallet)
         end
       end
 
@@ -257,6 +277,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
 
           expect(result).not_to be_success
           expect(result.error.messages[:recurring_transaction_rules]).to eq(['invalid_recurring_rule'])
+
+          expect(SendWebhookJob).not_to have_been_enqueued.with('wallet.updated', Wallet)
         end
       end
 
@@ -277,6 +299,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
 
           expect(result).not_to be_success
           expect(result.error.messages[:recurring_transaction_rules]).to eq(['invalid_recurring_rule'])
+
+          expect(SendWebhookJob).not_to have_been_enqueued.with('wallet.updated', Wallet)
         end
       end
 
@@ -288,6 +312,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
 
           expect(result).not_to be_success
           expect(result.error.messages[:recurring_transaction_rules]).to eq(['invalid_recurring_rule'])
+
+          expect(SendWebhookJob).not_to have_been_enqueued.with('wallet.updated', Wallet)
         end
       end
     end

--- a/spec/services/webhooks/wallets/created_service_spec.rb
+++ b/spec/services/webhooks/wallets/created_service_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Wallets::CreatedService do
+  subject(:webhook_service) { described_class.new(object: wallet) }
+
+  let(:wallet) { create(:wallet, balance_cents: 999_00) }
+
+  describe '.call' do
+    it_behaves_like 'creates webhook', 'wallet.created', 'wallet', {
+      "balance_cents" => 999_00,
+      "created_at" => String,
+      "terminated_at" => nil,
+      "recurring_transaction_rules" => []
+    }
+  end
+end

--- a/spec/services/webhooks/wallets/terminated_service_spec.rb
+++ b/spec/services/webhooks/wallets/terminated_service_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Wallets::TerminatedService do
+  subject(:webhook_service) { described_class.new(object: wallet) }
+
+  let(:wallet) { create(:wallet, :terminated) }
+
+  before { Timecop.freeze(DateTime.new(2025, 1, 31, 12, 5, 55)) }
+
+  describe '.call' do
+    it_behaves_like 'creates webhook', 'wallet.terminated', 'wallet', {
+      "balance_cents" => 0,
+      "created_at" => "2025-01-31T12:05:55Z",
+      "terminated_at" => "2025-01-31T12:05:55.000Z",
+      "recurring_transaction_rules" => []
+    }
+  end
+end

--- a/spec/support/queues_helper.rb
+++ b/spec/support/queues_helper.rb
@@ -8,4 +8,16 @@ module QueuesHelper
       :webhook
     end
   end
+
+  # This performs any enqueued-jobs, and continues doing so until the queue is empty.
+  # Lots of the jobs enqueue other jobs as part of their work, and this ensures that
+  # everything that's supposed to happen, happens.
+  #
+  # ⚠️ Notice that `have_been_enqueued` does not work with perform_all_enqueued_jobs because of the loop.
+  def perform_all_enqueued_jobs
+    until enqueued_jobs.empty?
+      perform_enqueued_jobs
+      Sidekiq::Worker.drain_all
+    end
+  end
 end

--- a/spec/support/queues_helper.rb
+++ b/spec/support/queues_helper.rb
@@ -13,7 +13,8 @@ module QueuesHelper
   # Lots of the jobs enqueue other jobs as part of their work, and this ensures that
   # everything that's supposed to happen, happens.
   #
-  # ⚠️ Notice that `have_been_enqueued` does not work with perform_all_enqueued_jobs because of the loop.
+  # ⚠️ Notice that `have_been_enqueued` might not work with perform_all_enqueued_jobs
+  # because it's only aware of the last run of the loop.
   def perform_all_enqueued_jobs
     until enqueued_jobs.empty?
       perform_enqueued_jobs

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -162,16 +162,6 @@ module ScenariosHelper
     put_with_token(organization, "/api/v1/fees/#{fee.id}", params)
   end
 
-  # This performs any enqueued-jobs, and continues doing so until the queue is empty.
-  # Lots of the jobs enqueue other jobs as part of their work, and this ensures that
-  # everything that's supposed to happen, happens.
-  def perform_all_enqueued_jobs
-    until enqueued_jobs.empty?
-      perform_enqueued_jobs
-      Sidekiq::Worker.drain_all
-    end
-  end
-
   def perform_billing
     Clock::SubscriptionsBillerJob.perform_later
     Clock::FreeTrialSubscriptionsBillerJob.perform_later


### PR DESCRIPTION
## Context

Wallet operations trigger 3 webhooks today: 
* `wallet.depleted_ongoing_balance`
* `wallet_transaction.updated`
* `wallet_transaction.payment_failure`.

We want to add the following: 
* `wallet.created`
* `wallet.updated`
* `wallet.terminated`

https://docs.getlago.com/api-reference/webhooks/messages#wallets-and-prepaid-credits

## Description

### `wallet.created`

Notice that the webhook job is dispatched by `WalletTransactions::CreateJob` so the wallet sent in the webhook has the initial balance instead of 0. Unlike the API which returns 0.

The `WalletTransactions::CreateJob` is always dispatch even if the `WalletTransactions::CreateService` might do nothing.

### `wallet.terminated`

The webhook is set only of the wallet just got terminated. If the service is called on a terminated service, no webhook is sent.

### `wallet.updated`

This webhook is dispatched when 
* an attribute of the wallet is updated (name, expiration date or invoice_requires_successful_payment config)
* a recurring transaction rule is updated because recurring **rules are part of a wallet**, unlike wallet_transactions which are "related to a wallet" (and have their own webhooks)
* the balance is increased or decreased

**No webhook is sent when the ongoing balance is updated** because it would trigger too many events. Tracking ongoing balance is part of the "real time usage" effort.
