### PR TITLE
Feat(multi-entities): add references to and from billing_entity

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -31,6 +31,7 @@ class BillingEntity < ApplicationRecord
   has_many :wallet_transactions, through: :wallets
   has_many :credit_notes, through: :invoices
 
+  has_one :applied_dunning_campaign, class_name: "DunningCampaign"
   has_many :applied_taxes, class_name: "BillingEntity::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes
 

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -20,6 +20,17 @@ class BillingEntity < ApplicationRecord
 
   belongs_to :organization
 
+  has_many :customers
+  has_many :invoices
+  has_many :invoice_custom_section_selections
+  has_many :selected_invoice_custom_sections, through: :invoice_custom_section_selections, source: :invoice_custom_section
+  has_many :fees
+
+  has_many :subscriptions, through: :customers
+  has_many :wallets, through: :customers
+  has_many :wallet_transactions, through: :wallets
+  has_many :credit_notes, through: :invoices
+
   has_many :applied_taxes, class_name: "BillingEntity::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes
 
@@ -69,12 +80,14 @@ end
 #  zipcode                      :string
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
+#  applied_dunning_campaign_id  :uuid
 #  organization_id              :uuid             not null
 #
 # Indexes
 #
-#  index_billing_entities_on_organization_id       (organization_id)
-#  unique_default_billing_entity_per_organization  (organization_id) UNIQUE WHERE ((is_default = true) AND (archived_at IS NULL) AND (deleted_at IS NULL))
+#  index_billing_entities_on_applied_dunning_campaign_id  (applied_dunning_campaign_id)
+#  index_billing_entities_on_organization_id              (organization_id)
+#  unique_default_billing_entity_per_organization         (organization_id) UNIQUE WHERE ((is_default = true) AND (archived_at IS NULL) AND (deleted_at IS NULL))
 #
 # Foreign Keys
 #

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -20,21 +20,20 @@ class BillingEntity < ApplicationRecord
 
   belongs_to :organization
 
+  has_many :applied_taxes, class_name: "BillingEntity::AppliedTax", dependent: :destroy
   has_many :customers
-  has_many :invoices
-  has_many :invoice_custom_section_selections
-  has_many :selected_invoice_custom_sections, through: :invoice_custom_section_selections, source: :invoice_custom_section
   has_many :fees
+  has_many :invoices
+  has_many :invoice_custom_section_selections, dependent: :destroy
 
+  has_many :credit_notes, through: :invoices
+  has_many :selected_invoice_custom_sections, through: :invoice_custom_section_selections, source: :invoice_custom_section
   has_many :subscriptions, through: :customers
+  has_many :taxes, through: :applied_taxes
   has_many :wallets, through: :customers
   has_many :wallet_transactions, through: :wallets
-  has_many :credit_notes, through: :invoices
 
   belongs_to :applied_dunning_campaign, class_name: "DunningCampaign", optional: true
-
-  has_many :applied_taxes, class_name: "BillingEntity::AppliedTax", dependent: :destroy
-  has_many :taxes, through: :applied_taxes
 
   enum :document_numbering, DOCUMENT_NUMBERINGS
 

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -31,7 +31,8 @@ class BillingEntity < ApplicationRecord
   has_many :wallet_transactions, through: :wallets
   has_many :credit_notes, through: :invoices
 
-  has_one :applied_dunning_campaign, class_name: "DunningCampaign"
+  belongs_to :applied_dunning_campaign, class_name: "DunningCampaign", optional: true
+
   has_many :applied_taxes, class_name: "BillingEntity::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -35,6 +35,7 @@ class Customer < ApplicationRecord
   before_save :ensure_slug
 
   belongs_to :organization
+  belongs_to :billing_entity, optional: true
   belongs_to :applied_dunning_campaign, optional: true, class_name: "DunningCampaign"
 
   has_many :subscriptions
@@ -279,6 +280,7 @@ end
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
 #  applied_dunning_campaign_id      :uuid
+#  billing_entity_id                :uuid
 #  external_id                      :string           not null
 #  external_salesforce_id           :string
 #  organization_id                  :uuid             not null
@@ -288,6 +290,7 @@ end
 #
 #  index_customers_on_account_type                     (account_type)
 #  index_customers_on_applied_dunning_campaign_id      (applied_dunning_campaign_id)
