### PR TITLE
Feat(multi-entities): add services to update billing_entity

### DIFF
--- a/app/jobs/invoices/update_all_invoice_grace_period_from_billing_entity_job.rb
+++ b/app/jobs/invoices/update_all_invoice_grace_period_from_billing_entity_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Invoices
+  class UpdateAllInvoiceGracePeriodFromBillingEntityJob < ApplicationJob
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_BILLING"])
+        :billing
+      else
+        :invoices
+      end
+    end
+
+    def perform(billing_entity, old_grace_period)
+      Invoices::UpdateAllInvoiceGracePeriodFromBilingEntityService.call!(billing_entity:, old_grace_period:)
+    end
+  end
+end

--- a/app/jobs/invoices/update_all_invoice_grace_period_from_billing_entity_job.rb
+++ b/app/jobs/invoices/update_all_invoice_grace_period_from_billing_entity_job.rb
@@ -11,7 +11,7 @@ module Invoices
     end
 
     def perform(billing_entity, old_grace_period)
-      Invoices::UpdateAllInvoiceGracePeriodFromBilingEntityService.call!(billing_entity:, old_grace_period:)
+      Invoices::UpdateAllInvoiceGracePeriodFromBillingEntityService.call!(billing_entity:, old_grace_period:)
     end
   end
 end

--- a/app/jobs/invoices/update_grace_period_from_billing_entity_job.rb
+++ b/app/jobs/invoices/update_grace_period_from_billing_entity_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Invoices
+  class UpdateGracePeriodFromBillingEntityJob < ApplicationJob
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_BILLING"])
+        :billing
+      else
+        :invoices
+      end
+    end
+
+    def perform(invoice, old_grace_period)
+      Invoices::UpdateGracePeriodFromBillingEntityService.call!(invoice:, old_grace_period:)
+    end
+  end
+end

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -65,6 +65,29 @@ class BillingEntity < ApplicationRecord
 
   after_create :generate_document_number_prefix
 
+  def document_number_prefix=(value)
+    super(value&.upcase)
+  end
+
+  def logo_url
+    return if logo.blank?
+
+    Rails.application.routes.url_helpers.rails_blob_url(logo, host: ENV["LAGO_API_URL"])
+  end
+
+  def base64_logo
+    return if logo.blank?
+
+    logo.blob.open do |tempfile|
+      data = tempfile.read
+      Base64.encode64(data)
+    end
+  end
+
+  def eu_vat_eligible?
+    country && LagoEuVat::Rate.new.countries_code.include?(country)
+  end
+
   private
 
   def generate_document_number_prefix

--- a/app/services/billing_entities/update_invoice_grace_period_service.rb
+++ b/app/services/billing_entities/update_invoice_grace_period_service.rb
@@ -3,6 +3,7 @@
 module BillingEntities
   class UpdateInvoiceGracePeriodService < BaseService
     Result = BaseResult[:billing_entity]
+
     def initialize(billing_entity:, grace_period:)
       @billing_entity = billing_entity
       @grace_period = grace_period.to_i
@@ -16,7 +17,8 @@ module BillingEntities
         billing_entity.invoice_grace_period = grace_period
         billing_entity.save!
 
-        Invoices::UpdateAllInvoiceGracePeriodFromBillingEntityJob.perform_later(billing_entity, old_grace_period)
+        # TODO: uncomment when billing_entity is the source of truth
+        # Invoices::UpdateAllInvoiceGracePeriodFromBillingEntityJob.perform_later(billing_entity, old_grace_period)
       end
 
       result.billing_entity = billing_entity

--- a/app/services/billing_entities/update_invoice_grace_period_service.rb
+++ b/app/services/billing_entities/update_invoice_grace_period_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module BillingEntities
+  class UpdateInvoiceGracePeriodService < BaseService
+    Result = BaseResult[:billing_entity]
+    def initialize(billing_entity:, grace_period:)
+      @billing_entity = billing_entity
+      @grace_period = grace_period.to_i
+      super
+    end
+
+    def call
+      old_grace_period = billing_entity.invoice_grace_period.to_i
+
+      if grace_period != old_grace_period
+        billing_entity.invoice_grace_period = grace_period
+        billing_entity.save!
+
+        Invoices::UpdateAllInvoiceGracePeriodFromBillingEntityJob.perform_later(billing_entity, old_grace_period)
+      end
+
+      result.billing_entity = billing_entity
+      result
+    end
+
+    private
+
+    attr_reader :billing_entity, :grace_period
+  end
+end

--- a/app/services/billing_entities/update_invoice_payment_due_date_service.rb
+++ b/app/services/billing_entities/update_invoice_payment_due_date_service.rb
@@ -2,6 +2,8 @@
 
 module BillingEntities
   class UpdateInvoicePaymentDueDateService < BaseService
