### PR TITLE
feat(invoice-preview): add base multiple subscription setup

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -221,7 +221,7 @@ module Api
 
         result = Invoices::PreviewService.call(
           customer: result.customer,
-          subscription: result.subscription,
+          subscriptions: result.subscriptions,
           applied_coupons: result.applied_coupons
         )
         if result.success?

--- a/app/services/invoices/preview_context_service.rb
+++ b/app/services/invoices/preview_context_service.rb
@@ -2,6 +2,8 @@
 
 module Invoices
   class PreviewContextService < BaseService
+    Result = BaseResult[:customer, :subscriptions, :applied_coupons]
+
     def initialize(organization:, params:)
       @organization = organization
       @params = params.presence || {}
@@ -10,7 +12,7 @@ module Invoices
 
     def call
       result.customer = find_or_build_customer
-      result.subscription = build_subscription
+      result.subscriptions = find_or_build_subscriptions
       result.applied_coupons = find_or_build_applied_coupons
       result
     rescue ActiveRecord::RecordNotFound => exception
@@ -86,6 +88,10 @@ module Invoices
         created_at: params[:subscription_at].presence || Time.current,
         updated_at: Time.current
       )
+    end
+
+    def find_or_build_subscriptions
+      [build_subscription]
     end
 
     def plan

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -2,9 +2,11 @@
 
 module Invoices
   class PreviewService < BaseService
-    def initialize(customer:, subscription:, applied_coupons: [])
+    Result = BaseResult[:subscriptions, :invoice, :fees_taxes]
+
+    def initialize(customer:, subscriptions:, applied_coupons: [])
       @customer = customer
-      @subscription = subscription
+      @subscriptions = subscriptions
       @applied_coupons = applied_coupons
 
       super
@@ -13,13 +15,14 @@ module Invoices
     def call
       return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: 'customer') unless customer
-      return result.not_found_failure!(resource: 'subscription') unless subscription
+      return result.not_found_failure!(resource: 'subscription') if subscriptions.empty?
+      return result unless currencies_aligned?
 
       @invoice = Invoice.new(
         organization: customer.organization,
         customer:,
         invoice_type: :subscription,
-        currency: subscription.plan&.amount_currency,
+        currency: subscriptions.first.plan.amount_currency,
         timezone: customer.applicable_timezone,
         issuing_date:,
         payment_due_date:,
@@ -28,36 +31,41 @@ module Invoices
         updated_at: Time.current
       )
       invoice.credits = []
-      invoice.subscriptions = [subscription]
+      invoice.subscriptions = subscriptions
 
-      add_subscription_fee
+      add_subscription_fees
       compute_tax_and_totals
 
       result.invoice = invoice
-      result.subscription = subscription
+      result.subscriptions = subscriptions
       result
     end
 
     private
 
-    attr_accessor :customer, :subscription, :invoice, :applied_coupons
+    attr_accessor :customer, :subscriptions, :invoice, :applied_coupons
 
-    def boundaries
-      {
-        from_datetime: date_service.from_datetime,
-        to_datetime: date_service.to_datetime,
-        charges_from_datetime: date_service.charges_from_datetime,
-        charges_to_datetime: date_service.charges_to_datetime,
-        timestamp: billing_time
-      }
-    end
+    def currencies_aligned?
+      subscription_currencies = subscriptions.filter_map { |s| s.plan&.amount_currency }
 
-    def date_service
-      Subscriptions::DatesService.new_instance(subscription, billing_time)
+      if subscription_currencies.uniq.count > 1
+        result.single_validation_failure!(error_code: "subscription_currencies_does_not_match")
+        return false
+      end
+
+      if customer.currency && customer.currency != subscription_currencies.first
+        result.single_validation_failure!(error_code: "customer_currency_does_not_match")
+        return false
+      end
+
+      true
     end
 
     def billing_time
       return @billing_time if defined? @billing_time
+
+      subscription = subscriptions.first
+
       return subscription.subscription_at if subscription.plan.pay_in_advance?
 
       ds = Subscriptions::DatesService.new_instance(subscription, subscription.subscription_at, current_usage: true)
@@ -73,16 +81,29 @@ module Invoices
       (issuing_date + customer.applicable_net_payment_term.days).to_date
     end
 
-    def add_subscription_fee
-      invoice.fees =
-        [
-          Fees::SubscriptionService.call(
-            invoice:,
-            subscription:,
-            boundaries:,
-            context: :preview
-          ).raise_if_error!.fee
-        ]
+    def add_subscription_fees
+      invoice.fees = subscriptions.map do |subscription|
+        date_service = Subscriptions::DatesService.new_instance(subscription, billing_time)
+
+        boundaries = {
+          from_datetime: date_service.from_datetime,
+          to_datetime: date_service.to_datetime,
+          charges_from_datetime: date_service.charges_from_datetime,
+          charges_to_datetime: date_service.charges_to_datetime,
+          timestamp: billing_time
+        }
+
+        fee = Fees::SubscriptionService.call(
+          invoice:,
+          subscription:,
+          boundaries:,
+          context: :preview
+        ).raise_if_error!.fee
+
+        subscription.fees = [fee]
+
+        fee
+      end
     end
 
     def compute_tax_and_totals
