### PR TITLE
fix(spec): tentative fix for flacky test

### DIFF
--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
       let(:response) { instance_double(Net::HTTPOK) }
 
       before do
-        allow(lago_client).to receive(:post_with_response).with(params, headers).and_return(response)
+        allow(lago_client).to receive(:post_with_response).with(array_including(params), headers).and_return(response)
         allow(response).to receive(:body).and_return(body)
       end
 


### PR DESCRIPTION
There is a flacky test (main branch is failing). I believe this is because the mock is relying on the order of the fees, maybe `array_including` will fix it.

Ideally, we should rely on webmock instead of mocking the class.

![CleanShot 2025-02-18 at 09 38 43@2x](https://github.com/user-attachments/assets/822b27d4-4b82-41bb-90e3-41b00023a181)


![CleanShot 2025-02-18 at 09 36 40@2x](https://github.com/user-attachments/assets/eebe5ce2-a17b-4094-b191-e45dcdd3e2a1)
