### PR TITLE
chore(spec): group scattered it blocks for Graphql Types

### DIFF
--- a/spec/graphql/types/add_ons/create_input_spec.rb
+++ b/spec/graphql/types/add_ons/create_input_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::AddOns::CreateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to accept_argument(:amount_currency).of_type('CurrencyEnum!') }
-  it { is_expected.to accept_argument(:code).of_type('String!') }
-  it { is_expected.to accept_argument(:description).of_type('String') }
-  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
-  it { is_expected.to accept_argument(:name).of_type('String!') }
-  it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
+  it do
+    expect(subject).to accept_argument(:amount_cents).of_type('BigInt!')
+    expect(subject).to accept_argument(:amount_currency).of_type('CurrencyEnum!')
+    expect(subject).to accept_argument(:code).of_type('String!')
+    expect(subject).to accept_argument(:description).of_type('String')
+    expect(subject).to accept_argument(:invoice_display_name).of_type('String')
+    expect(subject).to accept_argument(:name).of_type('String!')
+    expect(subject).to accept_argument(:tax_codes).of_type('[String!]')
+  end
 end

--- a/spec/graphql/types/add_ons/object_spec.rb
+++ b/spec/graphql/types/add_ons/object_spec.rb
@@ -5,19 +5,21 @@ require 'rails_helper'
 RSpec.describe Types::AddOns::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:organization).of_type('Organization') }
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:description).of_type('String') }
-  it { is_expected.to have_field(:invoice_display_name).of_type('String') }
-  it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:amount_currency).of_type('CurrencyEnum!') }
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:deleted_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:applied_add_ons_count).of_type('Int!') }
-  it { is_expected.to have_field(:customers_count).of_type('Int!') }
-  it { is_expected.to have_field(:taxes).of_type('[Tax!]') }
-  it { is_expected.to have_field(:integration_mappings).of_type('[Mapping!]') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:organization).of_type('Organization')
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:description).of_type('String')
+    expect(subject).to have_field(:invoice_display_name).of_type('String')
+    expect(subject).to have_field(:name).of_type('String!')
+    expect(subject).to have_field(:amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:amount_currency).of_type('CurrencyEnum!')
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:deleted_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:applied_add_ons_count).of_type('Int!')
+    expect(subject).to have_field(:customers_count).of_type('Int!')
+    expect(subject).to have_field(:taxes).of_type('[Tax!]')
+    expect(subject).to have_field(:integration_mappings).of_type('[Mapping!]')
+  end
 end

--- a/spec/graphql/types/add_ons/update_input_spec.rb
+++ b/spec/graphql/types/add_ons/update_input_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 RSpec.describe Types::AddOns::UpdateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to accept_argument(:amount_currency).of_type('CurrencyEnum!') }
-  it { is_expected.to accept_argument(:code).of_type('String!') }
-  it { is_expected.to accept_argument(:description).of_type('String') }
-  it { is_expected.to accept_argument(:id).of_type('ID!') }
-  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
-  it { is_expected.to accept_argument(:name).of_type('String!') }
-  it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
+  it do
+    expect(subject).to accept_argument(:amount_cents).of_type('BigInt!')
+    expect(subject).to accept_argument(:amount_currency).of_type('CurrencyEnum!')
+    expect(subject).to accept_argument(:code).of_type('String!')
+    expect(subject).to accept_argument(:description).of_type('String')
+    expect(subject).to accept_argument(:id).of_type('ID!')
+    expect(subject).to accept_argument(:invoice_display_name).of_type('String')
+    expect(subject).to accept_argument(:name).of_type('String!')
+    expect(subject).to accept_argument(:tax_codes).of_type('[String!]')
+  end
 end

--- a/spec/graphql/types/adjusted_fees/create_input_spec.rb
+++ b/spec/graphql/types/adjusted_fees/create_input_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 RSpec.describe Types::AdjustedFees::CreateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:invoice_id).of_type('ID!') }
-  it { is_expected.to accept_argument(:fee_id).of_type('ID') }
-  it { is_expected.to accept_argument(:charge_id).of_type('ID') }
-  it { is_expected.to accept_argument(:charge_filter_id).of_type('ID') }
-  it { is_expected.to accept_argument(:subscription_id).of_type('ID') }
-  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
-  it { is_expected.to accept_argument(:unit_precise_amount).of_type('String') }
-  it { is_expected.to accept_argument(:units).of_type('Float') }
+  it do
+    expect(subject).to accept_argument(:invoice_id).of_type('ID!')
+    expect(subject).to accept_argument(:fee_id).of_type('ID')
+    expect(subject).to accept_argument(:charge_id).of_type('ID')
+    expect(subject).to accept_argument(:charge_filter_id).of_type('ID')
+    expect(subject).to accept_argument(:subscription_id).of_type('ID')
+    expect(subject).to accept_argument(:invoice_display_name).of_type('String')
+    expect(subject).to accept_argument(:unit_precise_amount).of_type('String')
+    expect(subject).to accept_argument(:units).of_type('Float')
+  end
 end

--- a/spec/graphql/types/analytics/gross_revenues/object_spec.rb
+++ b/spec/graphql/types/analytics/gross_revenues/object_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe Types::Analytics::GrossRevenues::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:month).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt') }
-  it { is_expected.to have_field(:currency).of_type('CurrencyEnum') }
+  it do
+    expect(subject).to have_field(:month).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:amount_cents).of_type('BigInt')
+    expect(subject).to have_field(:currency).of_type('CurrencyEnum')
+  end
 end

--- a/spec/graphql/types/analytics/invoice_collections/object_spec.rb
+++ b/spec/graphql/types/analytics/invoice_collections/object_spec.rb
@@ -5,9 +5,11 @@ require 'rails_helper'
 RSpec.describe Types::Analytics::InvoiceCollections::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:month).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:payment_status).of_type('InvoicePaymentStatusTypeEnum') }
-  it { is_expected.to have_field(:invoices_count).of_type('BigInt!') }
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:currency).of_type('CurrencyEnum') }
+  it do
+    expect(subject).to have_field(:month).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:payment_status).of_type('InvoicePaymentStatusTypeEnum')
+    expect(subject).to have_field(:invoices_count).of_type('BigInt!')
+    expect(subject).to have_field(:amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:currency).of_type('CurrencyEnum')
+  end
 end

--- a/spec/graphql/types/analytics/invoiced_usages/object_spec.rb
+++ b/spec/graphql/types/analytics/invoiced_usages/object_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 RSpec.describe Types::Analytics::InvoicedUsages::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:month).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:code).of_type('String') }
-  it { is_expected.to have_field(:currency).of_type('CurrencyEnum!') }
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
+  it do
+    expect(subject).to have_field(:month).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:code).of_type('String')
+    expect(subject).to have_field(:currency).of_type('CurrencyEnum!')
+    expect(subject).to have_field(:amount_cents).of_type('BigInt!')
+  end
 end

--- a/spec/graphql/types/analytics/mrrs/object_spec.rb
+++ b/spec/graphql/types/analytics/mrrs/object_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe Types::Analytics::Mrrs::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:month).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt') }
-  it { is_expected.to have_field(:currency).of_type('CurrencyEnum') }
+  it do
+    expect(subject).to have_field(:month).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:amount_cents).of_type('BigInt')
+    expect(subject).to have_field(:currency).of_type('CurrencyEnum')
+  end
 end

--- a/spec/graphql/types/analytics/overdue_balances/object_spec.rb
+++ b/spec/graphql/types/analytics/overdue_balances/object_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 RSpec.describe Types::Analytics::OverdueBalances::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:currency).of_type('CurrencyEnum!') }
-  it { is_expected.to have_field(:lago_invoice_ids).of_type('[String!]!') }
-  it { is_expected.to have_field(:month).of_type('ISO8601DateTime!') }
+  it do
+    expect(subject).to have_field(:amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:currency).of_type('CurrencyEnum!')
+    expect(subject).to have_field(:lago_invoice_ids).of_type('[String!]!')
+    expect(subject).to have_field(:month).of_type('ISO8601DateTime!')
+  end
 end

--- a/spec/graphql/types/api_keys/object_spec.rb
+++ b/spec/graphql/types/api_keys/object_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::ApiKeys::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:name).of_type('String') }
-  it { is_expected.to have_field(:permissions).of_type('JSON!') }
-  it { is_expected.to have_field(:value).of_type('String!') }
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:expires_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:last_used_at).of_type('ISO8601DateTime') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:name).of_type('String')
+    expect(subject).to have_field(:permissions).of_type('JSON!')
+    expect(subject).to have_field(:value).of_type('String!')
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:expires_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:last_used_at).of_type('ISO8601DateTime')
+  end
 end

--- a/spec/graphql/types/api_keys/rotate_input_spec.rb
+++ b/spec/graphql/types/api_keys/rotate_input_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe Types::ApiKeys::RotateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID!') }
-  it { is_expected.to accept_argument(:name).of_type('String') }
-  it { is_expected.to accept_argument(:expires_at).of_type('ISO8601DateTime') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('ID!')
+    expect(subject).to accept_argument(:name).of_type('String')
+    expect(subject).to accept_argument(:expires_at).of_type('ISO8601DateTime')
+  end
 end

--- a/spec/graphql/types/api_keys/sanitized_object_spec.rb
+++ b/spec/graphql/types/api_keys/sanitized_object_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::ApiKeys::SanitizedObject do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:name).of_type('String') }
-  it { is_expected.to have_field(:permissions).of_type('JSON!') }
-  it { is_expected.to have_field(:value).of_type('String!') }
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:expires_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:last_used_at).of_type('ISO8601DateTime') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:name).of_type('String')
+    expect(subject).to have_field(:permissions).of_type('JSON!')
+    expect(subject).to have_field(:value).of_type('String!')
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:expires_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:last_used_at).of_type('ISO8601DateTime')
+  end
 end

--- a/spec/graphql/types/api_keys/update_input_spec.rb
+++ b/spec/graphql/types/api_keys/update_input_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe Types::ApiKeys::UpdateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID!') }
-  it { is_expected.to accept_argument(:name).of_type('String') }
-  it { is_expected.to accept_argument(:permissions).of_type('JSON') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('ID!')
+    expect(subject).to accept_argument(:name).of_type('String')
+    expect(subject).to accept_argument(:permissions).of_type('JSON')
+  end
 end

--- a/spec/graphql/types/billable_metric_filters/input_spec.rb
+++ b/spec/graphql/types/billable_metric_filters/input_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Types::BillableMetricFilters::Input do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:key).of_type('String!') }
-  it { is_expected.to accept_argument(:values).of_type('[String!]!') }
+  it do
+    expect(subject).to accept_argument(:key).of_type('String!')
+    expect(subject).to accept_argument(:values).of_type('[String!]!')
+  end
 end

--- a/spec/graphql/types/billable_metric_filters/object_spec.rb
+++ b/spec/graphql/types/billable_metric_filters/object_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe Types::BillableMetricFilters::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:key).of_type('String!') }
-  it { is_expected.to have_field(:values).of_type('[String!]!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:key).of_type('String!')
+    expect(subject).to have_field(:values).of_type('[String!]!')
+  end
 end

--- a/spec/graphql/types/billable_metrics/create_input_spec.rb
+++ b/spec/graphql/types/billable_metrics/create_input_spec.rb
@@ -5,15 +5,17 @@ require 'rails_helper'
 RSpec.describe Types::BillableMetrics::CreateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:aggregation_type).of_type('AggregationTypeEnum!') }
-  it { is_expected.to accept_argument(:code).of_type('String!') }
-  it { is_expected.to accept_argument(:description).of_type('String!') }
-  it { is_expected.to accept_argument(:expression).of_type('String') }
-  it { is_expected.to accept_argument(:field_name).of_type('String') }
-  it { is_expected.to accept_argument(:name).of_type('String!') }
-  it { is_expected.to accept_argument(:recurring).of_type('Boolean') }
-  it { is_expected.to accept_argument(:rounding_function).of_type('RoundingFunctionEnum') }
-  it { is_expected.to accept_argument(:rounding_precision).of_type('Int') }
-  it { is_expected.to accept_argument(:weighted_interval).of_type('WeightedIntervalEnum') }
-  it { is_expected.to accept_argument(:filters).of_type('[BillableMetricFiltersInput!]') }
+  it do
+    expect(subject).to accept_argument(:aggregation_type).of_type('AggregationTypeEnum!')
+    expect(subject).to accept_argument(:code).of_type('String!')
+    expect(subject).to accept_argument(:description).of_type('String!')
+    expect(subject).to accept_argument(:expression).of_type('String')
+    expect(subject).to accept_argument(:field_name).of_type('String')
+    expect(subject).to accept_argument(:name).of_type('String!')
+    expect(subject).to accept_argument(:recurring).of_type('Boolean')
+    expect(subject).to accept_argument(:rounding_function).of_type('RoundingFunctionEnum')
+    expect(subject).to accept_argument(:rounding_precision).of_type('Int')
+    expect(subject).to accept_argument(:weighted_interval).of_type('WeightedIntervalEnum')
+    expect(subject).to accept_argument(:filters).of_type('[BillableMetricFiltersInput!]')
+  end
 end

--- a/spec/graphql/types/billable_metrics/object_spec.rb
+++ b/spec/graphql/types/billable_metrics/object_spec.rb
@@ -5,25 +5,27 @@ require 'rails_helper'
 RSpec.describe Types::BillableMetrics::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:organization).of_type('Organization') }
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:description).of_type('String') }
-  it { is_expected.to have_field(:aggregation_type).of_type('AggregationTypeEnum!') }
-  it { is_expected.to have_field(:expression).of_type('String') }
-  it { is_expected.to have_field(:field_name).of_type('String') }
-  it { is_expected.to have_field(:weighted_interval).of_type('WeightedIntervalEnum') }
-  it { is_expected.to have_field(:filters).of_type('[BillableMetricFilter!]') }
-  it { is_expected.to have_field(:active_subscriptions_count).of_type('Int!') }
-  it { is_expected.to have_field(:draft_invoices_count).of_type('Int!') }
-  it { is_expected.to have_field(:plans_count).of_type('Int!') }
-  it { is_expected.to have_field(:recurring).of_type('Boolean!') }
-  it { is_expected.to have_field(:subscriptions_count).of_type('Int!') }
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:deleted_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:integration_mappings).of_type('[Mapping!]') }
-  it { is_expected.to have_field(:rounding_function).of_type('RoundingFunctionEnum') }
-  it { is_expected.to have_field(:rounding_precision).of_type('Int') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:organization).of_type('Organization')
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:name).of_type('String!')
+    expect(subject).to have_field(:description).of_type('String')
+    expect(subject).to have_field(:aggregation_type).of_type('AggregationTypeEnum!')
+    expect(subject).to have_field(:expression).of_type('String')
+    expect(subject).to have_field(:field_name).of_type('String')
+    expect(subject).to have_field(:weighted_interval).of_type('WeightedIntervalEnum')
+    expect(subject).to have_field(:filters).of_type('[BillableMetricFilter!]')
+    expect(subject).to have_field(:active_subscriptions_count).of_type('Int!')
+    expect(subject).to have_field(:draft_invoices_count).of_type('Int!')
+    expect(subject).to have_field(:plans_count).of_type('Int!')
+    expect(subject).to have_field(:recurring).of_type('Boolean!')
+    expect(subject).to have_field(:subscriptions_count).of_type('Int!')
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:deleted_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:integration_mappings).of_type('[Mapping!]')
+    expect(subject).to have_field(:rounding_function).of_type('RoundingFunctionEnum')
+    expect(subject).to have_field(:rounding_precision).of_type('Int')
+  end
 end

--- a/spec/graphql/types/billable_metrics/update_input_spec.rb
+++ b/spec/graphql/types/billable_metrics/update_input_spec.rb
@@ -5,16 +5,18 @@ require 'rails_helper'
 RSpec.describe Types::BillableMetrics::UpdateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('String!') }
-  it { is_expected.to accept_argument(:aggregation_type).of_type('AggregationTypeEnum!') }
-  it { is_expected.to accept_argument(:code).of_type('String!') }
-  it { is_expected.to accept_argument(:description).of_type('String!') }
-  it { is_expected.to accept_argument(:expression).of_type('String') }
-  it { is_expected.to accept_argument(:field_name).of_type('String') }
-  it { is_expected.to accept_argument(:name).of_type('String!') }
-  it { is_expected.to accept_argument(:recurring).of_type('Boolean') }
-  it { is_expected.to accept_argument(:rounding_function).of_type('RoundingFunctionEnum') }
-  it { is_expected.to accept_argument(:rounding_precision).of_type('Int') }
-  it { is_expected.to accept_argument(:weighted_interval).of_type('WeightedIntervalEnum') }
-  it { is_expected.to accept_argument(:filters).of_type('[BillableMetricFiltersInput!]') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('String!')
+    expect(subject).to accept_argument(:aggregation_type).of_type('AggregationTypeEnum!')
+    expect(subject).to accept_argument(:code).of_type('String!')
+    expect(subject).to accept_argument(:description).of_type('String!')
+    expect(subject).to accept_argument(:expression).of_type('String')
+    expect(subject).to accept_argument(:field_name).of_type('String')
+    expect(subject).to accept_argument(:name).of_type('String!')
+    expect(subject).to accept_argument(:recurring).of_type('Boolean')
+    expect(subject).to accept_argument(:rounding_function).of_type('RoundingFunctionEnum')
+    expect(subject).to accept_argument(:rounding_precision).of_type('Int')
+    expect(subject).to accept_argument(:weighted_interval).of_type('WeightedIntervalEnum')
+    expect(subject).to accept_argument(:filters).of_type('[BillableMetricFiltersInput!]')
+  end
 end

--- a/spec/graphql/types/charge_filters/input_spec.rb
+++ b/spec/graphql/types/charge_filters/input_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe Types::ChargeFilters::Input do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
-  it { is_expected.to accept_argument(:properties).of_type('PropertiesInput!') }
-  it { is_expected.to accept_argument(:values).of_type('ChargeFilterValues!') }
+  it do
+    expect(subject).to accept_argument(:invoice_display_name).of_type('String')
+    expect(subject).to accept_argument(:properties).of_type('PropertiesInput!')
+    expect(subject).to accept_argument(:values).of_type('ChargeFilterValues!')
+  end
 end

--- a/spec/graphql/types/charge_filters/object_spec.rb
+++ b/spec/graphql/types/charge_filters/object_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 RSpec.describe Types::ChargeFilters::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:invoice_display_name).of_type('String') }
-  it { is_expected.to have_field(:properties).of_type('Properties!') }
-  it { is_expected.to have_field(:values).of_type('ChargeFilterValues!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:invoice_display_name).of_type('String')
+    expect(subject).to have_field(:properties).of_type('Properties!')
+    expect(subject).to have_field(:values).of_type('ChargeFilterValues!')
+  end
 end

--- a/spec/graphql/types/charges/input_spec.rb
+++ b/spec/graphql/types/charges/input_spec.rb
@@ -5,18 +5,20 @@ require 'rails_helper'
 RSpec.describe Types::Charges::Input do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:billable_metric_id).of_type('ID!') }
-  it { is_expected.to accept_argument(:charge_model).of_type('ChargeModelEnum!') }
-  it { is_expected.to accept_argument(:id).of_type('ID') }
-  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
-  it { is_expected.to accept_argument(:invoiceable).of_type('Boolean') }
-  it { is_expected.to accept_argument(:min_amount_cents).of_type('BigInt') }
-  it { is_expected.to accept_argument(:pay_in_advance).of_type('Boolean') }
-  it { is_expected.to accept_argument(:prorated).of_type('Boolean') }
-  it { is_expected.to accept_argument(:regroup_paid_fees).of_type('RegroupPaidFeesEnum') }
+  it do
+    expect(subject).to accept_argument(:billable_metric_id).of_type('ID!')
+    expect(subject).to accept_argument(:charge_model).of_type('ChargeModelEnum!')
+    expect(subject).to accept_argument(:id).of_type('ID')
+    expect(subject).to accept_argument(:invoice_display_name).of_type('String')
+    expect(subject).to accept_argument(:invoiceable).of_type('Boolean')
+    expect(subject).to accept_argument(:min_amount_cents).of_type('BigInt')
+    expect(subject).to accept_argument(:pay_in_advance).of_type('Boolean')
+    expect(subject).to accept_argument(:prorated).of_type('Boolean')
+    expect(subject).to accept_argument(:regroup_paid_fees).of_type('RegroupPaidFeesEnum')
 
