### PR TITLE
feat(data): Add graphql endpoint for revenue streams plans

### DIFF
--- a/app/graphql/resolvers/data_api/revenue_streams/plans_resolver.rb
+++ b/app/graphql/resolvers/data_api/revenue_streams/plans_resolver.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module DataApi
+    module RevenueStreams
+      class PlansResolver < Resolvers::BaseResolver
+        include AuthenticableApiUser
+        include RequiredOrganization
+
+        REQUIRED_PERMISSION = "data_api:revenue_streams:view"
+
+        description "Query revenue streams plans of an organization"
+
+        argument :currency, Types::CurrencyEnum, required: false
+        argument :order_by, Types::DataApi::RevenueStreams::OrderByEnum, required: false
+
+        type Types::DataApi::RevenueStreams::Plans::Object.collection_type, null: false
+
+        def resolve(**args)
+          result = ::DataApi::RevenueStreams::PlansService.call(current_organization, **args)
+          result.revenue_streams_plans
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/data_api/revenue_streams_resolver.rb
+++ b/app/graphql/resolvers/data_api/revenue_streams_resolver.rb
@@ -28,8 +28,6 @@ module Resolvers
       type Types::DataApi::RevenueStreams::Object.collection_type, null: false
 
       def resolve(**args)
-        raise unauthorized_error unless License.premium?
-
         result = ::DataApi::RevenueStreamsService.call(current_organization, **args)
         result.revenue_streams
       end

--- a/app/graphql/types/data_api/revenue_streams/object.rb
+++ b/app/graphql/types/data_api/revenue_streams/object.rb
@@ -4,7 +4,7 @@ module Types
   module DataApi
     module RevenueStreams
       class Object < Types::BaseObject
-        graphql_name "RevenueStreams"
+        graphql_name "RevenueStream"
 
         field :amount_currency, Types::CurrencyEnum, null: false
 

--- a/app/graphql/types/data_api/revenue_streams/order_by_enum.rb
+++ b/app/graphql/types/data_api/revenue_streams/order_by_enum.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  module DataApi
+    module RevenueStreams
+      class OrderByEnum < Types::BaseEnum
+        value :gross_revenue_amount_cents
+        value :net_revenue_amount_cents
+      end
+    end
+  end
+end

--- a/app/graphql/types/data_api/revenue_streams/plans/object.rb
+++ b/app/graphql/types/data_api/revenue_streams/plans/object.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Types
+  module DataApi
+    module RevenueStreams
+      module Plans
+        class Object < Types::BaseObject
+          graphql_name "RevenueStreamPlan"
+
+          field :plan_code, String, null: false
+          field :plan_id, ID, null: false
+          field :plan_interval, Types::Plans::IntervalEnum, null: false
+          field :plan_name, String, null: false
+
+          field :customers_count, Integer, null: false
+          field :customers_share, Float, null: false
+
+          field :amount_currency, Types::CurrencyEnum, null: false
+          field :gross_revenue_amount_cents, GraphQL::Types::BigInt, null: false
+          field :gross_revenue_share, Float, null: false
+          field :net_revenue_amount_cents, GraphQL::Types::BigInt, null: false
+          field :net_revenue_share, Float, null: false
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -69,6 +69,7 @@ module Types
     field :plan, resolver: Resolvers::PlanResolver
     field :plans, resolver: Resolvers::PlansResolver
     field :revenue_streams, resolver: Resolvers::DataApi::RevenueStreamsResolver
+    field :revenue_streams_plans, resolver: Resolvers::DataApi::RevenueStreams::PlansResolver
     field :subscription, resolver: Resolvers::SubscriptionResolver
     field :subscriptions, resolver: Resolvers::SubscriptionsResolver
     field :tax, resolver: Resolvers::TaxResolver

--- a/app/services/data_api/revenue_streams/plans_service.rb
+++ b/app/services/data_api/revenue_streams/plans_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module DataApi
+  module RevenueStreams
+    class PlansService < DataApi::BaseService
+      Result = BaseResult[:revenue_streams_plans]
+
+      def call
+        return result.forbidden_failure! unless License.premium?
+
+        data_revenue_streams_plans = http_client.get(headers:, params:)
+
+        result.revenue_streams_plans = data_revenue_streams_plans
+        result
+      end
+
+      private
+
+      def action_path
+        "revenue_streams/#{organization.id}/plans"
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -6208,6 +6208,11 @@ input OktaLoginInput {
   state: String!
 }
 
