### PR TITLE
bug(advance_charges): invoice paid in advance succeeded fees

### DIFF
--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -46,7 +46,7 @@ module Invoices
       # NOTE: filter all active/terminated subscriptions having non-invoiceable fees not yet attached to an invoice
       @subscriptions ||= organization.subscriptions
         .where(
-          id: Fee.where(organization_id: organization.id)
+          id: Fee.from_organization(organization)
             .where(invoice_id: nil, payment_status: :succeeded)
             .where("succeeded_at <= ?", billing_at)
             .joins(:subscription)

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -222,6 +222,20 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
         expect(sub.charges_from_datetime).to match_datetime fee_boundaries[:charges_from_datetime]
         expect(sub.invoicing_reason).to eq "in_advance_charge_periodic"
       end
+
+      context "when the fee does not have organization_id set (regression)" do
+        before do
+          paid_in_advance_fee.update!(organization_id: nil)
+        end
+
+        it "does not fail" do
+          result = invoice_service.call
+
+          expect(result).to be_success
+          expect(result.invoice).to be_a Invoice
+          expect(result.invoice.fees.count).to eq 1
+        end
+      end
     end
 
     context "with integration requiring sync" do


### PR DESCRIPTION
when fee has `organization_id = nil`