### PR TITLE
Feat(multi-entities): migration to remove is_default from billing_entities

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -115,7 +115,6 @@ end
 #
 #  index_billing_entities_on_applied_dunning_campaign_id  (applied_dunning_campaign_id)
 #  index_billing_entities_on_organization_id              (organization_id)
-#  unique_default_billing_entity_per_organization         (organization_id) UNIQUE WHERE ((is_default = true) AND (archived_at IS NULL) AND (deleted_at IS NULL))
 #
 # Foreign Keys
 #

--- a/db/migrate/20250227091909_remove_is_default_from_billing_entity.rb
+++ b/db/migrate/20250227091909_remove_is_default_from_billing_entity.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveIsDefaultFromBillingEntity < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_column :billing_entities, :is_default, :boolean, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -235,7 +235,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_27_155522) do
     t.string "code", null: false
     t.string "tax_identification_number"
     t.float "vat_rate", default: 0.0, null: false
-    t.boolean "is_default", default: false, null: false
     t.datetime "archived_at"
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
@@ -243,7 +242,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_27_155522) do
     t.uuid "applied_dunning_campaign_id"
     t.index ["applied_dunning_campaign_id"], name: "index_billing_entities_on_applied_dunning_campaign_id"
     t.index ["organization_id"], name: "index_billing_entities_on_organization_id"
-    t.index ["organization_id"], name: "unique_default_billing_entity_per_organization", unique: true, where: "((is_default = true) AND (archived_at IS NULL) AND (deleted_at IS NULL))"
   end
 
   create_table "billing_entities_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Context

Column drop should be happening in a separate commit
