### PR TITLE
New `remove_branding_watermark` Premium addons

### DIFF
--- a/app/controllers/dev_tools/invoices_controller.rb
+++ b/app/controllers/dev_tools/invoices_controller.rb
@@ -7,7 +7,7 @@ module DevTools
 
       # For PDFs we need to use a simple file name and the file is passed to `gotenberg`
       # In order to reuse the exact same template to display in HTML, we replace the image path
-      html = service.render_html.gsub!('src="lago-logo-invoice.png', 'src="/assets/images/lago-logo-invoice.png')
+      html = service.render_html.gsub('src="lago-logo-invoice.png', 'src="/assets/images/lago-logo-invoice.png')
 
       render(html: html.html_safe) # rubocop:disable Rails/OutputSafety
     end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -8,6 +8,7 @@ class ApplicationMailer < ActionMailer::Base
   before_action :set_shared_variables
 
   def set_shared_variables
+    @show_lago_logo = true
     @lago_logo_url = "https://assets.getlago.com/lago-logo-email.png"
   end
 end

--- a/app/mailers/credit_note_mailer.rb
+++ b/app/mailers/credit_note_mailer.rb
@@ -7,6 +7,7 @@ class CreditNoteMailer < ApplicationMailer
     @credit_note = params[:credit_note]
     @organization = @credit_note.organization
     @customer = @credit_note.customer
+    @show_lago_logo = !@organization.remove_branding_watermark_enabled?
 
     return if @organization.email.blank?
     return if @customer.email.blank?

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -7,6 +7,7 @@ class InvoiceMailer < ApplicationMailer
     @invoice = params[:invoice]
     @organization = @invoice.organization
     @customer = @invoice.customer
+    @show_lago_logo = !@organization.remove_branding_watermark_enabled?
 
     return if @organization.email.blank?
     return if @customer.email.blank?

--- a/app/mailers/payment_request_mailer.rb
+++ b/app/mailers/payment_request_mailer.rb
@@ -6,6 +6,7 @@ class PaymentRequestMailer < ApplicationMailer
   def requested
     @payment_request = params[:payment_request]
     @organization = @payment_request.organization
+    @show_lago_logo = !@organization.remove_branding_watermark_enabled?
 
     return if @payment_request.email.blank?
     return if @organization.email.blank?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -75,6 +75,7 @@ class Organization < ApplicationRecord
     api_permissions
     revenue_share
     zero_amount_fees
+    remove_branding_watermark
   ].freeze
   PREMIUM_INTEGRATIONS = INTEGRATIONS - %w[anrok]
 

--- a/app/views/layouts/mailer.slim
+++ b/app/views/layouts/mailer.slim
@@ -67,9 +67,11 @@ html
                               | &nbsp;
                               a style="text-decoration: none; color: #006cfa" href="mailto:#{@organization.email}"
                                 = @organization.email
-                table cellpadding="0" cellspacing="0" style="margin: auto; padding-top: 32px"
-                  tr
-                    td style="font-size: 12px; font-weight: 400; line-height: 16px; letter-spacing: 0em; text-align: center; color: #8c95a6; padding-right: 4px;"
-                      = I18n.t('email.powered_by')
-                    td style="padding-right: 4px; padding-top: 2px"
-                      img src="#{@lago_logo_url}" style="width: 40px; height: 12px;" width="40" height="12" alt="Lago Logo"
+
+                - if @show_lago_logo
+                  table cellpadding="0" cellspacing="0" style="margin: auto; padding-top: 32px"
+                    tr
+                      td style="font-size: 12px; font-weight: 400; line-height: 16px; letter-spacing: 0em; text-align: center; color: #8c95a6; padding-right: 4px;"
+                        = I18n.t('email.powered_by')
+                      td style="padding-right: 4px; padding-top: 2px"
+                        img src="#{@lago_logo_url}" style="width: 40px; height: 12px;" width="40" height="12" alt="Lago Logo"

--- a/app/views/templates/credit_notes/_powered_by_logo.slim
+++ b/app/views/templates/credit_notes/_powered_by_logo.slim
@@ -1,0 +1,5 @@
+- unless organization.remove_branding_watermark_enabled?
+  .powered-by
+    span.body-2
+      | #{I18n.t('credit_note.powered_by')} &nbsp;
+    img src="#{::SlimHelper::PDF_LOGO_FILENAME}" alt="Lago Logo"

--- a/app/views/templates/credit_notes/credit_note.slim
+++ b/app/views/templates/credit_notes/credit_note.slim
@@ -95,7 +95,4 @@ html
       == SlimHelper.render('templates/credit_notes/_eu_tax_management', self)
       p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
 
-      .powered-by
-        span.body-2
-          | #{I18n.t('credit_note.powered_by')} &nbsp;
-        img src="#{::SlimHelper::PDF_LOGO_FILENAME}" alt="Lago Logo"
+      == SlimHelper.render('templates/credit_notes/_powered_by_logo', self)

