### PR TITLE
feat(data): Do not create daily usage when no usage

### DIFF
--- a/app/services/daily_usages/compute_service.rb
+++ b/app/services/daily_usages/compute_service.rb
@@ -19,24 +19,27 @@ module DailyUsages
         return result
       end
 
-      current_usage.fees = current_usage.fees.select { |f| f.units.positive? }
+      if current_usage.total_amount_cents.positive?
+        current_usage.fees = current_usage.fees.select { |f| f.units.positive? }
 
-      daily_usage = DailyUsage.new(
-        organization: subscription.organization,
-        customer: subscription.customer,
-        subscription:,
-        external_subscription_id: subscription.external_id,
-        usage: ::V1::Customers::UsageSerializer.new(current_usage, includes: %i[charges_usage]).serialize,
-        from_datetime: current_usage.from_datetime,
-        to_datetime: current_usage.to_datetime,
-        refreshed_at: timestamp,
-        usage_date:
-      )
+        daily_usage = DailyUsage.new(
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription:,
+          external_subscription_id: subscription.external_id,
+          usage: ::V1::Customers::UsageSerializer.new(current_usage, includes: %i[charges_usage]).serialize,
+          from_datetime: current_usage.from_datetime,
+          to_datetime: current_usage.to_datetime,
+          refreshed_at: timestamp,
+          usage_date:
+        )
 
-      daily_usage.usage_diff = diff_usage(daily_usage)
-      daily_usage.save!
+        daily_usage.usage_diff = diff_usage(daily_usage)
+        daily_usage.save!
 
-      result.daily_usage = daily_usage
+        result.daily_usage = daily_usage
+      end
+
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:) }
   let(:plan) { create(:plan, organization:) }
   let(:subscription) do
     create(:subscription, :calendar, customer:, plan:, started_at: 1.year.ago, subscription_at: 1.year.ago)
@@ -15,114 +17,50 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
   let(:timestamp) { Time.zone.parse("2024-10-22 00:05:00") }
   let(:usage_date) { Date.parse("2024-10-21") }
 
+  let(:event) do
+    create(
+      :event,
+      organization:,
+      external_subscription_id: subscription.external_id,
+      code: billable_metric.code,
+      timestamp: timestamp - 2.hours,
+      created_at: timestamp - 2.hours
+    )
+  end
+
   describe "#call" do
-    it "creates a daily usage" do
-      travel_to(timestamp) do
-        expect { compute_service.call }.to change(DailyUsage, :count).by(1)
+    before { charge }
 
-        daily_usage = DailyUsage.order(created_at: :asc).last
-        expect(daily_usage).to have_attributes(
-          organization_id: organization.id,
-          customer_id: customer.id,
-          subscription_id: subscription.id,
-          external_subscription_id: subscription.external_id,
-          usage: Hash,
-          usage_diff: Hash,
-          usage_date: Date.parse("2024-10-21")
-        )
-        expect(daily_usage.refreshed_at).to match_datetime(timestamp)
-        expect(daily_usage.from_datetime).to match_datetime(timestamp.beginning_of_month)
-        expect(daily_usage.to_datetime).to match_datetime(timestamp.end_of_month)
-      end
-    end
-
-    context "when usage contains charges usage with 0 units due to filters" do
-      it "does not include fees with 0 units" do
-        billable_metric = create(:billable_metric, organization:)
-        billable_metric_filter = create(:billable_metric_filter, billable_metric:)
-        charge = create(:standard_charge, plan:, billable_metric:)
-        charge_filter = create(:charge_filter, charge:, properties: {amount: "10"})
-        create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: [billable_metric_filter.values.first])
-
-        travel_to(timestamp) do
-          expect { compute_service.call }.to change(DailyUsage, :count).by(1)
-          daily_usage = DailyUsage.order(created_at: :asc).last
-          expect(daily_usage.usage["charges_usage"]).to be_empty
-        end
-      end
-    end
-
-    context "when a daily usage already exists" do
-      let(:existing_daily_usage) do
-        create(:daily_usage, subscription:, organization:, customer:, usage_date:)
-      end
-
-      before { existing_daily_usage }
-
-      it "returns the existing daily usage" do
-        result = compute_service.call
-
-        expect(result).to be_success
-        expect(result.daily_usage).to eq(existing_daily_usage)
-      end
-
-      context "when the organization has a timezone" do
-        let(:organization) { create(:organization, timezone: "America/Sao_Paulo") }
-
-        let(:existing_daily_usage) do
-          create(:daily_usage, subscription:, organization:, customer:, usage_date: usage_date - 4.hours)
-        end
-
-        it "takes the timezone into account" do
-          result = compute_service.call
-
-          expect(result).to be_success
-          expect(result.daily_usage).to eq(existing_daily_usage)
-        end
-      end
-
-      context "when the customer has a timezone" do
-        let(:customer) { create(:customer, organization:, timezone: "America/Sao_Paulo") }
-
-        let(:existing_daily_usage) do
-          create(:daily_usage, subscription:, organization:, customer:, usage_date: usage_date - 4.hours)
-        end
-
-        it "takes the timezone into account" do
-          result = compute_service.call
-
-          expect(result).to be_success
-          expect(result.daily_usage).to eq(existing_daily_usage)
-        end
-      end
-    end
-
-    context "when timestamp is on subscription billing day" do
-      let(:subscription) do
-        create(:subscription, :anniversary, customer:, plan:, started_at: 1.year.ago, subscription_at: 1.year.ago)
-      end
-
-      let(:timestamp) { subscription.subscription_at + 1.year }
-
+    context "when there is no usage" do
       it "does not create a daily usage" do
