### PR TITLE
fix(webhook): wallet.updated needs to be sent only after_commit

### DIFF
--- a/app/services/wallets/balance/decrease_service.rb
+++ b/app/services/wallets/balance/decrease_service.rb
@@ -23,8 +23,9 @@ module Wallets
           last_consumed_credit_at: Time.current
         )
 
-        SendWebhookJob.perform_later("wallet.updated", wallet)
         Wallets::Balance::RefreshOngoingService.call(wallet:)
+
+        after_commit { SendWebhookJob.perform_later("wallet.updated", wallet) }
 
         result.wallet = wallet
         result

--- a/app/services/wallets/balance/increase_service.rb
+++ b/app/services/wallets/balance/increase_service.rb
@@ -28,8 +28,9 @@ module Wallets
 
         wallet.update!(update_params)
 
-        SendWebhookJob.perform_later("wallet.updated", wallet)
         Wallets::Balance::RefreshOngoingService.call(wallet:)
+
+        after_commit { SendWebhookJob.perform_later("wallet.updated", wallet) }
 
         result.wallet = wallet
         result


### PR DESCRIPTION
When a Wallet Transaction is settled, the balance of the wallet is increased or decreased. The IncreasedService and DecreasedService are called within a db transaction but the `wallet.updated` job was dispatched immediately, so before the transaction was committed.
