### PR TITLE
chore(spec): Merging rails_helper into spec_helper

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,97 +1,9 @@
 # frozen_string_literal: true
 
-# This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV["RAILS_ENV"] = "test"
-require_relative "../config/environment"
-
-require "spec_helper"
-require "simplecov"
-require "money-rails/test_helpers"
-require "active_storage_validations/matchers"
-
 def pp(*args)
   # Uncomment the following line if you can't find where you left a `pp` call
   # ap caller.first
   args.each do |arg|
     ap arg, {sort_vars: false, sort_keys: false, indent: -2}
   end
-end
-
-DatabaseCleaner.allow_remote_database_url = true
-
-SimpleCov.start do
-  enable_coverage :branch
-
-  add_filter %r{^/config/}
-  add_filter %r{^/db/}
-  add_filter "/spec/"
-
-  add_group "Controllers", "app/controllers"
-  add_group "Models", "app/models"
-  add_group "Jobs", %w[app/jobs app/workers]
-  add_group "Services", "app/services"
-  add_group "GraphQL", "app/graphql"
-end
-
-# Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
-require "rspec/rails"
-require "paper_trail/frameworks/rspec"
-require "sidekiq/testing"
-Sidekiq::Testing.fake!
-ActiveJob::Uniqueness.test_mode!
-
-Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
-
-# Checks for pending migrations and applies them before tests are run.
-# If you are not using ActiveRecord, you can remove these lines.
-begin
-  ActiveRecord::Migration.maintain_test_schema!
-rescue ActiveRecord::PendingMigrationError => e
-  puts e.to_s.strip
-  exit 1
-end
-
-RSpec.configure do |config|
-  config.include FactoryBot::Syntax::Methods
-  config.include GraphQLHelper, type: :graphql
-  config.include AdminHelper, type: :request
-  config.include ApiHelper, type: :request
-  config.include ScenariosHelper
-  config.include LicenseHelper
-  config.include PdfHelper
-  config.include QueuesHelper
-  config.include ActiveSupport::Testing::TimeHelpers
-  config.include ActiveStorageValidations::Matchers
-
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_paths = [Rails.root.join("spec/fixtures").to_s]
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
-  config.use_transactional_fixtures = false
-
-  # You can uncomment this line to turn off ActiveRecord support entirely.
-  # config.use_active_record = false
-
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, type: :controller do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://relishapp.com/rspec/rspec-rails/docs
-  config.infer_spec_type_from_file_location!
-
-  # Filter lines from Rails gems in backtraces.
-  config.filter_rails_from_backtrace!
-  # arbitrary gems may also be filtered via:
-  # config.filter_gems_from_backtrace("gem name")
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require "webmock/rspec"
+# This file is copied to spec/ when you run 'rails generate rspec:install'
+ENV["RAILS_ENV"] = "test"
+require_relative "../config/environment"
 
 # Allow remote debugging when RUBY_DEBUG_PORT is set
 if ENV["RUBY_DEBUG_PORT"]
@@ -9,7 +11,67 @@ else
   require "debug"
 end
 
+require "webmock/rspec"
+require "simplecov"
+require "money-rails/test_helpers"
+require "active_storage_validations/matchers"
+
+DatabaseCleaner.allow_remote_database_url = true
+
+SimpleCov.start do
+  enable_coverage :branch
+
+  add_filter %r{^/config/}
+  add_filter %r{^/db/}
+  add_filter "/spec/"
+
+  add_group "Controllers", "app/controllers"
+  add_group "Models", "app/models"
+  add_group "Jobs", %w[app/jobs app/workers]
+  add_group "Services", "app/services"
+  add_group "GraphQL", "app/graphql"
+end
+
+# Prevent database truncation if the environment is production
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require "rspec/rails"
+require "paper_trail/frameworks/rspec"
+require "sidekiq/testing"
+Sidekiq::Testing.fake!
+ActiveJob::Uniqueness.test_mode!
+
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
+
+# Checks for pending migrations and applies them before tests are run.
+# If you are not using ActiveRecord, you can remove these lines.
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  puts e.to_s.strip
+  exit 1
+end
+
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+  config.include GraphQLHelper, type: :graphql
+  config.include AdminHelper, type: :request
+  config.include ApiHelper, type: :request
+  config.include ScenariosHelper
+  config.include LicenseHelper
+  config.include PdfHelper
+  config.include QueuesHelper
+  config.include ActiveSupport::Testing::TimeHelpers
+  config.include ActiveStorageValidations::Matchers
+
+  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+  config.fixture_paths = [Rails.root.join("spec/fixtures").to_s]
+
+  # If you're not using ActiveRecord, or you'd prefer not to run each of your
+  # examples within a transaction, assign false
+  config.use_transactional_fixtures = false
+
+  config.infer_spec_type_from_file_location!
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
@@ -23,21 +85,39 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = "tmp/rspec_examples.txt"
   config.filter_run_when_matching :focus
 
+  # Filter lines from Rails gems in backtraces.
+  config.filter_rails_from_backtrace!
+  # arbitrary gems may also be filtered via:
+  # config.filter_gems_from_backtrace("gem name")
+
+  config.define_derived_metadata do |meta|
+    unless meta.key?(:aggregate_failures)
+      meta[:aggregate_failures] = true
+    end
+  end
+
   # NOTE: Database cleaner config to turn off/on transactional mode
   config.before(:suite) do
     DatabaseCleaner.clean_with(:deletion)
   end
 
-  config.before do
-    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
-  end
-
-  config.before do
-    DatabaseCleaner.strategy = :transaction
-  end
-
-  # Custom metadata
   config.before do |example|
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    DatabaseCleaner.strategy = :transaction
+
+    if example.metadata[:transaction] == false
+      DatabaseCleaner.strategy = :deletion
+    end
+
+    if example.metadata[:scenarios]
+      stub_pdf_generation
+    end
+
+    if example.metadata[:clickhouse]
+      DatabaseCleaner.strategy = :deletion
+      WebMock.disable_net_connect!(allow: ENV.fetch("LAGO_CLICKHOUSE_HOST", "clickhouse"))
+    end
+
     if example.metadata[:cache]
       Rails.cache = if example.metadata[:cache].to_sym == :memory
         ActiveSupport::Cache.lookup_store(:memory_store)
@@ -51,24 +131,9 @@ RSpec.configure do |config|
     end
   end
 
-  config.before(:each, transaction: false) do
-    DatabaseCleaner.strategy = :deletion
-  end
-
   config.around do |example|
     DatabaseCleaner.cleaning do
       example.run
-    end
-  end
-
-  config.before(:each, clickhouse: true) do
-    DatabaseCleaner.strategy = :deletion
-    WebMock.disable_net_connect!(allow: ENV.fetch("LAGO_CLICKHOUSE_HOST", "clickhouse"))
-  end
-
-  config.define_derived_metadata do |meta|
-    unless meta.key?(:aggregate_failures)
-      meta[:aggregate_failures] = true
     end
   end
 end

--- a/spec/support/pdf_helper.rb
+++ b/spec/support/pdf_helper.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.configure do |config|
-  config.before(:each, :scenarios) do
-    stub_pdf_generation
-  end
-end
-
 module PdfHelper
   def stub_pdf_generation(response_body = nil, status = 200)
     response_body ||= File.read(Rails.root.join("spec/fixtures/blank.pdf"))


### PR DESCRIPTION
## Description

Currently, we have both `spec_helper.rb` and `rails_helper.rb`.

My main goal was to merge them so we have only one place defining all the before/after actions. I realized that we could get rid of the rails_helper file entirely, so we don't have to require it manually anymore.

Any reason you'd like to keep it?