### PR TITLE
feat(webhooks): Add subscription updated webhook

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -54,6 +54,7 @@ class SendWebhookJob < ApplicationJob
     "subscription.started" => Webhooks::Subscriptions::StartedService,
     "subscription.termination_alert" => Webhooks::Subscriptions::TerminationAlertService,
     "subscription.trial_ended" => Webhooks::Subscriptions::TrialEndedService,
+    "subscription.updated" => Webhooks::Subscriptions::UpdatedService,
     "subscription.usage_threshold_reached" => Webhooks::Subscriptions::UsageThresholdsReachedService,
     "wallet.created" => Webhooks::Wallets::CreatedService,
     "wallet.updated" => Webhooks::Wallets::UpdatedService,

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -163,7 +163,7 @@ module Subscriptions
         ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at
       )
 
-      after_commit { SendWebhookJob.perform_later('subscription.updated', current_subscription) }
+      after_commit { SendWebhookJob.perform_later("subscription.updated", current_subscription) }
 
       current_subscription
     end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -163,6 +163,8 @@ module Subscriptions
         ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at
       )
 
+      after_commit { SendWebhookJob.perform_later('subscription.updated', current_subscription) }
+
       current_subscription
     end
 

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -37,7 +37,7 @@ module Subscriptions
       else
         subscription.save!
 
-        after_commit { SendWebhookJob.perform_later('subscription.updated', subscription) }
+        after_commit { SendWebhookJob.perform_later("subscription.updated", subscription) }
 
         if subscription.should_sync_hubspot_subscription?
           Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_later(subscription:)

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -37,6 +37,8 @@ module Subscriptions
       else
         subscription.save!
 
+        after_commit { SendWebhookJob.perform_later('subscription.updated', subscription) }
+
         if subscription.should_sync_hubspot_subscription?
           Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_later(subscription:)
         end

--- a/app/services/webhooks/subscriptions/updated_service.rb
+++ b/app/services/webhooks/subscriptions/updated_service.rb
@@ -10,17 +10,17 @@ module Webhooks
       def object_serializer
         ::V1::SubscriptionSerializer.new(
           object,
-          root_name: 'subscription',
+          root_name: "subscription",
           includes: %i[plan customer]
         )
       end
 
       def webhook_type
-        'subscription.updated'
+        "subscription.updated"
       end
 
       def object_type
-        'subscription'
+        "subscription"
       end
     end
   end

--- a/app/services/webhooks/subscriptions/updated_service.rb
+++ b/app/services/webhooks/subscriptions/updated_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Subscriptions
+    class UpdatedService < Webhooks::BaseService
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::SubscriptionSerializer.new(
+          object,
+          root_name: 'subscription',
+          includes: %i[plan customer]
+        )
+      end
+
+      def webhook_type
+        'subscription.updated'
+      end
+
+      def object_type
+        'subscription'
+      end
+    end
+  end
+end

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -483,6 +483,10 @@ RSpec.describe SendWebhookJob, type: :job do
       Webhooks::Subscriptions::TerminatedService
 
     it_behaves_like "a webhook service",
+      "subscription.updated",
+      Webhooks::Subscriptions::UpdatedService
+
+    it_behaves_like "a webhook service",
       "subscription.termination_alert",
       Webhooks::Subscriptions::TerminationAlertService
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -646,6 +646,11 @@ RSpec.describe Subscriptions::CreateService, type: :service do
             end
           end
 
+          it "sends updated subscription webhook", :aggregate_failures do
+            create_service.call
+            expect(SendWebhookJob).to have_been_enqueued.with("subscription.updated", subscription)
+          end
+
           it "keeps the current subscription" do
             result = create_service.call
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -646,7 +646,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
             end
           end
 
-          it "sends updated subscription webhook", :aggregate_failures do
+          it "sends updated subscription webhook" do
             create_service.call
             expect(SendWebhookJob).to have_been_enqueued.with("subscription.updated", subscription)
           end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
       end
     end
 
+    it "sends updated subscription webhook", :aggregate_failures do
+      update_service.call
+      expect(SendWebhookJob).to have_been_enqueued.with("subscription.updated", subscription)
+    end
+
     context "when subscription should sync Hubspot subscription" do
       let(:params) { {name: "new name"} }
 

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
       end
     end
 
-    it "sends updated subscription webhook", :aggregate_failures do
+    it "sends updated subscription webhook" do
       update_service.call
       expect(SendWebhookJob).to have_been_enqueued.with("subscription.updated", subscription)
     end

--- a/spec/services/webhooks/subscriptions/updated_service_spec.rb
+++ b/spec/services/webhooks/subscriptions/updated_service_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Subscriptions::UpdatedService do
+  subject(:webhook_service) { described_class.new(object: subscription) }
+
+  let(:subscription) { create(:subscription) }
+  let(:organization) { subscription.organization }
+
+  describe '.call' do
+    it_behaves_like 'creates webhook', 'subscription.updated', 'subscription'
+  end
+end

--- a/spec/services/webhooks/subscriptions/updated_service_spec.rb
+++ b/spec/services/webhooks/subscriptions/updated_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Webhooks::Subscriptions::UpdatedService do
   subject(:webhook_service) { described_class.new(object: subscription) }
@@ -8,7 +8,7 @@ RSpec.describe Webhooks::Subscriptions::UpdatedService do
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }
 
-  describe '.call' do
-    it_behaves_like 'creates webhook', 'subscription.updated', 'subscription'
+  describe ".call" do
+    it_behaves_like "creates webhook", "subscription.updated", "subscription"
   end
 end


### PR DESCRIPTION
## Context

When downgrading a plan customers won't receive a webhook right away.
We're adding a new webhook  `subscription.updated` that called in case of downgrade or update of subscription.
