### PR TITLE
feat(data): Rename customerCurrency to currency for revenue streams

### DIFF
--- a/app/graphql/resolvers/data_api/revenue_streams_resolver.rb
+++ b/app/graphql/resolvers/data_api/revenue_streams_resolver.rb
@@ -10,8 +10,9 @@ module Resolvers
 
       description "Query revenue streams of an organization"
 
+      argument :currency, Types::CurrencyEnum, required: false
+
       argument :customer_country, Types::CountryCodeEnum, required: false
-      argument :customer_currency, Types::CurrencyEnum, required: false
       argument :customer_type, Types::Customers::CustomerTypeEnum, required: false
 
       argument :from_date, GraphQL::Types::ISO8601Date, required: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -7047,7 +7047,7 @@ type Query {
   """
   Query revenue streams of an organization
   """
-  revenueStreams(customerCountry: CountryCode, customerCurrency: CurrencyEnum, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): RevenueStreamsCollection!
+  revenueStreams(currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): RevenueStreamsCollection!
 
   """
   Query a single subscription of an organization

--- a/schema.json
+++ b/schema.json
@@ -34843,11 +34843,11 @@
               "deprecationReason": null,
               "args": [
                 {
-                  "name": "customerCountry",
+                  "name": "currency",
                   "description": null,
                   "type": {
                     "kind": "ENUM",
-                    "name": "CountryCode",
+                    "name": "CurrencyEnum",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -34855,11 +34855,11 @@
                   "deprecationReason": null
                 },
                 {
-                  "name": "customerCurrency",
+                  "name": "customerCountry",
                   "description": null,
                   "type": {
                     "kind": "ENUM",
-                    "name": "CurrencyEnum",
+                    "name": "CountryCode",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/spec/graphql/resolvers/data_api/revenue_streams_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::DataApi::RevenueStreamsResolver, type: :graphql do
   let(:required_permission) { "data_api:revenue_streams:view" }
   let(:query) do
     <<~GQL
-      query($customerCurrency: CurrencyEnum, $externalCustomerId: String) {
-        revenueStreams(customerCurrency: $customerCurrency, externalCustomerId: $externalCustomerId) {
+      query($currency: CurrencyEnum, $externalCustomerId: String) {
+        revenueStreams(currency: $currency, externalCustomerId: $externalCustomerId) {
           collection {
             amountCurrency
             couponsAmountCents


### PR DESCRIPTION
**Context**

A lot of users ain’t using our analytics feature because it’s not detailed enough. Thus, we are revamping the Analytics dashboard.

**Description**

This pull request renames `customerCurrency` parameter to `currency` for revenue streams.