### PR TITLE
misc: Extract DailyUsages::FillHistoryJob to a new long_running queue

### DIFF
--- a/app/jobs/daily_usages/fill_history_job.rb
+++ b/app/jobs/daily_usages/fill_history_job.rb
@@ -2,7 +2,7 @@
 
 module DailyUsages
   class FillHistoryJob < ApplicationJob
-    queue_as "low_priority"
+    queue_as "long_running"
 
     def perform(subscription:, from_datetime:)
       DailyUsages::FillHistoryService.call!(subscription:, from_datetime:)

--- a/config/sidekiq/sidekiq.yml
+++ b/config/sidekiq/sidekiq.yml
@@ -12,6 +12,7 @@ queues:
   - wallets # Remove as all wallet jobs have moved to other queues
   - integrations
   - low_priority
+  - long_running
 
 production:
   concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 10) %>


### PR DESCRIPTION
The goal of this PR is to introduce a new Sidekiq queue `long_running` and extract `DailyUsages::FillHistoryJob` to that queue.

Indeed, we've seen in the past that running such a one-time job can be long and delay the execution of other tasks inside the `low_priority` queue.