### PR TITLE
Feat stripe bank transfers

### DIFF
--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -2,11 +2,12 @@
 
 module PaymentProviderCustomers
   class StripeCustomer < BaseCustomer
-    PAYMENT_METHODS = %w[card sepa_debit us_bank_account bacs_debit link boleto crypto].freeze
+    PAYMENT_METHODS = %w[card sepa_debit us_bank_account bacs_debit link boleto crypto customer_balance].freeze
 
     validates :provider_payment_methods, presence: true
     validate :allowed_provider_payment_methods
     validate :link_payment_method_can_exist_only_with_card
+    validate :customer_balance_must_be_exclusive
 
     settings_accessors :payment_method_id
 
@@ -30,6 +31,13 @@ module PaymentProviderCustomers
       return if provider_payment_methods.exclude?("link") || provider_payment_methods.include?("card")
 
       errors.add(:provider_payment_methods, :invalid)
+    end
+
+    def customer_balance_must_be_exclusive
+      return unless provider_payment_methods.include?("customer_balance")
+      return if provider_payment_methods == ["customer_balance"]
+
+      errors.add(:provider_payment_methods, "customer_balance cannot be combined with other payment methods")
     end
   end
 end

--- a/app/services/integration_customers/create_or_update_service.rb
+++ b/app/services/integration_customers/create_or_update_service.rb
@@ -12,6 +12,7 @@ module IntegrationCustomers
     end
 
     def call
+      pp integration_customers
       return if integration_customers.nil? || customer.nil?
       return if customer.partner_account?
 

--- a/app/services/integration_customers/create_or_update_service.rb
+++ b/app/services/integration_customers/create_or_update_service.rb
@@ -12,7 +12,6 @@ module IntegrationCustomers
     end
 
     def call
-      pp integration_customers
       return if integration_customers.nil? || customer.nil?
       return if customer.partner_account?
 

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -171,8 +171,8 @@ module PaymentProviders
         # to permit 3D secure authentication
         # https://docs.stripe.com/india-recurring-payments
         def off_session?
-          return false if customer.country == "IN"
-          return false if customer.stripe_customer.provider_payment_methods.include?("customer_balance")
+          return false if invoice.customer.country == "IN"
+          return false if provider_customer.provider_payment_methods == ["customer_balance"]
 
           true
         end

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -171,8 +171,10 @@ module PaymentProviders
         # to permit 3D secure authentication
         # https://docs.stripe.com/india-recurring-payments
         def off_session?
-          return false if provider_customer.provider_payment_methods == ["customer_balance"]
-          invoice.customer.country != "IN"
+          return false if customer.country == "IN"
+          return false if customer.stripe_customer.provider_payment_methods.include?("customer_balance")
+
+          true
         end
 
         # NOTE: Same as off_session?

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -149,30 +149,17 @@ module PaymentProviders
           currency = payment.amount_currency.downcase
           return handle_eu_bank_transfer if currency == "eur"
 
-          case currency
-          when "usd" then {type: "us_bank_transfer"}
-          when "gbp" then {type: "gb_bank_transfer"}
-          when "jpy" then {type: "jp_bank_transfer"}
-          when "mxn" then {type: "mx_bank_transfer"}
-          else
-            result.service_failure!(
-              code: "stripe_error",
-              message: "customer_balance is not supported for currency: #{currency}"
-            )
-          end
+          transfer_types = {
+            "usd" => {type: "us_bank_transfer"},
+            "gbp" => {type: "gb_bank_transfer"},
+            "jpy" => {type: "jp_bank_transfer"},
+            "mxn" => {type: "mx_bank_transfer"}
+          }
+          transfer_types[currency]
         end
 
         def handle_eu_bank_transfer
-          allowed_countries = %w[BE DE ES FR IE NL]
           customer_country = payment.customer.country.upcase
-
-          unless allowed_countries.include?(customer_country)
-            return result.service_failure!(
-              code: "stripe_error",
-              message: "EU bank transfer is not supported for country: #{customer_country}"
-            )
-          end
-
           {type: "eu_bank_transfer", eu_bank_transfer: {country: customer_country}}
         end
 

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -139,10 +139,25 @@ module PaymentProviders
             payment_method_options: {
               customer_balance: {
                 funding_type: "bank_transfer",
-                bank_transfer: {type: "us_bank_transfer"}
+                bank_transfer: {type: bank_transfer_type}
               }
             }
           }
+        end
+
+        def bank_transfer_type
+          case payment.amount_currency.downcase
+          when "usd" then "us_bank_transfer"
+          when "gbp" then "gb_bank_transfer"
+          when "eur" then "eu_bank_transfer"
+          when "jpy" then "jp_bank_transfer"
+          when "mxn" then "mx_bank_transfer"
+          else
+            result.service_failure!(
+              code: "stripe_error",
+              message: "customer_balance is not supported for currency: #{payment.amount_currency}"
+            )
+          end
         end
 
         def success_redirect_url

--- a/schema.graphql
+++ b/schema.graphql
@@ -6580,6 +6580,7 @@ enum ProviderPaymentMethodsEnum {
   boleto
   card
   crypto
+  customer_balance
   link
   sepa_debit
   us_bank_account

--- a/schema.json
+++ b/schema.json
@@ -31802,6 +31802,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "customer_balance",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/graphql/types/payment_provider_customers/provider_payment_methods_enum_spec.rb
+++ b/spec/graphql/types/payment_provider_customers/provider_payment_methods_enum_spec.rb
@@ -4,6 +4,6 @@ require "rails_helper"
 
 RSpec.describe Types::PaymentProviderCustomers::ProviderPaymentMethodsEnum do
   it "enumerates the correct values" do
-    expect(described_class.values.keys).to match_array(%w[card sepa_debit us_bank_account bacs_debit link boleto crypto])
+    expect(described_class.values.keys).to match_array(%w[card sepa_debit us_bank_account bacs_debit link boleto crypto customer_balance])
   end
 end

--- a/spec/models/payment_provider_customers/stripe_customer_spec.rb
+++ b/spec/models/payment_provider_customers/stripe_customer_spec.rb
@@ -106,6 +106,24 @@ RSpec.describe PaymentProviderCustomers::StripeCustomer, type: :model do
             expect(errors.where(:provider_payment_methods, :invalid)).not_to be_present
           end
         end
+
+        context "when provider_payment_methods contains 'customer_balance'" do
+          context "with other payment methods" do
+            let(:provider_payment_methods) { %w[customer_balance card] }
+
+            it "adds an error" do
+              expect(errors[:provider_payment_methods]).to include("customer_balance cannot be combined with other payment methods")
+            end
+          end
+
+          context "without other methods" do
+            let(:provider_payment_methods) { %w[customer_balance] }
+
+            it "does not add an error" do
+              expect(errors[:provider_payment_methods]).to be_empty
+            end
+          end
+        end
       end
     end
   end

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service
         context "when currency is GBP" do
           let(:currency) { "GBP" }
 
-          it "includes US bank transfer details" do
+          it "includes GBP bank transfer details" do
             expected_payload = base_payload.deep_merge(
               payment_method_options: {
                 customer_balance: {


### PR DESCRIPTION
## Context
Lago does not currently support Bank Transfer payments for users receiving payouts through Stripe’s customer balance. This PR adds support for this payment method to accommodate use cases where Bank Transfers are required.

## Description
Added support for Bank Transfer payments when using Stripe’s customer balance.
Updated relevant service logic to handle this payment method.