### PR TITLE
fix(invoices): Fix progressive billing

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/base_payload.rb
@@ -123,6 +123,17 @@ module Integrations
               }
             end
 
+            if credit_item && invoice.progressive_billing_credit_amount_cents > 0
+              output << {
+                "external_id" => credit_item.external_id,
+                "description" => "Usage already billed",
+                "units" => 1,
+                "precise_unit_amount" => -amount(invoice.progressive_billing_credit_amount_cents, resource: invoice),
+                "taxes_amount_cents" => 0,
+                "account_code" => credit_item.external_account_code
+              }
+            end
+
             if credit_note_item && invoice.credit_notes_amount_cents > 0
               output << {
                 "external_id" => credit_note_item.external_id,

--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -150,6 +150,16 @@ module Integrations
               }
             end
 
+            if credit_item && invoice.progressive_billing_credit_amount_cents > 0
+              output << {
+                "item" => credit_item.external_id,
+                "account" => credit_item.external_account_code,
+                "quantity" => 1,
+                "rate" => -amount(invoice.progressive_billing_credit_amount_cents, resource: invoice),
+                "taxdetailsreference" => "credit_item_progressive_billing"
+              }
+            end
+
             if credit_note_item && invoice.credit_notes_amount_cents > 0
               output << {
                 "item" => credit_note_item.external_id,
@@ -187,6 +197,17 @@ module Integrations
                 "taxtype" => tax_item.tax_type,
                 "taxcode" => tax_item.tax_code,
                 "taxdetailsreference" => "credit_item"
+              }
+            end
+
+            if credit_item && invoice.progressive_billing_credit_amount_cents > 0
+              output << {
+                "taxbasis" => 1,
+                "taxamount" => 0,
+                "taxrate" => invoice.taxes_rate,
+                "taxtype" => tax_item.tax_type,
+                "taxcode" => tax_item.tax_code,
+                "taxdetailsreference" => "credit_item_progressive_billing"
               }
             end
 

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
       organization:,
       coupons_amount_cents: 2000,
       prepaid_credit_amount_cents: 4000,
+      progressive_billing_credit_amount_cents: 100,
       credit_notes_amount_cents: 6000,
       taxes_amount_cents: 200,
       issuing_date: DateTime.new(2024, 7, 8)
@@ -211,6 +212,13 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
                 "quantity" => 1,
                 "rate" => -40.0,
                 "taxdetailsreference" => "credit_item"
+              },
+              {
+                "item" => "6",
+                "account" => "66",
+                "quantity" => 1,
+                "rate" => -1.0,
+                "taxdetailsreference" => "credit_item_progressive_billing"
               },
               {
                 "item" => "1", # Fallback item instead of credit note

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -365,6 +365,14 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
                     "taxamount" => 0,
                     "taxbasis" => 1,
                     "taxcode" => "some_code",
+                    "taxdetailsreference" => "credit_item_progressive_billing",
+                    "taxrate" => 0.0,
+                    "taxtype" => "some_type"
+                  },
+                  {
+                    "taxamount" => 0,
+                    "taxbasis" => 1,
+                    "taxcode" => "some_code",
                     "taxdetailsreference" => "credit_note_item",
                     "taxrate" => 0.0,
                     "taxtype" => "some_type"

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
         organization:,
         coupons_amount_cents: 2000,
         prepaid_credit_amount_cents: 4000,
+        progressive_billing_credit_amount_cents: 100,
         credit_notes_amount_cents: 6000,
         taxes_amount_cents: 200,
         issuing_date: DateTime.new(2024, 7, 8)
@@ -171,6 +172,14 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
               "description" => "Prepaid credit",
               "units" => 1,
               "precise_unit_amount" => -40.0,
+              "taxes_amount_cents" => 0,
+              "account_code" => "66"
+            },
+            {
+              "external_id" => "6",
+              "description" => "Usage already billed",
+              "units" => 1,
+              "precise_unit_amount" => -1.0,
               "taxes_amount_cents" => 0,
               "account_code" => "66"
             },


### PR DESCRIPTION
## Context

Invoices synced to Netsuite don't contain line item for already billed usage (progressive billing).

## Description

Add already billed usage as credit to Netsuite and Xero invoices.