### PR TITLE
feat(invoice-preview): Add invoice preview with simulated termination date on subscription

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -275,6 +275,7 @@ module Api
           :billing_time,
           :subscription_at,
           subscriptions: [
+            :terminated_at,
             external_ids: []
           ],
           coupons: [

--- a/app/services/invoices/preview/subscriptions_service.rb
+++ b/app/services/invoices/preview/subscriptions_service.rb
@@ -41,6 +41,7 @@ module Invoices
 
         customer_subscriptions.map do |subscription|
           subscription.terminated_at = terminated_at
+          subscription.status = :terminated
           subscription
         end
       end

--- a/app/services/invoices/preview/subscriptions_service.rb
+++ b/app/services/invoices/preview/subscriptions_service.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Preview
+    class SubscriptionsService < BaseService
+      Result = BaseResult[:subscriptions]
+
+      def initialize(organization:, customer:, params:)
+        @organization = organization
+        @customer = customer
+        @params = params
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: "customer") unless customer
+
+        result.subscriptions = handle_subscriptions
+        result
+      rescue ActiveRecord::RecordNotFound => exception
+        result.not_found_failure!(resource: exception.model.demodulize.underscore)
+        result
+      end
+
+      private
+
+      attr_reader :params, :organization, :customer
+
+      def handle_subscriptions
+        return handle_customer_subscriptions if external_ids.any?
+
+        plan ? [build_subscription] : []
+      end
+
+      def handle_customer_subscriptions
+        terminated_at ? terminate_subscriptions : customer_subscriptions
+      end
+
+      def terminate_subscriptions
+        return [] unless valid_termination?
+
+        customer_subscriptions.map do |subscription|
+          subscription.terminated_at = terminated_at
+          subscription
+        end
+      end
+
+      def build_subscription
+        Subscription.new(
+          customer: customer,
+          plan:,
+          subscription_at: params[:subscription_at].presence || Time.current,
+          started_at: params[:subscription_at].presence || Time.current,
+          billing_time:,
+          created_at: params[:subscription_at].presence || Time.current,
+          updated_at: Time.current
+        )
+      end
+
+      def billing_time
+        if Subscription::BILLING_TIME.include?(params[:billing_time]&.to_sym)
+          params[:billing_time]
+        else
+          "calendar"
+        end
+      end
+
+      def customer_subscriptions
+        @customer_subscriptions ||= customer
+          .subscriptions
+          .active
+          .where(external_id: external_ids)
+      end
+
+      def valid_termination?
+        if customer_subscriptions.size > 1
+          result.single_validation_failure!(
+            error_code: "only_one_subscription_allowed_for_termination",
+            field: :subscriptions
+          )
+        end
+
+        if parsed_terminated_at&.to_date&.past?
+          result.single_validation_failure!(
+            error_code: "cannot_be_in_past",
+            field: :terminated_at
+          )
+        end
+
+        result.success?
+      end
+
+      def parsed_terminated_at
+        Time.zone.parse(terminated_at)
+      rescue ArgumentError
+        result.single_validation_failure!(error_code: "invalid_timestamp", field: :terminated_at)
+        nil
+      end
+
+      def terminated_at
+        params.dig(:subscriptions, :terminated_at)
+      end
+
+      def external_ids
+        Array(params.dig(:subscriptions, :external_ids))
+      end
+
+      def plan
+        organization.plans.find_by!(code: params[:plan_code])
+      end
+    end
+  end
+end

--- a/app/services/invoices/preview/subscriptions_service.rb
+++ b/app/services/invoices/preview/subscriptions_service.rb
@@ -92,10 +92,12 @@ module Invoices
       end
 
       def parsed_terminated_at
-        Time.zone.parse(terminated_at)
-      rescue ArgumentError
-        result.single_validation_failure!(error_code: "invalid_timestamp", field: :terminated_at)
-        nil
+        if Utils::Datetime.valid_format?(terminated_at)
+          Time.zone.parse(terminated_at)
+        else
+          result.single_validation_failure!(error_code: "invalid_timestamp", field: :terminated_at)
+          nil
+        end
       end
 
       def terminated_at

