### PR TITLE
Feat(multientities): add billing_entity code uniqueness validation

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -41,6 +41,11 @@ class BillingEntity < ApplicationRecord
 
   default_scope -> { kept }
 
+  validates :code,
+    uniqueness: {
+      conditions: -> { where(archived_at: nil, deleted_at: nil) },
+      scope: :organization_id
+    }
   validates :country, country_code: true, unless: -> { country.nil? }
   validates :default_currency, inclusion: {in: currency_list}
   validates :document_locale, language_code: true
@@ -113,6 +118,7 @@ end
 # Indexes
 #
 #  index_billing_entities_on_applied_dunning_campaign_id  (applied_dunning_campaign_id)
+#  index_billing_entities_on_code_and_organization_id     (code,organization_id) UNIQUE WHERE ((deleted_at IS NULL) AND (archived_at IS NULL))
 #  index_billing_entities_on_organization_id              (organization_id)
 #
 # Foreign Keys

--- a/db/migrate/20250303104151_add_code_uniqueness_index_to_billing_entities.rb
+++ b/db/migrate/20250303104151_add_code_uniqueness_index_to_billing_entities.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddCodeUniquenessIndexToBillingEntities < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :billing_entities, [:code, :organization_id],
+      unique: true,
+      where: "deleted_at IS NULL AND archived_at IS NULL",
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_27_155522) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_03_104151) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -241,6 +241,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_27_155522) do
     t.datetime "updated_at", null: false
     t.uuid "applied_dunning_campaign_id"
     t.index ["applied_dunning_campaign_id"], name: "index_billing_entities_on_applied_dunning_campaign_id"
+    t.index ["code", "organization_id"], name: "index_billing_entities_on_code_and_organization_id", unique: true, where: "((deleted_at IS NULL) AND (archived_at IS NULL))"
     t.index ["organization_id"], name: "index_billing_entities_on_organization_id"
   end
 


### PR DESCRIPTION
## Context

When creating or updating a billing entities, the code should be unique within the organization for not deleted and not archived records

## Description

added uniqueness index and validation for code with organization_id 