### PR TITLE
feat(gql): Introduce ObfuscatedStringType

### DIFF
--- a/app/graphql/types/integrations/anrok.rb
+++ b/app/graphql/types/integrations/anrok.rb
@@ -5,19 +5,13 @@ module Types
     class Anrok < Types::BaseObject
       graphql_name "AnrokIntegration"
 
-      field :api_key, String, null: false
+      field :api_key, ObfuscatedStringType, null: false
       field :code, String, null: false
       field :external_account_id, String, null: true
       field :failed_invoices_count, Integer, null: true
       field :has_mappings_configured, Boolean
       field :id, ID, null: false
       field :name, String, null: false
-
-      # NOTE: Client secret is a sensitive information. It should not be sent back to the
-      #       front end application. Instead we send an obfuscated value
-      def api_key
-        "#{"•" * 8}…#{object.api_key[-3..]}"
-      end
 
       def has_mappings_configured
         object.integration_collection_mappings.where(type: "IntegrationCollectionMappings::AnrokCollectionMapping").any?

--- a/app/graphql/types/integrations/netsuite.rb
+++ b/app/graphql/types/integrations/netsuite.rb
@@ -7,7 +7,7 @@ module Types
 
       field :account_id, String, null: true
       field :client_id, String, null: true
-      field :client_secret, String, null: true
+      field :client_secret, ObfuscatedStringType, null: true
       field :code, String, null: false
       field :connection_id, ID, null: false
       field :has_mappings_configured, Boolean
@@ -18,19 +18,7 @@ module Types
       field :sync_invoices, Boolean
       field :sync_payments, Boolean
       field :token_id, String, null: true
-      field :token_secret, String, null: true
-
-      # NOTE: Client secret is a sensitive information. It should not be sent back to the
-      #       front end application. Instead we send an obfuscated value
-      def client_secret
-        "#{"•" * 8}…#{object.client_secret[-3..]}"
-      end
-
-      def token_secret
-        return nil unless object.token_secret
-
-        "#{"•" * 8}…#{object.token_secret[-3..]}"
-      end
+      field :token_secret, ObfuscatedStringType, null: true
 
       def has_mappings_configured
         object.integration_collection_mappings

--- a/app/graphql/types/integrations/okta.rb
+++ b/app/graphql/types/integrations/okta.rb
@@ -6,18 +6,12 @@ module Types
       graphql_name "OktaIntegration"
 
       field :client_id, String, null: true
-      field :client_secret, String, null: true
+      field :client_secret, ObfuscatedStringType, null: true
       field :code, String, null: false
       field :domain, String, null: false
       field :id, ID, null: false
       field :name, String, null: false
       field :organization_name, String, null: false
-
-      # NOTE: Client secret is a sensitive information. It should not be sent back to the
-      #       front end application. Instead we send an obfuscated value
-      def client_secret
-        "#{"•" * 8}…#{object.client_secret[-3..]}"
-      end
     end
   end
 end

--- a/app/graphql/types/obfuscated_string_type.rb
+++ b/app/graphql/types/obfuscated_string_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  class ObfuscatedStringType < GraphQL::Schema::Scalar
+    def self.coerce_result(value, _ctx)
+      return nil unless value
+
+      "#{"•" * 8}…#{value.to_s[-3..]}"
+    end
+  end
+end

--- a/app/graphql/types/payment_providers/adyen.rb
+++ b/app/graphql/types/payment_providers/adyen.rb
@@ -9,21 +9,11 @@ module Types
       field :id, ID, null: false
       field :name, String, null: false
 
-      field :api_key, String, null: true, permission: "organization:integrations:view"
-      field :hmac_key, String, null: true, permission: "organization:integrations:view"
+      field :api_key, ObfuscatedStringType, null: true, permission: "organization:integrations:view"
+      field :hmac_key, ObfuscatedStringType, null: true, permission: "organization:integrations:view"
       field :live_prefix, String, null: true, permission: "organization:integrations:view"
       field :merchant_account, String, null: false, permission: "organization:integrations:view"
       field :success_redirect_url, String, null: true, permission: "organization:integrations:view"
-
-      # NOTE: Api key is a sensitive information. It should not be sent back to the
-      #       front end application. Instead we send an obfuscated value
-      def api_key
-        "#{"•" * 8}…#{object.api_key[-3..]}"
-      end
-
-      def hmac_key
-        "#{"•" * 8}…#{object.hmac_key[-3..]}" if object.hmac_key.present?
-      end
     end
   end
 end

--- a/app/graphql/types/payment_providers/stripe.rb
+++ b/app/graphql/types/payment_providers/stripe.rb
@@ -9,14 +9,8 @@ module Types
       field :id, ID, null: false
       field :name, String, null: false
 
-      field :secret_key, String, null: true, permission: "organization:integrations:view"
+      field :secret_key, ObfuscatedStringType, null: true, permission: "organization:integrations:view"
       field :success_redirect_url, String, null: true, permission: "organization:integrations:view"
