### PR TITLE
Fix(revenue-share): add self-billed field to data exports

### DIFF
--- a/app/graphql/types/data_exports/credit_notes/filters_input.rb
+++ b/app/graphql/types/data_exports/credit_notes/filters_input.rb
@@ -19,6 +19,7 @@ module Types
         argument :reason, [Types::CreditNotes::ReasonTypeEnum], required: false
         argument :refund_status, [Types::CreditNotes::RefundStatusTypeEnum], required: false
         argument :search_term, String, required: false
+        argument :self_billed, Boolean, required: false
       end
     end
   end

--- a/app/graphql/types/data_exports/invoices/filters_input.rb
+++ b/app/graphql/types/data_exports/invoices/filters_input.rb
@@ -19,6 +19,7 @@ module Types
         argument :payment_status, [Types::Invoices::PaymentStatusTypeEnum], required: false
         argument :search_term, String, required: false
         argument :status, [Types::Invoices::StatusTypeEnum], required: false
+        argument :self_billed, Boolean, required: false
       end
     end
   end

--- a/app/graphql/types/data_exports/invoices/filters_input.rb
+++ b/app/graphql/types/data_exports/invoices/filters_input.rb
@@ -18,8 +18,8 @@ module Types
         argument :payment_overdue, Boolean, required: false
         argument :payment_status, [Types::Invoices::PaymentStatusTypeEnum], required: false
         argument :search_term, String, required: false
-        argument :status, [Types::Invoices::StatusTypeEnum], required: false
         argument :self_billed, Boolean, required: false
+        argument :status, [Types::Invoices::StatusTypeEnum], required: false
       end
     end
   end

--- a/app/services/data_exports/csv/credit_notes.rb
+++ b/app/services/data_exports/csv/credit_notes.rb
@@ -48,12 +48,12 @@ module DataExports
       attr_reader :data_export_part, :serializer_klass
 
       def serialize_item(credit_note, csv)
