### PR TITLE
feat(invoice-preview): add charges support

### DIFF
--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -35,7 +35,7 @@ module Fees
           precise_amount_cents: result.fees.sum(&:precise_amount_cents)
         )
       end
-      return result unless result.success?
+      return result if !result.success? || context == :invoice_preview
 
       ActiveRecord::Base.transaction do
         result.fees.reject! { |f| !should_persit_fee?(f, result.fees) }

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -38,6 +38,7 @@ module Invoices
       invoice.subscriptions = subscriptions
 
       add_subscription_fees
+      add_charge_fees
       compute_tax_and_totals
 
       result.invoice = invoice
@@ -124,16 +125,45 @@ module Invoices
 
     def add_subscription_fees
       invoice.fees = subscriptions.map do |subscription|
-        fee = Fees::SubscriptionService.call(
+        Fees::SubscriptionService.call(
           invoice:,
           subscription:,
           boundaries: boundaries(subscription),
           context: :preview
         ).raise_if_error!.fee
+      end
+    end
 
-        subscription.fees = [fee]
+    def add_charge_fees
+      return unless persisted_subscriptions
 
-        fee
+      subscriptions.map do |subscription|
+        boundaries = boundaries(subscription)
+
+        query = subscription.plan.charges.joins(:billable_metric)
+          .includes(:taxes, billable_metric: :organization, filters: {values: :billable_metric_filter})
+          .where(invoiceable: true)
+          .where
+          .not(pay_in_advance: true, billable_metric: {recurring: false})
+
+        context = OpenTelemetry::Context.current
+
+        invoice.fees << Parallel.flat_map(query.all, in_threads: ENV["LAGO_PARALLEL_THREADS_COUNT"]&.to_i || 0) do |charge|
+          OpenTelemetry::Context.with_current(context) do
+            ActiveRecord::Base.connection_pool.with_connection do
+              cache_middleware = Subscriptions::ChargeCacheMiddleware.new(
+                subscription:,
+                charge:,
+                to_datetime: boundaries[:charges_to_datetime],
+                cache: !organization.clickhouse_events_store?
+              )
+
+              Fees::ChargeService
+                .call!(invoice:, charge:, subscription:, boundaries:, context: :invoice_preview, cache_middleware:)
+                .fees
+            end
+          end
+        end
       end
     end
 

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -125,12 +125,12 @@ module Invoices
 
     def add_subscription_fees
       invoice.fees = subscriptions.map do |subscription|
-        Fees::SubscriptionService.call(
+        Fees::SubscriptionService.call!(
           invoice:,
           subscription:,
           boundaries: boundaries(subscription),
           context: :preview
-        ).raise_if_error!.fee
+        ).fee
       end
     end
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -91,6 +91,18 @@ RSpec.describe Fees::ChargeService do
             payment_status: "pending"
           )
         end
+
+        it "persists fee" do
+          expect { charge_subscription_service.call }.to change(Fee, :count)
+        end
+
+        context "with preview context" do
+          let(:context) { :invoice_preview }
+
+          it "does not persist fee" do
+            expect { charge_subscription_service.call }.not_to change(Fee, :count)
+          end
+        end
       end
 
       context "with grouped standard charge" do

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             end
           end
 
-          context 'with charge fees' do
+          context "with charge fees" do
             let(:billable_metric) do
               create(:billable_metric, aggregation_type: "count_agg")
             end
@@ -215,10 +215,10 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             end
           end
 
-          context 'when preview premium integration does not exist' do
-            before { organization.update!(premium_integrations: ['netsuite']) }
+          context "when preview premium integration does not exist" do
+            before { organization.update!(premium_integrations: ["netsuite"]) }
 
-            it 'returns an error' do
+            it "returns an error" do
               result = preview_service.call
 
               aggregate_failures do
@@ -276,7 +276,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             )
           end
 
-          before { organization.update!(premium_integrations: ['preview']) }
+          before { organization.update!(premium_integrations: ["preview"]) }
 
           it "creates preview invoice for next invoice" do
             travel_to(timestamp) do
@@ -295,10 +295,10 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             end
           end
 
