### PR TITLE
bug(GracePeriod) - Make grace period update async for increased reliability

### DIFF
--- a/app/jobs/invoices/update_all_invoice_grace_period_from_organization_job.rb
+++ b/app/jobs/invoices/update_all_invoice_grace_period_from_organization_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Invoices
+  class UpdateAllInvoiceGracePeriodFromOrganizationJob < ApplicationJob
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_BILLING'])
+        :billing
+      else
+        :invoices
+      end
+    end
+
+    def perform(organization, old_grace_period)
+      Invoices::UpdateAllInvoiceGracePeriodFromOrganizationService.call!(organization:, old_grace_period:)
+    end
+  end
+end

--- a/app/jobs/invoices/update_grace_period_from_organization_job.rb
+++ b/app/jobs/invoices/update_grace_period_from_organization_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Invoices
+  class UpdateGracePeriodFromOrganizationJob < ApplicationJob
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_BILLING'])
+        :billing
+      else
+        :invoices
+      end
+    end
+
+    def perform(invoice, old_grace_period)
+      Invoices::UpdateGracePeriodFromOrganizationService.call!(invoice:, old_grace_period:)
+    end
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -477,6 +477,7 @@ end
 # Table name: invoices
 #
 #  id                                      :uuid             not null, primary key
+#  applied_grace_period                    :integer
 #  coupons_amount_cents                    :bigint           default(0), not null
 #  credit_notes_amount_cents               :bigint           default(0), not null
 #  currency                                :string

--- a/app/services/invoices/update_all_invoice_grace_period_from_organization_service.rb
+++ b/app/services/invoices/update_all_invoice_grace_period_from_organization_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Invoices
+  class UpdateAllInvoiceGracePeriodFromOrganizationService < BaseService
+    def initialize(organization:, old_grace_period:)
+      @organization = organization
+      @old_grace_period = old_grace_period
+
+      super
+    end
+
+    def call
+      organization.invoices.draft.find_each do |invoice|
+        Invoices::UpdateGracePeriodFromOrganizationJob.perform_later(invoice:, old_grace_period:)
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :organization, :old_grace_period
+  end
+end

--- a/app/services/invoices/update_all_invoice_grace_period_from_organization_service.rb
+++ b/app/services/invoices/update_all_invoice_grace_period_from_organization_service.rb
@@ -11,7 +11,7 @@ module Invoices
 
     def call
       organization.invoices.draft.find_each do |invoice|
-        Invoices::UpdateGracePeriodFromOrganizationJob.perform_later(invoice:, old_grace_period:)
+        Invoices::UpdateGracePeriodFromOrganizationJob.perform_later(invoice, old_grace_period)
       end
 
       result

--- a/app/services/invoices/update_grace_period_from_organization_service.rb
+++ b/app/services/invoices/update_grace_period_from_organization_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Invoices
+  class UpdateGracePeriodFromOrganizationService < BaseService
+    Result = BaseResult[:invoice]
+
+    def initialize(invoice:, old_grace_period:)
+      @invoice = invoice
+      @old_grace_period = old_grace_period
+      super
+    end
+
+    def call
+      result.invoice = invoice
+      # only update issuing_date when there is no override on customer
+      return result if invoice.customer.invoice_grace_period.present?
+      return result if !invoice.draft?
+
+      new_grace_period = invoice.organization.invoice_grace_period
+      # Idempotency! if the applied_grace_period is already the same, we should not update the dates
+      return result if invoice.applied_grace_period == new_grace_period
+
+      grace_period_diff = new_grace_period - old_grace_period
+
+      invoice.issuing_date = invoice.issuing_date + grace_period_diff.days
+      invoice.applied_grace_period = new_grace_period
+      invoice.payment_due_date = invoice.issuing_date + invoice.customer.applicable_net_payment_term.days
+      invoice.save!
+
+      result
+    end
+
+    private
+
+    attr_reader :invoice, :old_grace_period
+  end
+end

--- a/app/services/organizations/update_invoice_grace_period_service.rb
+++ b/app/services/organizations/update_invoice_grace_period_service.rb
@@ -15,7 +15,7 @@ module Organizations
         organization.invoice_grace_period = grace_period
         organization.save!
 
-        Invoices::UpdateAllInvoiceGracePeriodFromOrganizationJob.perform_later(organization:, old_grace_period:)
+        Invoices::UpdateAllInvoiceGracePeriodFromOrganizationJob.perform_later(organization, old_grace_period)
       end
 
       result.organization = organization

