### PR TITLE
misc(integration): Add retry for invoice creation on Net::ReadTimeout

### DIFF
--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -11,6 +11,7 @@ module Integrations
         unique :until_executed, on_conflict: :log
 
         retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 3
+        retry_on Net::ReadTimeout, wait: :polynomially_longer, attempts: 6
         retry_on RequestLimitError, wait: :polynomially_longer, attempts: 100
         retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
 


### PR DESCRIPTION
## Description

This PR adds an auto retry logic for `Net::ReadTimeout` error on `Integrations::Aggregator::Invoices::CreateJob`