### PR TITLE
misc: Change queue from low_priority to default when creating a payment

### DIFF
--- a/app/jobs/invoices/payments/create_job.rb
+++ b/app/jobs/invoices/payments/create_job.rb
@@ -3,7 +3,7 @@
 module Invoices
   module Payments
     class CreateJob < ApplicationJob
-      queue_as "low_priority"
+      queue_as "default"
 
       unique :until_executed, on_conflict: :log
 


### PR DESCRIPTION
Currently, creating a payment is done in the `low_priority` sidekiq queue.

It seems that we want to increase the priority of this job, by moving it to the `default` queue.