### PR TITLE
fix(integration): Fix error handling for Bad Gateway errors received as HTTP 200

### DIFF
--- a/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
+++ b/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
@@ -6,6 +6,7 @@ module Invoices
       queue_as "providers"
 
       retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
+      retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 6
 
       def perform(invoice:)
         Invoices::ProviderTaxes::PullTaxesAndApplyService.call!(invoice:)

--- a/app/services/integrations/aggregator/taxes/invoices/create_draft_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_draft_service.rb
@@ -16,13 +16,14 @@ module Integrations
             throttle!(:anrok)
 
             response = http_client.post_with_response(payload, headers)
-            body = JSON.parse(response.body)
+            body = parse_response(response)
 
             process_response(body)
 
             result
           rescue LagoHttpClient::HttpError => e
             raise RequestLimitError(e) if request_limit_error?(e)
+            raise e if bad_gateway_error?(e)
 
             code = code(e)
             message = message(e)

--- a/app/services/integrations/aggregator/taxes/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_service.rb
@@ -16,14 +16,15 @@ module Integrations
             throttle!(:anrok)
 
             response = http_client.post_with_response(payload, headers)
-            body = JSON.parse(response.body)
+            body = parse_response(response)
 
             process_response(body)
             assign_external_customer_id
 
             result
           rescue LagoHttpClient::HttpError => e
-            raise RequestLimitError(e) if request_limit_error?(e)
+            raise Integrations::Aggregator::RequestLimitError(e) if request_limit_error?(e)
+            raise e if bad_gateway_error?(e)
 
             code = code(e)
             message = message(e)

--- a/lib/lago_http_client/lago_http_client/client.rb
+++ b/lib/lago_http_client/lago_http_client/client.rb
@@ -6,6 +6,8 @@ module LagoHttpClient
   class Client
     RESPONSE_SUCCESS_CODES = [200, 201, 202, 204].freeze
 
+    attr_reader :uri
+
     def initialize(url, read_timeout: nil)
       @uri = URI(url)
       @http_client = Net::HTTP.new(uri.host, uri.port)
@@ -109,7 +111,7 @@ module LagoHttpClient
 
     private
 
-    attr_reader :uri, :http_client
+    attr_reader :http_client
 
     def raise_error(response)
       raise(::LagoHttpClient::HttpError.new(response.code, response.body, uri))

--- a/spec/fixtures/integration_aggregator/bad_gateway_error.html
+++ b/spec/fixtures/integration_aggregator/bad_gateway_error.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>502 Bad Gateway</title>
+  </head>
+  <body>
+    <center><h1>502 Bad Gateway</h1></center>
+    <hr />
+    <center>cloudflare</center>
+  </body>
+</html>

--- a/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
       before do
         allow(lago_client).to receive(:post_with_response).with(kind_of(Array), headers).and_return(response)
         allow(response).to receive(:body).and_return(body)
+        allow(lago_client).to receive(:uri).and_return(endpoint)
       end
 
       context "when taxes are successfully fetched" do
@@ -250,6 +251,17 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
               expect(result.error).to be_a(BaseService::ServiceFailure)
               expect(result.error.code).to eq("validationError")
             end
+          end
+        end
+
+        context "when the body contains a bad gateway error" do
+          let(:body) do
+            path = Rails.root.join("spec/fixtures/integration_aggregator/bad_gateway_error.html")
+            File.read(path)
+          end
+
+          it "raises an HTTP error" do
+            expect { service_call }.to raise_error(LagoHttpClient::HttpError)
           end
         end
       end

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
       before do
         allow(lago_client).to receive(:post_with_response).with(array_including(params), headers).and_return(response)
         allow(response).to receive(:body).and_return(body)
+        allow(lago_client).to receive(:uri).and_return(endpoint)
       end
 
       context "when taxes are successfully fetched for finalized invoice" do
@@ -179,6 +180,17 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
           service_call
 
           expect(integration_customer.reload.external_customer_id).to eq(nil)
+        end
+
+        context "when the body contains a bad gateway error" do
+          let(:body) do
+            path = Rails.root.join("spec/fixtures/integration_aggregator/bad_gateway_error.html")
+            File.read(path)
+          end
+
+          it "raises an HTTP error" do
+            expect { service_call }.to raise_error(LagoHttpClient::HttpError)
+          end
         end
       end
     end


### PR DESCRIPTION
## Context

Sometime jobs to fetch taxes from Anrock are failing with a `JSON::ParseError`. It happens because the server is responding with an `HTTP 200` even if the message contains the HTML markup for an `HTTP 502 Bad Gateway`...   

## Description

This PR adds some logic to detect the presence of the error in the response body and re-reraise the right error for a correct handling, in this case an auto-retry of job 
