### PR TITLE
feat(regroup_fee): Sum fees to get invoice totals instead of recomputing taxes

### DIFF
--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -2,7 +2,7 @@
 
 module Fees
   class CreatePayInAdvanceService < BaseService
-    Result = BaseResult[:fees]
+    Result = BaseResult[:fees, :fees_taxes, :invoice_id]
 
     def initialize(charge:, event:, billing_at: nil, estimate: false)
       @charge = charge

--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -79,7 +79,16 @@ module Invoices
           raise ActiveRecord::Rollback
         end
 
-        Invoices::ComputeAmountsFromFees.call(invoice:)
+        # NOTE: We don't want to use Invoices::ComputeAmountsFromFees here
+        #       because it would recompute taxes from pre-tax values. All Fees are already paid
+        #       this invoice should show how much taxes were paid in total.
+        # NOTE: progressing billing, coupons and credit notes are not supported here
+        invoice.fees_amount_cents = invoice.fees.sum(&:amount_cents)
+        invoice.taxes_amount_cents = invoice.fees.sum(&:taxes_amount_cents)
+        invoice.total_amount_cents = invoice.fees_amount_cents + invoice.taxes_amount_cents
+        invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
+        invoice.sub_total_including_taxes_amount_cents = invoice.sub_total_excluding_taxes_amount_cents + invoice.taxes_amount_cents
+
         Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
 
         invoice.payment_status = :succeeded

--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -82,12 +82,7 @@ module Invoices
         # NOTE: We don't want to use Invoices::ComputeAmountsFromFees here
         #       because it would recompute taxes from pre-tax values. All Fees are already paid
         #       this invoice should show how much taxes were paid in total.
-        # NOTE: progressing billing, coupons and credit notes are not supported here
-        invoice.fees_amount_cents = invoice.fees.sum(&:amount_cents)
-        invoice.taxes_amount_cents = invoice.fees.sum(&:taxes_amount_cents)
-        invoice.total_amount_cents = invoice.fees_amount_cents + invoice.taxes_amount_cents
-        invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
-        invoice.sub_total_including_taxes_amount_cents = invoice.sub_total_excluding_taxes_amount_cents + invoice.taxes_amount_cents
+        Invoices::AggregateAmountsAndTaxesFromFees.call!(invoice:)
 
         Invoices::ApplyInvoiceCustomSectionsService.call(invoice:)
 

--- a/app/services/invoices/aggregate_amounts_and_taxes_from_fees.rb
+++ b/app/services/invoices/aggregate_amounts_and_taxes_from_fees.rb
@@ -22,6 +22,13 @@ module Invoices
       invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
       invoice.sub_total_including_taxes_amount_cents = invoice.sub_total_excluding_taxes_amount_cents + invoice.taxes_amount_cents
 
+      # Note: This field is populated for consistency but probably shouldn't be use
+      invoice.taxes_rate = if invoice.fees_amount_cents.zero?
+        0
+      else
+        (invoice.taxes_amount_cents.to_f * 100 / invoice.fees_amount_cents).round(2)
+      end
+
       invoice.applied_taxes = invoice.fees.flat_map(&:applied_taxes).group_by(&:tax_id).map do |tax_id, taxes|
         t = taxes.first
         Invoice::AppliedTax.new(

--- a/app/services/invoices/aggregate_amounts_and_taxes_from_fees.rb
+++ b/app/services/invoices/aggregate_amounts_and_taxes_from_fees.rb
@@ -7,14 +7,14 @@ module Invoices
     def initialize(invoice:)
       @invoice = invoice
 
+      raise ArgumentError.new("invoice type must be `advance_charges`") unless invoice.advance_charges?
+
       super
     end
 
     # NOTE: progressing billing, coupons and credit notes are not supported here
     def call
       return result if invoice.fees.empty?
-
-      # TODO: Return error if some fees are :succeeded
 
       invoice.fees_amount_cents = invoice.fees.sum(&:amount_cents)
       invoice.taxes_amount_cents = invoice.fees.sum(&:taxes_amount_cents)
@@ -34,7 +34,7 @@ module Invoices
 
           amount_cents: taxes.sum(&:amount_cents),
           fees_amount_cents: taxes.sum(&:amount_cents),
-          taxable_base_amount_cents: taxes.sum(&:precise_amount_cents), # ???
+          taxable_base_amount_cents: taxes.sum(&:precise_amount_cents)
         )
       end
 