-  it { is_expected.to accept_argument(:filters).of_type('[ChargeFilterInput!]') }
-  it { is_expected.to accept_argument(:properties).of_type('PropertiesInput') }
+    expect(subject).to accept_argument(:filters).of_type('[ChargeFilterInput!]')
+    expect(subject).to accept_argument(:properties).of_type('PropertiesInput')
 
-  it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
+    expect(subject).to accept_argument(:tax_codes).of_type('[String!]')
+  end
 end

--- a/spec/graphql/types/charges/object_spec.rb
+++ b/spec/graphql/types/charges/object_spec.rb
@@ -5,19 +5,21 @@ require 'rails_helper'
 RSpec.describe Types::Charges::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:invoice_display_name).of_type('String') }
-  it { is_expected.to have_field(:billable_metric).of_type('BillableMetric!') }
-  it { is_expected.to have_field(:charge_model).of_type('ChargeModelEnum!') }
-  it { is_expected.to have_field(:regroup_paid_fees).of_type('RegroupPaidFeesEnum') }
-  it { is_expected.to have_field(:invoiceable).of_type('Boolean!') }
-  it { is_expected.to have_field(:min_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:pay_in_advance).of_type('Boolean!') }
-  it { is_expected.to have_field(:properties).of_type('Properties') }
-  it { is_expected.to have_field(:prorated).of_type('Boolean!') }
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:deleted_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:taxes).of_type('[Tax!]') }
-  it { is_expected.to have_field(:filters).of_type('[ChargeFilter!]') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:invoice_display_name).of_type('String')
+    expect(subject).to have_field(:billable_metric).of_type('BillableMetric!')
+    expect(subject).to have_field(:charge_model).of_type('ChargeModelEnum!')
+    expect(subject).to have_field(:regroup_paid_fees).of_type('RegroupPaidFeesEnum')
+    expect(subject).to have_field(:invoiceable).of_type('Boolean!')
+    expect(subject).to have_field(:min_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:pay_in_advance).of_type('Boolean!')
+    expect(subject).to have_field(:properties).of_type('Properties')
+    expect(subject).to have_field(:prorated).of_type('Boolean!')
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:deleted_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:taxes).of_type('[Tax!]')
+    expect(subject).to have_field(:filters).of_type('[ChargeFilter!]')
+  end
 end

--- a/spec/graphql/types/charges/properties_input_spec.rb
+++ b/spec/graphql/types/charges/properties_input_spec.rb
@@ -5,24 +5,26 @@ require 'rails_helper'
 RSpec.describe Types::Charges::PropertiesInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:amount).of_type('String') }
-  it { is_expected.to accept_argument(:grouped_by).of_type('[String!]') }
+  it do
+    expect(subject).to accept_argument(:amount).of_type('String')
+    expect(subject).to accept_argument(:grouped_by).of_type('[String!]')
 
-  it { is_expected.to accept_argument(:graduated_ranges).of_type('[GraduatedRangeInput!]') }
+    expect(subject).to accept_argument(:graduated_ranges).of_type('[GraduatedRangeInput!]')
 
-  it { is_expected.to accept_argument(:graduated_percentage_ranges).of_type('[GraduatedPercentageRangeInput!]') }
+    expect(subject).to accept_argument(:graduated_percentage_ranges).of_type('[GraduatedPercentageRangeInput!]')
 
-  it { is_expected.to accept_argument(:free_units).of_type('BigInt') }
-  it { is_expected.to accept_argument(:package_size).of_type('BigInt') }
+    expect(subject).to accept_argument(:free_units).of_type('BigInt')
+    expect(subject).to accept_argument(:package_size).of_type('BigInt')
 
-  it { is_expected.to accept_argument(:fixed_amount).of_type('String') }
-  it { is_expected.to accept_argument(:free_units_per_events).of_type('BigInt') }
-  it { is_expected.to accept_argument(:free_units_per_total_aggregation).of_type('String') }
-  it { is_expected.to accept_argument(:per_transaction_max_amount).of_type('String') }
-  it { is_expected.to accept_argument(:per_transaction_min_amount).of_type('String') }
-  it { is_expected.to accept_argument(:rate).of_type('String') }
+    expect(subject).to accept_argument(:fixed_amount).of_type('String')
+    expect(subject).to accept_argument(:free_units_per_events).of_type('BigInt')
+    expect(subject).to accept_argument(:free_units_per_total_aggregation).of_type('String')
+    expect(subject).to accept_argument(:per_transaction_max_amount).of_type('String')
+    expect(subject).to accept_argument(:per_transaction_min_amount).of_type('String')
+    expect(subject).to accept_argument(:rate).of_type('String')
 
-  it { is_expected.to accept_argument(:volume_ranges).of_type('[VolumeRangeInput!]') }
+    expect(subject).to accept_argument(:volume_ranges).of_type('[VolumeRangeInput!]')
 
-  it { is_expected.to accept_argument(:custom_properties).of_type('JSON') }
+    expect(subject).to accept_argument(:custom_properties).of_type('JSON')
+  end
 end

--- a/spec/graphql/types/charges/properties_spec.rb
+++ b/spec/graphql/types/charges/properties_spec.rb
@@ -5,24 +5,26 @@ require 'rails_helper'
 RSpec.describe Types::Charges::Properties do
   subject { described_class }
 
-  it { is_expected.to have_field(:amount).of_type('String') }
-  it { is_expected.to have_field(:grouped_by).of_type('[String!]') }
+  it do
+    expect(subject).to have_field(:amount).of_type('String')
+    expect(subject).to have_field(:grouped_by).of_type('[String!]')
 
-  it { is_expected.to have_field(:graduated_ranges).of_type('[GraduatedRange!]') }
+    expect(subject).to have_field(:graduated_ranges).of_type('[GraduatedRange!]')
 
-  it { is_expected.to have_field(:graduated_percentage_ranges).of_type('[GraduatedPercentageRange!]') }
+    expect(subject).to have_field(:graduated_percentage_ranges).of_type('[GraduatedPercentageRange!]')
 
-  it { is_expected.to have_field(:free_units).of_type('BigInt') }
-  it { is_expected.to have_field(:package_size).of_type('BigInt') }
+    expect(subject).to have_field(:free_units).of_type('BigInt')
+    expect(subject).to have_field(:package_size).of_type('BigInt')
 
-  it { is_expected.to have_field(:fixed_amount).of_type('String') }
-  it { is_expected.to have_field(:free_units_per_events).of_type('BigInt') }
-  it { is_expected.to have_field(:free_units_per_total_aggregation).of_type('String') }
-  it { is_expected.to have_field(:per_transaction_max_amount).of_type('String') }
-  it { is_expected.to have_field(:per_transaction_min_amount).of_type('String') }
-  it { is_expected.to have_field(:rate).of_type('String') }
+    expect(subject).to have_field(:fixed_amount).of_type('String')
+    expect(subject).to have_field(:free_units_per_events).of_type('BigInt')
+    expect(subject).to have_field(:free_units_per_total_aggregation).of_type('String')
+    expect(subject).to have_field(:per_transaction_max_amount).of_type('String')
+    expect(subject).to have_field(:per_transaction_min_amount).of_type('String')
+    expect(subject).to have_field(:rate).of_type('String')
 
-  it { is_expected.to have_field(:volume_ranges).of_type('[VolumeRange!]') }
+    expect(subject).to have_field(:volume_ranges).of_type('[VolumeRange!]')
 
-  it { is_expected.to have_field(:custom_properties).of_type('JSON') }
+    expect(subject).to have_field(:custom_properties).of_type('JSON')
+  end
 end

--- a/spec/graphql/types/commitments/input_spec.rb
+++ b/spec/graphql/types/commitments/input_spec.rb
@@ -5,9 +5,11 @@ require 'rails_helper'
 RSpec.describe Types::Commitments::Input do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID') }
-  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
-  it { is_expected.to accept_argument(:amount_cents).of_type('BigInt') }
-  it { is_expected.to accept_argument(:commitment_type).of_type('CommitmentTypeEnum') }
-  it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('ID')
+    expect(subject).to accept_argument(:invoice_display_name).of_type('String')
+    expect(subject).to accept_argument(:amount_cents).of_type('BigInt')
+    expect(subject).to accept_argument(:commitment_type).of_type('CommitmentTypeEnum')
+    expect(subject).to accept_argument(:tax_codes).of_type('[String!]')
+  end
 end

--- a/spec/graphql/types/commitments/object_spec.rb
+++ b/spec/graphql/types/commitments/object_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 RSpec.describe Types::Commitments::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:commitment_type).of_type('CommitmentTypeEnum!') }
-  it { is_expected.to have_field(:invoice_display_name).of_type('String') }
-  it { is_expected.to have_field(:plan).of_type('Plan!') }
-  it { is_expected.to have_field(:taxes).of_type('[Tax!]') }
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:commitment_type).of_type('CommitmentTypeEnum!')
+    expect(subject).to have_field(:invoice_display_name).of_type('String')
+    expect(subject).to have_field(:plan).of_type('Plan!')
+    expect(subject).to have_field(:taxes).of_type('[Tax!]')
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
+  end
 end

--- a/spec/graphql/types/credit_note_items/estimate_spec.rb
+++ b/spec/graphql/types/credit_note_items/estimate_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Types::CreditNoteItems::Estimate do
   subject { described_class }
 
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:fee).of_type('Fee!') }
+  it do
+    expect(subject).to have_field(:amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:fee).of_type('Fee!')
+  end
 end

--- a/spec/graphql/types/credit_notes/estimate_spec.rb
+++ b/spec/graphql/types/credit_notes/estimate_spec.rb
@@ -5,13 +5,15 @@ require 'rails_helper'
 RSpec.describe Types::CreditNotes::Estimate do
   subject { described_class }
 
-  it { is_expected.to have_field(:currency).of_type('CurrencyEnum!') }
-  it { is_expected.to have_field(:taxes_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:sub_total_excluding_taxes_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:max_creditable_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:max_refundable_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:coupons_adjustment_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:taxes_rate).of_type('Float!') }
-  it { is_expected.to have_field(:items).of_type('[CreditNoteItemEstimate!]!') }
-  it { is_expected.to have_field(:applied_taxes).of_type('[CreditNoteAppliedTax!]!') }
+  it do
+    expect(subject).to have_field(:currency).of_type('CurrencyEnum!')
+    expect(subject).to have_field(:taxes_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:sub_total_excluding_taxes_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:max_creditable_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:max_refundable_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:coupons_adjustment_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:taxes_rate).of_type('Float!')
+    expect(subject).to have_field(:items).of_type('[CreditNoteItemEstimate!]!')
+    expect(subject).to have_field(:applied_taxes).of_type('[CreditNoteAppliedTax!]!')
+  end
 end

--- a/spec/graphql/types/credit_notes/object_spec.rb
+++ b/spec/graphql/types/credit_notes/object_spec.rb
@@ -5,43 +5,45 @@ require 'rails_helper'
 RSpec.describe Types::CreditNotes::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:number).of_type('String!') }
-  it { is_expected.to have_field(:sequential_id).of_type('ID!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:number).of_type('String!')
+    expect(subject).to have_field(:sequential_id).of_type('ID!')
 
-  it { is_expected.to have_field(:issuing_date).of_type('ISO8601Date!') }
+    expect(subject).to have_field(:issuing_date).of_type('ISO8601Date!')
 
-  it { is_expected.to have_field(:description).of_type('String') }
-  it { is_expected.to have_field(:reason).of_type('CreditNoteReasonEnum!') }
+    expect(subject).to have_field(:description).of_type('String')
+    expect(subject).to have_field(:reason).of_type('CreditNoteReasonEnum!')
 
-  it { is_expected.to have_field(:credit_status).of_type('CreditNoteCreditStatusEnum') }
-  it { is_expected.to have_field(:refund_status).of_type('CreditNoteRefundStatusEnum') }
+    expect(subject).to have_field(:credit_status).of_type('CreditNoteCreditStatusEnum')
+    expect(subject).to have_field(:refund_status).of_type('CreditNoteRefundStatusEnum')
 
-  it { is_expected.to have_field(:currency).of_type('CurrencyEnum!') }
-  it { is_expected.to have_field(:taxes_rate).of_type('Float!') }
+    expect(subject).to have_field(:currency).of_type('CurrencyEnum!')
+    expect(subject).to have_field(:taxes_rate).of_type('Float!')
 
-  it { is_expected.to have_field(:balance_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:coupons_adjustment_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:credit_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:refund_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:sub_total_excluding_taxes_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:taxes_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:total_amount_cents).of_type('BigInt!') }
+    expect(subject).to have_field(:balance_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:coupons_adjustment_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:credit_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:refund_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:sub_total_excluding_taxes_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:taxes_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:total_amount_cents).of_type('BigInt!')
 
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:refunded_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:voided_at).of_type('ISO8601DateTime') }
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:refunded_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:voided_at).of_type('ISO8601DateTime')
 
-  it { is_expected.to have_field(:file_url).of_type('String') }
+    expect(subject).to have_field(:file_url).of_type('String')
 
-  it { is_expected.to have_field(:applied_taxes).of_type('[CreditNoteAppliedTax!]') }
-  it { is_expected.to have_field(:customer).of_type('Customer!') }
-  it { is_expected.to have_field(:invoice).of_type('Invoice') }
-  it { is_expected.to have_field(:items).of_type('[CreditNoteItem!]!') }
+    expect(subject).to have_field(:applied_taxes).of_type('[CreditNoteAppliedTax!]')
+    expect(subject).to have_field(:customer).of_type('Customer!')
+    expect(subject).to have_field(:invoice).of_type('Invoice')
+    expect(subject).to have_field(:items).of_type('[CreditNoteItem!]!')
 
-  it { is_expected.to have_field(:can_be_voided).of_type('Boolean!') }
+    expect(subject).to have_field(:can_be_voided).of_type('Boolean!')
 
-  it { is_expected.to have_field(:external_integration_id).of_type('String') }
-  it { is_expected.to have_field(:integration_syncable).of_type('Boolean!') }
+    expect(subject).to have_field(:external_integration_id).of_type('String')
+    expect(subject).to have_field(:integration_syncable).of_type('Boolean!')
+  end
 end

--- a/spec/graphql/types/customer_portal/customers/object_spec.rb
+++ b/spec/graphql/types/customer_portal/customers/object_spec.rb
@@ -5,31 +5,33 @@ require "rails_helper"
 RSpec.describe Types::CustomerPortal::Customers::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type("ID!") }
+  it do
+    expect(subject).to have_field(:id).of_type("ID!")
 
-  it { is_expected.to have_field(:account_type).of_type("CustomerAccountTypeEnum!") }
-  it { is_expected.to have_field(:applicable_timezone).of_type("TimezoneEnum!") }
-  it { is_expected.to have_field(:currency).of_type("CurrencyEnum") }
-  it { is_expected.to have_field(:customer_type).of_type("CustomerTypeEnum") }
-  it { is_expected.to have_field(:display_name).of_type("String!") }
-  it { is_expected.to have_field(:firstname).of_type("String") }
-  it { is_expected.to have_field(:lastname).of_type("String") }
-  it { is_expected.to have_field(:name).of_type("String") }
-  it { is_expected.to have_field(:email).of_type("String") }
-  it { is_expected.to have_field(:legal_name).of_type("String") }
-  it { is_expected.to have_field(:legal_number).of_type("String") }
-  it { is_expected.to have_field(:tax_identification_number).of_type("String") }
+    expect(subject).to have_field(:account_type).of_type("CustomerAccountTypeEnum!")
+    expect(subject).to have_field(:applicable_timezone).of_type("TimezoneEnum!")
+    expect(subject).to have_field(:currency).of_type("CurrencyEnum")
+    expect(subject).to have_field(:customer_type).of_type("CustomerTypeEnum")
+    expect(subject).to have_field(:display_name).of_type("String!")
+    expect(subject).to have_field(:firstname).of_type("String")
+    expect(subject).to have_field(:lastname).of_type("String")
+    expect(subject).to have_field(:name).of_type("String")
+    expect(subject).to have_field(:email).of_type("String")
+    expect(subject).to have_field(:legal_name).of_type("String")
+    expect(subject).to have_field(:legal_number).of_type("String")
+    expect(subject).to have_field(:tax_identification_number).of_type("String")
 
-  it { is_expected.to have_field(:address_line1).of_type("String") }
-  it { is_expected.to have_field(:address_line2).of_type("String") }
-  it { is_expected.to have_field(:city).of_type("String") }
-  it { is_expected.to have_field(:country).of_type("CountryCode") }
-  it { is_expected.to have_field(:state).of_type("String") }
-  it { is_expected.to have_field(:zipcode).of_type("String") }
+    expect(subject).to have_field(:address_line1).of_type("String")
+    expect(subject).to have_field(:address_line2).of_type("String")
+    expect(subject).to have_field(:city).of_type("String")
+    expect(subject).to have_field(:country).of_type("CountryCode")
+    expect(subject).to have_field(:state).of_type("String")
+    expect(subject).to have_field(:zipcode).of_type("String")
 
-  it { is_expected.to have_field(:shipping_address).of_type("CustomerAddress") }
+    expect(subject).to have_field(:shipping_address).of_type("CustomerAddress")
 
-  it { is_expected.to have_field(:billing_configuration).of_type('CustomerBillingConfiguration') }
+    expect(subject).to have_field(:billing_configuration).of_type('CustomerBillingConfiguration')
 
-  it { is_expected.to have_field(:premium).of_type("Boolean!") }
+    expect(subject).to have_field(:premium).of_type("Boolean!")
+  end
 end

--- a/spec/graphql/types/customer_portal/customers/update_input_spec.rb
+++ b/spec/graphql/types/customer_portal/customers/update_input_spec.rb
@@ -5,21 +5,23 @@ require "rails_helper"
 RSpec.describe Types::CustomerPortal::Customers::UpdateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:customer_type).of_type("CustomerTypeEnum") }
-  it { is_expected.to accept_argument(:document_locale).of_type("String") }
-  it { is_expected.to accept_argument(:email).of_type("String") }
-  it { is_expected.to accept_argument(:firstname).of_type("String") }
-  it { is_expected.to accept_argument(:lastname).of_type("String") }
-  it { is_expected.to accept_argument(:legal_name).of_type("String") }
-  it { is_expected.to accept_argument(:name).of_type("String") }
-  it { is_expected.to accept_argument(:tax_identification_number).of_type("String") }
+  it do
+    expect(subject).to accept_argument(:customer_type).of_type("CustomerTypeEnum")
+    expect(subject).to accept_argument(:document_locale).of_type("String")
+    expect(subject).to accept_argument(:email).of_type("String")
+    expect(subject).to accept_argument(:firstname).of_type("String")
+    expect(subject).to accept_argument(:lastname).of_type("String")
+    expect(subject).to accept_argument(:legal_name).of_type("String")
+    expect(subject).to accept_argument(:name).of_type("String")
+    expect(subject).to accept_argument(:tax_identification_number).of_type("String")
 
-  it { is_expected.to accept_argument(:address_line1).of_type("String") }
-  it { is_expected.to accept_argument(:address_line2).of_type("String") }
-  it { is_expected.to accept_argument(:city).of_type("String") }
-  it { is_expected.to accept_argument(:country).of_type("CountryCode") }
-  it { is_expected.to accept_argument(:state).of_type("String") }
-  it { is_expected.to accept_argument(:zipcode).of_type("String") }
+    expect(subject).to accept_argument(:address_line1).of_type("String")
+    expect(subject).to accept_argument(:address_line2).of_type("String")
+    expect(subject).to accept_argument(:city).of_type("String")
+    expect(subject).to accept_argument(:country).of_type("CountryCode")
+    expect(subject).to accept_argument(:state).of_type("String")
+    expect(subject).to accept_argument(:zipcode).of_type("String")
 
-  it { is_expected.to accept_argument(:shipping_address).of_type("CustomerAddressInput") }
+    expect(subject).to accept_argument(:shipping_address).of_type("CustomerAddressInput")
+  end
 end

--- a/spec/graphql/types/customer_portal/organizations/object_spec.rb
+++ b/spec/graphql/types/customer_portal/organizations/object_spec.rb
@@ -5,13 +5,15 @@ require "rails_helper"
 RSpec.describe Types::CustomerPortal::Organizations::Object do
   subject { described_class }
 
