### PR TITLE
feat(invoice-preview): Add support for generating credit note during invoice preview

### DIFF
--- a/app/services/invoices/preview/credits_service.rb
+++ b/app/services/invoices/preview/credits_service.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Preview
+    class CreditsService < BaseService
+      Result = BaseResult[:credits]
+
+      def initialize(invoice:, terminated_subscription: nil)
+        @invoice = invoice
+        @terminated_subscription = terminated_subscription
+        super
+      end
+
+      def call
+        result.credits = credits_from_terminated_subscription + persisted_credits
+        result
+      end
+
+      private
+
+      attr_accessor :invoice, :terminated_subscription
+
+      def persisted_credits
+        Credits::CreditNoteService
+          .call!(invoice:, context: :preview)
+          .credits
+      end
+
+      def credits_from_terminated_subscription
+        return [] unless terminated_subscription&.plan&.pay_in_advance?
+
+        credit_note = generate_credit_note
+        return [] unless credit_note
+
+        credit_amount = [credit_note.balance_amount_cents, invoice.total_amount_cents].min
+        return [] unless credit_amount.positive?
+        credit = Credit.new(
+          invoice:,
+          credit_note:,
+          amount_cents: credit_amount,
+          amount_currency: invoice.currency,
+          before_taxes: false
+        )
+
+        invoice.credit_notes_amount_cents += credit.amount_cents
+        [credit]
+      end
+
+      def generate_credit_note
+        return unless terminated_subscription.plan.pay_in_advance?
+
+        CreditNotes::CreateFromTermination.call!(
+          subscription: terminated_subscription,
+          reason: "order_cancellation",
+          context: :preview
+        ).credit_note
+      end
+    end
+  end
+end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -222,10 +222,10 @@ module Invoices
     end
 
     def create_credit_note_credits
-      credit_result = Credits::CreditNoteService.call(invoice:, context: :preview)
-      credit_result.raise_if_error!
+      terminated_subscription = subscriptions.find(&:terminated?)
+      credits = Preview::CreditsService.call!(invoice:, terminated_subscription:).credits
 
-      invoice.total_amount_cents -= credit_result.credits.sum(&:amount_cents)
+      invoice.total_amount_cents -= credits.sum(&:amount_cents)
     end
 
     def create_applied_prepaid_credits

--- a/spec/services/invoices/preview/credits_service_spec.rb
+++ b/spec/services/invoices/preview/credits_service_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::Preview::CreditsService, type: :service do
+  describe ".call" do
+    subject(:result) { described_class.call(invoice:, terminated_subscription:) }
+
+    let(:credits) { result.credits.map { |c| c.attributes.symbolize_keys } }
+
+    let(:customer) { create(:customer) }
+    let(:organization) { customer.organization }
+    let(:invoice) { build(:invoice, customer:, organization:, total_amount_cents: 10_000) }
+
+    let(:credit_notes) do
+      create_pair(
+        :credit_note,
+        customer:,
+        invoice: build(:invoice, customer:, organization:)
+      )
+    end
+
+    let(:expected_credits_from_customer) do
+      credit_notes.map do |note|
+        hash_including(
+          amount_cents: note.total_amount_cents,
+          amount_currency: note.total_amount_currency
+        )
+      end
+    end
+
+    context "when terminated_subscription is present" do
+      let(:plan) { create(:plan, organization:, pay_in_advance:, amount_cents: 10_000) }
+
+      let(:subscription) do
+        create(
+          :subscription,
+          organization:,
+          customer:,
+          plan:,
+          subscription_at: Time.zone.parse("2025-02-01"),
+          started_at: Time.zone.parse("2025-02-01")
+        )
+      end
+
+      let(:terminated_subscription) do
+        subscription.tap do |sub|
+          sub.assign_attributes(
+            status: :terminated,
+            terminated_at: Time.zone.parse("15-02-2025")
+          )
+        end
+      end
+
+      before do
+        BillSubscriptionJob.perform_now(
+          [subscription],
+          Time.zone.parse("2025-02-01").to_i,
+          invoicing_reason: :subscription_starting
+        )
+
+        credit_notes
+      end
+
+      context "when subscription has a credit note" do
+        let(:pay_in_advance) { true }
+
+        let(:expected_credits_from_subscription) do
+          [
+            hash_including(
+              amount_cents: 4643,
+              amount_currency: "EUR"
+            )
+          ]
+        end
+
+        it "returns credits generated from subscription and customer credit notes" do
+          expect(result).to be_success
+          expect(credits).to match_array expected_credits_from_customer + expected_credits_from_subscription
+        end
+      end
+
+      context "when subscription has no credit note" do
+        let(:pay_in_advance) { false }
+
+        it "returns credits generated from customer's credit notes" do
+          expect(result).to be_success
+          expect(credits).to match_array expected_credits_from_customer
+        end
+      end
+    end
+
+    context "when terminated_subscription is missing" do
+      let(:terminated_subscription) { nil }
+
+      before { credit_notes }
+
+      it "returns credits generated from customer's credit notes" do
+        expect(result).to be_success
+        expect(credits).to match_array expected_credits_from_customer
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

For generating proper invoice preview for terminated subscription with plan paid in advance we need to generate credit note and later credit which will be accounted in the termination invoice.

## Description

Adjust credit note creation during subscription terminated to allow get non-persisted records.
Extract credits related logic from the `PreviewService` to the `Preview::CreditsService`.