+enum OrderByEnum {
+  gross_revenue_amount_cents
+  net_revenue_amount_cents
+}
+
 """
 Safe Organization Type
 """
@@ -7047,7 +7052,12 @@ type Query {
   """
   Query revenue streams of an organization
   """
-  revenueStreams(currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): RevenueStreamsCollection!
+  revenueStreams(currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): RevenueStreamCollection!
+
+  """
+  Query revenue streams plans of an organization
+  """
+  revenueStreamsPlans(currency: CurrencyEnum, orderBy: OrderByEnum): RevenueStreamPlanCollection!
 
   """
   Query a single subscription of an organization
@@ -7306,7 +7316,7 @@ input RetryWebhookInput {
   id: ID!
 }
 
-type RevenueStreams {
+type RevenueStream {
   amountCurrency: CurrencyEnum!
   commitmentFeeAmountCents: BigInt!
   couponsAmountCents: BigInt!
@@ -7320,13 +7330,42 @@ type RevenueStreams {
 }
 
 """
-RevenueStreamsCollection type
+RevenueStreamCollection type
 """
-type RevenueStreamsCollection {
+type RevenueStreamCollection {
   """
-  A collection of paginated RevenueStreamsCollection
+  A collection of paginated RevenueStreamCollection
   """
-  collection: [RevenueStreams!]!
+  collection: [RevenueStream!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
+type RevenueStreamPlan {
+  amountCurrency: CurrencyEnum!
+  customersCount: Int!
+  customersShare: Float!
+  grossRevenueAmountCents: BigInt!
+  grossRevenueShare: Float!
+  netRevenueAmountCents: BigInt!
+  netRevenueShare: Float!
+  planCode: String!
+  planId: ID!
+  planInterval: PlanInterval!
+  planName: String!
+}
+
+"""
+RevenueStreamPlanCollection type
+"""
+type RevenueStreamPlanCollection {
+  """
+  A collection of paginated RevenueStreamPlanCollection
+  """
+  collection: [RevenueStreamPlan!]!
 
   """
   Pagination Metadata for navigating the Pagination

--- a/schema.json
+++ b/schema.json
@@ -28186,6 +28186,29 @@
           "enumValues": null
         },
         {
+          "kind": "ENUM",
+          "name": "OrderByEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "gross_revenue_amount_cents",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "net_revenue_amount_cents",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
           "kind": "OBJECT",
           "name": "Organization",
           "description": "Safe Organization Type",
@@ -34835,7 +34858,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "RevenueStreamsCollection",
+                  "name": "RevenueStreamCollection",
                   "ofType": null
                 }
               },
@@ -34944,6 +34967,47 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "revenueStreamsPlans",
+              "description": "Query revenue streams plans of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RevenueStreamPlanCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "OrderByEnum",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -36365,7 +36429,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "RevenueStreams",
+          "name": "RevenueStream",
           "description": null,
           "interfaces": [],
           "possibleTypes": null,
