### PR TITLE
feat(api_key): cache api key and organization

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -21,20 +21,19 @@ module Api
     def authenticate
       return unauthorized_error unless auth_token
 
-      @current_api_key = ApiKey.find_by(value: auth_token)
-
+      @current_api_key, organization = ApiKeys::CacheService.call(auth_token, with_cache: cached_api_key?)
       return unauthorized_error unless current_api_key
 
-      @current_organization = current_api_key.organization
+      @current_organization = organization
       true
     end
 
     def auth_token
-      request.headers['Authorization']&.split(' ')&.second
+      request.headers["Authorization"]&.split(" ")&.second
     end
 
     def set_context_source
-      CurrentContext.source = 'api'
+      CurrentContext.source = "api"
     end
 
     def track_api_key_usage
@@ -61,7 +60,11 @@ module Api
     end
 
     def mode
-      (request.method == 'GET') ? 'read' : 'write'
+      (request.method == "GET") ? "read" : "write"
+    end
+
+    def cached_api_key?
+      false
     end
   end
 end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class EventsController < Api::BaseController
+      ACTIONS_WITH_CACHED_API_KEY = %i[create batch estimate_instant_fees batch_estimate_instant_fees].freeze
+
       def create
         result = ::Events::CreateService.call(
           organization: current_organization,
@@ -15,7 +17,7 @@ module Api
           render(
             json: ::V1::EventSerializer.new(
               result.event,
-              root_name: 'event'
+              root_name: "event"
             )
           )
         else
@@ -36,7 +38,7 @@ module Api
             json: ::CollectionSerializer.new(
               result.events,
               ::V1::EventSerializer,
-              collection_name: 'events'
+              collection_name: "events"
             )
           )
         else
@@ -51,12 +53,12 @@ module Api
           transaction_id: params[:id]
         )
 
-        return not_found_error(resource: 'event') unless event
+        return not_found_error(resource: "event") unless event
 
         render(
           json: ::V1::EventSerializer.new(
             event,
-            root_name: 'event'
+            root_name: "event"
           )
         )
       end
@@ -76,7 +78,7 @@ module Api
             json: ::CollectionSerializer.new(
               result.events,
               ::V1::EventSerializer,
-              collection_name: 'events',
+              collection_name: "events",
               meta: pagination_metadata(result.events)
             )
           )
@@ -126,7 +128,7 @@ module Api
             json: ::CollectionSerializer.new(
               result.fees,
               ::V1::FeeSerializer,
-              collection_name: 'fees',
+              collection_name: "fees",
               includes: %i[applied_taxes]
             )
           )
@@ -185,7 +187,11 @@ module Api
       end
 
       def resource_name
-        'event'
+        "event"
+      end
+
+      def cached_api_key?
+        ACTIONS_WITH_CACHED_API_KEY.include?(action_name&.to_sym)
       end
     end
   end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -25,7 +25,7 @@ class ApiKey < ApplicationRecord
 
   default_scope { active }
 
-  scope :active, -> { where('expires_at IS NULL OR expires_at > ?', Time.current) }
+  scope :active, -> { where("expires_at IS NULL OR expires_at > ?", Time.current) }
   scope :non_expiring, -> { where(expires_at: nil) }
 
   def permit?(resource, mode)
@@ -36,6 +36,10 @@ class ApiKey < ApplicationRecord
 
   def self.default_permissions
     RESOURCES.index_with { MODES.dup }
+  end
+
+  def expired?(time = Time.current)
+    expires_at.present? && expires_at < time
   end
 
   private

--- a/app/services/api_keys/cache_service.rb
+++ b/app/services/api_keys/cache_service.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module ApiKeys
+  class CacheService < ::CacheService
+    CACHE_KEY_VERSION = "1"
+    CACHE_DURATION = 1.hour
+
+    def initialize(auth_token, with_cache: false)
+      @auth_token = auth_token
+      @with_cache = with_cache
+      super(auth_token, expires_in: CACHE_DURATION)
+    end
+
+    def self.expire_all_cache(organization)
+      organization.api_keys.each { expire_cache(_1.value) }
+    end
+
+    def call
+      # When no cache, just return the values from the database
+      return fetch_from_database unless with_cache
+
+      # Fetch API key and organization from the cache
+      cache = Rails.cache.read(cache_key)
+      if cache
+        cache_json = JSON.parse(cache)
+        api_key = ApiKey.instantiate(cache_json["api_key"].slice(*ApiKey.column_names))
+
+        # Avoid returning an expired API key
+        unless api_key.expired?
+          organization = Organization.instantiate(cache_json["organization"].slice(*Organization.column_names))
+          return api_key, organization
+        end
+      end
+
+      # In last resort, fetch from the database and write to the cache
+      api_key, organization = fetch_from_database
+      write_to_cache(api_key) if api_key
+
+      [api_key, organization]
+    end
+
+    def cache_key
+      [
+        "api_key",
+        CACHE_KEY_VERSION,
+        auth_token
+      ].compact.join("/")
+    end
+
+    private
+
+    attr_reader :auth_token, :with_cache
+
+    def fetch_from_database
+      api_key = ApiKey.includes(:organization).find_by(value: auth_token)
+      [api_key, api_key&.organization]
+    end
+
+    def write_to_cache(api_key)
+      # Ensure cache is kept for 1 hour at most
+      expiration = if api_key.expires_at && api_key.expires_at < Time.current + CACHE_DURATION
+        (api_key.expires_at - Time.current).to_i.seconds
+      else
+        CACHE_DURATION
+      end
+
+      Rails.cache.write(
+        cache_key,
+        {
+          organization: api_key.organization.attributes,
+          api_key: api_key.attributes
+        }.to_json,
+        expires_in: expiration
+      )
+    end
+  end
+end

