### PR TITLE
feat: add Singapore to tax invoices label countries

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -10,6 +10,7 @@ class Invoice < ApplicationRecord
 
   CREDIT_NOTES_MIN_VERSION = 2
   COUPON_BEFORE_VAT_VERSION = 3
+  TAX_INVOICE_LABEL_COUNTRIES = %w[AU AE NZ ID SG].freeze
 
   before_save :ensure_organization_sequential_id, if: -> { organization.per_organization? && !self_billed }
   before_save :ensure_number
@@ -368,7 +369,7 @@ class Invoice < ApplicationRecord
     return I18n.t("invoice.self_billed.document_name") if self_billed?
     return I18n.t('invoice.prepaid_credit_invoice') if credit?
 
-    if %w[AU AE ID NZ].include?(organization.country)
+    if TAX_INVOICE_LABEL_COUNTRIES.include?(organization.country)
       return I18n.t('invoice.paid_tax_invoice') if advance_charges?
       return I18n.t('invoice.document_tax_name')
     end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -842,6 +842,15 @@ RSpec.describe Invoice, type: :model do
       end
     end
 
+    context 'when the organization country is in TAX_INVOICE_LABEL_COUNTRIES' do
+      let(:country) { Invoice::TAX_INVOICE_LABEL_COUNTRIES.sample }
+      let(:organization) { create(:organization, name: 'LAGO', country:) }
+
+      it 'returns the correct tax invoice name' do
+        expect(invoice.document_invoice_name).to eq(I18n.t('invoice.document_tax_name'))
+      end
+    end
+
     context 'when it is credit invoice' do
       let(:invoice) { create(:invoice, customer:, organization:, invoice_type: :credit) }
 


### PR DESCRIPTION
## Context

In certain countries, tax regulations require invoices to be labeled as **"Tax Invoice"** instead of just **"Invoice"** when taxes are applied.

## Description

This PR introduces a constant `TAX_INVOICE_LABEL_COUNTRIES` to centralize the list of countries that require this label. 
- Added `TAX_INVOICE_LABEL_COUNTRIES` (`%w[AU AE NZ ID SG]`) as a constant.
- Included **Singapore (SG)** as a country requiring the "Tax Invoice" label.