### PR TITLE
Allow to override existing customer attributes

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -203,6 +203,16 @@ module Api
       end
 
       def preview
+        if preview_params[:coupons] && !preview_params[:coupons].is_a?(Array)
+          return render(
+            json: {
+              status: 400,
+              error: "coupons_must_be_an_array"
+            },
+            status: :bad_request
+          )
+        end
+
         result = Invoices::PreviewContextService.call(
           organization: current_organization,
           params: preview_params.to_h.deep_symbolize_keys
@@ -281,14 +291,12 @@ module Api
             :tax_identification_number,
             :currency,
             :timezone,
-            shipping_address: [
-              :address_line1,
-              :address_line2,
-              :city,
-              :zipcode,
-              :state,
-              :country
-            ],
+            :address_line1,
+            :address_line2,
+            :city,
+            :zipcode,
+            :state,
+            :country,
             integration_customers: [
               :integration_type,
               :integration_code

--- a/app/services/invoices/preview_context_service.rb
+++ b/app/services/invoices/preview_context_service.rb
@@ -26,29 +26,32 @@ module Invoices
     def find_or_build_customer
       customer_params = params[:customer] || {}
 
-      if customer_params.key?(:external_id)
+      customer = if customer_params.key?(:external_id)
         organization.customers.find_by!(external_id: customer_params[:external_id])
       else
-        Customer.new(
-          name: customer_params[:name],
-          organization: organization,
-          tax_identification_number: customer_params[:tax_identification_number],
-          currency: customer_params[:currency],
-          timezone: customer_params[:timezone],
-          shipping_address_line1: customer_params.dig(:shipping_address, :address_line1),
-          shipping_address_line2: customer_params.dig(:shipping_address, :address_line2),
-          shipping_city: customer_params.dig(:shipping_address, :city),
-          shipping_zipcode: customer_params.dig(:shipping_address, :zipcode),
-          shipping_state: customer_params.dig(:shipping_address, :state),
-          shipping_country: customer_params.dig(:shipping_address, :country),
-          created_at: Time.current,
-          updated_at: Time.current
-        ) do |customer|
-          customer.integration_customers = Array(customer_params[:integration_customers]).map do |integration_params|
-            build_customer_integration(customer, integration_params)
-          end
-        end
+        organization.customers.new(created_at: Time.current, updated_at: Time.current)
       end
+
+      customer.assign_attributes(
+        customer_params.slice(
+          :name,
+          :tax_identification_number,
+          :currency,
+          :timezone,
+          :address_line1,
+          :address_line2,
+          :city,
+          :zipcode,
+          :state,
+          :country
+        )
+      )
+
+      customer.integration_customers = Array(customer_params[:integration_customers]).map do |integration_params|
+        build_customer_integration(customer, integration_params)
+      end
+
+      customer
     end
 
     def build_customer_integration(customer, attrs)

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -1053,5 +1053,21 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'when params have invalid structure' do
+      let(:preview_params) do
+        {
+          coupons: {
+            code: 'unknown'
+          }
+        }
+      end
+
+      it 'returns a bad request error' do
+        subject
+        expect(response).to have_http_status(:bad_request)
+        expect(json[:error]).to eq "coupons_must_be_an_array"
+      end
+    end
   end
 end

--- a/spec/services/invoices/preview_context_service_spec.rb
+++ b/spec/services/invoices/preview_context_service_spec.rb
@@ -39,7 +39,15 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
     context "when customer external id is provided" do
       let(:params) do
         {
-          customer: {external_id:}
+          customer: {
+            external_id:,
+            tax_identification_number: "123",
+            currency: "USD",
+            address_line1: "Rue de Tax",
+            city: "Paris",
+            zipcode: "75011",
+            country: "IT"
+          }
         }
       end
 
@@ -47,8 +55,16 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
         let(:customer) { create(:customer, organization:) }
         let(:external_id) { customer.external_id }
 
-        it "returns customer" do
-          expect(subject).to eq customer
+        it "returns customer with overrides from params" do
+          expect(subject)
+            .to be_a(Customer)
+            .and be_persisted
+            .and have_attributes(
+                   id: customer.id,
+                   name: customer.name,
+                   currency: params.dig(:customer, :currency),
+                   address_line1: params.dig(:customer, :address_line1)
+                 )
         end
       end
 
@@ -65,21 +81,19 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
       end
     end
 
-    context "when customer external id is omitted" do
+    context "when customer external id is missing" do
       let(:params) do
         {
           customer: {
             name: "Mislav M",
             tax_identification_number: "123",
             currency: "EUR",
-            shipping_address: {
-              address_line1: "Rue de Tax",
-              address_line2: nil,
-              state: nil,
-              city: "Paris",
-              zipcode: "75011",
-              country: "IT"
-            },
+            address_line1: "Rue de Tax",
+            address_line2: nil,
+            state: nil,
+            city: "Paris",
+            zipcode: "75011",
+            country: "IT",
             integration_customers:
           }
         }


### PR DESCRIPTION
## Context

Adjustments to invoice preview input params.

## Description

Validate that "coupons" params are array.
Allow to override customer attributes.
Get rid of `shipping_address` wrapper.
