### PR TITLE
chore(versions): Bump redis related gems and configure reconnection in redlock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,8 +99,8 @@ GEM
     activejob-traceable (0.4.2)
       activejob
       activesupport
-    activejob-uniqueness (0.3.2)
-      activejob (>= 4.2, < 7.3)
+    activejob-uniqueness (0.4.0)
+      activejob (>= 4.2, < 8.1)
       redlock (>= 2.0, < 3)
     activemodel (7.1.5.1)
       activesupport (= 7.1.5.1)
@@ -185,7 +185,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.3.5)
-    connection_pool (2.4.1)
+    connection_pool (2.5.0)
     countries (5.7.2)
       unaccent (~> 0.3)
     crack (0.4.6)
@@ -718,7 +718,7 @@ GEM
       psych (>= 4.0.0)
     redis (5.3.0)
       redis-client (>= 0.22.0)
-    redis-client (0.22.2)
+    redis-client (0.23.2)
       connection_pool
     redis-prescription (2.6.0)
     redlock (2.0.6)

--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -16,6 +16,6 @@ ActiveJob::Uniqueness.configure do |config|
       host = [host, uri.query].join('?')
     end
 
-    config.redlock_servers = ["#{uri.scheme}://:#{ENV["REDIS_PASSWORD"]}@#{host}:#{uri.port}"]
+    config.redlock_servers = [RedisClient.new(url: "#{uri.scheme}://:#{ENV["REDIS_PASSWORD"]}@#{host}:#{uri.port}", reconnect_attempts: 2)]
   end
 end


### PR DESCRIPTION
## Description

We're sometimes getting errors related to Redis connections. based on https://github.com/redis-rb/redis-client/issues/116#issuecomment-1534406659 we shoud configure reconnection attempts to prevent these.