@@ -36536,14 +36600,14 @@
         },
         {
           "kind": "OBJECT",
-          "name": "RevenueStreamsCollection",
-          "description": "RevenueStreamsCollection type",
+          "name": "RevenueStreamCollection",
+          "description": "RevenueStreamCollection type",
           "interfaces": [],
           "possibleTypes": null,
           "fields": [
             {
               "name": "collection",
-              "description": "A collection of paginated RevenueStreamsCollection",
+              "description": "A collection of paginated RevenueStreamCollection",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -36555,7 +36619,245 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "RevenueStreams",
+                      "name": "RevenueStream",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RevenueStreamPlan",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "customersCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "customersShare",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "grossRevenueAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "grossRevenueShare",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "netRevenueAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "netRevenueShare",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "planCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "planId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "planInterval",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "PlanInterval",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "planName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RevenueStreamPlanCollection",
+          "description": "RevenueStreamPlanCollection type",
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated RevenueStreamPlanCollection",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "RevenueStreamPlan",
                       "ofType": null
                     }
                   }

--- a/spec/fixtures/lago_data_api/revenue_streams_plans.json
+++ b/spec/fixtures/lago_data_api/revenue_streams_plans.json
@@ -1,0 +1,58 @@
+[
+  {
+      "plan_id": "8d39f27f-8371-43ea-a327-c9579e70eeb3",
+      "amount_currency": "EUR",
+      "plan_code": "custom_plan_penny",
+      "customers_count": 1,
+      "gross_revenue_amount_cents": 120735293,
+      "net_revenue_amount_cents": 120735293,
+      "plan_name": "Penny",
+      "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+      "plan_interval": "monthly",
+      "customers_share": 0.0055,
+      "gross_revenue_share": 0.1148,
+      "net_revenue_share": 0.1148
+  },
+  {
+      "plan_id": "bea5197f-d862-4a38-89e0-4244b07aa365",
+      "amount_currency": "EUR",
+      "plan_code": "custom_plan_indy",
+      "customers_count": 1,
+      "gross_revenue_amount_cents": 79260312,
+      "net_revenue_amount_cents": 79260312,
+      "plan_name": "Indy",
+      "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+      "plan_interval": "monthly",
+      "customers_share": 0.0055,
+      "gross_revenue_share": 0.0754,
+      "net_revenue_share": 0.0754
+  },
+  {
+      "plan_id": "627ee06a-6e08-47f7-8eae-a07eec5a9ba3",
+      "amount_currency": "EUR",
+      "plan_code": "custom_plan_place",
+      "customers_count": 1,
+      "gross_revenue_amount_cents": 57755092,
+      "net_revenue_amount_cents": 57755092,
+      "plan_name": "Place",
+      "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+      "plan_interval": "monthly",
+      "customers_share": 0.0055,
+      "gross_revenue_share": 0.0549,
+      "net_revenue_share": 0.0549
+  },
+  {
+      "plan_id": "25d18c15-71ae-49af-bd38-94c7c2c80c7c",
+      "amount_currency": "EUR",
+      "plan_code": "custom_plan_piano",
+      "customers_count": 1,
+      "gross_revenue_amount_cents": 40018661,
+      "net_revenue_amount_cents": 40018661,
+      "plan_name": "Piano",
+      "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+      "plan_interval": "monthly",
+      "customers_share": 0.0055,
+      "gross_revenue_share": 0.0381,
+      "net_revenue_share": 0.0381
+  }
+]

--- a/spec/graphql/resolvers/data_api/revenue_streams/plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams/plans_resolver_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::DataApi::RevenueStreams::PlansResolver, type: :graphql do
+  let(:required_permission) { "data_api:revenue_streams:view" }
+  let(:query) do
+    <<~GQL
+      query($currency: CurrencyEnum, $orderBy: OrderByEnum) {
+        revenueStreamsPlans(currency: $currency, orderBy: $orderBy) {
+          collection {
+            planCode
+            planId
+            planInterval
+            planName
+            customersCount
+            customersShare
+            amountCurrency
+            grossRevenueAmountCents
+            grossRevenueShare
+            netRevenueAmountCents
+            netRevenueShare
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams_plans.json") }
+
+  around { |test| lago_premium!(&test) }
+
+  before do
+    stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/revenue_streams/#{organization.id}/plans")
+      .to_return(status: 200, body: body_response, headers: {})
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "data_api:revenue_streams:view"
+
+  it "returns a list of revenue streams plans" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:
+    )
+
+    revenue_streams_response = result["data"]["revenueStreamsPlans"]
+    expect(revenue_streams_response["collection"].first).to include(
+      {
+        "planId" => "8d39f27f-8371-43ea-a327-c9579e70eeb3",
+        "amountCurrency" => "EUR",
+        "planCode" => "custom_plan_penny",
+        "customersCount" => 1,
+        "grossRevenueAmountCents" => "120735293",
+        "netRevenueAmountCents" => "120735293",
+        "planName" => "Penny",
+        "planInterval" => "monthly",
+        "customersShare" => 0.0055,
+        "grossRevenueShare" => 0.1148,
+        "netRevenueShare" => 0.1148
+      }
+    )
+  end
+end

--- a/spec/graphql/types/data_api/revenue_streams/object_spec.rb
+++ b/spec/graphql/types/data_api/revenue_streams/object_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Types::DataApi::RevenueStreams::Object do
   subject { described_class }
 
   it do
-    expect(subject.graphql_name).to eq("RevenueStreams")
+    expect(subject.graphql_name).to eq("RevenueStream")
     expect(subject).to have_field(:amount_currency).of_type("CurrencyEnum!")
     expect(subject).to have_field(:coupons_amount_cents).of_type("BigInt!")
     expect(subject).to have_field(:gross_revenue_amount_cents).of_type("BigInt!")

--- a/spec/graphql/types/data_api/revenue_streams/order_by_enum_spec.rb
+++ b/spec/graphql/types/data_api/revenue_streams/order_by_enum_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::DataApi::RevenueStreams::OrderByEnum do
+  subject { described_class }
+
+  it "supports sorting by gross revenue and net revenue" do
+    expect(subject.values.keys).to match_array(%w[
+      gross_revenue_amount_cents
+      net_revenue_amount_cents
+    ])
+  end
+end

--- a/spec/graphql/types/data_api/revenue_streams/plans/object_spec.rb
+++ b/spec/graphql/types/data_api/revenue_streams/plans/object_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::DataApi::RevenueStreams::Plans::Object do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:plan_code).of_type("String!")
+    expect(subject).to have_field(:plan_id).of_type("ID!")
+    expect(subject).to have_field(:plan_interval).of_type("PlanInterval!")
+    expect(subject).to have_field(:plan_name).of_type("String!")
+    expect(subject).to have_field(:customers_count).of_type("Int!")
+    expect(subject).to have_field(:customers_share).of_type("Float!")
+    expect(subject).to have_field(:amount_currency).of_type("CurrencyEnum!")
+    expect(subject).to have_field(:gross_revenue_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:gross_revenue_share).of_type("Float!")
+    expect(subject).to have_field(:net_revenue_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:net_revenue_share).of_type("Float!")
+  end
+end

--- a/spec/services/data_api/revenue_streams/plans_service_spec.rb
+++ b/spec/services/data_api/revenue_streams/plans_service_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DataApi::RevenueStreams::PlansService, type: :service do
+  let(:service) { described_class.new(organization, **params) }
+  let(:customer) { create(:customer, organization:) }
+  let(:organization) { create(:organization) }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams_plans.json") }
+  let(:params) { {} }
+
+  before do
+    stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/revenue_streams/#{organization.id}/plans")
+      .to_return(status: 200, body: body_response, headers: {})
+  end
+
+  describe "#call" do
+    subject(:service_call) { service.call }
+
+    context "when licence is not premium" do
+      it "returns an error" do
+        expect(service_call).not_to be_success
+        expect(service_call.error.code).to eq("feature_unavailable")
+      end
+    end
+
+    context "when licence is premium" do
+      around { |test| lago_premium!(&test) }
+
+      it "returns expected revenue streams" do
+        expect(service_call).to be_success
+        expect(service_call.revenue_streams_plans.count).to eq(4)
+        expect(service_call.revenue_streams_plans.first).to eq(
+          {
+            "plan_id" => "8d39f27f-8371-43ea-a327-c9579e70eeb3",
+            "amount_currency" => "EUR",
+            "plan_code" => "custom_plan_penny",
+            "customers_count" => 1,
+            "gross_revenue_amount_cents" => 120735293,
+            "net_revenue_amount_cents" => 120735293,
+            "organization_id" => "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+            "plan_name" => "Penny",
+            "plan_interval" => "monthly",
+            "customers_share" => 0.0055,
+            "gross_revenue_share" => 0.1148,
+            "net_revenue_share" => 0.1148
+          }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Context**

A lot of users ain’t using our analytics feature because it’s not detailed enough. Thus, we are revamping the Analytics dashboard.

**Description**

This pull request introduces a new feature to query revenue streams plans of an organization using GraphQL.
It requests the `lago-data` api service and returns revenue streams per plans for an organization.