-
-      # NOTE: Secret key is a sensitive information. It should not be sent back to the
-      #       front end application. Instead we send an obfuscated value
-      def secret_key
-        "#{"•" * 8}…#{object.secret_key[-3..]}"
-      end
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -121,9 +121,9 @@ enum AdjustedFeeTypeEnum {
 }
 
 type AdyenProvider {
-  apiKey: String
+  apiKey: ObfuscatedString
   code: String!
-  hmacKey: String
+  hmacKey: ObfuscatedString
   id: ID!
   livePrefix: String
   merchantAccount: String
@@ -183,7 +183,7 @@ type AnrokFeeObjectCollection {
 }
 
 type AnrokIntegration {
-  apiKey: String!
+  apiKey: ObfuscatedString!
   code: String!
   externalAccountId: String
   failedInvoicesCount: Int
@@ -6142,7 +6142,7 @@ type NetsuiteCustomer {
 type NetsuiteIntegration {
   accountId: String
   clientId: String
-  clientSecret: String
+  clientSecret: ObfuscatedString
   code: String!
   connectionId: ID!
   hasMappingsConfigured: Boolean
@@ -6153,8 +6153,10 @@ type NetsuiteIntegration {
   syncInvoices: Boolean
   syncPayments: Boolean
   tokenId: String
-  tokenSecret: String
+  tokenSecret: ObfuscatedString
 }
+
+scalar ObfuscatedString
 
 """
 Accept Invite with Okta Oauth input arguments
@@ -6183,7 +6185,7 @@ input OktaAuthorizeInput {
 
 type OktaIntegration {
   clientId: String
-  clientSecret: String
+  clientSecret: ObfuscatedString
   code: String!
   domain: String!
   id: ID!
@@ -7417,7 +7419,7 @@ type StripeProvider {
   code: String!
   id: ID!
   name: String!
-  secretKey: String
+  secretKey: ObfuscatedString
   successRedirectUrl: String
 }
 

--- a/schema.json
+++ b/schema.json
@@ -802,7 +802,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "ObfuscatedString",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -830,7 +830,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "ObfuscatedString",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -1277,7 +1277,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "ObfuscatedString",
                   "ofType": null
                 }
               },
@@ -27702,7 +27702,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "ObfuscatedString",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -27854,7 +27854,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "ObfuscatedString",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -27862,6 +27862,16 @@
               "args": []
             }
           ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ObfuscatedString",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
           "inputFields": null,
           "enumValues": null
         },
@@ -28011,7 +28021,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "ObfuscatedString",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -37116,7 +37126,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "String",
+                "name": "ObfuscatedString",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/graphql/types/integrations/anrok_spec.rb
+++ b/spec/graphql/types/integrations/anrok_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Types::Integrations::Anrok do
   it do
     expect(subject).to have_field(:id).of_type("ID!")
 
-    expect(subject).to have_field(:api_key).of_type("String!")
+    expect(subject).to have_field(:api_key).of_type("ObfuscatedString!")
     expect(subject).to have_field(:code).of_type("String!")
     expect(subject).to have_field(:failed_invoices_count).of_type("Int")
     expect(subject).to have_field(:has_mappings_configured).of_type("Boolean")

--- a/spec/graphql/types/integrations/netsuite_spec.rb
+++ b/spec/graphql/types/integrations/netsuite_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Types::Integrations::Netsuite do
     expect(subject).to have_field(:id).of_type("ID!")
 
     expect(subject).to have_field(:client_id).of_type("String")
-    expect(subject).to have_field(:client_secret).of_type("String")
+    expect(subject).to have_field(:client_secret).of_type("ObfuscatedString")
     expect(subject).to have_field(:code).of_type("String!")
     expect(subject).to have_field(:has_mappings_configured).of_type("Boolean")
     expect(subject).to have_field(:name).of_type("String!")
     expect(subject).to have_field(:script_endpoint_url).of_type("String!")
     expect(subject).to have_field(:token_id).of_type("String")
-    expect(subject).to have_field(:token_secret).of_type("String")
+    expect(subject).to have_field(:token_secret).of_type("ObfuscatedString")
 
     expect(subject).to have_field(:sync_credit_notes).of_type("Boolean")
     expect(subject).to have_field(:sync_invoices).of_type("Boolean")

--- a/spec/graphql/types/payment_providers/adyen_spec.rb
+++ b/spec/graphql/types/payment_providers/adyen_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Types::PaymentProviders::Adyen do
     expect(subject).to have_field(:code).of_type("String!")
     expect(subject).to have_field(:name).of_type("String!")
 
-    expect(subject).to have_field(:api_key).of_type("String").with_permission("organization:integrations:view")
-    expect(subject).to have_field(:hmac_key).of_type("String").with_permission("organization:integrations:view")
+    expect(subject).to have_field(:api_key).of_type("ObfuscatedString").with_permission("organization:integrations:view")
+    expect(subject).to have_field(:hmac_key).of_type("ObfuscatedString").with_permission("organization:integrations:view")
     expect(subject).to have_field(:live_prefix).of_type("String").with_permission("organization:integrations:view")
     expect(subject).to have_field(:merchant_account).of_type("String").with_permission("organization:integrations:view")
     expect(subject).to have_field(:success_redirect_url).of_type("String").with_permission("organization:integrations:view")

--- a/spec/graphql/types/payment_providers/stripe_spec.rb
+++ b/spec/graphql/types/payment_providers/stripe_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Types::PaymentProviders::Stripe do
     expect(subject).to have_field(:code).of_type("String!")
     expect(subject).to have_field(:name).of_type("String!")
 
-    expect(subject).to have_field(:secret_key).of_type("String").with_permission("organization:integrations:view")
+    expect(subject).to have_field(:secret_key).of_type("ObfuscatedString").with_permission("organization:integrations:view")
     expect(subject).to have_field(:success_redirect_url).of_type("String").with_permission("organization:integrations:view")
   end
 end


### PR DESCRIPTION
## Context

For api keys or token, the graphql exposes a string with dots and only shows the last 3 characters.

## Description

This PR introduces a custom `ObfuscatedStringType` to our graphql schema so you don't have to redeclare it every time you need to hide a sensitive information.

![CleanShot 2025-02-19 at 14 38 10@2x](https://github.com/user-attachments/assets/087b5cbf-226c-4245-aabc-853403487258)