+    Result = BaseResult[:billing_entity]
+
     def initialize(billing_entity:, net_payment_term:)
       @billing_entity = billing_entity
       @net_payment_term = net_payment_term
@@ -10,18 +12,18 @@ module BillingEntities
 
     def call
       ActiveRecord::Base.transaction do
-        # NOTE: Update payment_due_date if net_payment_term changed
-
+        # NOTE: Set payment_due_date if net_payment_term changed
         if billing_entity.net_payment_term != net_payment_term
           billing_entity.net_payment_term = net_payment_term
 
-          # update only invoices, where the customer does not have a setting
-          billing_entity.invoices.includes(:customer).draft.find_each do |invoice|
-            # the customer has a setting of their own, no update needed.
-            next unless invoice.customer.net_payment_term.nil?
-
-            invoice.update!(net_payment_term:, payment_due_date: invoice_payment_due_date(invoice))
-          end
+          # TODO: uncomment when billing_entity is the source of truth
+          # # update only invoices, where the customer does not have a setting
+          # billing_entity.invoices.includes(:customer).draft.find_each do |invoice|
+          #   # the customer has a setting of their own, no update needed.
+          #   next unless invoice.customer.net_payment_term.nil?
+          #
+          #   invoice.update!(net_payment_term:, payment_due_date: invoice_payment_due_date(invoice))
+          # end
         end
 
         result.billing_entity = billing_entity

--- a/app/services/billing_entities/update_invoice_payment_due_date_service.rb
+++ b/app/services/billing_entities/update_invoice_payment_due_date_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module BillingEntities
+  class UpdateInvoicePaymentDueDateService < BaseService
+    def initialize(billing_entity:, net_payment_term:)
+      @billing_entity = billing_entity
+      @net_payment_term = net_payment_term
+      super
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        # NOTE: Update payment_due_date if net_payment_term changed
+
+        if billing_entity.net_payment_term != net_payment_term
+          billing_entity.net_payment_term = net_payment_term
+
+          # update only invoices, where the customer does not have a setting
+          billing_entity.invoices.includes(:customer).draft.find_each do |invoice|
+            # the customer has a setting of their own, no update needed.
+            next unless invoice.customer.net_payment_term.nil?
+
+            invoice.update!(net_payment_term:, payment_due_date: invoice_payment_due_date(invoice))
+          end
+        end
+
+        result.billing_entity = billing_entity
+        result
+      end
+    end
+
+    private
+
+    attr_reader :billing_entity, :net_payment_term
+
+    def invoice_payment_due_date(invoice)
+      invoice.issuing_date + net_payment_term.days
+    end
+  end
+end

