### PR TITLE
Fix(rev-share): do not display logo in credit note PDF

### DIFF
--- a/app/views/templates/credit_notes/self_billed.slim
+++ b/app/views/templates/credit_notes/self_billed.slim
@@ -11,8 +11,6 @@ html
     .wrapper
       .mb-24
         h1.credit-note-title = I18n.t('credit_note.document_name')
-        - if organization.logo.present?
-          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
 
       .mb-24.overflow-auto
         .credit-note-information-column


### PR DESCRIPTION
## Context

removed Logo from self-billed credit note PDF