+#  index_customers_on_billing_entity_id                (billing_entity_id)
 #  index_customers_on_deleted_at                       (deleted_at)
 #  index_customers_on_external_id_and_organization_id  (external_id,organization_id) UNIQUE WHERE (deleted_at IS NULL)
 #  index_customers_on_organization_id                  (organization_id)

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -247,6 +247,7 @@ end
 #  updated_at                          :datetime         not null
 #  add_on_id                           :uuid
 #  applied_add_on_id                   :uuid
+#  billing_entity_id                   :uuid
 #  charge_filter_id                    :uuid
 #  charge_id                           :uuid
 #  group_id                            :uuid
@@ -263,6 +264,7 @@ end
 #  idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167  (pay_in_advance_event_transaction_id,charge_id,charge_filter_id) UNIQUE WHERE ((created_at > '2025-01-21 00:00:00'::timestamp without time zone) AND (pay_in_advance_event_transaction_id IS NOT NULL) AND (pay_in_advance = true))
 #  index_fees_on_add_on_id                                         (add_on_id)
 #  index_fees_on_applied_add_on_id                                 (applied_add_on_id)
+#  index_fees_on_billing_entity_id                                 (billing_entity_id)
 #  index_fees_on_charge_filter_id                                  (charge_filter_id)
 #  index_fees_on_charge_id                                         (charge_id)
 #  index_fees_on_charge_id_and_invoice_id                          (charge_id,invoice_id) WHERE (deleted_at IS NULL)

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -19,6 +19,7 @@ class Fee < ApplicationRecord
   has_one :adjusted_fee, dependent: :nullify
   has_one :customer, through: :subscription
   has_one :organization, through: :invoice
+  has_one :billing_entity, through: :invoice
   has_one :billable_metric, -> { with_discarded }, through: :charge
   has_one :true_up_fee, class_name: "Fee", foreign_key: :true_up_parent_fee_id, dependent: :destroy
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -17,6 +17,7 @@ class Invoice < ApplicationRecord
 
   belongs_to :customer, -> { with_discarded }
   belongs_to :organization
+  belongs_to :billing_entity, optional: true
 
   has_many :fees
   has_many :credits
@@ -520,6 +521,8 @@ end
 #  voided_at                               :datetime
 #  created_at                              :datetime         not null
 #  updated_at                              :datetime         not null
+#  billing_entity_id                       :uuid
+#  billing_entity_sequential_id            :integer          default(0)
 #  customer_id                             :uuid
 #  organization_id                         :uuid             not null
 #  organization_sequential_id              :integer          default(0), not null
@@ -527,17 +530,19 @@ end
 #
 # Indexes
 #
-#  idx_on_organization_id_organization_sequential_id_2387146f54  (organization_id,organization_sequential_id DESC)
-#  index_invoices_on_customer_id                                 (customer_id)
-#  index_invoices_on_customer_id_and_sequential_id               (customer_id,sequential_id) UNIQUE
-#  index_invoices_on_issuing_date                                (issuing_date)
-#  index_invoices_on_number                                      (number)
-#  index_invoices_on_organization_id                             (organization_id)
-#  index_invoices_on_payment_overdue                             (payment_overdue)
-#  index_invoices_on_ready_to_be_refreshed                       (ready_to_be_refreshed) WHERE (ready_to_be_refreshed = true)
-#  index_invoices_on_self_billed                                 (self_billed)
-#  index_invoices_on_sequential_id                               (sequential_id)
-#  index_invoices_on_status                                      (status)
+#  idx_on_organization_id_billing_entity_sequential_id_20bfd08c5a  (organization_id,billing_entity_sequential_id DESC)
+#  idx_on_organization_id_organization_sequential_id_2387146f54    (organization_id,organization_sequential_id DESC)
+#  index_invoices_on_billing_entity_id                             (billing_entity_id)
+#  index_invoices_on_customer_id                                   (customer_id)
+#  index_invoices_on_customer_id_and_sequential_id                 (customer_id,sequential_id) UNIQUE
+#  index_invoices_on_issuing_date                                  (issuing_date)
+#  index_invoices_on_number                                        (number)
+#  index_invoices_on_organization_id                               (organization_id)
+#  index_invoices_on_payment_overdue                               (payment_overdue)
+#  index_invoices_on_ready_to_be_refreshed                         (ready_to_be_refreshed) WHERE (ready_to_be_refreshed = true)
+#  index_invoices_on_self_billed                                   (self_billed)
+#  index_invoices_on_sequential_id                                 (sequential_id)
+#  index_invoices_on_status                                        (status)
 #
 # Foreign Keys
 #

