### PR TITLE
feat(invoice-preview): add premium addon validation and apply small refactoring

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -76,6 +76,7 @@ class Organization < ApplicationRecord
     revenue_share
     zero_amount_fees
     remove_branding_watermark
+    preview
   ].freeze
   PREMIUM_INTEGRATIONS = INTEGRATIONS - %w[anrok]
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -4450,6 +4450,7 @@ enum IntegrationTypeEnum {
   hubspot
   netsuite
   okta
+  preview
   progressive_billing
   remove_branding_watermark
   revenue_analytics
@@ -6438,6 +6439,7 @@ enum PremiumIntegrationTypeEnum {
   hubspot
   netsuite
   okta
+  preview
   progressive_billing
   remove_branding_watermark
   revenue_analytics

--- a/schema.json
+++ b/schema.json
@@ -20598,6 +20598,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "preview",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -30659,6 +30665,12 @@
             },
             {
               "name": "remove_branding_watermark",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "preview",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -1025,6 +1025,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       }
     end
 
+    before { organization.update!(premium_integrations: ['preview']) }
+
     around { |test| lago_premium!(&test) }
 
     it 'creates a preview invoice' do

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -86,6 +86,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
           create(:subscription, plan: plan2, customer:, subscription_at: Time.current.beginning_of_month - 9.days, billing_time: 'anniversary')
         end
 
+        before { organization.update!(premium_integrations: ['preview']) }
+
         it 'returns an error' do
           result = preview_service.call
 
@@ -128,6 +130,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             )
           end
 
+          before { organization.update!(premium_integrations: ['preview']) }
+
           it 'creates preview invoice for 2 days' do
             # Two days should be billed, Mar 30 and Mar 31
 
@@ -144,6 +148,19 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               expect(result.invoice.taxes_amount_cents).to eq(3)
               expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(9)
               expect(result.invoice.total_amount_cents).to eq(9)
+            end
+          end
+
+          context 'when preview premium integration does not exist' do
+            before { organization.update!(premium_integrations: ['netsuite']) }
+
+            it 'returns an error' do
+              result = preview_service.call
+
+              aggregate_failures do
+                expect(result).not_to be_success
+                expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+              end
             end
           end
         end
@@ -195,6 +212,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             )
           end
 
+          before { organization.update!(premium_integrations: ['preview']) }
+
           it 'creates preview invoice for next invoice' do
             travel_to(timestamp) do
               result = preview_service.call
@@ -209,6 +228,19 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               expect(result.invoice.taxes_amount_cents).to eq(50)
               expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(150)
               expect(result.invoice.total_amount_cents).to eq(150)
+            end
+          end
+
+          context 'when preview premium integration does not exist' do
+            before { organization.update!(premium_integrations: ['netsuite']) }
+
+            it 'returns an error' do
+              result = preview_service.call
+
+              aggregate_failures do
+                expect(result).not_to be_success
+                expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+              end
             end
           end
         end
@@ -434,6 +466,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             )
           end
 
+          before { organization.update!(premium_integrations: ['preview']) }
+
           it 'creates preview invoice for full month' do
             travel_to(timestamp) do
               result = preview_service.call
@@ -479,6 +513,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               created_at: timestamp
             )
           end
+
+          before { organization.update!(premium_integrations: ['preview']) }
 
           it 'creates preview invoice for full month' do
             travel_to(timestamp + 5.days) do


### PR DESCRIPTION
## Context

Preview feature allows to see first invoice preview. It works for both non-existing subscriptions but also for active subscriptions.

## Description

This PR adds premium add-on validation for part 2 and part 3, where preview invoice is generated on existing subscriptions. Only lightweight preview invoice with subscription fee is enabled without premium add-on (only basic license is needed).