--- a/app/services/api_keys/destroy_service.rb
+++ b/app/services/api_keys/destroy_service.rb
@@ -2,21 +2,24 @@
 
 module ApiKeys
   class DestroyService < BaseService
+    Result = BaseResult[:api_key]
+
     def initialize(api_key)
       @api_key = api_key
       super
     end
 
     def call
-      return result.not_found_failure!(resource: 'api_key') unless api_key
+      return result.not_found_failure!(resource: "api_key") unless api_key
 
       unless api_key.organization.api_keys.non_expiring.without(api_key).exists?
-        return result.single_validation_failure!(error_code: 'last_non_expiring_api_key')
+        return result.single_validation_failure!(error_code: "last_non_expiring_api_key")
       end
 
       api_key.touch(:expires_at) # rubocop:disable Rails/SkipsModelValidations
 
       ApiKeyMailer.with(api_key:).destroyed.deliver_later
+      ApiKeys::CacheService.expire_cache(api_key.value)
 
       result.api_key = api_key
       result

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -1,66 +1,68 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ApiKey, type: :model do
-  subject { build(:api_key) }
+  subject { build(:api_key, expires_at:) }
 
-  it_behaves_like 'paper_trail traceable'
+  let(:expires_at) { nil }
+
+  it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:organization) }
 
   it { is_expected.to validate_presence_of(:permissions) }
 
-  describe 'validations' do
-    describe 'of value uniqueness' do
+  describe "validations" do
+    describe "of value uniqueness" do
       before { create(:api_key) }
 
       it { is_expected.to validate_uniqueness_of(:value) }
     end
 
-    describe 'of value presence' do
+    describe "of value presence" do
       subject { api_key }
 
-      context 'with a new record' do
+      context "with a new record" do
         let(:api_key) { build(:api_key) }
 
         it { is_expected.not_to validate_presence_of(:value) }
       end
 
-      context 'with a persisted record' do
+      context "with a persisted record" do
         let(:api_key) { create(:api_key) }
 
         it { is_expected.to validate_presence_of(:value) }
       end
     end
 
-    describe 'of permissions structure' do
+    describe "of permissions structure" do
       subject { api_key.valid? }
 
       let(:api_key) { build_stubbed(:api_key) }
       let(:error) { api_key.errors.where(:permissions, :forbidden_keys) }
 
-      context 'when permissions has forbidden keys' do
+      context "when permissions has forbidden keys" do
         before do
           api_key.permissions = api_key.permissions.merge(forbidden: [])
           subject
         end
 
-        it 'adds forbidden keys error' do
+        it "adds forbidden keys error" do
           expect(error).to be_present
         end
       end
 
-      context 'when permissions has no forbidden keys' do
+      context "when permissions has no forbidden keys" do
         before { subject }
 
-        it 'does not add forbidden keys error' do
+        it "does not add forbidden keys error" do
           expect(error).not_to be_present
         end
       end
     end
 
-    describe 'of permissions values' do
+    describe "of permissions values" do
       subject { api_key.valid? }
 
       let(:api_key) { build_stubbed(:api_key, permissions:) }
@@ -68,28 +70,28 @@ RSpec.describe ApiKey, type: :model do
 
       before { subject }
 
-      context 'when permission contains forbidden values' do
-        let(:permissions) { {add_on: ['forbidden', 'read']} }
+      context "when permission contains forbidden values" do
+        let(:permissions) { {add_on: ["forbidden", "read"]} }
 
-        it 'adds an error' do
+        it "adds an error" do
           expect(error).to be_present
         end
       end
 
-      context 'when permission contains only allowed values' do
-        let(:permissions) { {add_on: ['read', 'write']} }
+      context "when permission contains only allowed values" do
+        let(:permissions) { {add_on: ["read", "write"]} }
 
-        it 'does not add an error' do
+        it "does not add an error" do
           expect(error).not_to be_present
         end
       end
     end
   end
 
-  describe '#save' do
+  describe "#save" do
     subject { api_key.save! }
 
-    context 'with a new record' do
+    context "with a new record" do
       let(:api_key) { build(:api_key) }
       let(:used_value) { create(:api_key).value }
       let(:unique_value) { SecureRandom.uuid }
@@ -98,21 +100,21 @@ RSpec.describe ApiKey, type: :model do
         allow(SecureRandom).to receive(:uuid).and_return(used_value, unique_value)
       end
 
