### PR TITLE
fix: Don't raise error when invoice's status is invalid

### DIFF
--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -12,8 +12,8 @@ module Invoices
       def call
         return result.not_found_failure!(resource: "invoice") unless invoice
         return result.not_found_failure!(resource: "integration_customer") unless customer.anrok_customer
-        return result.not_allowed_failure!(code: "invalid_status") unless invoice.pending? || invoice.draft?
-        return result.not_allowed_failure!(code: "invalid_tax_status") unless invoice.tax_pending?
+        return result unless invoice.pending? || invoice.draft?
+        return result unless invoice.tax_pending?
 
         invoice.error_details.tax_error.discard_all
         taxes_result = if invoice.draft?

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -172,20 +172,18 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
       it "generates expected invoice totals" do
         result = pull_taxes_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.invoice.fees.charge.count).to eq(1)
-          expect(result.invoice.fees.subscription.count).to eq(1)
+        expect(result).to be_success
+        expect(result.invoice.fees.charge.count).to eq(1)
+        expect(result.invoice.fees.subscription.count).to eq(1)
 
-          expect(result.invoice.currency).to eq("EUR")
-          expect(result.invoice.fees_amount_cents).to eq(3_000)
+        expect(result.invoice.currency).to eq("EUR")
+        expect(result.invoice.fees_amount_cents).to eq(3_000)
 
-          expect(result.invoice.taxes_amount_cents).to eq(350)
-          expect(result.invoice.taxes_rate.round(2)).to eq(11.67) # (0.667 * 10) + (0.333 * 15)
-          expect(result.invoice.applied_taxes.count).to eq(2)
+        expect(result.invoice.taxes_amount_cents).to eq(350)
+        expect(result.invoice.taxes_rate.round(2)).to eq(11.67) # (0.667 * 10) + (0.333 * 15)
+        expect(result.invoice.applied_taxes.count).to eq(2)
 
-          expect(result.invoice.total_amount_cents).to eq(3_350)
-        end
+        expect(result.invoice.total_amount_cents).to eq(3_350)
       end
 
       it_behaves_like "syncs invoice" do
@@ -264,17 +262,15 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
         it "updates the invoice accordingly" do
           result = pull_taxes_service.call
 
-          aggregate_failures do
-            expect(result).to be_success
-            expect(result.invoice.fees_amount_cents).to eq(3_000)
-            expect(result.invoice.taxes_amount_cents).to eq(350)
-            expect(result.invoice.total_amount_cents).to eq(3_340)
-            expect(result.invoice.credits.count).to eq(1)
+          expect(result).to be_success
+          expect(result.invoice.fees_amount_cents).to eq(3_000)
+          expect(result.invoice.taxes_amount_cents).to eq(350)
+          expect(result.invoice.total_amount_cents).to eq(3_340)
+          expect(result.invoice.credits.count).to eq(1)
 
-            credit = result.invoice.credits.first
-            expect(credit.credit_note).to eq(credit_note)
-            expect(credit.amount_cents).to eq(10)
-          end
+          credit = result.invoice.credits.first
+          expect(credit.credit_note).to eq(credit_note)
+          expect(credit.amount_cents).to eq(10)
         end
 
         context "when invoice type is one_off" do
@@ -285,13 +281,11 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
           it "does not apply credit note" do
             result = pull_taxes_service.call
 
-            aggregate_failures do
-              expect(result).to be_success
-              expect(result.invoice.fees_amount_cents).to eq(3_000)
-              expect(result.invoice.taxes_amount_cents).to eq(350)
-              expect(result.invoice.total_amount_cents).to eq(3_350)
-              expect(result.invoice.credits.count).to eq(0)
-            end
+            expect(result).to be_success
+            expect(result.invoice.fees_amount_cents).to eq(3_000)
+            expect(result.invoice.taxes_amount_cents).to eq(350)
+            expect(result.invoice.total_amount_cents).to eq(3_350)
+            expect(result.invoice.credits.count).to eq(0)
           end
         end
       end
@@ -320,20 +314,18 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
         it "generates expected invoice totals" do
           result = pull_taxes_service.call
 
-          aggregate_failures do
-            expect(result).to be_success
-            expect(result.invoice.fees.charge.count).to eq(1)
-            expect(result.invoice.fees.subscription.count).to eq(1)
+          expect(result).to be_success
+          expect(result.invoice.fees.charge.count).to eq(1)
+          expect(result.invoice.fees.subscription.count).to eq(1)
 