-        expect { compute_service.call }.not_to change(DailyUsage, :count)
+        travel_to(timestamp) do
+          expect { compute_service.call }.not_to change(DailyUsage, :count)
+        end
       end
     end
 
-    context "when subscription is terminated after the timestamp" do
-      let(:subscription) do
-        create(:subscription, :terminated, :calendar, customer:, plan:, started_at: 1.year.ago)
-      end
+    context "when there is usage" do
+      before { event }
 
-      let(:timestamp) { subscription.terminated_at - 1.day }
+      context "when usage contains charges usage with 0 units due to filters" do
+        it "does not include fees with 0 units" do
+          billable_metric_filter = create(:billable_metric_filter, billable_metric:)
+          charge_filter = create(:charge_filter, charge:, properties: {amount: "10"})
+          create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: [billable_metric_filter.values.first])
+
+          travel_to(timestamp) do
+            expect { compute_service.call }.to change(DailyUsage, :count).by(1)
+            daily_usage = DailyUsage.order(created_at: :asc).last
+            expect(daily_usage.usage["charges_usage"].count).to eq(1)
+          end
+        end
+      end
 
       it "creates a daily usage" do
-        travel_to("2024-11-24") do
-          result = compute_service.call
+        travel_to(timestamp) do
+          expect { compute_service.call }.to change(DailyUsage, :count).by(1)
 
-          expect(result).to be_success
-
-          daily_usage = result.daily_usage
+          daily_usage = DailyUsage.order(created_at: :asc).last
           expect(daily_usage).to have_attributes(
             organization_id: organization.id,
             customer_id: customer.id,
@@ -130,25 +68,114 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
             external_subscription_id: subscription.external_id,
             usage: Hash,
             usage_diff: Hash,
-            usage_date: timestamp.to_date - 1.day
+            usage_date: Date.parse("2024-10-21")
           )
           expect(daily_usage.refreshed_at).to match_datetime(timestamp)
           expect(daily_usage.from_datetime).to match_datetime(timestamp.beginning_of_month)
-          expect(daily_usage.to_datetime).to match_datetime(subscription.terminated_at)
+          expect(daily_usage.to_datetime).to match_datetime(timestamp.end_of_month)
         end
       end
-    end
 
-    context "with customer timezone" do
-      let(:customer) { create(:customer, organization:, timezone: "Australia/Sydney") }
-      let(:timestamp) { Time.zone.parse("2024-10-21 15:05:00") }
+      context "when a daily usage already exists" do
+        let(:existing_daily_usage) do
+          create(:daily_usage, subscription:, organization:, customer:, usage_date:)
+        end
 
-      it "creates a daily usage with expected usage_date" do
-        expect { compute_service.call }.to change(DailyUsage, :count).by(1)
+        before { existing_daily_usage }
 