-          context 'when preview premium integration does not exist' do
-            before { organization.update!(premium_integrations: ['netsuite']) }
+          context "when preview premium integration does not exist" do
+            before { organization.update!(premium_integrations: ["netsuite"]) }
 
-            it 'returns an error' do
+            it "returns an error" do
               result = preview_service.call
 
               aggregate_failures do
@@ -516,7 +516,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
           end
         end
 
-        context 'with one persisted subscriptions' do
+        context "with one persisted subscriptions" do
           let(:customer) { create(:customer, organization:) }
           let(:subscription) do
             create(
@@ -530,17 +530,17 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             )
           end
 
-          before { organization.update!(premium_integrations: ['preview']) }
+          before { organization.update!(premium_integrations: ["preview"]) }
 
-          it 'creates preview invoice for full month' do
+          it "creates preview invoice for full month" do
             travel_to(timestamp) do
               result = preview_service.call
 
               expect(result).to be_success
               expect(result.invoice.subscriptions.first).to eq(subscription)
               expect(result.invoice.fees.length).to eq(1)
-              expect(result.invoice.invoice_type).to eq('subscription')
-              expect(result.invoice.issuing_date.to_s).to eq('2024-04-30')
+              expect(result.invoice.invoice_type).to eq("subscription")
+              expect(result.invoice.issuing_date.to_s).to eq("2024-04-30")
               expect(result.invoice.fees_amount_cents).to eq(100)
               expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(100)
               expect(result.invoice.taxes_amount_cents).to eq(50)
@@ -549,7 +549,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             end
           end
 
-          context 'with charge fees' do
+          context "with charge fees" do
             let(:billable_metric) do
               create(:billable_metric, aggregation_type: "count_agg")
             end
@@ -586,8 +586,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 expect(result).to be_success
                 expect(result.invoice.subscriptions.first).to eq(subscription)
                 expect(result.invoice.fees.length).to eq(2)
-                expect(result.invoice.invoice_type).to eq('subscription')
-                expect(result.invoice.issuing_date.to_s).to eq('2024-04-30')
+                expect(result.invoice.invoice_type).to eq("subscription")
+                expect(result.invoice.issuing_date.to_s).to eq("2024-04-30")
                 expect(result.invoice.fees_amount_cents).to eq(2632)
                 expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(2632)
                 expect(result.invoice.taxes_amount_cents).to eq(1316)
@@ -598,10 +598,10 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
           end
         end
 
-        context 'with multiple persisted subscriptions' do
+        context "with multiple persisted subscriptions" do
           let(:customer) { create(:customer, organization:) }
-          let(:plan1) { create(:plan, organization:, interval: 'monthly') }
-          let(:plan2) { create(:plan, organization:, interval: 'monthly') }
+          let(:plan1) { create(:plan, organization:, interval: "monthly") }
+          let(:plan2) { create(:plan, organization:, interval: "monthly") }
           let(:subscriptions) { [subscription1, subscription2] }
           let(:subscription1) do
             create(
@@ -626,17 +626,17 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             )
           end
 
-          before { organization.update!(premium_integrations: ['preview']) }
+          before { organization.update!(premium_integrations: ["preview"]) }
 
-          it 'creates preview invoice for full month' do
+          it "creates preview invoice for full month" do
             travel_to(timestamp + 5.days) do
               result = preview_service.call
 
               expect(result).to be_success
               expect(result.invoice.subscriptions.map { |s| s.id }).to match_array([subscription1.id, subscription2.id])
               expect(result.invoice.fees.length).to eq(2)
-              expect(result.invoice.invoice_type).to eq('subscription')
-              expect(result.invoice.issuing_date.to_s).to eq('2024-04-30')
+              expect(result.invoice.invoice_type).to eq("subscription")
+              expect(result.invoice.issuing_date.to_s).to eq("2024-04-30")
               expect(result.invoice.fees_amount_cents).to eq(200)
               expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(200)
               expect(result.invoice.taxes_amount_cents).to eq(100)


### PR DESCRIPTION
## Context

Preview feature allows to see first invoice preview. It works for both non-existing subscriptions but also for active subscriptions.

## Description

This PR adds support for charges for subscriptions that are persisted in the DB.
