### PR TITLE
feat(stripe): Add Stripe `crypto` payment method

### DIFF
--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -2,7 +2,7 @@
 
 module PaymentProviderCustomers
   class StripeCustomer < BaseCustomer
-    PAYMENT_METHODS = %w[card sepa_debit us_bank_account bacs_debit link boleto].freeze
+    PAYMENT_METHODS = %w[card sepa_debit us_bank_account bacs_debit link boleto crypto].freeze
 
     validates :provider_payment_methods, presence: true
     validate :allowed_provider_payment_methods

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -208,7 +208,10 @@ module Invoices
       # to permit 3D secure authentication
       # https://docs.stripe.com/india-recurring-payments
       def off_session?
-        invoice.customer.country != "IN"
+        return false if customer.country == "IN"
+        return false if customer.stripe_customer.provider_payment_methods.include?("crypto")
+
+        true
       end
 
       # NOTE: Same as off_session?

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -114,7 +114,7 @@ module PaymentProviderCustomers
       {
         success_url: success_redirect_url,
         mode: "setup",
-        payment_method_types: stripe_customer.provider_payment_methods,
+        payment_method_types: stripe_customer.provider_payment_methods - %w[crypto], # NOTE: crypto doesn't work with setup mode
         customer: stripe_customer.provider_customer_id
       }
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -6573,6 +6573,7 @@ enum ProviderPaymentMethodsEnum {
   bacs_debit
   boleto
   card
+  crypto
   link
   sepa_debit
   us_bank_account

--- a/schema.json
+++ b/schema.json
@@ -31762,6 +31762,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "crypto",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/graphql/types/payment_provider_customers/provider_payment_methods_enum_spec.rb
+++ b/spec/graphql/types/payment_provider_customers/provider_payment_methods_enum_spec.rb
@@ -4,6 +4,6 @@ require "rails_helper"
 
 RSpec.describe Types::PaymentProviderCustomers::ProviderPaymentMethodsEnum do
   it "enumerates the correct values" do
-    expect(described_class.values.keys).to match_array(%w[card sepa_debit us_bank_account bacs_debit link boleto])
+    expect(described_class.values.keys).to match_array(%w[card sepa_debit us_bank_account bacs_debit link boleto crypto])
   end
 end


### PR DESCRIPTION
## Description

* Add `crypto` to the list of available payment methods
* When generating customer checkout url, we remove crypto from the list because it cannot be used in setup mode
* When paying an invoice with crypto, the same `payment_intent.succeeded` stripe webhook is sent so we correctly update the invoice payment status 


![CleanShot 2025-02-18 at 10 40 18@2x](https://github.com/user-attachments/assets/73b47724-b896-4371-b742-2e44ef3588a2)