--- a/app/services/billing_entities/update_service.rb
+++ b/app/services/billing_entities/update_service.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module BillingEntities
+  class UpdateService < BaseService
+    Result = BaseResult[:billing_entity]
+
+    def initialize(billing_entity:, params:)
+      @billing_entity = billing_entity
+      @params = params
+
+      super(nil)
+    end
+
+    def call
+      billing_entity.email = params[:email] if params.key?(:email)
+      billing_entity.legal_name = params[:legal_name] if params.key?(:legal_name)
+      billing_entity.legal_number = params[:legal_number] if params.key?(:legal_number)
+      if params.key?(:tax_identification_number)
+        billing_entity.tax_identification_number = params[:tax_identification_number]
+      end
+      billing_entity.address_line1 = params[:address_line1] if params.key?(:address_line1)
+      billing_entity.address_line2 = params[:address_line2] if params.key?(:address_line2)
+      billing_entity.zipcode = params[:zipcode] if params.key?(:zipcode)
+      billing_entity.city = params[:city] if params.key?(:city)
+      billing_entity.state = params[:state] if params.key?(:state)
+      billing_entity.country = params[:country]&.upcase if params.key?(:country)
+      billing_entity.default_currency = params[:default_currency]&.upcase if params.key?(:default_currency)
+      billing_entity.document_numbering = params[:document_numbering] if params.key?(:document_numbering)
+      billing_entity.document_number_prefix = params[:document_number_prefix] if params.key?(:document_number_prefix)
+      billing_entity.finalize_zero_amount_invoice = params[:finalize_zero_amount_invoice] if params.key?(:finalize_zero_amount_invoice)
+
+      billing = params[:billing_configuration]&.to_h || {}
+      billing_entity.invoice_footer = billing[:invoice_footer] if billing.key?(:invoice_footer)
+      billing_entity.document_locale = billing[:document_locale] if billing.key?(:document_locale)
+
+      # NOTE: handle eu tax management for billing_entity
+      handle_eu_tax_management(params[:eu_tax_management]) if params.key?(:eu_tax_management)
+
+      if License.premium? && billing.key?(:invoice_grace_period)
+        BillingEntities::UpdateInvoiceGracePeriodService.call(
+          billing_entity:,
+          grace_period: billing[:invoice_grace_period]
+        )
+      end
+
+      if params.key?(:net_payment_term)
+        BillingEntities::UpdateInvoicePaymentDueDateService.call(
+          billing_entity:,
+          net_payment_term: params[:net_payment_term]
+        )
+      end
+
+      assign_premium_attributes
+      handle_base64_logo if params.key?(:logo)
+
+      billing_entity.save!
+
+      # I guess we dont need this...
+      # ApiKeys::CacheService.expire_all_cache(billing_entity)
+
+      result.billing_entity = billing_entity
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      result.fail_with_error!(e)
+    end
+
+    private
+
+    attr_reader :billing_entity, :params
+
+    def assign_premium_attributes
+      return unless License.premium?
+
+      billing_entity.timezone = params[:timezone] if params.key?(:timezone)
+      billing_entity.email_settings = params[:email_settings] if params.key?(:email_settings)
+    end
+
+    def handle_base64_logo
+      return if params[:logo].blank?
+
+      base64_data = params[:logo].split(",")
+      data = base64_data.second
+      decoded_base_64_data = Base64.decode64(data)
+
+      # NOTE: data:image/png;base64, should give image/png content_type
+      content_type = base64_data.first.split(";").first.split(":").second
+
+      billing_entity.logo.attach(
+        io: StringIO.new(decoded_base_64_data),
+        filename: "logo",
+        content_type:
+      )
+    end
+
+    def handle_eu_tax_management(eu_tax_management)
+      trying_to_enable_eu_tax_management = params[:eu_tax_management] && !billing_entity.eu_tax_management
+      if !billing_entity.eu_vat_eligible? && trying_to_enable_eu_tax_management
+        result.single_validation_failure!(error_code: "org_must_be_in_eu", field: :eu_tax_management)
+              .raise_if_error!
+      end
+
+      # NOTE: autogenerate service generates taxes.Taxes still belong to organization, but are applied on the billing_entities,
+      # so we need to generate taxes for the organization
+      Taxes::AutoGenerateService.new(billing_entity.organization).call if eu_tax_management
+
+      billing_entity.eu_tax_management = eu_tax_management
+    end
+  end
+end

--- a/app/services/invoices/update_all_invoice_grace_period_from_billing_entity_service.rb
+++ b/app/services/invoices/update_all_invoice_grace_period_from_billing_entity_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Invoices
+  class UpdateAllInvoiceGracePeriodFromBillingEntityService < BaseService
+    def initialize(billing_entity:, old_grace_period:)
+      @billing_entity = billing_entity
+      @old_grace_period = old_grace_period
+
+      super
+    end
+
+    def call
+      billing_entity.invoices.draft.find_each do |invoice|
+        Invoices::UpdateGracePeriodFromBillingEntityJob.perform_later(invoice, old_grace_period)
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :billing_entity, :old_grace_period
+  end
+end

--- a/app/services/invoices/update_grace_period_from_billing_entity_service.rb
+++ b/app/services/invoices/update_grace_period_from_billing_entity_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Invoices
+  class UpdateGracePeriodFromBillingEntityService < BaseService
+    Result = BaseResult[:invoice]
+
+    def initialize(invoice:, old_grace_period:)
+      @invoice = invoice
+      @old_grace_period = old_grace_period
+      super
+    end
+
+    def call
+      result.invoice = invoice
+      # only update issuing_date when there is no override on customer
+      return result if invoice.customer.invoice_grace_period.present?
+      return result if !invoice.draft?
+
+      new_grace_period = invoice.billing_entity.invoice_grace_period
+      # Idempotency! if the applied_grace_period is already the same, we should not update the dates
+      return result if invoice.applied_grace_period == new_grace_period
+
+      grace_period_diff = new_grace_period - old_grace_period
+
+      invoice.issuing_date = invoice.issuing_date + grace_period_diff.days
+      invoice.applied_grace_period = new_grace_period
+      invoice.payment_due_date = invoice.issuing_date + invoice.customer.applicable_net_payment_term.days
+      invoice.save!
+
+      result
+    end
+
+    private
+
+    attr_reader :invoice, :old_grace_period
+  end
+end

--- a/app/services/organizations/update_invoice_payment_due_date_service.rb
+++ b/app/services/organizations/update_invoice_payment_due_date_service.rb
@@ -10,7 +10,7 @@ module Organizations
 
     def call
       ActiveRecord::Base.transaction do
