### PR TITLE
bug(ProgressiveBilling): take failed invoices into account 

### DIFF
--- a/app/services/subscriptions/progressive_billed_amount.rb
+++ b/app/services/subscriptions/progressive_billed_amount.rb
@@ -19,7 +19,7 @@ module Subscriptions
         .where("charges_from_datetime <= ?", timestamp)
         .joins(:invoice)
         .merge(Invoice.progressive_billing)
-        .merge(Invoice.finalized)
+        .merge(Invoice.finalized.or(Invoice.failed))
         .where(subscription: subscription)
         .order("invoices.issuing_date" => :desc, "invoices.created_at" => :desc).first
 


### PR DESCRIPTION
## Description

An invoice can be failed because the taxes fail to calculate. if we don't take these progressive billed invoices into account that would mean that we'd continuously generate new progressive billing invoices.

The goal of this PR is to take those into account as well 