### PR TITLE
Feat(multientities): remove default migration cleanup

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -7,7 +7,6 @@ class BillingEntity < ApplicationRecord
   include Discard::Model
 
   self.discard_column = :deleted_at
-  self.ignored_columns += ["is_default"]
 
   EMAIL_SETTINGS = [
     "invoice.finalized",


### PR DESCRIPTION
## Context

we decided to proceed with billing_entities without adding :default flag, so we needed to add ignored column before running the migration. Now it's time to clean up the ignored column