### PR TITLE
feat(data): Add graphql endpoint for revenue streams customers

### DIFF
--- a/app/graphql/resolvers/data_api/revenue_streams/customers_resolver.rb
+++ b/app/graphql/resolvers/data_api/revenue_streams/customers_resolver.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module DataApi
+    module RevenueStreams
+      class CustomersResolver < Resolvers::BaseResolver
+        include AuthenticableApiUser
+        include RequiredOrganization
+
+        REQUIRED_PERMISSION = "data_api:revenue_streams:view"
+
+        description "Query revenue streams customers of an organization"
+
+        argument :currency, Types::CurrencyEnum, required: false
+        argument :limit, Integer, required: false
+        argument :offset, Integer, required: false
+        argument :order_by, Types::DataApi::RevenueStreams::OrderByEnum, required: false
+
+        type Types::DataApi::RevenueStreams::Customers::Object.collection_type, null: false
+
+        def resolve(**args)
+          result = ::DataApi::RevenueStreams::CustomersService.call(current_organization, **args)
+          result.revenue_streams_customers
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/data_api/revenue_streams/customers/object.rb
+++ b/app/graphql/types/data_api/revenue_streams/customers/object.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Types
+  module DataApi
+    module RevenueStreams
+      module Customers
+        class Object < Types::BaseObject
+          graphql_name "RevenueStreamCustomer"
+
+          field :customer_id, ID, null: false
+          field :customer_name, String, null: false
+          field :external_customer_id, String, null: false
+
+          field :amount_currency, Types::CurrencyEnum, null: false
+          field :gross_revenue_amount_cents, GraphQL::Types::BigInt, null: false
+          field :gross_revenue_share, Float, null: false
+          field :net_revenue_amount_cents, GraphQL::Types::BigInt, null: false
+          field :net_revenue_share, Float, null: false
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -69,6 +69,7 @@ module Types
     field :plan, resolver: Resolvers::PlanResolver
     field :plans, resolver: Resolvers::PlansResolver
     field :revenue_streams, resolver: Resolvers::DataApi::RevenueStreamsResolver
+    field :revenue_streams_customers, resolver: Resolvers::DataApi::RevenueStreams::CustomersResolver
     field :revenue_streams_plans, resolver: Resolvers::DataApi::RevenueStreams::PlansResolver
     field :subscription, resolver: Resolvers::SubscriptionResolver
     field :subscriptions, resolver: Resolvers::SubscriptionsResolver

