### PR TITLE
feat(invoice-preview): support terminated preview invoices

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -182,6 +182,42 @@ class Subscription < ApplicationRecord
 
     terminated_at.round <= timestamp.round
   end
+
+  # TODO: Apply this method in CreateInvoiceSubscriptionService
+  # This method calculates boundaries for terminated subscription. If termination is happening on billing date
+  # new boundaries will be calculated only if there is no invoice subscription object for previous period.
+  # Basically, we will bill regular subscription amount for previous period.
+  # If subscription is happening on any other day, method is returning boundaries only for the used dates in
+  # current period
+  def termination_boundaries(datetime, boundaries)
+    return boundaries unless terminated? && next_subscription.nil?
+
+    # First we need to ensure that termination date is not started_at date. In that case boundaries are correct
+    # and we should bill only one day. If this is not the case we should proceed.
+    return boundaries if (datetime - 1.day) < started_at
+
+    # Date service has various checks for terminated subscriptions. We want to avoid it and fetch boundaries
+    # for current usage (current period) but when subscription was active (one day ago)
+    duplicate = self.dup.tap { |s| s.status = :active }
+
+    dates_service = Subscriptions::DatesService.new_instance(duplicate, datetime - 1.day, current_usage: true)
+    return boundaries if datetime < dates_service.charges_to_datetime
+    return boundaries unless (datetime - dates_service.charges_to_datetime) < 1.day
+
+    # We should calculate boundaries as if subscription was not terminated
+    dates_service = Subscriptions::DatesService.new_instance(duplicate, datetime, current_usage: false)
+
+    previous_period_boundaries = {
+      from_datetime: dates_service.from_datetime,
+      to_datetime: dates_service.to_datetime,
+      charges_from_datetime: dates_service.charges_from_datetime,
+      charges_to_datetime: dates_service.charges_to_datetime,
+      timestamp: datetime,
+      charges_duration: dates_service.charges_duration_in_days
+    }
+
+    InvoiceSubscription.matching?(self, previous_period_boundaries) ? boundaries : previous_period_boundaries
+  end
 end
 
 # == Schema Information

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -189,7 +189,7 @@ class Subscription < ApplicationRecord
   # Basically, we will bill regular subscription amount for previous period.
   # If subscription is happening on any other day, method is returning boundaries only for the used dates in
   # current period
-  def termination_boundaries(datetime, boundaries)
+  def adjusted_boundaries(datetime, boundaries)
     return boundaries unless terminated? && next_subscription.nil?
 
     # First we need to ensure that termination date is not started_at date. In that case boundaries are correct

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -198,7 +198,7 @@ class Subscription < ApplicationRecord
 
     # Date service has various checks for terminated subscriptions. We want to avoid it and fetch boundaries
     # for current usage (current period) but when subscription was active (one day ago)
-    duplicate = self.dup.tap { |s| s.status = :active }
+    duplicate = dup.tap { |s| s.status = :active }
 
     dates_service = Subscriptions::DatesService.new_instance(duplicate, datetime - 1.day, current_usage: true)
     return boundaries if datetime < dates_service.charges_to_datetime

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -114,7 +114,7 @@ module Invoices
         timestamp: billing_time
       }
 
-      subscription_context == :terminated ? subscription.termination_boundaries(billing_time, boundaries) : boundaries
+      (subscription_context == :terminated) ? subscription.termination_boundaries(billing_time, boundaries) : boundaries
     end
 
     def billing_time
@@ -163,7 +163,6 @@ module Invoices
           .where(invoiceable: true)
           .where
           .not(pay_in_advance: true, billable_metric: {recurring: false}).find_each do |c|
-
           next if should_not_create_charge_fee?(c, subscription)
           charges << c
         end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -10,6 +10,7 @@ module Invoices
       @applied_coupons = applied_coupons
       @first_subscription = subscriptions.first
       @persisted_subscriptions = subscriptions.any?(&:persisted?)
+      @subscription_context = fetch_context
 
       super
     end
@@ -19,6 +20,7 @@ module Invoices
       return result.not_found_failure!(resource: "customer") unless customer
       return result.not_found_failure!(resource: "subscription") if subscriptions.empty?
       return result.not_allowed_failure!(code: "premium_integration_missing") if persisted_subscriptions && !organization.preview_enabled?
+      return result unless terminate_allowed?
       return result unless currencies_aligned?
       return result unless billing_times_aligned?
 
