### PR TITLE
fix: Add unique index on payment provider id

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -103,12 +103,13 @@ end
 #
 # Indexes
 #
-#  index_payments_on_invoice_id                    (invoice_id)
-#  index_payments_on_payable_id_and_payable_type   (payable_id,payable_type) UNIQUE WHERE ((payable_payment_status = ANY (ARRAY['pending'::payment_payable_payment_status, 'processing'::payment_payable_payment_status])) AND (payment_type = 'provider'::payment_type))
-#  index_payments_on_payable_type_and_payable_id   (payable_type,payable_id)
-#  index_payments_on_payment_provider_customer_id  (payment_provider_customer_id)
-#  index_payments_on_payment_provider_id           (payment_provider_id)
-#  index_payments_on_payment_type                  (payment_type)
+#  index_payments_on_invoice_id                                   (invoice_id)
+#  index_payments_on_payable_id_and_payable_type                  (payable_id,payable_type) UNIQUE WHERE ((payable_payment_status = ANY (ARRAY['pending'::payment_payable_payment_status, 'processing'::payment_payable_payment_status])) AND (payment_type = 'provider'::payment_type))
+#  index_payments_on_payable_type_and_payable_id                  (payable_type,payable_id)
+#  index_payments_on_payment_provider_customer_id                 (payment_provider_customer_id)
+#  index_payments_on_payment_provider_id                          (payment_provider_id)
+#  index_payments_on_payment_type                                 (payment_type)
+#  index_payments_on_provider_payment_id_and_payment_provider_id  (provider_payment_id,payment_provider_id) UNIQUE WHERE (provider_payment_id IS NOT NULL)
 #
 # Foreign Keys
 #

--- a/db/migrate/20250220085848_add_unique_index_to_provider_payment_id.rb
+++ b/db/migrate/20250220085848_add_unique_index_to_provider_payment_id.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToProviderPaymentId < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      execute <<-SQL
+        UPDATE invoices i
+        SET total_paid_amount_cents = total_amount_cents
+        WHERE total_paid_amount_cents > total_amount_cents;
+
+        DELETE FROM payments p1
+        USING payments p2
+        WHERE p1.payment_provider_id = p2.payment_provider_id
+        AND p1.provider_payment_id = p2.provider_payment_id
+        AND p1.created_at > p2.created_at;
+      SQL
+
+      add_index :payments,
+        %i[provider_payment_id payment_provider_id],
+        unique: true,
+        where: "provider_payment_id IS NOT NULL",
+        algorithm: :concurrently
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_index :payments, %i[provider_payment_id payment_provider_id]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_19_124948) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_20_085848) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1171,6 +1171,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_19_124948) do
     t.index ["payment_provider_customer_id"], name: "index_payments_on_payment_provider_customer_id"
     t.index ["payment_provider_id"], name: "index_payments_on_payment_provider_id"
     t.index ["payment_type"], name: "index_payments_on_payment_type"
+    t.index ["provider_payment_id", "payment_provider_id"], name: "index_payments_on_provider_payment_id_and_payment_provider_id", unique: true, where: "(provider_payment_id IS NOT NULL)"
   end
 
   create_table "plans", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Context

We have seen some duplicate payments due to a race condition when receiving two stripe webhooks at the same time.

## Description

The objective of this PR is to add a unique constraint for the table `payments`, on the columns `provider_payment_id` and `payment_provider_id`.

We took the opportunity to fix invalid `total_paid_amount_cents` on the impacted invoices.