--- a/app/services/invoices/aggregate_amounts_and_taxes_from_fees.rb
+++ b/app/services/invoices/aggregate_amounts_and_taxes_from_fees.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Invoices
+  class AggregateAmountsAndTaxesFromFees < BaseService
+    Result = BaseResult
+
+    def initialize(invoice:)
+      @invoice = invoice
+
+      super
+    end
+
+    # NOTE: progressing billing, coupons and credit notes are not supported here
+    def call
+      return result if invoice.fees.empty?
+
+      # TODO: Return error if some fees are :succeeded
+
+      invoice.fees_amount_cents = invoice.fees.sum(&:amount_cents)
+      invoice.taxes_amount_cents = invoice.fees.sum(&:taxes_amount_cents)
+      invoice.total_amount_cents = invoice.fees_amount_cents + invoice.taxes_amount_cents
+      invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
+      invoice.sub_total_including_taxes_amount_cents = invoice.sub_total_excluding_taxes_amount_cents + invoice.taxes_amount_cents
+
+      invoice.applied_taxes = invoice.fees.flat_map(&:applied_taxes).group_by(&:tax_id).map do |tax_id, taxes|
+        t = taxes.first
+        Invoice::AppliedTax.new(
+          tax_id: tax_id,
+          tax_name: t.tax_name,
+          tax_code: t.tax_code,
+          tax_description: t.tax_description,
+          tax_rate: t.tax_rate,
+          amount_currency: t.amount_currency,
+
+          amount_cents: taxes.sum(&:amount_cents),
+          fees_amount_cents: taxes.sum(&:amount_cents),
+          taxable_base_amount_cents: taxes.sum(&:precise_amount_cents), # ???
+        )
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :invoice
+  end
+end

--- a/spec/scenarios/invoices/advance_charges_taxes_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_taxes_spec.rb
@@ -31,14 +31,14 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
   end
 
   before do
-    create(:tax, organization:, rate: tax_rate_1)
-    create(:tax, organization:, rate: tax_rate_2)
+    create(:tax, organization:, rate: tax_rate_1, code: "tax-1", description: "VAT 1", name: "VAT")
+    create(:tax, organization:, rate: tax_rate_2, code: "tax-2", description: "VAT 2", name: "bug VAT")
     create(:standard_charge, billable_metric: billable_metric_cards, regroup_paid_fees: "invoice", pay_in_advance: true, invoiceable: false, prorated: true, plan:, properties: {amount: "30", grouped_by: nil})
     create(:standard_charge, billable_metric: billable_metric_transfer, regroup_paid_fees: "invoice", pay_in_advance: true, invoiceable: false, prorated: false, plan:, properties: {amount: "1", grouped_by: nil})
   end
 
   context "when subscription is renewed" do
