### PR TITLE
fix(rate-limit): Fix rate limit errors

### DIFF
--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -150,8 +150,6 @@ module Integrations
       end
 
       def request_limit_error?(http_error)
-        return false unless [500, 424].include?(http_error.error_code.to_i)
-
         http_error.error_body.include?(REQUEST_LIMIT_ERROR_CODE)
       end
     end

--- a/spec/services/integrations/aggregator/base_service_spec.rb
+++ b/spec/services/integrations/aggregator/base_service_spec.rb
@@ -1,32 +1,29 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Integrations::Aggregator::BaseService do
   subject(:sync_service) { described_class.new(integration:) }
 
   let(:integration) { create(:netsuite_integration) }
 
-  describe '#request_limit_error?' do
+  describe "#request_limit_error?" do
     let(:http_error) { instance_double(LagoHttpClient::HttpError, error_body:) }
 
+    context "when error body includes request limit error code" do
+      let(:error_body) { "Some error message including SSS_REQUEST_LIMIT_EXCEEDED" }
 
-
-    context 'when error body includes request limit error code' do
-      let(:error_body) { 'Some error message including SSS_REQUEST_LIMIT_EXCEEDED' }
-
-      it 'returns true' do
+      it "returns true" do
         expect(sync_service.send(:request_limit_error?, http_error)).to be true
       end
     end
 
-    context 'when error body does not include request limit error code' do
-      let(:error_body) { 'Some other error message' }
+    context "when error body does not include request limit error code" do
+      let(:error_body) { "Some other error message" }
 
-      it 'returns false' do
+      it "returns false" do
         expect(sync_service.send(:request_limit_error?, http_error)).to be false
       end
     end
   end
 end
-

--- a/spec/services/integrations/aggregator/base_service_spec.rb
+++ b/spec/services/integrations/aggregator/base_service_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::BaseService do
+  subject(:sync_service) { described_class.new(integration:) }
+
+  let(:integration) { create(:netsuite_integration) }
+
+  describe '#request_limit_error?' do
+    let(:http_error) { instance_double(LagoHttpClient::HttpError, error_body:) }
+
+
+
+    context 'when error body includes request limit error code' do
+      let(:error_body) { 'Some error message including SSS_REQUEST_LIMIT_EXCEEDED' }
+
+      it 'returns true' do
+        expect(sync_service.send(:request_limit_error?, http_error)).to be true
+      end
+    end
+
+    context 'when error body does not include request limit error code' do
+      let(:error_body) { 'Some other error message' }
+
+      it 'returns false' do
+        expect(sync_service.send(:request_limit_error?, http_error)).to be false
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
## Context

We never raise `RequestLimitError` because `request_limit_error?` never returns true

## Description

This PR fixes `request_limit_error?` method so that we can process rate limit errors properly.