### PR TITLE
feat(data): Add graphql endpoint for mrrs

### DIFF
--- a/app/config/permissions/definition.yml
+++ b/app/config/permissions/definition.yml
@@ -9,8 +9,7 @@ billable_metrics:
   update:
   delete:
 data_api:
-  revenue_streams:
-    view:
+  view:
 plans:
   view: true
   create:

--- a/app/config/permissions/role-finance.yml
+++ b/app/config/permissions/role-finance.yml
@@ -9,8 +9,7 @@ billable_metrics:
   update: false
   delete: false
 data_api:
-  revenue_streams:
-    view: true
+  view: true
 plans:
   create: false
   update: false

--- a/app/config/permissions/role-manager.yml
+++ b/app/config/permissions/role-manager.yml
@@ -9,8 +9,7 @@ billable_metrics:
   update: false
   delete: false
 data_api:
-  revenue_streams:
-    view: false
+  view: false
 plans:
   create: false
   update: false

--- a/app/graphql/resolvers/data_api/mrrs_resolver.rb
+++ b/app/graphql/resolvers/data_api/mrrs_resolver.rb
@@ -2,14 +2,14 @@
 
 module Resolvers
   module DataApi
-    class RevenueStreamsResolver < Resolvers::BaseResolver
+    class MrrsResolver < Resolvers::BaseResolver
       include AuthenticableApiUser
       include RequiredOrganization
 
       REQUIRED_PERMISSION = "data_api:view"
 
-      graphql_name "DataApiRevenueStreams"
-      description "Query revenue streams of an organization"
+      graphql_name "DataApiMrrs"
+      description "Query monthly recurring revenues of an organization"
 
       argument :currency, Types::CurrencyEnum, required: false
 
@@ -26,11 +26,11 @@ module Resolvers
 
       argument :plan_code, String, required: false
 
-      type Types::DataApi::RevenueStreams::Object.collection_type, null: false
+      type Types::DataApi::Mrrs::Object.collection_type, null: false
 
       def resolve(**args)
-        result = ::DataApi::RevenueStreamsService.call(current_organization, **args)
-        result.revenue_streams
+        result = ::DataApi::MrrsService.call(current_organization, **args)
+        result.mrrs
       end
     end
   end

--- a/app/graphql/resolvers/data_api/revenue_streams/customers_resolver.rb
+++ b/app/graphql/resolvers/data_api/revenue_streams/customers_resolver.rb
@@ -7,8 +7,9 @@ module Resolvers
         include AuthenticableApiUser
         include RequiredOrganization
 
-        REQUIRED_PERMISSION = "data_api:revenue_streams:view"
+        REQUIRED_PERMISSION = "data_api:view"
 
+        graphql_name "DataApiRevenueStreamsCustomers"
         description "Query revenue streams customers of an organization"
 
         argument :currency, Types::CurrencyEnum, required: false

--- a/app/graphql/resolvers/data_api/revenue_streams/plans_resolver.rb
+++ b/app/graphql/resolvers/data_api/revenue_streams/plans_resolver.rb
@@ -7,8 +7,9 @@ module Resolvers
         include AuthenticableApiUser
         include RequiredOrganization
 
-        REQUIRED_PERMISSION = "data_api:revenue_streams:view"
+        REQUIRED_PERMISSION = "data_api:view"
 
+        graphql_name "DataApiRevenueStreamsPlans"
         description "Query revenue streams plans of an organization"
 
         argument :currency, Types::CurrencyEnum, required: false

--- a/app/graphql/resolvers/data_api/revenue_streams/plans_resolver.rb
+++ b/app/graphql/resolvers/data_api/revenue_streams/plans_resolver.rb
@@ -13,6 +13,8 @@ module Resolvers
         description "Query revenue streams plans of an organization"
 
         argument :currency, Types::CurrencyEnum, required: false
+        argument :limit, Integer, required: false
+        argument :offset, Integer, required: false
         argument :order_by, Types::DataApi::RevenueStreams::OrderByEnum, required: false
 
         type Types::DataApi::RevenueStreams::Plans::Object.collection_type, null: false