-    it "generates an invoice with the correct charges" do
+    it "generates an invoice with the correct taxes" do
       travel_to(DateTime.new(2024, 6, 5, 10)) do
         create_subscription(
           {
@@ -61,6 +61,8 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
           expect(created_fee.amount_cents).to eq((21 - i) * 100)
           expect(created_fee.taxes_rate).to eq(tax_rate_1 + tax_rate_2)
           expect(created_fee.applied_taxes.count).to eq(2)
+          expect(created_fee.applied_taxes.find { _1.tax_code == "tax-1" }.amount_cents).to eq (created_fee.amount_cents * tax_rate_1 / 100).round
+          expect(created_fee.applied_taxes.find { _1.tax_code == "tax-2" }.amount_cents).to eq (created_fee.amount_cents * tax_rate_2 / 100).round
         end
       end
 
@@ -87,6 +89,18 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
 
         advance_charges_invoice = customer.invoices.where(invoice_type: :advance_charges).sole
         expect(advance_charges_invoice.applied_taxes.count).to eq(2)
+
+        total_tax_1 = 0
+        total_tax_2 = 0
+        advance_charges_invoice.fees.flat_map(&:applied_taxes).each do |applied_tax|
+          if applied_tax.tax_code == "tax-1"
+            total_tax_1 += applied_tax.amount_cents
+          elsif applied_tax.tax_code == "tax-2"
+            total_tax_2 += applied_tax.amount_cents
+          end
+        end
+        expect(advance_charges_invoice.applied_taxes.find { _1.tax_code == "tax-1" }.amount_cents).to eq total_tax_1
+        expect(advance_charges_invoice.applied_taxes.find { _1.tax_code == "tax-2" }.amount_cents).to eq total_tax_2
       end
     end
   end

--- a/spec/scenarios/invoices/advance_charges_taxes_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_taxes_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Advance Charges Invoices Scenarios', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+  let(:tax_rate_1) { 9.3 }
+  let(:tax_rate_2) { 12 }
+  let(:billable_metric_cards) { create(:unique_count_billable_metric, organization:, code: 'cards', recurring: true) }
+  let(:billable_metric_transfer) { create(:sum_billable_metric, organization:, code: 'transfer', recurring: false) }
+  let(:plan) { create(:plan, organization:, pay_in_advance: true, amount_cents: 49) }
+  let(:external_subscription_id) { 'sub_' + SecureRandom.uuid }
+
+  def send_card_event!(item_id = SecureRandom.uuid)
+    send_event!(code: billable_metric_cards.code,item_id:)
+  end
+
+  def send_card_transfer!(item_id = SecureRandom.uuid)
+    send_event!(code: billable_metric_transfer.code,item_id:)
+  end
+
+  def send_event!(code:, item_id:)
+    create_event({
+      code:,
+      transaction_id: "tr_#{SecureRandom.hex(10)}",
+      external_customer_id: customer.external_id,
+      external_subscription_id:,
+      properties: {item_id:}
+    })
+  end
+
+  before do
+    create(:tax, organization:, rate: tax_rate_1)
+    create(:tax, organization:, rate: tax_rate_2)
+    create(:standard_charge, billable_metric: billable_metric_cards, regroup_paid_fees: 'invoice', pay_in_advance: true, invoiceable: false, prorated: true, plan:, properties: {amount: '30', grouped_by: nil})
+    create(:standard_charge, billable_metric: billable_metric_transfer, regroup_paid_fees: 'invoice', pay_in_advance: true, invoiceable: false, prorated: false, plan:, properties: {amount: '1', grouped_by: nil})
+  end
+
+  context 'when subscription is renewed' do
+    it 'generates an invoice with the correct charges' do
+      travel_to(DateTime.new(2024, 6, 5, 10)) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: external_subscription_id,
+            plan_code: plan.code
+          }
+        )
+        perform_billing
+      end
+
+      subscription = customer.subscriptions.sole
+
+      (1..3).each do |i|
+        travel_to(DateTime.new(2024, 6, 10 + i, 1)) do
+          send_card_event! "card_#{i}"
+          expect(subscription.fees.charge.where(invoice_id: nil).count).to eq(i)
+          created_fee = subscription.fees.charge.order(created_at: :desc).first
+
+          expect(created_fee.amount_cents).to eq((21 - i) * 100)
+          expect(created_fee.taxes_rate).to eq(tax_rate_1 + tax_rate_2)
+          expect(created_fee.applied_taxes.count).to eq(2)
+        end
+      end
+
+      travel_to(DateTime.new(2024, 6, 22, 1)) do
+        send_card_event! "transfer_1"
+        send_card_event! "transfer_2"
+        expect(subscription.fees.charge.where(invoice_id: nil).count).to eq(5)
+
+        fees = subscription.fees.charge.order(created_at: :desc).first(2)
+        fees.each do |fee|
+          expect(fee.applied_taxes.count).to eq(2)
+        end
+      end
+
+      expect(subscription.fees.charge.where(invoice_id: nil).count).to eq 5
+      subscription.fees.charge.order(created_at: :asc).update!(
+        payment_status: :succeeded,
+        succeeded_at: DateTime.new(2024, 6, 24)
+      )
+
+      travel_to(DateTime.new(2024, 7, 1, 0, 10)) do
+        perform_billing
+        expect(customer.invoices.count).to eq(3) # 2 subscription invoices, 1 advance_charges invoice
+
+        advance_charges_invoice = customer.invoices.where(invoice_type: :advance_charges).sole
+        expect(advance_charges_invoice.applied_taxes.count).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/scenarios/invoices/advance_charges_taxes_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_taxes_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Advance Charges Invoices Scenarios', :scenarios, type: :request do
+describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
   let(:tax_rate_1) { 9.3 }
   let(:tax_rate_2) { 12 }
