### PR TITLE
fix: retry Net::ReadTimeout for pulling taxes

### DIFF
--- a/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
+++ b/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
@@ -7,6 +7,7 @@ module Invoices
 
       retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
       retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 6
+      retry_on Net::ReadTimeout, wait: :polynomially_longer, attempts: 6
 
       def perform(invoice:)
         Invoices::ProviderTaxes::PullTaxesAndApplyService.call!(invoice:)


### PR DESCRIPTION
## Context

Integration aggregator often returns Net::ReadTimeout

## Description

This PR auto retries mentioned error