--- a/app/models/invoice_custom_section_selection.rb
+++ b/app/models/invoice_custom_section_selection.rb
@@ -3,6 +3,7 @@
 class InvoiceCustomSectionSelection < ApplicationRecord
   belongs_to :invoice_custom_section
   belongs_to :organization, optional: true
+  belongs_to :billing_entity, optional: true
   belongs_to :customer, optional: true
 end
 
@@ -13,15 +14,17 @@ end
 #  id                        :uuid             not null, primary key
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
+#  billing_entity_id         :uuid
 #  customer_id               :uuid
 #  invoice_custom_section_id :uuid             not null
 #  organization_id           :uuid
 #
 # Indexes
 #
-#  idx_on_invoice_custom_section_id_7edbcef7b5                 (invoice_custom_section_id)
-#  index_invoice_custom_section_selections_on_customer_id      (customer_id)
-#  index_invoice_custom_section_selections_on_organization_id  (organization_id)
+#  idx_on_invoice_custom_section_id_7edbcef7b5                   (invoice_custom_section_id)
+#  index_invoice_custom_section_selections_on_billing_entity_id  (billing_entity_id)
+#  index_invoice_custom_section_selections_on_customer_id        (customer_id)
+#  index_invoice_custom_section_selections_on_organization_id    (organization_id)
 #
 # Foreign Keys
 #

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -11,6 +11,7 @@ class Organization < ApplicationRecord
   ].freeze
 
   has_many :api_keys
+  has_many :billing_entities
   has_many :memberships
   has_many :users, through: :memberships
   has_many :billable_metrics
@@ -50,6 +51,7 @@ class Organization < ApplicationRecord
   has_one :salesforce_integration, class_name: "Integrations::SalesforceIntegration"
 
   has_one :applied_dunning_campaign, -> { where(applied_to_organization: true) }, class_name: "DunningCampaign"
+  has_one :default_billing_entity, -> { where(is_default: true) }, class_name: "BillingEntity"
 
   has_many :invoice_custom_sections
   has_many :invoice_custom_section_selections

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,6 +8,7 @@ class Subscription < ApplicationRecord
   belongs_to :previous_subscription, class_name: "Subscription", optional: true
 
   has_one :organization, through: :customer
+  has_one :billing_entity, through: :customer
   has_many :next_subscriptions, class_name: "Subscription", foreign_key: :previous_subscription_id
   has_many :events
   has_many :invoice_subscriptions

--- a/db/migrate/20250219152213_add_references_to_billing_entities.rb
+++ b/db/migrate/20250219152213_add_references_to_billing_entities.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddReferencesToBillingEntities < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :billing_entities, :applied_dunning_campaign, index: {algorithm: :concurrently}, type: :uuid
+
+    add_reference :customers, :billing_entity, index: {algorithm: :concurrently}, type: :uuid
+    add_reference :invoices, :billing_entity, index: {algorithm: :concurrently}, type: :uuid
+    add_reference :invoice_custom_section_selections, :billing_entity, index: {algorithm: :concurrently}, type: :uuid
+    add_reference :fees, :billing_entity, index: {algorithm: :concurrently}, type: :uuid
+
+    # will be populated with the part to create billing_entities
+    add_column :invoices, :billing_entity_sequential_id, :integer, default: 0
+
+    add_index :invoices, [:organization_id, :billing_entity_sequential_id],
+      order: {billing_entity_sequential_id: :desc},
+      algorithm: :concurrently,
+      if_not_exists: true,
+      include: %i[self_billed]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -240,6 +240,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_085848) do
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "applied_dunning_campaign_id"
+    t.index ["applied_dunning_campaign_id"], name: "index_billing_entities_on_applied_dunning_campaign_id"
     t.index ["organization_id"], name: "index_billing_entities_on_organization_id"
     t.index ["organization_id"], name: "unique_default_billing_entity_per_organization", unique: true, where: "((is_default = true) AND (archived_at IS NULL) AND (deleted_at IS NULL))"
   end