-  let(:billable_metric_cards) { create(:unique_count_billable_metric, organization:, code: 'cards', recurring: true) }
-  let(:billable_metric_transfer) { create(:sum_billable_metric, organization:, code: 'transfer', recurring: false) }
+  let(:billable_metric_cards) { create(:unique_count_billable_metric, organization:, code: "cards", recurring: true) }
+  let(:billable_metric_transfer) { create(:sum_billable_metric, organization:, code: "transfer", recurring: false) }
   let(:plan) { create(:plan, organization:, pay_in_advance: true, amount_cents: 49) }
-  let(:external_subscription_id) { 'sub_' + SecureRandom.uuid }
+  let(:external_subscription_id) { "sub_" + SecureRandom.uuid }
 
   def send_card_event!(item_id = SecureRandom.uuid)
     send_event!(code: billable_metric_cards.code, item_id:)
@@ -33,12 +33,12 @@ describe 'Advance Charges Invoices Scenarios', :scenarios, type: :request do
   before do
     create(:tax, organization:, rate: tax_rate_1)
     create(:tax, organization:, rate: tax_rate_2)
-    create(:standard_charge, billable_metric: billable_metric_cards, regroup_paid_fees: 'invoice', pay_in_advance: true, invoiceable: false, prorated: true, plan:, properties: {amount: '30', grouped_by: nil})
-    create(:standard_charge, billable_metric: billable_metric_transfer, regroup_paid_fees: 'invoice', pay_in_advance: true, invoiceable: false, prorated: false, plan:, properties: {amount: '1', grouped_by: nil})
+    create(:standard_charge, billable_metric: billable_metric_cards, regroup_paid_fees: "invoice", pay_in_advance: true, invoiceable: false, prorated: true, plan:, properties: {amount: "30", grouped_by: nil})
+    create(:standard_charge, billable_metric: billable_metric_transfer, regroup_paid_fees: "invoice", pay_in_advance: true, invoiceable: false, prorated: false, plan:, properties: {amount: "1", grouped_by: nil})
   end
 
-  context 'when subscription is renewed' do
-    it 'generates an invoice with the correct charges' do
+  context "when subscription is renewed" do
+    it "generates an invoice with the correct charges" do
       travel_to(DateTime.new(2024, 6, 5, 10)) do
         create_subscription(
           {

--- a/spec/scenarios/invoices/advance_charges_taxes_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_taxes_spec.rb
@@ -13,11 +13,11 @@ describe 'Advance Charges Invoices Scenarios', :scenarios, type: :request do
   let(:external_subscription_id) { 'sub_' + SecureRandom.uuid }
 
   def send_card_event!(item_id = SecureRandom.uuid)
-    send_event!(code: billable_metric_cards.code,item_id:)
+    send_event!(code: billable_metric_cards.code, item_id:)
   end
 
   def send_card_transfer!(item_id = SecureRandom.uuid)
-    send_event!(code: billable_metric_transfer.code,item_id:)
+    send_event!(code: billable_metric_transfer.code, item_id:)
   end
 
   def send_event!(code:, item_id:)

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
           invoice_id: nil,
           subscription:,
           charge:,
-          amount_cents: 100,
+          amount_cents: 61,
+          taxes_amount_cents: 13,
           properties: fee_boundaries
         )
         create_list(:charge_fee, 2, :failed, invoice_id: nil, subscription:, charge:, amount_cents: 100, properties: fee_boundaries)
@@ -74,7 +75,7 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
           subscription:,
           charge:,
           properties: {
-            timestamp: (billing_at - 1.month).end_of_month + 1.day
+            timestamp: (billing_at - 1.month).end_of_month + 1.day # ??
           }
         )
 