--- a/app/services/data_api/revenue_streams/customers_service.rb
+++ b/app/services/data_api/revenue_streams/customers_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module DataApi
+  module RevenueStreams
+    class CustomersService < DataApi::BaseService
+      Result = BaseResult[:revenue_streams_customers]
+
+      def call
+        return result.forbidden_failure! unless License.premium?
+
+        data_revenue_streams_customers = http_client.get(headers:, params:)
+
+        result.revenue_streams_customers = data_revenue_streams_customers
+        result
+      end
+
+      private
+
+      def action_path
+        "revenue_streams/#{organization.id}/customers"
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -7055,6 +7055,11 @@ type Query {
   revenueStreams(currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): RevenueStreamCollection!
 
   """
+  Query revenue streams customers of an organization
+  """
+  revenueStreamsCustomers(currency: CurrencyEnum, limit: Int, offset: Int, orderBy: OrderByEnum): RevenueStreamCustomerCollection!
+
+  """
   Query revenue streams plans of an organization
   """
   revenueStreamsPlans(currency: CurrencyEnum, orderBy: OrderByEnum): RevenueStreamPlanCollection!
@@ -7337,6 +7342,32 @@ type RevenueStreamCollection {
   A collection of paginated RevenueStreamCollection
   """
   collection: [RevenueStream!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
+type RevenueStreamCustomer {
+  amountCurrency: CurrencyEnum!
+  customerId: ID!
+  customerName: String!
+  externalCustomerId: String!
+  grossRevenueAmountCents: BigInt!
+  grossRevenueShare: Float!
+  netRevenueAmountCents: BigInt!
+  netRevenueShare: Float!
+}
+
+"""
+RevenueStreamCustomerCollection type
+"""
+type RevenueStreamCustomerCollection {
+  """
+  A collection of paginated RevenueStreamCustomerCollection
+  """
+  collection: [RevenueStreamCustomer!]!
 
   """
   Pagination Metadata for navigating the Pagination

--- a/schema.json
+++ b/schema.json
@@ -34976,6 +34976,71 @@
               ]
             },
             {
+              "name": "revenueStreamsCustomers",
+              "description": "Query revenue streams customers of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RevenueStreamCustomerCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "OrderByEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "revenueStreamsPlans",
               "description": "Query revenue streams plans of an organization",
               "type": {
@@ -36620,6 +36685,196 @@
                     "ofType": {
                       "kind": "OBJECT",
                       "name": "RevenueStream",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RevenueStreamCustomer",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "customerId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "customerName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "externalCustomerId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "grossRevenueAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "grossRevenueShare",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "netRevenueAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "netRevenueShare",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RevenueStreamCustomerCollection",
+          "description": "RevenueStreamCustomerCollection type",
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated RevenueStreamCustomerCollection",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "RevenueStreamCustomer",
                       "ofType": null
                     }
                   }

--- a/spec/fixtures/lago_data_api/revenue_streams_customers.json
+++ b/spec/fixtures/lago_data_api/revenue_streams_customers.json
@@ -1,0 +1,46 @@
+[
+  {
+      "amount_currency": "EUR",
+      "customer_id": "e4676e50-1234-4606-bcdb-42effbc2b635",
+      "customer_name": "Penny",
+      "gross_revenue_share": 0.1185,
+      "net_revenue_share": 0.1185,
+      "organization_id": "c0047031-41b6-4386-a10b-0a36f787c84f",
+      "external_customer_id": "2537afc4-1234-4abb-89b7-d9b28c35780b",
+      "gross_revenue_amount_cents": 124628322,
+      "net_revenue_amount_cents": 124628322
+  },
+  {
+      "amount_currency": "EUR",
+      "customer_id": "144944d4-5678-4136-854f-11b92b171847",
+      "customer_name": "Indy",
+      "gross_revenue_share": 0.0767,
+      "net_revenue_share": 0.0767,
+      "organization_id": "c0047031-41b6-4386-a10b-0a36f787c84f",
+      "external_customer_id": "cb999dff-4567-4d08-962d-93565dfdbad8",
+      "gross_revenue_amount_cents": 80609006,
+      "net_revenue_amount_cents": 80609006
+  },
+  {
+      "amount_currency": "EUR",
+      "customer_id": "93fdf149-9012-4f7e-b799-20b7edbb9628",
+      "customer_name": "Place",
+      "gross_revenue_share": 0.056,
+      "net_revenue_share": 0.056,
+      "organization_id": "c0047031-41b6-4386-a10b-0a36f787c84f",
+      "external_customer_id": "58dd4fa2-8910-4a41-825b-ca3b865fe81b",
+      "gross_revenue_amount_cents": 58883577,
+      "net_revenue_amount_cents": 58883577
+  },
+  {
+      "amount_currency": "EUR",
+      "customer_id": "8fd8731f-3456-4d2e-96c9-a9aa7a6a2550",
+      "customer_name": "Piano",
+      "gross_revenue_share": 0.042,
+      "net_revenue_share": 0.042,
+      "organization_id": "c0047031-41b6-4386-a10b-0a36f787c84f",
+      "external_customer_id": "ca3535f0-2345-4f5e-9238-e6ed7372b133",
+      "gross_revenue_amount_cents": 44196934,
+      "net_revenue_amount_cents": 44196934
+  }
+]

--- a/spec/graphql/resolvers/data_api/revenue_streams/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams/customers_resolver_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::DataApi::RevenueStreams::CustomersResolver, type: :graphql do
+  let(:required_permission) { "data_api:revenue_streams:view" }
+  let(:query) do
+    <<~GQL
+      query($currency: CurrencyEnum, $orderBy: OrderByEnum, $limit: Int, $offset: Int) {
+        revenueStreamsCustomers(currency: $currency, orderBy: $orderBy, limit: $limit, offset: $offset) {
+          collection {
+            customerId
+            externalCustomerId
+            customerName
+            amountCurrency
+            grossRevenueAmountCents
+            grossRevenueShare
+            netRevenueAmountCents
+            netRevenueShare
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams_customers.json") }
+
+  around { |test| lago_premium!(&test) }
+
+  before do
+    stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/revenue_streams/#{organization.id}/customers")
+      .to_return(status: 200, body: body_response, headers: {})
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "data_api:revenue_streams:view"
+
+  it "returns a list of revenue streams customers" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:
+    )
+
+    revenue_streams_response = result["data"]["revenueStreamsCustomers"]
+    expect(revenue_streams_response["collection"].first).to include(
+      {
+        "amountCurrency" => "EUR",
+        "customerId" => "e4676e50-1234-4606-bcdb-42effbc2b635",
+        "externalCustomerId" => "2537afc4-1234-4abb-89b7-d9b28c35780b",
+        "customerName" => "Penny",
+        "grossRevenueAmountCents" => "124628322",
+        "netRevenueAmountCents" => "124628322",
+        "grossRevenueShare" => 0.1185,
+        "netRevenueShare" => 0.1185
+      }
+    )
+  end
+end

--- a/spec/graphql/types/data_api/revenue_streams/customers/object_spec.rb
+++ b/spec/graphql/types/data_api/revenue_streams/customers/object_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::DataApi::RevenueStreams::Customers::Object do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:customer_id).of_type("ID!")
+    expect(subject).to have_field(:external_customer_id).of_type("String!")
+    expect(subject).to have_field(:customer_name).of_type("String!")
+    expect(subject).to have_field(:amount_currency).of_type("CurrencyEnum!")
+    expect(subject).to have_field(:gross_revenue_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:gross_revenue_share).of_type("Float!")
+    expect(subject).to have_field(:net_revenue_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:net_revenue_share).of_type("Float!")
+  end
+end

--- a/spec/services/data_api/revenue_streams/customers_service_spec.rb
+++ b/spec/services/data_api/revenue_streams/customers_service_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DataApi::RevenueStreams::CustomersService, type: :service do
+  let(:service) { described_class.new(organization, **params) }
+  let(:customer) { create(:customer, organization:) }
+  let(:organization) { create(:organization) }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams_customers.json") }
+  let(:params) { {} }
+
+  before do
+    stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/revenue_streams/#{organization.id}/customers")
+      .to_return(status: 200, body: body_response, headers: {})
+  end
+
+  describe "#call" do
+    subject(:service_call) { service.call }
+
+    context "when licence is not premium" do
+      it "returns an error" do
+        expect(service_call).not_to be_success
+        expect(service_call.error.code).to eq("feature_unavailable")
+      end
+    end
+
+    context "when licence is premium" do
+      around { |test| lago_premium!(&test) }
+
+      it "returns expected revenue streams" do
+        expect(service_call).to be_success
+        expect(service_call.revenue_streams_customers.count).to eq(4)
+        expect(service_call.revenue_streams_customers.first).to eq(
+          {
+            "amount_currency" => "EUR",
+            "customer_id" => "e4676e50-1234-4606-bcdb-42effbc2b635",
+            "customer_name" => "Penny",
+            "external_customer_id" => "2537afc4-1234-4abb-89b7-d9b28c35780b",
+            "gross_revenue_amount_cents" => 124628322,
+            "gross_revenue_share" => 0.1185,
+            "net_revenue_amount_cents" => 124628322,
+            "net_revenue_share" => 0.1185,
+            "organization_id" => "c0047031-41b6-4386-a10b-0a36f787c84f"
+          }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Context**

A lot of users ain’t using our analytics feature because it’s not detailed enough. Thus, we are revamping the Analytics dashboard.

**Description**

This pull request introduces a new feature to query revenue streams customers of an organization using GraphQL.
It requests the `lago-data` api service and returns revenue streams per customers for an organization.