### PR TITLE
feat(multi-entities): Add multi_entities premium integrations with two tiers...

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -81,6 +81,8 @@ class Organization < ApplicationRecord
     manual_payments
     from_email
     preview
+    multi_entities_pro
+    multi_entities_enterprise
   ].freeze
   PREMIUM_INTEGRATIONS = INTEGRATIONS - %w[anrok]
 
@@ -172,6 +174,10 @@ class Organization < ApplicationRecord
     ENV["LAGO_FROM_EMAIL"]
   end
 
+  def can_create_billing_entities?
+    remaining_billing_entities > 0
+  end
+
   private
 
   # NOTE: After creating an organization, default document_number_prefix needs to be generated.
@@ -191,6 +197,13 @@ class Organization < ApplicationRecord
       self.hmac_key = SecureRandom.uuid
       break unless self.class.exists?(hmac_key:)
     end
+  end
+
+  def remaining_billing_entities
+    return Float::INFINITY if multi_entities_enterprise_enabled?
+    return 2 - billing_entities.count if multi_entities_pro_enabled?
+
+    0
   end
 end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -4465,6 +4465,8 @@ enum IntegrationTypeEnum {
   from_email
   hubspot
   manual_payments
+  multi_entities_enterprise
+  multi_entities_pro
   netsuite
   okta
   preview
@@ -6516,6 +6518,8 @@ enum PremiumIntegrationTypeEnum {
   from_email
   hubspot
   manual_payments
+  multi_entities_enterprise
+  multi_entities_pro
   netsuite
   okta
   preview

--- a/schema.json
+++ b/schema.json
@@ -20703,6 +20703,18 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "multi_entities_pro",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "multi_entities_enterprise",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -31198,6 +31210,18 @@
             },
             {
               "name": "preview",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "multi_entities_pro",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "multi_entities_enterprise",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
+++ b/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Types::Integrations::PremiumIntegrationTypeEnum do
       manual_payments
       from_email
       preview
+      multi_entities_pro
+      multi_entities_enterprise
     ]
   end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -244,6 +244,48 @@ RSpec.describe Organization, type: :model do
     end
   end
 
+  describe "#can_create_more_billing_entities?" do
+    subject { organization.can_create_billing_entities? }
+
+    around { |test| lago_premium!(&test) }
+
+    context "when no premium multi entities integration is enabled" do
+      it { is_expected.to eq(false) }
+    end
+
+    context "when the premium multi_entities_pro integration is enabled" do
+      before do
+        organization.update!(premium_integrations: ["multi_entities_pro"])
+      end
+
+      it { is_expected.to eq(true) }
+
+      context "when the organization has reached the limit" do
+        before do
+          create_list(:billing_entity, 2, organization:)
+        end
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    context "when the premium multi_entities_enterprise integration is enabled" do
+      before do
+        organization.update!(premium_integrations: ["multi_entities_enterprise"])
+      end
+
+      it { is_expected.to eq(true) }
+
+      context "when the organization has some billing entities" do
+        before do
+          create_list(:billing_entity, 2, organization:)
+        end
+
+        it { is_expected.to eq(true) }
+      end
+    end
+  end
+
   describe "#admins" do
     subject { organization.admins }
 


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

## Description

`multi_entities_pro` -> allows 2 billing entities
`multi_entities_enterprise` -> allows unlimited billing entities

Also add the means to check if the organzation can create new entities not reaching already the max number of billing entities per integration tier.