@@ -536,8 +538,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_085848) do
     t.datetime "last_dunning_campaign_attempt_at", precision: nil
     t.boolean "skip_invoice_custom_sections", default: false, null: false
     t.enum "account_type", default: "customer", null: false, enum_type: "customer_account_type"
+    t.uuid "billing_entity_id"
     t.index ["account_type"], name: "index_customers_on_account_type"
     t.index ["applied_dunning_campaign_id"], name: "index_customers_on_applied_dunning_campaign_id"
+    t.index ["billing_entity_id"], name: "index_customers_on_billing_entity_id"
     t.index ["deleted_at"], name: "index_customers_on_deleted_at"
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_customers_on_organization_id"
@@ -717,8 +721,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_085848) do
     t.decimal "taxes_precise_amount_cents", precision: 40, scale: 15, default: "0.0", null: false
     t.float "taxes_base_rate", default: 1.0, null: false
     t.uuid "organization_id"
+    t.uuid "billing_entity_id"
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
+    t.index ["billing_entity_id"], name: "index_fees_on_billing_entity_id"
     t.index ["charge_filter_id"], name: "index_fees_on_charge_filter_id"
     t.index ["charge_id", "invoice_id"], name: "index_fees_on_charge_id_and_invoice_id", where: "(deleted_at IS NULL)"
     t.index ["charge_id"], name: "index_fees_on_charge_id"
@@ -890,6 +896,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_085848) do
     t.uuid "customer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "billing_entity_id"
+    t.index ["billing_entity_id"], name: "index_invoice_custom_section_selections_on_billing_entity_id"
     t.index ["customer_id"], name: "index_invoice_custom_section_selections_on_customer_id"
     t.index ["invoice_custom_section_id"], name: "idx_on_invoice_custom_section_id_7edbcef7b5"
     t.index ["organization_id"], name: "index_invoice_custom_section_selections_on_organization_id"
@@ -990,10 +998,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_085848) do
     t.bigint "total_paid_amount_cents", default: 0, null: false
     t.boolean "self_billed", default: false, null: false
     t.integer "applied_grace_period"
+    t.uuid "billing_entity_id"
+    t.integer "billing_entity_sequential_id", default: 0
+    t.index ["billing_entity_id"], name: "index_invoices_on_billing_entity_id"
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["issuing_date"], name: "index_invoices_on_issuing_date"
     t.index ["number"], name: "index_invoices_on_number"
+    t.index ["organization_id", "billing_entity_sequential_id"], name: "idx_on_organization_id_billing_entity_sequential_id_20bfd08c5a", order: { billing_entity_sequential_id: :desc }, include: ["self_billed"]
     t.index ["organization_id", "organization_sequential_id"], name: "idx_on_organization_id_organization_sequential_id_2387146f54", order: { organization_sequential_id: :desc }, include: ["self_billed"]
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
     t.index ["payment_overdue"], name: "index_invoices_on_payment_overdue"

--- a/spec/factories/billing_entities.rb
+++ b/spec/factories/billing_entities.rb
@@ -9,6 +9,9 @@ FactoryBot.define do
     email { Faker::Internet.email }
     email_settings { ["invoice.finalized", "credit_note.created"] }
 
+    # TODO: remove this magic after is_default field is deleted
+    # we need firstly to set is_default on the current billing_entity,
+    # so when creating organization we won't need to create a default billing entity
     after :build do |billing_entity, values|
       billing_entity.is_default = true if values.organization&.billing_entities&.where(is_default: true).blank?
       billing_entity.organization = build(:organization, billing_entities: [billing_entity]) if values.organization.blank?

--- a/spec/factories/billing_entities.rb
+++ b/spec/factories/billing_entities.rb
@@ -2,13 +2,17 @@
 
 FactoryBot.define do
   factory :billing_entity do
-    organization
     name { Faker::Company.name }
     code { "entity_#{SecureRandom.uuid}" }
     default_currency { "USD" }
 
     email { Faker::Internet.email }
     email_settings { ["invoice.finalized", "credit_note.created"] }
