### PR TITLE
Feat(multientities):remove usage of is_default flag on billing_entities

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -42,11 +42,6 @@ class BillingEntity < ApplicationRecord
 
   default_scope -> { kept }
 
-  validates :is_default,
-    uniqueness: {
-      conditions: -> { where(is_default: true, archived_at: nil, deleted_at: nil) },
-      scope: :organization_id
-    }
   validates :country, country_code: true, unless: -> { country.nil? }
   validates :default_currency, inclusion: {in: currency_list}
   validates :document_locale, language_code: true

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -96,7 +96,6 @@ end
 #  finalize_zero_amount_invoice :boolean          default(TRUE), not null
 #  invoice_footer               :text
 #  invoice_grace_period         :integer          default(0), not null
-#  is_default                   :boolean          default(FALSE), not null
 #  legal_name                   :string
 #  legal_number                 :string
 #  logo                         :string

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -7,6 +7,7 @@ class BillingEntity < ApplicationRecord
   include Discard::Model
 
   self.discard_column = :deleted_at
+  self.ignored_columns += ["is_default"]
 
   EMAIL_SETTINGS = [
     "invoice.finalized",

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -51,7 +51,6 @@ class Organization < ApplicationRecord
   has_one :salesforce_integration, class_name: "Integrations::SalesforceIntegration"
 
   has_one :applied_dunning_campaign, -> { where(applied_to_organization: true) }, class_name: "DunningCampaign"
-  has_one :default_billing_entity, -> { where(is_default: true) }, class_name: "BillingEntity"
 
   has_many :invoice_custom_sections
   has_many :invoice_custom_section_selections
@@ -176,6 +175,14 @@ class Organization < ApplicationRecord
 
   def can_create_billing_entity?
     remaining_billing_entities > 0
+  end
+
+  # By default all organizations have only one billing_entity. If an organization has more than one billing_entity,
+  # the billing_entity_id should be provided instead of relying on default
+  def default_billing_entity
+    return nil if billing_entities.count > 1
+
+    billing_entities.first
   end
 
   private

--- a/spec/factories/billing_entities.rb
+++ b/spec/factories/billing_entities.rb
@@ -8,18 +8,7 @@ FactoryBot.define do
 
     email { Faker::Internet.email }
     email_settings { ["invoice.finalized", "credit_note.created"] }
-
-    # TODO: remove this magic after is_default field is deleted
-    # we need firstly to set is_default on the current billing_entity,
-    # so when creating organization we won't need to create a default billing entity
-    after :build do |billing_entity, values|
-      billing_entity.is_default = true if values.organization&.billing_entities&.where(is_default: true).blank?
-      billing_entity.organization = build(:organization, billing_entities: [billing_entity]) if values.organization.blank?
-    end
-
-    trait :default do
-      is_default { true }
-    end
+    organization
 
     trait :deleted do
       deleted_at { Time.current }

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     currency { "EUR" }
 
     after :build do |customer, values|
-      customer.billing_entity = values.organization.default_billing_entity unless customer.billing_entity
+      customer.billing_entity = values.organization&.default_billing_entity unless customer.billing_entity
     end
 
     trait :with_shipping_address do

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     currency { "EUR" }
 
     after :build do |customer, values|
-      customer.billing_entity = values.organization&.default_billing_entity unless customer.billing_entity
+      customer.billing_entity ||= values.organization&.default_billing_entity
     end
 
     trait :with_shipping_address do

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     organization_sequential_id { rand(1_000_000) }
 
     after :build do |invoice, values|
-      invoice.billing_entity = values.organization.default_billing_entity unless invoice.billing_entity
+      invoice.billing_entity = values.organization&.default_billing_entity unless invoice.billing_entity
     end
 
     trait :draft do

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     organization_sequential_id { rand(1_000_000) }
 
     after :build do |invoice, values|
-      invoice.billing_entity = values.organization&.default_billing_entity unless invoice.billing_entity
+      invoice.billing_entity ||= values.organization&.default_billing_entity
     end
 
     trait :draft do

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     email_settings { ["invoice.finalized", "credit_note.created"] }
 
     api_keys { [association(:api_key, organization: instance)] }
+    billing_entities { [association(:billing_entity, organization: instance)] }
 
     transient do
       webhook_url { Faker::Internet.url }
@@ -17,11 +18,6 @@ FactoryBot.define do
     after(:create) do |organization, evaluator|
       if evaluator.webhook_url
         organization.webhook_endpoints.create!(webhook_url: evaluator.webhook_url)
-      end
-      # default billing entity on organization will be used in services as intermediate step
-      # before we start accepting billing_entity_id in the request. After that we can drop the column and this method
-      if organization.billing_entities.where(is_default: true).blank?
-        create(:billing_entity, :default, organization:)
       end
     end
 

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -23,27 +23,6 @@ RSpec.describe BillingEntity, type: :model do
   it { is_expected.to have_many(:applied_taxes).dependent(:destroy) }
   it { is_expected.to have_many(:taxes).through(:applied_taxes) }
 
-  describe "is_default validation" do
-    let(:organization) { create :organization }
-
-    it "validates uniqueness of organization_id for is_default excluding deleted and archived records" do
-      # by default an organization is built with a default billing entity
-      expect(organization.default_billing_entity.discard!).to be true
-      archived_record = create(:billing_entity, :default, :archived, organization:)
-      expect(archived_record).to be_valid
-
-      record_1 = create(:billing_entity, :default, organization:)
-      expect(record_1).to be_valid
-
-      record_2 = build(:billing_entity, :default, organization:)
-      expect(record_2).not_to be_valid
-      expect(record_2.errors[:is_default]).to include("value_already_exist")
-
-      record_3 = build(:billing_entity, :default)
-      expect(record_3).to be_valid
-    end
-  end
-
   describe "Validations" do
     let(:billing_entity) { build(:billing_entity) }
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -316,31 +316,31 @@ RSpec.describe Organization, type: :model do
     end
   end
 
-  describe '#default_billing_entity' do
+  describe "#default_billing_entity" do
     let(:organization) { create(:organization, billing_entities: []) }
 
-    context 'when the organization has no billing entities' do
-      it 'returns the default billing entity' do
+    context "when the organization has no billing entities" do
+      it "returns the default billing entity" do
         expect(organization.default_billing_entity).to eq(nil)
       end
     end
 
-    context 'when the organization has one billing entity' do
+    context "when the organization has one billing entity" do
       let(:billing_entity) { create(:billing_entity, organization:) }
 
       before { billing_entity }
 
-      it 'returns the default billing entity' do
+      it "returns the default billing entity" do
         expect(organization.reload.default_billing_entity).to eq(billing_entity)
       end
     end
 
-    context 'when the organization has multiple billing entities' do
+    context "when the organization has multiple billing entities" do
       let(:billing_entities) { create_list(:billing_entity, 2, organization:) }
 
       before { billing_entities }
 
-      it 'returns the default billing entity' do
+      it "returns the default billing entity" do
         expect(organization.default_billing_entity).to eq(nil)
       end
     end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:selected_invoice_custom_sections) }
 
   it { is_expected.to have_one(:applied_dunning_campaign).conditions(applied_to_organization: true) }