--- a/spec/services/invoices/preview/subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/subscriptions_service_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "pry"
-
 RSpec.describe Invoices::Preview::SubscriptionsService, type: :service do
   let(:result) { described_class.call(organization:, customer:, params:) }
 

--- a/spec/services/invoices/preview/subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/subscriptions_service_spec.rb
@@ -83,7 +83,10 @@ RSpec.describe Invoices::Preview::SubscriptionsService, type: :service do
           it "returns result with subscriptions marked as terminated" do
             expect(subject).to all(
               be_a(Subscription)
-                .and(have_attributes(terminated_at: terminated_at.change(usec: 0)))
+                .and(have_attributes(
+                  terminated_at: terminated_at.change(usec: 0),
+                  status: "terminated"
+                ))
             )
           end
         end

--- a/spec/services/invoices/preview/subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/subscriptions_service_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "pry"
+
+RSpec.describe Invoices::Preview::SubscriptionsService, type: :service do
+  let(:result) { described_class.call(organization:, customer:, params:) }
+
+  describe "#call" do
+    subject { result.subscriptions }
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+
+    context "when customer is missing" do
+      let(:customer) { nil }
+      let(:params) { {} }
+
+      it "returns a failed result with customer not found error" do
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq("customer_not_found")
+      end
+    end
+
+    context "when external_ids are provided" do
+      let!(:subscriptions) { create_pair(:subscription, customer:) }
+      let(:subscription_ids) { subscriptions.map(&:external_id) }
+
+      context "when terminated at is not provided" do
+        let(:params) do
+          {
+            subscriptions: {
+              external_ids: subscriptions.map(&:external_id)
+            }
+          }
+        end
+
+        it "returns persisted customer subscriptions" do
+          expect(subject.pluck(:external_id)).to match_array subscriptions.map(&:external_id)
+        end
+      end
+
+      context "when terminated at is provided" do
+        let(:external_ids) { [subscriptions.first.external_id] }
+        let(:terminated_at) { generate(:future_date) }
+
+        let(:params) do
+          {
+            subscriptions: {
+              external_ids: external_ids,
+              terminated_at: terminated_at.to_s
+            }
+          }
+        end
+
+        context "when invalid timestamp provided" do
+          let(:terminated_at) { "2025" }
+
+          it "returns a failed result with invalid timestamp error" do
+            expect(result).not_to be_success
+            expect(result.error.messages).to match(terminated_at: ["invalid_timestamp"])
+          end
+        end
+
+        context "when past timestamp provided" do
+          let(:terminated_at) { generate(:past_date) }
+
+          it "returns a failed result with past timestamp error" do
+            expect(result).not_to be_success
+            expect(result.error.messages).to match(terminated_at: ["cannot_be_in_past"])
+          end
+        end
+
+        context "when multiple subscriptions passed" do
+          let(:external_ids) { subscriptions.map(&:external_id) }
+
+          it "returns a failed result with multiple subscriptions error" do
+            expect(result).not_to be_success
+
+            expect(result.error.messages)
+              .to match(subscriptions: ["only_one_subscription_allowed_for_termination"])
+          end
+        end
+
+        context "when all validations passed" do
+          it "returns result with subscriptions marked as terminated" do
+            expect(subject).to all(
+              be_a(Subscription)
+                .and(have_attributes(terminated_at: terminated_at.change(usec: 0)))
+            )
+          end
+        end
+      end
+    end
+
+    context "when external_ids are not provided" do
+      let(:params) do
+        {
+          billing_time:,
+          plan_code: plan&.code,
+          subscription_at: subscription_at&.iso8601
+        }
+      end
+
+      context "when plan matching provided code exists" do
+        let(:plan) { create(:plan, organization:) }
+
+        before { freeze_time }
+
+        context "when billing time and subscription date are present" do
+          let(:subscription_at) { generate(:past_date) }
+          let(:billing_time) { "anniversary" }
+
+          it "returns new subscription with provided params" do
+            expect(subject)
+              .to all(
+                be_a(Subscription)
+                  .and(have_attributes(
+                    customer:,
+                    plan:,
+                    subscription_at: subscription_at,
+                    started_at: subscription_at,
+                    billing_time: params[:billing_time]
+                  ))
+              )
+          end
+        end
+
+        context "when billing time and subscription date are missing" do
+          let(:subscription_at) { nil }
+          let(:billing_time) { nil }
+
+          it "returns new subscription with default values for subscription date and billing time" do
+            expect(subject)
+              .to all(
+                be_a(Subscription)
+                  .and(have_attributes(
+                    customer:,
+                    plan:,
+                    subscription_at: Time.current,
+                    started_at: Time.current,
+                    billing_time: "calendar"
+                  ))
+              )
+          end
+        end
+      end
+
+      context "when plan matching provided code does not exist" do
+        let(:plan) { nil }
+        let(:subscription_at) { nil }
+        let(:billing_time) { nil }
+
+        it "returns nil" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("plan_not_found")
+
+          expect(subject).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/preview_context_service_spec.rb
+++ b/spec/services/invoices/preview_context_service_spec.rb
@@ -182,50 +182,29 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
       }
     end
 