@@ -37,7 +39,7 @@ module Invoices
       invoice.credits = []
       invoice.subscriptions = subscriptions
 
-      add_subscription_fees
+      add_subscription_fees if should_create_subscription_fee?
       add_charge_fees
       compute_tax_and_totals
 
@@ -48,8 +50,14 @@ module Invoices
 
     private
 
-    attr_accessor :customer, :subscriptions, :invoice, :applied_coupons, :first_subscription, :persisted_subscriptions
+    attr_accessor :customer, :subscriptions, :invoice, :applied_coupons, :first_subscription, :persisted_subscriptions, :subscription_context
     delegate :organization, to: :customer
+
+    def fetch_context
+      return :terminated if subscriptions.any?(&:terminated?)
+
+      :default
+    end
 
     def currencies_aligned?
       subscription_currencies = subscriptions.filter_map { |s| s.plan&.amount_currency }
@@ -78,6 +86,15 @@ module Invoices
       true
     end
 
+    def terminate_allowed?
+      return true unless subscription_context == :terminated
+      return true if subscriptions.size == 1 && persisted_subscriptions
+
+      result.single_validation_failure!(error_code: "terminate_unavailable")
+
+      false
+    end
+
     def end_of_periods
       @end_of_periods ||= subscriptions.map do |subscription|
         Subscriptions::DatesService
@@ -89,19 +106,23 @@ module Invoices
     def boundaries(subscription)
       date_service = Subscriptions::DatesService.new_instance(subscription, billing_time)
 