@@ -87,7 +88,8 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
 
         expect(result.invoice.fees.count).to eq 3
 
-        expect(result.invoice.total_amount_cents).to eq(100 * 3 * (100 + tax_rate) / 100)
+        expect(result.invoice.total_amount_cents).to eq(61 * 3 + 13 * 3)
+        expect(result.invoice.taxes_amount_cents).to eq(13 * 3) # Sum of taxes in each paid fees
 
         expect(result.invoice).to be_finalized.and(have_attributes({
           invoice_type: "advance_charges",

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
       end
     end
 
-    context "when there is a successful non invoiceable paid in advance fees" do
+    context "when there are paid non invoiceable pay_in_advance fees" do
       let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
 
       let(:charge) do
@@ -169,11 +169,25 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
         create(
           :fee,
           :succeeded,
-          organization_id: organization.id,
+          organization:,
           succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days,
           invoice_id: nil,
           subscription: subscription_2,
-          amount_cents: 999,
+          amount_cents: 12,
+          taxes_amount_cents: 2,
+          properties: fee_boundaries,
+          charge:
+        )
+
+        create(
+          :fee,
+          :succeeded,
+          organization:,
+          succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days,
+          invoice_id: nil,
+          subscription: subscription_2,
+          amount_cents: 12,
+          taxes_amount_cents: 2,
           properties: fee_boundaries,
           charge:
         )
@@ -187,7 +201,10 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
         expect(result).to be_success
         expect(result.invoice).to be_a Invoice
         expect(result.invoice.fees.count).to eq 1
-        expect(result.invoice.total_amount_cents).to eq(paid_in_advance_fee.amount_cents)
+
+        expect(result.invoice.fees_amount_cents).to eq 24
+        expect(result.invoice.taxes_amount_cents).to eq 4
+        expect(result.invoice.total_amount_cents).to eq 28
 
         expect(result.invoice)
           .to be_finalized

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:tax_rate) { 20 }
+  let(:tax_rate) { 89 }
   let(:tax) { create(:tax, organization:, rate: tax_rate) }
 
   describe "#call" do
@@ -62,7 +62,7 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
           subscription:,
           charge:,
           amount_cents: 61,
-          taxes_amount_cents: 13,
+          taxes_amount_cents: 16,
           properties: fee_boundaries
         )
         create_list(:charge_fee, 2, :failed, invoice_id: nil, subscription:, charge:, amount_cents: 100, properties: fee_boundaries)
@@ -88,15 +88,15 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
 
         expect(result.invoice.fees.count).to eq 3
 
-        expect(result.invoice.total_amount_cents).to eq(61 * 3 + 13 * 3)
-        expect(result.invoice.taxes_amount_cents).to eq(13 * 3) # Sum of taxes in each paid fees
+        expect(result.invoice.total_amount_cents).to eq(61 * 3 + 16 * 3)
+        expect(result.invoice.taxes_amount_cents).to eq(16 * 3) # Sum of taxes in each paid fees
 
         expect(result.invoice).to be_finalized.and(have_attributes({
           invoice_type: "advance_charges",
           currency: "EUR",
           issuing_date: billing_at.to_date,
           skip_charges: true,
-          taxes_rate: tax_rate
+          taxes_rate: (16.0 * 100 / 61).round(2)
         }))
 
         expect(result.invoice.invoice_subscriptions.count).to eq(1)

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
       end
     end
 
-    context "when there are paid non invoiceable pay_in_advance fees" do
+    context "when there is a successful non invoiceable paid in advance fees" do
       let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }
 
       let(:charge) do
