### PR TITLE
fix: Remove tax cache from invoice preview

### DIFF
--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -152,7 +152,7 @@ module Invoices
     end
 
     def apply_provider_taxes
-      taxes_result = fetch_provider_taxes
+      taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:, fees: invoice.fees)
 
       if taxes_result.success?
         result.fees_taxes = taxes_result.fees
@@ -175,10 +175,6 @@ module Invoices
     def apply_zero_tax
       invoice.taxes_amount_cents = 0
       invoice.taxes_rate = 0
-    end
-
-    def fetch_provider_taxes
-      Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:, fees: invoice.fees)
     end
 
     def provider_taxation?

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -157,7 +157,7 @@ module Invoices
       if taxes_result.success?
         result.fees_taxes = taxes_result.fees
         invoice.fees.each do |fee|
-          fee_taxes = result.fees_taxes.find { |item| item.item_id == fee.id }
+          fee_taxes = result.fees_taxes.find { |item| item.item_key == fee.item_key }
 
           res = Fees::ApplyProviderTaxesService.call(fee:, fee_taxes:)
           res.raise_if_error!

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -221,13 +221,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         context 'with provider taxes' do
           let(:integration) { create(:anrok_integration, organization:) }
           let(:integration_customer) { build(:anrok_customer, integration:, customer:) }
-          let(:response) { instance_double(Net::HTTPOK) }
-          let(:lago_client) { instance_double(LagoHttpClient::Client) }
           let(:endpoint) { 'https://api.nango.dev/v1/anrok/draft_invoices' }
-          let(:body) do
-            p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
-            File.read(p)
-          end
           let(:integration_collection_mapping) do
             create(
               :netsuite_collection_mapping,
@@ -240,34 +234,49 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
           before do
             integration_collection_mapping
             customer.integration_customers = [integration_customer]
-
-            allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
-            allow(lago_client).to receive(:post_with_response).and_return(response)
-            allow(response).to receive(:body).and_return(body)
-            allow_any_instance_of(Fee).to receive(:id).and_return('lago_fee_id') # rubocop:disable RSpec/AnyInstance
           end
 
-          it 'creates preview invoice for 2 days' do
-            travel_to(timestamp) do
-              result = preview_service.call
+          context 'when there is no error' do
+            before do
+              stub_request(:post, endpoint).to_return do |request|
+                response = JSON.parse(File.read(
+                  Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
+                ))
 
-              expect(result).to be_success
-              expect(result.invoice.subscriptions.first).to eq(subscription)
-              expect(result.invoice.fees.length).to eq(1)
-              expect(result.invoice.invoice_type).to eq('subscription')
-              expect(result.invoice.issuing_date.to_s).to eq('2024-04-01')
-              expect(result.invoice.fees_amount_cents).to eq(6)
-              expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(6)
-              expect(result.invoice.taxes_amount_cents).to eq(1) # 6 x 0.1
-              expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(7)
-              expect(result.invoice.total_amount_cents).to eq(7)
+                # setting item_id based on the test example
+                key = JSON.parse(request.body).first['fees'].last['item_key']
+                response['succeededInvoices'].first['fees'].last['item_key'] = key
+
+                {body: response.to_json}
+              end
+            end
+
+            it 'creates preview invoice for 2 days' do
+              travel_to(timestamp) do
+                result = preview_service.call
+
+                expect(result).to be_success
+                expect(result.invoice.subscriptions.first).to eq(subscription)
+                expect(result.invoice.fees.length).to eq(1)
+                expect(result.invoice.invoice_type).to eq('subscription')
+                expect(result.invoice.issuing_date.to_s).to eq('2024-04-01')
+                expect(result.invoice.fees_amount_cents).to eq(6)
+                expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(6)
+                expect(result.invoice.taxes_amount_cents).to eq(1) # 6 x 0.1
+                expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(7)
+                expect(result.invoice.total_amount_cents).to eq(7)
+              end
             end
           end
 
           context 'when there is error received from the provider' do
-            let(:body) do
-              p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
-              File.read(p)
+            before do
+              stub_request(:post, endpoint).to_return do |request|
+                response = File.read(
+                  Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+                )
+                {body: response}
+              end
             end
 
             it 'uses zero taxes' do

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -287,26 +287,6 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               end
             end
           end
-
-          context 'with rails cache' do
-            let(:customer) { create(:customer, organization:) }
-
-            before { Rails.cache.clear }
-
-            it 'uses the Rails cache' do
-              travel_to(timestamp) do
-                key = [
-                  'preview-taxes',
-                  customer.id,
-                  plan.updated_at.iso8601
-                ].join('/')
-
-                expect do
-                  preview_service.call
-                end.to change { Rails.cache.exist?(key) }.from(false).to(true)
-              end
-            end
-          end
         end
       end
 


### PR DESCRIPTION
Some clients want to override address in preview feature. Address is one of the parameters that determine tax and we decided to always fetch fresh taxes in preview feature