### PR TITLE
fix(manual_payments): Fix Incorrect total_paid_amount_cents for Invoices Without Payments

### DIFF
--- a/db/migrate/20250219205535_fix_invoices_with_incorrect_total_paid_amount.rb
+++ b/db/migrate/20250219205535_fix_invoices_with_incorrect_total_paid_amount.rb
@@ -9,7 +9,7 @@ class FixInvoicesWithIncorrectTotalPaidAmount < ActiveRecord::Migration[7.1]
         WHERE id IN (
             SELECT invoices.id
             FROM invoices
-            LEFT JOIN payments ON invoices.id = payments.invoice_id
+            LEFT JOIN payments ON invoices.id = payments.payable_id
             LEFT JOIN invoices_payment_requests ON invoices.id = invoices_payment_requests.invoice_id
             WHERE payments.id IS NULL 
             AND invoices_payment_requests.id IS NULL

--- a/db/migrate/20250219205535_fix_invoices_with_incorrect_total_paid_amount.rb
+++ b/db/migrate/20250219205535_fix_invoices_with_incorrect_total_paid_amount.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class FixInvoicesWithIncorrectTotalPaidAmount < ActiveRecord::Migration[7.1]
+  def up
+    safety_assured do
+      execute <<~SQL
+        UPDATE invoices
+        SET total_paid_amount_cents = 0
+        WHERE id IN (
+            SELECT invoices.id
+            FROM invoices
+            LEFT JOIN payments ON invoices.id = payments.invoice_id
+            LEFT JOIN invoices_payment_requests ON invoices.id = invoices_payment_requests.invoice_id
+            WHERE payments.id IS NULL 
+            AND invoices_payment_requests.id IS NULL
+            AND total_amount_cents > 0
+            AND invoice_type <> 4
+            AND total_amount_cents = total_paid_amount_cents  
+            AND payment_status = 1
+        );
+      SQL
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20250219205535_fix_invoices_with_incorrect_total_paid_amount.rb
+++ b/db/migrate/20250219205535_fix_invoices_with_incorrect_total_paid_amount.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class FixInvoicesWithIncorrectTotalPaidAmount < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
   def up
     safety_assured do
       execute <<~SQL


### PR DESCRIPTION
## Context

During a backfill migration, we updated all invoices with payment_status: succeeded by setting:

``` ruby
Invoice.where(payment_status: Invoice::PAYMENT_STATUS[:succeeded])
      .update_all("total_paid_amount_cents = total_amount_cents")
```

However, some invoices were marked as fully paid without ever receiving payments or payment requests. This led to incorrect total_paid_amount_cents, affecting refund calculations.

## Description

we need to revert this value back to zero on this cases so we don't have wrong values on the refundable_amount_cents

SQL Used for Validation

``` sql
SELECT *
FROM invoices
LEFT JOIN payments ON invoices.id = payments.payable_id
LEFT JOIN invoices_payment_requests ON invoices.id = invoices_payment_requests.invoice_id
WHERE payments.id IS NULL 
AND invoices_payment_requests.id IS NULL
AND total_amount_cents > 0
AND invoice_type <> 4
AND total_amount_cents = total_paid_amount_cents  
AND payment_status = 1;
```

