### PR TITLE
chore(spec): Use instance_double instead of OpenStruct

### DIFF
--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
   describe "#call" do
     let(:result) do
       BaseService::Result.new.tap do |r|
-        r.payment = OpenStruct.new(payable_payment_status: "processing")
+        r.payment = instance_double(Payment, payable_payment_status: "processing")
       end
     end
 
@@ -193,7 +193,7 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
     context "when provider service raises a service failure" do
       let(:result) do
         BaseService::Result.new.tap do |r|
-          r.payment = OpenStruct.new(status: "failed", payable_payment_status: "failed")
+          r.payment = instance_double(Payment, status: "failed", payable_payment_status: "failed")
           r.error_message = "error"
           r.error_code = "code"
           r.reraise = true
@@ -223,7 +223,7 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
       context "when payment has a payable_payment_status" do
         let(:result) do
           BaseService::Result.new.tap do |r|
-            r.payment = OpenStruct.new(payable_payment_status: "failed")
+            r.payment = instance_double(Payment, payable_payment_status: "failed")
             r.error_message = "error"
             r.error_code = "code"
             r.reraise = true
@@ -270,7 +270,7 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
       context "when payable_payment_status is pending" do
         let(:result) do
           BaseService::Result.new.tap do |r|
-            r.payment = OpenStruct.new(status: "failed", payable_payment_status: "pending")
+            r.payment = instance_double(Payment, status: "failed", payable_payment_status: "pending")
             r.error_message = "stripe_error"
             r.error_code = "amount_too_small"
           end

--- a/spec/services/payment_requests/payments/create_service_spec.rb
+++ b/spec/services/payment_requests/payments/create_service_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
 
     let(:service_result) do
       BaseService::Result.new.tap do |r|
-        r.payment = OpenStruct.new(payable_payment_status: "succeeded")
+        r.payment = instance_double(Payment, payable_payment_status: "succeeded")
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
 
       let(:service_result) do
         BaseService::Result.new.tap do |r|
-          r.payment = OpenStruct.new(payable_payment_status: "succeeded")
+          r.payment = instance_double(Payment, payable_payment_status: "succeeded")
         end
       end
 
@@ -124,7 +124,7 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
       context "when the payment fails" do
         let(:service_result) do
           BaseService::Result.new.tap do |r|
-            r.payment = OpenStruct.new(payable_payment_status: "failed")
+            r.payment = instance_double(Payment, payable_payment_status: "failed")
           end
         end
 
@@ -181,7 +181,7 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
       context "when the payment fails" do
         let(:service_result) do
           BaseService::Result.new.tap do |r|
-            r.payment = OpenStruct.new(payable_payment_status: "failed")
+            r.payment = instance_double(Payment, payable_payment_status: "failed")
           end
         end
 
@@ -231,7 +231,7 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
       context "when the payment fails" do
         let(:service_result) do
           BaseService::Result.new.tap do |r|
-            r.payment = OpenStruct.new(payable_payment_status: "failed")
+            r.payment = instance_double(Payment, payable_payment_status: "failed")
           end
         end
 
@@ -334,7 +334,7 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
     context "when provider service raises a service failure" do
       let(:service_result) do
         BaseService::Result.new.tap do |r|
-          r.payment = OpenStruct.new(status: "pending", payable_payment_status: "pending")
+          r.payment = instance_double(Payment, status: "pending", payable_payment_status: "pending")
           r.error_message = "error"
           r.error_code = "code"
           r.reraise = true
@@ -364,7 +364,7 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
       context "when payment has a payable_payment_status" do
         let(:service_result) do
           BaseService::Result.new.tap do |r|
-            r.payment = OpenStruct.new(payable_payment_status: "failed")
+            r.payment = instance_double(Payment, payable_payment_status: "failed")
             r.error_message = "error"
             r.error_code = "code"
             r.reraise = true
@@ -382,7 +382,7 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
       context "when payable_payment_status is pending" do
         let(:service_result) do
           BaseService::Result.new.tap do |r|
-            r.payment = OpenStruct.new(status: "failed", payable_payment_status: "pending")
+            r.payment = instance_double(Payment, status: "failed", payable_payment_status: "pending")
             r.error_message = "stripe_error"
             r.error_code = "amount_too_small"
           end
@@ -407,7 +407,7 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
     context "when payment status is processing" do
       let(:service_result) do
         BaseService::Result.new.tap do |r|
-          r.payment = OpenStruct.new(payable_payment_status: "pending", status: "processing")
+          r.payment = instance_double(Payment, payable_payment_status: "pending", status: "processing")
         end
       end
 

--- a/spec/services/webhook_endpoints/update_service_spec.rb
+++ b/spec/services/webhook_endpoints/update_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe WebhookEndpoints::UpdateService, type: :service do
     end
 
     context 'when webhook endpoint does not exist' do
-      let(:webhook_endpoint) { OpenStruct.new(id: '123456') }
+      let(:webhook_endpoint) { instance_double(WebhookEndpoint, id: '123456') }
 
       it 'returns a not found error' do
         result = update_service.call


### PR DESCRIPTION
## Description

Some test uses OpenStruct where I think it should be a double.

Piece by piece we'll get rid of every OpenStruct usage 😝 