### PR TITLE
feat(invoice-preview): update logic for multiple peristed subscriptions

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -274,6 +274,9 @@ module Api
           :plan_code,
           :billing_time,
           :subscription_at,
+          subscriptions: [
+            external_ids: []
+          ],
           coupons: [
             :code,
             :name,

--- a/app/services/invoices/preview_context_service.rb
+++ b/app/services/invoices/preview_context_service.rb
@@ -71,8 +71,6 @@ module Invoices
     end
 
     def build_subscription
-      return if !plan || !result.customer
-
       billing_time = if Subscription::BILLING_TIME.include?(params[:billing_time]&.to_sym)
         params[:billing_time]
       else
@@ -91,7 +89,15 @@ module Invoices
     end
 
     def find_or_build_subscriptions
-      [build_subscription]
+      subscriptions_params = params[:subscriptions] || {}
+
+      if subscriptions_params[:external_ids].present?
+        result.customer.subscriptions.active.where(external_id: subscriptions_params[:external_ids])
+      else
+        return [] if !plan || !result.customer
+
+        [build_subscription]
+      end
     end
 
     def plan

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -1040,6 +1040,85 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       )
     end
 
+    context 'when subscriptions are persisted' do
+      let(:customer) { create(:customer, organization:, external_id: '123456789') }
+      let(:subscription1) { create(:subscription, customer:, billing_time: 'anniversary', subscription_at: Time.current) }
+      let(:subscription2) { create(:subscription, customer:, billing_time: 'anniversary', subscription_at: Time.current) }
+      let(:preview_params) do
+        {
+          customer: {
+            external_id: '123456789'
+          },
+          subscriptions: {
+            external_ids: [subscription1.external_id, subscription2.external_id]
+          }
+        }
+      end
+
+      it 'creates a preview invoice' do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoice]).to include(
+          invoice_type: 'subscription',
+          fees_amount_cents: 200,
+          taxes_amount_cents: 40,
+          total_amount_cents: 240,
+          currency: 'EUR'
+        )
+      end
+    end
+
+    context 'when subscriptions are persisted but only one belongs to the customer' do
+      let(:customer) { create(:customer, organization:, external_id: '123456789') }
+      let(:subscription1) { create(:subscription, billing_time: 'anniversary', subscription_at: Time.current) }
+      let(:subscription2) { create(:subscription, customer:, billing_time: 'anniversary', subscription_at: Time.current) }
+      let(:preview_params) do
+        {
+          customer: {
+            external_id: '123456789'
+          },
+          subscriptions: {
+            external_ids: [subscription1.external_id, subscription2.external_id]
+          }
+        }
+      end
+
+      it 'creates a preview invoice' do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoice]).to include(
+          invoice_type: 'subscription',
+          fees_amount_cents: 100,
+          taxes_amount_cents: 20,
+          total_amount_cents: 120,
+          currency: 'EUR'
+        )
+      end
+    end
+
+    context 'when subscriptions do not belong to the customer' do
+      let(:customer) { create(:customer, organization:, external_id: '123456789') }
+      let(:subscription1) { create(:subscription, billing_time: 'anniversary', subscription_at: Time.current) }
+      let(:subscription2) { create(:subscription, billing_time: 'anniversary', subscription_at: Time.current) }
+      let(:preview_params) do
+        {
+          customer: {
+            external_id: '123456789'
+          },
+          subscriptions: {
+            external_ids: [subscription1.external_id, subscription2.external_id]
+          }
+        }
+      end
+
+      it 'returns a not found error' do
+        subject
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context 'when customer does not exist' do
       let(:preview_params) do
         {

--- a/spec/services/invoices/preview_context_service_spec.rb
+++ b/spec/services/invoices/preview_context_service_spec.rb
@@ -238,6 +238,28 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
         expect(subject).to be_nil
       end
     end
+
+    context 'when subscriptions are fetched from the database' do
+      let(:subscription1) { create(:subscription, customer:) }
+      let(:subscription2) { create(:subscription, customer:) }
+      let(:params) do
+        {
+          customer: {external_id: customer.external_id},
+          subscriptions: {
+            external_ids: [subscription1.external_id, subscription2.external_id]
+          }
+        }
+      end
+
+      before do
+        subscription1
+        subscription2
+      end
+
+      it "returns subscriptions that are persisted" do
+        expect(subject.pluck(:external_id)).to eq([subscription1.external_id, subscription2.external_id])
+      end
+    end
   end
 
   describe "#applied_coupons" do

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
-  subject(:preview_service) { described_class.new(customer:, subscriptions: [subscription]) }
+  subject(:preview_service) { described_class.new(customer:, subscriptions:) }
 
   describe '#call' do
     let(:organization) { create(:organization) }
@@ -12,6 +12,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
     let(:timestamp) { Time.zone.parse('30 Mar 2024') }
     let(:plan) { create(:plan, organization:, interval: 'monthly') }
     let(:billing_time) { 'calendar' }
+    let(:subscriptions) { [subscription] }
     let(:subscription) do
       build(
         :subscription,
@@ -52,8 +53,10 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
       end
 
       context 'when subscriptions are missing' do
+        let(:subscriptions) { [] }
+
         it 'returns an error' do
-          result = described_class.new(customer:, subscriptions: []).call
+          result = preview_service.call
 
           expect(result).not_to be_success
           expect(result.error.error_code).to eq('subscription_not_found')
@@ -68,6 +71,26 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
 
           expect(result).not_to be_success
           expect(result.error.messages[:base]).to include('customer_currency_does_not_match')
+        end
+      end
+
+      context 'when billing periods do not match' do
+        let(:customer) { create(:customer, organization:) }
+        let(:plan1) { create(:plan, organization:, interval: 'monthly') }
+        let(:plan2) { create(:plan, organization:, interval: 'monthly') }
+        let(:subscriptions) { [subscription1, subscription2] }
+        let(:subscription1) do
+          create(:subscription, plan: plan1, customer:, subscription_at: Time.current.beginning_of_month - 10.days, billing_time: 'anniversary')
+        end
+        let(:subscription2) do
+          create(:subscription, plan: plan2, customer:, subscription_at: Time.current.beginning_of_month - 9.days, billing_time: 'anniversary')
+        end
+
+        it 'returns an error' do
+          result = preview_service.call
+
+          expect(result).not_to be_success
+          expect(result.error.messages[:base]).to include('billing_periods_does_not_match')
         end
       end
 
@@ -88,6 +111,40 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             expect(result.invoice.taxes_amount_cents).to eq(3)
             expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(9)
             expect(result.invoice.total_amount_cents).to eq(9)
+          end
+        end
+
+        context 'with one persisted subscription' do
+          let(:customer) { create(:customer, organization:) }
+          let(:subscription) do
+            create(
+              :subscription,
+              customer:,
+              plan:,
+              billing_time:,
+              subscription_at: timestamp,
+              started_at: timestamp,
+              created_at: timestamp
+            )
+          end
+
+          it 'creates preview invoice for 2 days' do
+            # Two days should be billed, Mar 30 and Mar 31
+
+            travel_to(timestamp) do
+              result = preview_service.call
+
+              expect(result).to be_success
+              expect(result.invoice.subscriptions.first).to eq(subscription)
+              expect(result.invoice.fees.length).to eq(1)
+              expect(result.invoice.invoice_type).to eq('subscription')
+              expect(result.invoice.issuing_date.to_s).to eq('2024-04-01')
+              expect(result.invoice.fees_amount_cents).to eq(6)
+              expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(6)
+              expect(result.invoice.taxes_amount_cents).to eq(3)
+              expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(9)
+              expect(result.invoice.total_amount_cents).to eq(9)
+            end
           end
         end
 
@@ -119,6 +176,39 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               expect(result.invoice.taxes_amount_cents).to eq(2)
               expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(5)
               expect(result.invoice.total_amount_cents).to eq(5)
+            end
+          end
+        end
+
+        context 'with in advance billing with persisted subscription' do
+          let(:customer) { create(:customer, organization:) }
+          let(:plan) { create(:plan, organization:, interval: 'monthly', pay_in_advance: true) }
+          let(:subscription) do
+            create(
+              :subscription,
+              customer:,
+              plan:,
+              billing_time:,
+              subscription_at: timestamp - 1.day,
+              started_at: timestamp - 1.day,
+              created_at: timestamp - 1.day
+            )
+          end
+
+          it 'creates preview invoice for next invoice' do
+            travel_to(timestamp) do
+              result = preview_service.call
+
+              expect(result).to be_success
+              expect(result.invoice.subscriptions.first).to eq(subscription)
+              expect(result.invoice.fees.length).to eq(1)
+              expect(result.invoice.invoice_type).to eq('subscription')
+              expect(result.invoice.issuing_date.to_s).to eq('2024-04-01')
+              expect(result.invoice.fees_amount_cents).to eq(100)
+              expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(100)
+              expect(result.invoice.taxes_amount_cents).to eq(50)
+              expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(150)
+              expect(result.invoice.total_amount_cents).to eq(150)
             end
           end
         end
@@ -327,6 +417,84 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             expect(result.invoice.taxes_amount_cents).to eq(50)
             expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(150)
             expect(result.invoice.total_amount_cents).to eq(150)
+          end
+        end
+
+        context 'with one persisted subscriptions' do
+          let(:customer) { create(:customer, organization:) }
+          let(:subscription) do
+            create(
+              :subscription,
+              customer:,
+              plan:,
+              billing_time:,
+              subscription_at: timestamp,
+              started_at: timestamp,
+              created_at: timestamp
+            )
+          end
+
+          it 'creates preview invoice for full month' do
+            travel_to(timestamp) do
+              result = preview_service.call
+
+              expect(result).to be_success
+              expect(result.invoice.subscriptions.first).to eq(subscription)
+              expect(result.invoice.fees.length).to eq(1)
+              expect(result.invoice.invoice_type).to eq('subscription')
+              expect(result.invoice.issuing_date.to_s).to eq('2024-04-30')
+              expect(result.invoice.fees_amount_cents).to eq(100)
+              expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(100)
+              expect(result.invoice.taxes_amount_cents).to eq(50)
+              expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(150)
+              expect(result.invoice.total_amount_cents).to eq(150)
+            end
+          end
+        end
+
+        context 'with multiple persisted subscriptions' do
+          let(:customer) { create(:customer, organization:) }
+          let(:plan1) { create(:plan, organization:, interval: 'monthly') }
+          let(:plan2) { create(:plan, organization:, interval: 'monthly') }
+          let(:subscriptions) { [subscription1, subscription2] }
+          let(:subscription1) do
+            create(
+              :subscription,
+              customer:,
+              plan: plan1,
+              billing_time:,
+              subscription_at: timestamp,
+              started_at: timestamp,
+              created_at: timestamp
+            )
+          end
+          let(:subscription2) do
+            create(
+              :subscription,
+              customer:,
+              plan: plan2,
+              billing_time:,
+              subscription_at: timestamp,
+              started_at: timestamp,
+              created_at: timestamp
+            )
+          end
+
+          it 'creates preview invoice for full month' do
+            travel_to(timestamp + 5.days) do
+              result = preview_service.call
+
+              expect(result).to be_success
+              expect(result.invoice.subscriptions.pluck(:id)).to match_array([subscription1.id, subscription2.id])
+              expect(result.invoice.fees.length).to eq(2)
+              expect(result.invoice.invoice_type).to eq('subscription')
+              expect(result.invoice.issuing_date.to_s).to eq('2024-04-30')
+              expect(result.invoice.fees_amount_cents).to eq(200)
+              expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(200)
+              expect(result.invoice.taxes_amount_cents).to eq(100)
+              expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(300)
+              expect(result.invoice.total_amount_cents).to eq(300)
+            end
           end
         end
       end


### PR DESCRIPTION
## Context

Preview feature allows to see first invoice preview. It works for both non-existing subscriptions but also for active subscriptions.

## Description

This PR adds missing logic in order to properly handle persisted subscriptions
