### PR TITLE
fix: prevent calling eu tax service when not needed

### DIFF
--- a/app/services/customer_portal/customer_update_service.rb
+++ b/app/services/customer_portal/customer_update_service.rb
@@ -13,6 +13,8 @@ module CustomerPortal
       return result.not_found_failure!(resource: "customer") unless customer
 
       ActiveRecord::Base.transaction do
+        original_tax_values = customer.slice(:tax_identification_number, :zipcode, :country).symbolize_keys
+
         customer.customer_type = args[:customer_type] if args.key?(:customer_type)
         customer.name = args[:name] if args.key?(:name)
         customer.firstname = args[:firstname] if args.key?(:firstname)
@@ -46,7 +48,7 @@ module CustomerPortal
         eu_tax_code_result = Customers::EuAutoTaxesService.call(
           customer:,
           new_record: false,
-          tax_attributes_changed: args.key?(:tax_identification_number) || args.key?(:zipcode) || args.key?(:country)
+          tax_attributes_changed: original_tax_values.any? { |key, value| args.key?(key) && args[key] != value }
         )
         tax_codes << eu_tax_code_result.tax_code if eu_tax_code_result.success?
 

--- a/app/services/customer_portal/customer_update_service.rb
+++ b/app/services/customer_portal/customer_update_service.rb
@@ -43,12 +43,12 @@ module CustomerPortal
 
         tax_codes = []
         # This service does not return a 'result' object but a string