--- a/app/graphql/types/data_api/mrrs/object.rb
+++ b/app/graphql/types/data_api/mrrs/object.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Types
+  module DataApi
+    module Mrrs
+      class Object < Types::BaseObject
+        graphql_name "DataApiMrr"
+
+        field :amount_currency, Types::CurrencyEnum, null: false
+
+        field :ending_mrr, GraphQL::Types::BigInt, null: false
+        field :starting_mrr, GraphQL::Types::BigInt, null: false
+
+        field :mrr_change, GraphQL::Types::BigInt, null: false
+        field :mrr_churn, GraphQL::Types::BigInt, null: false
+        field :mrr_contraction, GraphQL::Types::BigInt, null: false
+        field :mrr_expansion, GraphQL::Types::BigInt, null: false
+        field :mrr_new, GraphQL::Types::BigInt, null: false
+
+        field :end_of_period_dt, GraphQL::Types::ISO8601Date, null: false
+        field :start_of_period_dt, GraphQL::Types::ISO8601Date, null: false
+      end
+    end
+  end
+end

--- a/app/graphql/types/data_api/revenue_streams/customers/object.rb
+++ b/app/graphql/types/data_api/revenue_streams/customers/object.rb
@@ -5,7 +5,7 @@ module Types
     module RevenueStreams
       module Customers
         class Object < Types::BaseObject
-          graphql_name "RevenueStreamCustomer"
+          graphql_name "DataApiRevenueStreamCustomer"
 
           field :customer_id, ID, null: false
           field :customer_name, String, null: false

--- a/app/graphql/types/data_api/revenue_streams/object.rb
+++ b/app/graphql/types/data_api/revenue_streams/object.rb
@@ -4,7 +4,7 @@ module Types
   module DataApi
     module RevenueStreams
       class Object < Types::BaseObject
-        graphql_name "RevenueStream"
+        graphql_name "DataApiRevenueStream"
 
         field :amount_currency, Types::CurrencyEnum, null: false
 

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -68,9 +68,6 @@ module Types
     field :payments, resolver: Resolvers::PaymentsResolver
     field :plan, resolver: Resolvers::PlanResolver
     field :plans, resolver: Resolvers::PlansResolver
-    field :revenue_streams, resolver: Resolvers::DataApi::RevenueStreamsResolver
-    field :revenue_streams_customers, resolver: Resolvers::DataApi::RevenueStreams::CustomersResolver
-    field :revenue_streams_plans, resolver: Resolvers::DataApi::RevenueStreams::PlansResolver
     field :subscription, resolver: Resolvers::SubscriptionResolver
     field :subscriptions, resolver: Resolvers::SubscriptionsResolver
     field :tax, resolver: Resolvers::TaxResolver
@@ -81,5 +78,10 @@ module Types
     field :webhook_endpoint, resolver: Resolvers::WebhookEndpointResolver
     field :webhook_endpoints, resolver: Resolvers::WebhookEndpointsResolver
     field :webhooks, resolver: Resolvers::WebhooksResolver
+
+    field :data_api_mrrs, resolver: Resolvers::DataApi::MrrsResolver
+    field :data_api_revenue_streams, resolver: Resolvers::DataApi::RevenueStreamsResolver
+    field :data_api_revenue_streams_customers, resolver: Resolvers::DataApi::RevenueStreams::CustomersResolver
+    field :data_api_revenue_streams_plans, resolver: Resolvers::DataApi::RevenueStreams::PlansResolver
   end
 end