-        # NOTE: Update payment_due_date if net_payment_term changed
+        # NOTE: Set payment_due_date if net_payment_term changed
 
         if organization.net_payment_term != net_payment_term
           organization.net_payment_term = net_payment_term

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -49,6 +49,7 @@ module Organizations
       end
 
       if params.key?(:net_payment_term)
+        # note: this service only assigns new net_payment_term to the organization but doesn't save it
         Organizations::UpdateInvoicePaymentDueDateService.call(
           organization:,
           net_payment_term: params[:net_payment_term]

--- a/spec/factories/billing_entities.rb
+++ b/spec/factories/billing_entities.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
 
     email { Faker::Internet.email }
     email_settings { ["invoice.finalized", "credit_note.created"] }
-    organization
+    organization { create(:organization, billing_entities: [instance]) }
 
     trait :deleted do
       deleted_at { Time.current }

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :invoice do
     customer
+    # TODO: change building invoices from billing_entity by default
     organization
 
     issuing_date { Time.zone.now - 1.day }

--- a/spec/jobs/invoices/update_all_invoice_grace_period_from_billing_entity_job_spec.rb
+++ b/spec/jobs/invoices/update_all_invoice_grace_period_from_billing_entity_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::UpdateAllInvoiceGracePeriodFromBillingEntityJob, type: :job do
+  subject { described_class.perform_now(billing_entity, old_grace_period) }
+
+  let(:billing_entity) { create(:billing_entity) }
+  let(:old_grace_period) { 1 }
+
+  it "calls the service" do
+    allow(Invoices::UpdateAllInvoiceGracePeriodFromBillingEntityService).to receive(:call).with(billing_entity:, old_grace_period:).and_call_original
+    subject
+
+    expect(Invoices::UpdateAllInvoiceGracePeriodFromBillingEntityService).to have_received(:call)
+  end
+end

--- a/spec/jobs/invoices/update_grace_period_from_billing_entity_job_spec.rb
+++ b/spec/jobs/invoices/update_grace_period_from_billing_entity_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::UpdateGracePeriodFromBillingEntityJob, type: :job do
+  subject { described_class.perform_now(invoice, old_grace_period) }
+
+  let(:invoice) { create(:invoice) }
+  let(:old_grace_period) { 1 }
+
+  it "calls the service" do
+    allow(Invoices::UpdateGracePeriodFromBillingEntityService).to receive(:call).with(invoice:, old_grace_period:).and_call_original
+
+    subject
+
+    expect(Invoices::UpdateGracePeriodFromBillingEntityService).to have_received(:call)
+  end
+end

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -176,4 +176,60 @@ RSpec.describe BillingEntity, type: :model do
       end
     end
   end
+
+  describe "#document_number_prefix=" do
+    it "upcases the value" do
+      billing_entity.document_number_prefix = "abc-1234"
+      expect(billing_entity.document_number_prefix).to eq "ABC-1234"
+    end
+  end
+
+  describe "#logo_url" do
+    it "returns the url of the logo saved locally" do
+      logo_file = File.read(Rails.root.join("spec/factories/images/logo.png"))
+      billing_entity.logo.attach(
+        io: StringIO.new(logo_file),
+        filename: "logo",
+        content_type: "image/png"
+      )
+      billing_entity.save!
+      expect(billing_entity.logo_url).to include("rails/active_storage/blobs")
+    end
+  end
+
+  describe "#base64_logo" do
+    it "returns the base64 encoded logo" do
+      logo_file = File.read(Rails.root.join("spec/factories/images/logo.png"))
+      billing_entity.logo.attach(
+        io: StringIO.new(logo_file),
+        filename: "logo",
+        content_type: "image/png"
+      )
+      billing_entity.save!
+      expect(billing_entity.base64_logo).to eq Base64.encode64(logo_file)
+    end
+  end
+
+  describe "#eu_vat_eligible?" do
+    context "when country is nil" do
+      it "returns false" do
+        billing_entity.country = nil
+        expect(billing_entity).not_to be_eu_vat_eligible
+      end
+    end
+
+    context "when country is not in the EU" do
+      it "returns false" do
+        billing_entity.country = "US"
+        expect(billing_entity).not_to be_eu_vat_eligible
+      end
+    end
+
+    context "when country is in the EU" do
+      it "returns true" do
+        billing_entity.country = "FR"
+        expect(billing_entity).to be_eu_vat_eligible
+      end
+    end
+  end
 end

--- a/spec/services/billing_entities/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/billing_entities/update_invoice_grace_period_service_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BillingEntities::UpdateInvoiceGracePeriodService, type: :service do
+  include ActiveJob::TestHelper
+  subject(:update_service) { described_class.new(billing_entity:, grace_period:) }
+
+  let(:billing_entity) { create(:billing_entity) }
+  let(:organization) { billing_entity.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:grace_period) { 2 }
+
+  describe "#call" do
+    # let(:invoice_to_be_finalized) do
+    #   create(:invoice, status: :draft, customer:, issuing_date: DateTime.parse("19 Jun 2022").to_date, billing_entity:)
+    # end
+    #
+    # let(:invoice_to_not_be_finalized) do
+    #   create(:invoice, status: :draft, customer:, issuing_date: DateTime.parse("21 Jun 2022").to_date, billing_entity:)
+    # end
+    #
+    # before do
+    #   invoice_to_be_finalized
+    #   invoice_to_not_be_finalized
+    #   allow(Invoices::FinalizeJob).to receive(:perform_later)
+    # end
+
+    it "updates invoice grace period on billing_entity" do
+      expect { update_service.call }.to change { billing_entity.reload.invoice_grace_period }.from(0).to(2)
+    end
+
+    #   TODO: uncomment when we start updating invoices
+    #   it "does not finalizes drafts that should be finalized" do
+    #     current_date = DateTime.parse("22 Jun 2022")
+    #
+    #     travel_to(current_date) do
+    #       expect {
+    #         perform_enqueued_jobs { update_service.call }
+    #       }.to change { invoice_to_be_finalized.reload.issuing_date }.to(DateTime.parse("21 Jun 2022"))
+    #       expect(Invoices::FinalizeJob).not_to have_received(:perform_later).with(invoice_to_be_finalized)
+    #       expect(invoice_to_be_finalized.reload.status).to eq("draft")
+    #     end
+    #   end
+    #
+    #   it "updates issuing_date and payment_due_date on draft invoices" do
+    #     current_date = DateTime.parse("22 Jun 2022")
+    #
+    #     travel_to(current_date) do
+    #       expect {
+    #         perform_enqueued_jobs { update_service.call }
+    #       }.to change { invoice_to_not_be_finalized.reload.issuing_date }
+    #         .to(DateTime.parse("23 Jun 2022"))
+    #         .and change { invoice_to_not_be_finalized.reload.payment_due_date }
+    #         .to(DateTime.parse("23 Jun 2022"))
+    #         .and change { invoice_to_be_finalized.reload.issuing_date }
+    #         .to(DateTime.parse("21 Jun 2022"))
+    #         .and change { invoice_to_not_be_finalized.reload.payment_due_date }
+    #         .to(DateTime.parse("23 Jun 2022"))
+    #     end
+    #   end
+    #
+    #   context "when customer has net_payment_term" do
+    #     let(:customer) { create(:customer, organization:, net_payment_term: 3, billing_entity:) }
+    #
+    #     it "updates issuing_date on draft invoices" do
+    #       current_date = DateTime.parse("22 Jun 2022")
+    #
+    #       travel_to(current_date) do
+    #         expect { perform_enqueued_jobs { update_service.call } }.to change { invoice_to_not_be_finalized.reload.issuing_date }
+    #           .to(DateTime.parse("23 Jun 2022"))
+    #           .and change { invoice_to_not_be_finalized.reload.payment_due_date }
+    #           .to(DateTime.parse("26 Jun 2022"))
+    #       end
+    #     end
+    #   end
+    #
+    #   context "when grace_period is the same as the current one" do
+    #     let(:grace_period) { billing_entity.invoice_grace_period }
+    #
+    #     it "does not finalize any draft invoices" do
+    #       current_date = DateTime.parse("22 Jun 2022")
+    #
+    #       travel_to(current_date) do
+    #         update_service.call
+    #
+    #         expect(Invoices::FinalizeJob).not_to have_received(:perform_later)
+    #       end
+    #     end
+    #
+    #     it "does not update issuing_date on draft invoices" do
+    #       current_date = DateTime.parse("22 Jun 2022")
+    #
+    #       travel_to(current_date) do
+    #         expect { update_service.call }.not_to change { invoice_to_not_be_finalized.reload.issuing_date }
+    #       end
+    #     end
+    #   end
+  end
+end

--- a/spec/services/billing_entities/update_invoice_payment_due_date_service_spec.rb
+++ b/spec/services/billing_entities/update_invoice_payment_due_date_service_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BillingEntities::UpdateInvoicePaymentDueDateService, type: :service do
+  subject(:update_service) { described_class.new(billing_entity:, net_payment_term:) }
+
+  let(:billing_entity) { create(:billing_entity) }
+  let(:organization) { billing_entity.organization }
+  let(:customer) { create(:customer, organization:, net_payment_term: customer_net_payment_term) }
+  let(:customer_net_payment_term) { nil }
+  let(:net_payment_term) { 30 }
+
+  describe "#call" do
+    it "updates invoice payment_due_date" do
+      result = update_service.call
+      expect(result.billing_entity.net_payment_term).to eq(30)
+    end
+
+    # TODO: uncomment when we start updating invoices
+    # let(:draft_invoice) do
+    #   create(:invoice, status: :draft, customer:, organization:, issuing_date: DateTime.parse("21 Jun 2022"), billing_entity:)
+    # end
+    #
+    # before do
+    #   draft_invoice
+    # end
+    #
+    # it "updates invoice payment_due_date" do
+    #   expect { update_service.call }.to change { draft_invoice.reload.payment_due_date }
+    #     .from(DateTime.parse("21 Jun 2022"))
+    #     .to(DateTime.parse("21 Jun 2022") + net_payment_term.days)
+    # end
+    #
+    # it "updates invoice net_payment_date" do
+    #   expect { update_service.call }.to change { draft_invoice.reload.net_payment_term }
+    #     .from(0).to(30)
+    # end
+    #
+    # context "when customer has their own net_payment_term" do
+    #   let(:customer_net_payment_term) { 10 }
+    #
+    #   it "doesn't update fields" do
+    #     expect { update_service.call }.not_to change { draft_invoice.reload.payment_due_date }
+    #     expect { update_service.call }.not_to change { draft_invoice.reload.net_payment_term }
+    #   end
+    # end
+  end
+end

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BillingEntities::UpdateService do
+  subject(:update_service) { described_class.new(billing_entity:, params:) }
+
+  let(:billing_entity) { create(:billing_entity) }
+
+  let(:timezone) { nil }
+  let(:email_settings) { [] }
+  let(:invoice_grace_period) { 0 }
+  let(:logo) { nil }
+  let(:country) { "fr" }
+
+  let(:params) do
+    {
+      legal_name: "Foobar",
+      legal_number: "1234",
+      tax_identification_number: "2246",
+      email: "foo@bar.com",
+      address_line1: "Line 1",
+      address_line2: "Line 2",
+      state: "Foobar",
+      zipcode: "FOO1234",
+      city: "Foobar",
+      default_currency: "EUR",
+      country:,
+      timezone:,
+      logo:,
+      email_settings:,
+      billing_configuration: {
+        invoice_footer: "invoice footer",
+        document_locale: "fr",
+        invoice_grace_period:
+      }
+    }
+  end
+
+  describe "#call" do
+    it "updates the billing_entity" do
+      result = update_service.call
+
+      expect(result.billing_entity.legal_name).to eq("Foobar")
+      expect(result.billing_entity.legal_number).to eq("1234")
+      expect(result.billing_entity.tax_identification_number).to eq("2246")
+      expect(result.billing_entity.email).to eq("foo@bar.com")
+      expect(result.billing_entity.address_line1).to eq("Line 1")
+      expect(result.billing_entity.address_line2).to eq("Line 2")
+      expect(result.billing_entity.state).to eq("Foobar")
+      expect(result.billing_entity.zipcode).to eq("FOO1234")
+      expect(result.billing_entity.city).to eq("Foobar")
+      expect(result.billing_entity.country).to eq("FR")
+      expect(result.billing_entity.default_currency).to eq("EUR")
+      expect(result.billing_entity.timezone).to eq("UTC")
+
+      expect(result.billing_entity.invoice_footer).to eq("invoice footer")
+      expect(result.billing_entity.document_locale).to eq("fr")
+    end
+
+    context "when document_number_prefix is sent" do
+      before { params[:document_number_prefix] = "abc" }
+
+      it "converts document_number_prefix to upcase version" do
+        result = update_service.call
+
+        expect(result.billing_entity.document_number_prefix).to eq("ABC")
+      end
+    end
+
+    context "when finalize_zero_amount_invoice is sent" do
+      before { params[:finalize_zero_amount_invoice] = "false" }
+
+      it "sets finalize_zero_amount_invoice" do
+        result = update_service.call
+
+        expect(result.billing_entity.finalize_zero_amount_invoice).to eq(false)
+      end
+    end
+
+    context "when document_number_prefix is invalid" do
+      before { params[:document_number_prefix] = "aaaaaaaaaaaaaaa" }
+
+      it "returns an error" do
+        result = update_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:document_number_prefix]).to eq(["value_is_too_long"])
+      end
+    end
+
+    context "with premium features" do
+      around { |test| lago_premium!(&test) }
+
+      let(:timezone) { "Europe/Paris" }
+      let(:email_settings) { ["invoice.finalized"] }
+
+      it "updates the billing_entity" do
+        result = update_service.call
+
+        expect(result.billing_entity.timezone).to eq("Europe/Paris")
+      end
+
+      context "when updating invoice grace period" do
+        let(:customer) { create(:customer, billing_entity:) }
+
+        let(:invoice_grace_period) { 2 }
+
+        # before do
+        #   allow(Invoices::UpdateAllInvoiceGracePeriodFromOrganizationJob).to receive(:perform_later)
+        # end
+
+        it "triggers async updates grace_period of invoices" do
+          current_date = DateTime.parse("22 Jun 2022")
+
+          travel_to(current_date) do
+            result = update_service.call
+
+            expect(result.billing_entity.invoice_grace_period).to eq(2)
+            # expect(Invoices::UpdateAllInvoiceGracePeriodFromOrganizationJob).not_to have_received(:perform_later).with(billing_entity, invoice_grace_period)
+          end
+        end
+      end
+
+      context "when updating net_payment_term" do
+        let(:customer) { create(:customer, billing_entity:) }
+
+        let(:params) do
+          {
+            net_payment_term: 2
+          }
+        end
+
+        # before do
+        # allow(BillingEntities::UpdateInvoicePaymentDueDateService).to receive(:call).and_call_original
+        # end
+
+        it "updates the corresponding draft invoices" do
+          current_date = DateTime.parse("22 Jun 2022")
+
+          travel_to(current_date) do
+            result = update_service.call
+            expect(result).to be_success
+
+            expect(result.billing_entity.net_payment_term).to eq(2)
+            # expect(BillingEntities::UpdateInvoicePaymentDueDateService).to have_received(:call).with(billing_entity:, net_payment_term: 2)
+          end
+        end
+      end
+    end
+
+    context "with base64 logo" do
+      let(:logo) do
+        logo_file = File.read(Rails.root.join("spec/factories/images/logo.png"))
+        base64_logo = Base64.encode64(logo_file)
+
+        "data:image/png;base64,#{base64_logo}"
+      end
+
+      it "updates the billing_entity with logo" do
+        result = update_service.call
+        expect(result.billing_entity.logo.blob).not_to be_nil
+      end
+    end
+
+    context "with validation errors" do
+      let(:country) { "---" }
+
+      it "returns an error" do
+        result = update_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:country]).to eq(["not_a_valid_country_code"])
+      end
+    end
+
+    context "with eu tax management" do
+      context "with org within the EU" do
+        let(:params) { {eu_tax_management: true, country: "fr"} }
+        let(:tax_auto_generate_service) { instance_double(Taxes::AutoGenerateService) }
+
+        before do
+          allow(Taxes::AutoGenerateService).to receive(:new).and_return(tax_auto_generate_service)
+          allow(tax_auto_generate_service).to receive(:call)
+        end
+
+        it "calls the taxes auto generate service" do
+          result = update_service.call
+
+          expect(result).to be_success
+          expect(tax_auto_generate_service).to have_received(:call)
+        end
+      end
+
+      context "with org outside the EU" do
+        let(:params) { {eu_tax_management: true, country: "us"} }
+        let(:tax_auto_generate_service) { instance_double(Taxes::AutoGenerateService) }
+
+        before do
+          allow(Taxes::AutoGenerateService).to receive(:new).and_return(tax_auto_generate_service)
+          allow(tax_auto_generate_service).to receive(:call)
+        end
+
+        it "calls the taxes auto generate service" do
+          result = update_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({eu_tax_management: ["org_must_be_in_eu"]})
+          expect(tax_auto_generate_service).not_to have_received(:call)
+        end
+      end
+
+      context "with org is outside the EU but feature is already enabled" do
+        let(:params) { {eu_tax_management: false} }
+        let(:tax_auto_generate_service) { instance_double(Taxes::AutoGenerateService) }
+
+        before do
+          billing_entity.country = "us"
+          billing_entity.eu_tax_management = true
+          allow(Taxes::AutoGenerateService).to receive(:new).and_return(tax_auto_generate_service)
+          allow(tax_auto_generate_service).to receive(:call)
+        end
+
+        it "can disable eu_tax_management" do
+          result = update_service.call
+
+          expect(result).to be_success
+          expect(tax_auto_generate_service).not_to have_received(:call)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/update_all_invoice_grace_period_from_billing_entity_service_spec.rb
+++ b/spec/services/invoices/update_all_invoice_grace_period_from_billing_entity_service_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::UpdateAllInvoiceGracePeriodFromBillingEntityService do
+  subject { described_class.new(billing_entity:, old_grace_period:) }
+
+  let(:billing_entity) { create(:billing_entity) }
+  let(:organization) { billing_entity.organization }
+  let(:old_grace_period) { 12 }
+
+  context "without draft invoices" do
+    it "enqueues zero jobs" do
+      expect { subject.call }.not_to enqueue_job(Invoices::UpdateGracePeriodFromBillingEntityJob)
+    end
+  end
+
+  context "with draft invoice present" do
+    let(:draft_invoice) { create(:invoice, :draft, organization:) }
+
+    before { draft_invoice }
+
+    it "enqueues 1 job for the draft invoice" do
+      expect { subject.call }.to enqueue_job(Invoices::UpdateGracePeriodFromBillingEntityJob)
+        .with(draft_invoice, old_grace_period)
+    end
+
+    context "with finalized invoice present" do
+      let(:finalized_invoice) { create(:invoice, :finalized, organization:) }
+
+      before { finalized_invoice }
+
+      it "enqueues only 1 job for the draft invoice" do
+        expect { subject.call }.to enqueue_job(Invoices::UpdateGracePeriodFromBillingEntityJob)
+          .with(draft_invoice, old_grace_period)
+      end
+    end
+  end
+end

