### PR TITLE
chore(GraphQL): rename invoice subscription attribute

### DIFF
--- a/app/graphql/types/invoice_subscriptions/object.rb
+++ b/app/graphql/types/invoice_subscriptions/object.rb
@@ -23,7 +23,7 @@ module Types
       field :from_datetime, GraphQL::Types::ISO8601DateTime, null: true
       field :to_datetime, GraphQL::Types::ISO8601DateTime, null: true
 
-      field :accept_new_fees, Boolean, null: false
+      field :accept_new_charge_fees, Boolean, null: false
 
       def in_advance_charges_from_datetime
         return nil unless should_use_in_advance_charges_interval

--- a/schema.graphql
+++ b/schema.graphql
@@ -4671,7 +4671,7 @@ enum InvoiceStatusTypeEnum {
 }
 
 type InvoiceSubscription {
-  acceptNewFees: Boolean!
+  acceptNewChargeFees: Boolean!
   chargeAmountCents: BigInt!
   chargesFromDatetime: ISO8601DateTime
   chargesToDatetime: ISO8601DateTime

--- a/schema.json
+++ b/schema.json
@@ -22542,7 +22542,7 @@
           "possibleTypes": null,
           "fields": [
             {
-              "name": "acceptNewFees",
+              "name": "acceptNewChargeFees",
               "description": null,
               "type": {
                 "kind": "NON_NULL",

--- a/spec/graphql/types/invoice_subscriptions/object_spec.rb
+++ b/spec/graphql/types/invoice_subscriptions/object_spec.rb
@@ -23,5 +23,5 @@ RSpec.describe Types::InvoiceSubscriptions::Object do
   it { is_expected.to have_field(:from_datetime).of_type("ISO8601DateTime") }
   it { is_expected.to have_field(:to_datetime).of_type("ISO8601DateTime") }
 
-  it { is_expected.to have_field(:accept_new_fees).of_type("Boolean!") }
+  it { is_expected.to have_field(:accept_new_charge_fees).of_type("Boolean!") }
 end


### PR DESCRIPTION
## Context

We recently added a new attribute on GraphQL that combines a new field with a new associated definition.

The two were named differently tho.

## Description

This PR makes sure we have the same name on the field and it's associated method.

c.f. https://github.com/getlago/lago-api/pull/3152