### PR TITLE
feat(dev): Add console helpers for local development

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,6 +1,22 @@
 # frozen_string_literal: true
 
 module Rails::ConsoleMethods
+  if Rails.env.development?
+    def gavin
+      @gavin ||= hooli.users.find_by email: "gavin@hooli.com"
+    end
+
+    def hooli
+      @hooli ||= Organization.find_by name: "Hooli"
+    end
+
+    def delete_hooli_webhooks
+      hooli.webhook_endpoints.map do |endpoint|
+        endpoint.webhooks.delete_all
+      end.sum
+    end
+  end
+
   def find(id)
     if /^gid/.match?(id)
       GlobalID::Locator.locate(id)


### PR DESCRIPTION
## Description

This PR adds some helpers that I like to use locally. I use Hooli and Gavin's user account when developing to 2 methods let's you retrieve the org and the user easily.

The third one let's you delete all the webhooks for the hooli work so when testing, you can get rid of all previous webhooks for some clarity.