-  it { is_expected.to be < ::Types::Organizations::BaseOrganizationType }
+  it do
+    expect(subject).to be < ::Types::Organizations::BaseOrganizationType
 
-  it { is_expected.to have_field(:id).of_type("ID!") }
-  it { is_expected.to have_field(:billing_configuration).of_type("OrganizationBillingConfiguration") }
-  it { is_expected.to have_field(:default_currency).of_type("CurrencyEnum!") }
-  it { is_expected.to have_field(:logo_url).of_type("String") }
-  it { is_expected.to have_field(:name).of_type("String!") }
-  it { is_expected.to have_field(:premium_integrations).of_type("[PremiumIntegrationTypeEnum!]!") }
-  it { is_expected.to have_field(:timezone).of_type("TimezoneEnum") }
+    expect(subject).to have_field(:id).of_type("ID!")
+    expect(subject).to have_field(:billing_configuration).of_type("OrganizationBillingConfiguration")
+    expect(subject).to have_field(:default_currency).of_type("CurrencyEnum!")
+    expect(subject).to have_field(:logo_url).of_type("String")
+    expect(subject).to have_field(:name).of_type("String!")
+    expect(subject).to have_field(:premium_integrations).of_type("[PremiumIntegrationTypeEnum!]!")
+    expect(subject).to have_field(:timezone).of_type("TimezoneEnum")
+  end
 end

--- a/spec/graphql/types/customer_portal/wallet_transactions/object_spec.rb
+++ b/spec/graphql/types/customer_portal/wallet_transactions/object_spec.rb
@@ -5,17 +5,19 @@ require "rails_helper"
 RSpec.describe Types::CustomerPortal::WalletTransactions::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type("ID!") }
+  it do
+    expect(subject).to have_field(:id).of_type("ID!")
 
-  it { is_expected.to have_field(:wallet).of_type("CustomerPortalWallet") }
+    expect(subject).to have_field(:wallet).of_type("CustomerPortalWallet")
 
-  it { is_expected.to have_field(:amount).of_type("String!") }
-  it { is_expected.to have_field(:credit_amount).of_type("String!") }
-  it { is_expected.to have_field(:status).of_type("WalletTransactionStatusEnum!") }
-  it { is_expected.to have_field(:transaction_status).of_type("WalletTransactionTransactionStatusEnum!") }
-  it { is_expected.to have_field(:transaction_type).of_type("WalletTransactionTransactionTypeEnum!") }
+    expect(subject).to have_field(:amount).of_type("String!")
+    expect(subject).to have_field(:credit_amount).of_type("String!")
+    expect(subject).to have_field(:status).of_type("WalletTransactionStatusEnum!")
+    expect(subject).to have_field(:transaction_status).of_type("WalletTransactionTransactionStatusEnum!")
+    expect(subject).to have_field(:transaction_type).of_type("WalletTransactionTransactionTypeEnum!")
 
-  it { is_expected.to have_field(:created_at).of_type("ISO8601DateTime!") }
-  it { is_expected.to have_field(:settled_at).of_type("ISO8601DateTime") }
-  it { is_expected.to have_field(:updated_at).of_type("ISO8601DateTime!") }
+    expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:settled_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+  end
 end

--- a/spec/graphql/types/customer_portal/wallets/object_spec.rb
+++ b/spec/graphql/types/customer_portal/wallets/object_spec.rb
@@ -5,20 +5,22 @@ require "rails_helper"
 RSpec.describe Types::CustomerPortal::Wallets::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type("ID!") }
+  it do
+    expect(subject).to have_field(:id).of_type("ID!")
 
-  it { is_expected.to have_field(:currency).of_type("CurrencyEnum!") }
-  it { is_expected.to have_field(:expiration_at).of_type("ISO8601DateTime") }
-  it { is_expected.to have_field(:name).of_type("String") }
-  it { is_expected.to have_field(:status).of_type("WalletStatusEnum!") }
+    expect(subject).to have_field(:currency).of_type("CurrencyEnum!")
+    expect(subject).to have_field(:expiration_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:name).of_type("String")
+    expect(subject).to have_field(:status).of_type("WalletStatusEnum!")
 
-  it { is_expected.to have_field(:balance_cents).of_type("BigInt!") }
-  it { is_expected.to have_field(:consumed_amount_cents).of_type("BigInt!") }
-  it { is_expected.to have_field(:consumed_credits).of_type("Float!") }
-  it { is_expected.to have_field(:credits_balance).of_type("Float!") }
-  it { is_expected.to have_field(:credits_ongoing_balance).of_type("Float!") }
-  it { is_expected.to have_field(:ongoing_balance_cents).of_type("BigInt!") }
-  it { is_expected.to have_field(:ongoing_usage_balance_cents).of_type("BigInt!") }
-  it { is_expected.to have_field(:rate_amount).of_type("Float!") }
-  it { is_expected.to have_field(:last_balance_sync_at).of_type('ISO8601DateTime') }
+    expect(subject).to have_field(:balance_cents).of_type("BigInt!")
+    expect(subject).to have_field(:consumed_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:consumed_credits).of_type("Float!")
+    expect(subject).to have_field(:credits_balance).of_type("Float!")
+    expect(subject).to have_field(:credits_ongoing_balance).of_type("Float!")
+    expect(subject).to have_field(:ongoing_balance_cents).of_type("BigInt!")
+    expect(subject).to have_field(:ongoing_usage_balance_cents).of_type("BigInt!")
+    expect(subject).to have_field(:rate_amount).of_type("Float!")
+    expect(subject).to have_field(:last_balance_sync_at).of_type('ISO8601DateTime')
+  end
 end

--- a/spec/graphql/types/customers/create_customer_input_spec.rb
+++ b/spec/graphql/types/customers/create_customer_input_spec.rb
@@ -5,37 +5,39 @@ require 'rails_helper'
 RSpec.describe Types::Customers::CreateCustomerInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:account_type).of_type(Types::Customers::AccountTypeEnum) }
-  it { is_expected.to accept_argument(:address_line1).of_type('String') }
-  it { is_expected.to accept_argument(:address_line2).of_type('String') }
-  it { is_expected.to accept_argument(:city).of_type('String') }
-  it { is_expected.to accept_argument(:country).of_type('CountryCode') }
-  it { is_expected.to accept_argument(:currency).of_type('CurrencyEnum') }
-  it { is_expected.to accept_argument(:customer_type).of_type('CustomerTypeEnum') }
-  it { is_expected.to accept_argument(:email).of_type('String') }
-  it { is_expected.to accept_argument(:external_id).of_type('String!') }
-  it { is_expected.to accept_argument(:external_salesforce_id).of_type('String') }
-  it { is_expected.to accept_argument(:firstname).of_type('String') }
-  it { is_expected.to accept_argument(:invoice_grace_period).of_type('Int') }
-  it { is_expected.to accept_argument(:lastname).of_type('String') }
-  it { is_expected.to accept_argument(:legal_name).of_type('String') }
-  it { is_expected.to accept_argument(:legal_number).of_type('String') }
-  it { is_expected.to accept_argument(:logo_url).of_type('String') }
-  it { is_expected.to accept_argument(:name).of_type('String') }
-  it { is_expected.to accept_argument(:net_payment_term).of_type('Int') }
-  it { is_expected.to accept_argument(:phone).of_type('String') }
-  it { is_expected.to accept_argument(:state).of_type('String') }
-  it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
-  it { is_expected.to accept_argument(:tax_identification_number).of_type('String') }
-  it { is_expected.to accept_argument(:timezone).of_type('TimezoneEnum') }
-  it { is_expected.to accept_argument(:url).of_type('String') }
-  it { is_expected.to accept_argument(:zipcode).of_type('String') }
-  it { is_expected.to accept_argument(:shipping_address).of_type('CustomerAddressInput') }
-  it { is_expected.to accept_argument(:metadata).of_type('[CustomerMetadataInput!]') }
-  it { is_expected.to accept_argument(:payment_provider).of_type('ProviderTypeEnum') }
-  it { is_expected.to accept_argument(:payment_provider_code).of_type('String') }
-  it { is_expected.to accept_argument(:provider_customer).of_type('ProviderCustomerInput') }
-  it { is_expected.to accept_argument(:integration_customers).of_type('[IntegrationCustomerInput!]') }
-  it { is_expected.to accept_argument(:billing_configuration).of_type('CustomerBillingConfigurationInput') }
-  it { is_expected.to accept_argument(:finalize_zero_amount_invoice).of_type('FinalizeZeroAmountInvoiceEnum') }
+  it do
+    expect(subject).to accept_argument(:account_type).of_type(Types::Customers::AccountTypeEnum)
+    expect(subject).to accept_argument(:address_line1).of_type('String')
+    expect(subject).to accept_argument(:address_line2).of_type('String')
+    expect(subject).to accept_argument(:city).of_type('String')
+    expect(subject).to accept_argument(:country).of_type('CountryCode')
+    expect(subject).to accept_argument(:currency).of_type('CurrencyEnum')
+    expect(subject).to accept_argument(:customer_type).of_type('CustomerTypeEnum')
+    expect(subject).to accept_argument(:email).of_type('String')
+    expect(subject).to accept_argument(:external_id).of_type('String!')
+    expect(subject).to accept_argument(:external_salesforce_id).of_type('String')
+    expect(subject).to accept_argument(:firstname).of_type('String')
+    expect(subject).to accept_argument(:invoice_grace_period).of_type('Int')
+    expect(subject).to accept_argument(:lastname).of_type('String')
+    expect(subject).to accept_argument(:legal_name).of_type('String')
+    expect(subject).to accept_argument(:legal_number).of_type('String')
+    expect(subject).to accept_argument(:logo_url).of_type('String')
+    expect(subject).to accept_argument(:name).of_type('String')
+    expect(subject).to accept_argument(:net_payment_term).of_type('Int')
+    expect(subject).to accept_argument(:phone).of_type('String')
+    expect(subject).to accept_argument(:state).of_type('String')
+    expect(subject).to accept_argument(:tax_codes).of_type('[String!]')
+    expect(subject).to accept_argument(:tax_identification_number).of_type('String')
+    expect(subject).to accept_argument(:timezone).of_type('TimezoneEnum')
+    expect(subject).to accept_argument(:url).of_type('String')
+    expect(subject).to accept_argument(:zipcode).of_type('String')
+    expect(subject).to accept_argument(:shipping_address).of_type('CustomerAddressInput')
+    expect(subject).to accept_argument(:metadata).of_type('[CustomerMetadataInput!]')
+    expect(subject).to accept_argument(:payment_provider).of_type('ProviderTypeEnum')
+    expect(subject).to accept_argument(:payment_provider_code).of_type('String')
+    expect(subject).to accept_argument(:provider_customer).of_type('ProviderCustomerInput')
+    expect(subject).to accept_argument(:integration_customers).of_type('[IntegrationCustomerInput!]')
+    expect(subject).to accept_argument(:billing_configuration).of_type('CustomerBillingConfigurationInput')
+    expect(subject).to accept_argument(:finalize_zero_amount_invoice).of_type('FinalizeZeroAmountInvoiceEnum')
+  end
 end

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -5,79 +5,81 @@ require 'rails_helper'
 RSpec.describe Types::Customers::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
 
-  it { is_expected.to have_field(:account_type).of_type("CustomerAccountTypeEnum!") }
-  it { is_expected.to have_field(:customer_type).of_type(Types::Customers::CustomerTypeEnum) }
-  it { is_expected.to have_field(:display_name).of_type('String!') }
-  it { is_expected.to have_field(:external_id).of_type('String!') }
-  it { is_expected.to have_field(:firstname).of_type('String') }
-  it { is_expected.to have_field(:lastname).of_type('String') }
-  it { is_expected.to have_field(:name).of_type('String') }
-  it { is_expected.to have_field(:sequential_id).of_type('String!') }
-  it { is_expected.to have_field(:slug).of_type('String!') }
+    expect(subject).to have_field(:account_type).of_type("CustomerAccountTypeEnum!")
+    expect(subject).to have_field(:customer_type).of_type(Types::Customers::CustomerTypeEnum)
+    expect(subject).to have_field(:display_name).of_type('String!')
+    expect(subject).to have_field(:external_id).of_type('String!')
+    expect(subject).to have_field(:firstname).of_type('String')
+    expect(subject).to have_field(:lastname).of_type('String')
+    expect(subject).to have_field(:name).of_type('String')
+    expect(subject).to have_field(:sequential_id).of_type('String!')
+    expect(subject).to have_field(:slug).of_type('String!')
 
-  it { is_expected.to have_field(:address_line1).of_type('String') }
-  it { is_expected.to have_field(:address_line2).of_type('String') }
+    expect(subject).to have_field(:address_line1).of_type('String')
+    expect(subject).to have_field(:address_line2).of_type('String')
 
-  it { is_expected.to have_field(:applicable_timezone).of_type('TimezoneEnum!') }
-  it { is_expected.to have_field(:city).of_type('String') }
-  it { is_expected.to have_field(:country).of_type('CountryCode') }
-  it { is_expected.to have_field(:currency).of_type('CurrencyEnum') }
-  it { is_expected.to have_field(:email).of_type('String') }
-  it { is_expected.to have_field(:external_salesforce_id).of_type('String') }
-  it { is_expected.to have_field(:invoice_grace_period).of_type('Int') }
-  it { is_expected.to have_field(:legal_name).of_type('String') }
-  it { is_expected.to have_field(:legal_number).of_type('String') }
-  it { is_expected.to have_field(:logo_url).of_type('String') }
-  it { is_expected.to have_field(:net_payment_term).of_type('Int') }
-  it { is_expected.to have_field(:payment_provider).of_type('ProviderTypeEnum') }
-  it { is_expected.to have_field(:payment_provider_code).of_type('String') }
-  it { is_expected.to have_field(:phone).of_type('String') }
-  it { is_expected.to have_field(:state).of_type('String') }
-  it { is_expected.to have_field(:tax_identification_number).of_type('String') }
-  it { is_expected.to have_field(:timezone).of_type('TimezoneEnum') }
-  it { is_expected.to have_field(:url).of_type('String') }
-  it { is_expected.to have_field(:zipcode).of_type('String') }
+    expect(subject).to have_field(:applicable_timezone).of_type('TimezoneEnum!')
+    expect(subject).to have_field(:city).of_type('String')
+    expect(subject).to have_field(:country).of_type('CountryCode')
+    expect(subject).to have_field(:currency).of_type('CurrencyEnum')
+    expect(subject).to have_field(:email).of_type('String')
+    expect(subject).to have_field(:external_salesforce_id).of_type('String')
+    expect(subject).to have_field(:invoice_grace_period).of_type('Int')
+    expect(subject).to have_field(:legal_name).of_type('String')
+    expect(subject).to have_field(:legal_number).of_type('String')
+    expect(subject).to have_field(:logo_url).of_type('String')
+    expect(subject).to have_field(:net_payment_term).of_type('Int')
+    expect(subject).to have_field(:payment_provider).of_type('ProviderTypeEnum')
+    expect(subject).to have_field(:payment_provider_code).of_type('String')
+    expect(subject).to have_field(:phone).of_type('String')
+    expect(subject).to have_field(:state).of_type('String')
+    expect(subject).to have_field(:tax_identification_number).of_type('String')
+    expect(subject).to have_field(:timezone).of_type('TimezoneEnum')
+    expect(subject).to have_field(:url).of_type('String')
+    expect(subject).to have_field(:zipcode).of_type('String')
 
-  it { is_expected.to have_field(:metadata).of_type('[CustomerMetadata!]') }
+    expect(subject).to have_field(:metadata).of_type('[CustomerMetadata!]')
 
-  it { is_expected.to have_field(:billing_configuration).of_type('CustomerBillingConfiguration') }
+    expect(subject).to have_field(:billing_configuration).of_type('CustomerBillingConfiguration')
 
-  it { is_expected.to have_field(:shipping_address).of_type('CustomerAddress') }
+    expect(subject).to have_field(:shipping_address).of_type('CustomerAddress')
 
-  it { is_expected.to have_field(:anrok_customer).of_type('AnrokCustomer') }
-  it { is_expected.to have_field(:hubspot_customer).of_type('HubspotCustomer') }
-  it { is_expected.to have_field(:netsuite_customer).of_type('NetsuiteCustomer') }
-  it { is_expected.to have_field(:salesforce_customer).of_type('SalesforceCustomer') }
-  it { is_expected.to have_field(:provider_customer).of_type('ProviderCustomer') }
-  it { is_expected.to have_field(:subscriptions).of_type('[Subscription!]!') }
-  it { is_expected.to have_field(:xero_customer).of_type('XeroCustomer') }
+    expect(subject).to have_field(:anrok_customer).of_type('AnrokCustomer')
+    expect(subject).to have_field(:hubspot_customer).of_type('HubspotCustomer')
+    expect(subject).to have_field(:netsuite_customer).of_type('NetsuiteCustomer')
+    expect(subject).to have_field(:salesforce_customer).of_type('SalesforceCustomer')
+    expect(subject).to have_field(:provider_customer).of_type('ProviderCustomer')
+    expect(subject).to have_field(:subscriptions).of_type('[Subscription!]!')
+    expect(subject).to have_field(:xero_customer).of_type('XeroCustomer')
 
-  it { is_expected.to have_field(:invoices).of_type('[Invoice!]') }
+    expect(subject).to have_field(:invoices).of_type('[Invoice!]')
 
-  it { is_expected.to have_field(:applied_add_ons).of_type('[AppliedAddOn!]') }
-  it { is_expected.to have_field(:applied_coupons).of_type('[AppliedCoupon!]') }
-  it { is_expected.to have_field(:taxes).of_type('[Tax!]') }
+    expect(subject).to have_field(:applied_add_ons).of_type('[AppliedAddOn!]')
+    expect(subject).to have_field(:applied_coupons).of_type('[AppliedCoupon!]')
+    expect(subject).to have_field(:taxes).of_type('[Tax!]')
 
-  it { is_expected.to have_field(:credit_notes).of_type('[CreditNote!]') }
+    expect(subject).to have_field(:credit_notes).of_type('[CreditNote!]')
 
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:deleted_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:deleted_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
 
-  it { is_expected.to have_field(:active_subscriptions_count).of_type('Int!') }
-  it { is_expected.to have_field(:credit_notes_balance_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:credit_notes_credits_available_count).of_type('Int!') }
-  it { is_expected.to have_field(:has_active_wallet).of_type('Boolean!') }
-  it { is_expected.to have_field(:has_credit_notes).of_type('Boolean!') }
-  it { is_expected.to have_field(:has_overdue_invoices).of_type('Boolean!') }
+    expect(subject).to have_field(:active_subscriptions_count).of_type('Int!')
+    expect(subject).to have_field(:credit_notes_balance_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:credit_notes_credits_available_count).of_type('Int!')
+    expect(subject).to have_field(:has_active_wallet).of_type('Boolean!')
+    expect(subject).to have_field(:has_credit_notes).of_type('Boolean!')
+    expect(subject).to have_field(:has_overdue_invoices).of_type('Boolean!')
 
-  it { is_expected.to have_field(:can_edit_attributes).of_type('Boolean!') }
-  it { is_expected.to have_field(:finalize_zero_amount_invoice).of_type('FinalizeZeroAmountInvoiceEnum') }
+    expect(subject).to have_field(:can_edit_attributes).of_type('Boolean!')
+    expect(subject).to have_field(:finalize_zero_amount_invoice).of_type('FinalizeZeroAmountInvoiceEnum')
 
-  it { is_expected.to have_field(:applied_dunning_campaign).of_type("DunningCampaign") }
-  it { is_expected.to have_field(:exclude_from_dunning_campaign).of_type("Boolean!") }
-  it { is_expected.to have_field(:last_dunning_campaign_attempt).of_type("Int!") }
-  it { is_expected.to have_field(:last_dunning_campaign_attempt_at).of_type("ISO8601DateTime") }
+    expect(subject).to have_field(:applied_dunning_campaign).of_type("DunningCampaign")
+    expect(subject).to have_field(:exclude_from_dunning_campaign).of_type("Boolean!")
+    expect(subject).to have_field(:last_dunning_campaign_attempt).of_type("Int!")
+    expect(subject).to have_field(:last_dunning_campaign_attempt_at).of_type("ISO8601DateTime")
+  end
 end

