### PR TITLE
fix(stripe): Avoid raising for concurent status update

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -43,6 +43,8 @@ module Invoices
         result
       rescue ActiveRecord::RecordInvalid => e
         result.record_validation_failure!(record: e.record)
+      rescue ActiveRecord::RecordNotUnique
+        result
       rescue BaseService::FailedResult => e
         result.fail_with_error!(e)
       end

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -67,6 +67,8 @@ module PaymentRequests
         result
       rescue ActiveRecord::RecordInvalid => e
         result.record_validation_failure!(record: e.record)
+      rescue ActiveRecord::RecordNotUnique
+        result
       rescue BaseService::FailedResult => e
         result.fail_with_error!(e)
       end


### PR DESCRIPTION
## Context
This PR is related to https://github.com/getlago/lago-api/pull/3223

## Description

Since the introduction of the index on `payments(payment_provider_id, provider_payment_id)` an `ActiveRecord::RecordNotUnique` is raised if two concurrent stripe webhooks are handled by the system. This PR makes sure that it does not end in a dead jobs.

NOTE: https://github.com/getlago/lago-api/pull/3228 will drastically reduce the risk of concurrent status update