### PR TITLE
feat(Uniqueness) - Mark BillNonInvoiceableFeesJob as unique

### DIFF
--- a/app/jobs/bill_non_invoiceable_fees_job.rb
+++ b/app/jobs/bill_non_invoiceable_fees_job.rb
@@ -11,6 +11,8 @@ class BillNonInvoiceableFeesJob < ApplicationJob
 
   retry_on Sequenced::SequenceError, ActiveJob::DeserializationError
 
+  unique :until_executed, on_conflict: :log, lock_ttl: 4.hours
+
   def perform(subscriptions, billing_at)
     result = Invoices::AdvanceChargesService.call(initial_subscriptions: subscriptions, billing_at:)
     result.raise_if_error!


### PR DESCRIPTION
## Description

During monthly billing we can spend a lot of time enqueueing jobs (which we do every hour). In order to avoid duplication of billing jobs, we should mark them as unique. (Similar to what we did for the BillSubscriptionJob).

I've opted for a 4 hour lock window instead of 12 hours. 