-      it 'sets the value' do
+      it "sets the value" do
         expect { subject }.to change(api_key, :value).to unique_value
       end
     end
 
-    context 'with a persisted record' do
+    context "with a persisted record" do
       let(:api_key) { create(:api_key) }
 
-      it 'does not change the value' do
+      it "does not change the value" do
         expect { subject }.not_to change(api_key, :value)
       end
     end
   end
 
-  describe 'default_scope' do
+  describe "default_scope" do
     subject { described_class.all }
 
     let!(:scoped) do
@@ -124,19 +126,19 @@ RSpec.describe ApiKey, type: :model do
 
     before { create(:api_key, :expired) }
 
-    it 'returns API keys with either no expiration or future expiration dates' do
+    it "returns API keys with either no expiration or future expiration dates" do
       expect(subject).to match_array scoped
     end
   end
 
-  describe '.non_expiring' do
+  describe ".non_expiring" do
     subject { described_class.non_expiring }
 
     let!(:scoped) { create(:api_key) }
 
     before { create(:api_key, :expiring) }
 
-    it 'returns API keys with no expiration date' do
+    it "returns API keys with no expiration date" do
       expect(subject).to contain_exactly scoped
     end
   end
@@ -213,6 +215,22 @@ RSpec.describe ApiKey, type: :model do
         it "returns true" do
           expect(subject).to be true
         end
+      end
+    end
+  end
+
+  describe "#expired?" do
+    it { expect(subject).not_to be_expired }
+
+    context "with an expires_at value" do
+      let(:expires_at) { Time.current + 1.hour }
+
+      it { expect(subject).not_to be_expired }
+
+      context "when expires_at is in the past" do
+        let(:expires_at) { Time.current - 1.hour }
+
+        it { expect(subject).to be_expired }
       end
     end
   end

--- a/spec/services/api_keys/cache_service_spec.rb
+++ b/spec/services/api_keys/cache_service_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApiKeys::CacheService, type: :service, cache: :redis do
+  subject(:cache_service) { described_class.new(auth_token, with_cache:) }
+
+  let(:auth_token) { "token" }
+  let(:with_cache) { false }
+
+  describe "#cache_key" do
+    it "returns the cache key" do
+      expect(cache_service.cache_key).to eq("api_key/#{described_class::CACHE_KEY_VERSION}/token")
+    end
+  end
+
+  describe "#expire_cache" do
+    it "deletes the cached value" do
+      allow(Rails.cache).to receive(:delete).with(cache_service.cache_key)
+
+      cache_service.expire_cache
+
+      expect(Rails.cache).to have_received(:delete).with(cache_service.cache_key)
+    end
+  end
+
+  describe "#expire_all_cache" do
+    let(:organization) { create(:organization, api_keys:) }
+    let(:api_keys) { create_list(:api_key, 3) }
+
+    it "deletes all cached values" do
+      allow(Rails.cache).to receive(:delete)
+
+      described_class.expire_all_cache(organization)
+
+      expect(Rails.cache).to have_received(:delete).exactly(3).times
+    end
+  end
+
+  describe "#call" do
+    let(:organization) { create(:organization, api_keys: [api_key]) }
+    let(:api_key) { create(:api_key) }
+    let(:auth_token) { api_key.value }
+
+    before { organization }
+
+    it "returns the api_key and the organization" do
+      expect(cache_service.call).to eq([api_key, organization])
+    end
+
+    context "when cache is enabled" do
+      let(:with_cache) { true }
+
+      before { Rails.cache.clear }
+
+      it "returns the api_key and the organization and create the cache" do
+        expect(cache_service.call).to eq([api_key, organization])
+
+        expect(Rails.cache.read(cache_service.cache_key)).to be_present
+      end
+
+      context "when cache exists" do
+        before { cache_service.call }
+
+        it "returns the api_key and the organization" do
+          expect(cache_service.call).to eq([api_key, organization])
+        end
+      end
+
+      context "when cached value is expired" do
+        let(:api_key) { create(:api_key, expires_at: Time.current - 10.minutes) }
+
+        before do
+          Rails.cache.write(cache_service.cache_key, {
+            api_key: api_key.attributes,
+            organization: organization.attributes
+          }.to_json)
+        end
+
+        it "does not return the cache key and organization" do
+          expect(cache_service.call).to eq([nil, nil])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR is part of a global initiative to improve the performance of the LAGO Rest API.

Today every request made received by the API leads to at least two database queries to authenticate the organization. A first one is fetching the `api_key` using the provided bearer token from the HTTP header, the second one loads the related `organization`.

As by nature, api_keys and organizations are not update really often, adding a caching strategy could reduce drastically the time consumed authenticating the organization.

## Description

This PR changes the authentication mechanism by:
- Adding a dedicated cache service for API key. It default to no cache unless cache is explicitly turned on.
- If cache is on:
  - Checking for cached api_key and organization
  - Fetching the values from the DB is no cache is present
  - Caching the values
  - Handling cache expiration when updating api keys and organization