-        daily_usage = DailyUsage.order(created_at: :asc).last
-        # Timestamp is 22 Oct 2024 02:05:00 AEDT
-        expect(daily_usage.usage_date).to eq(Date.parse("2024-10-21"))
+        it "returns the existing daily usage" do
+          result = compute_service.call
+
+          expect(result).to be_success
+          expect(result.daily_usage).to eq(existing_daily_usage)
+        end
+
+        context "when the organization has a timezone" do
+          let(:organization) { create(:organization, timezone: "America/Sao_Paulo") }
+
+          let(:existing_daily_usage) do
+            create(:daily_usage, subscription:, organization:, customer:, usage_date: usage_date - 4.hours)
+          end
+
+          it "takes the timezone into account" do
+            result = compute_service.call
+
+            expect(result).to be_success
+            expect(result.daily_usage).to eq(existing_daily_usage)
+          end
+        end
+
+        context "when the customer has a timezone" do
+          let(:customer) { create(:customer, organization:, timezone: "America/Sao_Paulo") }
+
+          let(:existing_daily_usage) do
+            create(:daily_usage, subscription:, organization:, customer:, usage_date: usage_date - 4.hours)
+          end
+
+          it "takes the timezone into account" do
+            result = compute_service.call
+
+            expect(result).to be_success
+            expect(result.daily_usage).to eq(existing_daily_usage)
+          end
+        end
+      end
+
+      context "when timestamp is on subscription billing day" do
+        let(:subscription) do
+          create(:subscription, :anniversary, customer:, plan:, started_at: 1.year.ago, subscription_at: 1.year.ago)
+        end
+
+        let(:timestamp) { subscription.subscription_at + 1.year }
+
+        it "does not create a daily usage" do
+          expect { compute_service.call }.not_to change(DailyUsage, :count)
+        end
+      end
+
+      context "when subscription is terminated after the timestamp" do
+        let(:subscription) do
+          create(:subscription, :terminated, :calendar, customer:, plan:, started_at: 1.year.ago)
+        end
+
+        let(:timestamp) { subscription.terminated_at - 1.day }
+
+        it "creates a daily usage" do
+          travel_to("2024-11-24") do
+            result = compute_service.call
+
+            expect(result).to be_success
+
+            daily_usage = result.daily_usage
+            expect(daily_usage).to have_attributes(
+              organization_id: organization.id,
+              customer_id: customer.id,
+              subscription_id: subscription.id,
+              external_subscription_id: subscription.external_id,
+              usage: Hash,
+              usage_diff: Hash,
+              usage_date: timestamp.to_date - 1.day
+            )
+            expect(daily_usage.refreshed_at).to match_datetime(timestamp)
+            expect(daily_usage.from_datetime).to match_datetime(timestamp.beginning_of_month)
+            expect(daily_usage.to_datetime).to match_datetime(subscription.terminated_at)
+          end
+        end
+      end
+
+      context "with customer timezone" do
+        let(:customer) { create(:customer, organization:, timezone: "Australia/Sydney") }
+        let(:timestamp) { Time.zone.parse("2024-10-21 15:05:00") }
+
+        it "creates a daily usage with expected usage_date" do
+          travel_to(timestamp) do
+            expect { compute_service.call }.to change(DailyUsage, :count).by(1)
+
+            daily_usage = DailyUsage.order(created_at: :asc).last
+            # Timestamp is 22 Oct 2024 02:05:00 AEDT
+            expect(daily_usage.usage_date).to eq(Date.parse("2024-10-21"))
+          end
+        end
       end
     end
   end

--- a/spec/services/daily_usages/fill_from_invoice_service_spec.rb
+++ b/spec/services/daily_usages/fill_from_invoice_service_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe DailyUsages::FillFromInvoiceService, type: :service do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
-
   let(:subscriptions) { [subscription] }
 
   let(:timestamp) { Time.zone.parse("2025-01-01T01:00:00") }
@@ -38,84 +37,22 @@ RSpec.describe DailyUsages::FillFromInvoiceService, type: :service do
   before { invoice_subscription }
 
   describe "#call" do
-    it "creates daily usages for the subscriptions" do
-      expect { fill_service.call }.to change(DailyUsage, :count).by(1)
-
-      daily_usage = subscription.daily_usages.order(:created_at).last
-      expect(daily_usage).to have_attributes(
-        organization:,
-        customer:,
-        subscription:,
-        external_subscription_id: subscription.external_id,
-        usage: Hash,
-        from_datetime: invoice_subscription.from_datetime,
-        to_datetime: invoice_subscription.to_datetime,
-        refreshed_at: invoice_subscription.timestamp,
-        usage_diff: Hash,
-        usage_date: invoice_subscription.charges_to_datetime.to_date
-      )
-    end
-
-    context "when invoice contains fees with 0 units" do
-      it "does not include those fees in the usage" do
-        charge = create(:standard_charge, plan: subscription.plan)
-        create(:charge_fee, invoice:, charge:, units: 0, amount_cents: 0, subscription:)
-
+    context "when there is no usage" do
+      it "does not create a daily usage" do
         travel_to(timestamp) do
-          expect { fill_service.call }.to change(DailyUsage, :count).by(1)
-          daily_usage = subscription.daily_usages.order(:created_at).last
-          expect(daily_usage.usage["charges_usage"]).to be_empty
+          expect { fill_service.call }.not_to change(DailyUsage, :count)
         end
       end
     end
 
-    context "when the daily usage already exists" do
+    context "when there is usage" do
       before do
-        create(
-          :daily_usage,
-          organization:,
-          customer:,
-          subscription:,
-          external_subscription_id: subscription.external_id,
-          from_datetime: invoice_subscription.from_datetime,
-          to_datetime: invoice_subscription.to_datetime,
-          refreshed_at: invoice_subscription.timestamp,
-          usage_date: invoice_subscription.charges_to_datetime.to_date
-        )
+        charge = create(:standard_charge, plan: subscription.plan)
+        create(:charge_fee, invoice:, charge:, units: 12, amount_cents: 1200, subscription:)
       end
 
