### PR TITLE
misc(mailer): Improve attachements names

### DIFF
--- a/app/mailers/credit_note_mailer.rb
+++ b/app/mailers/credit_note_mailer.rb
@@ -13,7 +13,7 @@ class CreditNoteMailer < ApplicationMailer
     return if @customer.email.blank?
 
     @credit_note.file.open do |file|
-      attachments["credit_note.pdf"] = file.read
+      attachments["credit_note-#{@credit_note.number}.pdf"] = file.read
     end
 
     I18n.with_locale(@customer.preferred_document_locale) do

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -16,7 +16,7 @@ class InvoiceMailer < ApplicationMailer
     I18n.locale = @customer.preferred_document_locale
 
     @invoice.file.open do |file|
-      attachments["invoice.pdf"] = file.read
+      attachments["invoice-#{@invoice.number}.pdf"] = file.read
     end
 
     I18n.with_locale(@customer.preferred_document_locale) do

--- a/spec/mailers/credit_note_mailer_spec.rb
+++ b/spec/mailers/credit_note_mailer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe CreditNoteMailer, type: :mailer do
       expect(mailer.to).to eq([credit_note.customer.email])
       expect(mailer.reply_to).to eq([credit_note.organization.email])
       expect(mailer.attachments).not_to be_empty
+      expect(mailer.attachments.first.filename).to eq("credit_note-#{credit_note.number}.pdf")
     end
 
     context "with no pdf file" do

--- a/spec/mailers/invoice_mailer_spec.rb
+++ b/spec/mailers/invoice_mailer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe InvoiceMailer, type: :mailer do
       expect(mailer.to).to eq([invoice.customer.email])
       expect(mailer.reply_to).to eq([invoice.organization.email])
       expect(mailer.attachments).not_to be_empty
+      expect(mailer.attachments.first.filename).to eq("invoice-#{invoice.number}.pdf")
     end
 
     context "with no pdf file" do


### PR DESCRIPTION
## Context

Currently, invoices and credit notes attached to emails are named generically (e.g., invoice.pdf, credit_note.pdf). This makes it difficult for customers to organize and retrieve specific documents especially when dealing with multiple invoices or credit notes.

## Description

This PR improves the naming by including the number in the attachments file names:
- For invoices: `invoice-NUMBER.pdf`
- For credit notes: `credit_notes-NUMBER.pdf`