### PR TITLE
feat(stripe): Pre-authorize payment before creating subscription

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -37,8 +37,8 @@ module Api
           end
 
           result = PaymentProviders::Stripe::Payments::AuthorizeService.call(
-            amount: params[:authorization][:amount],
-            currency: params[:authorization][:currency],
+            amount: params[:authorization].fetch(:amount_cents),
+            currency: params[:authorization].fetch(:amount_currency),
             provider_customer: customer.provider_customer,
             metadata: {plan_code: create_params[:plan_code]},
             unique_id: request.request_id

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -57,6 +57,20 @@ module ApiErrors
     )
   end
 
+  def provider_error(provider, error_details)
+    response = {
+      status: 422,
+      error: "Unprocessable Entity",
+      code: "provider_error",
+      provider: {
+        code: provider.code
+      },
+      error_details:
+    }
+
+    render json: response, status: :unprocessable_entity
+  end
+
   def thirdpary_error(error:)
     render(
       json: {
@@ -84,6 +98,8 @@ module ApiErrors
       forbidden_error(code: error_result.error.code)
     when BaseService::UnauthorizedFailure
       unauthorized_error(message: error_result.error.message)
+    when BaseService::ProviderFailure
+      provider_error(error_result.error.provider, error_result.error.error_details)
     when BaseService::ThirdPartyFailure
       thirdpary_error(error: error_result.error)
     else

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -67,7 +67,8 @@ module ApiErrors
           third_party: error.third_party,
           thirdparty_error: error.error_message
         }
-      }
+      },
+      status: :unprocessable_entity
     )
   end
 

--- a/app/jobs/payment_providers/cancel_payment_authorization_job.rb
+++ b/app/jobs/payment_providers/cancel_payment_authorization_job.rb
@@ -5,11 +5,13 @@ module PaymentProviders
     queue_as "providers"
 
     def perform(payment_provider:, id:)
-      case payment_provider.payment_type.to_s
+      provider_name = payment_provider.payment_type.to_s
+      
+      case provider_name
       when "stripe"
         ::Stripe::PaymentIntent.cancel(id, {}, api_key: payment_provider.secret_key)
       else
-        raise NotImplementedError.new("Cancelling payment authorization not implemented for #{provider}")
+        raise NotImplementedError.new("Cancelling payment authorization not implemented for #{provider_name}")
       end
     end
   end

--- a/app/jobs/payment_providers/cancel_payment_authorization_job.rb
+++ b/app/jobs/payment_providers/cancel_payment_authorization_job.rb
@@ -6,7 +6,7 @@ module PaymentProviders
 
     def perform(payment_provider:, id:)
       provider_name = payment_provider.payment_type.to_s
-      
+
       case provider_name
       when "stripe"
         ::Stripe::PaymentIntent.cancel(id, {}, api_key: payment_provider.secret_key)