@@ -178,7 +199,7 @@ module Invoices
     end
 
     def provider_taxation?
-      customer.integration_customers&.find { |ic| ic.type == 'IntegrationCustomers::AnrokCustomer' }
+      customer.integration_customers.find { |ic| ic.type == 'IntegrationCustomers::AnrokCustomer' }
     end
   end
 end

--- a/spec/services/invoices/preview_context_service_spec.rb
+++ b/spec/services/invoices/preview_context_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
     it "assigns customer, plan, and applied coupons to result" do
       expect(result)
         .to be_success
-        .and have_attributes(customer:, subscription: Subscription, applied_coupons: customer.applied_coupons)
+        .and have_attributes(customer:, subscriptions: [Subscription], applied_coupons: customer.applied_coupons)
     end
   end
 
@@ -167,8 +167,8 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
     end
   end
 
-  describe "#subscription" do
-    subject { result.subscription }
+  describe "#subscriptions" do
+    subject { result.subscriptions }
 
     let(:organization) { customer.organization }
     let(:customer) { create(:customer) }
@@ -193,13 +193,15 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
 
         it "returns new subscription with provided params" do
           expect(subject)
-            .to be_a(Subscription)
-            .and have_attributes(
-              customer:,
-              plan:,
-              subscription_at: subscription_at,
-              started_at: subscription_at,
-              billing_time: params[:billing_time]
+            .to all(
+              be_a(Subscription)
+                .and(have_attributes(
+                  customer:,
+                  plan:,
+                  subscription_at: subscription_at,
+                  started_at: subscription_at,
+                  billing_time: params[:billing_time]
+                ))
             )
         end
       end
@@ -210,13 +212,14 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
 
         it "returns new subscription with default values for subscription date and billing time" do
           expect(subject)
-            .to be_a(Subscription)
-            .and have_attributes(
-              customer:,
-              plan:,
-              subscription_at: Time.current,
-              started_at: Time.current,
-              billing_time: 'calendar'
+            .to all(
+              be_a(Subscription).and(have_attributes(
+                customer:,
+                plan:,
+                subscription_at: Time.current,
+                started_at: Time.current,
+                billing_time: 'calendar'
+              ))
             )
         end
       end

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
-  subject(:preview_service) { described_class.new(customer:, subscription:) }
+  subject(:preview_service) { described_class.new(customer:, subscriptions: [subscription]) }
 
   describe '#call' do
     let(:organization) { create(:organization) }
@@ -44,19 +44,30 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
 
       context 'when customer does not exist' do
         it 'returns an error' do
-          result = described_class.new(customer: nil, subscription:).call
+          result = described_class.new(customer: nil, subscriptions: [subscription]).call
 
           expect(result).not_to be_success
           expect(result.error.error_code).to eq('customer_not_found')
         end
       end
 
-      context 'when subscription does not exist' do
+      context 'when subscriptions are missing' do
         it 'returns an error' do
-          result = described_class.new(customer:, subscription: nil).call
+          result = described_class.new(customer:, subscriptions: []).call
 
           expect(result).not_to be_success
           expect(result.error.error_code).to eq('subscription_not_found')
+        end
+      end
+
+      context 'when currencies do not match' do
+        let(:customer) { build(:customer, organization:, currency: 'USD') }
+
+        it 'returns an error' do
+          result = preview_service.call
+
+          expect(result).not_to be_success
+          expect(result.error.messages[:base]).to include('customer_currency_does_not_match')
         end
       end
 
@@ -124,7 +135,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
 
           it 'creates preview invoice for 2 days with applied coupons' do
             travel_to(timestamp) do
-              result = described_class.new(customer:, subscription:, applied_coupons: [applied_coupon]).call
+              result = described_class.new(customer:, subscriptions: [subscription], applied_coupons: [applied_coupon]).call
 
               expect(result).to be_success
               expect(result.invoice.subscriptions.first).to eq(subscription)


### PR DESCRIPTION
## Context

With invoice preview feature, customers will have possibility to check how next invoice will look like

## Description

This is the first PR in second part that covers persisted subscriptions. Here is the setup for multiple subscription and there is added validation that ensures that multiple subscriptions has the same currency.

Since part 1 is already released, second part PRs will be created from part 2 feature branch: `ftr-invoice-preview-two`