### PR TITLE
fix: remove amount check when cache is used

### DIFF
--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -166,7 +166,7 @@ module Invoices
 
       invoice.fees.each do |fee|
         fee_taxes = result.fees_taxes.find do |item|
-          (item.item_id == fee.item_id) && (item.amount_cents.to_i == fee.sub_total_excluding_taxes_amount_cents&.to_i)
+          item.item_id == fee.item_id
         end
 
         res = Fees::ApplyProviderTaxesService.call(fee:, fee_taxes:)


### PR DESCRIPTION
Amount check makes sense only when fresh tax result is fetched. When cache is used it can lead to unwanted errors.