--- a/spec/graphql/types/customers/update_customer_input_spec.rb
+++ b/spec/graphql/types/customers/update_customer_input_spec.rb
@@ -5,41 +5,43 @@ require 'rails_helper'
 RSpec.describe Types::Customers::UpdateCustomerInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID!') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('ID!')
 
-  it { is_expected.to accept_argument(:account_type).of_type(Types::Customers::AccountTypeEnum) }
-  it { is_expected.to accept_argument(:address_line1).of_type('String') }
-  it { is_expected.to accept_argument(:address_line2).of_type('String') }
-  it { is_expected.to accept_argument(:city).of_type('String') }
-  it { is_expected.to accept_argument(:country).of_type('CountryCode') }
-  it { is_expected.to accept_argument(:currency).of_type('CurrencyEnum') }
-  it { is_expected.to accept_argument(:customer_type).of_type('CustomerTypeEnum') }
-  it { is_expected.to accept_argument(:email).of_type('String') }
-  it { is_expected.to accept_argument(:external_id).of_type('String!') }
-  it { is_expected.to accept_argument(:external_salesforce_id).of_type('String') }
-  it { is_expected.to accept_argument(:firstname).of_type('String') }
-  it { is_expected.to accept_argument(:invoice_grace_period).of_type('Int') }
-  it { is_expected.to accept_argument(:lastname).of_type('String') }
-  it { is_expected.to accept_argument(:legal_name).of_type('String') }
-  it { is_expected.to accept_argument(:legal_number).of_type('String') }
-  it { is_expected.to accept_argument(:logo_url).of_type('String') }
-  it { is_expected.to accept_argument(:name).of_type('String') }
-  it { is_expected.to accept_argument(:net_payment_term).of_type('Int') }
-  it { is_expected.to accept_argument(:phone).of_type('String') }
-  it { is_expected.to accept_argument(:state).of_type('String') }
-  it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
-  it { is_expected.to accept_argument(:tax_identification_number).of_type('String') }
-  it { is_expected.to accept_argument(:timezone).of_type('TimezoneEnum') }
-  it { is_expected.to accept_argument(:url).of_type('String') }
-  it { is_expected.to accept_argument(:zipcode).of_type('String') }
-  it { is_expected.to accept_argument(:shipping_address).of_type('CustomerAddressInput') }
-  it { is_expected.to accept_argument(:metadata).of_type('[CustomerMetadataInput!]') }
-  it { is_expected.to accept_argument(:payment_provider).of_type('ProviderTypeEnum') }
-  it { is_expected.to accept_argument(:payment_provider_code).of_type('String') }
-  it { is_expected.to accept_argument(:provider_customer).of_type('ProviderCustomerInput') }
-  it { is_expected.to accept_argument(:integration_customers).of_type('[IntegrationCustomerInput!]') }
-  it { is_expected.to accept_argument(:billing_configuration).of_type('CustomerBillingConfigurationInput') }
+    expect(subject).to accept_argument(:account_type).of_type(Types::Customers::AccountTypeEnum)
+    expect(subject).to accept_argument(:address_line1).of_type('String')
+    expect(subject).to accept_argument(:address_line2).of_type('String')
+    expect(subject).to accept_argument(:city).of_type('String')
+    expect(subject).to accept_argument(:country).of_type('CountryCode')
+    expect(subject).to accept_argument(:currency).of_type('CurrencyEnum')
+    expect(subject).to accept_argument(:customer_type).of_type('CustomerTypeEnum')
+    expect(subject).to accept_argument(:email).of_type('String')
+    expect(subject).to accept_argument(:external_id).of_type('String!')
+    expect(subject).to accept_argument(:external_salesforce_id).of_type('String')
+    expect(subject).to accept_argument(:firstname).of_type('String')
+    expect(subject).to accept_argument(:invoice_grace_period).of_type('Int')
+    expect(subject).to accept_argument(:lastname).of_type('String')
+    expect(subject).to accept_argument(:legal_name).of_type('String')
+    expect(subject).to accept_argument(:legal_number).of_type('String')
+    expect(subject).to accept_argument(:logo_url).of_type('String')
+    expect(subject).to accept_argument(:name).of_type('String')
+    expect(subject).to accept_argument(:net_payment_term).of_type('Int')
+    expect(subject).to accept_argument(:phone).of_type('String')
+    expect(subject).to accept_argument(:state).of_type('String')
+    expect(subject).to accept_argument(:tax_codes).of_type('[String!]')
+    expect(subject).to accept_argument(:tax_identification_number).of_type('String')
+    expect(subject).to accept_argument(:timezone).of_type('TimezoneEnum')
+    expect(subject).to accept_argument(:url).of_type('String')
+    expect(subject).to accept_argument(:zipcode).of_type('String')
+    expect(subject).to accept_argument(:shipping_address).of_type('CustomerAddressInput')
+    expect(subject).to accept_argument(:metadata).of_type('[CustomerMetadataInput!]')
+    expect(subject).to accept_argument(:payment_provider).of_type('ProviderTypeEnum')
+    expect(subject).to accept_argument(:payment_provider_code).of_type('String')
+    expect(subject).to accept_argument(:provider_customer).of_type('ProviderCustomerInput')
+    expect(subject).to accept_argument(:integration_customers).of_type('[IntegrationCustomerInput!]')
+    expect(subject).to accept_argument(:billing_configuration).of_type('CustomerBillingConfigurationInput')
 
-  it { is_expected.to accept_argument(:applied_dunning_campaign_id).of_type("ID") }
-  it { is_expected.to accept_argument(:exclude_from_dunning_campaign).of_type("Boolean") }
+    expect(subject).to accept_argument(:applied_dunning_campaign_id).of_type("ID")
+    expect(subject).to accept_argument(:exclude_from_dunning_campaign).of_type("Boolean")
+  end
 end

--- a/spec/graphql/types/customers/usage/charge_filter_spec.rb
+++ b/spec/graphql/types/customers/usage/charge_filter_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe Types::Customers::Usage::ChargeFilter do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID') }
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:events_count).of_type('Int!') }
-  it { is_expected.to have_field(:invoice_display_name).of_type('String') }
-  it { is_expected.to have_field(:units).of_type('Float!') }
-  it { is_expected.to have_field(:values).of_type('ChargeFilterValues!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID')
+    expect(subject).to have_field(:amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:events_count).of_type('Int!')
+    expect(subject).to have_field(:invoice_display_name).of_type('String')
+    expect(subject).to have_field(:units).of_type('Float!')
+    expect(subject).to have_field(:values).of_type('ChargeFilterValues!')
+  end
 end

--- a/spec/graphql/types/customers/usage/charge_spec.rb
+++ b/spec/graphql/types/customers/usage/charge_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 RSpec.describe Types::Customers::Usage::Charge do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:events_count).of_type('Int!') }
-  it { is_expected.to have_field(:units).of_type('Float!') }
-  it { is_expected.to have_field(:billable_metric).of_type('BillableMetric!') }
-  it { is_expected.to have_field(:charge).of_type('Charge!') }
-  it { is_expected.to have_field(:grouped_usage).of_type('[GroupedChargeUsage!]!') }
-  it { is_expected.to have_field(:filters).of_type('[ChargeFilterUsage!]') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:events_count).of_type('Int!')
+    expect(subject).to have_field(:units).of_type('Float!')
+    expect(subject).to have_field(:billable_metric).of_type('BillableMetric!')
+    expect(subject).to have_field(:charge).of_type('Charge!')
+    expect(subject).to have_field(:grouped_usage).of_type('[GroupedChargeUsage!]!')
+    expect(subject).to have_field(:filters).of_type('[ChargeFilterUsage!]')
+  end
 end

--- a/spec/graphql/types/customers/usage/grouped_usage_spec.rb
+++ b/spec/graphql/types/customers/usage/grouped_usage_spec.rb
@@ -5,9 +5,11 @@ require 'rails_helper'
 RSpec.describe Types::Customers::Usage::GroupedUsage do
   subject { described_class }
 
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:events_count).of_type('Int!') }
-  it { is_expected.to have_field(:units).of_type('Float!') }
-  it { is_expected.to have_field(:filters).of_type('[ChargeFilterUsage!]') }
-  it { is_expected.to have_field(:grouped_by).of_type('JSON') }
+  it do
+    expect(subject).to have_field(:amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:events_count).of_type('Int!')
+    expect(subject).to have_field(:units).of_type('Float!')
+    expect(subject).to have_field(:filters).of_type('[ChargeFilterUsage!]')
+    expect(subject).to have_field(:grouped_by).of_type('JSON')
+  end
 end

--- a/spec/graphql/types/data_exports/credit_notes/filters_input_spec.rb
+++ b/spec/graphql/types/data_exports/credit_notes/filters_input_spec.rb
@@ -5,16 +5,18 @@ require 'rails_helper'
 RSpec.describe Types::DataExports::CreditNotes::FiltersInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:amount_from).of_type('Int') }
-  it { is_expected.to accept_argument(:amount_to).of_type('Int') }
-  it { is_expected.to accept_argument(:credit_status).of_type('[CreditNoteCreditStatusEnum!]') }
-  it { is_expected.to accept_argument(:currency).of_type('CurrencyEnum') }
-  it { is_expected.to accept_argument(:customer_external_id).of_type('String') }
-  it { is_expected.to accept_argument(:customer_id).of_type('ID') }
-  it { is_expected.to accept_argument(:invoice_number).of_type('String') }
-  it { is_expected.to accept_argument(:issuing_date_from).of_type('ISO8601Date') }
-  it { is_expected.to accept_argument(:issuing_date_to).of_type('ISO8601Date') }
-  it { is_expected.to accept_argument(:reason).of_type('[CreditNoteReasonEnum!]') }
-  it { is_expected.to accept_argument(:refund_status).of_type('[CreditNoteRefundStatusEnum!]') }
-  it { is_expected.to accept_argument(:search_term).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:amount_from).of_type('Int')
+    expect(subject).to accept_argument(:amount_to).of_type('Int')
+    expect(subject).to accept_argument(:credit_status).of_type('[CreditNoteCreditStatusEnum!]')
+    expect(subject).to accept_argument(:currency).of_type('CurrencyEnum')
+    expect(subject).to accept_argument(:customer_external_id).of_type('String')
+    expect(subject).to accept_argument(:customer_id).of_type('ID')
+    expect(subject).to accept_argument(:invoice_number).of_type('String')
+    expect(subject).to accept_argument(:issuing_date_from).of_type('ISO8601Date')
+    expect(subject).to accept_argument(:issuing_date_to).of_type('ISO8601Date')
+    expect(subject).to accept_argument(:reason).of_type('[CreditNoteReasonEnum!]')
+    expect(subject).to accept_argument(:refund_status).of_type('[CreditNoteRefundStatusEnum!]')
+    expect(subject).to accept_argument(:search_term).of_type('String')
+  end
 end

--- a/spec/graphql/types/data_exports/invoices/filters_input_spec.rb
+++ b/spec/graphql/types/data_exports/invoices/filters_input_spec.rb
@@ -5,16 +5,18 @@ require 'rails_helper'
 RSpec.describe Types::DataExports::Invoices::FiltersInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:amount_from).of_type('Int') }
-  it { is_expected.to accept_argument(:amount_to).of_type('Int') }
-  it { is_expected.to accept_argument(:currency).of_type('CurrencyEnum') }
-  it { is_expected.to accept_argument(:customer_external_id).of_type('String') }
-  it { is_expected.to accept_argument(:invoice_type).of_type('[InvoiceTypeEnum!]') }
-  it { is_expected.to accept_argument(:issuing_date_from).of_type('ISO8601Date') }
-  it { is_expected.to accept_argument(:issuing_date_to).of_type('ISO8601Date') }
-  it { is_expected.to accept_argument(:payment_dispute_lost).of_type('Boolean') }
-  it { is_expected.to accept_argument(:payment_overdue).of_type('Boolean') }
-  it { is_expected.to accept_argument(:payment_status).of_type('[InvoicePaymentStatusTypeEnum!]') }
-  it { is_expected.to accept_argument(:search_term).of_type('String') }
-  it { is_expected.to accept_argument(:status).of_type('[InvoiceStatusTypeEnum!]') }
+  it do
+    expect(subject).to accept_argument(:amount_from).of_type('Int')
+    expect(subject).to accept_argument(:amount_to).of_type('Int')
+    expect(subject).to accept_argument(:currency).of_type('CurrencyEnum')
+    expect(subject).to accept_argument(:customer_external_id).of_type('String')
+    expect(subject).to accept_argument(:invoice_type).of_type('[InvoiceTypeEnum!]')
+    expect(subject).to accept_argument(:issuing_date_from).of_type('ISO8601Date')
+    expect(subject).to accept_argument(:issuing_date_to).of_type('ISO8601Date')
+    expect(subject).to accept_argument(:payment_dispute_lost).of_type('Boolean')
+    expect(subject).to accept_argument(:payment_overdue).of_type('Boolean')
+    expect(subject).to accept_argument(:payment_status).of_type('[InvoicePaymentStatusTypeEnum!]')
+    expect(subject).to accept_argument(:search_term).of_type('String')
+    expect(subject).to accept_argument(:status).of_type('[InvoiceStatusTypeEnum!]')
+  end
 end

--- a/spec/graphql/types/data_exports/object_spec.rb
+++ b/spec/graphql/types/data_exports/object_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Types::DataExports::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:status).of_type('DataExportStatusEnum!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:status).of_type('DataExportStatusEnum!')
+  end
 end

--- a/spec/graphql/types/dunning_campaign_thresholds/input_spec.rb
+++ b/spec/graphql/types/dunning_campaign_thresholds/input_spec.rb
@@ -5,8 +5,10 @@ require "rails_helper"
 RSpec.describe Types::DunningCampaignThresholds::Input do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type("ID") }
+  it do
+    expect(subject).to accept_argument(:id).of_type("ID")
 
-  it { is_expected.to accept_argument(:amount_cents).of_type("BigInt!") }
-  it { is_expected.to accept_argument(:currency).of_type("CurrencyEnum!") }
+    expect(subject).to accept_argument(:amount_cents).of_type("BigInt!")
+    expect(subject).to accept_argument(:currency).of_type("CurrencyEnum!")
+  end
 end

--- a/spec/graphql/types/dunning_campaign_thresholds/object_spec.rb
+++ b/spec/graphql/types/dunning_campaign_thresholds/object_spec.rb
@@ -5,8 +5,10 @@ require "rails_helper"
 RSpec.describe Types::DunningCampaignThresholds::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
 
-  it { is_expected.to have_field(:amount_cents).of_type("BigInt!") }
-  it { is_expected.to have_field(:currency).of_type("CurrencyEnum!") }
+    expect(subject).to have_field(:amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:currency).of_type("CurrencyEnum!")
+  end
 end

--- a/spec/graphql/types/dunning_campaigns/create_input_spec.rb
+++ b/spec/graphql/types/dunning_campaigns/create_input_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 RSpec.describe Types::DunningCampaigns::CreateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:applied_to_organization).of_type('Boolean!') }
-  it { is_expected.to accept_argument(:code).of_type('String!') }
-  it { is_expected.to accept_argument(:days_between_attempts).of_type('Int!') }
-  it { is_expected.to accept_argument(:max_attempts).of_type('Int!') }
-  it { is_expected.to accept_argument(:name).of_type('String!') }
-  it { is_expected.to accept_argument(:thresholds).of_type('[DunningCampaignThresholdInput!]!') }
+  it do
+    expect(subject).to accept_argument(:applied_to_organization).of_type('Boolean!')
+    expect(subject).to accept_argument(:code).of_type('String!')
+    expect(subject).to accept_argument(:days_between_attempts).of_type('Int!')
+    expect(subject).to accept_argument(:max_attempts).of_type('Int!')
+    expect(subject).to accept_argument(:name).of_type('String!')
+    expect(subject).to accept_argument(:thresholds).of_type('[DunningCampaignThresholdInput!]!')
 
-  it { is_expected.to accept_argument(:description).of_type('String') }
+    expect(subject).to accept_argument(:description).of_type('String')
+  end
 end

--- a/spec/graphql/types/dunning_campaigns/object_spec.rb
+++ b/spec/graphql/types/dunning_campaigns/object_spec.rb
@@ -5,18 +5,20 @@ require "rails_helper"
 RSpec.describe Types::DunningCampaigns::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type("ID!") }
+  it do
+    expect(subject).to have_field(:id).of_type("ID!")
 
-  it { is_expected.to have_field(:customers_count).of_type("Int!") }
-  it { is_expected.to have_field(:applied_to_organization).of_type("Boolean!") }
-  it { is_expected.to have_field(:code).of_type("String!") }
-  it { is_expected.to have_field(:days_between_attempts).of_type("Int!") }
-  it { is_expected.to have_field(:max_attempts).of_type("Int!") }
-  it { is_expected.to have_field(:name).of_type("String!") }
-  it { is_expected.to have_field(:thresholds).of_type("[DunningCampaignThreshold!]!") }
+    expect(subject).to have_field(:customers_count).of_type("Int!")
+    expect(subject).to have_field(:applied_to_organization).of_type("Boolean!")
+    expect(subject).to have_field(:code).of_type("String!")
+    expect(subject).to have_field(:days_between_attempts).of_type("Int!")
+    expect(subject).to have_field(:max_attempts).of_type("Int!")
+    expect(subject).to have_field(:name).of_type("String!")
+    expect(subject).to have_field(:thresholds).of_type("[DunningCampaignThreshold!]!")
 
-  it { is_expected.to have_field(:description).of_type("String") }
+    expect(subject).to have_field(:description).of_type("String")
 
-  it { is_expected.to have_field(:created_at).of_type("ISO8601DateTime!") }
-  it { is_expected.to have_field(:updated_at).of_type("ISO8601DateTime!") }
+    expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+  end
 end

--- a/spec/graphql/types/dunning_campaigns/update_input_spec.rb
+++ b/spec/graphql/types/dunning_campaigns/update_input_spec.rb
@@ -5,13 +5,15 @@ require 'rails_helper'
 RSpec.describe Types::DunningCampaigns::UpdateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID!') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('ID!')
 
-  it { is_expected.to accept_argument(:applied_to_organization).of_type('Boolean') }
-  it { is_expected.to accept_argument(:code).of_type('String') }
-  it { is_expected.to accept_argument(:days_between_attempts).of_type('Int') }
-  it { is_expected.to accept_argument(:description).of_type('String') }
-  it { is_expected.to accept_argument(:max_attempts).of_type('Int') }
-  it { is_expected.to accept_argument(:name).of_type('String') }
-  it { is_expected.to accept_argument(:thresholds).of_type('[DunningCampaignThresholdInput!]') }
+    expect(subject).to accept_argument(:applied_to_organization).of_type('Boolean')
+    expect(subject).to accept_argument(:code).of_type('String')
+    expect(subject).to accept_argument(:days_between_attempts).of_type('Int')
+    expect(subject).to accept_argument(:description).of_type('String')
+    expect(subject).to accept_argument(:max_attempts).of_type('Int')
+    expect(subject).to accept_argument(:name).of_type('String')
+    expect(subject).to accept_argument(:thresholds).of_type('[DunningCampaignThresholdInput!]')
+  end
 end

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -5,22 +5,24 @@ require 'rails_helper'
 RSpec.describe Types::Fees::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:invoice_display_name).of_type('String') }
