### PR TITLE
bug(LifetimeUsage) - refresh lifetime usage when creating subscriptions / updating plans

### DIFF
--- a/app/jobs/lifetime_usages/flag_refresh_from_plan_update_job.rb
+++ b/app/jobs/lifetime_usages/flag_refresh_from_plan_update_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module LifetimeUsages
+  class FlagRefreshFromPlanUpdateJob < ApplicationJob
+    queue_as :default
+
+    def perform(plan)
+      LifetimeUsages::FlagRefreshFromPlanUpdateService.call(plan:)
+    end
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -56,11 +56,8 @@ class Subscription < ApplicationRecord
 
   def mark_as_active!(timestamp = Time.current)
     self.started_at ||= timestamp
-    self.lifetime_usage ||= previous_subscription&.lifetime_usage || build_lifetime_usage(
-      organization:,
-      recalculate_current_usage: false,
-      recalculate_invoiced_usage: false
-    )
+    self.lifetime_usage ||= previous_subscription&.lifetime_usage || build_lifetime_usage(organization:)
+    self.lifetime_usage.recalculate_invoiced_usage = true
     active!
   end
 

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -35,8 +35,6 @@ module Invoices
         invoice.finalized!
       end
 
-      # TODO: deduct previous progressive billing invoices
-
       Utils::SegmentTrack.invoice_created(invoice)
       SendWebhookJob.perform_later("invoice.created", invoice)
       Invoices::GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)

--- a/app/services/lifetime_usages/calculate_service.rb
+++ b/app/services/lifetime_usages/calculate_service.rb
@@ -16,11 +16,6 @@ module LifetimeUsages
         return result
       end
 
-      if lifetime_usage.recalculate_current_usage
-        lifetime_usage.current_usage_amount_cents = calculate_current_usage_amount_cents
-        lifetime_usage.recalculate_current_usage = false
-        lifetime_usage.current_usage_amount_refreshed_at = Time.current
-      end
       if lifetime_usage.recalculate_invoiced_usage
         lifetime_usage.invoiced_usage_amount_cents = calculate_invoiced_usage_amount_cents
         lifetime_usage.current_usage_amount_cents = calculate_current_usage_amount_cents
@@ -29,6 +24,13 @@ module LifetimeUsages
         lifetime_usage.invoiced_usage_amount_refreshed_at = Time.current
         lifetime_usage.current_usage_amount_refreshed_at = Time.current
       end
+
+      if lifetime_usage.recalculate_current_usage
+        lifetime_usage.current_usage_amount_cents = calculate_current_usage_amount_cents
+        lifetime_usage.recalculate_current_usage = false
+        lifetime_usage.current_usage_amount_refreshed_at = Time.current
+      end
+
       lifetime_usage.save!
 
       result

--- a/app/services/lifetime_usages/flag_refresh_from_plan_update_service.rb
+++ b/app/services/lifetime_usages/flag_refresh_from_plan_update_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module LifetimeUsages
+  class FlagRefreshFromPlanUpdateService < BaseService
+    Result = BaseResult[:updated_lifetime_usages]
+
+    def initialize(plan:)
+      @plan = plan
+      super
+    end
+
+    def call
+      result.updated_lifetime_usages = LifetimeUsage
+        .where(subscription_id: plan.subscriptions.active.select(:id))
+        .update_all(recalculate_invoiced_usage: true) # rubocop:disable Rails/SkipsModelValidations
+      result
+    end
+
+    private
+
+    attr_reader :plan
+  end
+end

--- a/app/services/lifetime_usages/usage_thresholds/check_service.rb
+++ b/app/services/lifetime_usages/usage_thresholds/check_service.rb
@@ -3,6 +3,8 @@
 module LifetimeUsages
   module UsageThresholds
     class CheckService < BaseService
+      Result = BaseResult[:passed_thresholds]
+
       def initialize(lifetime_usage:, progressive_billed_amount: 0)
         @lifetime_usage = lifetime_usage
         @progressive_billed_amount = progressive_billed_amount
@@ -12,6 +14,7 @@ module LifetimeUsages
 
       def call
         result.passed_thresholds = []
+        return result unless thresholds.any?
 
         fixed_thresholds = thresholds.not_recurring.order(:amount_cents)
         # There is only 1 recurring threshold, `first` will return it or nil

