### PR TITLE
fix(anrok): Remove cache for Current Usage

### DIFF
--- a/app/controllers/api/v1/customers/usage_controller.rb
+++ b/app/controllers/api/v1/customers/usage_controller.rb
@@ -5,11 +5,13 @@ module Api
     module Customers
       class UsageController < Api::BaseController
         def current
+          apply_taxes = ActiveModel::Type::Boolean.new.cast(params.fetch(:apply_taxes, true))
           result = ::Invoices::CustomerUsageService
             .with_external_ids(
               customer_external_id: params[:customer_external_id],
               external_subscription_id: params[:external_subscription_id],
-              organization_id: current_organization.id
+              organization_id: current_organization.id,
+              apply_taxes:
             ).call
 
           if result.success?

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -83,6 +83,10 @@ class Fee < ApplicationRecord
     from_organization_pay_in_advance(org).where("customers.external_id = ?", external_customer_id)
   end
 
+  def item_key
+    id || object_id
+  end
+
   def item_id
     return billable_metric.id if charge?
     return add_on.id if add_on?

--- a/app/services/integrations/aggregator/taxes/base_service.rb
+++ b/app/services/integrations/aggregator/taxes/base_service.rb
@@ -47,6 +47,7 @@ module Integrations
               taxes_to_pay = fee['tax_amount_cents']
 
               OpenStruct.new(
+                item_key: fee['item_key'],
                 item_id: fee['item_id'],
                 item_code: fee['item_code'],
                 amount_cents: fee['amount_cents'],

--- a/app/services/integrations/aggregator/taxes/invoices/payload.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payload.rb
@@ -47,6 +47,7 @@ module Integrations
             mapped_item ||= empty_struct
 
             {
+              'item_key' => fee.item_key,
               'item_id' => fee.id || fee.item_id,
               'item_code' => mapped_item.external_id,
               'amount_cents' => fee.sub_total_excluding_taxes_amount_cents&.to_i

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -158,7 +158,7 @@ module Invoices
 
       invoice.fees.each do |fee|
         fee_taxes = result.fees_taxes.find do |item|
-          (item.item_id == fee.item_id) && (item.amount_cents.to_i == fee.sub_total_excluding_taxes_amount_cents&.to_i)
+          item.item_key == fee.item_key
         end
 
         res = Fees::ApplyProviderTaxesService.call(fee:, fee_taxes:)

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -91,6 +91,22 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
       end
     end
 
+    context 'when apply_taxes is false' do
+      let(:params) { {external_subscription_id: subscription.external_id, apply_taxes: false} }
+
+      it 'returns the usage for the customer without applying taxes' do
+        subject
+
+        aggregate_failures do
+          expect(response).to have_http_status(:success)
+          # With taxes disabled, fees_amount_cents remains 5 and no tax is added.
+          expect(json[:customer_usage][:amount_cents]).to eq(5)
+          expect(json[:customer_usage][:taxes_amount_cents]).to eq(0)
+          expect(json[:customer_usage][:total_amount_cents]).to eq(5)
+        end
+      end
+    end
+
     context 'with filters' do
       let(:billable_metric_filter) do
         create(:billable_metric_filter, billable_metric: metric, key: 'cloud', values: %w[aws google])

--- a/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
@@ -82,11 +82,13 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
         },
         'fees' => [
           {
+            'item_key' => fee_add_on.item_key,
             'item_id' => fee_add_on.id,
             'item_code' => 'm1',
             'amount_cents' => 200
           },
           {
+            'item_key' => fee_add_on_two.item_key,
             'item_id' => fee_add_on_two.id,
             'item_code' => '1',
             'amount_cents' => 200

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -83,11 +83,13 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
         },
         'fees' => [
           {
+            'item_key' => fee_add_on.item_key,
             'item_id' => fee_add_on.id,
             'item_code' => 'm1',
             'amount_cents' => 200
           },
           {
+            'item_key' => fee_add_on_two.item_key,
             'item_id' => fee_add_on_two.id,
             'item_code' => '1',
             'amount_cents' => 200

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -181,18 +181,6 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
         end
       end
 
-      it 'uses the Rails cache' do
-        key = [
-          'provider-taxes',
-          subscription.id,
-          plan.updated_at.iso8601
-        ].join('/')
-
-        expect do
-          usage_service.call
-        end.to change { Rails.cache.exist?(key) }.from(false).to(true)
-      end
-
       context 'when there is error received from the provider' do
         let(:body) do
           p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -128,20 +128,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
     context 'when there is tax provider integration' do
       let(:integration) { create(:anrok_integration, organization:) }
       let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
-      let(:response) { instance_double(Net::HTTPOK) }
-      let(:lago_client) { instance_double(LagoHttpClient::Client) }
       let(:endpoint) { 'https://api.nango.dev/v1/anrok/draft_invoices' }
-      let(:body) do
-        p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
-        json = File.read(p)
-
-        # setting item_id based on the test example
-        response = JSON.parse(json)
-        response['succeededInvoices'].first['fees'].last['item_id'] = charge.billable_metric.id
-        response['succeededInvoices'].first['fees'].last['amount_cents'] = 2532
-
-        response.to_json
-      end
       let(:integration_collection_mapping) do
         create(
           :netsuite_collection_mapping,
@@ -154,37 +141,55 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
       before do
         integration_collection_mapping
         integration_customer
-
-        allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
-        allow(lago_client).to receive(:post_with_response).and_return(response)
-        allow(response).to receive(:body).and_return(body)
       end
 
-      it 'initializes an invoice' do
-        result = usage_service.call
+      context 'when there is no error' do
+        before do
+          stub_request(:post, endpoint).to_return do |request|
+            response = JSON.parse(File.read(
+              Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
+            ))
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.invoice).to be_a(Invoice)
+            # setting item_id based on the test example
+            key = JSON.parse(request.body).first['fees'].last['item_key']
+            response['succeededInvoices'].first['fees'].last['item_key'] = key
+            response['succeededInvoices'].first['fees'].last['item_id'] = charge.billable_metric.id
+            response['succeededInvoices'].first['fees'].last['amount_cents'] = 2532
 
-          expect(result.usage).to have_attributes(
-            from_datetime: Time.current.beginning_of_month.iso8601,
-            to_datetime: Time.current.end_of_month.iso8601,
-            issuing_date: Time.zone.today.end_of_month.iso8601,
-            currency: 'EUR',
-            amount_cents: 2532, # 1266 * 2,
-            taxes_amount_cents: 253, # 2532 * 0.1
-            total_amount_cents: 2785
-          )
-          expect(result.usage.fees.size).to eq(1)
-          expect(result.usage.fees.first.charge.invoice_display_name).to eq(charge.invoice_display_name)
+            {body: response.to_json}
+          end
+        end
+
+        it 'initializes an invoice' do
+          result = usage_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.invoice).to be_a(Invoice)
+
+            expect(result.usage).to have_attributes(
+              from_datetime: Time.current.beginning_of_month.iso8601,
+              to_datetime: Time.current.end_of_month.iso8601,
+              issuing_date: Time.zone.today.end_of_month.iso8601,
+              currency: 'EUR',
+              amount_cents: 2532, # 1266 * 2,
+              taxes_amount_cents: 253, # 2532 * 0.1
+              total_amount_cents: 2785
+            )
+            expect(result.usage.fees.size).to eq(1)
+            expect(result.usage.fees.first.charge.invoice_display_name).to eq(charge.invoice_display_name)
+          end
         end
       end
 
       context 'when there is error received from the provider' do
-        let(:body) do
-          p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
-          File.read(p)
+        before do
+          stub_request(:post, endpoint).to_return do |request|
+            response = File.read(
+              Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+            )
+            {body: response}
+          end
         end
 
         it 'returns tax error' do


### PR DESCRIPTION
## Context

When calling `GET /customers/:cust_id/current_usage?external_subscription_id=:sub_id` Lago computes the current usage

## Description

The taxes are computed by a thrid party (Anrok through Nango). We originally implemented a cache to avoir http calls to third party but it comes with drawbacks. We recently [tried to improve this](https://github.com/getlago/lago-api/pull/3115).
After investigation we believe it's best to remove the cache.

- [x] Remove Anrok cache
- [x] Introduce new `item_key` to reconcile fees when they are not persisted
- [x] Add new `apply_taxes` params to the API
  - If you get an error due to third party, you can call again without taxes
  - In case you only need pre-tax amounts (like for b2b), passing `apply_taxes: false` will be more performant
  - https://github.com/getlago/lago-openapi/pull/332