### PR TITLE
feat: change BillPaidCreditJob to high_priority

### DIFF
--- a/app/jobs/bill_paid_credit_job.rb
+++ b/app/jobs/bill_paid_credit_job.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
 class BillPaidCreditJob < ApplicationJob
-  queue_as do
-    if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_BILLING'])
-      :billing
-    else
-      :default
-    end
-  end
+  queue_as 'high_priority'
 
   retry_on Sequenced::SequenceError
 


### PR DESCRIPTION
## Context

During the start of a new billing period, the system generates a large number of invoices, which in turn delays wallet top-up jobs. While other critical jobs like `Invoices::PrepaidCreditJob` and `WalletTransactions::CreateJob` have already been moved to the high-priority queue, `BillPaidCreditJob` remains in the default queue. 

## Description

This PR moves the `BillPaidCreditJob` to the high-priority queue. 