--- a/app/services/data_api/mrrs_service.rb
+++ b/app/services/data_api/mrrs_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module DataApi
+  class MrrsService < BaseService
+    Result = BaseResult[:mrrs]
+
+    def call
+      return result.forbidden_failure! unless License.premium?
+
+      data_mrrs = http_client.get(headers:, params:)
+
+      result.mrrs = data_mrrs
+      result
+    end
+
+    private
+
+    def action_path
+      "mrrs/#{organization.id}/"
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -6896,7 +6896,7 @@ type Query {
   """
   Query revenue streams plans of an organization
   """
-  dataApiRevenueStreamsPlans(currency: CurrencyEnum, orderBy: OrderByEnum): RevenueStreamPlanCollection!
+  dataApiRevenueStreamsPlans(currency: CurrencyEnum, limit: Int, offset: Int, orderBy: OrderByEnum): RevenueStreamPlanCollection!
 
   """
   Query a single dunning campaign of an organization

--- a/schema.graphql
+++ b/schema.graphql
@@ -3527,6 +3527,88 @@ type CustomerUsage {
   totalAmountCents: BigInt!
 }
 
+type DataApiMrr {
+  amountCurrency: CurrencyEnum!
+  endOfPeriodDt: ISO8601Date!
+  endingMrr: BigInt!
+  mrrChange: BigInt!
+  mrrChurn: BigInt!
+  mrrContraction: BigInt!
+  mrrExpansion: BigInt!
+  mrrNew: BigInt!
+  startOfPeriodDt: ISO8601Date!
+  startingMrr: BigInt!
+}
+
+"""
+DataApiMrrCollection type
+"""
+type DataApiMrrCollection {
+  """
+  A collection of paginated DataApiMrrCollection
+  """
+  collection: [DataApiMrr!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
+type DataApiRevenueStream {
+  amountCurrency: CurrencyEnum!
+  commitmentFeeAmountCents: BigInt!
+  couponsAmountCents: BigInt!
+  endOfPeriodDt: ISO8601Date!
+  grossRevenueAmountCents: BigInt!
+  netRevenueAmountCents: BigInt!
+  oneOffFeeAmountCents: BigInt!
+  startOfPeriodDt: ISO8601Date!
+  subscriptionFeeAmountCents: BigInt!
+  usageBasedFeeAmountCents: BigInt!
+}
+
+"""
+DataApiRevenueStreamCollection type
+"""
+type DataApiRevenueStreamCollection {
+  """
+  A collection of paginated DataApiRevenueStreamCollection
+  """
+  collection: [DataApiRevenueStream!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
+type DataApiRevenueStreamCustomer {
+  amountCurrency: CurrencyEnum!
+  customerId: ID!
+  customerName: String!
+  externalCustomerId: String!
+  grossRevenueAmountCents: BigInt!
+  grossRevenueShare: Float!
+  netRevenueAmountCents: BigInt!
+  netRevenueShare: Float!
+}
+
+"""
+DataApiRevenueStreamCustomerCollection type
+"""
+type DataApiRevenueStreamCustomerCollection {
+  """
+  A collection of paginated DataApiRevenueStreamCustomerCollection
+  """
+  collection: [DataApiRevenueStreamCustomer!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
 type DataExport {
   id: ID!
   status: DataExportStatusEnum!
@@ -6402,7 +6484,7 @@ type Permissions {
   customersDelete: Boolean!
   customersUpdate: Boolean!
   customersView: Boolean!
-  dataApiRevenueStreamsView: Boolean!
+  dataApiView: Boolean!
   developersKeysManage: Boolean!
   developersManage: Boolean!
   draftInvoicesUpdate: Boolean!
@@ -6797,6 +6879,26 @@ type Query {
   customers(accountType: [CustomerAccountTypeEnum!], limit: Int, page: Int, searchTerm: String): CustomerCollection!
 
   """
+  Query monthly recurring revenues of an organization
+  """
+  dataApiMrrs(currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiMrrCollection!
+
+  """
+  Query revenue streams of an organization
+  """
+  dataApiRevenueStreams(currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiRevenueStreamCollection!
+
+  """
+  Query revenue streams customers of an organization
+  """
+  dataApiRevenueStreamsCustomers(currency: CurrencyEnum, limit: Int, offset: Int, orderBy: OrderByEnum): DataApiRevenueStreamCustomerCollection!
+
+  """
+  Query revenue streams plans of an organization
+  """
+  dataApiRevenueStreamsPlans(currency: CurrencyEnum, orderBy: OrderByEnum): RevenueStreamPlanCollection!
+
+  """
   Query a single dunning campaign of an organization
   """
   dunningCampaign(
@@ -7057,21 +7159,6 @@ type Query {
   plans(limit: Int, page: Int, searchTerm: String): PlanCollection!
 
   """
-  Query revenue streams of an organization
-  """
-  revenueStreams(currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): RevenueStreamCollection!
-
-  """
-  Query revenue streams customers of an organization
-  """
-  revenueStreamsCustomers(currency: CurrencyEnum, limit: Int, offset: Int, orderBy: OrderByEnum): RevenueStreamCustomerCollection!
-
-  """
-  Query revenue streams plans of an organization
-  """
-  revenueStreamsPlans(currency: CurrencyEnum, orderBy: OrderByEnum): RevenueStreamPlanCollection!
-
-  """
   Query a single subscription of an organization
   """
   subscription(
@@ -7326,60 +7413,6 @@ input RetryWebhookInput {
   """
   clientMutationId: String
   id: ID!
-}
-
-type RevenueStream {
-  amountCurrency: CurrencyEnum!
-  commitmentFeeAmountCents: BigInt!
-  couponsAmountCents: BigInt!
-  endOfPeriodDt: ISO8601Date!
-  grossRevenueAmountCents: BigInt!
-  netRevenueAmountCents: BigInt!
-  oneOffFeeAmountCents: BigInt!
-  startOfPeriodDt: ISO8601Date!
-  subscriptionFeeAmountCents: BigInt!
-  usageBasedFeeAmountCents: BigInt!
-}
-
-"""
-RevenueStreamCollection type
-"""
-type RevenueStreamCollection {
-  """
-  A collection of paginated RevenueStreamCollection
-  """
-  collection: [RevenueStream!]!
-
-  """
-  Pagination Metadata for navigating the Pagination
-  """
-  metadata: CollectionMetadata!
-}
-
-type RevenueStreamCustomer {
-  amountCurrency: CurrencyEnum!
-  customerId: ID!
-  customerName: String!
-  externalCustomerId: String!
-  grossRevenueAmountCents: BigInt!
-  grossRevenueShare: Float!
-  netRevenueAmountCents: BigInt!
-  netRevenueShare: Float!
-}
-
-"""
-RevenueStreamCustomerCollection type
-"""
-type RevenueStreamCustomerCollection {
-  """
-  A collection of paginated RevenueStreamCustomerCollection
-  """
-  collection: [RevenueStreamCustomer!]!
-
-  """
-  Pagination Metadata for navigating the Pagination
-  """
-  metadata: CollectionMetadata!
 }
 
 type RevenueStreamPlan {

--- a/schema.json
+++ b/schema.json
@@ -15107,6 +15107,640 @@
         },
         {
           "kind": "OBJECT",
+          "name": "DataApiMrr",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "endOfPeriodDt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "endingMrr",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "mrrChange",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "mrrChurn",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "mrrContraction",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "mrrExpansion",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "mrrNew",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "startOfPeriodDt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "startingMrr",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DataApiMrrCollection",
+          "description": "DataApiMrrCollection type",
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated DataApiMrrCollection",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DataApiMrr",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DataApiRevenueStream",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "commitmentFeeAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "couponsAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "endOfPeriodDt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "grossRevenueAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "netRevenueAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "oneOffFeeAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "startOfPeriodDt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "subscriptionFeeAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "usageBasedFeeAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DataApiRevenueStreamCollection",
+          "description": "DataApiRevenueStreamCollection type",
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated DataApiRevenueStreamCollection",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DataApiRevenueStream",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DataApiRevenueStreamCustomer",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "customerId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "customerName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "externalCustomerId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "grossRevenueAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "grossRevenueShare",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "netRevenueAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "netRevenueShare",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DataApiRevenueStreamCustomerCollection",
+          "description": "DataApiRevenueStreamCustomerCollection type",
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated DataApiRevenueStreamCustomerCollection",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DataApiRevenueStreamCustomer",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "DataExport",
           "description": null,
           "interfaces": [],
@@ -29747,7 +30381,7 @@
               "args": []
             },
             {
-              "name": "dataApiRevenueStreamsView",
+              "name": "dataApiView",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -33229,6 +33863,362 @@
               ]
             },
             {
+              "name": "dataApiMrrs",
+              "description": "Query monthly recurring revenues of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "DataApiMrrCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "customerCountry",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CountryCode",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "customerType",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CustomerTypeEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "fromDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601Date",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "toDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601Date",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "timeGranularity",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "TimeGranularityEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "externalCustomerId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "externalSubscriptionId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "planCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "dataApiRevenueStreams",
+              "description": "Query revenue streams of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "DataApiRevenueStreamCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "customerCountry",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CountryCode",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "customerType",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CustomerTypeEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "fromDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601Date",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "toDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601Date",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "timeGranularity",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "TimeGranularityEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "externalCustomerId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "externalSubscriptionId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "planCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "dataApiRevenueStreamsCustomers",
+              "description": "Query revenue streams customers of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "DataApiRevenueStreamCustomerCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "OrderByEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "dataApiRevenueStreamsPlans",
+              "description": "Query revenue streams plans of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RevenueStreamPlanCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "orderBy",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "OrderByEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "dunningCampaign",
               "description": "Query a single dunning campaign of an organization",
               "type": {
@@ -34869,237 +35859,6 @@
               ]
             },
             {
-              "name": "revenueStreams",
-              "description": "Query revenue streams of an organization",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "RevenueStreamCollection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-                {
-                  "name": "currency",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "CurrencyEnum",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "customerCountry",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "CountryCode",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "customerType",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "CustomerTypeEnum",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "fromDate",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ISO8601Date",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "toDate",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ISO8601Date",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "timeGranularity",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "TimeGranularityEnum",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "externalCustomerId",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "externalSubscriptionId",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "planCode",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                }
-              ]
-            },
-            {
-              "name": "revenueStreamsCustomers",
-              "description": "Query revenue streams customers of an organization",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "RevenueStreamCustomerCollection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-                {
-                  "name": "currency",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "CurrencyEnum",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "limit",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "offset",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "orderBy",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "OrderByEnum",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                }
-              ]
-            },
-            {
-              "name": "revenueStreamsPlans",
-              "description": "Query revenue streams plans of an organization",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "RevenueStreamPlanCollection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-                {
-                  "name": "currency",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "CurrencyEnum",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "orderBy",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "OrderByEnum",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                }
-              ]
-            },
-            {
               "name": "subscription",
               "description": "Query a single subscription of an organization",
               "type": {
@@ -36508,418 +37267,6 @@
               "deprecationReason": null
             }
           ],