-  it { is_expected.to have_field(:charge).of_type('Charge') }
-  it { is_expected.to have_field(:currency).of_type('CurrencyEnum!') }
-  it { is_expected.to have_field(:subscription).of_type('Subscription') }
-  it { is_expected.to have_field(:true_up_fee).of_type('Fee') }
-  it { is_expected.to have_field(:true_up_parent_fee).of_type('Fee') }
-  it { is_expected.to have_field(:creditable_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:events_count).of_type('BigInt') }
-  it { is_expected.to have_field(:fee_type).of_type('FeeTypesEnum!') }
-  it { is_expected.to have_field(:taxes_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:taxes_rate).of_type('Float') }
-  it { is_expected.to have_field(:units).of_type('Float!') }
-  it { is_expected.to have_field(:applied_taxes).of_type('[FeeAppliedTax!]') }
-  it { is_expected.to have_field(:adjusted_fee).of_type('Boolean!') }
-  it { is_expected.to have_field(:adjusted_fee_type).of_type('AdjustedFeeTypeEnum') }
-  it { is_expected.to have_field(:grouped_by).of_type('JSON!') }
+  it do
+    expect(subject).to have_field(:invoice_display_name).of_type('String')
+    expect(subject).to have_field(:charge).of_type('Charge')
+    expect(subject).to have_field(:currency).of_type('CurrencyEnum!')
+    expect(subject).to have_field(:subscription).of_type('Subscription')
+    expect(subject).to have_field(:true_up_fee).of_type('Fee')
+    expect(subject).to have_field(:true_up_parent_fee).of_type('Fee')
+    expect(subject).to have_field(:creditable_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:events_count).of_type('BigInt')
+    expect(subject).to have_field(:fee_type).of_type('FeeTypesEnum!')
+    expect(subject).to have_field(:taxes_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:taxes_rate).of_type('Float')
+    expect(subject).to have_field(:units).of_type('Float!')
+    expect(subject).to have_field(:applied_taxes).of_type('[FeeAppliedTax!]')
+    expect(subject).to have_field(:adjusted_fee).of_type('Boolean!')
+    expect(subject).to have_field(:adjusted_fee_type).of_type('AdjustedFeeTypeEnum')
+    expect(subject).to have_field(:grouped_by).of_type('JSON!')
 
-  it { is_expected.to have_field(:charge_filter).of_type('ChargeFilter') }
+    expect(subject).to have_field(:charge_filter).of_type('ChargeFilter')
+  end
 end

--- a/spec/graphql/types/integration_collection_mappings/create_input_spec.rb
+++ b/spec/graphql/types/integration_collection_mappings/create_input_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationCollectionMappings::CreateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:integration_id).of_type('ID!') }
-  it { is_expected.to accept_argument(:mapping_type).of_type('MappingTypeEnum!') }
-  it { is_expected.to accept_argument(:external_account_code).of_type('String') }
-  it { is_expected.to accept_argument(:external_id).of_type('String!') }
-  it { is_expected.to accept_argument(:external_name).of_type('String') }
-  it { is_expected.to accept_argument(:tax_code).of_type('String') }
-  it { is_expected.to accept_argument(:tax_nexus).of_type('String') }
-  it { is_expected.to accept_argument(:tax_type).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:integration_id).of_type('ID!')
+    expect(subject).to accept_argument(:mapping_type).of_type('MappingTypeEnum!')
+    expect(subject).to accept_argument(:external_account_code).of_type('String')
+    expect(subject).to accept_argument(:external_id).of_type('String!')
+    expect(subject).to accept_argument(:external_name).of_type('String')
+    expect(subject).to accept_argument(:tax_code).of_type('String')
+    expect(subject).to accept_argument(:tax_nexus).of_type('String')
+    expect(subject).to accept_argument(:tax_type).of_type('String')
+  end
 end

--- a/spec/graphql/types/integration_collection_mappings/object_spec.rb
+++ b/spec/graphql/types/integration_collection_mappings/object_spec.rb
@@ -5,13 +5,15 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationCollectionMappings::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:integration_id).of_type('ID!') }
-  it { is_expected.to have_field(:mapping_type).of_type('MappingTypeEnum!') }
-  it { is_expected.to have_field(:external_account_code).of_type('String') }
-  it { is_expected.to have_field(:external_id).of_type('String!') }
-  it { is_expected.to have_field(:external_name).of_type('String') }
-  it { is_expected.to have_field(:tax_code).of_type('String') }
-  it { is_expected.to have_field(:tax_nexus).of_type('String') }
-  it { is_expected.to have_field(:tax_type).of_type('String') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:integration_id).of_type('ID!')
+    expect(subject).to have_field(:mapping_type).of_type('MappingTypeEnum!')
+    expect(subject).to have_field(:external_account_code).of_type('String')
+    expect(subject).to have_field(:external_id).of_type('String!')
+    expect(subject).to have_field(:external_name).of_type('String')
+    expect(subject).to have_field(:tax_code).of_type('String')
+    expect(subject).to have_field(:tax_nexus).of_type('String')
+    expect(subject).to have_field(:tax_type).of_type('String')
+  end
 end

--- a/spec/graphql/types/integration_collection_mappings/update_input_spec.rb
+++ b/spec/graphql/types/integration_collection_mappings/update_input_spec.rb
@@ -5,13 +5,15 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationCollectionMappings::UpdateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID!') }
-  it { is_expected.to accept_argument(:integration_id).of_type('ID') }
-  it { is_expected.to accept_argument(:mapping_type).of_type('MappingTypeEnum') }
-  it { is_expected.to accept_argument(:external_account_code).of_type('String') }
-  it { is_expected.to accept_argument(:external_id).of_type('String') }
-  it { is_expected.to accept_argument(:external_name).of_type('String') }
-  it { is_expected.to accept_argument(:tax_code).of_type('String') }
-  it { is_expected.to accept_argument(:tax_nexus).of_type('String') }
-  it { is_expected.to accept_argument(:tax_type).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('ID!')
+    expect(subject).to accept_argument(:integration_id).of_type('ID')
+    expect(subject).to accept_argument(:mapping_type).of_type('MappingTypeEnum')
+    expect(subject).to accept_argument(:external_account_code).of_type('String')
+    expect(subject).to accept_argument(:external_id).of_type('String')
+    expect(subject).to accept_argument(:external_name).of_type('String')
+    expect(subject).to accept_argument(:tax_code).of_type('String')
+    expect(subject).to accept_argument(:tax_nexus).of_type('String')
+    expect(subject).to accept_argument(:tax_type).of_type('String')
+  end
 end

--- a/spec/graphql/types/integration_customers/anrok_spec.rb
+++ b/spec/graphql/types/integration_customers/anrok_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationCustomers::Anrok do
   subject { described_class }
 
-  it { is_expected.to have_field(:external_account_id).of_type('String') }
-  it { is_expected.to have_field(:external_customer_id).of_type('String') }
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:integration_type).of_type('IntegrationTypeEnum') }
-  it { is_expected.to have_field(:integration_id).of_type('ID') }
-  it { is_expected.to have_field(:integration_code).of_type('String') }
-  it { is_expected.to have_field(:sync_with_provider).of_type('Boolean') }
+  it do
+    expect(subject).to have_field(:external_account_id).of_type('String')
+    expect(subject).to have_field(:external_customer_id).of_type('String')
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:integration_type).of_type('IntegrationTypeEnum')
+    expect(subject).to have_field(:integration_id).of_type('ID')
+    expect(subject).to have_field(:integration_code).of_type('String')
+    expect(subject).to have_field(:sync_with_provider).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/integration_customers/hubspot_spec.rb
+++ b/spec/graphql/types/integration_customers/hubspot_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationCustomers::Hubspot do
   subject { described_class }
 
-  it { is_expected.to have_field(:external_customer_id).of_type('String') }
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:integration_type).of_type('IntegrationTypeEnum') }
-  it { is_expected.to have_field(:integration_id).of_type('ID') }
-  it { is_expected.to have_field(:integration_code).of_type('String') }
-  it { is_expected.to have_field(:targeted_object).of_type('HubspotTargetedObjectsEnum') }
-  it { is_expected.to have_field(:sync_with_provider).of_type('Boolean') }
+  it do
+    expect(subject).to have_field(:external_customer_id).of_type('String')
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:integration_type).of_type('IntegrationTypeEnum')
+    expect(subject).to have_field(:integration_id).of_type('ID')
+    expect(subject).to have_field(:integration_code).of_type('String')
+    expect(subject).to have_field(:targeted_object).of_type('HubspotTargetedObjectsEnum')
+    expect(subject).to have_field(:sync_with_provider).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/integration_customers/input_spec.rb
+++ b/spec/graphql/types/integration_customers/input_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationCustomers::Input do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID') }
-  it { is_expected.to accept_argument(:external_customer_id).of_type('String') }
-  it { is_expected.to accept_argument(:integration_type).of_type('IntegrationTypeEnum') }
-  it { is_expected.to accept_argument(:integration_id).of_type('ID') }
-  it { is_expected.to accept_argument(:integration_code).of_type('String') }
-  it { is_expected.to accept_argument(:subsidiary_id).of_type('String') }
-  it { is_expected.to accept_argument(:sync_with_provider).of_type('Boolean') }
-  it { is_expected.to accept_argument(:targeted_object).of_type('HubspotTargetedObjectsEnum') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('ID')
+    expect(subject).to accept_argument(:external_customer_id).of_type('String')
+    expect(subject).to accept_argument(:integration_type).of_type('IntegrationTypeEnum')
+    expect(subject).to accept_argument(:integration_id).of_type('ID')
+    expect(subject).to accept_argument(:integration_code).of_type('String')
+    expect(subject).to accept_argument(:subsidiary_id).of_type('String')
+    expect(subject).to accept_argument(:sync_with_provider).of_type('Boolean')
+    expect(subject).to accept_argument(:targeted_object).of_type('HubspotTargetedObjectsEnum')
+  end
 end

--- a/spec/graphql/types/integration_customers/netsuite_spec.rb
+++ b/spec/graphql/types/integration_customers/netsuite_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationCustomers::Netsuite do
   subject { described_class }
 
-  it { is_expected.to have_field(:external_customer_id).of_type('String') }
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:integration_type).of_type('IntegrationTypeEnum') }
-  it { is_expected.to have_field(:integration_id).of_type('ID') }
-  it { is_expected.to have_field(:integration_code).of_type('String') }
-  it { is_expected.to have_field(:subsidiary_id).of_type('String') }
-  it { is_expected.to have_field(:sync_with_provider).of_type('Boolean') }
+  it do
+    expect(subject).to have_field(:external_customer_id).of_type('String')
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:integration_type).of_type('IntegrationTypeEnum')
+    expect(subject).to have_field(:integration_id).of_type('ID')
+    expect(subject).to have_field(:integration_code).of_type('String')
+    expect(subject).to have_field(:subsidiary_id).of_type('String')
+    expect(subject).to have_field(:sync_with_provider).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/integration_customers/salesforce_spec.rb
+++ b/spec/graphql/types/integration_customers/salesforce_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationCustomers::Salesforce do
   subject { described_class }
 
-  it { is_expected.to have_field(:external_customer_id).of_type('String') }
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:integration_type).of_type('IntegrationTypeEnum') }
-  it { is_expected.to have_field(:integration_id).of_type('ID') }
-  it { is_expected.to have_field(:integration_code).of_type('String') }
-  it { is_expected.to have_field(:sync_with_provider).of_type('Boolean') }
+  it do
+    expect(subject).to have_field(:external_customer_id).of_type('String')
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:integration_type).of_type('IntegrationTypeEnum')
+    expect(subject).to have_field(:integration_id).of_type('ID')
+    expect(subject).to have_field(:integration_code).of_type('String')
+    expect(subject).to have_field(:sync_with_provider).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/integration_customers/xero_spec.rb
+++ b/spec/graphql/types/integration_customers/xero_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationCustomers::Xero do
   subject { described_class }
 
-  it { is_expected.to have_field(:external_customer_id).of_type('String') }
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:integration_type).of_type('IntegrationTypeEnum') }
-  it { is_expected.to have_field(:integration_id).of_type('ID') }
-  it { is_expected.to have_field(:integration_code).of_type('String') }
-  it { is_expected.to have_field(:sync_with_provider).of_type('Boolean') }
+  it do
+    expect(subject).to have_field(:external_customer_id).of_type('String')
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:integration_type).of_type('IntegrationTypeEnum')
+    expect(subject).to have_field(:integration_id).of_type('ID')
+    expect(subject).to have_field(:integration_code).of_type('String')
+    expect(subject).to have_field(:sync_with_provider).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/integration_items/object_spec.rb
+++ b/spec/graphql/types/integration_items/object_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationItems::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:external_account_code).of_type('String') }
-  it { is_expected.to have_field(:external_id).of_type('String!') }
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:integration_id).of_type('ID!') }
-  it { is_expected.to have_field(:item_type).of_type('IntegrationItemTypeEnum!') }
-  it { is_expected.to have_field(:external_name).of_type('String') }
+  it do
+    expect(subject).to have_field(:external_account_code).of_type('String')
+    expect(subject).to have_field(:external_id).of_type('String!')
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:integration_id).of_type('ID!')
+    expect(subject).to have_field(:item_type).of_type('IntegrationItemTypeEnum!')
+    expect(subject).to have_field(:external_name).of_type('String')
+  end
 end

--- a/spec/graphql/types/integration_mappings/create_input_spec.rb
+++ b/spec/graphql/types/integration_mappings/create_input_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationMappings::CreateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:integration_id).of_type('ID!') }
-  it { is_expected.to accept_argument(:mappable_id).of_type('ID!') }
-  it { is_expected.to accept_argument(:mappable_type).of_type('MappableTypeEnum!') }
-  it { is_expected.to accept_argument(:external_account_code).of_type('String') }
-  it { is_expected.to accept_argument(:external_id).of_type('String!') }
-  it { is_expected.to accept_argument(:external_name).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:integration_id).of_type('ID!')
+    expect(subject).to accept_argument(:mappable_id).of_type('ID!')
+    expect(subject).to accept_argument(:mappable_type).of_type('MappableTypeEnum!')
+    expect(subject).to accept_argument(:external_account_code).of_type('String')
+    expect(subject).to accept_argument(:external_id).of_type('String!')
+    expect(subject).to accept_argument(:external_name).of_type('String')
+  end
 end

--- a/spec/graphql/types/integration_mappings/object_spec.rb
+++ b/spec/graphql/types/integration_mappings/object_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationMappings::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:integration_id).of_type('ID!') }
-  it { is_expected.to have_field(:mappable_id).of_type('ID!') }
-  it { is_expected.to have_field(:mappable_type).of_type('MappableTypeEnum!') }
-  it { is_expected.to have_field(:external_account_code).of_type('String') }
-  it { is_expected.to have_field(:external_id).of_type('String!') }
-  it { is_expected.to have_field(:external_name).of_type('String') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:integration_id).of_type('ID!')
+    expect(subject).to have_field(:mappable_id).of_type('ID!')
+    expect(subject).to have_field(:mappable_type).of_type('MappableTypeEnum!')
+    expect(subject).to have_field(:external_account_code).of_type('String')
+    expect(subject).to have_field(:external_id).of_type('String!')
+    expect(subject).to have_field(:external_name).of_type('String')
+  end
 end

--- a/spec/graphql/types/integration_mappings/update_input_spec.rb
+++ b/spec/graphql/types/integration_mappings/update_input_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationMappings::UpdateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID!') }
-  it { is_expected.to accept_argument(:integration_id).of_type('ID') }
-  it { is_expected.to accept_argument(:mappable_id).of_type('ID') }
-  it { is_expected.to accept_argument(:mappable_type).of_type('MappableTypeEnum') }
-  it { is_expected.to accept_argument(:external_account_code).of_type('String') }
-  it { is_expected.to accept_argument(:external_id).of_type('String') }
-  it { is_expected.to accept_argument(:external_name).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('ID!')
+    expect(subject).to accept_argument(:integration_id).of_type('ID')
+    expect(subject).to accept_argument(:mappable_id).of_type('ID')
+    expect(subject).to accept_argument(:mappable_type).of_type('MappableTypeEnum')
+    expect(subject).to accept_argument(:external_account_code).of_type('String')
+    expect(subject).to accept_argument(:external_id).of_type('String')
+    expect(subject).to accept_argument(:external_name).of_type('String')
+  end
 end

--- a/spec/graphql/types/integrations/accounts/object_spec.rb
+++ b/spec/graphql/types/integrations/accounts/object_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::Accounts::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:external_account_code).of_type('String!') }
-  it { is_expected.to have_field(:external_id).of_type('String!') }
-  it { is_expected.to have_field(:external_name).of_type('String') }
+  it do
+    expect(subject).to have_field(:external_account_code).of_type('String!')
+    expect(subject).to have_field(:external_id).of_type('String!')
+    expect(subject).to have_field(:external_name).of_type('String')
+  end
 end

--- a/spec/graphql/types/integrations/anrok_spec.rb
+++ b/spec/graphql/types/integrations/anrok_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::Anrok do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
 
-  it { is_expected.to have_field(:api_key).of_type('String!') }
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:failed_invoices_count).of_type('Int') }
-  it { is_expected.to have_field(:has_mappings_configured).of_type('Boolean') }
-  it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:external_account_id).of_type('String') }
+    expect(subject).to have_field(:api_key).of_type('String!')
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:failed_invoices_count).of_type('Int')
+    expect(subject).to have_field(:has_mappings_configured).of_type('Boolean')
+    expect(subject).to have_field(:name).of_type('String!')
+    expect(subject).to have_field(:external_account_id).of_type('String')
+  end
 end

--- a/spec/graphql/types/integrations/hubspot/create_input_spec.rb
+++ b/spec/graphql/types/integrations/hubspot/create_input_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::Hubspot::CreateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:code).of_type('String!') }
-  it { is_expected.to accept_argument(:name).of_type('String!') }
-  it { is_expected.to accept_argument(:connection_id).of_type('String!') }
-  it { is_expected.to accept_argument(:default_targeted_object).of_type('HubspotTargetedObjectsEnum!') }
-  it { is_expected.to accept_argument(:sync_invoices).of_type('Boolean') }
-  it { is_expected.to accept_argument(:sync_subscriptions).of_type('Boolean') }
+  it do
+    expect(subject).to accept_argument(:code).of_type('String!')
+    expect(subject).to accept_argument(:name).of_type('String!')
+    expect(subject).to accept_argument(:connection_id).of_type('String!')
+    expect(subject).to accept_argument(:default_targeted_object).of_type('HubspotTargetedObjectsEnum!')
+    expect(subject).to accept_argument(:sync_invoices).of_type('Boolean')
+    expect(subject).to accept_argument(:sync_subscriptions).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/integrations/hubspot/update_input_spec.rb
+++ b/spec/graphql/types/integrations/hubspot/update_input_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::Hubspot::UpdateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID') }
-  it { is_expected.to accept_argument(:code).of_type('String') }
-  it { is_expected.to accept_argument(:name).of_type('String') }
-  it { is_expected.to accept_argument(:connection_id).of_type('String') }
-  it { is_expected.to accept_argument(:default_targeted_object).of_type('HubspotTargetedObjectsEnum') }
-  it { is_expected.to accept_argument(:sync_invoices).of_type('Boolean') }
-  it { is_expected.to accept_argument(:sync_subscriptions).of_type('Boolean') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('ID')
+    expect(subject).to accept_argument(:code).of_type('String')
+    expect(subject).to accept_argument(:name).of_type('String')
+    expect(subject).to accept_argument(:connection_id).of_type('String')
+    expect(subject).to accept_argument(:default_targeted_object).of_type('HubspotTargetedObjectsEnum')
+    expect(subject).to accept_argument(:sync_invoices).of_type('Boolean')
+    expect(subject).to accept_argument(:sync_subscriptions).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/integrations/hubspot_spec.rb
+++ b/spec/graphql/types/integrations/hubspot_spec.rb
@@ -5,17 +5,19 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::Hubspot do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
 
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:connection_id).of_type('ID!') }
-  it { is_expected.to have_field(:default_targeted_object).of_type('HubspotTargetedObjectsEnum!') }
-  it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:portal_id).of_type('String') }
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:connection_id).of_type('ID!')
+    expect(subject).to have_field(:default_targeted_object).of_type('HubspotTargetedObjectsEnum!')
+    expect(subject).to have_field(:name).of_type('String!')
+    expect(subject).to have_field(:portal_id).of_type('String')
 
-  it { is_expected.to have_field(:invoices_object_type_id).of_type('String') }
-  it { is_expected.to have_field(:subscriptions_object_type_id).of_type('String') }
+    expect(subject).to have_field(:invoices_object_type_id).of_type('String')
+    expect(subject).to have_field(:subscriptions_object_type_id).of_type('String')
 
-  it { is_expected.to have_field(:sync_invoices).of_type('Boolean') }
-  it { is_expected.to have_field(:sync_subscriptions).of_type('Boolean') }
+    expect(subject).to have_field(:sync_invoices).of_type('Boolean')
+    expect(subject).to have_field(:sync_subscriptions).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/integrations/netsuite_spec.rb
+++ b/spec/graphql/types/integrations/netsuite_spec.rb
@@ -5,18 +5,20 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::Netsuite do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
 
