### PR TITLE
fix(netsuite): Prevent trying to create customer with max netsuite state reached

### DIFF
--- a/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
@@ -5,6 +5,8 @@ module Integrations
     module Contacts
       module Payloads
         class Netsuite < BasePayload
+          STATE_LIMIT = 30
+
           def create_body
             {
               "type" => "customer", # Fixed value
@@ -75,7 +77,7 @@ module Integrations
                         "addr2" => customer.address_line2,
                         "city" => customer.city,
                         "zip" => customer.zipcode,
-                        "state" => customer.state,
+                        "state" => customer.state.first(STATE_LIMIT),
                         "country" => customer.country
                       }
                     }
@@ -96,7 +98,7 @@ module Integrations
                         "addr2" => customer.address_line2,
                         "city" => customer.city,
                         "zip" => customer.zipcode,
-                        "state" => customer.state,
+                        "state" => customer.state.first(STATE_LIMIT),
                         "country" => customer.country
                       }
                     },


### PR DESCRIPTION
## Context

We currently receive deadjobs when trying to sync customers on Netsuite.
This is because `state` sent contains more characters than the maximum size allowed by Netsuite (`30`).

Deadjob:
> action_script_runtime_error: The field state contained more than the maximum number ( 30 ) of characters allowed.

## Description

The goal of this PR is to only select the first 30 characters for the state when creating a customer on Netsuite.
