### PR TITLE
feat(data): Compute daily usages for positive fees only

### DIFF
--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -19,6 +19,8 @@ module DailyUsages
         return result
       end
 
+      current_usage.fees = current_usage.fees.select { |f| f.units.positive? }
+
       daily_usage = DailyUsage.new(
         organization: subscription.organization,
         customer: subscription.customer,

--- a/app/services/daily_usages/fill_from_invoice_service.rb
+++ b/app/services/daily_usages/fill_from_invoice_service.rb
@@ -55,7 +55,7 @@ module DailyUsages
         amount_cents: invoice.fees_amount_cents,
         total_amount_cents: invoice.fees.sum(&:total_amount_cents),
         taxes_amount_cents: invoice.fees.sum(:taxes_amount_cents),
-        fees: invoice.fees.charge.select { |f| f.subscription_id == subscription.id }
+        fees: invoice.fees.charge.select { |f| f.subscription_id == subscription.id && f.units.positive? }
       )
     end
 

--- a/app/services/daily_usages/fill_history_service.rb
+++ b/app/services/daily_usages/fill_history_service.rb
@@ -35,6 +35,8 @@ module DailyUsages
             previous_daily_usage = nil
           end
 
+          usage.fees = usage.fees.select { |f| f.units.positive? }
+
           daily_usage = DailyUsage.new(
             organization:,
             customer: subscription.customer,

--- a/spec/jobs/daily_usages/compute_job_spec.rb
+++ b/spec/jobs/daily_usages/compute_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe DailyUsages::ComputeJob, type: :job do
   subject(:compute_job) { described_class }
@@ -10,8 +10,8 @@ RSpec.describe DailyUsages::ComputeJob, type: :job do
 
   let(:result) { BaseService::Result.new }
 
-  describe '.perform' do
-    it 'removes all old webhooks' do
+  describe ".perform" do
+    it "delegates to DailyUsages::ComputeService" do
       allow(DailyUsages::ComputeService).to receive(:call)
         .with(subscription:, timestamp:)
         .and_return(result)


### PR DESCRIPTION
The daily usage is needed for the data part of Lago. Currently it contains a lot of useless information due to 0 unit fees.
The goal of this PR is to not populate those fees inside the daily usages.