@@ -171,25 +171,12 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
         create(
           :fee,
           :succeeded,
-          organization:,
+          organization_id: organization.id,
           succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days,
           invoice_id: nil,
           subscription: subscription_2,
-          amount_cents: 12,
-          taxes_amount_cents: 2,
-          properties: fee_boundaries,
-          charge:
-        )
-
-        create(
-          :fee,
-          :succeeded,
-          organization:,
-          succeeded_at: fee_boundaries[:charges_to_datetime] - 2.days,
-          invoice_id: nil,
-          subscription: subscription_2,
-          amount_cents: 12,
-          taxes_amount_cents: 2,
+          amount_cents: 999,
+          taxes_amount_cents: 24,
           properties: fee_boundaries,
           charge:
         )
@@ -203,10 +190,9 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
         expect(result).to be_success
         expect(result.invoice).to be_a Invoice
         expect(result.invoice.fees.count).to eq 1
-
-        expect(result.invoice.fees_amount_cents).to eq 24
-        expect(result.invoice.taxes_amount_cents).to eq 4
-        expect(result.invoice.total_amount_cents).to eq 28
+        expect(result.invoice.total_amount_cents).to eq(999 + 24)
+        expect(result.invoice.taxes_amount_cents).to eq 24
+        expect(result.invoice.fees_amount_cents).to eq 999
 
         expect(result.invoice)
           .to be_finalized

--- a/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
+++ b/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Invoices::AggregateAmountsAndTaxesFromFees, type: :service do
     expect(invoice.fees_amount_cents).to eq(200 + 50 + 120)
     # if we compute taxes: 200 * 0.05 + 50 * 0.12 + 120 * 0.05 + 120 * 0.12 = 36.4
     # but this service sums already computed taxes
-    expect(invoice.taxes_amount_cents).to eq(33)
+    expect(invoice.taxes_amount_cents).to eq(9 + 1 + 23)
     expect(invoice.total_amount_cents).to eq(200 + 50 + 120 + 33)
     expect(invoice.sub_total_excluding_taxes_amount_cents).to eq invoice.fees_amount_cents
     expect(invoice.sub_total_including_taxes_amount_cents).to eq invoice.total_amount_cents

--- a/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
+++ b/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Invoices::AggregateAmountsAndTaxesFromFees, type: :service do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, customer:) }
+  let(:invoice) { create(:invoice, invoice_type: :advance_charges, customer:) }
   let(:tax_5) { create(:tax, rate: 5, name: 'VAT', description: 'VAT 5%', code: 'tax-1234') }
   let(:tax_12) { create(:tax, rate: 12, name: 'VAT', description: 'VAT 12%', code: 'tax-8901') }
 

--- a/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
+++ b/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Invoices::AggregateAmountsAndTaxesFromFees, type: :service do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, invoice_type: :advance_charges, customer:) }
-  let(:tax_5) { create(:tax, rate: 5, name: 'VAT', description: 'VAT 5%', code: 'tax-1234') }
-  let(:tax_12) { create(:tax, rate: 12, name: 'VAT', description: 'VAT 12%', code: 'tax-8901') }
+  let(:tax_5) { create(:tax, rate: 5, name: "VAT", description: "VAT 5%", code: "tax-1234") }
+  let(:tax_12) { create(:tax, rate: 12, name: "VAT", description: "VAT 12%", code: "tax-8901") }
 
   it do
     fee1 = create(:charge_fee, :succeeded, invoice:, amount_cents: 200, taxes_amount_cents: 9)

