### PR TITLE
chore(rubocop): Disable or fix last errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,18 @@ AllCops:
     - 'coverage/**/*'
     - 'log/**/*'
 
+# TODO: Fix these services
+Lago/ServiceCall:
+  Exclude:
+    - 'app/services/integration_mappings/create_service.rb'
+    - 'app/services/integrations/anrok/create_service.rb'
+    - 'app/services/integrations/okta/create_service.rb'
+    - 'app/services/integrations/xero/create_service.rb'
+    - 'app/services/invites/accept_service.rb'
+    - 'app/services/invoices/finalize_batch_service.rb'
+    - 'app/services/invoices/payments/retry_batch_service.rb'
+    - 'app/services/invoices/retry_batch_service.rb'
+
 # TODO: Enable when we have time to fix all the offenses
 Style/StringLiterals:
   Enabled: false

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -37,8 +37,6 @@ module DunningCampaigns
     end
 
     def handle_thresholds
-      thresholds_updated = false
-
       input_threshold_ids = params[:thresholds].map { |t| t[:id] }.compact
 
       # Delete thresholds not included in the payload

--- a/db/migrate/20221010142031_update_credit_notes.rb
+++ b/db/migrate/20221010142031_update_credit_notes.rb
@@ -12,8 +12,7 @@ class UpdateCreditNotes < ActiveRecord::Migration[7.0]
       change_table :credit_notes, bulk: true do |t|
         t.bigint :total_amount_cents, null: false, default: 0
 
-        # NOTE: Disable rubocop comment as table is not used in production yet
-        t.string :total_amount_currency, null: false
+        t.string :total_amount_currency, null: false # rubocop:disable Rails/NotNullColumn
       end
     end
   end

--- a/db/migrate/20230216145442_change_webhooks_object_nullable.rb
+++ b/db/migrate/20230216145442_change_webhooks_object_nullable.rb
@@ -2,7 +2,7 @@
 
 class ChangeWebhooksObjectNullable < ActiveRecord::Migration[7.0]
   def change
-    change_column_null :webhooks, :object_id, true
-    change_column_null :webhooks, :object_type, true
+    change_column_null :webhooks, :object_id, true # rubocop:disable Rails/BulkChangeTable
+    change_column_null :webhooks, :object_type, true # rubocop:disable Rails/BulkChangeTable
   end
 end

--- a/db/migrate/20231117123744_add_organization_id_to_quantified_events.rb
+++ b/db/migrate/20231117123744_add_organization_id_to_quantified_events.rb
@@ -32,7 +32,7 @@ class AddOrganizationIdToQuantifiedEvents < ActiveRecord::Migration[7.0]
         AND customers.organization_id = quantified_events.organization_id
     SQL
 
-    change_column_null :quantified_events, :customer_id, false
+    change_column_null :quantified_events, :customer_id, false # rubocop:disable Rails/BulkChangeTable
     remove_column :quantified_events, :organization_id
   end
 end

--- a/db/migrate/20240314163426_add_multiple_values_to_charge_filter_values.rb
+++ b/db/migrate/20240314163426_add_multiple_values_to_charge_filter_values.rb
@@ -13,7 +13,7 @@ class AddMultipleValuesToChargeFilterValues < ActiveRecord::Migration[7.0]
   def down
     change_table :charge_filter_values, bulk: true do |t|
       t.remove :values
-      t.string :value, null: false
+      t.string :value, null: false # rubocop:disable Rails/NotNullColumn
     end
   end
 end

--- a/db/migrate/20240425131701_update_cached_aggregations.rb
+++ b/db/migrate/20240425131701_update_cached_aggregations.rb
@@ -2,7 +2,7 @@
 
 class UpdateCachedAggregations < ActiveRecord::Migration[7.0]
   def change
-    change_column_null :cached_aggregations, :event_id, true
+    change_column_null :cached_aggregations, :event_id, true # rubocop:disable Rails/BulkChangeTable
     add_column :cached_aggregations, :current_amount, :decimal
   end
 end

--- a/db/migrate/20240808080611_remove_amount_currency_from_usage_tresholds.rb
+++ b/db/migrate/20240808080611_remove_amount_currency_from_usage_tresholds.rb
@@ -11,7 +11,7 @@ class RemoveAmountCurrencyFromUsageTresholds < ActiveRecord::Migration[7.1]
 
   def down
     change_table :usage_thresholds, bulk: true do |t|
-      t.string :amount_currency, null: false
+      t.string :amount_currency, null: false # rubocop:disable Rails/NotNullColumn
     end
   end
 end

--- a/dev/cops/service_call_cop.rb
+++ b/dev/cops/service_call_cop.rb
@@ -12,6 +12,10 @@ module Cops
 
     MSG = "Subclasses of Baseservice should have #call without arguments"
 
+    def self.badge
+      @badge ||= ::RuboCop::Cop::Badge.for("Lago::ServiceCall") # rubocop:disable ThreadSafety/InstanceVariableInClassMethod
+    end
+
     def on_def(node)
       return unless inherits_base_service?(node)
       return unless call_method?(node)

--- a/lib/tasks/tests/seed_plans.rake
+++ b/lib/tasks/tests/seed_plans.rake
@@ -92,12 +92,12 @@ def generate_children_plans(plan, all_metrics, delete_charge_parents)
     # change plan, do not change charges
     res = Plans::OverrideService.call(plan: plan, params: {name: "Plan '#{plan.code}' child"})
     pl = res.plan
-    pl.charges.update_all(parent_id: nil) if delete_charge_parents
+    pl.charges.update_all(parent_id: nil) if delete_charge_parents # rubocop:disable Rails/SkipsModelValidations
 
     # change charges models and properties (randomly)
     res = Plans::OverrideService.call(plan: plan, params: {charges: override_charges_rand(plan, all_metrics)})
     pl = res.plan
-    pl.charges.update_all(parent_id: nil) if delete_charge_parents
+    pl.charges.update_all(parent_id: nil) if delete_charge_parents # rubocop:disable Rails/SkipsModelValidations
   end
 end
 


### PR DESCRIPTION
As I'm fixing the quotes for string literals, there are other errors showing up so let's fix those. I'm going to merge this one first before updating the quote PRs.

Many of them are about old migrations that I don't think we should change. I simply disabled the rule for them.

`Cops/ServiceCallCop` was renamed `Lago/ServiceCall` and I excluded the services failing. It's not so easy to fix in this kind of cosmetic PR but it should be done one day.

> 3234 files inspected, no offenses detected

![CleanShot 2025-02-13 at 13 58 18@2x](https://github.com/user-attachments/assets/1ec3f073-152a-4219-b2fe-165b1565a983)