-          "enumValues": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RevenueStream",
-          "description": null,
-          "interfaces": [],
-          "possibleTypes": null,
-          "fields": [
-            {
-              "name": "amountCurrency",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "CurrencyEnum",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "commitmentFeeAmountCents",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "couponsAmountCents",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "endOfPeriodDt",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ISO8601Date",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "grossRevenueAmountCents",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "netRevenueAmountCents",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "oneOffFeeAmountCents",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "startOfPeriodDt",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ISO8601Date",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "subscriptionFeeAmountCents",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "usageBasedFeeAmountCents",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            }
-          ],
-          "inputFields": null,
-          "enumValues": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RevenueStreamCollection",
-          "description": "RevenueStreamCollection type",
-          "interfaces": [],
-          "possibleTypes": null,
-          "fields": [
-            {
-              "name": "collection",
-              "description": "A collection of paginated RevenueStreamCollection",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "RevenueStream",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "metadata",
-              "description": "Pagination Metadata for navigating the Pagination",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CollectionMetadata",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            }
-          ],
-          "inputFields": null,
-          "enumValues": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RevenueStreamCustomer",
-          "description": null,
-          "interfaces": [],
-          "possibleTypes": null,
-          "fields": [
-            {
-              "name": "amountCurrency",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "CurrencyEnum",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "customerId",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "customerName",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "externalCustomerId",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "grossRevenueAmountCents",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "grossRevenueShare",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "netRevenueAmountCents",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "netRevenueShare",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            }
-          ],
-          "inputFields": null,
-          "enumValues": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "RevenueStreamCustomerCollection",
-          "description": "RevenueStreamCustomerCollection type",
-          "interfaces": [],
-          "possibleTypes": null,
-          "fields": [
-            {
-              "name": "collection",
-              "description": "A collection of paginated RevenueStreamCustomerCollection",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "RevenueStreamCustomer",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "metadata",
-              "description": "Pagination Metadata for navigating the Pagination",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CollectionMetadata",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            }
-          ],
-          "inputFields": null,
           "enumValues": null
         },
         {

--- a/schema.json
+++ b/schema.json
@@ -34205,6 +34205,30 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "orderBy",
                   "description": null,
                   "type": {

--- a/spec/fixtures/lago_data_api/mrrs.json
+++ b/spec/fixtures/lago_data_api/mrrs.json
@@ -1,0 +1,54 @@
+[
+  {
+      "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+      "start_of_period_dt": "2023-11-01",
+      "end_of_period_dt": "2023-11-30",
+      "amount_currency": "EUR",
+      "starting_mrr": 0,
+      "ending_mrr": 23701746,
+      "mrr_new": 25016546,
+      "mrr_expansion": 0,
+      "mrr_contraction": 0,
+      "mrr_churn": -1314800,
+      "mrr_change": 23701746
+  },
+  {
+      "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+      "start_of_period_dt": "2023-12-01",
+      "end_of_period_dt": "2023-12-31",
+      "amount_currency": "EUR",
+      "starting_mrr": 23701746,
+      "ending_mrr": 23457216,
+      "mrr_new": 6171791,
+      "mrr_expansion": 0,
+      "mrr_contraction": 0,
+      "mrr_churn": -6416321,
+      "mrr_change": -244530
+  },
+  {
+      "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+      "start_of_period_dt": "2024-01-01",
+      "end_of_period_dt": "2024-01-31",
+      "amount_currency": "EUR",
+      "starting_mrr": 23457216,
+      "ending_mrr": 24821948,
+      "mrr_new": 4334134,
+      "mrr_expansion": 0,
+      "mrr_contraction": 0,
+      "mrr_churn": -2969402,
+      "mrr_change": 1364732
+  },
+  {
+      "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+      "start_of_period_dt": "2024-02-01",
+      "end_of_period_dt": "2024-02-29",
+      "amount_currency": "EUR",
+      "starting_mrr": 24821948,
+      "ending_mrr": 25828288,
+      "mrr_new": 1306340,
+      "mrr_expansion": 0,
+      "mrr_contraction": 0,
+      "mrr_churn": -300000,
+      "mrr_change": 1006340
+  }
+]

--- a/spec/graphql/resolvers/data_api/mrrs_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/mrrs_resolver_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::DataApi::MrrsResolver, type: :graphql do
+  let(:required_permission) { "data_api:view" }
+  let(:query) do
+    <<~GQL
+      query($currency: CurrencyEnum) {
+        dataApiMrrs(currency: $currency) {
+          collection {
+            amountCurrency
+            startingMrr
+            endingMrr
+            mrrNew
+            mrrExpansion
+            mrrContraction
+            mrrChurn
+            mrrChange
+            startOfPeriodDt
+            endOfPeriodDt
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/mrrs.json") }
+
+  before do
+    stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/mrrs/#{organization.id}/")
+      .to_return(status: 200, body: body_response, headers: {})
+  end
+
+  around { |test| lago_premium!(&test) }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "data_api:view"
+
+  it "returns a list of mrrs" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:
+    )
+
+    mrrs_response = result["data"]["dataApiMrrs"]
+    expect(mrrs_response["collection"].first).to eq(
+      {
+        "startOfPeriodDt" => "2023-11-01",
+        "endOfPeriodDt" => "2023-11-30",
+        "amountCurrency" => "EUR",
+        "startingMrr" => "0",
+        "endingMrr" => "23701746",
+        "mrrNew" => "25016546",
+        "mrrExpansion" => "0",
+        "mrrContraction" => "0",
+        "mrrChurn" => "-1314800",
+        "mrrChange" => "23701746"
+      }
+    )
+  end
+end

--- a/spec/graphql/resolvers/data_api/revenue_streams/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams/customers_resolver_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::RevenueStreams::CustomersResolver, type: :graphql do
-  let(:required_permission) { "data_api:revenue_streams:view" }
+  let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $orderBy: OrderByEnum, $limit: Int, $offset: Int) {
-        revenueStreamsCustomers(currency: $currency, orderBy: $orderBy, limit: $limit, offset: $offset) {
+        dataApiRevenueStreamsCustomers(currency: $currency, orderBy: $orderBy, limit: $limit, offset: $offset) {
           collection {
             customerId
             externalCustomerId
@@ -36,7 +36,7 @@ RSpec.describe Resolvers::DataApi::RevenueStreams::CustomersResolver, type: :gra
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
-  it_behaves_like "requires permission", "data_api:revenue_streams:view"
+  it_behaves_like "requires permission", "data_api:view"
 
   it "returns a list of revenue streams customers" do
     result = execute_graphql(
@@ -46,7 +46,7 @@ RSpec.describe Resolvers::DataApi::RevenueStreams::CustomersResolver, type: :gra
       query:
     )
 
-    revenue_streams_response = result["data"]["revenueStreamsCustomers"]
+    revenue_streams_response = result["data"]["dataApiRevenueStreamsCustomers"]
     expect(revenue_streams_response["collection"].first).to include(
       {
         "amountCurrency" => "EUR",

--- a/spec/graphql/resolvers/data_api/revenue_streams/plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams/plans_resolver_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::RevenueStreams::PlansResolver, type: :graphql do
-  let(:required_permission) { "data_api:revenue_streams:view" }
+  let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $orderBy: OrderByEnum) {
-        revenueStreamsPlans(currency: $currency, orderBy: $orderBy) {
+        dataApiRevenueStreamsPlans(currency: $currency, orderBy: $orderBy) {
           collection {
             planCode
             planId
@@ -39,7 +39,7 @@ RSpec.describe Resolvers::DataApi::RevenueStreams::PlansResolver, type: :graphql
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
-  it_behaves_like "requires permission", "data_api:revenue_streams:view"
+  it_behaves_like "requires permission", "data_api:view"
 
   it "returns a list of revenue streams plans" do
     result = execute_graphql(
@@ -49,7 +49,7 @@ RSpec.describe Resolvers::DataApi::RevenueStreams::PlansResolver, type: :graphql
       query:
     )
 
-    revenue_streams_response = result["data"]["revenueStreamsPlans"]
+    revenue_streams_response = result["data"]["dataApiRevenueStreamsPlans"]
     expect(revenue_streams_response["collection"].first).to include(
       {
         "planId" => "8d39f27f-8371-43ea-a327-c9579e70eeb3",

--- a/spec/graphql/resolvers/data_api/revenue_streams/plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams/plans_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::DataApi::RevenueStreams::PlansResolver, type: :graphql
   let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL
-      query($currency: CurrencyEnum, $orderBy: OrderByEnum) {
-        dataApiRevenueStreamsPlans(currency: $currency, orderBy: $orderBy) {
+      query($currency: CurrencyEnum, $orderBy: OrderByEnum, $limit: Int, $offset: Int) {
+        dataApiRevenueStreamsPlans(currency: $currency, orderBy: $orderBy, limit: $limit, offset: $offset) {
           collection {
             planCode
             planId

--- a/spec/graphql/resolvers/data_api/revenue_streams_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams_resolver_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::DataApi::RevenueStreamsResolver, type: :graphql do
-  let(:required_permission) { "data_api:revenue_streams:view" }
+  let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $externalCustomerId: String) {
-        revenueStreams(currency: $currency, externalCustomerId: $externalCustomerId) {
+        dataApiRevenueStreams(currency: $currency, externalCustomerId: $externalCustomerId) {
           collection {
             amountCurrency
             couponsAmountCents
@@ -38,7 +38,7 @@ RSpec.describe Resolvers::DataApi::RevenueStreamsResolver, type: :graphql do
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
-  it_behaves_like "requires permission", "data_api:revenue_streams:view"
+  it_behaves_like "requires permission", "data_api:view"
 
   it "returns a list of revenue streams" do
     result = execute_graphql(
@@ -48,7 +48,7 @@ RSpec.describe Resolvers::DataApi::RevenueStreamsResolver, type: :graphql do
       query:
     )
 
-    revenue_streams_response = result["data"]["revenueStreams"]
+    revenue_streams_response = result["data"]["dataApiRevenueStreams"]
     expect(revenue_streams_response["collection"].first).to include(
       {
         "startOfPeriodDt" => "2024-01-01",

--- a/spec/graphql/types/data_api/mrrs/object_spec.rb
+++ b/spec/graphql/types/data_api/mrrs/object_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::DataApi::Mrrs::Object do
+  subject { described_class }
+
+  it do
+    expect(subject.graphql_name).to eq("DataApiMrr")
+    expect(subject).to have_field(:amount_currency).of_type("CurrencyEnum!")
+    expect(subject).to have_field(:ending_mrr).of_type("BigInt!")
+    expect(subject).to have_field(:starting_mrr).of_type("BigInt!")
+    expect(subject).to have_field(:mrr_new).of_type("BigInt!")
+    expect(subject).to have_field(:mrr_expansion).of_type("BigInt!")
+    expect(subject).to have_field(:mrr_contraction).of_type("BigInt!")
+    expect(subject).to have_field(:mrr_churn).of_type("BigInt!")
+    expect(subject).to have_field(:mrr_change).of_type("BigInt!")
+    expect(subject).to have_field(:end_of_period_dt).of_type("ISO8601Date!")
+    expect(subject).to have_field(:start_of_period_dt).of_type("ISO8601Date!")
+  end
+end

--- a/spec/graphql/types/data_api/revenue_streams/customers/object_spec.rb
+++ b/spec/graphql/types/data_api/revenue_streams/customers/object_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Types::DataApi::RevenueStreams::Customers::Object do
   subject { described_class }
 
   it do
+    expect(subject.graphql_name).to eq("DataApiRevenueStreamCustomer")
     expect(subject).to have_field(:customer_id).of_type("ID!")
     expect(subject).to have_field(:external_customer_id).of_type("String!")
     expect(subject).to have_field(:customer_name).of_type("String!")

--- a/spec/graphql/types/data_api/revenue_streams/object_spec.rb
+++ b/spec/graphql/types/data_api/revenue_streams/object_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Types::DataApi::RevenueStreams::Object do
   subject { described_class }
 
   it do
-    expect(subject.graphql_name).to eq("RevenueStream")
+    expect(subject.graphql_name).to eq("DataApiRevenueStream")
     expect(subject).to have_field(:amount_currency).of_type("CurrencyEnum!")
     expect(subject).to have_field(:coupons_amount_cents).of_type("BigInt!")
     expect(subject).to have_field(:gross_revenue_amount_cents).of_type("BigInt!")

--- a/spec/services/data_api/mrrs_service_spec.rb
+++ b/spec/services/data_api/mrrs_service_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DataApi::MrrsService, type: :service do
+  let(:service) { described_class.new(organization, **params) }
+  let(:customer) { create(:customer, organization:) }
+  let(:organization) { create(:organization) }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/mrrs.json") }
+  let(:params) { {} }
+
+  before do
+    stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/mrrs/#{organization.id}/")
+      .to_return(status: 200, body: body_response, headers: {})
+  end
+
+  describe "#call" do
+    subject(:service_call) { service.call }
+
+    context "when licence is not premium" do
+      it "returns an error" do
+        expect(service_call).not_to be_success
+        expect(service_call.error.code).to eq("feature_unavailable")
+      end
+    end
+
+    context "when licence is premium" do
+      around { |test| lago_premium!(&test) }
+
+      it "returns expected mrrs" do
+        expect(service_call).to be_success
+        expect(service_call.mrrs.count).to eq(4)
+        expect(service_call.mrrs.first).to eq(
+          {
+            "organization_id" => "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+            "start_of_period_dt" => "2023-11-01",
+            "end_of_period_dt" => "2023-11-30",
+            "amount_currency" => "EUR",
+            "starting_mrr" => 0,
+            "ending_mrr" => 23701746,
+            "mrr_new" => 25016546,
+            "mrr_expansion" => 0,
+            "mrr_contraction" => 0,
+            "mrr_churn" => -1314800,
+            "mrr_change" => 23701746
+          }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Context**

A lot of users ain’t using our analytics feature because it’s not detailed enough. Thus, we are revamping the Analytics dashboard.

**Description**

This pull request introduces a new feature to query mrrs of an organization using GraphQL.
It requests the `lago-data` api service and returns mrrs for an organization.