--- a/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
+++ b/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::AggregateAmountsAndTaxesFromFees, type: :service do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, customer:) }
+  let(:tax_5) { create(:tax, rate: 5, name: 'VAT', description: 'VAT 5%', code: 'tax-1234') }
+  let(:tax_12) { create(:tax, rate: 12, name: 'VAT', description: 'VAT 12%', code: 'tax-8901') }
+
+  it do
+    fee1 = create(:charge_fee, :succeeded, invoice:, amount_cents: 200, taxes_amount_cents: 9)
+    fee2 = create(:charge_fee, :succeeded, invoice:, amount_cents: 50, taxes_amount_cents: 1)
+    fee3 = create(:charge_fee, :succeeded, invoice:, amount_cents: 120, taxes_amount_cents: 23)
+
+    create(:fee_applied_tax, fee: fee1, tax: tax_5, tax_name: tax_5.name, tax_description: tax_5.description, tax_rate: tax_5.rate, amount_cents: 16)
+    create(:fee_applied_tax, fee: fee2, tax: tax_12, tax_name: tax_12.name, tax_description: tax_12.description, tax_rate: tax_12.rate, amount_cents: 2)
+    create(:fee_applied_tax, fee: fee3, tax: tax_5, tax_name: tax_5.name, tax_description: tax_5.description, tax_rate: tax_5.rate, amount_cents: 9)
+    create(:fee_applied_tax, fee: fee3, tax: tax_12, tax_name: tax_12.name, tax_description: tax_12.description, tax_rate: tax_12.rate, amount_cents: 11)
+
+    described_class.call(invoice:)
+
+    expect(invoice.fees_amount_cents).to eq(200 + 50 + 120)
+    # if we compute taxes: 200 * 0.05 + 50 * 0.12 + 120 * 0.05 + 120 * 0.12 = 36.4
+    # but this service sums already computed taxes
+    expect(invoice.taxes_amount_cents).to eq(33)
+    expect(invoice.total_amount_cents).to eq(200 + 50 + 120 + 33)
+    expect(invoice.sub_total_excluding_taxes_amount_cents).to eq invoice.fees_amount_cents
+    expect(invoice.sub_total_including_taxes_amount_cents).to eq invoice.total_amount_cents
+
+    expect(invoice.applied_taxes.count).to eq 2
+    applied_tax_5 = invoice.applied_taxes.find { |at| at.tax_code == tax_5.code }
+    expect(applied_tax_5.tax_name).to eq tax_5.name
+    expect(applied_tax_5.tax_description).to eq tax_5.description
+    expect(applied_tax_5.tax_rate).to eq tax_5.rate
+    expect(applied_tax_5.amount_cents).to eq(9 + 16)
+
+    applied_tax_12 = invoice.applied_taxes.find { |at| at.tax_code == tax_12.code }
+    expect(applied_tax_12.tax_name).to eq tax_12.name
+    expect(applied_tax_12.tax_description).to eq tax_12.description
+    expect(applied_tax_12.tax_rate).to eq tax_12.rate
+    expect(applied_tax_12.amount_cents).to eq(2 + 11)
+  end
+end


### PR DESCRIPTION
## Context

Using Fees with the following attributes, you will get an invoice at the end of the period that regroups all PAID fees.
* pay_in_advance: true
* invoiceable: false
* regroup_paid_fees: 'invoice'

## Description

The taxes on these fees are computed for each fee. The final invoice should show the amount of taxes actually paid, not the amount of taxes that would have been paid if the fees were paid at once in a single invoice invoice.

**Example**

Fee 1:
* amount_cents: 12
* taxes: 20%
* taxes_amount_cents: 2.4 rounded to 2

Fee 2:
* amount_cents: 12
* taxes: 20%
* taxes_amount_cents: 2.4 rounded to 2

Final invoice:
* 2 fees 
* fees_amount_cents: 24 (12 * 2)
* taxes_amount_cents: **4 if you sum the existing fees, but 20% of 24 is 4.8, rounded to 5**
* total_amount_cents: 28 with this PR (actually paid taxes) but 29 before. There is 1 cent invoiced but not collected.