### PR TITLE
fix(netsuite): Use max length when creating netsuite customer

### DIFF
--- a/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
@@ -6,6 +6,7 @@ module Integrations
       module Payloads
         class Netsuite < BasePayload
           STATE_LIMIT = 30
+          ADDR1_LIMIT = 150
 
           def create_body
             {
@@ -73,7 +74,7 @@ module Integrations
                       "defaultbilling" => true,
                       "subObjectId" => "addressbookaddress",
                       "subObject" => {
-                        "addr1" => customer.address_line1,
+                        "addr1" => customer.address_line1&.first(ADDR1_LIMIT),
                         "addr2" => customer.address_line2,
                         "city" => customer.city,
                         "zip" => customer.zipcode,
@@ -94,7 +95,7 @@ module Integrations
                       "defaultbilling" => true,
                       "subObjectId" => "addressbookaddress",
                       "subObject" => {
-                        "addr1" => customer.address_line1,
+                        "addr1" => customer.address_line1&.first(ADDR1_LIMIT),
                         "addr2" => customer.address_line2,
                         "city" => customer.city,
                         "zip" => customer.zipcode,
@@ -107,11 +108,11 @@ module Integrations
                       "defaultbilling" => false,
                       "subObjectId" => "addressbookaddress",
                       "subObject" => {
-                        "addr1" => customer.shipping_address_line1,
+                        "addr1" => customer.shipping_address_line1&.first(ADDR1_LIMIT),
                         "addr2" => customer.shipping_address_line2,
                         "city" => customer.shipping_city,
                         "zip" => customer.shipping_zipcode,
-                        "state" => customer.shipping_state,
+                        "state" => customer.shipping_state&.first(STATE_LIMIT),
                         "country" => customer.shipping_country
                       }
                     }


### PR DESCRIPTION
## Context

We currently receive deadjobs when trying to sync customers on Netsuite.
This is because `state` sent contains more characters than the maximum size allowed by Netsuite (`30`).

Deadjob:
> action_script_runtime_error: The field addr1 contained more than the maximum number ( 150 ) of characters allowed.

## Description

The goal of this PR is to only select the first 30 characters for the state when creating a customer on Netsuite.