### PR TITLE
bug(PayInAdvance) - Don't loose precision when converting timestamp

### DIFF
--- a/app/services/events/common_factory.rb
+++ b/app/services/events/common_factory.rb
@@ -12,7 +12,7 @@ module Events
           organization_id: source["organization_id"],
           transaction_id: source["transaction_id"],
           external_subscription_id: source["external_subscription_id"],
-          timestamp: Time.zone.at(source["timestamp"].to_i),
+          timestamp: Time.zone.at(source["timestamp"].to_f),
           code: source["code"],
           properties: source["properties"]
         )

--- a/app/services/events/common_factory.rb
+++ b/app/services/events/common_factory.rb
@@ -12,6 +12,7 @@ module Events
           organization_id: source["organization_id"],
           transaction_id: source["transaction_id"],
           external_subscription_id: source["external_subscription_id"],
+          # Keep in mind that we need the milliseconds precision!
           timestamp: Time.zone.at(source["timestamp"].to_f),
           code: source["code"],
           properties: source["properties"]

--- a/spec/services/events/common_factory_spec.rb
+++ b/spec/services/events/common_factory_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Events::CommonFactory do
         expect(new_instance.organization_id).to eq(source["organization_id"])
         expect(new_instance.transaction_id).to eq(source["transaction_id"])
         expect(new_instance.external_subscription_id).to eq(source["external_subscription_id"])
-        expect(new_instance.timestamp).to eq(Time.zone.at(source["timestamp"].to_i))
+        # Keep in mind that we need the milliseconds precision!
+        expect(new_instance.timestamp).to eq(Time.zone.at(source["timestamp"].to_f))
         expect(new_instance.code).to eq(source["code"])
         expect(new_instance.properties).to eq(source["properties"])
       end


### PR DESCRIPTION
## Description

This small changes ensure that we find subscriptions that start on the same *second* as the event timestamp. previously the conversion to an integer would drop the milliseconds from the float, resulting in a timestamp that starts that the start of the second. 

Due to this we could no longer find subscriptions starting in the same second. (as the event now suddenly falls before the start date of the subscription).

This change fixes that and converts the timestamp to a float. 
