### PR TITLE
fix(payment): Handle deleted customers

### DIFF
--- a/app/services/payment_provider_customers/stripe/check_payment_method_service.rb
+++ b/app/services/payment_provider_customers/stripe/check_payment_method_service.rb
@@ -1,0 +1,38 @@
+# frozen_String_literal: true
+
+module PaymentProviderCustomers
+  module Stripe
+    class CheckPaymentMethodService < BaseService
+      Result = BaseResult[:payment_method]
+
+      def initialize(stripe_customer:, payment_method_id:)
+        @stripe_customer = stripe_customer
+        @payment_method_id = payment_method_id
+
+        super
+      end
+
+      def call
+        payment_method = ::Stripe::Customer
+          .new(id: stripe_customer.provider_customer_id)
+          .retrieve_payment_method(payment_method_id, {}, {api_key:})
+
+        result.payment_method = payment_method
+        result
+      rescue ::Stripe::InvalidRequestError
+        # NOTE: The payment method is no longer valid
+        stripe_customer.update!(payment_method_id: nil)
+
+        result.single_validation_failure!(field: :payment_method_id, error_code: "value_is_invalid")
+      end
+
+      private
+
+      attr_reader :stripe_customer, :payment_method_id
+
+      def api_key
+        stripe_customer.payment_provider.secret_key
+      end
+    end
+  end
+end

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -60,19 +60,6 @@ module PaymentProviderCustomers
       result.record_validation_failure!(record: e.record)
     end
 
-    def check_payment_method(payment_method_id)
-      payment_method = ::Stripe::Customer.new(id: stripe_customer.provider_customer_id)
-        .retrieve_payment_method(payment_method_id, {}, {api_key:})
-
-      result.payment_method = payment_method
-      result
-    rescue ::Stripe::InvalidRequestError
-      # NOTE: The payment method is no longer valid
-      stripe_customer.update!(payment_method_id: nil)
-
-      result.single_validation_failure!(field: :payment_method_id, error_code: "value_is_invalid")
-    end
-
     def generate_checkout_url(send_webhook: true)
       return result unless customer # NOTE: Customer is nil when deleted.
       return result if customer.organization.webhook_endpoints.none? && send_webhook && payment_provider(customer)

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -70,9 +70,11 @@ module PaymentProviders
 
           if payment_method_id
             # NOTE: Check if payment method still exists
-            customer_service = PaymentProviderCustomers::StripeService.new(provider_customer)
-            customer_service_result = customer_service.check_payment_method(payment_method_id)
-            return customer_service_result.payment_method.id if customer_service_result.success?
+            check_result = PaymentProviderCustomers::Stripe::CheckPaymentMethodService.call(
+              stripe_customer: provider_customer,
+              payment_method_id:
+            )
+            return check_result.payment_method.id if check_result.success?
           end
 
           # NOTE: Retrieve list of existing payment_methods

--- a/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviderCustomers::Stripe::CheckPaymentMethodService, type: :service do
+  subject(:check_service) { described_class.new(stripe_customer:, payment_method_id:) }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:stripe_provider) { create(:stripe_provider) }
+  let(:organization) { stripe_provider.organization }
+
+  let(:stripe_customer) do
+    create(
+      :stripe_customer,
+      payment_provider: stripe_provider,
+      customer:,
+      provider_customer_id: "cus_123456",
+      payment_method_id:
+    )
+  end
+
+  let(:payment_method_id) { "card_12345" }
+  let(:payment_method) { Stripe::PaymentMethod.new(id: payment_method_id) }
+  let(:stripe_api_customer) { instance_double(Stripe::Customer) }
+
+  before do
+    allow(Stripe::Customer).to receive(:new)
+      .and_return(stripe_api_customer)
+  end
+
+  describe "#call" do
+    it "checks for the existance of the payment method" do
+      allow(stripe_api_customer)
+        .to receive(:retrieve_payment_method)
+        .and_return(payment_method)
+
+      result = check_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.payment_method.id).to eq(payment_method_id)
+
+        expect(Stripe::Customer).to have_received(:new)
+        expect(stripe_api_customer).to have_received(:retrieve_payment_method)
+      end
+    end
+
+    context "when payment method is not found on stripe" do
+      before do
+        allow(stripe_api_customer)
+          .to receive(:retrieve_payment_method)
+          .and_raise(::Stripe::InvalidRequestError.new("error", {}))
+      end
+
+      it "returns a failed result" do
+        result = check_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+
+          expect(Stripe::Customer).to have_received(:new)
+          expect(stripe_api_customer).to have_received(:retrieve_payment_method)
+        end
+      end
+    end
+
+    context "when customer is deleted" do
+      let(:customer) { create(:customer, :deleted, organization:) }
+
+      it "checks for the existance of the payment method" do
+        allow(stripe_api_customer)
+          .to receive(:retrieve_payment_method)
+          .and_return(payment_method)
+
+        result = check_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.payment_method.id).to eq(payment_method_id)
+
+          expect(Stripe::Customer).to have_received(:new)
+          expect(stripe_api_customer).to have_received(:retrieve_payment_method)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -449,63 +449,6 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
     end
   end
 