--- a/db/migrate/20250207094842_add_applied_grace_period_to_invoices.rb
+++ b/db/migrate/20250207094842_add_applied_grace_period_to_invoices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAppliedGracePeriodToInvoices < ActiveRecord::Migration[7.1]
+  def change
+    add_column :invoices, :applied_grace_period, :integer
+  end
+end

--- a/db/migrate/20250207142402_backfill_applied_grace_period_on_draft_invoices.rb
+++ b/db/migrate/20250207142402_backfill_applied_grace_period_on_draft_invoices.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class BackfillAppliedGracePeriodOnDraftInvoices < ActiveRecord::Migration[7.1]
+  def up
+    update_query = <<~SQL
+      with inv as (
+        select invoices.id, COALESCE(customers.invoice_grace_period, organizations.invoice_grace_period) as grace_period
+        from invoices
+        INNER JOIN organizations ON organizations.id = invoices.organization_id
+        INNER JOIN customers ON customers.id = invoices.customer_id
+        where status = 0 -- draft
+      )
+      update invoices
+      set applied_grace_period = inv.grace_period
+      from inv
+      where invoices.id = inv.id
+    SQL
+
+    safety_assured { execute(update_query) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_07_094842) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_07_142402) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_05_184611) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_07_094842) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -941,6 +941,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_05_184611) do
     t.enum "tax_status", enum_type: "tax_status"
     t.bigint "total_paid_amount_cents", default: 0, null: false
     t.boolean "self_billed", default: false, null: false
+    t.integer "applied_grace_period"
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["issuing_date"], name: "index_invoices_on_issuing_date"

--- a/spec/jobs/invoices/update_all_invoice_grace_period_from_organization_job_spec.rb
+++ b/spec/jobs/invoices/update_all_invoice_grace_period_from_organization_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::UpdateAllInvoiceGracePeriodFromOrganizationJob, type: :job do
+  subject { described_class.perform_now(organization, old_grace_period) }
+
+  let(:organization) { create(:organization) }
+  let(:old_grace_period) { 1 }
+
+  it "calls the service" do
+    allow(Invoices::UpdateAllInvoiceGracePeriodFromOrganizationService).to receive(:call).with(organization:, old_grace_period:).and_call_original
+
+    subject
+
+    expect(Invoices::UpdateAllInvoiceGracePeriodFromOrganizationService).to have_received(:call)
+  end
+end

--- a/spec/jobs/invoices/update_grace_period_from_organization_job_spec.rb
+++ b/spec/jobs/invoices/update_grace_period_from_organization_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::UpdateGracePeriodFromOrganizationJob, type: :job do
+  subject { described_class.perform_now(invoice, old_grace_period) }
+
+  let(:invoice) { create(:invoice) }
+  let(:old_grace_period) { 1 }
+
+  it "calls the service" do
+    allow(Invoices::UpdateGracePeriodFromOrganizationService).to receive(:call).with(invoice:, old_grace_period:).and_call_original
+
+    subject
+
+    expect(Invoices::UpdateGracePeriodFromOrganizationService).to have_received(:call)
+  end
+end

--- a/spec/services/invoices/update_all_invoice_grace_period_from_organization_service_spec.rb
+++ b/spec/services/invoices/update_all_invoice_grace_period_from_organization_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::UpdateAllInvoiceGracePeriodFromOrganizationService do
+  subject { described_class.new(organization:, old_grace_period:) }
+
+  let(:organization) { create(:organization) }
+  let(:old_grace_period) { 12 }
+
+  context "without draft invoices" do
+    it "enqueues zero jobs" do
+      expect { subject.call }.not_to enqueue_job(Invoices::UpdateGracePeriodFromOrganizationJob)
+    end
+  end
+
+  context "with draft invoice present" do
+    let(:draft_invoice) { create(:invoice, :draft, organization:) }
+
+    before { draft_invoice }
+
+    it "enqueues 1 job for the draft invoice" do
+      expect { subject.call }.to enqueue_job(Invoices::UpdateGracePeriodFromOrganizationJob)
+        .with(invoice: draft_invoice, old_grace_period:)
+    end
+
+    context "with finalized invoice present" do
+      let(:finalized_invoice) { create(:invoice, :finalized, organization:) }
+
+      before { finalized_invoice }
+
+      it "enqueues 1 job for the draft invoice" do
+        expect { subject.call }.to enqueue_job(Invoices::UpdateGracePeriodFromOrganizationJob)
+          .with(invoice: draft_invoice, old_grace_period:)
+      end
+    end
+  end
+end

