### PR TITLE
feat(multi-entities): Add billing entities applied taxes relationship

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -20,6 +20,9 @@ class BillingEntity < ApplicationRecord
 
   belongs_to :organization
 
+  has_many :applied_taxes, class_name: "BillingEntity::AppliedTax", dependent: :destroy
+  has_many :taxes, through: :applied_taxes
+
   enum :document_numbering, DOCUMENT_NUMBERINGS
 
   default_scope -> { kept }

--- a/app/models/billing_entity/applied_tax.rb
+++ b/app/models/billing_entity/applied_tax.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class BillingEntity
+  class AppliedTax < ApplicationRecord
+    self.table_name = "billing_entities_taxes"
+
+    belongs_to :billing_entity
+    belongs_to :tax
+  end
+end
+
+# == Schema Information
+#
+# Table name: billing_entities_taxes
+#
+#  id                :uuid             not null, primary key
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  billing_entity_id :uuid             not null
+#  tax_id            :uuid             not null
+#
+# Indexes
+#
+#  index_billing_entities_taxes_on_billing_entity_id             (billing_entity_id)
+#  index_billing_entities_taxes_on_billing_entity_id_and_tax_id  (billing_entity_id,tax_id) UNIQUE
+#  index_billing_entities_taxes_on_tax_id                        (tax_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (billing_entity_id => billing_entities.id)
+#  fk_rails_...  (tax_id => taxes.id)
+#

--- a/app/models/billing_entity/applied_tax.rb
+++ b/app/models/billing_entity/applied_tax.rb
@@ -6,6 +6,8 @@ class BillingEntity
 
     belongs_to :billing_entity
     belongs_to :tax
+
+    validates :tax_id, uniqueness: {scope: :billing_entity_id}
   end
 end
 

--- a/app/models/tax.rb
+++ b/app/models/tax.rb
@@ -8,6 +8,8 @@ class Tax < ApplicationRecord
   has_many :applied_taxes, class_name: "Customer::AppliedTax", dependent: :destroy
   has_many :customers, through: :applied_taxes
 
+  has_many :billing_entities_taxes, class_name: "BillingEntity::AppliedTax", dependent: :destroy
+  has_many :billing_entities, through: :billing_entities_taxes
   has_many :fees_taxes, class_name: "Fee::AppliedTax", dependent: :destroy
   has_many :fees, through: :fees_taxes
   has_many :invoices_taxes, class_name: "Invoice::AppliedTax", dependent: :destroy

--- a/db/migrate/20250219164502_create_billing_entities_taxes.rb
+++ b/db/migrate/20250219164502_create_billing_entities_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateBillingEntitiesTaxes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :billing_entities_taxes, id: :uuid do |t|
+      t.references :billing_entity, null: false, foreign_key: true, type: :uuid
+      t.references :tax, null: false, foreign_key: true, type: :uuid
+
+      t.index %i[billing_entity_id tax_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -244,6 +244,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_085848) do
     t.index ["organization_id"], name: "unique_default_billing_entity_per_organization", unique: true, where: "((is_default = true) AND (archived_at IS NULL) AND (deleted_at IS NULL))"
   end
 
+  create_table "billing_entities_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "billing_entity_id", null: false
+    t.uuid "tax_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["billing_entity_id", "tax_id"], name: "index_billing_entities_taxes_on_billing_entity_id_and_tax_id", unique: true
+    t.index ["billing_entity_id"], name: "index_billing_entities_taxes_on_billing_entity_id"
+    t.index ["tax_id"], name: "index_billing_entities_taxes_on_tax_id"
+  end
+
   create_table "cached_aggregations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "organization_id", null: false
     t.uuid "event_id"
@@ -1432,6 +1442,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_20_085848) do
   add_foreign_key "billable_metric_filters", "billable_metrics"
   add_foreign_key "billable_metrics", "organizations"
   add_foreign_key "billing_entities", "organizations"
+  add_foreign_key "billing_entities_taxes", "billing_entities"
+  add_foreign_key "billing_entities_taxes", "taxes"
   add_foreign_key "cached_aggregations", "groups"
   add_foreign_key "charge_filter_values", "billable_metric_filters"
   add_foreign_key "charge_filter_values", "charge_filters"

--- a/spec/factories/billing_entity_applied_taxes.rb
+++ b/spec/factories/billing_entity_applied_taxes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :billing_entity_applied_tax, class: "BillingEntity::AppliedTax" do
+    billing_entity
+    tax
+  end
+end

--- a/spec/models/billing_entity/applied_tax_spec.rb
+++ b/spec/models/billing_entity/applied_tax_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BillingEntity::AppliedTax, type: :model do
+  subject(:billing_entity_applied_tax) { create(:billing_entity_applied_tax) }
+
+  it { is_expected.to belong_to(:billing_entity) }
+  it { is_expected.to belong_to(:tax) }
+
+  it { is_expected.to validate_presence_of(:billing_entity) }
+  it { is_expected.to validate_presence_of(:tax) }
+
+  it { is_expected.to validate_uniqueness_of(:tax_id).scoped_to(:billing_entity_id) }
+end

--- a/spec/models/billing_entity/applied_tax_spec.rb
+++ b/spec/models/billing_entity/applied_tax_spec.rb
@@ -8,8 +8,5 @@ RSpec.describe BillingEntity::AppliedTax, type: :model do
   it { is_expected.to belong_to(:billing_entity) }
   it { is_expected.to belong_to(:tax) }
 
-  it { is_expected.to validate_presence_of(:billing_entity) }
-  it { is_expected.to validate_presence_of(:tax) }
-
   it { is_expected.to validate_uniqueness_of(:tax_id).scoped_to(:billing_entity_id) }
 end

--- a/spec/models/billing_entity/applied_tax_spec.rb
+++ b/spec/models/billing_entity/applied_tax_spec.rb
@@ -7,6 +7,4 @@ RSpec.describe BillingEntity::AppliedTax, type: :model do
 
   it { is_expected.to belong_to(:billing_entity) }
   it { is_expected.to belong_to(:tax) }
-
-  it { is_expected.to validate_uniqueness_of(:tax_id).scoped_to(:billing_entity_id) }
 end

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe BillingEntity, type: :model do
 
   it { is_expected.to belong_to(:organization) }
 
+  it { is_expected.to have_many(:applied_taxes).dependent(:destroy) }
+  it { is_expected.to have_many(:taxes).through(:applied_taxes) }
+
   describe "is_default validation" do
     let(:organization) { create :organization }
 

--- a/spec/models/tax_spec.rb
+++ b/spec/models/tax_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe Tax, type: :model do
 
   let(:applied_to_organization) { false }
 
+  it { is_expected.to belong_to(:organization) }
+
+  it { is_expected.to have_many(:billing_entities_taxes).dependent(:destroy) }
+  it { is_expected.to have_many(:billing_entities).through(:billing_entities_taxes) }
+
   it_behaves_like "paper_trail traceable"
 
   describe "customers_count" do


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

 ## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

 ## Description

Add billing entities applied taxes