--- a/app/services/plans/update_usage_thresholds_service.rb
+++ b/app/services/plans/update_usage_thresholds_service.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Plans
+  class UpdateUsageThresholdsService < BaseService
+    Result = BaseResult[:plan]
+
+    def initialize(plan:, usage_thresholds_params:)
+      @plan = plan
+      @usage_thresholds_params = usage_thresholds_params
+      super
+    end
+
+    def call
+      result.plan = plan
+      return result unless plan.organization.progressive_billing_enabled?
+
+      if usage_thresholds_params.empty?
+        plan.usage_thresholds.discard_all
+      else
+        process_usage_thresholds
+      end
+
+      result
+    end
+
+    private
+
+    def process_usage_thresholds
+      created_thresholds_ids = []
+
+      hash_thresholds = usage_thresholds_params.map { |c| c.to_h.deep_symbolize_keys }
+      hash_thresholds.each do |payload_threshold|
+        usage_threshold = plan.usage_thresholds.find_by(id: payload_threshold[:id])
+
+        if usage_threshold
+          if payload_threshold.key?(:threshold_display_name)
+            usage_threshold.threshold_display_name = payload_threshold[:threshold_display_name]
+          end
+
+          if payload_threshold.key?(:amount_cents)
+            usage_threshold.amount_cents = payload_threshold[:amount_cents]
+          end
+
+          if payload_threshold.key?(:recurring)
+            usage_threshold.recurring = payload_threshold[:recurring]
+          end
+
+          # This means that in the UI we just removed an existing threshold
+          # and then just re-added a threshold (which no longer has an id) with the same amount
+          # so we discard the existing one and we're inserting a new one instead
+          if !usage_threshold.valid? && usage_threshold.errors.where(:amount_cents, :taken).present?
+            usage_threshold.discard!
+          else
+            usage_threshold.save!
+            next
+          end
+        end
+
+        created_threshold = create_usage_threshold(plan.reload, payload_threshold)
+        created_thresholds_ids.push(created_threshold.id)
+      end
+      # NOTE: Delete thresholds that are no more linked to the plan
+      sanitize_thresholds(plan, hash_thresholds, created_thresholds_ids)
+    end
+
+    def sanitize_thresholds(plan, args_thresholds, created_thresholds_ids)
+      args_thresholds_ids = args_thresholds.map { |c| c[:id] }.compact
+      thresholds_ids = plan.usage_thresholds.pluck(:id) - args_thresholds_ids - created_thresholds_ids
+      plan.usage_thresholds.where(id: thresholds_ids).discard_all
+    end
+
+    def create_usage_threshold(plan, params)
+      usage_threshold = plan.usage_thresholds.find_or_initialize_by(
+        recurring: params[:recurring] || false,
+        amount_cents: params[:amount_cents]
+      )
+
+      existing_recurring_threshold = plan.usage_thresholds.recurring.first
+
+      if params[:recurring] && existing_recurring_threshold
+        usage_threshold = existing_recurring_threshold
+      end
+
+      usage_threshold.threshold_display_name = params[:threshold_display_name]
+      usage_threshold.amount_cents = params[:amount_cents]
+
+      usage_threshold.save!
+      usage_threshold
+    end
+
+    attr_reader :plan, :usage_thresholds_params
+  end
+end

--- a/app/services/plans/update_usage_thresholds_service.rb
+++ b/app/services/plans/update_usage_thresholds_service.rb
@@ -18,6 +18,7 @@ module Plans
         plan.usage_thresholds.discard_all
       else
         process_usage_thresholds
+        LifetimeUsages::FlagRefreshFromPlanUpdateJob.perform_later(plan)
       end
 
       result

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,7 +61,7 @@ Rails.application.configure do
   config.hosts << "api.lago.dev"
   config.hosts << "api"
 
-  config.license_url = "http://license:3000"
+  config.license_url = ENV.fetch("LAGO_LICENSE_URL", "http://license:3000")
 
   config.action_mailer.perform_caching = false
   config.action_mailer.perform_deliveries = true

