### PR TITLE
fix(customer): Add validation om customer type

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -28,7 +28,7 @@ class Customer < ApplicationRecord
   attribute :finalize_zero_amount_invoice, :integer
   enum :finalize_zero_amount_invoice, FINALIZE_ZERO_AMOUNT_INVOICE_OPTIONS, prefix: :finalize_zero_amount_invoice
   attribute :customer_type, :string
-  enum :customer_type, CUSTOMER_TYPES, prefix: :customer_type
+  enum :customer_type, CUSTOMER_TYPES, prefix: :customer_type, validate: {allow_nil: true}
   attribute :account_type, :string
   enum :account_type, ACCOUNT_TYPES, suffix: :account
 

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -127,6 +127,8 @@ RSpec.describe Customer, type: :model do
         end
       end
     end
+
+    it { is_expected.to validate_inclusion_of(:customer_type).in_array(described_class::CUSTOMER_TYPES.keys) }
   end
 
   describe "#display_name" do

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -192,6 +192,31 @@ RSpec.describe Customers::CreateService, type: :service do
           expect(customer.customer_type).to eq(create_args[:customer_type])
         end
       end
+
+      context "with invalid customer_type" do
+        let(:create_args) do
+          {
+            external_id:,
+            name: "Foo Bar",
+            currency: "EUR",
+            customer_type: "default_type"
+          }
+        end
+
+        it "fails to create customer" do
+          result = customers_service.create_from_api(
+            organization:,
+            params: create_args
+          )
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages.keys).to include(:customer_type)
+            expect(result.error.messages[:customer_type]).to include("value_is_invalid")
+          end
+        end
+      end
     end
 
     context "with metadata" do


### PR DESCRIPTION
## Context

Some errors are raised on api when sending and invalid `customer_type` to `POST /api/v1/customers`

The server raises the following error: `ArgumentError 'xxx' is not a valid customer_type (ArgumentError)` and returns an HTTP 500

## Description

This PR adds a validation rule on the `customer_type` enum, making sure that teh API will return an `HTTP 422`