+
+    after :build do |billing_entity, values|
+      billing_entity.is_default = true if values.organization&.billing_entities&.where(is_default: true).blank?
+      billing_entity.organization = build(:organization, billing_entities: [billing_entity]) if values.organization.blank?
+    end
 
     trait :default do
       is_default { true }

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -22,6 +22,10 @@ FactoryBot.define do
     legal_number { Faker::Company.duns_number }
     currency { "EUR" }
 
+    after :build do |customer, values|
+      customer.billing_entity = values.organization.default_billing_entity if customer.billing_entity.nil?
+    end
+
     trait :with_shipping_address do
       shipping_address_line1 { Faker::Address.street_address }
       shipping_address_line2 { Faker::Address.secondary_address }

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     currency { "EUR" }
 
     after :build do |customer, values|
-      customer.billing_entity = values.organization.default_billing_entity if customer.billing_entity.nil?
+      customer.billing_entity = values.organization.default_billing_entity unless customer.billing_entity
     end
 
     trait :with_shipping_address do

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
 
     after(:create) do |fee, context|
       fee.organization = fee.invoice&.organization || fee.subscription&.organization
+      fee.billing_entity = fee.invoice&.billing_entity || fee.subscription&.billing_entity
     end
 
     amount_cents { 200 }

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -12,6 +12,10 @@ FactoryBot.define do
 
     organization_sequential_id { rand(1_000_000) }
 
+    after :build do |invoice, values|
+      invoice.billing_entity = values.organization.default_billing_entity if invoice.billing_entity.nil?
+    end
+
     trait :draft do
       status { :draft }
     end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     organization_sequential_id { rand(1_000_000) }
 
     after :build do |invoice, values|
-      invoice.billing_entity = values.organization.default_billing_entity if invoice.billing_entity.nil?
+      invoice.billing_entity = values.organization.default_billing_entity unless invoice.billing_entity
     end
 
     trait :draft do

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -18,6 +18,8 @@ FactoryBot.define do
       if evaluator.webhook_url
         organization.webhook_endpoints.create!(webhook_url: evaluator.webhook_url)
       end
+      # default billing entity on organization will be used in services as intermediate sep
+      # before we start accepting billing_entity_id in the request. After that we can drop the column and this method
       if organization.billing_entities.where(is_default: true).blank?
         create(:billing_entity, :default, organization:)
       end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     email_settings { ["invoice.finalized", "credit_note.created"] }
 
     api_keys { [association(:api_key, organization: instance)] }
+    billing_entities { [association(:billing_entity, organization: instance, is_default: true)] }
 
     transient do
       webhook_url { Faker::Internet.url }

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
     email_settings { ["invoice.finalized", "credit_note.created"] }
 
     api_keys { [association(:api_key, organization: instance)] }
-    billing_entities { [association(:billing_entity, organization: instance, is_default: true)] }
 
     transient do
       webhook_url { Faker::Internet.url }
@@ -18,6 +17,9 @@ FactoryBot.define do
     after(:create) do |organization, evaluator|
       if evaluator.webhook_url
         organization.webhook_endpoints.create!(webhook_url: evaluator.webhook_url)
+      end
+      if organization.billing_entities.where(is_default: true).blank?
+        create(:billing_entity, :default, organization: )
       end
     end
 

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
         organization.webhook_endpoints.create!(webhook_url: evaluator.webhook_url)
       end
       if organization.billing_entities.where(is_default: true).blank?
-        create(:billing_entity, :default, organization: )
+        create(:billing_entity, :default, organization:)
       end
     end
 

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
       if evaluator.webhook_url
         organization.webhook_endpoints.create!(webhook_url: evaluator.webhook_url)
       end
-      # default billing entity on organization will be used in services as intermediate sep
+      # default billing entity on organization will be used in services as intermediate step
       # before we start accepting billing_entity_id in the request. After that we can drop the column and this method
       if organization.billing_entities.where(is_default: true).blank?
         create(:billing_entity, :default, organization:)

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe BillingEntity, type: :model do
   it { is_expected.to have_many(:wallets).through(:customers) }
   it { is_expected.to have_many(:wallet_transactions).through(:wallets) }
   it { is_expected.to have_many(:credit_notes).through(:invoices) }
