### PR TITLE
fix(stripe): Avoid raising not_found for deleted stripe customers

### DIFF
--- a/app/services/payment_providers/stripe/webhooks/customer_updated_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/customer_updated_service.rb
@@ -34,7 +34,7 @@ module PaymentProviders
         end
 
         def deleted_stripe_customer
-          stripe_customer_scope.with_discarded.first
+          stripe_customer_scope.with_discarded.discarded.first
         end
 
         def payment_method_id

--- a/app/services/payment_providers/stripe/webhooks/customer_updated_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/customer_updated_service.rb
@@ -5,7 +5,10 @@ module PaymentProviders
     module Webhooks
       class CustomerUpdatedService < BaseService
         def call
-          return handle_missing_customer unless stripe_customer
+          unless stripe_customer
+            return result if deleted_stripe_customer.present?
+            return handle_missing_customer
+          end
 
           PaymentProviderCustomers::Stripe::UpdatePaymentMethodService.call(
             stripe_customer:,
@@ -21,10 +24,17 @@ module PaymentProviders
           event.data.object.id
         end
 
-        def stripe_customer
-          @stripe_customer ||= PaymentProviderCustomers::StripeCustomer
+        def stripe_customer_scope
+          PaymentProviderCustomers::StripeCustomer
             .by_provider_id_from_organization(organization.id, stripe_customer_id)
-            .first
+        end
+
+        def stripe_customer
+          @stripe_customer ||= stripe_customer_scope.first
+        end
+
+        def deleted_stripe_customer
+          stripe_customer_scope.with_discarded.first
         end
 
         def payment_method_id

--- a/spec/services/payment_providers/stripe/webhooks/customer_updated_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/customer_updated_service_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerUpdatedService, type:
         expect(result.stripe_customer).to be_nil
       end
 
+      context "when stripe customer is deleted" do
+        let(:stripe_customer) do
+          create(:stripe_customer, :deleted, payment_provider: stripe_provider, customer:, provider_customer_id:)
+        end
+
+        it "returns an empty result" do
+          result = webhook_service.call
+
+          expect(result).to be_success
+          expect(result.stripe_customer).to be_nil
+        end
+      end
+
       context "when customer in metadata is not found" do
         let(:event_json) { File.read("spec/fixtures/stripe/customer_updated_event_with_metadata.json") }
 


### PR DESCRIPTION
## Context

Some `customer.updated` Stripe webhooks are failing with a `stripe_customer_not_found` error.

The metadata of the webhook payload includes a `lago_customer_id`, meaning that it was initially created from Lago and should be found in the database.

After some investigation it appears that a deleted `StripeCustomer` is present in the database meaning the the webhook should not raise an error but should instead be ignored.

## Description

This PR checks for the presence of a deleted `stripe_customer` to return an empty success result when a deleted one is found in the database.