-      it "does not create a new daily usage" do
-        expect { fill_service.call }.not_to change(DailyUsage, :count)
-      end
-    end
-
-    context "when multiples subscriptions are passed to the service" do
-      let(:subscription2) { create(:subscription, customer:) }
-      let(:subscriptions) { [subscription, subscription2] }
-
-      let(:invoice_subscription2) do
-        create(
-          :invoice_subscription,
-          subscription: subscription2,
-          invoice:,
-          timestamp:,
-          from_datetime: Time.zone.parse("2024-12-01T00:00:00"),
-          to_datetime: Time.zone.parse("2024-12-31T23:59:59"),
-          charges_from_datetime: Time.zone.parse("2024-12-01T00:00:00"),
-          charges_to_datetime: Time.zone.parse("2024-12-31T23:59:59")
-        )
-      end
-
-      before { invoice_subscription2 }
-
-      it "creates daily usages for all the subscriptions" do
-        expect { fill_service.call }.to change(DailyUsage, :count).by(2)
-      end
-
-      context "when only one subscription has to be updated" do
-        let(:subscriptions) { [subscription] }
-
-        it "creates daily usages for the subscriptions" do
+      it "creates daily usages for the subscriptions" do
+        travel_to(timestamp) do
           expect { fill_service.call }.to change(DailyUsage, :count).by(1)
 
           daily_usage = subscription.daily_usages.order(:created_at).last
@@ -131,6 +68,85 @@ RSpec.describe DailyUsages::FillFromInvoiceService, type: :service do
             usage_diff: Hash,
             usage_date: invoice_subscription.charges_to_datetime.to_date
           )
+        end
+      end
+
+      context "when invoice contains fees with 0 units" do
+        it "does not include those fees in the usage" do
+          charge = create(:standard_charge, plan: subscription.plan)
+          create(:charge_fee, invoice:, charge:, units: 0, amount_cents: 0, subscription:)
+
+          travel_to(timestamp) do
+            expect { fill_service.call }.to change(DailyUsage, :count).by(1)
+            daily_usage = subscription.daily_usages.order(:created_at).last
+            expect(daily_usage.usage["charges_usage"].count).to eq(1)
+          end
+        end
+      end
+
+      context "when the daily usage already exists" do
+        before do
+          create(
+            :daily_usage,
+            organization:,
+            customer:,
+            subscription:,
+            external_subscription_id: subscription.external_id,
+            from_datetime: invoice_subscription.from_datetime,
+            to_datetime: invoice_subscription.to_datetime,
+            refreshed_at: invoice_subscription.timestamp,
+            usage_date: invoice_subscription.charges_to_datetime.to_date
+          )
+        end
+
+        it "does not create a new daily usage" do
+          expect { fill_service.call }.not_to change(DailyUsage, :count)
+        end
+      end
+
+      context "when multiples subscriptions are passed to the service" do
+        let(:subscription2) { create(:subscription, customer:) }
+        let(:subscriptions) { [subscription, subscription2] }
+
+        let(:invoice_subscription2) do
+          create(
+            :invoice_subscription,
+            subscription: subscription2,
+            invoice:,
+            timestamp:,
+            from_datetime: Time.zone.parse("2024-12-01T00:00:00"),
+            to_datetime: Time.zone.parse("2024-12-31T23:59:59"),
+            charges_from_datetime: Time.zone.parse("2024-12-01T00:00:00"),
+            charges_to_datetime: Time.zone.parse("2024-12-31T23:59:59")
+          )
+        end
+
+        before { invoice_subscription2 }
+
+        it "creates daily usages for all the subscriptions" do
+          expect { fill_service.call }.to change(DailyUsage, :count).by(2)
+        end
+
+        context "when only one subscription has to be updated" do
+          let(:subscriptions) { [subscription] }
+
+          it "creates daily usages for the subscriptions" do
+            expect { fill_service.call }.to change(DailyUsage, :count).by(1)
+
+            daily_usage = subscription.daily_usages.order(:created_at).last
+            expect(daily_usage).to have_attributes(
+              organization:,
+              customer:,
+              subscription:,
+              external_subscription_id: subscription.external_id,
+              usage: Hash,
+              from_datetime: invoice_subscription.from_datetime,
+              to_datetime: invoice_subscription.to_datetime,
+              refreshed_at: invoice_subscription.timestamp,
+              usage_diff: Hash,
+              usage_date: invoice_subscription.charges_to_datetime.to_date
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
This PR includes improvements to the `DailyUsages::ComputeService` class to ensure better handling of daily usage records and their associated fees. The changes include adding conditions to **filter out zero-unit fees**.

In an effort of improving performances of daily usages, we decided to not create daily usage records when there is no subscription usage (`total_amount_cents: 0`).