-        serialized_note = serializer_klass.new(credit_note, includes: %i[customer invoice]).serialize
+        serialized_note = serializer_klass.new(credit_note, includes: %i[customer]).serialize
 
         csv << [
           serialized_note[:lago_id],
           serialized_note[:sequential_id],
-          serialized_note.dig(:invocie, :self_billed),
+          serialized_note[:self_billed],
           serialized_note[:issuing_date],
           serialized_note.dig(:customer, :lago_id),
           serialized_note.dig(:customer, :external_id),
@@ -79,7 +79,7 @@ module DataExports
       end
 
       def collection
-        CreditNote.includes(:customer, :invoice).find(data_export_part.object_ids)
+        CreditNote.includes(:customer).find(data_export_part.object_ids)
       end
     end
   end

--- a/app/services/data_exports/csv/credit_notes.rb
+++ b/app/services/data_exports/csv/credit_notes.rb
@@ -18,6 +18,7 @@ module DataExports
         %w[
           lago_id
           sequential_id
+          partner_billing
           issuing_date
           customer_lago_id
           customer_external_id
@@ -47,11 +48,12 @@ module DataExports
       attr_reader :data_export_part, :serializer_klass
 
       def serialize_item(credit_note, csv)
-        serialized_note = serializer_klass.new(credit_note, includes: %i[customer]).serialize
+        serialized_note = serializer_klass.new(credit_note, includes: %i[customer invoice]).serialize
 
         csv << [
           serialized_note[:lago_id],
           serialized_note[:sequential_id],
+          serialized_note.dig(:invocie, :self_billed),
           serialized_note[:issuing_date],
           serialized_note.dig(:customer, :lago_id),
           serialized_note.dig(:customer, :external_id),
@@ -77,7 +79,7 @@ module DataExports
       end
 
       def collection
-        CreditNote.includes(:customer).find(data_export_part.object_ids)
+        CreditNote.includes(:customer, :invoice).find(data_export_part.object_ids)
       end
     end
   end

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -18,6 +18,7 @@ module DataExports
         %w[
           lago_id
           sequential_id
+          partner_billing
           issuing_date
           customer_lago_id
           customer_external_id
@@ -54,6 +55,7 @@ module DataExports
         csv << [
           serialized_invoice[:lago_id],
           serialized_invoice[:sequential_id],
+          serialized_invoice[:self_billed],
           serialized_invoice[:issuing_date],
           serialized_invoice.dig(:customer, :lago_id),
           serialized_invoice.dig(:customer, :external_id),

--- a/schema.graphql
+++ b/schema.graphql
@@ -3537,6 +3537,7 @@ input DataExportCreditNoteFiltersInput {
   reason: [CreditNoteReasonEnum!]
   refundStatus: [CreditNoteRefundStatusEnum!]
   searchTerm: String
+  selfBilled: Boolean
 }
 
 enum DataExportFormatTypeEnum {
@@ -3558,6 +3559,7 @@ input DataExportInvoiceFiltersInput {
   paymentOverdue: Boolean
   paymentStatus: [InvoicePaymentStatusTypeEnum!]
   searchTerm: String
+  selfBilled: Boolean
   status: [InvoiceStatusTypeEnum!]
 }
 

--- a/schema.json
+++ b/schema.json
@@ -15236,6 +15236,18 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "selfBilled",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "enumValues": null
@@ -15428,6 +15440,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "selfBilled",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -15426,6 +15426,18 @@
               "deprecationReason": null
             },
             {
+              "name": "selfBilled",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "status",
               "description": null,
               "type": {
@@ -15440,18 +15452,6 @@
                     "ofType": null
                   }
                 }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "selfBilled",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/services/data_exports/csv/credit_notes_spec.rb
+++ b/spec/services/data_exports/csv/credit_notes_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe DataExports::Csv::CreditNotes do
         [
           credit_note.id,
           credit_note.sequential_id,
+          credit_note.invoice.self_billed,
           credit_note.issuing_date.iso8601,
           credit_note.customer.id,
           credit_note.customer.external_id,

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe DataExports::Csv::Invoices do
       payment_overdue:,
       payment_status:,
       search_term:,
+      self_billed:,
       status:
     }
   end
@@ -33,6 +34,7 @@ RSpec.describe DataExports::Csv::Invoices do
   let(:payment_overdue) { true }
   let(:payment_status) { 'pending' }
   let(:search_term) { 'service ABC' }
+  let(:self_billed) { false }
   let(:status) { 'finalized' }
 
   let(:serializer_klass) { class_double('V1::InvoiceSerializer') }
@@ -46,6 +48,7 @@ RSpec.describe DataExports::Csv::Invoices do
       lago_id: 'invoice-lago-id-123',
       sequential_id: 'SEQ123',
       issuing_date: '2023-01-01',
+      self_billed: false,
       customer: {
         name: 'customer name',
         lago_id: 'customer-lago-id-456',
@@ -86,7 +89,7 @@ RSpec.describe DataExports::Csv::Invoices do
 
     it 'generates the correct CSV output' do
       expected_csv = <<~CSV
-        invoice-lago-id-123,SEQ123,2023-01-01,customer-lago-id-456,CUST123,customer name,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false
+        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false
       CSV
 
       expect(result).to be_success

--- a/spec/services/data_exports/process_part_service_spec.rb
+++ b/spec/services/data_exports/process_part_service_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe DataExports::ProcessPartService, type: :service do
       lago_id: 'invoice-lago-id-123',
       sequential_id: 'SEQ123',
       issuing_date: '2023-01-01',
+      self_billed: false,
       customer: {
         name: 'customer name',
         lago_id: 'customer-lago-id-456',
@@ -50,7 +51,7 @@ RSpec.describe DataExports::ProcessPartService, type: :service do
   describe "#call" do
     it "processes the part" do
       expected_csv = <<~CSV
-        invoice-lago-id-123,SEQ123,2023-01-01,customer-lago-id-456,CUST123,customer name,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false
+        invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false
       CSV
       expect(result).to be_success
       expect(result.data_export_part.csv_lines).to eq(expected_csv)


### PR DESCRIPTION
## Context

When invoices are self-billed, we want to indicate them in data-exports

## Description

Added self_billed to filter inputs for invoices and credit notes data exports
Modified data export csv to include info if the invoice is self-billed
