### PR TITLE
bug(ProgressiveBilling) - Reset progressive billing credits when refreshing draft

### DIFF
--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -123,7 +123,7 @@ module Invoices
       invoice.applied_taxes.destroy_all
       invoice.error_details.discard_all
       invoice.applied_invoice_custom_sections.destroy_all
-      invoice.progressive_billing_credits.destroy_all
+      invoice.credits.progressive_billing_invoice_kind.destroy_all
 
       invoice.taxes_amount_cents = 0
       invoice.total_amount_cents = 0

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -123,6 +123,7 @@ module Invoices
       invoice.applied_taxes.destroy_all
       invoice.error_details.discard_all
       invoice.applied_invoice_custom_sections.destroy_all
+      invoice.progressive_billing_credits.destroy_all
 
       invoice.taxes_amount_cents = 0
       invoice.total_amount_cents = 0

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -59,14 +59,17 @@ module ScenariosHelper
 
   def refresh_invoice(invoice)
     put_with_token(organization, "/api/v1/invoices/#{invoice.id}/refresh", {})
+    invoice.reload
   end
 
   def finalize_invoice(invoice)
     put_with_token(organization, "/api/v1/invoices/#{invoice.id}/finalize", {})
+    invoice.reload
   end
 
   def update_invoice(invoice, params)
     put_with_token(organization, "/api/v1/invoices/#{invoice.id}", {invoice: params})
+    invoice.reload
   end
 
   def create_one_off_invoice(customer, addons)


### PR DESCRIPTION
## Description

Resetting the `progressive_billing_credits` was missed when refreshing draft invoices. 