### PR TITLE
feat(mailers): Add from email premium integration

### DIFF
--- a/app/mailers/credit_note_mailer.rb
+++ b/app/mailers/credit_note_mailer.rb
@@ -16,7 +16,6 @@ class CreditNoteMailer < ApplicationMailer
       attachments["credit_note-#{@credit_note.number}.pdf"] = file.read
     end
 
-    byebug
     from_email = if @organization.from_email_enabled?
       @organization.email
     else

--- a/app/mailers/credit_note_mailer.rb
+++ b/app/mailers/credit_note_mailer.rb
@@ -16,10 +16,17 @@ class CreditNoteMailer < ApplicationMailer
       attachments["credit_note-#{@credit_note.number}.pdf"] = file.read
     end
 
+    byebug
+    from_email = if @organization.from_email_enabled?
+      @organization.email
+    else
+      ENV["LAGO_FROM_EMAIL"]
+    end
+
     I18n.with_locale(@customer.preferred_document_locale) do
       mail(
         to: @customer.email,
-        from: email_address_with_name(ENV["LAGO_FROM_EMAIL"], @organization.name),
+        from: email_address_with_name(from_email, @organization.name),
         reply_to: email_address_with_name(@organization.email, @organization.name),
         subject: I18n.t(
           "email.credit_note.created.subject",

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -19,10 +19,16 @@ class InvoiceMailer < ApplicationMailer
       attachments["invoice-#{@invoice.number}.pdf"] = file.read
     end
 
+    from_email = if @organization.from_email_enabled?
+      @organization.email
+    else
+      ENV["LAGO_FROM_EMAIL"]
+    end
+
     I18n.with_locale(@customer.preferred_document_locale) do
       mail(
         to: @customer.email,
-        from: email_address_with_name(ENV["LAGO_FROM_EMAIL"], @organization.name),
+        from: email_address_with_name(from_email, @organization.name),
         reply_to: email_address_with_name(@organization.email, @organization.name),
         subject: I18n.t(
           "email.invoice.finalized.subject",

--- a/app/mailers/payment_request_mailer.rb
+++ b/app/mailers/payment_request_mailer.rb
@@ -15,10 +15,16 @@ class PaymentRequestMailer < ApplicationMailer
     @invoices = @payment_request.invoices
     @payment_url = ::PaymentRequests::Payments::GeneratePaymentUrlService.call(payable: @payment_request).payment_url
 
+    from_email = if @organization.from_email_enabled?
+      @organization.email
+    else
+      ENV["LAGO_FROM_EMAIL"]
+    end
+
     I18n.with_locale(@customer.preferred_document_locale) do
       mail(
         to: @payment_request.email,
-        from: email_address_with_name(ENV["LAGO_FROM_EMAIL"], @organization.name),
+        from: email_address_with_name(from_email, @organization.name),
         reply_to: email_address_with_name(@organization.email, @organization.name),
         subject: I18n.t(
           "email.payment_request.requested.subject",

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -77,6 +77,7 @@ class Organization < ApplicationRecord
     zero_amount_fees
     remove_branding_watermark
     manual_payments
+    from_email
   ].freeze
   PREMIUM_INTEGRATIONS = INTEGRATIONS - %w[anrok]
 

--- a/spec/mailers/credit_note_mailer_spec.rb
+++ b/spec/mailers/credit_note_mailer_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe CreditNoteMailer, type: :mailer do
 
   let(:credit_note) { create(:credit_note) }
 
+  around { |test| lago_premium!(&test) }
+
   before do
     credit_note.file.attach(io: File.open(Rails.root.join("spec/fixtures/blank.pdf")), filename: "blank.pdf")
   end
@@ -61,6 +63,18 @@ RSpec.describe CreditNoteMailer, type: :mailer do
         mailer = credit_note_mailer.with(credit_note:).created
 
         expect(mailer.to).to be_nil
+      end
+    end
+
+    context "when organization from_email integration is enabled" do
+      before do
+        credit_note.organization.update(premium_integrations: ["from_email"])
+      end
+
+      it "returns a mailer with organization email from" do
+        mailer = credit_note_mailer.with(credit_note:).created
+
+        expect(mailer.from).to eq([credit_note.customer.organization.email])
       end
     end
   end

--- a/spec/mailers/credit_note_mailer_spec.rb
+++ b/spec/mailers/credit_note_mailer_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe CreditNoteMailer, type: :mailer do
       it "returns a mailer with organization email from" do
         mailer = credit_note_mailer.with(credit_note:).created
 
-        expect(mailer.from).to eq([credit_note.customer.organization.email])
+        expect(mailer.from).to eq([credit_note.organization.email])
       end
     end
   end

--- a/spec/mailers/invoice_mailer_spec.rb
+++ b/spec/mailers/invoice_mailer_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe InvoiceMailer, type: :mailer do
 
   let(:invoice) { create(:invoice, fees_amount_cents: 100) }
 
+  around { |test| lago_premium!(&test) }
+
   before do
     invoice.file.attach(io: File.open(Rails.root.join("spec/fixtures/blank.pdf")), filename: "blank.pdf")
   end
@@ -73,6 +75,16 @@ RSpec.describe InvoiceMailer, type: :mailer do
         mailer = invoice_mailer.with(invoice:).finalized
 
         expect(mailer.to).to be_nil
+      end
+    end
+
+    context "when organization from_email integration is enabled" do
+      before { invoice.organization.update(premium_integrations: ["from_email"]) }
+
+      it "returns a mailer with organization email from" do
+        mailer = invoice_mailer.with(invoice:).finalized
+
+        expect(mailer.from).to eq([invoice.organization.email])
       end
     end
   end

--- a/spec/mailers/payment_request_mailer_spec.rb
+++ b/spec/mailers/payment_request_mailer_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe PaymentRequestMailer, type: :mailer do
   let(:second_invoice) { create(:invoice, total_amount_cents: 2000, total_paid_amount_cents: 2, organization:) }
   let(:payment_request) { create(:payment_request, organization:, invoices: [first_invoice, second_invoice]) }
 
+  around { |test| lago_premium!(&test) }
+
   before do
     first_invoice.file.attach(
       io: StringIO.new(File.read(Rails.root.join("spec/fixtures/blank.pdf"))),
@@ -90,6 +92,16 @@ RSpec.describe PaymentRequestMailer, type: :mailer do
 
         expect(parsed_body.css("a#payment_link")).not_to be_present
         expect(mailer.body.encoded).not_to include("Pay balance")
+      end
+    end
+
+    context "when organization from_email integration is enabled" do
+      before { organization.update(premium_integrations: ["from_email"]) }
+
+      it "returns a mailer with organization email from" do
+        mailer = payment_request_mailer.with(payment_request:).requested
+
+        expect(mailer.from).to eq([organization.email])
       end
     end
   end


### PR DESCRIPTION
- Support organization email defined as `from_email` for all customers emails
- Add new premium integration `from_email` 