### PR TITLE
fix(stripe): Better errors on Stripe customer checkout url

### DIFF
--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -2,7 +2,9 @@
 
 module PaymentProviderCustomers
   class StripeCustomer < BaseCustomer
-    PAYMENT_METHODS = %w[card sepa_debit us_bank_account bacs_debit link boleto crypto customer_balance].freeze
+    PAYMENT_METHODS_WITH_SETUP = %w[card sepa_debit us_bank_account bacs_debit link boleto].freeze
+    PAYMENT_METHODS_WITHOUT_SETUP = %w[crypto customer_balance].freeze
+    PAYMENT_METHODS = (PAYMENT_METHODS_WITH_SETUP + PAYMENT_METHODS_WITHOUT_SETUP).freeze
 
     validates :provider_payment_methods, presence: true
     validate :allowed_provider_payment_methods
@@ -13,6 +15,10 @@ module PaymentProviderCustomers
 
     def provider_payment_methods
       get_from_settings("provider_payment_methods")
+    end
+
+    def provider_payment_methods_with_setup
+      provider_payment_methods & PAYMENT_METHODS_WITH_SETUP
     end
 
     def provider_payment_methods=(provider_payment_methods)

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -84,7 +84,7 @@ module PaymentProviderCustomers
       result
     rescue ::Stripe::InvalidRequestError, ::Stripe::PermissionError => e
       deliver_error_webhook(e)
-      result
+      result.third_party_failure!(third_party: "Stripe", error_message: e.message)
     rescue ::Stripe::AuthenticationError => e
       deliver_error_webhook(e)
 

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -64,6 +64,13 @@ module PaymentProviderCustomers
       return result unless customer # NOTE: Customer is nil when deleted.
       return result if customer.organization.webhook_endpoints.none? && send_webhook && payment_provider(customer)
 
+      if stripe_customer.provider_payment_methods_with_setup.blank?
+        return result.single_validation_failure!(
+          field: :provider_payment_methods,
+          error_code: "no_payment_methods_to_setup_available"
+        )
+      end
+
       res = ::Stripe::Checkout::Session.create(
         checkout_link_params,
         {
@@ -114,7 +121,7 @@ module PaymentProviderCustomers
       {
         success_url: success_redirect_url,
         mode: "setup",
-        payment_method_types: stripe_customer.provider_payment_methods - %w[crypto], # NOTE: crypto doesn't work with setup mode
+        payment_method_types: stripe_customer.provider_payment_methods_with_setup,
         customer: stripe_customer.provider_customer_id
       }
     end

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -91,7 +91,7 @@ module PaymentProviderCustomers
       result
     rescue ::Stripe::InvalidRequestError, ::Stripe::PermissionError => e
       deliver_error_webhook(e)
-      result.third_party_failure!(third_party: "Stripe", error_message: e.message)
+      result.third_party_failure!(third_party: "Stripe", error_code: e.code, error_message: e.message)
     rescue ::Stripe::AuthenticationError => e
       deliver_error_webhook(e)
 

--- a/spec/models/payment_provider_customers/stripe_customer_spec.rb
+++ b/spec/models/payment_provider_customers/stripe_customer_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe PaymentProviderCustomers::StripeCustomer, type: :model do
     end
   end
 
+  describe "#provider_payment_methods_for_setup" do
+    it "returns only payment methods that require setup" do
+      expect(build(:stripe_customer, provider_payment_methods: %w[card]).provider_payment_methods_with_setup).to eq %w[card]
+      expect(build(:stripe_customer, provider_payment_methods: %w[card crypto]).provider_payment_methods_with_setup).to eq %w[card]
+      expect(build(:stripe_customer, provider_payment_methods: %w[crypto]).provider_payment_methods_with_setup).to eq []
+    end
+  end
+
   describe "validation" do
     describe "of provider payment methods" do
       subject(:valid) { stripe_customer.valid? }

--- a/spec/models/payment_provider_customers/stripe_customer_spec.rb
+++ b/spec/models/payment_provider_customers/stripe_customer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe PaymentProviderCustomers::StripeCustomer, type: :model do
     end
   end
 
-  describe "#provider_payment_methods_for_setup" do
+  describe "#provider_payment_methods_with_setup" do
     it "returns only payment methods that require setup" do
       expect(build(:stripe_customer, provider_payment_methods: %w[card]).provider_payment_methods_with_setup).to eq %w[card]
       expect(build(:stripe_customer, provider_payment_methods: %w[card crypto]).provider_payment_methods_with_setup).to eq %w[card]

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -473,6 +473,17 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
       end
     end
 
+    context "when customer has no payment method to be setup" do
+      let(:stripe_customer) { create(:stripe_customer, customer:, provider_customer_id: nil, provider_payment_methods: ::PaymentProviderCustomers::StripeCustomer::PAYMENT_METHODS_WITHOUT_SETUP) }
+
+      it "does not deliver a webhook" do
+        described_class.new(stripe_customer.reload).generate_checkout_url
+
+        expect(SendWebhookJob).not_to have_been_enqueued
+          .with("customer.checkout_url_generated", customer, checkout_url: "https://example.com")
+      end
+    end
+
     context "when stripe raises an invalid request error" do
       let(:stripe_error) { ::Stripe::InvalidRequestError.new("What is horrible request?!", {}) }
 

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -474,7 +474,7 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
     end
 
     context "when customer has no payment method to be setup" do
-      let(:stripe_customer) { create(:stripe_customer, customer:, provider_customer_id: nil, provider_payment_methods: ::PaymentProviderCustomers::StripeCustomer::PAYMENT_METHODS_WITHOUT_SETUP) }
+      let(:stripe_customer) { create(:stripe_customer, customer:, provider_customer_id: nil, provider_payment_methods: %w[crypto]) }
 
       it "does not deliver a webhook" do
         described_class.new(stripe_customer.reload).generate_checkout_url
@@ -485,7 +485,7 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
     end
 
     context "when stripe raises an invalid request error" do
-      let(:stripe_error) { ::Stripe::InvalidRequestError.new("What is horrible request?!", {}) }
+      let(:stripe_error) { ::Stripe::InvalidRequestError.new("wrong request!", {}) }
 
       before { allow(::Stripe::Checkout::Session).to receive(:create).and_raise(stripe_error) }
 
@@ -494,7 +494,7 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ThirdPartyFailure)
-        expect(result.error.message).to eq("Stripe: What is horrible request?!")
+        expect(result.error.message).to eq("Stripe:  - wrong request!")
       end
     end
 


### PR DESCRIPTION
## Description

Some stripe errors were not returned by the API when creating a customer checkout url.

This PR also split the payment methods into 2 categories. You cannot create a cutomer checkout url if all their available payment methods are not able to be setup. (this will be very useful for https://github.com/getlago/lago-api/pull/3236)
