### PR TITLE
fix(webhook): Handle errors with payment and refunds

### DIFF
--- a/app/services/payment_providers/gocardless/handle_event_service.rb
+++ b/app/services/payment_providers/gocardless/handle_event_service.rb
@@ -39,6 +39,9 @@ module PaymentProviders
         end
 
         result
+      rescue BaseService::NotFoundFailure => e
+        Rails.logger.warn("GoCardless resource not found: #{e.message}. JSON: #{event_json}")
+        BaseService::Result.new # NOTE: Prevents error from being re-raised
       end
 
       private

--- a/app/services/payment_providers/stripe/webhooks/charge_dispute_closed_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/charge_dispute_closed_service.rb
@@ -10,7 +10,7 @@ module PaymentProviders
           provider_payment_id = event.data.object.payment_intent
 
           payment = Payment.find_by(provider_payment_id:)
-          return result.not_found_failure!(resource: "stripe_payment") unless payment
+          return result unless payment
 
           if status == "lost"
             return Invoices::LoseDisputeService.call(invoice: payment.payable, payment_dispute_lost_at:, reason:)


### PR DESCRIPTION
## Description

This PR improve the handling of some payment provider's webhooks:
- `payment_not_found` for Stripe `charge.dispute.closed` webhook
- `payment_not_found` for GoCardless refund `failed` webhook

The PR also improve the handling of the `Stripe::InvalidRequestError` when refunding a payment, by preventing the re-raise of the error when the failure is `Refunds are not supported on this payment method.`
