### PR TITLE
feat(data): Extract revenue streams resolver to data_api namespace

### DIFF
--- a/app/config/permissions/definition.yml
+++ b/app/config/permissions/definition.yml
@@ -8,6 +8,9 @@ billable_metrics:
   create:
   update:
   delete:
+data_api:
+  revenue_streams:
+    view:
 plans:
   view: true
   create:

--- a/app/config/permissions/role-finance.yml
+++ b/app/config/permissions/role-finance.yml
@@ -8,6 +8,9 @@ billable_metrics:
   create: false
   update: false
   delete: false
+data_api:
+  revenue_streams:
+    view: true
 plans:
   create: false
   update: false

--- a/app/config/permissions/role-manager.yml
+++ b/app/config/permissions/role-manager.yml
@@ -8,6 +8,9 @@ billable_metrics:
   create: false
   update: false
   delete: false
+data_api:
+  revenue_streams:
+    view: false
 plans:
   create: false
   update: false

--- a/app/graphql/resolvers/data_api/revenue_streams_resolver.rb
+++ b/app/graphql/resolvers/data_api/revenue_streams_resolver.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module Resolvers
-  module Analytics
+  module DataApi
     class RevenueStreamsResolver < Resolvers::BaseResolver
       include AuthenticableApiUser
       include RequiredOrganization
 
-      REQUIRED_PERMISSION = "analytics:view"
+      REQUIRED_PERMISSION = "data_api:revenue_streams:view"
 
       description "Query revenue streams of an organization"
 
@@ -17,14 +17,14 @@ module Resolvers
       argument :from_date, GraphQL::Types::ISO8601Date, required: false
       argument :to_date, GraphQL::Types::ISO8601Date, required: false
 
-      argument :time_granularity, Types::Analytics::TimeGranularityEnum, required: false
+      argument :time_granularity, Types::DataApi::TimeGranularityEnum, required: false
 
       argument :external_customer_id, String, required: false
       argument :external_subscription_id, String, required: false
 
       argument :plan_code, String, required: false
 
-      type Types::Analytics::RevenueStreams::Object.collection_type, null: false
+      type Types::DataApi::RevenueStreams::Object.collection_type, null: false
 
       def resolve(**args)
         raise unauthorized_error unless License.premium?

--- a/app/graphql/types/data_api/revenue_streams/object.rb
+++ b/app/graphql/types/data_api/revenue_streams/object.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Types
-  module Analytics
+  module DataApi
     module RevenueStreams
       class Object < Types::BaseObject
         graphql_name "RevenueStreams"

--- a/app/graphql/types/data_api/time_granularity_enum.rb
+++ b/app/graphql/types/data_api/time_granularity_enum.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Types
-  module Analytics
+  module DataApi
     class TimeGranularityEnum < Types::BaseEnum
       value :daily
       value :weekly

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -68,7 +68,7 @@ module Types
     field :payments, resolver: Resolvers::PaymentsResolver
     field :plan, resolver: Resolvers::PlanResolver
     field :plans, resolver: Resolvers::PlansResolver
-    field :revenue_streams, resolver: Resolvers::Analytics::RevenueStreamsResolver
+    field :revenue_streams, resolver: Resolvers::DataApi::RevenueStreamsResolver
     field :subscription, resolver: Resolvers::SubscriptionResolver
     field :subscriptions, resolver: Resolvers::SubscriptionsResolver
     field :tax, resolver: Resolvers::TaxResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -6389,6 +6389,7 @@ type Permissions {
   customersDelete: Boolean!
   customersUpdate: Boolean!
   customersView: Boolean!
+  dataApiRevenueStreamsView: Boolean!
   developersKeysManage: Boolean!
   developersManage: Boolean!
   draftInvoicesUpdate: Boolean!

--- a/schema.json
+++ b/schema.json
@@ -29700,6 +29700,22 @@
               "args": []
             },
             {
+              "name": "dataApiRevenueStreamsView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "developersKeysManage",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/data_api/revenue_streams_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams_resolver_spec.rb
@@ -2,8 +2,8 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Analytics::RevenueStreamsResolver, type: :graphql do
-  let(:required_permission) { "analytics:view" }
+RSpec.describe Resolvers::DataApi::RevenueStreamsResolver, type: :graphql do
+  let(:required_permission) { "data_api:revenue_streams:view" }
   let(:query) do
     <<~GQL
       query($customerCurrency: CurrencyEnum, $externalCustomerId: String) {
@@ -30,7 +30,7 @@ RSpec.describe Resolvers::Analytics::RevenueStreamsResolver, type: :graphql do
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
-  it_behaves_like "requires permission", "analytics:view"
+  it_behaves_like "requires permission", "data_api:revenue_streams:view"
 
   context "without premium feature" do
     it "returns an error" do

--- a/spec/graphql/types/data_api/revenue_streams/object_spec.rb
+++ b/spec/graphql/types/data_api/revenue_streams/object_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::DataApi::RevenueStreams::Object do
+  subject { described_class }
+
+  it do
+    expect(subject.graphql_name).to eq("RevenueStreams")
+    expect(subject).to have_field(:amount_currency).of_type("CurrencyEnum!")
+    expect(subject).to have_field(:coupons_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:gross_revenue_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:net_revenue_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:commitment_fee_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:one_off_fee_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:subscription_fee_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:usage_based_fee_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:end_of_period_dt).of_type("ISO8601Date!")
+    expect(subject).to have_field(:start_of_period_dt).of_type("ISO8601Date!")
+  end
+end

--- a/spec/graphql/types/data_api/time_granularity_enum_spec.rb
+++ b/spec/graphql/types/data_api/time_granularity_enum_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::DataApi::TimeGranularityEnum do
+  it "enumerizes the correct values" do
+    expect(described_class.values.keys).to match_array(%w[daily weekly monthly])
+  end
+end


### PR DESCRIPTION
**Context**

A lot of users ain’t using our analytics feature because it’s not detailed enough. Thus, we are revamping the Analytics dashboard.

**Description**

This pull request extracts revenue streams resolver to `data_api` namespace.