### PR TITLE
fix(currency): Use some ISO codes instead of symbols

### DIFF
--- a/app/views/helpers/money_helper.rb
+++ b/app/views/helpers/money_helper.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class MoneyHelper
+  SYMBOLS_CURRENCIES = %w[$ € £ ¥].freeze
+
   def self.format(money)
     money&.format(
-      format: I18n.t("money.format"),
+      format: currency_format(money&.currency),
       decimal_mark: I18n.t("money.decimal_mark"),
       thousands_separator: I18n.t("money.thousands_separator")
     )
@@ -16,10 +18,19 @@ class MoneyHelper
       amount_cents.round(6)
     end
 
-    Utils::MoneyWithPrecision.from_amount(amount_cents, currency).format(
-      format: I18n.t("money.format"),
+    money = Utils::MoneyWithPrecision.from_amount(amount_cents, currency)
+    money.format(
+      format: currency_format(money.currency),
       decimal_mark: I18n.t("money.decimal_mark"),
       thousands_separator: I18n.t("money.thousands_separator")
     )
+  end
+
+  def self.currency_format(money_currency)
+    if SYMBOLS_CURRENCIES.include?(money_currency&.symbol)
+      I18n.t("money.format")
+    else
+      I18n.t("money.custom_format", iso_code: money_currency&.iso_code)
+    end
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -52,6 +52,7 @@ de:
     - :month
     - :day
   money:
+    custom_format: "%{iso_code} %n"
     decimal_mark: ","
     format: "%u%n"
     thousands_separator: "."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
     formats:
       default: "%b %d, %Y"
   money:
+    custom_format: "%{iso_code} %n"
     decimal_mark: "."
     format: "%u%n"
     thousands_separator: ","

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -52,6 +52,7 @@ es:
     - :month
     - :day
   money:
+    custom_format: "%{iso_code} %n"
     decimal_mark: "."
     format: "%u%n"
     thousands_separator: ","

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -52,6 +52,7 @@ fr:
     - :month
     - :day
   money:
+    custom_format: "%n %{iso_code}"
     decimal_mark: ","
     format: "%n %u"
     thousands_separator: " "

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -52,6 +52,7 @@ it:
     - :month
     - :day
   money:
+    custom_format: "%n %{iso_code}"
     decimal_mark: ","
     format: "%n %u"
     thousands_separator: "."

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -52,6 +52,7 @@ nb:
     - :month
     - :day
   money:
+    custom_format: "%{iso_code} %n"
     decimal_mark: ","
     format: "%u%n"
     thousands_separator: " "

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -52,6 +52,7 @@ sv:
     - :month
     - :day
   money:
+    custom_format: "%n %{iso_code}"
     decimal_mark: ","
     format: "%n %u"
     thousands_separator: " "

--- a/spec/views/helpers/money_helper_spec.rb
+++ b/spec/views/helpers/money_helper_spec.rb
@@ -5,23 +5,64 @@ require "rails_helper"
 RSpec.describe MoneyHelper do
   subject(:helper) { described_class }
 
+  describe ".format" do
+    let(:currency) { "USD" }
+    let(:amount) { Money.new(100, currency) }
+
+    it "formats the amount" do
+      expect(helper.format(amount)).to eq("$1.00")
+    end
+
+    context "when currency does not use a well known symbol" do
+      let(:currency) { "BHD" }
+
+      it "formats the amount" do
+        expect(helper.format(amount)).to eq("BHD 0.100")
+      end
+    end
+  end
+
   describe ".format_with_precision" do
+    let(:currency) { "USD" }
+
     it "rounds big decimals to 6 digits" do
-      html = helper.format_with_precision(BigDecimal("123.12345678"), "USD")
+      html = helper.format_with_precision(BigDecimal("123.12345678"), currency)
 
       expect(html).to eq("$123.123457")
     end
 
     it "shows six significant digits for values < 1" do
-      html = helper.format_with_precision(BigDecimal("0.000000012345"), "USD")
+      html = helper.format_with_precision(BigDecimal("0.000000012345"), currency)
 
       expect(html).to eq("$0.000000012345")
     end
 
     it "shows only six significant digits for values < 1" do
-      html = helper.format_with_precision(BigDecimal("0.100000012345"), "USD")
+      html = helper.format_with_precision(BigDecimal("0.100000012345"), currency)
 
       expect(html).to eq("$0.10")
+    end
+
+    context "when currency does not use a well known symbol" do
+      let(:currency) { "BHD" }
+
+      it "rounds big decimals to 6 digits" do
+        html = helper.format_with_precision(BigDecimal("123.12345678"), currency)
+
+        expect(html).to eq("BHD 123.123457")
+      end
+
+      it "shows six significant digits for values < 1" do
+        html = helper.format_with_precision(BigDecimal("0.000000012345"), currency)
+
+        expect(html).to eq("BHD 0.000000012345")
+      end
+
+      it "shows only six significant digits for values < 1" do
+        html = helper.format_with_precision(BigDecimal("0.100000012345"), currency)
+
+        expect(html).to eq("BHD 0.100")
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

This PR fixes https://github.com/getlago/lago-api/issues/3129

## Description

This PR will keep using symbols on invoice for currencies using "well known" symbols (`$`, `€`, `£` and `¥`) but will fallback on ISO codes for others:
- `100 USD`, or `100 CAD` will still be rendered as `$100.00`
- `100 BHD` will be rendred as `BHD 100.000`

The local is also taken into account, for example with french locale:
- `100 USD`, or `100 CAD` will still be rendered as `100.00 $`
- `100 BHD` will be rendred as `100.000 BHD`