### PR TITLE
bug(Event): Propagate expression evaluation failure 

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -120,6 +120,10 @@ class BaseService
       !failure
     end
 
+    def failure?
+      failure
+    end
+
     def fail_with_error!(error)
       @failure = true
       @error = error

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -21,7 +21,8 @@ module Events
       event.timestamp = Time.zone.at(params[:timestamp] ? Float(params[:timestamp]) : timestamp)
       event.precise_total_amount_cents = params[:precise_total_amount_cents]
 
-      CalculateExpressionService.call(organization:, event:).raise_if_error!
+      expression_result = CalculateExpressionService.call(organization:, event:)
+      return result.validation_failure!(errors: expression_result.error.message) unless expression_result.success?
 
       event.save! unless organization.clickhouse_events_store?
 

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -170,6 +170,25 @@ RSpec.describe Events::CreateService, type: :service do
         expect(result).to be_success
         expect(result.event.properties["result"]).to eq("3.0")
       end
+
+      context "when not all the event properties are not provided" do
+        let(:create_args) do
+          {
+            external_subscription_id:,
+            code:,
+            transaction_id:,
+            precise_total_amount_cents:,
+            properties: {},
+            timestamp:
+          }
+        end
+
+        it "returns a service failure when the expression fails to evaluate" do
+          result = create_service.call
+
+          expect(result).to be_failure
+        end
+      end
     end
 
     context 'with a precise_total_amount_cents' do


### PR DESCRIPTION
## Description

Currently /api/v1/events fails with a 500 error due to incomplete error propagation.
This PR addresses this by propagating the error as a validation error.