-  describe "#check_payment_method" do
-    let(:payment_method_id) { "card_12345" }
-
-    let(:stripe_customer) do
-      create(
-        :stripe_customer,
-        customer:,
-        provider_customer_id: "cus_123456",
-        payment_method_id:
-      )
-    end
-
-    let(:payment_method) { Stripe::PaymentMethod.new(id: payment_method_id) }
-
-    let(:stripe_api_customer) { instance_double(Stripe::Customer) }
-
-    before do
-      allow(Stripe::Customer).to receive(:new)
-        .and_return(stripe_api_customer)
-    end
-
-    it "checks for the existance of the payment method" do
-      allow(stripe_api_customer)
-        .to receive(:retrieve_payment_method)
-        .and_return(payment_method)
-
-      result = stripe_service.check_payment_method(payment_method_id)
-
-      aggregate_failures do
-        expect(result).to be_success
-        expect(result.payment_method.id).to eq(payment_method_id)
-
-        expect(Stripe::Customer).to have_received(:new)
-        expect(stripe_api_customer).to have_received(:retrieve_payment_method)
-      end
-    end
-
-    context "when payment method is not found on stripe" do
-      before do
-        allow(stripe_api_customer)
-          .to receive(:retrieve_payment_method)
-          .and_raise(::Stripe::InvalidRequestError.new("error", {}))
-      end
-
-      it "returns a failed result" do
-        result = stripe_service.check_payment_method(payment_method_id)
-
-        aggregate_failures do
-          expect(result).not_to be_success
-
-          expect(Stripe::Customer).to have_received(:new)
-          expect(stripe_api_customer).to have_received(:retrieve_payment_method)
-        end
-      end
-    end
-  end
-
   describe "#generate_checkout_url" do
     it "delivers a webhook with checkout url" do
       allow(::Stripe::Checkout::Session).to receive(:create)

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -44,8 +44,6 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service
   end
 
   describe ".call" do
-    let(:provider_customer_service) { instance_double(PaymentProviderCustomers::StripeService) }
-
     let(:provider_customer_service_result) do
       BaseService::Result.new.tap do |result|
         result.payment_method = Stripe::PaymentMethod.new(id: "pm_123456")
@@ -78,9 +76,7 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service
       allow(SegmentTrackJob).to receive(:perform_later)
       allow(Invoices::PrepaidCreditJob).to receive(:perform_later)
 
-      allow(PaymentProviderCustomers::StripeService).to receive(:new)
-        .and_return(provider_customer_service)
-      allow(provider_customer_service).to receive(:check_payment_method)
+      allow(PaymentProviderCustomers::Stripe::CheckPaymentMethodService).to receive(:call)
         .and_return(provider_customer_service_result)
 
       stub_request(:get, "https://api.stripe.com/v1/customers/#{stripe_customer.provider_customer_id}")


### PR DESCRIPTION
## Context

When we delete a customer, all related subscriptions are terminated and a termination invoice is generated. If the customer is linked to a payment provider, the system will try to collect it.

Some error will be raised as the application will not be able to find the discarded record in the database 

## Description

This PR extract the `PaymentProviderCustomers::StripeService#check_payment_method` into a dedicated `PaymentProviderCustomers::CheckPaymentMethodService` and makes sure it relies only on the `stripe_customer` to fetch the payment method.