-      {
+      boundaries = {
         from_datetime: date_service.from_datetime,
         to_datetime: date_service.to_datetime,
         charges_from_datetime: date_service.charges_from_datetime,
         charges_to_datetime: date_service.charges_to_datetime,
         timestamp: billing_time
       }
+
+      subscription_context == :terminated ? subscription.termination_boundaries(billing_time, boundaries) : boundaries
     end
 
     def billing_time
       return @billing_time if defined? @billing_time
 
-      @billing_time = if persisted_subscriptions
+      @billing_time = if subscription_context == :terminated
+        first_subscription.terminated_at
+      elsif persisted_subscriptions
         end_of_periods.first + 1.day
       elsif first_subscription.plan.pay_in_advance?
         first_subscription.subscription_at
@@ -136,15 +157,20 @@ module Invoices
       subscriptions.map do |subscription|
         boundaries = boundaries(subscription)
 
-        query = subscription.plan.charges.joins(:billable_metric)
+        charges = []
+        subscription.plan.charges.joins(:billable_metric)
           .includes(:taxes, billable_metric: :organization, filters: {values: :billable_metric_filter})
           .where(invoiceable: true)
           .where
-          .not(pay_in_advance: true, billable_metric: {recurring: false})
+          .not(pay_in_advance: true, billable_metric: {recurring: false}).find_each do |c|
+
+          next if should_not_create_charge_fee?(c, subscription)
+          charges << c
+        end
 
         context = OpenTelemetry::Context.current
 
-        invoice.fees << Parallel.flat_map(query.all, in_threads: ENV["LAGO_PARALLEL_THREADS_COUNT"]&.to_i || 0) do |charge|
+        invoice.fees << Parallel.flat_map(charges, in_threads: ENV["LAGO_PARALLEL_THREADS_COUNT"]&.to_i || 0) do |charge|
           OpenTelemetry::Context.with_current(context) do
             ActiveRecord::Base.connection_pool.with_connection do
               cache_middleware = Subscriptions::ChargeCacheMiddleware.new(
@@ -173,9 +199,9 @@ module Invoices
 
       invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents - invoice.coupons_amount_cents
 
-      if provider_taxation?
+      if provider_taxation? && invoice.fees.any?
         apply_provider_taxes
-      else
+      elsif invoice.fees.any?
         apply_taxes
       end
 
@@ -257,6 +283,26 @@ module Invoices
 
     def provider_taxation?
       customer.integration_customers.find { |ic| ic.type == "IntegrationCustomers::AnrokCustomer" }
+    end
+
+    def should_create_subscription_fee?
+      return true if subscription_context == :default
+
+      subscription_context == :terminated && first_subscription.plan.pay_in_arrear?
+    end
+
+    def should_not_create_charge_fee?(charge, subscription)
+      return false if subscription_context == :default
+
+      if charge.pay_in_advance?
+        condition = charge.billable_metric.recurring? &&
+          subscription.terminated? &&
+          (subscription.upgraded? || subscription.next_subscription.nil?)
+
+        return condition
+      end
+
+      false
     end
   end
 end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -39,7 +39,7 @@ module Invoices
       invoice.credits = []
       invoice.subscriptions = subscriptions
 
-      add_subscription_fees if should_create_subscription_fee?
+      add_subscription_fees
       add_charge_fees
       compute_tax_and_totals
 
@@ -114,7 +114,7 @@ module Invoices
         timestamp: billing_time
       }
 
-      (subscription_context == :terminated) ? subscription.termination_boundaries(billing_time, boundaries) : boundaries
+      subscription.adjusted_boundaries(billing_time, boundaries)
     end
 
     def billing_time
@@ -141,6 +141,11 @@ module Invoices
     end
 
     def add_subscription_fees
+      unless should_create_subscription_fee?
+        invoice.fees = []
+        return
+      end
+
       invoice.fees = subscriptions.map do |subscription|
         Fees::SubscriptionService.call!(
           invoice:,

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -560,18 +560,18 @@ RSpec.describe Subscription, type: :model do
     let(:billing_date) { Time.zone.parse("15 May 2024") }
     let(:date_service) { Subscriptions::DatesService.new_instance(subscription, billing_date) }
     let(:plan) { create(:plan, amount_cents: 100) }
-    let(:status) { 'active' }
+    let(:status) { "active" }
     let(:terminated_at) { nil }
     let(:subscription) do
       create(
         :subscription,
-        billing_time: 'calendar',
+        billing_time: "calendar",
         started_at: timestamp,
         created_at: timestamp,
         status:,
         terminated_at:,
         subscription_at: timestamp,
-        plan:,
+        plan:
       )
     end
     let(:default_boundaries) do
@@ -593,7 +593,7 @@ RSpec.describe Subscription, type: :model do
     end
 
     context "with termination on non billing day" do
-      let(:status) { 'terminated' }
+      let(:status) { "terminated" }
       let(:terminated_at) { billing_date }
 
       it "returns default boundaries" do
@@ -602,7 +602,7 @@ RSpec.describe Subscription, type: :model do
     end
 
     context "with termination on billing day without invoice for previous period" do
-      let(:status) { 'terminated' }
+      let(:status) { "terminated" }
       let(:billing_date) { Time.zone.parse("01 Jun 2024") }
       let(:terminated_at) { billing_date }
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -555,7 +555,7 @@ RSpec.describe Subscription, type: :model do
     end
   end
 
-  describe "#termination_boundaries" do
+  describe "#adjusted_boundaries" do
     let(:timestamp) { Time.zone.parse("30 Mar 2024") }
     let(:billing_date) { Time.zone.parse("15 May 2024") }
     let(:date_service) { Subscriptions::DatesService.new_instance(subscription, billing_date) }
@@ -588,7 +588,7 @@ RSpec.describe Subscription, type: :model do
       let(:billing_date) { Time.zone.parse("01 Jun 2024") }
 
       it "returns default boundaries" do
-        expect(subscription.termination_boundaries(billing_date, default_boundaries)).to eq(default_boundaries)
+        expect(subscription.adjusted_boundaries(billing_date, default_boundaries)).to eq(default_boundaries)
       end
     end
 
@@ -597,7 +597,7 @@ RSpec.describe Subscription, type: :model do
       let(:terminated_at) { billing_date }
 
       it "returns default boundaries" do
-        expect(subscription.termination_boundaries(billing_date, default_boundaries)).to eq(default_boundaries)
+        expect(subscription.adjusted_boundaries(billing_date, default_boundaries)).to eq(default_boundaries)
       end
     end
 
@@ -607,10 +607,9 @@ RSpec.describe Subscription, type: :model do
       let(:terminated_at) { billing_date }
 
       it "returns new boundaries based on previous billing period" do
-        new_boundaries = subscription.termination_boundaries(billing_date, default_boundaries)
+        new_boundaries = subscription.adjusted_boundaries(billing_date, default_boundaries)
 
-        expect(subscription.termination_boundaries(billing_date, default_boundaries)).not_to eq(default_boundaries)
-
+        expect(new_boundaries).not_to eq(default_boundaries)
         expect(new_boundaries[:from_datetime].iso8601).to eq("2024-05-01T00:00:00Z")
         expect(new_boundaries[:to_datetime].iso8601).to eq("2024-05-31T23:59:59Z")
         expect(new_boundaries[:charges_from_datetime].iso8601).to eq("2024-05-01T00:00:00Z")

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -277,9 +277,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               )
             end
             let(:events) do
-              create_list(
+              create_pair(
                 :event,
-                2,
                 organization:,
                 subscription:,
                 customer:,

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -74,6 +74,29 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
       end
 
+      context "when terminate action not applicable" do
+        let(:subscription) do
+          build(
+            :subscription,
+            customer:,
+            plan:,
+            billing_time:,
+            status: "terminated",
+            subscription_at: timestamp,
+            terminated_at: timestamp,
+            started_at: timestamp,
+            created_at: timestamp
+          )
+        end
+
+        it "returns an error if subscription is not persisted" do
+          result = preview_service.call
+
+          expect(result).not_to be_success
+          expect(result.error.messages[:base]).to include("terminate_unavailable")
+        end
+      end
+
       context "when billing periods do not match" do
         let(:customer) { create(:customer, organization:) }
         let(:plan1) { create(:plan, organization:, interval: "monthly") }
@@ -227,6 +250,69 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               end
             end
           end
+
+          context "when subscription is terminated" do
+            let(:subscription) do
+              create(
+                :subscription,
+                customer:,
+                plan:,
+                billing_time:,
+                status: "terminated",
+                terminated_at: timestamp + 15.hours,
+                subscription_at: timestamp,
+                started_at: timestamp,
+                created_at: timestamp
+              )
+            end
+            let(:billable_metric) do
+              create(:billable_metric, aggregation_type: "count_agg")
+            end
+            let(:charge) do
+              create(
+                :standard_charge,
+                plan:,
+                billable_metric:,
+                properties: {amount: "12.66"}
+              )
+            end
+            let(:events) do
+              create_list(
+                :event,
+                2,
+                organization:,
+                subscription:,
+                customer:,
+                code: billable_metric.code,
+                timestamp: timestamp + 5.hours
+              )
+            end
+
+            before do
+              events if subscription
+              charge
+              Rails.cache.clear
+            end
+
+            it "creates preview invoice for 1 day" do
+              # One days should be billed, Mar 30 only
+
+              travel_to(subscription.terminated_at) do
+                result = preview_service.call
+
+                expect(result).to be_success
+                expect(result.invoice.subscriptions.first).to eq(subscription)
+                expect(result.invoice.fees.length).to eq(2)
+                expect(result.invoice.invoice_type).to eq("subscription")
+                expect(result.invoice.issuing_date.to_s).to eq("2024-03-30")
+                expect(result.invoice.fees_amount_cents).to eq(2535) # 3.23 + 1266 x 2 = 2535
+                expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(2535)
+                expect(result.invoice.taxes_amount_cents).to eq(1268) # 1268
+                expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(3803) # 3803
+                expect(result.invoice.total_amount_cents).to eq(3803) # 3803
+              end
+            end
+          end
         end
 
         context "with in advance billing in the future" do
@@ -292,6 +378,39 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               expect(result.invoice.taxes_amount_cents).to eq(50)
               expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(150)
               expect(result.invoice.total_amount_cents).to eq(150)
+            end
+          end
+
+          context "with terminated subscription" do
+            let(:subscription) do
+              create(
+                :subscription,
+                customer:,
+                plan:,
+                billing_time:,
+                status: "terminated",
+                terminated_at: timestamp,
+                subscription_at: timestamp - 1.day,
+                started_at: timestamp - 1.day,
+                created_at: timestamp - 1.day
+              )
+            end
+
+            it "creates preview invoice without subscription fee since it has already been paid" do
+              travel_to(subscription.terminated_at) do
+                result = preview_service.call
+
+                expect(result).to be_success
+                expect(result.invoice.subscriptions.first).to eq(subscription)
+                expect(result.invoice.fees.length).to eq(0)
+                expect(result.invoice.invoice_type).to eq("subscription")
+                expect(result.invoice.issuing_date.to_s).to eq("2024-03-30")
+                expect(result.invoice.fees_amount_cents).to eq(0)
+                expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(0)
+                expect(result.invoice.taxes_amount_cents).to eq(0)
+                expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(0)
+                expect(result.invoice.total_amount_cents).to eq(0)
+              end
             end
           end
 


### PR DESCRIPTION
## Context

Preview feature enables to see invoice breakdown on the fly, without storing any object in the DB

## Description

This PR covers support for terminated invoices. For this specific case, correct boundaries are fetched and certain fees skipped if not applicable. 
