### PR TITLE
fix(add_on): Validate presence of code

### DIFF
--- a/app/models/add_on.rb
+++ b/app/models/add_on.rb
@@ -20,6 +20,7 @@ class AddOn < ApplicationRecord
 
   validates :name, presence: true
   validates :code,
+    presence: true,
     uniqueness: {conditions: -> { where(deleted_at: nil) }, scope: :organization_id}
 
   validates :amount_cents, numericality: {greater_than: 0}

--- a/spec/models/add_on_spec.rb
+++ b/spec/models/add_on_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe AddOn, type: :model do
 
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_numericality_of(:amount_cents) }
+  it { is_expected.to validate_presence_of(:code) }
 
   describe "validations" do
     let(:errors) { add_on.errors }


### PR DESCRIPTION
## Description

This PR adds a presence validation on the `code` property of `add_on`, to make sure `an HTTP 422` is returned from the REST API instead of a `500` 