--- a/spec/jobs/lifetime_usages/flag_refresh_from_plan_update_job_spec.rb
+++ b/spec/jobs/lifetime_usages/flag_refresh_from_plan_update_job_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LifetimeUsages::FlagRefreshFromPlanUpdateJob, type: :job do
+  let(:plan) { create(:plan) }
+
+  it "delegates to the FlagRefreshFromPlanUpdate service" do
+    allow(LifetimeUsages::FlagRefreshFromPlanUpdateService).to receive(:call)
+    described_class.perform_now(plan)
+    expect(LifetimeUsages::FlagRefreshFromPlanUpdateService).to have_received(:call).with(plan:)
+  end
+end

--- a/spec/scenarios/subscriptions/progressive_billing_enablement_spec.rb
+++ b/spec/scenarios/subscriptions/progressive_billing_enablement_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Progressive Billing enablement", :scenarios, type: :request do
+  let(:timezone) { "UTC" }
+  let(:organization) { create(:organization, webhook_url: nil, premium_integrations: ["progressive_billing"]) }
+  let(:billable_metric) { create(:sum_billable_metric, organization:) }
+
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:plan) do
+    create(
+      :plan,
+      organization:,
+      amount_cents: 5_000_000
+    )
+  end
+
+  let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {amount: "10"}) }
+  let(:usage_threshold) { create(:usage_threshold, plan: plan, amount_cents: 20000) }
+
+  around { |test| lago_premium!(&test) }
+
+  before do
+    charge
+  end
+
+  context "when enabled when usage has already been accumulating" do
+    it "correctly calculates thresholds and generates correct progressive billing invoices" do
+      time_0 = DateTime.new(2022, 12, 1)
+      travel_to time_0
+
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        }
+      )
+
+      subscription = customer.subscriptions.first
+
+      # no invoice expected to be generated
+      travel_to time_0 + 5.days
+
+      ingest_event(subscription, billable_metric, 1000000)
+      expect(Invoice.count).to eq(0)
+
+      # update plan and add a threshold
+      travel_to time_0 + 6.days
+
+      update_plan(plan, usage_thresholds: [
+        {
+          amount_cents: usage_threshold.amount_cents
+        }
+      ])
+
+      perform_all_enqueued_jobs
+      perform_usage_update
+
+      expect(Invoice.count).to eq(1)
+      invoice = Invoice.last
+
+      expect(invoice.invoice_type).to eq("progressive_billing")
+      expect(invoice.total_amount_cents).to eq(1000000 * 10 * 100)
+
+      travel_to time_0 + 1.month
+
+      perform_billing
+      expect(Invoice.count).to eq(2)
+
+      recurring_invoice = subscription.invoices.order(:created_at).last
+      expect(recurring_invoice.total_amount_cents).to eq(5_000_000)
+      expect(recurring_invoice.fees_amount_cents).to eq(5_000_000 + 1000000 * 10 * 100)
+      expect(recurring_invoice.progressive_billing_credit_amount_cents).to eq(1000000 * 10 * 100)
+    end
+  end
+
+  context "when enabled when usage has already been invoiced" do
+    it "correctly calculates thresholds and generates correct progressive billing invoices" do
+      time_0 = DateTime.new(2022, 12, 1)
+      travel_to time_0
+
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        }
+      )
+
+      subscription = customer.subscriptions.first
+
+      # no invoice expected to be generated
+      travel_to time_0 + 5.days
+
+      ingest_event(subscription, billable_metric, 1000000)
+      expect(Invoice.count).to eq(0)
+
+      travel_to time_0 + 31.days
+      perform_billing
+      expect(Invoice.count).to eq(1)
+
+      invoice = Invoice.last
+      expect(invoice.invoice_type).to eq("subscription")
+      expect(invoice.total_amount_cents).to eq(5_000_000 + 1000000 * 10 * 100)
+
+      # update plan and add a threshold
+      travel_to time_0 + 36.days
+
+      update_plan(plan, usage_thresholds: [
+        {
+          amount_cents: usage_threshold.amount_cents
+        }
+      ])
+
+      perform_all_enqueued_jobs
+      perform_usage_update
+
+      expect(Invoice.count).to eq(1)
+    end
+  end
+end