-  it { is_expected.to have_field(:client_id).of_type('String') }
-  it { is_expected.to have_field(:client_secret).of_type('String') }
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:has_mappings_configured).of_type('Boolean') }
-  it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:script_endpoint_url).of_type('String!') }
-  it { is_expected.to have_field(:token_id).of_type('String') }
-  it { is_expected.to have_field(:token_secret).of_type('String') }
+    expect(subject).to have_field(:client_id).of_type('String')
+    expect(subject).to have_field(:client_secret).of_type('String')
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:has_mappings_configured).of_type('Boolean')
+    expect(subject).to have_field(:name).of_type('String!')
+    expect(subject).to have_field(:script_endpoint_url).of_type('String!')
+    expect(subject).to have_field(:token_id).of_type('String')
+    expect(subject).to have_field(:token_secret).of_type('String')
 
-  it { is_expected.to have_field(:sync_credit_notes).of_type('Boolean') }
-  it { is_expected.to have_field(:sync_invoices).of_type('Boolean') }
-  it { is_expected.to have_field(:sync_payments).of_type('Boolean') }
+    expect(subject).to have_field(:sync_credit_notes).of_type('Boolean')
+    expect(subject).to have_field(:sync_invoices).of_type('Boolean')
+    expect(subject).to have_field(:sync_payments).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/integrations/salesforce/create_input_spec.rb
+++ b/spec/graphql/types/integrations/salesforce/create_input_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::Salesforce::CreateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:code).of_type('String!') }
-  it { is_expected.to accept_argument(:name).of_type('String!') }
-  it { is_expected.to accept_argument(:instance_id).of_type('String!') }
+  it do
+    expect(subject).to accept_argument(:code).of_type('String!')
+    expect(subject).to accept_argument(:name).of_type('String!')
+    expect(subject).to accept_argument(:instance_id).of_type('String!')
+  end
 end

--- a/spec/graphql/types/integrations/salesforce/sync_invoice_input_spec.rb
+++ b/spec/graphql/types/integrations/salesforce/sync_invoice_input_spec.rb
@@ -5,5 +5,7 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::Salesforce::SyncInvoiceInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:invoice_id).of_type('ID!') }
+  it do
+    expect(subject).to accept_argument(:invoice_id).of_type('ID!')
+  end
 end

--- a/spec/graphql/types/integrations/salesforce/update_input_spec.rb
+++ b/spec/graphql/types/integrations/salesforce/update_input_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::Salesforce::UpdateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID') }
-  it { is_expected.to accept_argument(:name).of_type('String') }
-  it { is_expected.to accept_argument(:instance_id).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('ID')
+    expect(subject).to accept_argument(:name).of_type('String')
+    expect(subject).to accept_argument(:instance_id).of_type('String')
+  end
 end

--- a/spec/graphql/types/integrations/salesforce_spec.rb
+++ b/spec/graphql/types/integrations/salesforce_spec.rb
@@ -5,9 +5,11 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::Salesforce do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
 
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:instance_id).of_type('String!') }
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:name).of_type('String!')
+    expect(subject).to have_field(:instance_id).of_type('String!')
+  end
 end

--- a/spec/graphql/types/integrations/subsidiaries/object_spec.rb
+++ b/spec/graphql/types/integrations/subsidiaries/object_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::Subsidiaries::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:external_id).of_type('String!') }
-  it { is_expected.to have_field(:external_name).of_type('String') }
+  it do
+    expect(subject).to have_field(:external_id).of_type('String!')
+    expect(subject).to have_field(:external_name).of_type('String')
+  end
 end

--- a/spec/graphql/types/integrations/sync_credit_note_input_spec.rb
+++ b/spec/graphql/types/integrations/sync_credit_note_input_spec.rb
@@ -5,5 +5,7 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::SyncCreditNoteInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:credit_note_id).of_type('ID!') }
+  it do
+    expect(subject).to accept_argument(:credit_note_id).of_type('ID!')
+  end
 end

--- a/spec/graphql/types/integrations/sync_hubspot_invoice_input_spec.rb
+++ b/spec/graphql/types/integrations/sync_hubspot_invoice_input_spec.rb
@@ -5,5 +5,7 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::SyncHubspotInvoiceInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:invoice_id).of_type('ID!') }
+  it do
+    expect(subject).to accept_argument(:invoice_id).of_type('ID!')
+  end
 end

--- a/spec/graphql/types/integrations/sync_invoice_input_spec.rb
+++ b/spec/graphql/types/integrations/sync_invoice_input_spec.rb
@@ -5,5 +5,7 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::SyncInvoiceInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:invoice_id).of_type('ID!') }
+  it do
+    expect(subject).to accept_argument(:invoice_id).of_type('ID!')
+  end
 end

--- a/spec/graphql/types/integrations/xero_spec.rb
+++ b/spec/graphql/types/integrations/xero_spec.rb
@@ -5,14 +5,16 @@ require 'rails_helper'
 RSpec.describe Types::Integrations::Xero do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
 
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:connection_id).of_type('ID!') }
-  it { is_expected.to have_field(:has_mappings_configured).of_type('Boolean') }
-  it { is_expected.to have_field(:name).of_type('String!') }
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:connection_id).of_type('ID!')
+    expect(subject).to have_field(:has_mappings_configured).of_type('Boolean')
+    expect(subject).to have_field(:name).of_type('String!')
 
-  it { is_expected.to have_field(:sync_credit_notes).of_type('Boolean') }
-  it { is_expected.to have_field(:sync_invoices).of_type('Boolean') }
-  it { is_expected.to have_field(:sync_payments).of_type('Boolean') }
+    expect(subject).to have_field(:sync_credit_notes).of_type('Boolean')
+    expect(subject).to have_field(:sync_invoices).of_type('Boolean')
+    expect(subject).to have_field(:sync_payments).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/invoice_custom_sections/create_input_spec.rb
+++ b/spec/graphql/types/invoice_custom_sections/create_input_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe Types::InvoiceCustomSections::CreateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:code).of_type('String!') }
-  it { is_expected.to accept_argument(:description).of_type('String') }
-  it { is_expected.to accept_argument(:details).of_type('String') }
-  it { is_expected.to accept_argument(:display_name).of_type('String') }
-  it { is_expected.to accept_argument(:name).of_type('String!') }
-  it { is_expected.to accept_argument(:selected).of_type('Boolean') }
+  it do
+    expect(subject).to accept_argument(:code).of_type('String!')
+    expect(subject).to accept_argument(:description).of_type('String')
+    expect(subject).to accept_argument(:details).of_type('String')
+    expect(subject).to accept_argument(:display_name).of_type('String')
+    expect(subject).to accept_argument(:name).of_type('String!')
+    expect(subject).to accept_argument(:selected).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/invoice_custom_sections/object_spec.rb
+++ b/spec/graphql/types/invoice_custom_sections/object_spec.rb
@@ -5,14 +5,16 @@ require 'rails_helper'
 RSpec.describe Types::InvoiceCustomSections::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:organization).of_type('Organization') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:organization).of_type('Organization')
 
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:description).of_type('String') }
-  it { is_expected.to have_field(:details).of_type('String') }
-  it { is_expected.to have_field(:display_name).of_type('String') }
-  it { is_expected.to have_field(:name).of_type('String!') }
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:description).of_type('String')
+    expect(subject).to have_field(:details).of_type('String')
+    expect(subject).to have_field(:display_name).of_type('String')
+    expect(subject).to have_field(:name).of_type('String!')
 
-  it { is_expected.to have_field(:selected).of_type('Boolean!') }
+    expect(subject).to have_field(:selected).of_type('Boolean!')
+  end
 end

--- a/spec/graphql/types/invoice_custom_sections/update_input_spec.rb
+++ b/spec/graphql/types/invoice_custom_sections/update_input_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::InvoiceCustomSections::UpdateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID!') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('ID!')
 
-  it { is_expected.to accept_argument(:description).of_type('String') }
-  it { is_expected.to accept_argument(:details).of_type('String') }
-  it { is_expected.to accept_argument(:display_name).of_type('String') }
-  it { is_expected.to accept_argument(:name).of_type('String') }
-  it { is_expected.to accept_argument(:selected).of_type('Boolean') }
+    expect(subject).to accept_argument(:description).of_type('String')
+    expect(subject).to accept_argument(:details).of_type('String')
+    expect(subject).to accept_argument(:display_name).of_type('String')
+    expect(subject).to accept_argument(:name).of_type('String')
+    expect(subject).to accept_argument(:selected).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/invoice_subscriptions/object_spec.rb
+++ b/spec/graphql/types/invoice_subscriptions/object_spec.rb
@@ -5,23 +5,25 @@ require "rails_helper"
 RSpec.describe Types::InvoiceSubscriptions::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:invoice).of_type("Invoice!") }
-  it { is_expected.to have_field(:subscription).of_type("Subscription!") }
+  it do
+    expect(subject).to have_field(:invoice).of_type("Invoice!")
+    expect(subject).to have_field(:subscription).of_type("Subscription!")
 
-  it { is_expected.to have_field(:charge_amount_cents).of_type("BigInt!") }
-  it { is_expected.to have_field(:subscription_amount_cents).of_type("BigInt!") }
-  it { is_expected.to have_field(:total_amount_cents).of_type("BigInt!") }
+    expect(subject).to have_field(:charge_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:subscription_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:total_amount_cents).of_type("BigInt!")
 
-  it { is_expected.to have_field(:fees).of_type("[Fee!]") }
+    expect(subject).to have_field(:fees).of_type("[Fee!]")
 
-  it { is_expected.to have_field(:charges_from_datetime).of_type("ISO8601DateTime") }
-  it { is_expected.to have_field(:charges_to_datetime).of_type("ISO8601DateTime") }
+    expect(subject).to have_field(:charges_from_datetime).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:charges_to_datetime).of_type("ISO8601DateTime")
 
-  it { is_expected.to have_field(:in_advance_charges_from_datetime).of_type("ISO8601DateTime") }
-  it { is_expected.to have_field(:in_advance_charges_to_datetime).of_type("ISO8601DateTime") }
+    expect(subject).to have_field(:in_advance_charges_from_datetime).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:in_advance_charges_to_datetime).of_type("ISO8601DateTime")
 
-  it { is_expected.to have_field(:from_datetime).of_type("ISO8601DateTime") }
-  it { is_expected.to have_field(:to_datetime).of_type("ISO8601DateTime") }
+    expect(subject).to have_field(:from_datetime).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:to_datetime).of_type("ISO8601DateTime")
 
-  it { is_expected.to have_field(:accept_new_charge_fees).of_type("Boolean!") }
+    expect(subject).to have_field(:accept_new_charge_fees).of_type("Boolean!")
+  end
 end

--- a/spec/graphql/types/invoices/fee_input_spec.rb
+++ b/spec/graphql/types/invoices/fee_input_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::Invoices::FeeInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:add_on_id).of_type('ID!') }
-  it { is_expected.to accept_argument(:description).of_type('String') }
-  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
-  it { is_expected.to accept_argument(:name).of_type('String') }
-  it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
-  it { is_expected.to accept_argument(:unit_amount_cents).of_type('BigInt') }
-  it { is_expected.to accept_argument(:units).of_type('Float') }
+  it do
+    expect(subject).to accept_argument(:add_on_id).of_type('ID!')
+    expect(subject).to accept_argument(:description).of_type('String')
+    expect(subject).to accept_argument(:invoice_display_name).of_type('String')
+    expect(subject).to accept_argument(:name).of_type('String')
+    expect(subject).to accept_argument(:tax_codes).of_type('[String!]')
+    expect(subject).to accept_argument(:unit_amount_cents).of_type('BigInt')
+    expect(subject).to accept_argument(:units).of_type('Float')
+  end
 end

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -5,60 +5,62 @@ require 'rails_helper'
 RSpec.describe Types::Invoices::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:customer).of_type('Customer!') }
+  it do
+    expect(subject).to have_field(:customer).of_type('Customer!')
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:number).of_type('String!') }
-  it { is_expected.to have_field(:sequential_id).of_type('ID!') }
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:number).of_type('String!')
+    expect(subject).to have_field(:sequential_id).of_type('ID!')
 
-  it { is_expected.to have_field(:self_billed).of_type('Boolean!') }
-  it { is_expected.to have_field(:version_number).of_type('Int!') }
+    expect(subject).to have_field(:self_billed).of_type('Boolean!')
+    expect(subject).to have_field(:version_number).of_type('Int!')
 
-  it { is_expected.to have_field(:invoice_type).of_type('InvoiceTypeEnum!') }
-  it { is_expected.to have_field(:payment_dispute_losable).of_type('Boolean!') }
-  it { is_expected.to have_field(:payment_dispute_lost_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:payment_status).of_type('InvoicePaymentStatusTypeEnum!') }
-  it { is_expected.to have_field(:status).of_type('InvoiceStatusTypeEnum!') }
-  it { is_expected.to have_field(:voidable).of_type('Boolean!') }
+    expect(subject).to have_field(:invoice_type).of_type('InvoiceTypeEnum!')
+    expect(subject).to have_field(:payment_dispute_losable).of_type('Boolean!')
+    expect(subject).to have_field(:payment_dispute_lost_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:payment_status).of_type('InvoicePaymentStatusTypeEnum!')
+    expect(subject).to have_field(:status).of_type('InvoiceStatusTypeEnum!')
+    expect(subject).to have_field(:voidable).of_type('Boolean!')
 
-  it { is_expected.to have_field(:currency).of_type('CurrencyEnum') }
-  it { is_expected.to have_field(:taxes_rate).of_type('Float!') }
+    expect(subject).to have_field(:currency).of_type('CurrencyEnum')
+    expect(subject).to have_field(:taxes_rate).of_type('Float!')
 
-  it { is_expected.to have_field(:charge_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:coupons_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:credit_notes_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:fees_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:prepaid_credit_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:progressive_billing_credit_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:sub_total_excluding_taxes_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:sub_total_including_taxes_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:taxes_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:total_amount_cents).of_type('BigInt!') }
+    expect(subject).to have_field(:charge_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:coupons_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:credit_notes_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:fees_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:prepaid_credit_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:progressive_billing_credit_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:sub_total_excluding_taxes_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:sub_total_including_taxes_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:taxes_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:total_amount_cents).of_type('BigInt!')
 
-  it { is_expected.to have_field(:issuing_date).of_type('ISO8601Date!') }
-  it { is_expected.to have_field(:payment_due_date).of_type('ISO8601Date!') }
-  it { is_expected.to have_field(:payment_overdue).of_type('Boolean!') }
-  it { is_expected.to have_field(:all_charges_have_fees).of_type('Boolean!') }
+    expect(subject).to have_field(:issuing_date).of_type('ISO8601Date!')
+    expect(subject).to have_field(:payment_due_date).of_type('ISO8601Date!')
+    expect(subject).to have_field(:payment_overdue).of_type('Boolean!')
+    expect(subject).to have_field(:all_charges_have_fees).of_type('Boolean!')
 
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
 
-  it { is_expected.to have_field(:creditable_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:refundable_amount_cents).of_type('BigInt!') }
+    expect(subject).to have_field(:creditable_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:refundable_amount_cents).of_type('BigInt!')
 
-  it { is_expected.to have_field(:file_url).of_type('String') }
-  it { is_expected.to have_field(:metadata).of_type('[InvoiceMetadata!]') }
+    expect(subject).to have_field(:file_url).of_type('String')
+    expect(subject).to have_field(:metadata).of_type('[InvoiceMetadata!]')
 
-  it { is_expected.to have_field(:applied_taxes).of_type('[InvoiceAppliedTax!]') }
-  it { is_expected.to have_field(:credit_notes).of_type('[CreditNote!]') }
-  it { is_expected.to have_field(:fees).of_type('[Fee!]') }
-  it { is_expected.to have_field(:invoice_subscriptions).of_type('[InvoiceSubscription!]') }
-  it { is_expected.to have_field(:subscriptions).of_type('[Subscription!]') }
+    expect(subject).to have_field(:applied_taxes).of_type('[InvoiceAppliedTax!]')
+    expect(subject).to have_field(:credit_notes).of_type('[CreditNote!]')
+    expect(subject).to have_field(:fees).of_type('[Fee!]')
+    expect(subject).to have_field(:invoice_subscriptions).of_type('[InvoiceSubscription!]')
+    expect(subject).to have_field(:subscriptions).of_type('[Subscription!]')
 
-  it { is_expected.to have_field(:external_hubspot_integration_id).of_type('String') }
-  it { is_expected.to have_field(:external_salesforce_integration_id).of_type('String') }
-  it { is_expected.to have_field(:external_integration_id).of_type('String') }
-  it { is_expected.to have_field(:integration_hubspot_syncable).of_type('Boolean!') }
-  it { is_expected.to have_field(:integration_salesforce_syncable).of_type('Boolean!') }
-  it { is_expected.to have_field(:integration_syncable).of_type('Boolean!') }
+    expect(subject).to have_field(:external_hubspot_integration_id).of_type('String')
+    expect(subject).to have_field(:external_salesforce_integration_id).of_type('String')
+    expect(subject).to have_field(:external_integration_id).of_type('String')
+    expect(subject).to have_field(:integration_hubspot_syncable).of_type('Boolean!')
+    expect(subject).to have_field(:integration_salesforce_syncable).of_type('Boolean!')
+    expect(subject).to have_field(:integration_syncable).of_type('Boolean!')
+  end
 end

--- a/spec/graphql/types/membership_type_spec.rb
+++ b/spec/graphql/types/membership_type_spec.rb
@@ -5,16 +5,18 @@ require 'rails_helper'
 RSpec.describe Types::MembershipType do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
 
-  it { is_expected.to have_field(:organization).of_type('Organization!') }
-  it { is_expected.to have_field(:user).of_type('User!') }
+    expect(subject).to have_field(:organization).of_type('Organization!')
+    expect(subject).to have_field(:user).of_type('User!')
 
-  it { is_expected.to have_field(:permissions).of_type('Permissions!') }
-  it { is_expected.to have_field(:role).of_type('MembershipRole!') }
-  it { is_expected.to have_field(:status).of_type('MembershipStatus!') }
+    expect(subject).to have_field(:permissions).of_type('Permissions!')
+    expect(subject).to have_field(:role).of_type('MembershipRole!')
+    expect(subject).to have_field(:status).of_type('MembershipStatus!')
 
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:revoked_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:revoked_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
+  end
 end

--- a/spec/graphql/types/organizations/current_organization_type_spec.rb
+++ b/spec/graphql/types/organizations/current_organization_type_spec.rb
@@ -4,44 +4,46 @@ require 'rails_helper'
 RSpec.describe Types::Organizations::CurrentOrganizationType do
   subject { described_class }
 
-  it { is_expected.to be < ::Types::Organizations::BaseOrganizationType }
+  it do
+    expect(subject).to be < ::Types::Organizations::BaseOrganizationType
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
+    expect(subject).to have_field(:id).of_type('ID!')
 
-  it { is_expected.to have_field(:default_currency).of_type('CurrencyEnum!') }
-  it { is_expected.to have_field(:email).of_type('String') }
-  it { is_expected.to have_field(:legal_name).of_type('String') }
-  it { is_expected.to have_field(:legal_number).of_type('String') }
-  it { is_expected.to have_field(:logo_url).of_type('String') }
-  it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:tax_identification_number).of_type('String') }
+    expect(subject).to have_field(:default_currency).of_type('CurrencyEnum!')
+    expect(subject).to have_field(:email).of_type('String')
+    expect(subject).to have_field(:legal_name).of_type('String')
+    expect(subject).to have_field(:legal_number).of_type('String')
+    expect(subject).to have_field(:logo_url).of_type('String')
+    expect(subject).to have_field(:name).of_type('String!')
+    expect(subject).to have_field(:tax_identification_number).of_type('String')
 