-  it { is_expected.to have_one(:default_billing_entity).conditions(is_default: true) }
 
   it { is_expected.to validate_inclusion_of(:default_currency).in_array(described_class.currency_list) }
 
@@ -313,6 +312,36 @@ RSpec.describe Organization, type: :model do
       it "returns the organization email" do
         organization.update!(premium_integrations: ["from_email"])
         expect(organization.from_email_address).to eq(organization.email)
+      end
+    end
+  end
+
+  describe '#default_billing_entity' do
+    let(:organization) { create(:organization, billing_entities: []) }
+
+    context 'when the organization has no billing entities' do
+      it 'returns the default billing entity' do
+        expect(organization.default_billing_entity).to eq(nil)
+      end
+    end
+
+    context 'when the organization has one billing entity' do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+
+      before { billing_entity }
+
+      it 'returns the default billing entity' do
+        expect(organization.reload.default_billing_entity).to eq(billing_entity)
+      end
+    end
+
+    context 'when the organization has multiple billing entities' do
+      let(:billing_entities) { create_list(:billing_entity, 2, organization:) }
+
+      before { billing_entities }
+
+      it 'returns the default billing entity' do
+        expect(organization.default_billing_entity).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
## Context

We decided to proceed without default billing entity. Instead we'll be treating the first active billing entity of organization as default if an organization has only one billing entity, otherwise we act as if organization has no default billing entity and forcing client to send the billing_entity_id