### PR TITLE
chore(git): Add #3167 to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # Enable TrailingCommaInHashLiteral rubocop rule for all files
 3803519f622313a50def9b5261dfce899bdaf12d
+f83dbe1f847414c927273523b6cf60f3a881a9f1


### PR DESCRIPTION
See https://github.com/getlago/lago-api/pull/3167