-  it { is_expected.to have_field(:address_line1).of_type('String') }
-  it { is_expected.to have_field(:address_line2).of_type('String') }
-  it { is_expected.to have_field(:city).of_type('String') }
-  it { is_expected.to have_field(:country).of_type('CountryCode') }
-  it { is_expected.to have_field(:net_payment_term).of_type('Int!') }
-  it { is_expected.to have_field(:state).of_type('String') }
-  it { is_expected.to have_field(:zipcode).of_type('String') }
+    expect(subject).to have_field(:address_line1).of_type('String')
+    expect(subject).to have_field(:address_line2).of_type('String')
+    expect(subject).to have_field(:city).of_type('String')
+    expect(subject).to have_field(:country).of_type('CountryCode')
+    expect(subject).to have_field(:net_payment_term).of_type('Int!')
+    expect(subject).to have_field(:state).of_type('String')
+    expect(subject).to have_field(:zipcode).of_type('String')
 
-  it { is_expected.to have_field(:api_key).of_type('String').with_permission('developers:keys:manage') }
-  it { is_expected.to have_field(:hmac_key).of_type('String').with_permission('developers:keys:manage') }
-  it { is_expected.to have_field(:webhook_url).of_type('String').with_permission('developers:manage') }
+    expect(subject).to have_field(:api_key).of_type('String').with_permission('developers:keys:manage')
+    expect(subject).to have_field(:hmac_key).of_type('String').with_permission('developers:keys:manage')
+    expect(subject).to have_field(:webhook_url).of_type('String').with_permission('developers:manage')
 
-  it { is_expected.to have_field(:timezone).of_type('TimezoneEnum') }
+    expect(subject).to have_field(:timezone).of_type('TimezoneEnum')
 
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
 
-  it { is_expected.to have_field(:finalize_zero_amount_invoice).of_type('Boolean!') }
-  it { is_expected.to have_field(:billing_configuration).of_type('OrganizationBillingConfiguration').with_permission('organization:invoices:view') }
-  it { is_expected.to have_field(:email_settings).of_type('[EmailSettingsEnum!]').with_permission('organization:emails:view') }
-  it { is_expected.to have_field(:taxes).of_type('[Tax!]').with_permission('organization:taxes:view') }
+    expect(subject).to have_field(:finalize_zero_amount_invoice).of_type('Boolean!')
+    expect(subject).to have_field(:billing_configuration).of_type('OrganizationBillingConfiguration').with_permission('organization:invoices:view')
+    expect(subject).to have_field(:email_settings).of_type('[EmailSettingsEnum!]').with_permission('organization:emails:view')
+    expect(subject).to have_field(:taxes).of_type('[Tax!]').with_permission('organization:taxes:view')
 
-  it { is_expected.to have_field(:adyen_payment_providers).of_type('[AdyenProvider!]').with_permission('organization:integrations:view') }
-  it { is_expected.to have_field(:cashfree_payment_providers).of_type('[CashfreeProvider!]').with_permission('organization:integrations:view') }
-  it { is_expected.to have_field(:gocardless_payment_providers).of_type('[GocardlessProvider!]').with_permission('organization:integrations:view') }
-  it { is_expected.to have_field(:stripe_payment_providers).of_type('[StripeProvider!]').with_permission('organization:integrations:view') }
+    expect(subject).to have_field(:adyen_payment_providers).of_type('[AdyenProvider!]').with_permission('organization:integrations:view')
+    expect(subject).to have_field(:cashfree_payment_providers).of_type('[CashfreeProvider!]').with_permission('organization:integrations:view')
+    expect(subject).to have_field(:gocardless_payment_providers).of_type('[GocardlessProvider!]').with_permission('organization:integrations:view')
+    expect(subject).to have_field(:stripe_payment_providers).of_type('[StripeProvider!]').with_permission('organization:integrations:view')
 
-  it { is_expected.to have_field(:applied_dunning_campaign).of_type("DunningCampaign") }
+    expect(subject).to have_field(:applied_dunning_campaign).of_type("DunningCampaign")
+  end
 end

--- a/spec/graphql/types/organizations/organization_type_spec.rb
+++ b/spec/graphql/types/organizations/organization_type_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::Organizations::OrganizationType do
   subject { described_class }
 
-  it { is_expected.to be < ::Types::Organizations::BaseOrganizationType }
+  it do
+    expect(subject).to be < ::Types::Organizations::BaseOrganizationType
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:logo_url).of_type('String') }
-  it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:timezone).of_type('TimezoneEnum') }
-  it { is_expected.to have_field(:default_currency).of_type('CurrencyEnum!') }
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:logo_url).of_type('String')
+    expect(subject).to have_field(:name).of_type('String!')
+    expect(subject).to have_field(:timezone).of_type('TimezoneEnum')
+    expect(subject).to have_field(:default_currency).of_type('CurrencyEnum!')
+  end
 end

--- a/spec/graphql/types/organizations/update_organization_input_spec.rb
+++ b/spec/graphql/types/organizations/update_organization_input_spec.rb
@@ -5,29 +5,31 @@ require 'rails_helper'
 RSpec.describe Types::Organizations::UpdateOrganizationInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:default_currency).of_type('CurrencyEnum') }
-  it { is_expected.to accept_argument(:email).of_type('String') }
-  it { is_expected.to accept_argument(:legal_name).of_type('String') }
-  it { is_expected.to accept_argument(:legal_number).of_type('String') }
-  it { is_expected.to accept_argument(:logo).of_type('String') }
-  it { is_expected.to accept_argument(:tax_identification_number).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:default_currency).of_type('CurrencyEnum')
+    expect(subject).to accept_argument(:email).of_type('String')
+    expect(subject).to accept_argument(:legal_name).of_type('String')
+    expect(subject).to accept_argument(:legal_number).of_type('String')
+    expect(subject).to accept_argument(:logo).of_type('String')
+    expect(subject).to accept_argument(:tax_identification_number).of_type('String')
 
-  it { is_expected.to accept_argument(:address_line1).of_type('String') }
-  it { is_expected.to accept_argument(:address_line2).of_type('String') }
-  it { is_expected.to accept_argument(:city).of_type('String') }
-  it { is_expected.to accept_argument(:country).of_type('CountryCode') }
-  it { is_expected.to accept_argument(:net_payment_term).of_type('Int') }
-  it { is_expected.to accept_argument(:state).of_type('String') }
-  it { is_expected.to accept_argument(:zipcode).of_type('String') }
+    expect(subject).to accept_argument(:address_line1).of_type('String')
+    expect(subject).to accept_argument(:address_line2).of_type('String')
+    expect(subject).to accept_argument(:city).of_type('String')
+    expect(subject).to accept_argument(:country).of_type('CountryCode')
+    expect(subject).to accept_argument(:net_payment_term).of_type('Int')
+    expect(subject).to accept_argument(:state).of_type('String')
+    expect(subject).to accept_argument(:zipcode).of_type('String')
 
-  it { is_expected.to accept_argument(:document_numbering).of_type('DocumentNumberingEnum') }
-  it { is_expected.to accept_argument(:document_number_prefix).of_type('String') }
+    expect(subject).to accept_argument(:document_numbering).of_type('DocumentNumberingEnum')
+    expect(subject).to accept_argument(:document_number_prefix).of_type('String')
 
-  it { is_expected.to accept_argument(:webhook_url).of_type('String').with_permission('developers:manage') }
+    expect(subject).to accept_argument(:webhook_url).of_type('String').with_permission('developers:manage')
 
-  it { is_expected.to accept_argument(:timezone).of_type('TimezoneEnum') }
+    expect(subject).to accept_argument(:timezone).of_type('TimezoneEnum')
 
-  it { is_expected.to accept_argument(:billing_configuration).of_type('OrganizationBillingConfigurationInput').with_permission('organization:invoices:view') }
-  it { is_expected.to accept_argument(:email_settings).of_type('[EmailSettingsEnum!]').with_permission('organization:emails:view') }
-  it { is_expected.to accept_argument(:finalize_zero_amount_invoice).of_type('Boolean') }
+    expect(subject).to accept_argument(:billing_configuration).of_type('OrganizationBillingConfigurationInput').with_permission('organization:invoices:view')
+    expect(subject).to accept_argument(:email_settings).of_type('[EmailSettingsEnum!]').with_permission('organization:emails:view')
+    expect(subject).to accept_argument(:finalize_zero_amount_invoice).of_type('Boolean')
+  end
 end

--- a/spec/graphql/types/payment_providers/adyen_input_spec.rb
+++ b/spec/graphql/types/payment_providers/adyen_input_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::PaymentProviders::AdyenInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:api_key).of_type('String!') }
-  it { is_expected.to accept_argument(:code).of_type('String!') }
-  it { is_expected.to accept_argument(:hmac_key).of_type('String') }
-  it { is_expected.to accept_argument(:live_prefix).of_type('String') }
-  it { is_expected.to accept_argument(:merchant_account).of_type('String!') }
-  it { is_expected.to accept_argument(:name).of_type('String!') }
-  it { is_expected.to accept_argument(:success_redirect_url).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:api_key).of_type('String!')
+    expect(subject).to accept_argument(:code).of_type('String!')
+    expect(subject).to accept_argument(:hmac_key).of_type('String')
+    expect(subject).to accept_argument(:live_prefix).of_type('String')
+    expect(subject).to accept_argument(:merchant_account).of_type('String!')
+    expect(subject).to accept_argument(:name).of_type('String!')
+    expect(subject).to accept_argument(:success_redirect_url).of_type('String')
+  end
 end

--- a/spec/graphql/types/payment_providers/adyen_spec.rb
+++ b/spec/graphql/types/payment_providers/adyen_spec.rb
@@ -5,13 +5,15 @@ require 'rails_helper'
 RSpec.describe Types::PaymentProviders::Adyen do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:name).of_type('String!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:name).of_type('String!')
 
-  it { is_expected.to have_field(:api_key).of_type('String').with_permission('organization:integrations:view') }
-  it { is_expected.to have_field(:hmac_key).of_type('String').with_permission('organization:integrations:view') }
-  it { is_expected.to have_field(:live_prefix).of_type('String').with_permission('organization:integrations:view') }
-  it { is_expected.to have_field(:merchant_account).of_type('String').with_permission('organization:integrations:view') }
-  it { is_expected.to have_field(:success_redirect_url).of_type('String').with_permission('organization:integrations:view') }
+    expect(subject).to have_field(:api_key).of_type('String').with_permission('organization:integrations:view')
+    expect(subject).to have_field(:hmac_key).of_type('String').with_permission('organization:integrations:view')
+    expect(subject).to have_field(:live_prefix).of_type('String').with_permission('organization:integrations:view')
+    expect(subject).to have_field(:merchant_account).of_type('String').with_permission('organization:integrations:view')
+    expect(subject).to have_field(:success_redirect_url).of_type('String').with_permission('organization:integrations:view')
+  end
 end

--- a/spec/graphql/types/payment_providers/cashfree_input_spec.rb
+++ b/spec/graphql/types/payment_providers/cashfree_input_spec.rb
@@ -5,9 +5,11 @@ require 'rails_helper'
 RSpec.describe Types::PaymentProviders::CashfreeInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:client_id).of_type('String!') }
-  it { is_expected.to accept_argument(:client_secret).of_type('String!') }
-  it { is_expected.to accept_argument(:code).of_type('String!') }
-  it { is_expected.to accept_argument(:name).of_type('String!') }
-  it { is_expected.to accept_argument(:success_redirect_url).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:client_id).of_type('String!')
+    expect(subject).to accept_argument(:client_secret).of_type('String!')
+    expect(subject).to accept_argument(:code).of_type('String!')
+    expect(subject).to accept_argument(:name).of_type('String!')
+    expect(subject).to accept_argument(:success_redirect_url).of_type('String')
+  end
 end

--- a/spec/graphql/types/payment_providers/cashfree_spec.rb
+++ b/spec/graphql/types/payment_providers/cashfree_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::PaymentProviders::Cashfree do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:name).of_type('String!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:name).of_type('String!')
 
-  it { is_expected.to have_field(:client_id).of_type('String').with_permission('organization:integrations:view') }
-  it { is_expected.to have_field(:client_secret).of_type('String').with_permission('organization:integrations:view') }
-  it { is_expected.to have_field(:success_redirect_url).of_type('String').with_permission('organization:integrations:view') }
+    expect(subject).to have_field(:client_id).of_type('String').with_permission('organization:integrations:view')
+    expect(subject).to have_field(:client_secret).of_type('String').with_permission('organization:integrations:view')
+    expect(subject).to have_field(:success_redirect_url).of_type('String').with_permission('organization:integrations:view')
+  end
 end

--- a/spec/graphql/types/payment_providers/gocardless_input_spec.rb
+++ b/spec/graphql/types/payment_providers/gocardless_input_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 RSpec.describe Types::PaymentProviders::GocardlessInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:access_code).of_type('String') }
-  it { is_expected.to accept_argument(:code).of_type('String!') }
-  it { is_expected.to accept_argument(:name).of_type('String!') }
-  it { is_expected.to accept_argument(:success_redirect_url).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:access_code).of_type('String')
+    expect(subject).to accept_argument(:code).of_type('String!')
+    expect(subject).to accept_argument(:name).of_type('String!')
+    expect(subject).to accept_argument(:success_redirect_url).of_type('String')
+  end
 end

--- a/spec/graphql/types/payment_providers/gocardless_spec.rb
+++ b/spec/graphql/types/payment_providers/gocardless_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::PaymentProviders::Gocardless do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:name).of_type('String!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:name).of_type('String!')
 
-  it { is_expected.to have_field(:has_access_token).of_type('Boolean').with_permission('organization:integrations:view') }
-  it { is_expected.to have_field(:success_redirect_url).of_type('String').with_permission('organization:integrations:view') }
-  it { is_expected.to have_field(:webhook_secret).of_type('String').with_permission('organization:integrations:view') }
+    expect(subject).to have_field(:has_access_token).of_type('Boolean').with_permission('organization:integrations:view')
+    expect(subject).to have_field(:success_redirect_url).of_type('String').with_permission('organization:integrations:view')
+    expect(subject).to have_field(:webhook_secret).of_type('String').with_permission('organization:integrations:view')
+  end
 end

--- a/spec/graphql/types/payment_providers/stripe_input_spec.rb
+++ b/spec/graphql/types/payment_providers/stripe_input_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 RSpec.describe Types::PaymentProviders::StripeInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:code).of_type('String!') }
-  it { is_expected.to accept_argument(:name).of_type('String!') }
-  it { is_expected.to accept_argument(:secret_key).of_type('String') }
-  it { is_expected.to accept_argument(:success_redirect_url).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:code).of_type('String!')
+    expect(subject).to accept_argument(:name).of_type('String!')
+    expect(subject).to accept_argument(:secret_key).of_type('String')
+    expect(subject).to accept_argument(:success_redirect_url).of_type('String')
+  end
 end

--- a/spec/graphql/types/payment_providers/stripe_spec.rb
+++ b/spec/graphql/types/payment_providers/stripe_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe Types::PaymentProviders::Stripe do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:name).of_type('String!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:name).of_type('String!')
 
-  it { is_expected.to have_field(:secret_key).of_type('String').with_permission('organization:integrations:view') }
-  it { is_expected.to have_field(:success_redirect_url).of_type('String').with_permission('organization:integrations:view') }
+    expect(subject).to have_field(:secret_key).of_type('String').with_permission('organization:integrations:view')
+    expect(subject).to have_field(:success_redirect_url).of_type('String').with_permission('organization:integrations:view')
+  end
 end

--- a/spec/graphql/types/payment_providers/update_input_spec.rb
+++ b/spec/graphql/types/payment_providers/update_input_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 RSpec.describe Types::PaymentProviders::UpdateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:code).of_type('String') }
-  it { is_expected.to accept_argument(:name).of_type('String') }
-  it { is_expected.to accept_argument(:id).of_type('ID!') }
-  it { is_expected.to accept_argument(:success_redirect_url).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:code).of_type('String')
+    expect(subject).to accept_argument(:name).of_type('String')
+    expect(subject).to accept_argument(:id).of_type('ID!')
+    expect(subject).to accept_argument(:success_redirect_url).of_type('String')
+  end
 end

--- a/spec/graphql/types/payment_requests/object_spec.rb
+++ b/spec/graphql/types/payment_requests/object_spec.rb
@@ -5,15 +5,17 @@ require "rails_helper"
 RSpec.describe Types::PaymentRequests::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:customer).of_type("Customer!") }
-  it { is_expected.to have_field(:invoices).of_type("[Invoice!]!") }
+  it do
+    expect(subject).to have_field(:customer).of_type("Customer!")
+    expect(subject).to have_field(:invoices).of_type("[Invoice!]!")
 
-  it { is_expected.to have_field(:id).of_type("ID!") }
-  it { is_expected.to have_field(:amount_cents).of_type("BigInt!") }
-  it { is_expected.to have_field(:amount_currency).of_type("CurrencyEnum!") }
-  it { is_expected.to have_field(:email).of_type("String!") }
-  it { is_expected.to have_field(:payment_status).of_type("InvoicePaymentStatusTypeEnum!") }
+    expect(subject).to have_field(:id).of_type("ID!")
+    expect(subject).to have_field(:amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:amount_currency).of_type("CurrencyEnum!")
+    expect(subject).to have_field(:email).of_type("String!")
+    expect(subject).to have_field(:payment_status).of_type("InvoicePaymentStatusTypeEnum!")
 
-  it { is_expected.to have_field(:created_at).of_type("ISO8601DateTime!") }
-  it { is_expected.to have_field(:updated_at).of_type("ISO8601DateTime!") }
+    expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+  end
 end

--- a/spec/graphql/types/plans/object_spec.rb
+++ b/spec/graphql/types/plans/object_spec.rb
@@ -5,29 +5,31 @@ require 'rails_helper'
 RSpec.describe Types::Plans::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:organization).of_type('Organization') }
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:amount_currency).of_type('CurrencyEnum!') }
-  it { is_expected.to have_field(:bill_charges_monthly).of_type('Boolean') }
-  it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:description).of_type('String') }
-  it { is_expected.to have_field(:has_overridden_plans).of_type('Boolean') }
-  it { is_expected.to have_field(:interval).of_type('PlanInterval!') }
-  it { is_expected.to have_field(:invoice_display_name).of_type('String') }
-  it { is_expected.to have_field(:minimum_commitment).of_type('Commitment') }
-  it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:parent).of_type('Plan') }
-  it { is_expected.to have_field(:pay_in_advance).of_type('Boolean!') }
-  it { is_expected.to have_field(:trial_period).of_type('Float') }
-  it { is_expected.to have_field(:charges).of_type('[Charge!]') }
-  it { is_expected.to have_field(:taxes).of_type('[Tax!]') }
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:active_subscriptions_count).of_type('Int!') }
-  it { is_expected.to have_field(:charges_count).of_type('Int!') }
-  it { is_expected.to have_field(:customers_count).of_type('Int!') }
-  it { is_expected.to have_field(:draft_invoices_count).of_type('Int!') }
-  it { is_expected.to have_field(:subscriptions_count).of_type('Int!') }
-  it { is_expected.to have_field(:usage_thresholds).of_type('[UsageThreshold!]') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:organization).of_type('Organization')
+    expect(subject).to have_field(:amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:amount_currency).of_type('CurrencyEnum!')
+    expect(subject).to have_field(:bill_charges_monthly).of_type('Boolean')
+    expect(subject).to have_field(:code).of_type('String!')
+    expect(subject).to have_field(:description).of_type('String')
+    expect(subject).to have_field(:has_overridden_plans).of_type('Boolean')
+    expect(subject).to have_field(:interval).of_type('PlanInterval!')
+    expect(subject).to have_field(:invoice_display_name).of_type('String')
+    expect(subject).to have_field(:minimum_commitment).of_type('Commitment')
+    expect(subject).to have_field(:name).of_type('String!')
+    expect(subject).to have_field(:parent).of_type('Plan')
+    expect(subject).to have_field(:pay_in_advance).of_type('Boolean!')
+    expect(subject).to have_field(:trial_period).of_type('Float')
+    expect(subject).to have_field(:charges).of_type('[Charge!]')
+    expect(subject).to have_field(:taxes).of_type('[Tax!]')
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:active_subscriptions_count).of_type('Int!')
+    expect(subject).to have_field(:charges_count).of_type('Int!')
+    expect(subject).to have_field(:customers_count).of_type('Int!')
+    expect(subject).to have_field(:draft_invoices_count).of_type('Int!')
+    expect(subject).to have_field(:subscriptions_count).of_type('Int!')
+    expect(subject).to have_field(:usage_thresholds).of_type('[UsageThreshold!]')
+  end
 end