-    context "when plan matching provided code exists" do
+    context "with valid params" do
       let(:plan) { create(:plan, organization:) }
+      let(:subscription_at) { generate(:past_date) }
+      let(:billing_time) { "anniversary" }
 
       before { freeze_time }
 
-      context "when billing time and subscription date are present" do
-        let(:subscription_at) { generate(:past_date) }
-        let(:billing_time) { "anniversary" }
-
-        it "returns new subscription with provided params" do
-          expect(subject)
-            .to all(
-              be_a(Subscription)
-                .and(have_attributes(
-                  customer:,
-                  plan:,
-                  subscription_at: subscription_at,
-                  started_at: subscription_at,
-                  billing_time: params[:billing_time]
-                ))
-            )
-        end
-      end
-
-      context "when billing time and subscription date are missing" do
-        let(:subscription_at) { nil }
-        let(:billing_time) { nil }
-
-        it "returns new subscription with default values for subscription date and billing time" do
-          expect(subject)
-            .to all(
-              be_a(Subscription).and(have_attributes(
+      it "returns new subscription with provided params" do
+        expect(subject)
+          .to all(
+            be_a(Subscription)
+              .and(have_attributes(
                 customer:,
                 plan:,
-                subscription_at: Time.current,
-                started_at: Time.current,
-                billing_time: "calendar"
+                subscription_at: subscription_at,
+                started_at: subscription_at,
+                billing_time: params[:billing_time]
               ))
-            )
-        end
+          )
       end
     end
 
-    context "when plan matching provided code does not exist" do
+    context "with invalid params" do
       let(:plan) { nil }
       let(:subscription_at) { nil }
       let(:billing_time) { nil }
@@ -236,28 +215,6 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
         expect(result.error.error_code).to eq("plan_not_found")
 
         expect(subject).to be_nil
-      end
-    end
-
-    context "when subscriptions are fetched from the database" do
-      let(:subscription1) { create(:subscription, customer:) }
-      let(:subscription2) { create(:subscription, customer:) }
-      let(:params) do
-        {
-          customer: {external_id: customer.external_id},
-          subscriptions: {
-            external_ids: [subscription1.external_id, subscription2.external_id]
-          }
-        }
-      end
-
-      before do
-        subscription1
-        subscription2
-      end
-
-      it "returns subscriptions that are persisted" do
-        expect(subject.pluck(:external_id)).to eq([subscription1.external_id, subscription2.external_id])
       end
     end
   end


### PR DESCRIPTION
## Context

Allow to simulate subscription termination for invoice preview. This part only accepts new param and prepare correct subscription object for `PreviewService` which responsible for all invoice generation.

## Description

Add support for `terminated_at` timestamp.
Add validation that only 1 subscription could be terminated.
Add validation for provided timestamp (valid + not in past).
Extract subscription building logic into dedicated class for better separation of concerns.
