### PR TITLE
revert: save payment method

### DIFF
--- a/app/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service.rb
@@ -5,26 +5,7 @@ module PaymentProviders
     module Webhooks
       class PaymentIntentSucceededService < BaseService
         def call
-          @result = update_payment_status! "succeeded"
-          update_provider_payment_method_data
-          result
-        end
-
-        private
-
-        def update_provider_payment_method_data
-          latest_charge = event.data.object.charges.data.last
-          data = {
-            id: event.data.object.payment_method,
-            type: latest_charge.payment_method_details.type
-          }
-          if data[:type] == "card"
-            data[:brand] = latest_charge.payment_method_details.card.brand
-            data[:last4] = latest_charge.payment_method_details.card.last4
-          end
-
-          # NOTE: `result.payment was set by the service handling update_payment_status!
-          result.payment.update(provider_payment_method_data: data)
+          update_payment_status! "succeeded"
         end
       end
     end

--- a/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
@@ -33,18 +33,18 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
           )
         ).and_call_original
 
-      payment = create(:payment, provider_payment_id: event.data.object.id)
+      create(:payment, provider_payment_id: event.data.object.id)
 
       result = event_service.call
 
       expect(result).to be_success
 
-      expect(payment.reload.provider_payment_method_data).to eq({
-        "id" => "pm_1Qu0lNQ8iJWBZFaMkKPH3KFv",
-        "type" => "card",
-        "brand" => "visa",
-        "last4" => "4242"
-      })
+      # expect(payment.reload.provider_payment_method_data).to eq({
+      #   "id" => "pm_1Qu0lNQ8iJWBZFaMkKPH3KFv",
+      #   "type" => "card",
+      #   "brand" => "visa",
+      #   "last4" => "4242"
+      # })
     end
   end
 
@@ -72,12 +72,12 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
       result = event_service.call
 
       expect(result).to be_success
-      expect(payment.reload.provider_payment_method_data).to eq({
-        "id" => "pm_1Qu0lNQ8iJWBZFaMkKPH3KFv",
-        "type" => "card",
-        "brand" => "visa",
-        "last4" => "4242"
-      })
+      # expect(payment.reload.provider_payment_method_data).to eq({
+      #   "id" => "pm_1Qu0lNQ8iJWBZFaMkKPH3KFv",
+      #   "type" => "card",
+      #   "brand" => "visa",
+      #   "last4" => "4242"
+      # })
     end
   end
 


### PR DESCRIPTION
## Description

Newer version of stripe api don't have the charges array bit instead, just the id of te last charge. I need to confirm how we lock API version.
Reverting for now