--- a/app/jobs/payment_providers/cancel_payment_authorization_job.rb
+++ b/app/jobs/payment_providers/cancel_payment_authorization_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  class CancelPaymentAuthorizationJob < ApplicationJob
+    queue_as "providers"
+
+    def perform(payment_provider:, id:)
+      case payment_provider.payment_type.to_s
+      when "stripe"
+        ::Stripe::PaymentIntent.cancel(id, {}, api_key: payment_provider.secret_key)
+      else
+        raise NotImplementedError.new("Cancelling payment authorization not implemented for #{provider}")
+      end
+    end
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -65,6 +65,7 @@ class Organization < ApplicationRecord
   ].freeze
 
   INTEGRATIONS = %w[
+    beta_payment_authorization
     netsuite
     okta
     anrok

--- a/app/services/base_result.rb
+++ b/app/services/base_result.rb
@@ -63,6 +63,10 @@ class BaseResult
     fail_with_error!(BaseService::UnauthorizedFailure.new(self, message:))
   end
 
+  def provider_failure!(provider:, error:)
+    fail_with_error!(BaseService::ProviderFailure.new(self, provider:, error:))
+  end
+
   def third_party_failure!(third_party:, error_code:, error_message:)
     fail_with_error!(BaseService::ThirdPartyFailure.new(self, third_party:, error_code:, error_message:))
   end

--- a/app/services/payment_providers/create_payment_factory.rb
+++ b/app/services/payment_providers/create_payment_factory.rb
@@ -7,8 +7,6 @@ module PaymentProviders
     end
 
     def self.service_class(provider:)
-      # TODO(payment): refactor Invoices::Payments::*Service#call
-      #                into PaymentProviders::*::Payments::CreateService#call
       case provider.to_sym
       when :adyen
         PaymentProviders::Adyen::Payments::CreateService

--- a/app/services/payment_providers/stripe/payments/authorize_service.rb
+++ b/app/services/payment_providers/stripe/payments/authorize_service.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    module Payments
+      class AuthorizeService < BaseService
+        Result = BaseResult[:stripe_payment_intent]
+
+        def initialize(amount:, currency:, provider_customer:, unique_id:, metadata: {})
+          @amount = amount
+          @currency = currency
+          @provider_customer = provider_customer
+          @unique_id = unique_id
+          @metadata = metadata
+
+          super(provider_customer.payment_provider)
+        end
+
+        def call
+          unless provider_customer.payment_method_id
+            return result.single_validation_failure!(field: :payment_method_id, error_code: "customer_has_no_payment_method")
+          end
+
+          pi = create_payment_intent
+
+          result.stripe_payment_intent = pi
+
+          unless is_valid(pi)
+            return result.third_party_failure!(third_party: "Stripe", error_code: "cannot_capture_amount", error_message: "The total amount was not captured.")
+          end
+
+          result
+        rescue ::Stripe::StripeError => e
+          result.third_party_failure!(third_party: "Stripe", error_message: e.message, error_code: e.code)
+        ensure
+          if pi
+            PaymentProviders::CancelPaymentAuthorizationJob.perform_later(
+              payment_provider: provider_customer.payment_provider, id: pi.id
+            )
+          end
+        end
+
+        private
+
+        def is_valid(pi)
+          pi.status == "requires_capture" && pi.amount == pi.amount_capturable
+        end
+
+        def create_payment_intent
+          ::Stripe::PaymentIntent.create(
+            {
+              amount:,
+              currency: currency.downcase,
+              confirm: true,
+              payment_method_options: {
+                card: {
+                  capture_method: "manual"
+                }
+              },
+              customer: provider_customer.provider_customer_id,
+              payment_method: provider_customer.payment_method_id,
+              description: "Pre-authorization for subscription",
+              metadata:
+            },
+            {
+              api_key:,
+              idempotency_key: "auth-#{provider_customer.id}-#{unique_id}"
+            }
+          )
+        end
+
+        attr_reader :amount, :currency, :provider_customer, :unique_id, :metadata
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/stripe/payments/authorize_service.rb
+++ b/app/services/payment_providers/stripe/payments/authorize_service.rb
@@ -31,7 +31,7 @@ module PaymentProviders
 
           result
         rescue ::Stripe::StripeError => e
-          result.third_party_failure!(third_party: "Stripe", error_message: e.message, error_code: e.code)
+          result.provider_failure!(provider: payment_provider, error: e)
         ensure
           if pi
             PaymentProviders::CancelPaymentAuthorizationJob.perform_later(

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -19,7 +19,7 @@ module Subscriptions
         return result
       end
 
-      new_subscription = new_subcription_with_overrides
+      new_subscription = new_subscription_with_overrides
 
       ActiveRecord::Base.transaction do
         cancel_pending_subscription if pending_subscription?
@@ -53,7 +53,7 @@ module Subscriptions
 
     attr_reader :current_subscription, :plan, :params, :name
 
-    def new_subcription_with_overrides
+    def new_subscription_with_overrides
       Subscription.new(
         customer: current_subscription.customer,
         plan: params.key?(:plan_overrides) ? override_plan : plan,

--- a/schema.graphql
+++ b/schema.graphql
@@ -4462,6 +4462,7 @@ enum IntegrationTypeEnum {
   anrok
   api_permissions
   auto_dunning
+  beta_payment_authorization
   from_email
   hubspot
   manual_payments
@@ -6516,6 +6517,7 @@ input PlanOverridesInput {
 enum PremiumIntegrationTypeEnum {
   api_permissions
   auto_dunning
+  beta_payment_authorization
   from_email
   hubspot
   manual_payments

--- a/schema.json
+++ b/schema.json
@@ -20609,6 +20609,12 @@
           "inputFields": null,
           "enumValues": [
             {
+              "name": "beta_payment_authorization",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "netsuite",
               "description": null,
               "isDeprecated": false,
@@ -31140,6 +31146,12 @@
           "fields": null,
           "inputFields": null,
           "enumValues": [
+            {
+              "name": "beta_payment_authorization",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "netsuite",
               "description": null,

--- a/spec/fixtures/stripe/payment_intent_authorization_failed.json
+++ b/spec/fixtures/stripe/payment_intent_authorization_failed.json
@@ -1,0 +1,305 @@
+{
+  "error": {
+    "advice_code": "try_again_later",
+    "charge": "ch_3QxY0cQ8iJWBZFaM1fnWlwJp",
+    "code": "card_declined",
+    "decline_code": "generic_decline",
+    "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+    "message": "Your card was declined.",
+    "payment_intent": {
+      "id": "pi_3QxY0cQ8iJWBZFaM1rmKGIIJ",
+      "object": "payment_intent",
+      "amount": 110,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {}
+      },
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {
+        "object": "list",
+        "data": [
+          {
+            "id": "ch_3QxY0cQ8iJWBZFaM1fnWlwJp",
+            "object": "charge",
+            "amount": 110,
+            "amount_captured": 0,
+            "amount_refunded": 0,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": "US",
+                "line1": null,
+                "line2": null,
+                "postal_code": "87654",
+                "state": null
+              },
+              "email": "adwawd@esef.com",
+              "name": "Testing Stripe",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "JULIEN",
+            "captured": false,
+            "created": 1740766203,
+            "currency": "usd",
+            "customer": "cus_RqyKy71Xwsb1Xr",
+            "description": "Pre-authorization for subscription",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_balance_transaction": null,
+            "failure_code": "card_declined",
+            "failure_message": "Your card was declined.",
+            "fraud_details": {},
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "plan_code": "plan_a"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "advice_code": "try_again_later",
+              "network_advice_code": null,
+              "network_decline_code": null,
+              "network_status": "declined_by_network",
+              "reason": "generic_decline",
+              "risk_level": "normal",
+              "risk_score": 52,
+              "seller_message": "The bank did not return any further details with this decline.",
+              "type": "issuer_declined"
+            },
+            "paid": false,
+            "payment_intent": "pi_3QxY0cQ8iJWBZFaM1rmKGIIJ",
+            "payment_method": "pm_1QxGfaQ8iJWBZFaMWvBuRccO",
+            "payment_method_details": {
+              "card": {
+                "amount_authorized": null,
+                "authorization_code": null,
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": "pass",
+                  "cvc_check": null
+                },
+                "country": "US",
+                "exp_month": 12,
+                "exp_year": 2028,
+                "extended_authorization": {
+                  "status": "disabled"
+                },
+                "fingerprint": "pmIfA8TCefcd72yD",
+                "funding": "credit",
+                "incremental_authorization": {
+                  "status": "unavailable"
+                },
+                "installments": null,
+                "last4": "0341",
+                "mandate": null,
+                "multicapture": {
+                  "status": "unavailable"
+                },
+                "network": "visa",
+                "network_token": {
+                  "used": false
+                },
+                "network_transaction_id": "112109731026556",
+                "overcapture": {
+                  "maximum_amount_capturable": 110,
+                  "status": "unavailable"
+                },
+                "regulated_status": "unregulated",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "radar_options": {},
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": null,
+            "refunded": false,
+            "refunds": {
+              "object": "list",
+              "data": [],
+              "has_more": false,
+              "total_count": 0,
+              "url": "/v1/charges/ch_3QxY0cQ8iJWBZFaM1fnWlwJp/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": null,
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "failed",
+            "transfer_data": null,
+            "transfer_group": null
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/charges?payment_intent=pi_3QxY0cQ8iJWBZFaM1rmKGIIJ"
+      },
+      "client_secret": "pi_3Q**********************_******_*********************eUu2",
+      "confirmation_method": "automatic",
+      "created": 1740766202,
+      "currency": "usd",
+      "customer": "cus_RqyKy71Xwsb1Xr",
+      "description": "Pre-authorization for subscription",
+      "invoice": null,
+      "last_payment_error": {
+        "advice_code": "try_again_later",
+        "charge": "ch_3QxY0cQ8iJWBZFaM1fnWlwJp",
+        "code": "card_declined",
+        "decline_code": "generic_decline",
+        "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+        "message": "Your card was declined.",
+        "payment_method": {
+          "id": "pm_1QxGfaQ8iJWBZFaMWvBuRccO",
+          "object": "payment_method",
+          "allow_redisplay": "always",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": "US",
+              "line1": null,
+              "line2": null,
+              "postal_code": "87654",
+              "state": null
+            },
+            "email": "adwawd@esef.com",
+            "name": "Testing Stripe",
+            "phone": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": "pass",
+              "cvc_check": "pass"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 12,
+            "exp_year": 2028,
+            "fingerprint": "pmIfA8TCefcd72yD",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0341",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1740699551,
+          "customer": "cus_RqyKy71Xwsb1Xr",
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        },
+        "type": "card_error"
+      },
+      "latest_charge": "ch_3QxY0cQ8iJWBZFaM1fnWlwJp",
+      "livemode": false,
+      "metadata": {
+        "plan_code": "plan_a"
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": null,
+      "payment_method_configuration_details": null,
+      "payment_method_options": {
+        "card": {
+          "capture_method": "manual",
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "requires_payment_method",
+      "transfer_data": null,
+      "transfer_group": null
+    },
+    "payment_method": {
+      "id": "pm_1QxGfaQ8iJWBZFaMWvBuRccO",
+      "object": "payment_method",
+      "allow_redisplay": "always",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": "US",
+          "line1": null,
+          "line2": null,
+          "postal_code": "87654",
+          "state": null
+        },
+        "email": "adwawd@esef.com",
+        "name": "Testing Stripe",
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": "pass",
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "display_brand": "visa",
+        "exp_month": 12,
+        "exp_year": 2028,
+        "fingerprint": "pmIfA8TCefcd72yD",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "0341",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "regulated_status": "unregulated",
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1740699551,
+      "customer": "cus_RqyKy71Xwsb1Xr",
+      "livemode": false,
+      "metadata": {},
+      "type": "card"
+    },
+    "request_log_url": "https://dashboard.stripe.com/test/logs/req_R6dwJQCrHDQkZr?t=1740766202",
+    "type": "card_error"
+  }
+}

--- a/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
+++ b/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe Types::Integrations::PremiumIntegrationTypeEnum do
   let(:premium_integration_types) do
     %w[
+      beta_payment_authorization
       api_permissions
       auto_dunning
       hubspot

--- a/spec/jobs/payment_providers/cancel_payment_authorization_job_spec.rb
+++ b/spec/jobs/payment_providers/cancel_payment_authorization_job_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviders::CancelPaymentAuthorizationJob, type: :job do
-
   it "calls the Stripe API" do
     payment_provider = create(:stripe_provider)
     stub_request(:post, %r{stripe}).and_return(status: 200, body: "{}")

--- a/spec/jobs/payment_providers/cancel_payment_authorization_job_spec.rb
+++ b/spec/jobs/payment_providers/cancel_payment_authorization_job_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::CancelPaymentAuthorizationJob, type: :job do
+
+  it "calls the Stripe API" do
+    payment_provider = create(:stripe_provider)
+    stub_request(:post, %r{stripe}).and_return(status: 200, body: "{}")
+
+    described_class.perform_now(payment_provider:, id: "pi_123456789")
+
+    expect(WebMock).to have_requested(:post, "https://api.stripe.com/v1/payment_intents/pi_123456789/cancel")
+  end
+
+  context "when the payment provider is not Stripe" do
+    it "raises NotImplementedError for Adyen provider" do
+      payment_provider = create(:adyen_provider)
+
+      expect {
+        described_class.perform_now(payment_provider:, id: "AUTH_123")
+      }.to raise_error(
+        NotImplementedError,
+        "Cancelling payment authorization not implemented for adyen"
+      )
+    end
+  end
+end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
   around { |test| lago_premium!(&test) }
 
   describe "POST /api/v1/subscriptions" do
-    subject { post_with_token(organization, "/api/v1/subscriptions", {subscription: params}) }
+    subject { post_with_token(organization, "/api/v1/subscriptions", body) }
 
+    let(:body) { {subscription: params} }
     let(:subscription_at) { Time.current.iso8601 }
     let(:ending_at) { (Time.current + 1.year).iso8601 }
     let(:plan_code) { plan.code }
@@ -189,6 +190,85 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
         expect(json[:subscription][:previous_plan_code]).to be_nil
         expect(json[:subscription][:next_plan_code]).to be_nil
         expect(json[:subscription][:downgrade_plan_date]).to be_nil
+      end
+    end
+
+    context "with payment pre-authorization" do
+      context "when the feature isn't enabled" do
+        let(:body) { {authorization: {}, subscription: params} }
+
+        it "returns a forbidden error" do
+          subject
+
+          expect(response).to have_http_status(:forbidden)
+          expect(json[:message]).to match(/beta_payment_authorization/)
+        end
+      end
+
+      context "when the feature is enabled" do
+        let(:organization) { create(:organization, premium_integrations: ["beta_payment_authorization"]) }
+        let(:body) do
+          {
+            authorization: {amount: "100", currency: "USD"},
+            subscription: params
+          }
+        end
+        let(:customer) { create(:customer, organization:, payment_provider: :stripe, external_id: "cust_12345") }
+        let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider: create(:stripe_provider, organization:), payment_method_id: "pm_12345") }
+        let(:stripe_pi) do
+          {
+            id: "pi_12345",
+            amount: "100",
+            amount_capturable: "100",
+            status: "requires_capture"
+          }
+        end
+
+        before do
+          stripe_customer
+          stub_request(:post, "https://api.stripe.com/v1/payment_intents").and_return(status: 200, body: stripe_pi.to_json)
+        end
+
+        it "returns a success" do
+          allow(PaymentProviders::CancelPaymentAuthorizationJob).to receive(:perform_later)
+
+          subject
+          expect(json[:authorization]).to include(stripe_pi)
+          expect(json[:subscription]).to include(status: "active")
+
+          expect(PaymentProviders::CancelPaymentAuthorizationJob).to have_received(:perform_later).with(
+            payment_provider: stripe_customer.payment_provider, id: stripe_pi[:id]
+          )
+        end
+
+        context "when customer has no payment method" do
+          let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider: create(:stripe_provider, organization:), payment_method_id: nil) }
+
+          it "returns an error" do
+            subject
+
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(json[:error_details][:payment_method_id]).to include "customer_has_no_payment_method"
+          end
+        end
+
+        context "when payment intent status is 'failed'" do
+          let(:stripe_pi) do
+            {
+              id: "pi_12345",
+              amount: "100",
+              amount_capturable: "0",
+              status: "something when wrong on stripe's side"
+            }
+          end
+
+          it "returns an error" do
+            subject
+
+            expect(response).to have_http_status(:unprocessable_entity)
+            expect(json[:error_details][:thirdparty_error]).to eq "The total amount was not captured."
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

When creating a subscription, the invoice and the payment are done asynchronously. We're introducing a way to make a pre-authorization on the credit card to mitigate payment failure.

## Description

**The feature should be released in BETA** until we're satisfied with the request/response shape and we added support for other payment provider. Only Stripe is supported now.

![CleanShot 2025-02-26 at 11 54 13@2x](https://github.com/user-attachments/assets/07587553-ccea-4435-aa5e-a6ef9619b516)

### Current situation

When creating a subscription, we'll handle the creation, termination of current subscription and update of future subscriptions if needed.

Then in async, we create the invoice, which in async, will collect the payment. The payment can fail but the subscription is already returned and active.

### Solution to mitigate payment issues

Before creating a subscription, we can create a pre-authorization on the customer cards. This will make a payment, lock the amount on the customer account but not actually take away the money (called capture). The amount and currency are passed to the API by the user.

This will ensure the card is valid and working.

Note that: 
* the total due amount is unknown at the moment of the subscription creation (only know after invoice is finalized)
* the payment intent created cannot be reused because the final amount could be higher than the capturable amount.
* the payment intent is cancelled **right away but asynchronously**.
* This is why it's recommended to **only do it with very small amounts** (like $1). This won't protect agains "insuffisant fund" but will definitely help reduce the number of error
  * If you lock too much money on the customer's account, I beleive we'll actually increase the number of "insuffisant fund" error.
  * example: If you need lock $20, then charge $22 before the initial $20 are released, you know need $42 available


> [!WARNING]  
> Nothing is saved in the database (no new `Payment` type for instance)
> The job directly calls the stripe API, it's not wrapped in a Service
> Only Stripe is supported
>
> **This is intentional** because I believe we should test this feature on beta before we go further with the implementation.


## TODO

- [x] Initial implement with Stripe
- [ ] Decide on API (parameter names and response)
- [x] Add tests

![CleanShot 2025-02-26 at 14 55 50@2x](https://github.com/user-attachments/assets/f4bd5720-5fb9-477e-ab5d-7ab895d3d66f)
![CleanShot 2025-02-26 at 14 57 29@2x](https://github.com/user-attachments/assets/6c21283e-662a-4f0d-bf37-b9984580e80e)