--- a/spec/services/invoices/update_all_invoice_grace_period_from_organization_service_spec.rb
+++ b/spec/services/invoices/update_all_invoice_grace_period_from_organization_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Invoices::UpdateAllInvoiceGracePeriodFromOrganizationService do
 
     it "enqueues 1 job for the draft invoice" do
       expect { subject.call }.to enqueue_job(Invoices::UpdateGracePeriodFromOrganizationJob)
-        .with(invoice: draft_invoice, old_grace_period:)
+        .with(draft_invoice, old_grace_period)
     end
 
     context "with finalized invoice present" do
@@ -31,7 +31,7 @@ RSpec.describe Invoices::UpdateAllInvoiceGracePeriodFromOrganizationService do
 
       it "enqueues 1 job for the draft invoice" do
         expect { subject.call }.to enqueue_job(Invoices::UpdateGracePeriodFromOrganizationJob)
-          .with(invoice: draft_invoice, old_grace_period:)
+          .with(draft_invoice, old_grace_period)
       end
     end
   end

--- a/spec/services/invoices/update_grace_period_from_organization_service_spec.rb
+++ b/spec/services/invoices/update_grace_period_from_organization_service_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::UpdateGracePeriodFromOrganizationService do
+  subject { described_class.new(invoice:, old_grace_period:) }
+
+  let(:invoice) { create(:invoice, :draft, issuing_date:, payment_due_date:, applied_grace_period: 12) }
+
+  let(:issuing_date) { Time.current + old_grace_period.days }
+  let(:payment_due_date) { issuing_date }
+
+  let(:old_grace_period) { 12 }
+
+  let(:new_grace_period) { 1 }
+
+  before do
+    invoice.organization.update invoice_grace_period: new_grace_period
+  end
+
+  context "when invoice grace period comes from the customer" do
+    before do
+      invoice.customer.update(invoice_grace_period: 12)
+    end
+
+    it "does not change the issuing_date" do
+      expect { subject.call }.not_to change(invoice, :issuing_date)
+    end
+
+    it "does not change the applied_grace_period" do
+      expect { subject.call }.not_to change(invoice, :applied_grace_period)
+    end
+  end
+
+  context "when new grace period is equal to the already applied one" do
+    before do
+      invoice.update applied_grace_period: new_grace_period
+    end
+
+    it "does not change the issuing_date" do
+      expect { subject.call }.not_to change(invoice, :issuing_date)
+    end
+
+    it "does not change the applied_grace_period" do
+      expect { subject.call }.not_to change(invoice, :applied_grace_period)
+    end
+  end
+
+  context "when invoice is not draft" do
+    before do
+      invoice.finalized!
+    end
+
+    it "does not change the issuing_date" do
+      expect { subject.call }.not_to change(invoice, :issuing_date)
+    end
+
+    it "does not change the applied_grace_period" do
+      expect { subject.call }.not_to change(invoice, :applied_grace_period)
+    end
+  end
+
+  context "when going from 12 to 15 days" do
+    let(:new_grace_period) { 15 }
+
+    it "changes the issuing_date by 3 days" do
+      expect { subject.call }.to change(invoice, :issuing_date).by(3)
+    end
+
+    it "changes the applied_grace_to 15" do
+      expect { subject.call }.to change(invoice, :applied_grace_period).to(15)
+    end
+
+    it "changes the payment_due_date by 3 days" do
+      expect { subject.call }.to change(invoice, :payment_due_date).by(3)
+    end
+  end
+
+  context "when going from 12 to 9 days" do
+    let(:new_grace_period) { 9 }
+
+    it "changes the issuing_date by 3 days" do
+      expect { subject.call }.to change(invoice, :issuing_date).by(-3)
+    end
+
+    it "changes the applied_grace_to 9" do
+      expect { subject.call }.to change(invoice, :applied_grace_period).to(9)
+    end
+
+    it "changes the payment_due_date by 3 days" do
+      expect { subject.call }.to change(invoice, :payment_due_date).by(-3)
+    end
+  end
+end


### PR DESCRIPTION
## Description

The grace period update service was not built to deal with many (>100k) draft invoices. This means that some issuing_dates could be set incorrectly if the request timed out. This PR moves the update to an asynchronous job.

For idempotency reasons it's important to store the applied_grace_period on the invoice, this way we can be certain that we're not running the job twice.