-            expect(result.invoice.currency).to eq("EUR")
-            expect(result.invoice.fees_amount_cents).to eq(3_000)
+          expect(result.invoice.currency).to eq("EUR")
+          expect(result.invoice.fees_amount_cents).to eq(3_000)
 
-            expect(result.invoice.taxes_amount_cents).to eq(350)
-            expect(result.invoice.taxes_rate.round(2)).to eq(11.67) # (0.667 * 10) + (0.333 * 15)
-            expect(result.invoice.applied_taxes.count).to eq(2)
+          expect(result.invoice.taxes_amount_cents).to eq(350)
+          expect(result.invoice.taxes_rate.round(2)).to eq(11.67) # (0.667 * 10) + (0.333 * 15)
+          expect(result.invoice.applied_taxes.count).to eq(2)
 
-            expect(result.invoice.total_amount_cents).to eq(3_350)
-          end
+          expect(result.invoice.total_amount_cents).to eq(3_350)
         end
 
         it "does not enqueue a SendWebhookJob" do
@@ -368,13 +360,11 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
           it "does not apply credit note" do
             result = pull_taxes_service.call
 
-            aggregate_failures do
-              expect(result).to be_success
-              expect(result.invoice.fees_amount_cents).to eq(3_000)
-              expect(result.invoice.taxes_amount_cents).to eq(350)
-              expect(result.invoice.total_amount_cents).to eq(3_350)
-              expect(result.invoice.credits.count).to eq(0)
-            end
+            expect(result).to be_success
+            expect(result.invoice.fees_amount_cents).to eq(3_000)
+            expect(result.invoice.taxes_amount_cents).to eq(350)
+            expect(result.invoice.total_amount_cents).to eq(3_350)
+            expect(result.invoice.credits.count).to eq(0)
           end
         end
       end
@@ -396,11 +386,9 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
       it "resolves old tax error and creates new one" do
         old_error_id = invoice.reload.error_details.last.id
         pull_taxes_service.call
-        aggregate_failures do
-          expect(invoice.error_details.tax_error.last.id).not_to eql(old_error_id)
-          expect(invoice.error_details.tax_error.count).to be(1)
-          expect(invoice.error_details.tax_error.order(created_at: :asc).last.discarded?).to be(false)
-        end
+        expect(invoice.error_details.tax_error.last.id).not_to eql(old_error_id)
+        expect(invoice.error_details.tax_error.count).to be(1)
+        expect(invoice.error_details.tax_error.order(created_at: :asc).last.discarded?).to be(false)
       end
 
       context "with api limit error" do
@@ -421,15 +409,13 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
 
           pull_taxes_service.call
 
-          aggregate_failures do
-            expect(invoice.error_details.tax_error.last.id).not_to eql(old_error_id)
-            expect(invoice.error_details.tax_error.count).to be(1)
-            expect(invoice.error_details.tax_error.order(created_at: :asc).last.discarded?).to be(false)
-            expect(invoice.error_details.tax_error.order(created_at: :asc).last.details["tax_error"])
-              .to eq("validationError")
-            expect(invoice.error_details.tax_error.order(created_at: :asc).last.details["tax_error_message"])
-              .to eq("You've exceeded your API limit of 10 per second")
-          end
+          expect(invoice.error_details.tax_error.last.id).not_to eql(old_error_id)
+          expect(invoice.error_details.tax_error.count).to be(1)
+          expect(invoice.error_details.tax_error.order(created_at: :asc).last.discarded?).to be(false)
+          expect(invoice.error_details.tax_error.order(created_at: :asc).last.details["tax_error"])
+            .to eq("validationError")
+          expect(invoice.error_details.tax_error.order(created_at: :asc).last.details["tax_error_message"])
+            .to eq("You've exceeded your API limit of 10 per second")
         end
       end
     end

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -127,11 +127,12 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
         invoice.update(status: %i[finalized voided generating].sample)
       end
 
-      it "returns an error" do
-        result = pull_taxes_service.call
+      it "does not change the invoice object" do
+        expect { pull_taxes_service.call }.not_to change { invoice.reload.attributes }
+      end
 
-        expect(result).not_to be_success
-        expect(result.error.code).to eq("invalid_status")
+      it "returns result" do
+        expect(pull_taxes_service.call).to be_success
       end
     end
 


### PR DESCRIPTION
## Context

Whenever we refresh the taxes of an invoice with an invalid status (not `pending`), we return an error and there's a deadjob.

## Description

The purpose of this PR is to prevent having deadjobs and return a successful result in that case without processing anything.