### PR TITLE
fix(invoice-preview): Prevent customer updates during invoice preview

### DIFF
--- a/app/services/invoices/preview_context_service.rb
+++ b/app/services/invoices/preview_context_service.rb
@@ -53,7 +53,8 @@ module Invoices
         shipping_country: customer_params.dig(:shipping_address, :country)
       )
 
-      customer.integration_customers = Array(customer_params[:integration_customers]).map do |integration_params|
+      Array(customer_params[:integration_customers]).map do |integration_params|
+        IntegrationCustomers::BaseCustomer.customer_type(integration_params[:integration_type])
         build_customer_integration(customer, integration_params)
       end
 
@@ -64,8 +65,7 @@ module Invoices
       integration_class = integration_type(attrs[:integration_type]).constantize
       integration = integration_class.find_by!(code: attrs[:integration_code], organization:)
 
-      integration_customer_class = IntegrationCustomers::BaseCustomer.customer_type(attrs[:integration_type]).constantize
-      integration_customer_class.new(integration:, customer:)
+      customer.public_send("build_#{attrs[:integration_type]}_customer", integration:)
     end
 
     def build_subscription

--- a/app/services/invoices/preview_context_service.rb
+++ b/app/services/invoices/preview_context_service.rb
@@ -54,7 +54,6 @@ module Invoices
       )
 
       Array(customer_params[:integration_customers]).map do |integration_params|
-        IntegrationCustomers::BaseCustomer.customer_type(integration_params[:integration_type])
         build_customer_integration(customer, integration_params)
       end
 
@@ -64,8 +63,9 @@ module Invoices
     def build_customer_integration(customer, attrs)
       integration_class = integration_type(attrs[:integration_type]).constantize
       integration = integration_class.find_by!(code: attrs[:integration_code], organization:)
+      type = IntegrationCustomers::BaseCustomer.customer_type(attrs[:integration_type]).constantize
 
-      customer.public_send("build_#{attrs[:integration_type]}_customer", integration:)
+      customer.integration_customers.build(integration:, type:)
     end
 
     def build_subscription

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -204,7 +204,7 @@ module Invoices
     end
 
     def provider_taxation?
-      customer.anrok_customer.present?
+      customer.integration_customers&.find { |ic| ic.type == 'IntegrationCustomers::AnrokCustomer' }
     end
   end
 end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -204,7 +204,7 @@ module Invoices
     end
 
     def provider_taxation?
-      customer.integration_customers&.find { |ic| ic.type == 'IntegrationCustomers::AnrokCustomer' }
+      customer.anrok_customer.present?
     end
   end
 end

--- a/spec/services/invoices/preview_context_service_spec.rb
+++ b/spec/services/invoices/preview_context_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
                 currency: params.dig(:customer, :currency),
                 address_line1: params.dig(:customer, :address_line1),
                 shipping_address_line1: params.dig(:customer, :shipping_address, :address_line1),
-                anrok_customer: IntegrationCustomers::AnrokCustomer
+                integration_customers: array_including(IntegrationCustomers::AnrokCustomer)
               )
           end
 
@@ -89,7 +89,7 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
           end
 
           it "does not persist integrations" do
-            expect { subject }.not_to change { customer.reload.anrok_customer }
+            expect { subject }.not_to change { customer.reload.integration_customers.empty? }
           end
         end
       end
@@ -141,8 +141,7 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
       context "when integration matching params exists" do
         let(:expected_attributes) do
           params[:customer].tap do |hash|
-            hash[:integration_customers] = []
-            hash[:anrok_customer] = IntegrationCustomers::AnrokCustomer
+            hash[:integration_customers] = array_including(IntegrationCustomers::AnrokCustomer)
           end
         end
 

--- a/spec/services/invoices/preview_context_service_spec.rb
+++ b/spec/services/invoices/preview_context_service_spec.rb
@@ -52,26 +52,45 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
               city: "Paris",
               zipcode: "75011",
               country: "IT"
-            }
+            },
+            integration_customers: [
+              {
+                integration_type: "anrok",
+                integration_code: "code"
+              }
+            ]
           }
         }
       end
+
+      before { create(:anrok_integration, organization:, code: "code") }
 
       context "when customer matching external id exists in organization" do
         let(:customer) { create(:customer, organization:) }
         let(:external_id) { customer.external_id }
 
-        it "returns customer with overrides from params" do
-          expect(subject)
-            .to be_a(Customer)
-            .and be_persisted
-            .and have_attributes(
-              id: customer.id,
-              name: customer.name,
-              currency: params.dig(:customer, :currency),
-              address_line1: params.dig(:customer, :address_line1),
-              shipping_address_line1: params.dig(:customer, :shipping_address, :address_line1)
-            )
+        context "when integration matching params exists" do
+          it "returns customer with overrides from params" do
+            expect(subject)
+              .to be_a(Customer)
+              .and be_persisted
+              .and have_attributes(
+                id: customer.id,
+                name: customer.name,
+                currency: params.dig(:customer, :currency),
+                address_line1: params.dig(:customer, :address_line1),
+                shipping_address_line1: params.dig(:customer, :shipping_address, :address_line1),
+                anrok_customer: IntegrationCustomers::AnrokCustomer
+              )
+          end
+
+          it "does not change existing customer" do
+            expect { subject }.not_to change { customer.reload.updated_at }
+          end
+
+          it "does not persist integrations" do
+            expect { subject }.not_to change { customer.reload.anrok_customer }
+          end
         end
       end
 
@@ -109,58 +128,41 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
               zipcode: "75011",
               country: "IT"
             },
-            integration_customers:
+            integration_customers: [
+              {
+                integration_type: "anrok",
+                integration_code: "code"
+              }
+            ]
           }
         }
       end
 
-      context "when integration customers params passed" do
-        let(:integration_customers) do
-          [
-            {
-              integration_type: "anrok",
-              integration_code: "code"
-            }
-          ]
-        end
-
-        context "when integration matching params exists" do
-          let(:expected_attributes) do
-            params[:customer].tap do |hash|
-              hash[:integration_customers] = [IntegrationCustomers::AnrokCustomer]
-            end
-          end
-
-          before { create(:anrok_integration, organization:, code: "code") }
-
-          it "returns new customer build from params including integration customers" do
-            expect(subject)
-              .to be_present
-              .and be_new_record
-              .and have_attributes(expected_attributes)
+      context "when integration matching params exists" do
+        let(:expected_attributes) do
+          params[:customer].tap do |hash|
+            hash[:integration_customers] = []
+            hash[:anrok_customer] = IntegrationCustomers::AnrokCustomer
           end
         end
 
-        context "when integration matching params does not exist" do
-          it "returns nil" do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.error_code).to eq("anrok_integration_not_found")
+        before { create(:anrok_integration, organization:, code: "code") }
 
-            expect(subject).to be_nil
-          end
-        end
-      end
-
-      context "when integration customers params is omitted or empty" do
-        let(:integration_customers) { [] }
-        let(:expected_attributes) { params[:customer] }
-
-        it "returns new customer build from params" do
+        it "returns new customer build from params including integration customers" do
           expect(subject)
             .to be_present
             .and be_new_record
             .and have_attributes(expected_attributes)
+        end
+      end
+
+      context "when integration matching params does not exist" do
+        it "returns nil" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("anrok_integration_not_found")
+
+          expect(subject).to be_nil
         end
       end
     end


### PR DESCRIPTION
## Context

During invoice preview it's possible to override customer attributes only for preview invoice. Customer integrations appears to be saved to DB when it shouldn't.

## Description

Change the way to build customer integrations in preview to avoid persisting.
Improve test to cover this case.
