### PR TITLE
feat(multi-entities): Add billing entity model

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class BillingEntity < ApplicationRecord
+  include PaperTrailTraceable
+  include OrganizationTimezone
+  include Currencies
+  include Discard::Model
+
+  self.discard_column = :deleted_at
+
+  EMAIL_SETTINGS = [
+    "invoice.finalized",
+    "credit_note.created"
+  ]
+
+  DOCUMENT_NUMBERINGS = {
+    per_customer: "per_customer",
+    per_billing_entity: "per_billing_entity"
+  }
+
+  belongs_to :organization
+
+  enum :document_numbering, DOCUMENT_NUMBERINGS
+
+  default_scope -> { kept }
+
+  validates :is_default,
+    uniqueness: {
+      conditions: -> { where(is_default: true, archived_at: nil, deleted_at: nil) },
+      scope: :organization_id
+    }
+end
+
+# == Schema Information
+#
+# Table name: billing_entities
+#
+#  id                           :uuid             not null, primary key
+#  address_line1                :string
+#  address_line2                :string
+#  archived_at                  :datetime
+#  city                         :string
+#  code                         :string           not null
+#  country                      :string
+#  default_currency             :string           default("USD"), not null
+#  deleted_at                   :datetime
+#  document_locale              :string           default("en"), not null
+#  document_number_prefix       :string
+#  document_numbering           :enum             default("per_customer"), not null
+#  email                        :string
+#  email_settings               :string           default([]), not null, is an Array
+#  eu_tax_management            :boolean          default(FALSE)
+#  finalize_zero_amount_invoice :boolean          default(TRUE), not null
+#  invoice_footer               :text
+#  invoice_grace_period         :integer          default(0), not null
+#  is_default                   :boolean          default(FALSE), not null
+#  legal_name                   :string
+#  legal_number                 :string
+#  logo                         :string
+#  name                         :string           not null
+#  net_payment_term             :integer          default(0), not null
+#  state                        :string
+#  tax_identification_number    :string
+#  timezone                     :string           default("UTC"), not null
+#  vat_rate                     :float            default(0.0), not null
+#  zipcode                      :string
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  organization_id              :uuid             not null
+#
+# Indexes
+#
+#  index_billing_entities_on_organization_id       (organization_id)
+#  unique_default_billing_entity_per_organization  (organization_id) UNIQUE WHERE ((is_default = true) AND (archived_at IS NULL) AND (deleted_at IS NULL))
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/db/migrate/20250219124948_create_billing_entities.rb
+++ b/db/migrate/20250219124948_create_billing_entities.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class CreateBillingEntities < ActiveRecord::Migration[7.1]
+  def change
+    create_enum :entity_document_numbering, %w[per_customer per_billing_entity]
+
+    create_table :billing_entities, id: :uuid do |t|
+      t.references :organization, type: :uuid, null: false, foreign_key: true
+
+      # address
+      t.string :address_line1
+      t.string :address_line2
+      t.string :city
+      t.string :country
+      t.string :zipcode
+      t.string :state
+      t.string :timezone, default: "UTC", null: false
+
+      # currency and locale
+      t.string :default_currency, default: "USD", null: false
+      t.string :document_locale, default: "en", null: false
+
+      # invoice settings
+      t.string :document_number_prefix
+      t.enum :document_numbering, enum_type: "entity_document_numbering", null: false, default: "per_customer"
+      t.boolean :finalize_zero_amount_invoice, default: true, null: false
+      t.text :invoice_footer
+      t.integer :invoice_grace_period, default: 0, null: false
+      t.integer :net_payment_term, default: 0, null: false
+
+      # entity settings
+      t.string :email
+      t.string :email_settings, array: true, default: [], null: false
+      t.boolean :eu_tax_management, default: false
+      t.string :legal_name
+      t.string :legal_number
+      t.string :logo
+      t.string :name, null: false
+      t.string :code, null: false
+      t.string :tax_identification_number
+      t.float :vat_rate, default: 0.0, null: false
+
+      t.boolean :is_default, default: false, null: false
+      t.index [:organization_id],
+        unique: true,
+        where: "is_default = TRUE AND archived_at IS NULL AND deleted_at IS NULL",
+        name: "unique_default_billing_entity_per_organization"
+
+      t.datetime :archived_at
+      t.datetime :deleted_at
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories/billing_entities.rb
+++ b/spec/factories/billing_entities.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :billing_entity do
+    organization
+    name { Faker::Company.name }
+    code { "entity_#{SecureRandom.uuid}" }
+    default_currency { "USD" }
+
+    email { Faker::Internet.email }
+    email_settings { ["invoice.finalized", "credit_note.created"] }
+
+    trait :default do
+      is_default { true }
+    end
+
+    trait :deleted do
+      deleted_at { Time.current }
+    end
+
+    trait :archived do
+      archived_at { Time.current }
+    end
+  end
+end

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BillingEntity, type: :model do
+  subject(:billing_entity) { build(:billing_entity) }
+
+  it_behaves_like "paper_trail traceable"
+
+  it { is_expected.to belong_to(:organization) }
+
+  describe "is_default validation" do
+    let(:organization) { create :organization }
+
+    it "validates uniqueness of organization_id for is_default excluding deleted and archived records" do
+      deleted_record = create(:billing_entity, :default, :deleted, organization:)
+      archived_record = create(:billing_entity, :default, :archived, organization:)
+      expect(deleted_record).to be_valid
+      expect(archived_record).to be_valid
+
+      record_1 = create(:billing_entity, :default, organization:)
+      expect(record_1).to be_valid
+
+      record_2 = build(:billing_entity, :default, organization:)
+      expect(record_2).not_to be_valid
+      expect(record_2.errors[:is_default]).to include("value_already_exist")
+
+      record_3 = build(:billing_entity, :default)
+      expect(record_3).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

## Description

Add billing entity model as a starting point to kick off this feature development.