--- a/spec/services/invoices/update_grace_period_from_billing_entity_service_spec.rb
+++ b/spec/services/invoices/update_grace_period_from_billing_entity_service_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::UpdateGracePeriodFromBillingEntityService do
+  subject { described_class.new(invoice:, old_grace_period:) }
+
+  let(:invoice) { create(:invoice, :draft, issuing_date:, payment_due_date:, applied_grace_period: 12) }
+
+  let(:issuing_date) { Time.current + old_grace_period.days }
+  let(:payment_due_date) { issuing_date }
+
+  let(:old_grace_period) { 12 }
+
+  let(:new_grace_period) { 1 }
+
+  before do
+    invoice.billing_entity.update invoice_grace_period: new_grace_period
+  end
+
+  context "when invoice grace period comes from the customer" do
+    before do
+      invoice.customer.update(invoice_grace_period: 12)
+    end
+
+    it "does not change the issuing_date" do
+      expect { subject.call }.not_to change(invoice, :issuing_date)
+    end
+
+    it "does not change the applied_grace_period" do
+      expect { subject.call }.not_to change(invoice, :applied_grace_period)
+    end
+  end
+
+  context "when new grace period is equal to the already applied one" do
+    before do
+      invoice.update applied_grace_period: new_grace_period
+    end
+
+    it "does not change the issuing_date" do
+      expect { subject.call }.not_to change(invoice, :issuing_date)
+    end
+
+    it "does not change the applied_grace_period" do
+      expect { subject.call }.not_to change(invoice, :applied_grace_period)
+    end
+  end
+
+  context "when invoice is not draft" do
+    before do
+      invoice.finalized!
+    end
+
+    it "does not change the issuing_date" do
+      expect { subject.call }.not_to change(invoice, :issuing_date)
+    end
+
+    it "does not change the applied_grace_period" do
+      expect { subject.call }.not_to change(invoice, :applied_grace_period)
+    end
+  end
+
+  context "when going from 12 to 15 days" do
+    let(:new_grace_period) { 15 }
+
+    it "changes the issuing_date by 3 days" do
+      expect { subject.call }.to change(invoice, :issuing_date).by(3)
+    end
+
+    it "changes the applied_grace_to 15" do
+      expect { subject.call }.to change(invoice, :applied_grace_period).to(15)
+    end
+
+    it "changes the payment_due_date by 3 days" do
+      expect { subject.call }.to change(invoice, :payment_due_date).by(3)
+    end
+  end
+
+  context "when going from 12 to 9 days" do
+    let(:new_grace_period) { 9 }
+
+    it "changes the issuing_date by 3 days" do
+      expect { subject.call }.to change(invoice, :issuing_date).by(-3)
+    end
+
+    it "changes the applied_grace_to 9" do
+      expect { subject.call }.to change(invoice, :applied_grace_period).to(9)
+    end
+
+    it "changes the payment_due_date by 3 days" do
+      expect { subject.call }.to change(invoice, :payment_due_date).by(-3)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We need a service to update billing_entity data that is doing exactly everything that is currently done when updating an organization.
Since in the future we'll be storing grace period, net_payment term only on billing_entity, we also need services that will be updating these values on invoices, but we shouldn't trigger invoices updates now

## Description

Added services:
- `billing_entities/update`
- `billing_entities/update_invoice_grace_period`
- `billing_entities/update_invoice_payment_due_date`
- `invoices/update_all_invoice_grace_period_from_billing_entity`
- `invoices/update_grace_period_from_billing_entity`

Also added jobs:
- `app/jobs/invoices/update_all_invoice_grace_period_from_billing_entity_job.rb`
- `app/jobs/invoices/update_grace_period_from_billing_entity_job.rb`

For now the jobs are not triggered and update invoice update services are not triggered