### PR TITLE
feat(netsuite): enforce customer external id to be NetSuite EntityId

### DIFF
--- a/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
@@ -19,7 +19,9 @@ module Integrations
                 "custentity_lago_sf_id" => customer.external_salesforce_id,
                 "custentity_lago_customer_link" => customer_url,
                 "email" => email,
-                "phone" => phone
+                "phone" => phone,
+                "entityid" => customer.external_customer_id,
+                "autoname" => false # fixed value
               }.merge(names),
               "options" => {
                 "ignoreMandatoryFields" => false # Fixed value
@@ -37,7 +39,8 @@ module Integrations
                 "custentity_lago_sf_id" => customer.external_salesforce_id,
                 "custentity_lago_customer_link" => customer_url,
                 "email" => email,
-                "phone" => phone
+                "phone" => phone,
+                "entityid" => customer.external_customer_id,
               }.merge(names),
               "options" => {
                 "isDynamic" => false

--- a/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
@@ -20,7 +20,7 @@ module Integrations
                 "custentity_lago_customer_link" => customer_url,
                 "email" => email,
                 "phone" => phone,
-                "entityid" => customer.external_customer_id,
+                "entityid" => customer.external_id,
                 "autoname" => false # fixed value
               }.merge(names),
               "options" => {
@@ -40,7 +40,8 @@ module Integrations
                 "custentity_lago_customer_link" => customer_url,
                 "email" => email,
                 "phone" => phone,
-                "entityid" => customer.external_customer_id,
+                "entityid" => customer.external_id,
+                "autoname" => false # fixed value
               }.merge(names),
               "options" => {
                 "isDynamic" => false

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -56,7 +56,9 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
               "custentity_lago_sf_id" => customer.external_salesforce_id,
               "custentity_lago_customer_link" => customer_link,
               "email" => customer.email,
-              "phone" => customer.phone
+              "phone" => customer.phone,
+              "entityid" => customer.external_id,
+              "autoname" => false
             },
             "options" => {
               "ignoreMandatoryFields" => false
@@ -197,7 +199,9 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
             "custentity_lago_sf_id" => customer.external_salesforce_id,
             "custentity_lago_customer_link" => customer_link,
             "email" => customer.email,
-            "phone" => customer.phone
+            "phone" => customer.phone,
+            "entityid" => customer.external_id,
+            "autoname" => false
           },
           "options" => {
             "ignoreMandatoryFields" => false

--- a/spec/services/integrations/aggregator/contacts/payloads/factory_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/factory_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Factory do
         aggregate_failures do
           expect(subject["recordId"]).to eq(integration_customer.external_customer_id)
           expect(subject["columns"]["companyname"]).to eq(customer.name)
-          expect(subject["columns"]["entityid"]).to eq(customer.external_customer_id)
+          expect(subject["columns"]["entityid"]).to eq(customer.external_id)
         end
       end
     end

--- a/spec/services/integrations/aggregator/contacts/payloads/factory_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/factory_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Factory do
         aggregate_failures do
           expect(subject["recordId"]).to eq(integration_customer.external_customer_id)
           expect(subject["columns"]["companyname"]).to eq(customer.name)
+          expect(subject["columns"]["entityid"]).to eq(customer.external_customer_id)
         end
       end
     end

--- a/spec/services/integrations/aggregator/contacts/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/netsuite_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Netsuite do
           "custentity_lago_sf_id" => customer.external_salesforce_id,
           "custentity_lago_customer_link" => customer_link,
           "email" => customer.email.to_s.split(",").first&.strip,
-          "phone" => customer.phone.to_s.split(",").first&.strip
+          "phone" => customer.phone.to_s.split(",").first&.strip,
+          "entityid" => customer.external_id,
+          "autoname" => false
         }.merge(
           customer.customer_type_individual? ? {"firstname" => customer.firstname, "lastname" => customer.lastname} : {}
         ),
@@ -317,13 +319,13 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Netsuite do
         "recordId" => integration_customer.external_customer_id,
         "columns" => {
           "isperson" => isperson,
-          "entityid" => customer.external_customer_id,
-          "autoname" => false,
           "subsidiary" => integration_customer.subsidiary_id,
           "custentity_lago_sf_id" => customer.external_salesforce_id,
           "custentity_lago_customer_link" => customer_link,
           "email" => customer.email.to_s.split(",").first&.strip,
-          "phone" => customer.phone.to_s.split(",").first&.strip
+          "phone" => customer.phone.to_s.split(",").first&.strip,
+          "entityid" => customer.external_id,
+          "autoname" => false
         }.merge(names),
         "options" => {
           "isDynamic" => false

--- a/spec/services/integrations/aggregator/contacts/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/netsuite_spec.rb
@@ -317,6 +317,8 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Netsuite do
         "recordId" => integration_customer.external_customer_id,
         "columns" => {
           "isperson" => isperson,
+          "entityid" => customer.external_customer_id,
+          "autoname" => false,
           "subsidiary" => integration_customer.subsidiary_id,
           "custentity_lago_sf_id" => customer.external_salesforce_id,
           "custentity_lago_customer_link" => customer_link,

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
               "custentity_lago_customer_link" => customer_link,
               "email" => customer.email,
               "phone" => customer.phone,
-              "entityid" => customer.external_customer_id,
+              "entityid" => customer.external_id,
               "autoname" => false
             },
             "options" => {
@@ -146,7 +146,9 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
             "custentity_lago_sf_id" => customer.external_salesforce_id,
             "custentity_lago_customer_link" => customer_link,
             "email" => customer.email,
-            "phone" => customer.phone
+            "phone" => customer.phone,
+            "entityid" => customer.external_id,
+            "autoname" => false
           },
           "options" => {
             "isDynamic" => false

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
               "custentity_lago_sf_id" => customer.external_salesforce_id,
               "custentity_lago_customer_link" => customer_link,
               "email" => customer.email,
-              "phone" => customer.phone
+              "phone" => customer.phone,
+              "entityid" => customer.external_customer_id,
+              "autoname" => false
             },
             "options" => {
               "isDynamic" => false


### PR DESCRIPTION
Some customers need Lago customer.external_id to be used at NetSuite entityId:
1. Pass `customer.external_id` to Netsuite `entityId`
2. Enforce this id by passing `autoname` to false