--- a/spec/services/lifetime_usages/flag_refresh_from_plan_update_service_spec.rb
+++ b/spec/services/lifetime_usages/flag_refresh_from_plan_update_service_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LifetimeUsages::FlagRefreshFromPlanUpdateService, type: :service do
+  subject { described_class.call(plan:) }
+
+  let(:plan) { create(:plan) }
+  let(:result) { subject }
+
+  describe "#call" do
+    context "when plan has no active subscriptions" do
+      it "returns zero for updated lifetime usages" do
+        expect(result.updated_lifetime_usages).to eq(0)
+      end
+    end
+
+    context "when plan has active subscriptions with lifetime usages" do
+      let(:active_subscription1) { create(:subscription, :active, plan: plan) }
+      let(:active_subscription2) { create(:subscription, :active, plan: plan) }
+      let(:terminated_subscription) { create(:subscription, :terminated, plan: plan) }
+
+      let(:lifetime_usage1) { create(:lifetime_usage, subscription: active_subscription1) }
+      let(:lifetime_usage2) { create(:lifetime_usage, subscription: active_subscription2) }
+      let(:lifetime_usage3) { create(:lifetime_usage, subscription: terminated_subscription) }
+
+      before do
+        lifetime_usage1
+        lifetime_usage2
+        lifetime_usage3
+      end
+
+      it "flags only lifetime usages of active subscriptions for recalculation" do
+        expect(result.updated_lifetime_usages).to eq(2)
+
+        expect(lifetime_usage1.reload.recalculate_invoiced_usage).to be_truthy
+        expect(lifetime_usage2.reload.recalculate_invoiced_usage).to be_truthy
+        expect(lifetime_usage3.reload.recalculate_invoiced_usage).to be_falsey
+      end
+    end
+
+    context "when plan has active subscriptions but no lifetime usages" do
+      before do
+        create(:subscription, :active, plan: plan)
+        create(:subscription, :active, plan: plan)
+      end
+
+      it "returns zero for updated lifetime usages" do
+        expect(result.updated_lifetime_usages).to eq(0)
+      end
+    end
+
+    context "when there are lifetime usages for other plans" do
+      let(:other_plan) { create(:plan) }
+      let(:other_subscription) { create(:subscription, :active, plan: other_plan) }
+      let(:current_subscription) { create(:subscription, :active, plan: plan) }
+
+      let(:other_lifetime_usage) { create(:lifetime_usage, subscription: other_subscription) }
+      let(:current_lifetime_usage) { create(:lifetime_usage, subscription: current_subscription) }
+
+      before do
+        other_lifetime_usage
+        current_lifetime_usage
+      end
+
+      it "only flags lifetime usages for the given plan" do
+        expect(result.updated_lifetime_usages).to eq(1)
+
+        expect(current_lifetime_usage.reload.recalculate_invoiced_usage).to be_truthy
+        expect(other_lifetime_usage.reload.recalculate_invoiced_usage).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/services/plans/update_usage_thresholds_service_spec.rb
+++ b/spec/services/plans/update_usage_thresholds_service_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Plans::UpdateUsageThresholdsService, type: :service do
+  subject { described_class.call(plan:, usage_thresholds_params:) }
+
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+
+  context "when usage_thresholds_params is empty" do
+    let(:usage_thresholds_params) { [] }
+
+    context "when progressive_billing is not enabled" do
+      it "does not update the plan" do
+        expect(subject.plan.usage_thresholds).to be_empty
+      end
+    end
+
+    context "when progressive_billing is enabled" do
+      around { |test| premium_integration!(organization, "progressive_billing", &test) }
+
+      it "does not update the plan" do
+        expect(subject.plan.usage_thresholds).to be_empty
+      end
+    end
+  end
+
+  context "when usage_thresholds_params is not empty" do
+    let(:usage_thresholds_params) do
+      [
+        {
+          threshold_display_name: "Threshold 1",
+          amount_cents: 1000
+        }
+      ]
+    end
+
+    context "when progressive_billing is not enabled" do
+      it "does not update the plan" do
+        expect(subject.plan.usage_thresholds).to be_empty
+      end
+    end
+
+    context "when progressive_billing is enabled" do
+      around { |test| premium_integration!(organization, "progressive_billing", &test) }
+
+      it "does update the plan" do
+        thresholds = subject.plan.usage_thresholds
+        expect(thresholds.size).to eq(1)
+        expect(thresholds.first.threshold_display_name).to eq("Threshold 1")
+        expect(thresholds.first.amount_cents).to eq(1000)
+      end
+    end
+  end
+
+  context "when plan already has usage_thresholds" do
+    let(:threshold1) do
+      create(:usage_threshold, plan:, threshold_display_name: "Threshold 1", amount_cents: 1)
+    end
+
+    let(:threshold2) do
+      create(:usage_threshold, plan:, threshold_display_name: "Threshold 2", amount_cents: 2)
+    end
+
+    before do
+      threshold1
+      threshold2
+    end
+
+    context "when usage_thresholds_params is empty" do
+      let(:usage_thresholds_params) { [] }
+
+      context "when progressive_billing is not enabled" do
+        it "does not update the plan" do
+          expect { subject }.not_to change(plan, :usage_thresholds)
+        end
+      end
+
+      context "when progressive_billing is enabled" do
+        around { |test| premium_integration!(organization, "progressive_billing", &test) }
+
+        it "clears the thresholds" do
+          expect(subject.plan.usage_thresholds).to be_empty
+        end
+      end
+    end
+
+    context "when usage_thresholds_params is not empty" do
+      let(:usage_thresholds_params) do
+        [
+          {
+            threshold_display_name: "Other threshold",
+            amount_cents: 1000
+          }
+        ]
+      end
+
+      context "when progressive_billing is not enabled" do
+        it "does not update the plan" do
+          expect { subject }.not_to change(plan, :usage_thresholds)
+        end
+      end
+
+      context "when progressive_billing is enabled" do
+        around { |test| premium_integration!(organization, "progressive_billing", &test) }
+
+        it "does update the plan" do
+          thresholds = subject.plan.usage_thresholds
+          expect(thresholds.size).to eq(1)
+          expect(thresholds.first.threshold_display_name).to eq("Other threshold")
+          expect(thresholds.first.amount_cents).to eq(1000)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         expect(subscription.external_id).to eq(external_id)
         expect(subscription).to be_anniversary
         expect(subscription.lifetime_usage).to be_present