-
-  it { is_expected.to have_one(:applied_dunning_campaign).class_name("DunningCampaign") }
+  it { is_expected.to belong_to(:applied_dunning_campaign).class_name("DunningCampaign").optional }
 
   it { is_expected.to have_many(:applied_taxes).dependent(:destroy) }
   it { is_expected.to have_many(:taxes).through(:applied_taxes) }

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -12,8 +12,14 @@ RSpec.describe BillingEntity, type: :model do
   it { is_expected.to have_many(:customers) }
   it { is_expected.to have_many(:invoices) }
   it { is_expected.to have_many(:invoice_custom_section_selections) }
-  it { is_expected.to have_many(:selected_invoice_custom_sections) }
+  it { is_expected.to have_many(:selected_invoice_custom_sections).through(:invoice_custom_section_selections) }
   it { is_expected.to have_many(:fees) }
+  it { is_expected.to have_many(:subscriptions).through(:customers) }
+  it { is_expected.to have_many(:wallets).through(:customers) }
+  it { is_expected.to have_many(:wallet_transactions).through(:wallets) }
+  it { is_expected.to have_many(:credit_notes).through(:invoices) }
+
+  it { is_expected.to have_one(:applied_dunning_campaign).class_name("DunningCampaign") }
 
   it { is_expected.to have_many(:applied_taxes).dependent(:destroy) }
   it { is_expected.to have_many(:taxes).through(:applied_taxes) }

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe BillingEntity, type: :model do
 
   it { is_expected.to belong_to(:organization) }
 
+  it { is_expected.to have_many(:customers) }
+  it { is_expected.to have_many(:invoices) }
+  it { is_expected.to have_many(:invoice_custom_section_selections) }
+  it { is_expected.to have_many(:selected_invoice_custom_sections) }
+  it { is_expected.to have_many(:fees) }
+
   it { is_expected.to have_many(:applied_taxes).dependent(:destroy) }
   it { is_expected.to have_many(:taxes).through(:applied_taxes) }
 
@@ -16,9 +22,9 @@ RSpec.describe BillingEntity, type: :model do
     let(:organization) { create :organization }
 
     it "validates uniqueness of organization_id for is_default excluding deleted and archived records" do
-      deleted_record = create(:billing_entity, :default, :deleted, organization:)
+      # by default an organization is built with a default billing entity
+      expect(organization.default_billing_entity.discard!).to be true
       archived_record = create(:billing_entity, :default, :archived, organization:)
-      expect(deleted_record).to be_valid
       expect(archived_record).to be_valid
 
       record_1 = create(:billing_entity, :default, organization:)

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Customer, type: :model do
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:applied_dunning_campaign).optional }
+  it { is_expected.to belong_to(:billing_entity).optional }
   it { is_expected.to have_many(:daily_usages) }
 
   it { is_expected.to have_many(:integration_customers).dependent(:destroy) }

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Invoice, type: :model do
   it { is_expected.to have_many(:applied_usage_thresholds) }
   it { is_expected.to have_many(:usage_thresholds).through(:applied_usage_thresholds) }
 
+  it { is_expected.to belong_to(:billing_entity).optional }
+
   it "has fixed status mapping" do
     expect(described_class::VISIBLE_STATUS).to match(draft: 0, finalized: 1, voided: 2, failed: 4, pending: 7)
     expect(described_class::INVISIBLE_STATUS).to match(generating: 3, open: 5, closed: 6)

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:adyen_payment_providers) }
 
   it { is_expected.to have_many(:api_keys) }
+  it { is_expected.to have_many(:billing_entities) }
   it { is_expected.to have_many(:webhook_endpoints) }
   it { is_expected.to have_many(:webhooks).through(:webhook_endpoints) }
   it { is_expected.to have_many(:hubspot_integrations) }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:selected_invoice_custom_sections) }
 
   it { is_expected.to have_one(:applied_dunning_campaign).conditions(applied_to_organization: true) }
+  it { is_expected.to have_one(:default_billing_entity).conditions(is_default: true) }
 
   it { is_expected.to validate_inclusion_of(:default_currency).in_array(described_class.currency_list) }
 


### PR DESCRIPTION
## Context

After we created the billing_entity model itself, we want to add references to it from different model that should be separated by billing entities

## Description

Added references to billing_entities
Added creation of default billing_entity when creating an organization
Updated tests
