### PR TITLE
feat(api): Introduce new error

### DIFF
--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -57,7 +57,20 @@ module ApiErrors
     )
   end
 
-  def thirdpary_error(error:)
+  def payment_provider_error(error_result)
+    render(
+      json: {
+        status: error_result.status,
+        error: error_result.message,
+        payment_provider: error_result.payment_provider,
+        payment_provider_code: error_result.payment_provider_code,
+        details: error_result.details
+      },
+      status: error_result.status
+    )
+  end
+
+  def thirdparty_error(error:)
     render(
       json: {
         status: 422,
@@ -83,8 +96,10 @@ module ApiErrors
       forbidden_error(code: error_result.error.code)
     when BaseService::UnauthorizedFailure
       unauthorized_error(message: error_result.error.message)
+    when BaseService::PaymentProviderFailure
+      payment_provider_error(error_result.error)
     when BaseService::ThirdPartyFailure
-      thirdpary_error(error: error_result.error)
+      thirdparty_error(error: error_result.error)
     else
       raise(error_result.error)
     end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -93,6 +93,20 @@ class BaseService
     end
   end
 
+  class PaymentProviderFailure < FailedResult
+    attr_reader :status, :details, :payment_provider, :payment_provider_code
+
+    def initialize(result, message:, status:, details:,
+      payment_provider:, payment_provider_code:)
+      @status = status
+      @details = details
+      @payment_provider = payment_provider
+      @payment_provider_code = payment_provider_code
+
+      super(result, "#{@payment_provider} (#{@payment_provider_code}): #{message}")
+    end
+  end
+
   class ThirdPartyFailure < FailedResult
     attr_reader :third_party, :error_message
 


### PR DESCRIPTION
## Context

As I was working on [adding crypto](https://github.com/getlago/lago-api/pull/3214), I realized if the checkout URL failed, we just return an 200 response where the checkout url is incorrect.

## Description

I sometimes find that the API swallow to many errors. You receive a webhook with all the details but the API will simply return a cryptic error code. 

Here I'm thinking about adding a new kind of failure for Payment Provider. 

A contributor recently introduced `thirdparty_errors` because there was no easy way to return error from another service. I don't like the name too much, we usually use "integrations" or "provider" rather than third parties but more importantly I think it's too limited to return only a message.

Please share anything you have in mind. I'm not too sure we should merge the PR in this state but I'd like the API to return more errors from payment provider.

**Error before**

![CleanShot 2025-02-18 at 11 46 01@2x](https://github.com/user-attachments/assets/7171bdce-57f0-439c-ae46-14b5b478a2a3)

**Error after**

![CleanShot 2025-02-18 at 12 39 48@2x](https://github.com/user-attachments/assets/037a8e3d-94a1-413e-b4fc-39261b7da2cb)


