### PR TITLE
feat(invoice-preview): add upgrade logic

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -150,6 +150,18 @@ class Charge < ApplicationRecord
 
     errors.add(:charge_model, :invalid_aggregation_type_or_charge_model)
   end
+
+  # NOTE: If same charge is NOT included in upgraded plan we still want to bill it. However if new plan is using
+  # the same charge it should not be billed since it is recurring and will be billed at the end of period
+  def charge_included_in_next_subscription?(subscription)
+    return false if subscription.next_subscription.nil?
+
+    next_subscription_charges = subscription.next_subscription.plan.charges
+
+    return false if next_subscription_charges.blank?
+
+    next_subscription_charges.pluck(:billable_metric_id).include?(billable_metric_id)
+  end
 end
 
 # == Schema Information

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -65,6 +65,18 @@ class Charge < ApplicationRecord
     charge_model == charge.charge_model && properties == charge.properties
   end
 
+  # NOTE: If same charge is NOT included in upgraded plan we still want to bill it. However if new plan is using
+  # the same charge it should not be billed since it is recurring and will be billed at the end of period
+  def charge_included_in_next_subscription?(subscription)
+    return false if subscription.next_subscription.nil?
+
+    next_subscription_charges = subscription.next_subscription.plan.charges
+
+    return false if next_subscription_charges.blank?
+
+    next_subscription_charges.pluck(:billable_metric_id).include?(billable_metric_id)
+  end
+
   private
 
   def validate_amount
@@ -149,18 +161,6 @@ class Charge < ApplicationRecord
     return if billable_metric.custom_agg?
 
     errors.add(:charge_model, :invalid_aggregation_type_or_charge_model)
-  end
-
-  # NOTE: If same charge is NOT included in upgraded plan we still want to bill it. However if new plan is using
-  # the same charge it should not be billed since it is recurring and will be billed at the end of period
-  def charge_included_in_next_subscription?(subscription)
-    return false if subscription.next_subscription.nil?
-
-    next_subscription_charges = subscription.next_subscription.plan.charges
-
-    return false if next_subscription_charges.blank?
-
-    next_subscription_charges.pluck(:billable_metric_id).include?(billable_metric_id)
   end
 end
 

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -67,7 +67,7 @@ class Charge < ApplicationRecord
 
   # NOTE: If same charge is NOT included in upgraded plan we still want to bill it. However if new plan is using
   # the same charge it should not be billed since it is recurring and will be billed at the end of period
-  def charge_included_in_next_subscription?(subscription)
+  def included_in_next_subscription?(subscription)
     return false if subscription.next_subscription.nil?
 
     next_subscription_charges = subscription.next_subscription.plan.charges

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -135,19 +135,7 @@ module Invoices
       charge.billable_metric.recurring? &&
         subscription.terminated? &&
         subscription.upgraded? &&
-        charge_included_in_next_subscription?(charge, subscription)
-    end
-
-    # NOTE: If same charge is NOT included in upgraded plan we still want to bill it. However if new plan is using
-    # the same charge it should not be billed since it is recurring and will be billed at the end of period
-    def charge_included_in_next_subscription?(charge, subscription)
-      return false if subscription.next_subscription.nil?
-
-      next_subscription_charges = subscription.next_subscription.plan.charges
-
-      return false if next_subscription_charges.blank?
-
-      next_subscription_charges.pluck(:billable_metric_id).include?(charge.billable_metric_id)
+        charge.charge_included_in_next_subscription?(subscription)
     end
 
     def should_create_recurring_non_invoiceable_fees?(subscription)

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -135,7 +135,7 @@ module Invoices
       charge.billable_metric.recurring? &&
         subscription.terminated? &&
         subscription.upgraded? &&
-        charge.charge_included_in_next_subscription?(subscription)
+        charge.included_in_next_subscription?(subscription)
     end
 
     def should_create_recurring_non_invoiceable_fees?(subscription)

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -302,7 +302,7 @@ module Invoices
       charge.billable_metric.recurring? &&
         subscription.terminated? &&
         subscription.upgraded? &&
-        charge.charge_included_in_next_subscription?(subscription)
+        charge.included_in_next_subscription?(subscription)
     end
   end
 end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -138,12 +138,12 @@ module Invoices
       invoice.fees = subscriptions
         .filter { |subscription| should_create_subscription_fee?(subscription) }
         .map do |subscription|
-          Fees::SubscriptionService.call!(
-            invoice:,
-            subscription:,
-            boundaries: boundaries(subscription),
-            context: :preview
-          ).fee
+        Fees::SubscriptionService.call!(
+          invoice:,
+          subscription:,
+          boundaries: boundaries(subscription),
+          context: :preview
+        ).fee
       end
     end
 

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -20,7 +20,6 @@ module Invoices
       return result.not_found_failure!(resource: "customer") unless customer
       return result.not_found_failure!(resource: "subscription") if subscriptions.empty?
       return result.not_allowed_failure!(code: "premium_integration_missing") if persisted_subscriptions && !organization.preview_enabled?
