### PR TITLE
misc(stripe): Improve error code handling

### DIFF
--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -5,7 +5,7 @@ module CreditNotes
     class StripeService < BaseService
       include Customers::PaymentProviderFinder
 
-      INVALID_PAYMENT_METHOD_ERROR = "Refunds are not supported on this payment method."
+      INVALID_PAYMENT_METHOD_ERROR = "charge_not_refundable"
 
       def initialize(credit_note = nil)
         @credit_note = credit_note
@@ -39,7 +39,7 @@ module CreditNotes
       rescue ::Stripe::InvalidRequestError => e
         deliver_error_webhook(message: e.message, code: e.code)
         update_credit_note_status(:failed)
-        return result if e.message == INVALID_PAYMENT_METHOD_ERROR
+        return result if e.code == INVALID_PAYMENT_METHOD_ERROR
 
         result.service_failure!(code: "stripe_error", message: e.message)
       end

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
 
       before do
         allow(Stripe::Refund).to receive(:create)
-          .and_raise(::Stripe::InvalidRequestError.new(error_message, {}))
+          .and_raise(::Stripe::InvalidRequestError.new(error_message, {}, code: error_message))
       end
 
       it "delivers an error webhook" do
@@ -107,7 +107,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
             provider_customer_id: stripe_customer.provider_customer_id,
             provider_error: {
               message: "error",
-              error_code: nil
+              error_code: "error"
             }
           )
       end
@@ -130,7 +130,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
               provider_customer_id: stripe_customer.provider_customer_id,
               provider_error: {
                 message: error_message,
-                error_code: nil
+                error_code: error_message
               }
             )
         end


### PR DESCRIPTION
This PR improves https://github.com/getlago/lago-api/pull/3200 by relying on the error code rather than on the error message