### PR TITLE
fix(invoice-webhooks): Fix progressive billing invoice not having webhook on payment retry

### DIFF
--- a/app/services/invoices/payments/retry_service.rb
+++ b/app/services/invoices/payments/retry_service.rb
@@ -7,7 +7,8 @@ module Invoices
         "subscription" => "invoice.created",
         "credit" => "invoice.paid_credit_added",
         "add_on" => "invoice.add_on_added",
-        "one_off" => "invoice.one_off_created"
+        "one_off" => "invoice.one_off_created",
+        "progressive_billing" => "invoice.created"
       }.freeze
 
       def initialize(invoice:)

--- a/spec/services/invoices/payments/retry_service_spec.rb
+++ b/spec/services/invoices/payments/retry_service_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe Invoices::Payments::RetryService, type: :service do
       end
     end
 
+    context "with one_off invoice type" do
+      let(:invoice) do
+        create(:invoice, customer:, organization: customer.organization, invoice_type: :progressive_billing)
+      end
+
+      it "enqueues SendWebhookJob with correct type" do
+        expect do
+          retry_service.call
+        end.to have_enqueued_job(SendWebhookJob).with("invoice.created", Invoice)
+      end
+    end
+
     context "with gocardless payment provider" do
       let(:payment_provider) { "gocardless" }
 

--- a/spec/services/invoices/payments/retry_service_spec.rb
+++ b/spec/services/invoices/payments/retry_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Invoices::Payments::RetryService, type: :service do
       end
     end
 
-    context "with one_off invoice type" do
+    context "with progressive billing invoice type" do
       let(:invoice) do
         create(:invoice, customer:, organization: customer.organization, invoice_type: :progressive_billing)
       end


### PR DESCRIPTION
## Context

We we retry payment for invoice we send webhook but `progressive_billing` invoices were missing their webhook.

## Description

Add missing webhook.
