### PR TITLE
fix(integration): Avoid raising RecordNotUnique on race condition

### DIFF
--- a/app/services/integration_customers/create_service.rb
+++ b/app/services/integration_customers/create_service.rb
@@ -19,6 +19,9 @@ module IntegrationCustomers
       return res if res&.error
 
       result
+    rescue ActiveRecord::RecordNotUnique
+      # NOTE: Avoid raising an error if the record already exists
+      result
     end
 
     private

--- a/app/services/integration_customers/create_service.rb
+++ b/app/services/integration_customers/create_service.rb
@@ -20,7 +20,10 @@ module IntegrationCustomers
 
       result
     rescue ActiveRecord::RecordNotUnique
-      # NOTE: Avoid raising an error if the record already exists
+      # Avoid raising on race conditions when multiple requests are made at the same time
+      result.integration_customer = IntegrationCustomers::BaseCustomer.find_by(
+        customer:, integration:, type: customer_type
+      )
       result
     end
 


### PR DESCRIPTION
## Description

This PR makes sure that we the `IntegrationCustomers::CreateService` does not raise an `ActiveRecord::RecordNotUnique` when two creation attempts are executed at the time but instead returns the unique `integration_customer`