-      return result unless terminate_allowed?
       return result unless currencies_aligned?
       return result unless billing_times_aligned?
 
@@ -86,15 +85,6 @@ module Invoices
       true
     end
 
-    def terminate_allowed?
-      return true unless subscription_context == :terminated
-      return true if subscriptions.size == 1 && persisted_subscriptions
-
-      result.single_validation_failure!(error_code: "terminate_unavailable")
-
-      false
-    end
-
     def end_of_periods
       @end_of_periods ||= subscriptions.map do |subscription|
         Subscriptions::DatesService
@@ -104,7 +94,11 @@ module Invoices
     end
 
     def boundaries(subscription)
-      date_service = Subscriptions::DatesService.new_instance(subscription, billing_time)
+      date_service = Subscriptions::DatesService.new_instance(
+        subscription,
+        billing_time,
+        current_usage: subscription.persisted? && subscription.terminated? && subscription.upgraded?
+      )
 
       boundaries = {
         from_datetime: date_service.from_datetime,
@@ -141,18 +135,15 @@ module Invoices
     end
 
     def add_subscription_fees
-      unless should_create_subscription_fee?
-        invoice.fees = []
-        return
-      end
-
-      invoice.fees = subscriptions.map do |subscription|
-        Fees::SubscriptionService.call!(
-          invoice:,
-          subscription:,
-          boundaries: boundaries(subscription),
-          context: :preview
-        ).fee
+      invoice.fees = subscriptions
+        .filter { |subscription| should_create_subscription_fee?(subscription) }
+        .map do |subscription|
+          Fees::SubscriptionService.call!(
+            invoice:,
+            subscription:,
+            boundaries: boundaries(subscription),
+            context: :preview
+          ).fee
       end
     end
 
@@ -289,10 +280,10 @@ module Invoices
       customer.integration_customers.find { |ic| ic.type == "IntegrationCustomers::AnrokCustomer" }
     end
 
-    def should_create_subscription_fee?
+    def should_create_subscription_fee?(subscription)
       return true if subscription_context == :default
 
-      subscription_context == :terminated && first_subscription.plan.pay_in_arrear?
+      subscription.terminated? == subscription.plan.pay_in_arrear?
     end
 
     def should_not_create_charge_fee?(charge, subscription)
@@ -306,7 +297,12 @@ module Invoices
         return condition
       end
 
-      false
+      return false if charge.prorated?
+
+      charge.billable_metric.recurring? &&
+        subscription.terminated? &&
+        subscription.upgraded? &&
+        charge.charge_included_in_next_subscription?(subscription)
     end
   end
 end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -573,4 +573,52 @@ RSpec.describe Charge, type: :model do
       end
     end
   end
+
+  describe "#included_in_next_subscription?" do
+    subject { charge.included_in_next_subscription?(subscription) }
+
+    let(:charge) { create(:standard_charge) }
+    let(:subscription) { create(:subscription, next_subscriptions:) }
+
+    context "when subscription has next subscription" do
+      let(:next_subscriptions) { [create(:subscription, plan: next_plan)] }
+      let(:next_plan) { build(:plan, charges:) }
+
+      context "when next subscription's plan has charges" do
+        let(:charges) { [create(:standard_charge, billable_metric:)] }
+
+        context "when next plan charges includes charge billable metric" do
+          let(:billable_metric) { charge.billable_metric }
+
+          it "returns true" do
+            expect(subject).to be true
+          end
+        end
+
+        context "when next plan charges does not include charge billable metric" do
+          let(:billable_metric) { create(:billable_metric) }
+
+          it "returns false" do
+            expect(subject).to be false
+          end
+        end
+      end
+
+      context "when next subscription's plan has no charges" do
+        let(:charges) { [] }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+    end
+
+    context "when subscription has no next subscription" do
+      let(:next_subscriptions) { [] }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
 end

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -353,7 +353,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
 
               terminated_subscription.assign_attributes(
                 status: "terminated",
-                terminated_at: timestamp  + 15.hours
+                terminated_at: timestamp + 15.hours
               )
 
               events if terminated_subscription

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -74,29 +74,6 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
       end
 
-      context "when terminate action not applicable" do
-        let(:subscription) do
-          build(
-            :subscription,
-            customer:,
-            plan:,
-            billing_time:,
-            status: "terminated",
-            subscription_at: timestamp,
-            terminated_at: timestamp,
-            started_at: timestamp,
-            created_at: timestamp
-          )
-        end
-
-        it "returns an error if subscription is not persisted" do
-          result = preview_service.call
-
-          expect(result).not_to be_success
-          expect(result.error.messages[:base]).to include("terminate_unavailable")
-        end
-      end
-
       context "when billing periods do not match" do
         let(:customer) { create(:customer, organization:) }
         let(:plan1) { create(:plan, organization:, interval: "monthly") }
@@ -312,6 +289,86 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               end
             end
           end
+
+          context "when subscription is upgraded" do
+            let(:timestamp) { Time.zone.parse("29 Mar 2024") }
+            let(:plan_new) { create(:plan, organization:, interval: "monthly", amount_cents: 200) }
+            let(:subscriptions) { [subscription1, subscription2] }
+            let(:subscription1) do
+              create(
+                :subscription,
+                customer:,
+                plan:,
+                billing_time:,
+                status: "terminated",
+                terminated_at: timestamp + 15.hours,
+                subscription_at: timestamp,
+                started_at: timestamp,
+                created_at: timestamp
+              )
+            end
+            let(:subscription2) do
+              build(
+                :subscription,
+                customer:,
+                plan: plan_new,
+                billing_time:,
+                status: "active",
+                subscription_at: timestamp + 15.hours,
+                started_at: timestamp + 15.hours,
+                created_at: timestamp + 15.hours
+              )
+            end
+            let(:billable_metric) do
+              create(:billable_metric, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
+            end
+            let(:charge) do
+              create(
+                :standard_charge,
+                plan:,
+                billable_metric:,
+                pay_in_advance: false,
+                prorated: true,
+                properties: {amount: "1"}
+              )
+            end
+            let(:events) do
+              create_pair(
+                :event,
+                organization:,
+                subscription: subscription1,
+                customer:,
+                code: billable_metric.code,
+                timestamp: timestamp + 5.hours,
+                properties: {amount: "5"}
+              )
+            end
+
+            before do
+              events if subscription1
+              charge
+              Rails.cache.clear
+            end
+
+            it "creates preview invoice for 1 day" do
+              # One days should be billed, Mar 30 only
+
+              travel_to(subscription1.terminated_at) do
+                result = preview_service.call
+
+                expect(result).to be_success
+                expect(result.invoice.subscriptions.size).to eq(2)
+                expect(result.invoice.fees.length).to eq(2)
+                expect(result.invoice.invoice_type).to eq("subscription")
+                expect(result.invoice.issuing_date.to_s).to eq("2024-03-29")
+                expect(result.invoice.fees_amount_cents).to eq(35) # 3.23 + 32.26 (charge) = 35
+                expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(35)
+                expect(result.invoice.taxes_amount_cents).to eq(18)
+                expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(53)
+                expect(result.invoice.total_amount_cents).to eq(53)
+              end
+            end
+          end
         end
 
         context "with in advance billing in the future" do
@@ -409,6 +466,54 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 expect(result.invoice.taxes_amount_cents).to eq(0)
                 expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(0)
                 expect(result.invoice.total_amount_cents).to eq(0)
+              end
+            end
+          end
+
+          context "with upgraded subscription" do
+            let(:timestamp) { Time.zone.parse("29 Mar 2024") }
+            let(:plan_new) { create(:plan, organization:, interval: "monthly", amount_cents: 200, pay_in_advance: true) }
+            let(:subscriptions) { [subscription1, subscription2] }
+            let(:subscription1) do
+              create(
+                :subscription,
+                customer:,
+                plan:,
+                billing_time:,
+                status: "terminated",
+                terminated_at: timestamp,
+                subscription_at: timestamp - 1.day,
+                started_at: timestamp - 1.day,
+                created_at: timestamp - 1.day
+              )
+            end
+            let(:subscription2) do
+              build(
+                :subscription,
+                customer:,
+                plan: plan_new,
+                billing_time:,
+                status: "active",
+                subscription_at: timestamp,
+                started_at: timestamp,
+                created_at: timestamp
+              )
+            end
+
+            it "creates preview invoice for upgrade case" do
+              travel_to(subscription1.terminated_at) do
+                result = preview_service.call
+
+                expect(result).to be_success
+                expect(result.invoice.subscriptions.size).to eq(2)
+                expect(result.invoice.fees.length).to eq(1)
+                expect(result.invoice.invoice_type).to eq("subscription")
+                expect(result.invoice.issuing_date.to_s).to eq("2024-03-29")
+                expect(result.invoice.fees_amount_cents).to eq(19) # 3 x 200 / 31
+                expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(19)
+                expect(result.invoice.taxes_amount_cents).to eq(10)
+                expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(29)
+                expect(result.invoice.total_amount_cents).to eq(29)
               end
             end
           end


### PR DESCRIPTION
## Context

Preview feature enables to see invoice breakdown on the fly, without storing any object in the DB

## Description

This PR covers support for upgraded invoices. For this specific case, correct boundaries are fetched and certain fees skipped if not applicable. 
