### PR TITLE
feat: added PaymentRequestMailer on rescue

### DIFF
--- a/app/services/payment_requests/payments/create_service.rb
+++ b/app/services/payment_requests/payments/create_service.rb
@@ -63,6 +63,7 @@ module PaymentRequests
 
         result
       rescue BaseService::ServiceFailure => e
+        PaymentRequestMailer.with(payment_request: payable).requested.deliver_later
         result.payment = e.result.payment
         deliver_error_webhook(e.result)
         update_payable_payment_status(payment_status: e.result.payment.payable_payment_status)

--- a/spec/services/payment_requests/payments/create_service_spec.rb
+++ b/spec/services/payment_requests/payments/create_service_spec.rb
@@ -359,6 +359,8 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
               error_code: "code"
             }
           ).on_queue(webhook_queue)
+          .and have_enqueued_mail(PaymentRequestMailer, :requested)
+          .with(params: {payment_request:}, args: [])
       end
 
       context "when payment has a payable_payment_status" do


### PR DESCRIPTION
## Context
In some cases, payment failure emails were not being sent when the BaseService::ServiceFailure was raised during payment processing. This was causing missed notifications for failed payment attempts

## Description
Ensured that PaymentRequestMailer.with(payment_request: payable).requested.deliver_later is called both when a payment fails and when a ServiceFailure is raised