### PR TITLE
fix(invoice): Add GraphQL flag to know editable status

### DIFF
--- a/app/graphql/types/invoice_subscriptions/object.rb
+++ b/app/graphql/types/invoice_subscriptions/object.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Types
-  module InvoiceSubscription
+  module InvoiceSubscriptions
     class Object < Types::BaseObject
-      graphql_name 'InvoiceSubscription'
+      graphql_name "InvoiceSubscription"
 
       field :invoice, Types::Invoices::Object, null: false
       field :subscription, Types::Subscriptions::Object, null: false
@@ -22,6 +22,8 @@ module Types
 
       field :from_datetime, GraphQL::Types::ISO8601DateTime, null: true
       field :to_datetime, GraphQL::Types::ISO8601DateTime, null: true
+
+      field :accept_new_fees, Boolean, null: false
 
       def in_advance_charges_from_datetime
         return nil unless should_use_in_advance_charges_interval
@@ -47,6 +49,12 @@ module Types
       def charge_pay_in_advance_interval
         @charge_pay_in_advance_interval ||=
           ::Subscriptions::DatesService.charge_pay_in_advance_interval(object.timestamp, object.subscription)
+      end
+
+      def accept_new_charge_fees
+        return false if object.invoice.skip_charge?
+
+        object.subscription_periodic? || object.subscription_terminating?
       end
     end
   end

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -3,8 +3,8 @@
 module Types
   module Invoices
     class Object < Types::BaseObject
-      description 'Invoice'
-      graphql_name 'Invoice'
+      description "Invoice"
+      graphql_name "Invoice"
 
       field :customer, Types::Customers::Object, null: false
 
@@ -58,7 +58,7 @@ module Types
       field :credit_notes, [Types::CreditNotes::Object], null: true
       field :error_details, [Types::ErrorDetails::Object], null: true
       field :fees, [Types::Fees::Object], null: true
-      field :invoice_subscriptions, [Types::InvoiceSubscription::Object]
+      field :invoice_subscriptions, [Types::InvoiceSubscriptions::Object]
       field :subscriptions, [Types::Subscriptions::Object]
 
       field :external_hubspot_integration_id, String, null: true
@@ -78,7 +78,7 @@ module Types
           object.integration_resources
             .joins(:integration)
             .where(integration: {type: ::Integrations::BaseIntegration::INTEGRATION_ACCOUNTING_TYPES})
-            .where(resource_type: 'invoice', syncable_type: 'Invoice').none?
+            .where(resource_type: "invoice", syncable_type: "Invoice").none?
       end
 
       def integration_hubspot_syncable
@@ -86,7 +86,7 @@ module Types
           object.integration_resources
             .joins(:integration)
             .where(integration: {type: "Integrations::HubspotIntegration"})
-            .where(resource_type: 'invoice', syncable_type: 'Invoice').none?
+            .where(resource_type: "invoice", syncable_type: "Invoice").none?
       end
 
       def integration_salesforce_syncable
@@ -94,7 +94,7 @@ module Types
           object.integration_resources
             .joins(:integration)
             .where(integration: {type: "Integrations::SalesforceIntegration"})
-            .where(resource_type: 'invoice', syncable_type: 'Invoice').none?
+            .where(resource_type: "invoice", syncable_type: "Invoice").none?
       end
 
       def tax_provider_voidable
@@ -111,7 +111,7 @@ module Types
         IntegrationResource.find_by(
           integration: integration_customer.integration,
           syncable_id: object.id,
-          syncable_type: 'Invoice',
+          syncable_type: "Invoice",
           resource_type: :invoice
         )&.external_id
       end
@@ -124,7 +124,7 @@ module Types
         IntegrationResource.find_by(
           integration: integration_customer.integration,
           syncable_id: object.id,
-          syncable_type: 'Invoice',
+          syncable_type: "Invoice",
           resource_type: :invoice
         )&.external_id
       end
@@ -137,7 +137,7 @@ module Types
         IntegrationResource.find_by(
           integration: integration_customer.integration,
           syncable_id: object.id,
-          syncable_type: 'Invoice',
+          syncable_type: "Invoice",
           resource_type: :invoice
         )&.external_id
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4669,6 +4669,7 @@ enum InvoiceStatusTypeEnum {
 }
 
 type InvoiceSubscription {
+  acceptNewFees: Boolean!
   chargeAmountCents: BigInt!
   chargesFromDatetime: ISO8601DateTime
   chargesToDatetime: ISO8601DateTime

--- a/schema.json
+++ b/schema.json
@@ -22518,6 +22518,22 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "acceptNewFees",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "chargeAmountCents",
               "description": null,
               "type": {

--- a/spec/graphql/types/invoice_subscriptions/object_spec.rb
+++ b/spec/graphql/types/invoice_subscriptions/object_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::InvoiceSubscriptions::Object do
+  subject { described_class }
+
+  it { is_expected.to have_field(:invoice).of_type("Invoice!") }
+  it { is_expected.to have_field(:subscription).of_type("Subscription!") }
+
+  it { is_expected.to have_field(:charge_amount_cents).of_type("BigInt!") }
+  it { is_expected.to have_field(:subscription_amount_cents).of_type("BigInt!") }
+  it { is_expected.to have_field(:total_amount_cents).of_type("BigInt!") }
+
+  it { is_expected.to have_field(:fees).of_type("[Fee!]") }
+
+  it { is_expected.to have_field(:charges_from_datetime).of_type("ISO8601DateTime") }
+  it { is_expected.to have_field(:charges_to_datetime).of_type("ISO8601DateTime") }
+
+  it { is_expected.to have_field(:in_advance_charges_from_datetime).of_type("ISO8601DateTime") }
+  it { is_expected.to have_field(:in_advance_charges_to_datetime).of_type("ISO8601DateTime") }
+
+  it { is_expected.to have_field(:from_datetime).of_type("ISO8601DateTime") }
+  it { is_expected.to have_field(:to_datetime).of_type("ISO8601DateTime") }
+
+  it { is_expected.to have_field(:accept_new_fees).of_type("Boolean!") }
+end


### PR DESCRIPTION
## Context

An issue was reported with creation of adjusted fees following the recent changes related to the removal of zero amount fees from draft invoices.

In case of `subscription_starting` invoice_subscription, adjustment creation is ignored because the invoice refresh is not creating charge fees. This behavior is expected as no charge fees are created when starting a subscription.
Updating the back-end to allow such edition would require a lot of changes with high risk of unexpected side effect.

## Description

This PR adds a new `AcceptNewChargeFees` boolean flag to the `InvoiceSubscription` GraphQL object to let the front-end know if the add new fee button should be displayed or not