--- a/app/views/templates/credit_notes/self_billed.slim
+++ b/app/views/templates/credit_notes/self_billed.slim
@@ -95,7 +95,4 @@ html
 
       p.body-3.mb-24 = LineBreakHelper.break_lines(I18n.t("credit_note.self_billed.footer"))
 
-      .powered-by
-        span.body-2
-          | #{I18n.t('credit_note.powered_by')} &nbsp;
-        img src="#{::SlimHelper::PDF_LOGO_FILENAME}" alt="Lago Logo"
+      == SlimHelper.render('templates/credit_notes/_powered_by_logo', self)

--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -471,10 +471,7 @@ html
 
       p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
 
-      .powered-by
-        span.body-2
-          | #{I18n.t('invoice.powered_by')} &nbsp;
-        img src="#{::SlimHelper::PDF_LOGO_FILENAME}" alt="Lago Logo"
+      == SlimHelper.render('templates/invoices/v4/_powered_by_logo', self)
 
       - if subscriptions.count > 1
         == SlimHelper.render('templates/invoices/v4/_subscription_details', self)

--- a/app/views/templates/invoices/v4/_powered_by_logo.slim
+++ b/app/views/templates/invoices/v4/_powered_by_logo.slim
@@ -1,0 +1,5 @@
+- unless organization.remove_branding_watermark_enabled?
+  .powered-by
+    span.body-2
+      | #{I18n.t('invoice.powered_by')} &nbsp;
+    img src="#{::SlimHelper::PDF_LOGO_FILENAME}" alt="Lago Logo"

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -565,7 +565,4 @@ html
 
       p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
 
-      .powered-by
-        span.body-2
-          | #{I18n.t('invoice.powered_by')} &nbsp;
-        img src="#{::SlimHelper::PDF_LOGO_FILENAME}" alt="Lago Logo"
+      == SlimHelper.render('templates/invoices/v4/_powered_by_logo', self)

--- a/app/views/templates/invoices/v4/one_off.slim
+++ b/app/views/templates/invoices/v4/one_off.slim
@@ -423,7 +423,5 @@ html
         == SlimHelper.render('templates/invoices/v4/_custom_sections', self)
 
       p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
-      .powered-by
-        span.body-2
-          | #{I18n.t('invoice.powered_by')} &nbsp;
-        img src="#{::SlimHelper::PDF_LOGO_FILENAME}" alt="Lago Logo"
+
+      == SlimHelper.render('templates/invoices/v4/_powered_by_logo', self)

--- a/app/views/templates/invoices/v4/self_billed.slim
+++ b/app/views/templates/invoices/v4/self_billed.slim
@@ -474,10 +474,7 @@ html
 
       p.body-3.mb-24 = LineBreakHelper.break_lines(I18n.t("invoice.self_billed.footer"))
 
-      .powered-by
-        span.body-2
-          | #{I18n.t('invoice.powered_by')} &nbsp;
-        img src="#{::SlimHelper::PDF_LOGO_FILENAME}" alt="Lago Logo"
+      == SlimHelper.render('templates/invoices/v4/_powered_by_logo', self)
 
       - if subscriptions.count > 1
         == SlimHelper.render('templates/invoices/v4/_subscription_details', self)

--- a/schema.graphql
+++ b/schema.graphql
@@ -4451,6 +4451,7 @@ enum IntegrationTypeEnum {
   netsuite
   okta
   progressive_billing
+  remove_branding_watermark
   revenue_analytics
   revenue_share
   salesforce
@@ -6438,6 +6439,7 @@ enum PremiumIntegrationTypeEnum {
   netsuite
   okta
   progressive_billing
+  remove_branding_watermark
   revenue_analytics
   revenue_share
   salesforce

--- a/schema.json
+++ b/schema.json
@@ -20592,6 +20592,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "remove_branding_watermark",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -30647,6 +30653,12 @@
             },
             {
               "name": "zero_amount_fees",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "remove_branding_watermark",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null


### PR DESCRIPTION
## Context

Lago adds a logo at the bottom of invoices and emails.

## Description

This premium addon allows Lago users to remove the Lago branding from customer facing invoice and emails.

## Screenshots


![CleanShot 2025-02-10 at 12 14 19@2x](https://github.com/user-attachments/assets/b23abf87-1d12-446f-ab30-ad4dfb3b0853)

![CleanShot 2025-02-10 at 12 07 19@2x](https://github.com/user-attachments/assets/4ccd64a4-f294-4742-b40e-1cbcca5e4249)
![CleanShot 2025-02-10 at 12 06 42@2x](https://github.com/user-attachments/assets/0d0e8598-54a6-48c0-b119-755bd031b0aa)
![CleanShot 2025-02-10 at 13 08 58@2x](https://github.com/user-attachments/assets/548fe32d-804f-4234-b937-c86bfe7e4403)
![CleanShot 2025-02-10 at 13 07 32@2x](https://github.com/user-attachments/assets/374a8e3c-646c-4aa1-ad00-57a2088ad089)
![CleanShot 2025-02-10 at 13 06 22@2x](https://github.com/user-attachments/assets/b6dad30f-a128-41c5-921d-d1881fe7868b)