--- a/spec/graphql/types/subscriptions/charge_overrides_input_spec.rb
+++ b/spec/graphql/types/subscriptions/charge_overrides_input_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::Subscriptions::ChargeOverridesInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:billable_metric_id).of_type('ID!') }
-  it { is_expected.to accept_argument(:id).of_type('ID') }
-  it { is_expected.to accept_argument(:filters).of_type('[ChargeFilterInput!]') }
-  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
-  it { is_expected.to accept_argument(:min_amount_cents).of_type('BigInt') }
-  it { is_expected.to accept_argument(:properties).of_type('PropertiesInput') }
-  it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
+  it do
+    expect(subject).to accept_argument(:billable_metric_id).of_type('ID!')
+    expect(subject).to accept_argument(:id).of_type('ID')
+    expect(subject).to accept_argument(:filters).of_type('[ChargeFilterInput!]')
+    expect(subject).to accept_argument(:invoice_display_name).of_type('String')
+    expect(subject).to accept_argument(:min_amount_cents).of_type('BigInt')
+    expect(subject).to accept_argument(:properties).of_type('PropertiesInput')
+    expect(subject).to accept_argument(:tax_codes).of_type('[String!]')
+  end
 end

--- a/spec/graphql/types/subscriptions/lifetime_usage_object_spec.rb
+++ b/spec/graphql/types/subscriptions/lifetime_usage_object_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe Types::Subscriptions::LifetimeUsageObject do
   subject { described_class }
 
-  it { is_expected.to have_field(:total_usage_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:total_usage_from_datetime).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:total_usage_to_datetime).of_type('ISO8601DateTime!') }
+  it do
+    expect(subject).to have_field(:total_usage_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:total_usage_from_datetime).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:total_usage_to_datetime).of_type('ISO8601DateTime!')
 
-  it { is_expected.to have_field(:last_threshold_amount_cents).of_type('BigInt') }
-  it { is_expected.to have_field(:next_threshold_amount_cents).of_type('BigInt') }
-  it { is_expected.to have_field(:next_threshold_ratio).of_type('Float') }
+    expect(subject).to have_field(:last_threshold_amount_cents).of_type('BigInt')
+    expect(subject).to have_field(:next_threshold_amount_cents).of_type('BigInt')
+    expect(subject).to have_field(:next_threshold_ratio).of_type('Float')
+  end
 end

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -5,34 +5,36 @@ require 'rails_helper'
 RSpec.describe Types::Subscriptions::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:customer).of_type('Customer!') }
-  it { is_expected.to have_field(:external_id).of_type('String!') }
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:plan).of_type('Plan!') }
+  it do
+    expect(subject).to have_field(:customer).of_type('Customer!')
+    expect(subject).to have_field(:external_id).of_type('String!')
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:plan).of_type('Plan!')
 
-  it { is_expected.to have_field(:name).of_type('String') }
-  it { is_expected.to have_field(:next_name).of_type('String') }
-  it { is_expected.to have_field(:next_pending_start_date).of_type('ISO8601Date') }
-  it { is_expected.to have_field(:period_end_date).of_type('ISO8601Date') }
-  it { is_expected.to have_field(:status).of_type('StatusTypeEnum') }
+    expect(subject).to have_field(:name).of_type('String')
+    expect(subject).to have_field(:next_name).of_type('String')
+    expect(subject).to have_field(:next_pending_start_date).of_type('ISO8601Date')
+    expect(subject).to have_field(:period_end_date).of_type('ISO8601Date')
+    expect(subject).to have_field(:status).of_type('StatusTypeEnum')
 
-  it { is_expected.to have_field(:billing_time).of_type('BillingTimeEnum') }
-  it { is_expected.to have_field(:canceled_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:ending_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:started_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:subscription_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:terminated_at).of_type('ISO8601DateTime') }
+    expect(subject).to have_field(:billing_time).of_type('BillingTimeEnum')
+    expect(subject).to have_field(:canceled_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:ending_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:started_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:subscription_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:terminated_at).of_type('ISO8601DateTime')
 
-  it { is_expected.to have_field(:current_billing_period_started_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:current_billing_period_ending_at).of_type('ISO8601DateTime') }
+    expect(subject).to have_field(:current_billing_period_started_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:current_billing_period_ending_at).of_type('ISO8601DateTime')
 
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
 
-  it { is_expected.to have_field(:next_plan).of_type('Plan') }
-  it { is_expected.to have_field(:next_subscription).of_type('Subscription') }
+    expect(subject).to have_field(:next_plan).of_type('Plan')
+    expect(subject).to have_field(:next_subscription).of_type('Subscription')
 
-  it { is_expected.to have_field(:fees).of_type('[Fee!]') }
+    expect(subject).to have_field(:fees).of_type('[Fee!]')
 
-  it { is_expected.to have_field(:lifetime_usage).of_type('SubscriptionLifetimeUsage') }
+    expect(subject).to have_field(:lifetime_usage).of_type('SubscriptionLifetimeUsage')
+  end
 end

--- a/spec/graphql/types/subscriptions/plan_overrides_input_spec.rb
+++ b/spec/graphql/types/subscriptions/plan_overrides_input_spec.rb
@@ -5,14 +5,16 @@ require 'rails_helper'
 RSpec.describe Types::Subscriptions::PlanOverridesInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:amount_cents).of_type('BigInt') }
-  it { is_expected.to accept_argument(:amount_currency).of_type('CurrencyEnum') }
-  it { is_expected.to accept_argument(:charges).of_type('[ChargeOverridesInput!]') }
-  it { is_expected.to accept_argument(:description).of_type('String') }
-  it { is_expected.to accept_argument(:minimum_commitment).of_type('CommitmentInput') }
-  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
-  it { is_expected.to accept_argument(:name).of_type('String') }
-  it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
-  it { is_expected.to accept_argument(:trial_period).of_type('Float') }
-  it { is_expected.to accept_argument(:usage_thresholds).of_type('[UsageThresholdOverridesInput!]') }
+  it do
+    expect(subject).to accept_argument(:amount_cents).of_type('BigInt')
+    expect(subject).to accept_argument(:amount_currency).of_type('CurrencyEnum')
+    expect(subject).to accept_argument(:charges).of_type('[ChargeOverridesInput!]')
+    expect(subject).to accept_argument(:description).of_type('String')
+    expect(subject).to accept_argument(:minimum_commitment).of_type('CommitmentInput')
+    expect(subject).to accept_argument(:invoice_display_name).of_type('String')
+    expect(subject).to accept_argument(:name).of_type('String')
+    expect(subject).to accept_argument(:tax_codes).of_type('[String!]')
+    expect(subject).to accept_argument(:trial_period).of_type('Float')
+    expect(subject).to accept_argument(:usage_thresholds).of_type('[UsageThresholdOverridesInput!]')
+  end
 end

--- a/spec/graphql/types/subscriptions/usage_threshold_overrides_input_spec.rb
+++ b/spec/graphql/types/subscriptions/usage_threshold_overrides_input_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 RSpec.describe Types::Subscriptions::UsageThresholdOverridesInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to accept_argument(:id).of_type('ID') }
-  it { is_expected.to accept_argument(:recurring).of_type('Boolean') }
-  it { is_expected.to accept_argument(:threshold_display_name).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:amount_cents).of_type('BigInt!')
+    expect(subject).to accept_argument(:id).of_type('ID')
+    expect(subject).to accept_argument(:recurring).of_type('Boolean')
+    expect(subject).to accept_argument(:threshold_display_name).of_type('String')
+  end
 end

--- a/spec/graphql/types/usage_thresholds/input_spec.rb
+++ b/spec/graphql/types/usage_thresholds/input_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 RSpec.describe Types::UsageThresholds::Input do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID') }
-  it { is_expected.to accept_argument(:amount_cents).of_type('BigInt') }
-  it { is_expected.to accept_argument(:recurring).of_type('Boolean') }
-  it { is_expected.to accept_argument(:threshold_display_name).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:id).of_type('ID')
+    expect(subject).to accept_argument(:amount_cents).of_type('BigInt')
+    expect(subject).to accept_argument(:recurring).of_type('Boolean')
+    expect(subject).to accept_argument(:threshold_display_name).of_type('String')
+  end
 end

--- a/spec/graphql/types/usage_thresholds/object_spec.rb
+++ b/spec/graphql/types/usage_thresholds/object_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe Types::UsageThresholds::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:threshold_display_name).of_type('String') }
-  it { is_expected.to have_field(:recurring).of_type('Boolean!') }
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:threshold_display_name).of_type('String')
+    expect(subject).to have_field(:recurring).of_type('Boolean!')
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
+  end
 end

--- a/spec/graphql/types/wallet_transactions/object_spec.rb
+++ b/spec/graphql/types/wallet_transactions/object_spec.rb
@@ -5,16 +5,18 @@ require 'rails_helper'
 RSpec.describe Types::WalletTransactions::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:wallet).of_type('Wallet') }
+  it do
+    expect(subject).to have_field(:wallet).of_type('Wallet')
 
-  it { is_expected.to have_field(:amount).of_type('String!') }
-  it { is_expected.to have_field(:credit_amount).of_type('String!') }
-  it { is_expected.to have_field(:invoice_requires_successful_payment).of_type('Boolean!') }
-  it { is_expected.to have_field(:status).of_type('WalletTransactionStatusEnum!') }
-  it { is_expected.to have_field(:transaction_status).of_type('WalletTransactionTransactionStatusEnum!') }
-  it { is_expected.to have_field(:transaction_type).of_type('WalletTransactionTransactionTypeEnum!') }
+    expect(subject).to have_field(:amount).of_type('String!')
+    expect(subject).to have_field(:credit_amount).of_type('String!')
+    expect(subject).to have_field(:invoice_requires_successful_payment).of_type('Boolean!')
+    expect(subject).to have_field(:status).of_type('WalletTransactionStatusEnum!')
+    expect(subject).to have_field(:transaction_status).of_type('WalletTransactionTransactionStatusEnum!')
+    expect(subject).to have_field(:transaction_type).of_type('WalletTransactionTransactionTypeEnum!')
 
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:settled_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:settled_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
+  end
 end

--- a/spec/graphql/types/wallets/object_spec.rb
+++ b/spec/graphql/types/wallets/object_spec.rb
@@ -5,33 +5,35 @@ require 'rails_helper'
 RSpec.describe Types::Wallets::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:customer).of_type('Customer') }
+  it do
+    expect(subject).to have_field(:customer).of_type('Customer')
 
-  it { is_expected.to have_field(:currency).of_type('CurrencyEnum!') }
-  it { is_expected.to have_field(:name).of_type('String') }
-  it { is_expected.to have_field(:status).of_type('WalletStatusEnum!') }
+    expect(subject).to have_field(:currency).of_type('CurrencyEnum!')
+    expect(subject).to have_field(:name).of_type('String')
+    expect(subject).to have_field(:status).of_type('WalletStatusEnum!')
 
-  it { is_expected.to have_field(:rate_amount).of_type('Float!') }
+    expect(subject).to have_field(:rate_amount).of_type('Float!')
 
-  it { is_expected.to have_field(:balance_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:consumed_amount_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:ongoing_balance_cents).of_type('BigInt!') }
-  it { is_expected.to have_field(:ongoing_usage_balance_cents).of_type('BigInt!') }
+    expect(subject).to have_field(:balance_cents).of_type('BigInt!')
+    expect(subject).to have_field(:consumed_amount_cents).of_type('BigInt!')
+    expect(subject).to have_field(:ongoing_balance_cents).of_type('BigInt!')
+    expect(subject).to have_field(:ongoing_usage_balance_cents).of_type('BigInt!')
 
-  it { is_expected.to have_field(:consumed_credits).of_type('Float!') }
-  it { is_expected.to have_field(:credits_balance).of_type('Float!') }
-  it { is_expected.to have_field(:credits_ongoing_balance).of_type('Float!') }
-  it { is_expected.to have_field(:credits_ongoing_usage_balance).of_type('Float!') }
+    expect(subject).to have_field(:consumed_credits).of_type('Float!')
+    expect(subject).to have_field(:credits_balance).of_type('Float!')
+    expect(subject).to have_field(:credits_ongoing_balance).of_type('Float!')
+    expect(subject).to have_field(:credits_ongoing_usage_balance).of_type('Float!')
 
-  it { is_expected.to have_field(:last_balance_sync_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:last_consumed_credit_at).of_type('ISO8601DateTime') }
+    expect(subject).to have_field(:last_balance_sync_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:last_consumed_credit_at).of_type('ISO8601DateTime')
 
-  it { is_expected.to have_field(:recurring_transaction_rules).of_type('[RecurringTransactionRule!]') }
+    expect(subject).to have_field(:recurring_transaction_rules).of_type('[RecurringTransactionRule!]')
 
-  it { is_expected.to have_field(:invoice_requires_successful_payment).of_type('Boolean!') }
+    expect(subject).to have_field(:invoice_requires_successful_payment).of_type('Boolean!')
 
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:expiration_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:terminated_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:expiration_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:terminated_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
+  end
 end

--- a/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe Types::Wallets::RecurringTransactionRules::CreateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:interval).of_type('RecurringTransactionIntervalEnum') }
-  it { is_expected.to accept_argument(:method).of_type('RecurringTransactionMethodEnum') }
-  it { is_expected.to accept_argument(:started_at).of_type('ISO8601DateTime') }
-  it { is_expected.to accept_argument(:target_ongoing_balance).of_type('String') }
-  it { is_expected.to accept_argument(:trigger).of_type('RecurringTransactionTriggerEnum!') }
-  it { is_expected.to accept_argument(:threshold_credits).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:interval).of_type('RecurringTransactionIntervalEnum')
+    expect(subject).to accept_argument(:method).of_type('RecurringTransactionMethodEnum')
+    expect(subject).to accept_argument(:started_at).of_type('ISO8601DateTime')
+    expect(subject).to accept_argument(:target_ongoing_balance).of_type('String')
+    expect(subject).to accept_argument(:trigger).of_type('RecurringTransactionTriggerEnum!')
+    expect(subject).to accept_argument(:threshold_credits).of_type('String')
+  end
 end

--- a/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
@@ -5,16 +5,18 @@ require 'rails_helper'
 RSpec.describe Types::Wallets::RecurringTransactionRules::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:lago_id).of_type('ID!') }
-  it { is_expected.to have_field(:method).of_type('RecurringTransactionMethodEnum!') }
-  it { is_expected.to have_field(:trigger).of_type('RecurringTransactionTriggerEnum!') }
-  it { is_expected.to have_field(:interval).of_type('RecurringTransactionIntervalEnum') }
+  it do
+    expect(subject).to have_field(:lago_id).of_type('ID!')
+    expect(subject).to have_field(:method).of_type('RecurringTransactionMethodEnum!')
+    expect(subject).to have_field(:trigger).of_type('RecurringTransactionTriggerEnum!')
+    expect(subject).to have_field(:interval).of_type('RecurringTransactionIntervalEnum')
 
-  it { is_expected.to have_field(:started_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:target_ongoing_balance).of_type('String') }
-  it { is_expected.to have_field(:threshold_credits).of_type('String') }
-  it { is_expected.to have_field(:paid_credits).of_type('String!') }
-  it { is_expected.to have_field(:granted_credits).of_type('String!') }
+    expect(subject).to have_field(:started_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:target_ongoing_balance).of_type('String')
+    expect(subject).to have_field(:threshold_credits).of_type('String')
+    expect(subject).to have_field(:paid_credits).of_type('String!')
+    expect(subject).to have_field(:granted_credits).of_type('String!')
 
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+  end
 end

--- a/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
@@ -5,13 +5,15 @@ require 'rails_helper'
 RSpec.describe Types::Wallets::RecurringTransactionRules::UpdateInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:interval).of_type('RecurringTransactionIntervalEnum') }
-  it { is_expected.to accept_argument(:method).of_type('RecurringTransactionMethodEnum') }
-  it { is_expected.to accept_argument(:started_at).of_type('ISO8601DateTime') }
-  it { is_expected.to accept_argument(:target_ongoing_balance).of_type('String') }
-  it { is_expected.to accept_argument(:trigger).of_type('RecurringTransactionTriggerEnum') }
-  it { is_expected.to accept_argument(:threshold_credits).of_type('String') }
-  it { is_expected.to accept_argument(:lago_id).of_type('ID') }
-  it { is_expected.to accept_argument(:paid_credits).of_type('String') }
-  it { is_expected.to accept_argument(:granted_credits).of_type('String') }
+  it do
+    expect(subject).to accept_argument(:interval).of_type('RecurringTransactionIntervalEnum')
+    expect(subject).to accept_argument(:method).of_type('RecurringTransactionMethodEnum')
+    expect(subject).to accept_argument(:started_at).of_type('ISO8601DateTime')
+    expect(subject).to accept_argument(:target_ongoing_balance).of_type('String')
+    expect(subject).to accept_argument(:trigger).of_type('RecurringTransactionTriggerEnum')
+    expect(subject).to accept_argument(:threshold_credits).of_type('String')
+    expect(subject).to accept_argument(:lago_id).of_type('ID')
+    expect(subject).to accept_argument(:paid_credits).of_type('String')
+    expect(subject).to accept_argument(:granted_credits).of_type('String')
+  end
 end

--- a/spec/graphql/types/webhook_endpoints/object_spec.rb
+++ b/spec/graphql/types/webhook_endpoints/object_spec.rb
@@ -5,9 +5,11 @@ require 'rails_helper'
 RSpec.describe Types::WebhookEndpoints::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:organization).of_type('Organization') }
-  it { is_expected.to have_field(:webhook_url).of_type('String!') }
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:organization).of_type('Organization')
+    expect(subject).to have_field(:webhook_url).of_type('String!')
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
+  end
 end

--- a/spec/graphql/types/webhooks/object_spec.rb
+++ b/spec/graphql/types/webhooks/object_spec.rb
@@ -5,17 +5,19 @@ require 'rails_helper'
 RSpec.describe Types::Webhooks::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:webhook_endpoint).of_type('WebhookEndpoint') }
-  it { is_expected.to have_field(:endpoint).of_type('String!') }
-  it { is_expected.to have_field(:object_type).of_type('String!') }
-  it { is_expected.to have_field(:retries).of_type('Int!') }
-  it { is_expected.to have_field(:status).of_type('WebhookStatusEnum!') }
-  it { is_expected.to have_field(:webhook_type).of_type('String!') }
-  it { is_expected.to have_field(:http_status).of_type('Int') }
-  it { is_expected.to have_field(:payload).of_type('String') }
-  it { is_expected.to have_field(:response).of_type('String') }
-  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
-  it { is_expected.to have_field(:last_retried_at).of_type('ISO8601DateTime') }
-  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+  it do
+    expect(subject).to have_field(:id).of_type('ID!')
+    expect(subject).to have_field(:webhook_endpoint).of_type('WebhookEndpoint')
+    expect(subject).to have_field(:endpoint).of_type('String!')
+    expect(subject).to have_field(:object_type).of_type('String!')
+    expect(subject).to have_field(:retries).of_type('Int!')
+    expect(subject).to have_field(:status).of_type('WebhookStatusEnum!')
+    expect(subject).to have_field(:webhook_type).of_type('String!')
+    expect(subject).to have_field(:http_status).of_type('Int')
+    expect(subject).to have_field(:payload).of_type('String')
+    expect(subject).to have_field(:response).of_type('String')
+    expect(subject).to have_field(:created_at).of_type('ISO8601DateTime!')
+    expect(subject).to have_field(:last_retried_at).of_type('ISO8601DateTime')
+    expect(subject).to have_field(:updated_at).of_type('ISO8601DateTime!')
+  end
 end


### PR DESCRIPTION
## Context

Our test suite has become pretty long to run.

## Description

This change **saves 951 examples**.

For all GQL types, we use one `it` block per line. It looks very good but this is not ideal. This PR groups all the it blocks

> [!NOTE]
Once merged, I'll add the merge commit to the `.git-blame-ignore-revs` file.

**Before**

```ruby
  it { is_expected.to ... }
  it { is_expected.to ... }
  it { is_expected.to ... }
```

**After**

```ruby
  it do
    expect(subject).to ...
    expect(subject).to ...
    expect(subject).to ...
  end
```

![CleanShot 2025-02-11 at 12 32 43@2x](https://github.com/user-attachments/assets/cf029987-221c-4340-a948-2dbca8dee6d8)

