### PR TITLE
fix(fee-estimation): fix rounding when small amounts provided

### DIFF
--- a/app/services/charges/amount_details/range_graduated_percentage_service.rb
+++ b/app/services/charges/amount_details/range_graduated_percentage_service.rb
@@ -42,7 +42,7 @@ module Charges
       end
 
       def per_unit_total_amount
-        @per_unit_total_amount ||= (units * rate).fdiv(100)
+        @per_unit_total_amount ||= units * rate / 100
       end
 
       def total_with_flat_amount

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -48,7 +48,7 @@ module Charges
       def compute_percentage_amount
         return 0 if free_units_value > units
 
-        (units - free_units_value) * rate.fdiv(100)
+        (units - free_units_value) * rate / 100
       end
 
       def compute_fixed_amount
@@ -156,7 +156,7 @@ module Charges
           end
 
           # NOTE: apply rate
-          event_amount = (value * rate).fdiv(100)
+          event_amount = (value * rate) / 100
 
           # NOTE: apply fixed amount
           event_amount += fixed_amount

--- a/app/services/charges/estimate_instant/percentage_service.rb
+++ b/app/services/charges/estimate_instant/percentage_service.rb
@@ -17,7 +17,7 @@ module Charges
           return result
         end
 
-        amount = units * rate.fdiv(100)
+        amount = units * rate / 100
         amount += fixed_amount
         amount = amount.clamp(per_transaction_min_amount, per_transaction_max_amount)
 
@@ -35,7 +35,7 @@ module Charges
 
       def per_transaction_max_amount
         return nil if properties['per_transaction_max_amount'].blank?
-        BigDecimal(properties['per_transaction_max_amount'])
+        BigDecimal(properties['per_transaction_max_amount'].to_s)
       end
 
       def fixed_amount
@@ -44,7 +44,7 @@ module Charges
 
       def per_transaction_min_amount
         return nil if properties['per_transaction_min_amount'].blank?
-        BigDecimal(properties['per_transaction_min_amount'])
+        BigDecimal(properties['per_transaction_min_amount'].to_s)
       end
     end
   end

--- a/spec/services/charges/amount_details/range_graduated_percentage_service_spec.rb
+++ b/spec/services/charges/amount_details/range_graduated_percentage_service_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Charges::AmountDetails::RangeGraduatedPercentageService, type: :s
   let(:total_units) { 15 }
   let(:range) do
     {
-      from_value: 0,
+      from_value: 7,
       to_value: 10,
-      rate: '2',
+      rate: '2.9',
       flat_amount: '2'
     }
   end
@@ -18,13 +18,13 @@ RSpec.describe Charges::AmountDetails::RangeGraduatedPercentageService, type: :s
   it 'returns expected amount details' do
     expect(service.call).to eq(
       {
-        from_value: 0,
+        from_value: 7,
         to_value: 10,
         flat_unit_amount: 2,
-        rate: 2,
-        units: '10.0',
-        per_unit_total_amount: '0.2',
-        total_with_flat_amount: 2.2
+        rate: 2.9,
+        units: '4.0',
+        per_unit_total_amount: '0.116',
+        total_with_flat_amount: 2.116
       }
     )
   end

--- a/spec/services/charges/charge_models/percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/percentage_service_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
     end
   end
 
-  fcontext "with small units amount" do
+  context "with small units amount" do
     let(:running_total) { [] }
     let(:fixed_amount) { nil }
     let(:aggregation) { 4 }
@@ -103,7 +103,7 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
         paid_units: "4.0",
         rate: 2.9,
         per_unit_total_amount: 0.116, # 4 * 0.029
-        paid_events: 4,
+        paid_events: 4
       )
     end
   end

--- a/spec/services/charges/estimate_instant/percentage_service_spec.rb
+++ b/spec/services/charges/estimate_instant/percentage_service_spec.rb
@@ -38,11 +38,11 @@ RSpec.describe Charges::EstimateInstant::PercentageService, type: :service do
 
     context "when units and rate are positive" do
       let(:units) { 20 }
-      let(:rate) { 20 }
+      let(:rate) { 2.99 }
 
       it "returns the percentage amount" do
         result = subject.call
-        expect(result.amount).to eq(4)
+        expect(result.amount).to eq(0.598)
         expect(result.units).to eq(20)
       end
 
@@ -51,27 +51,27 @@ RSpec.describe Charges::EstimateInstant::PercentageService, type: :service do
 
         it "includes the fixed amount" do
           result = subject.call
-          expect(result.amount).to eq(14)
+          expect(result.amount).to eq(10.598)
           expect(result.units).to eq(20)
         end
       end
 
       context "when a maximum is set" do
-        let(:per_transaction_max_amount) { 3 }
+        let(:per_transaction_max_amount) { 0.1 }
 
         it "returns the percentage amount capped at the max" do
           result = subject.call
-          expect(result.amount).to eq(3)
+          expect(result.amount).to eq(0.1)
           expect(result.units).to eq(20)
         end
       end
 
       context "when a minimum is set" do
-        let(:per_transaction_min_amount) { 5 }
+        let(:per_transaction_min_amount) { 5.5 }
 
         it "returns the percentage amount and at least the min" do
           result = subject.call
-          expect(result.amount).to eq(5)
+          expect(result.amount).to eq(5.5)
           expect(result.units).to eq(20)
         end
       end


### PR DESCRIPTION
## Context

Percentage charges have rounding issues with smaller units and decimal rates.
E.g this code
```ruby
amount = units * rate.fdiv(100)
```
produces rounding issues.
```ruby
rate = BigDecimal("2.9") # service always converts it to BigDecimal
units = 4

units * rate.fdiv(100) # => 0.11599999999999999
units * rate.fdiv(100).class # => Float
units * rate / 100 # => 0.116
(units * rate / 100).class # => BigDecimal
```

The issue that `.fdiv(100)` returns result as Float, in our case downgrading from BigDecimal to Float.
In changes cases we always have BigDecimal, so it's safe to use `/` instead of `fdiv`.
Btw, another way to address this issue by using `.fdiv(BigDecimal("100"))` which for me looks horrible.

## Description

Adjusted percentage calculation to return expected results with smaller amount.s
Adjusted tests to cover changes.