-        expect(subscription.lifetime_usage.recalculate_invoiced_usage).to eq(false)
+        expect(subscription.lifetime_usage.recalculate_invoiced_usage).to eq(true)
         expect(subscription.lifetime_usage.recalculate_current_usage).to eq(false)
       end
     end
@@ -344,7 +344,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           expect(subscription.external_id).to eq(external_id)
           expect(subscription).to be_anniversary
           expect(subscription.lifetime_usage).to be_present
-          expect(subscription.lifetime_usage.recalculate_invoiced_usage).to eq(false)
+          expect(subscription.lifetime_usage.recalculate_invoiced_usage).to eq(true)
           expect(subscription.lifetime_usage.recalculate_current_usage).to eq(false)
         end
       end

--- a/spec/support/license_helper.rb
+++ b/spec/support/license_helper.rb
@@ -6,4 +6,14 @@ module LicenseHelper
     yield
     License.instance_variable_set(:@premium, false)
   end
+
+  def premium_integration!(organization, premium_integration, &block)
+    old_integrations = organization.premium_integrations
+    organization.premium_integrations << premium_integration
+    organization.save!
+
+    lago_premium!(&block)
+
+    organization.update! premium_integrations: old_integrations
+  end
 end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -131,6 +131,16 @@ module ScenariosHelper
 
   ### Events
 
+  def ingest_event(subscription, billable_metric, amount)
+    create_event({
+      transaction_id: SecureRandom.uuid,
+      code: billable_metric.code,
+      external_subscription_id: subscription.external_id,
+      properties: {billable_metric&.field_name => amount}
+    })
+    perform_usage_update
+  end
+
   def create_event(params)
     post_with_token(organization, "/api/v1/events", {event: params})
     perform_all_enqueued_jobs


### PR DESCRIPTION
## Description

When setting up progressive billing on a plan we need to make sure to recalculate lifetime usage as well.

## changes

*  moves threshold update logic to a dedicated service.
* adds a job to flag lifetime usage refresh when plan is updated
* recalculate lifetime usage when subscription is marked as active. (deals with new subscription / upgrade / downgrade behavior)
