### PR TITLE
chore(spec): Use `stub_pdf_generation` helper

### DIFF
--- a/spec/graphql/mutations/customer_portal/download_invoice_spec.rb
+++ b/spec/graphql/mutations/customer_portal/download_invoice_spec.rb
@@ -18,22 +18,7 @@ RSpec.describe Mutations::CustomerPortal::DownloadInvoice, type: :graphql do
     GQL
   end
 
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-
-  let(:pdf_response) do
-    BaseService::Result.new.tap { |r| r.io = StringIO.new(pdf_content) }
-  end
-
-  let(:pdf_content) do
-    File.read(Rails.root.join('spec/fixtures/blank.pdf'))
-  end
-
-  before do
-    allow(Utils::PdfGenerator).to receive(:new)
-      .and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call)
-      .and_return(pdf_response)
-  end
+  before { stub_pdf_generation }
 
   it_behaves_like 'requires a customer portal user'
 

--- a/spec/graphql/mutations/invoices/download_spec.rb
+++ b/spec/graphql/mutations/invoices/download_spec.rb
@@ -19,22 +19,7 @@ RSpec.describe Mutations::Invoices::Download, type: :graphql do
     GQL
   end
 
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-
-  let(:pdf_response) do
-    BaseService::Result.new.tap { |r| r.io = StringIO.new(pdf_content) }
-  end
-
-  let(:pdf_content) do
-    File.read(Rails.root.join('spec/fixtures/blank.pdf'))
-  end
-
-  before do
-    allow(Utils::PdfGenerator).to receive(:new)
-      .and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call)
-      .and_return(pdf_response)
-  end
+  before { stub_pdf_generation }
 
   it_behaves_like 'requires current user'
   it_behaves_like 'requires current organization'

--- a/spec/scenarios/coupons_breakdown_spec.rb
+++ b/spec/scenarios/coupons_breakdown_spec.rb
@@ -5,15 +5,9 @@ require 'rails_helper'
 describe 'Coupons breakdown Spec', :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
 
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
-
   before do
     organization
-
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+    stub_pdf_generation
   end
 
   around { |test| lago_premium!(&test) }

--- a/spec/scenarios/customers/update_invoice_grace_period_spec.rb
+++ b/spec/scenarios/customers/update_invoice_grace_period_spec.rb
@@ -7,15 +7,10 @@ describe 'Update Customer Invoice Grace Period Scenarios', :scenarios, type: :re
   let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
   let(:plan) { create(:plan, pay_in_advance: true, organization:) }
 
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
-
   around { |test| lago_premium!(&test) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+    stub_pdf_generation
   end
 
   it 'updates the grace period of the customer' do

--- a/spec/scenarios/taxes_on_invoice_spec.rb
+++ b/spec/scenarios/taxes_on_invoice_spec.rb
@@ -5,15 +5,9 @@ require 'rails_helper'
 describe 'Taxes on Invoice Scenarios', :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
 
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
-
   before do
+    stub_pdf_generation
     organization
-
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
   end
 
   around { |test| lago_premium!(&test) }

--- a/spec/services/credit_notes/generate_service_spec.rb
+++ b/spec/services/credit_notes/generate_service_spec.rb
@@ -13,19 +13,11 @@ RSpec.describe CreditNotes::GenerateService, type: :service do
   let(:credit_note_item) { create(:credit_note_item, credit_note:, fee:) }
   let(:context) { nil }
 
-  let(:pdf_content) do
-    File.read(Rails.root.join('spec/fixtures/blank.pdf'))
-  end
-
-  let(:pdf_response) do
-    BaseService::Result.new.tap { |r| r.io = StringIO.new(pdf_content) }
-  end
-
   before do
     credit_note_item
 
-    allow(Utils::PdfGenerator).to receive(:call)
-      .and_return(pdf_response)
+    stub_pdf_generation
+    allow(Utils::PdfGenerator).to receive(:call).and_call_original
   end
 
   describe '.call' do

--- a/spec/services/invoices/generate_pdf_service_spec.rb
+++ b/spec/services/invoices/generate_pdf_service_spec.rb
@@ -12,23 +12,11 @@ RSpec.describe Invoices::GeneratePdfService, type: :service do
   let(:invoice) { create(:invoice, customer:, status: :finalized, organization:) }
   let(:credit) { create(:credit, invoice:) }
   let(:fees) { create_list(:fee, 3, invoice:) }
-  let(:invoice_subscription) { create(:invoice_subscription, invoice:, subscription:) }
-  let(:pdf_content) do
-    File.read(Rails.root.join('spec/fixtures/blank.pdf'))
-  end
-
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_response) do
-    BaseService::Result.new.tap { |r| r.io = StringIO.new(pdf_content) }
-  end
+  let(:invoice_subscription) { create(:invoice_subscription, :boundaries, invoice:, subscription:) }
 
   before do
     invoice_subscription
-
-    allow(Utils::PdfGenerator).to receive(:new)
-      .and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call)
-      .and_return(pdf_response)
+    stub_pdf_generation
   end
 
   describe '#call' do


### PR DESCRIPTION
## Description

There is a helper to stub PDF generation and many tests didn't use it. Instead of mocking multiple services, it mocks the HTTP requests to the gotemberg service.