-        eu_tax_code = Customers::EuAutoTaxesService.call(
+        eu_tax_code_result = Customers::EuAutoTaxesService.call(
           customer:,
           new_record: false,
-          changed_attributes: args.key?(:tax_identification_number) || args.key?(:zipcode) || args.key?(:country)
+          tax_attributes_changed: args.key?(:tax_identification_number) || args.key?(:zipcode) || args.key?(:country)
         )
-        tax_codes << eu_tax_code if eu_tax_code
+        tax_codes << eu_tax_code_result.tax_code if eu_tax_code_result.success?
 
         if tax_codes.present?
           taxes_result = Customers::ApplyTaxesService.call(customer:, tax_codes:)

--- a/app/services/customer_portal/customer_update_service.rb
+++ b/app/services/customer_portal/customer_update_service.rb
@@ -42,10 +42,13 @@ module CustomerPortal
         customer.reload
 
         tax_codes = []
-        if customer.organization.eu_tax_management
-          # This service does not return a 'result' object but a string
-          tax_codes << Customers::EuAutoTaxesService.call(customer:)
-        end
+        # This service does not return a 'result' object but a string
+        eu_tax_code = Customers::EuAutoTaxesService.call(
+          customer:,
+          new_record: false,
+          changed_attributes: args.key?(:tax_identification_number) || args.key?(:zipcode) || args.key?(:country)
+        )
+        tax_codes << eu_tax_code if eu_tax_code
 
         if tax_codes.present?
           taxes_result = Customers::ApplyTaxesService.call(customer:, tax_codes:)

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -76,15 +76,15 @@ module Customers
 
         customer.save!
 
-        eu_tax_code = Customers::EuAutoTaxesService.call(
+        eu_tax_code_result = Customers::EuAutoTaxesService.call(
           customer:,
           new_record: new_customer,
-          changed_attributes: params.key?(:tax_identification_number) || params.key?(:zipcode) || params.key?(:country)
+          tax_attributes_changed: params.key?(:tax_identification_number) || params.key?(:zipcode) || params.key?(:country)
         )
 
-        if eu_tax_code
+        if eu_tax_code_result.success?
           params[:tax_codes] ||= []
-          params[:tax_codes] = (params[:tax_codes] + [eu_tax_code]).uniq
+          params[:tax_codes] = (params[:tax_codes] + [eu_tax_code_result.tax_code]).uniq
         end
 
         if params.key?(:tax_codes)
@@ -192,11 +192,11 @@ module Customers
       ActiveRecord::Base.transaction do
         customer.save!
 
-        eu_tax_code = Customers::EuAutoTaxesService.call(customer:, new_record: true, changed_attributes: true)
+        eu_tax_code_result = Customers::EuAutoTaxesService.call(customer:, new_record: true, tax_attributes_changed: true)
 
-        if eu_tax_code
+        if eu_tax_code_result.success?
           args[:tax_codes] ||= []
-          args[:tax_codes] = (args[:tax_codes] + [eu_tax_code]).uniq
+          args[:tax_codes] = (args[:tax_codes] + [eu_tax_code_result.tax_code]).uniq
         end
 
         if args[:tax_codes].present?

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -76,9 +76,13 @@ module Customers
 
         customer.save!
 
-        if customer.organization.eu_tax_management
-          eu_tax_code = Customers::EuAutoTaxesService.call(customer:)
+        eu_tax_code = Customers::EuAutoTaxesService.call(
+          customer:,
+          new_record: new_customer,
+          changed_attributes: params.key?(:tax_identification_number) || params.key?(:zipcode) || params.key?(:country)
+        )
 
+        if eu_tax_code
           params[:tax_codes] ||= []
           params[:tax_codes] = (params[:tax_codes] + [eu_tax_code]).uniq
         end
@@ -188,9 +192,9 @@ module Customers
       ActiveRecord::Base.transaction do
         customer.save!
 
-        if customer.organization.eu_tax_management
-          eu_tax_code = Customers::EuAutoTaxesService.call(customer:)
+        eu_tax_code = Customers::EuAutoTaxesService.call(customer:, new_record: true, changed_attributes: true)
 
+        if eu_tax_code
           args[:tax_codes] ||= []
           args[:tax_codes] = (args[:tax_codes] + [eu_tax_code]).uniq
         end

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -31,6 +31,8 @@ module Customers
       end
 
       ActiveRecord::Base.transaction do
+        original_tax_values = customer.slice(:tax_identification_number, :zipcode, :country).symbolize_keys
+
         customer.name = params[:name] if params.key?(:name)
         customer.country = params[:country]&.upcase if params.key?(:country)
         customer.address_line1 = params[:address_line1] if params.key?(:address_line1)
@@ -79,7 +81,7 @@ module Customers
         eu_tax_code_result = Customers::EuAutoTaxesService.call(
           customer:,
           new_record: new_customer,
-          tax_attributes_changed: params.key?(:tax_identification_number) || params.key?(:zipcode) || params.key?(:country)
+          tax_attributes_changed: original_tax_values.any? { |key, value| params.key?(key) && params[key] != value }
         )
 
         if eu_tax_code_result.success?

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -138,15 +138,15 @@ module Customers
         customer.save!
         customer.reload
 
-        eu_tax_code = Customers::EuAutoTaxesService.call(
+        eu_tax_code_result = Customers::EuAutoTaxesService.call(
           customer:,
           new_record: false,
-          changed_attributes: args.key?(:tax_identification_number) || args.key?(:zipcode) || args.key?(:country)
+          tax_attributes_changed: args.key?(:tax_identification_number) || args.key?(:zipcode) || args.key?(:country)
         )
 
-        if eu_tax_code
+        if eu_tax_code_result.success?
           args[:tax_codes] ||= []
-          args[:tax_codes] = (args[:tax_codes] + [eu_tax_code]).uniq
+          args[:tax_codes] = (args[:tax_codes] + [eu_tax_code_result.tax_code]).uniq
         end
 
         if args[:tax_codes]

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -24,6 +24,7 @@ module Customers
 
       old_payment_provider = customer.payment_provider
       old_provider_customer = customer.provider_customer
+      original_tax_values = customer.slice(:tax_identification_number, :zipcode, :country).symbolize_keys
       ActiveRecord::Base.transaction do
         billing_configuration = args[:billing_configuration]&.to_h || {}
         shipping_address = args[:shipping_address]&.to_h || {}
@@ -141,7 +142,7 @@ module Customers
         eu_tax_code_result = Customers::EuAutoTaxesService.call(
           customer:,
           new_record: false,
-          tax_attributes_changed: args.key?(:tax_identification_number) || args.key?(:zipcode) || args.key?(:country)
+          tax_attributes_changed: original_tax_values.any? { |key, value| args.key?(key) && args[key] != value }
         )
 
         if eu_tax_code_result.success?

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -138,9 +138,13 @@ module Customers
         customer.save!
         customer.reload
 
-        if organization.eu_tax_management
-          eu_tax_code = Customers::EuAutoTaxesService.call(customer:)
+        eu_tax_code = Customers::EuAutoTaxesService.call(
+          customer:,
+          new_record: false,
+          changed_attributes: args.key?(:tax_identification_number) || args.key?(:zipcode) || args.key?(:country)
+        )
 
+        if eu_tax_code
           args[:tax_codes] ||= []
           args[:tax_codes] = (args[:tax_codes] + [eu_tax_code]).uniq
         end

--- a/spec/services/customer_portal/customer_update_service_spec.rb
+++ b/spec/services/customer_portal/customer_update_service_spec.rb
@@ -87,13 +87,15 @@ RSpec.describe CustomerPortal::CustomerUpdateService, type: :service do
     let(:eu_auto_tax_service) { instance_double(Customers::EuAutoTaxesService) }
     let(:organization) { customer.organization }
     let(:tax_code) { "lago_eu_fr_standard" }
+    let(:eu_tax_result) { Customers::EuAutoTaxesService::Result.new }
 
     before do
       create(:tax, organization:, code: "lago_eu_fr_standard", rate: 20.0)
       organization.update!(eu_tax_management: true)
 
+      eu_tax_result.tax_code = tax_code
       allow(Customers::EuAutoTaxesService).to receive(:new).and_return(eu_auto_tax_service)
-      allow(eu_auto_tax_service).to receive(:call).and_return(tax_code)
+      allow(eu_auto_tax_service).to receive(:call).and_return(eu_tax_result)
     end
 
     it "assigns the right tax to the customer", :aggregate_failures do
@@ -104,7 +106,7 @@ RSpec.describe CustomerPortal::CustomerUpdateService, type: :service do
     end
 
     context 'when eu tax code is not applicable' do
-      let(:tax_code) { nil }
+      let(:eu_tax_result) { Customers::EuAutoTaxesService::Result.new.not_allowed_failure!(code: '') }
 
       it 'does not apply tax' do
         expect(result).to be_success

--- a/spec/services/customer_portal/customer_update_service_spec.rb
+++ b/spec/services/customer_portal/customer_update_service_spec.rb
@@ -103,6 +103,16 @@ RSpec.describe CustomerPortal::CustomerUpdateService, type: :service do
       expect(tax.code).to eq(tax_code)
     end
 
+    context 'when eu tax code is not applicable' do
+      let(:tax_code) { nil }
+
+      it 'does not apply tax' do
+        expect(result).to be_success
+
+        expect(result.customer.taxes).to eq([])
+      end
+    end
+
     context "when applying taxes fails" do
       let(:apply_taxes_result) do
         BaseService::Result.new.not_found_failure!(resource: "tax")

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -1034,13 +1034,15 @@ RSpec.describe Customers::CreateService, type: :service do
     context 'when organization has eu tax management' do
       let(:eu_auto_tax_service) { instance_double(Customers::EuAutoTaxesService) }
       let(:tax_code) { 'lago_eu_fr_standard' }
+      let(:eu_tax_result) { Customers::EuAutoTaxesService::Result.new }
 
       before do
         create(:tax, organization:, code: 'lago_eu_fr_standard', rate: 20.0)
         organization.update(eu_tax_management: true)
 
+        eu_tax_result.tax_code = tax_code
         allow(Customers::EuAutoTaxesService).to receive(:new).and_return(eu_auto_tax_service)
-        allow(eu_auto_tax_service).to receive(:call).and_return(tax_code)
+        allow(eu_auto_tax_service).to receive(:call).and_return(eu_tax_result)
       end
 
       it 'assigns the right tax to the customer' do
@@ -1058,7 +1060,7 @@ RSpec.describe Customers::CreateService, type: :service do
       end
 
       context 'when eu tax code is not applicable' do
-        let(:tax_code) { nil }
+        let(:eu_tax_result) { Customers::EuAutoTaxesService::Result.new.not_allowed_failure!(code: '') }
 
         it 'does not apply tax' do
           result = customers_service.create_from_api(
@@ -1417,13 +1419,15 @@ RSpec.describe Customers::CreateService, type: :service do
     context 'when organization has eu tax management' do
       let(:eu_auto_tax_service) { instance_double(Customers::EuAutoTaxesService) }
       let(:tax_code) { 'lago_eu_fr_standard' }
+      let(:eu_tax_result) { Customers::EuAutoTaxesService::Result.new }
 
       before do
         create(:tax, organization:, code: 'lago_eu_fr_standard', rate: 20.0)
         organization.update(eu_tax_management: true)
 
+        eu_tax_result.tax_code = tax_code
         allow(Customers::EuAutoTaxesService).to receive(:new).and_return(eu_auto_tax_service)
-        allow(eu_auto_tax_service).to receive(:call).and_return(tax_code)
+        allow(eu_auto_tax_service).to receive(:call).and_return(eu_tax_result)
       end
 
       it 'assigns the right tax to the customer' do
@@ -1438,7 +1442,7 @@ RSpec.describe Customers::CreateService, type: :service do
       end
 
       context 'when eu tax code is not applicable' do
-        let(:tax_code) { nil }
+        let(:eu_tax_result) { Customers::EuAutoTaxesService::Result.new.not_allowed_failure!(code: '') }
 
         it 'does not apply tax' do
           result = customers_service.create(**create_args)

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -1033,13 +1033,14 @@ RSpec.describe Customers::CreateService, type: :service do
 
     context 'when organization has eu tax management' do
       let(:eu_auto_tax_service) { instance_double(Customers::EuAutoTaxesService) }
+      let(:tax_code) { 'lago_eu_fr_standard' }
 
       before do
         create(:tax, organization:, code: 'lago_eu_fr_standard', rate: 20.0)
         organization.update(eu_tax_management: true)
 
         allow(Customers::EuAutoTaxesService).to receive(:new).and_return(eu_auto_tax_service)
-        allow(eu_auto_tax_service).to receive(:call).and_return('lago_eu_fr_standard')
+        allow(eu_auto_tax_service).to receive(:call).and_return(tax_code)
       end
 
       it 'assigns the right tax to the customer' do
@@ -1052,7 +1053,22 @@ RSpec.describe Customers::CreateService, type: :service do
           expect(result).to be_success
 
           tax = result.customer.taxes.first
-          expect(tax.code).to eq('lago_eu_fr_standard')
+          expect(tax.code).to eq(tax_code)
+        end
+      end
+
+      context 'when eu tax code is not applicable' do
+        let(:tax_code) { nil }
+
+        it 'does not apply tax' do
+          result = customers_service.create_from_api(
+            organization:,
+            params: create_args
+          )
+
+          expect(result).to be_success
+
+          expect(result.customer.taxes).to eq([])
         end
       end
     end
@@ -1400,13 +1416,14 @@ RSpec.describe Customers::CreateService, type: :service do
 
     context 'when organization has eu tax management' do
       let(:eu_auto_tax_service) { instance_double(Customers::EuAutoTaxesService) }
+      let(:tax_code) { 'lago_eu_fr_standard' }
 
       before do
         create(:tax, organization:, code: 'lago_eu_fr_standard', rate: 20.0)
         organization.update(eu_tax_management: true)
 
         allow(Customers::EuAutoTaxesService).to receive(:new).and_return(eu_auto_tax_service)
-        allow(eu_auto_tax_service).to receive(:call).and_return('lago_eu_fr_standard')
+        allow(eu_auto_tax_service).to receive(:call).and_return(tax_code)
       end
 
       it 'assigns the right tax to the customer' do
@@ -1417,6 +1434,18 @@ RSpec.describe Customers::CreateService, type: :service do
 
           tax = result.customer.taxes.first
           expect(tax.code).to eq('lago_eu_fr_standard')
+        end
+      end
+
+      context 'when eu tax code is not applicable' do
+        let(:tax_code) { nil }
+
+        it 'does not apply tax' do
+          result = customers_service.create(**create_args)
+
+          expect(result).to be_success
+
+          expect(result.customer.taxes).to eq([])
         end
       end
     end

--- a/spec/services/customers/eu_auto_taxes_service_spec.rb
+++ b/spec/services/customers/eu_auto_taxes_service_spec.rb
@@ -4,18 +4,66 @@ require 'rails_helper'
 require 'valvat'
 
 RSpec.describe Customers::EuAutoTaxesService, type: :service do
-  subject(:eu_tax_service) { described_class.new(customer:) }
+  subject(:eu_tax_service) { described_class.new(customer:, new_record:, changed_attributes:) }
 
-  let(:organization) { create(:organization, country: 'FR') }
+  let(:organization) { create(:organization, country: 'FR', eu_tax_management: true) }
   let(:customer) { create(:customer, organization:, zipcode: nil) }
+  let(:new_record) { true }
+  let(:changed_attributes) { true }
 
   describe '.call' do
     context 'with B2B organization' do
       let(:vies_service) { instance_double(Valvat) }
+      let(:vies_response) { {} }
 
       before do
         allow(Valvat).to receive(:new).and_return(vies_service)
         allow(vies_service).to receive(:exists?).and_return(vies_response)
+      end
+
+      context 'when eu_tax_management is false' do
+        let(:organization) { create(:organization, country: 'FR', eu_tax_management: false) }
+
+        it 'returns nil' do
+          tax_code = eu_tax_service.call
+
+          expect(tax_code).to eq(nil)
+        end
+      end
+
+      context 'when customer is updated and there are eu taxes' do
+        let(:new_record) { false }
+        let(:changed_attributes) { false }
+        let(:applied_tax) { create(:customer_applied_tax, tax:, customer:) }
+        let(:tax) { create(:tax, organization:, code: 'lago_eu_tax_exempt') }
+
+        before { applied_tax }
+
+        it 'returns nil' do
+          tax_code = eu_tax_service.call
+
+          expect(tax_code).to eq(nil)
+        end
+      end
+
+      context 'when customer is updated and there are no eu taxes' do
+        let(:new_record) { false }
+        let(:changed_attributes) { false }
+        let(:applied_tax) { create(:customer_applied_tax, tax:, customer:) }
+        let(:tax) { create(:tax, organization:, code: 'unknown_eu_tax_exempt') }
+        let(:vies_response) do
+          {
+            country_code: 'FR'
+          }
+        end
+
+        before { applied_tax }
+
+        it 'returns the organization country tax code' do
+          tax_code = eu_tax_service.call
+
+          expect(tax_code).to eq('lago_eu_fr_standard')
+        end
       end
 
       context 'with same country as the organization' do

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -479,13 +479,14 @@ RSpec.describe Customers::UpdateService, type: :service do
 
     context 'when organization has eu tax management' do
       let(:eu_auto_tax_service) { instance_double(Customers::EuAutoTaxesService) }
+      let(:tax_code) { 'lago_eu_fr_standard' }
 
       before do
         create(:tax, organization:, code: 'lago_eu_fr_standard', rate: 20.0)
         organization.update(eu_tax_management: true)
 
         allow(Customers::EuAutoTaxesService).to receive(:new).and_return(eu_auto_tax_service)
-        allow(eu_auto_tax_service).to receive(:call).and_return('lago_eu_fr_standard')
+        allow(eu_auto_tax_service).to receive(:call).and_return(tax_code)
       end
 
       it 'assigns the right tax to the customer' do
@@ -495,7 +496,19 @@ RSpec.describe Customers::UpdateService, type: :service do
           expect(result).to be_success
 
           tax = result.customer.taxes.first
-          expect(tax.code).to eq('lago_eu_fr_standard')
+          expect(tax.code).to eq(tax_code)
+        end
+      end
+
+      context 'when eu tax code is not applicable' do
+        let(:tax_code) { nil }
+
+        it 'does not apply tax' do
+          result = customers_service.call
+
+          expect(result).to be_success
+
+          expect(result.customer.taxes).to eq([])
         end
       end
     end


### PR DESCRIPTION
This PR tries to reduce calling EU tax service in certain conditions.

The goal is NOT to call the service if customer is updated, there are existing EU taxes and tax relevant customer attributes haven't changed