### PR TITLE
Feat: update hard_delete_invoice Method

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -60,6 +60,7 @@ module Rails::ConsoleMethods
       invoice.fees.destroy_all
       invoice.taxes.destroy_all
       invoice.credits.destroy_all
+      invoice.applied_invoice_custom_sections.destroy_all
       invoice.destroy!
     end
 


### PR DESCRIPTION
## Context

Previously, the hard_delete_invoice method could fail because of the new feature invoice_custom_sections.
 
## Description

This PR modifies the hard_delete_invoice method to delete the applied_invoice_custom_sections too and then delete the invoice