### PR TITLE
feat(data): Add mrrs plans resolver

### DIFF
--- a/app/graphql/resolvers/data_api/mrrs/plans_resolver.rb
+++ b/app/graphql/resolvers/data_api/mrrs/plans_resolver.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module DataApi
+    module Mrrs
+      class PlansResolver < Resolvers::BaseResolver
+        include AuthenticableApiUser
+        include RequiredOrganization
+
+        REQUIRED_PERMISSION = "data_api:view"
+
+        graphql_name "DataApiMrrsPlans"
+        description "Query monthly recurring revenues plans of an organization"
+
+        argument :currency, Types::CurrencyEnum, required: false
+
+        type Types::DataApi::Mrrs::Plans::Object.collection_type, null: false
+
+        def resolve(**args)
+          result = ::DataApi::Mrrs::PlansService.call(current_organization, **args)
+          result.mrrs_plans
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/data_api/mrrs/plans/object.rb
+++ b/app/graphql/types/data_api/mrrs/plans/object.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Types
+  module DataApi
+    module Mrrs
+      module Plans
+        class Object < Types::BaseObject
+          graphql_name "DataApiMrrPlan"
+
+          field :amount_currency, Types::CurrencyEnum, null: false
+          field :dt, GraphQL::Types::ISO8601Date, null: false
+
+          field :plan_code, String, null: false
+          field :plan_id, ID, null: false
+          field :plan_interval, Types::Plans::IntervalEnum, null: false
+          field :plan_name, String, null: false
+
+          field :active_customers_count, GraphQL::Types::BigInt, null: false
+          field :active_customers_share, Float, null: false
+
+          field :mrr, Float, null: false
+          field :mrr_share, Float, null: false
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -80,6 +80,7 @@ module Types
     field :webhooks, resolver: Resolvers::WebhooksResolver
 
     field :data_api_mrrs, resolver: Resolvers::DataApi::MrrsResolver
+    field :data_api_mrrs_plans, resolver: Resolvers::DataApi::Mrrs::PlansResolver
     field :data_api_revenue_streams, resolver: Resolvers::DataApi::RevenueStreamsResolver
     field :data_api_revenue_streams_customers, resolver: Resolvers::DataApi::RevenueStreams::CustomersResolver
     field :data_api_revenue_streams_plans, resolver: Resolvers::DataApi::RevenueStreams::PlansResolver

--- a/app/services/data_api/mrrs/plans_service.rb
+++ b/app/services/data_api/mrrs/plans_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module DataApi
+  module Mrrs
+    class PlansService < DataApi::BaseService
+      Result = BaseResult[:mrrs_plans]
+
+      def call
+        return result.forbidden_failure! unless License.premium?
+
+        data_mrrs_plans = http_client.get(headers:, params:)
+
+        result.mrrs_plans = data_mrrs_plans
+        result
+      end
+
+      private
+
+      def action_path
+        "mrrs/#{organization.id}/plans"
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3555,6 +3555,34 @@ type DataApiMrrCollection {
   metadata: CollectionMetadata!
 }
 
+type DataApiMrrPlan {
+  activeCustomersCount: BigInt!
+  activeCustomersShare: Float!
+  amountCurrency: CurrencyEnum!
+  dt: ISO8601Date!
+  mrr: Float!
+  mrrShare: Float!
+  planCode: String!
+  planId: ID!
+  planInterval: PlanInterval!
+  planName: String!
+}
+
+"""
+DataApiMrrPlanCollection type
+"""
+type DataApiMrrPlanCollection {
+  """
+  A collection of paginated DataApiMrrPlanCollection
+  """
+  collection: [DataApiMrrPlan!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
 type DataApiRevenueStream {
   amountCurrency: CurrencyEnum!
   commitmentFeeAmountCents: BigInt!
@@ -6883,6 +6911,11 @@ type Query {
   Query monthly recurring revenues of an organization
   """
   dataApiMrrs(currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiMrrCollection!
+
+  """
+  Query monthly recurring revenues plans of an organization
+  """
+  dataApiMrrsPlans(currency: CurrencyEnum): DataApiMrrPlanCollection!
 
   """
   Query revenue streams of an organization

--- a/schema.json
+++ b/schema.json
@@ -15329,6 +15329,228 @@
         },
         {
           "kind": "OBJECT",
+          "name": "DataApiMrrPlan",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "activeCustomersCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "activeCustomersShare",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "dt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "mrr",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "mrrShare",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "planCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "planId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "planInterval",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "PlanInterval",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "planName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DataApiMrrPlanCollection",
+          "description": "DataApiMrrPlanCollection type",
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated DataApiMrrPlanCollection",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DataApiMrrPlan",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "DataApiRevenueStream",
           "description": null,
           "interfaces": [],
@@ -33995,6 +34217,35 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "dataApiMrrsPlans",
+              "description": "Query monthly recurring revenues plans of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "DataApiMrrPlanCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/spec/fixtures/lago_data_api/mrrs_plans.json
+++ b/spec/fixtures/lago_data_api/mrrs_plans.json
@@ -1,0 +1,54 @@
+[
+  {
+      "dt": "2025-02-25",
+      "amount_currency": "EUR",
+      "plan_id": "8f550d3e-1234-4f4d-a752-61b0f98a9ef7",
+      "active_customers_count": 1,
+      "mrr": 1000000.0,
+      "mrr_share": 0.0279,
+      "plan_name": "Tondr",
+      "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+      "plan_code": "custom_plan_tondr",
+      "plan_interval": "monthly",
+      "active_customers_share": 0.009
+  },
+  {
+      "dt": "2025-02-25",
+      "amount_currency": "EUR",
+      "plan_id": "627ee06a-4567-47f7-8eae-a07eec5a9ba3",
+      "active_customers_count": 1,
+      "mrr": 849000.0,
+      "mrr_share": 0.0237,
+      "plan_name": "Place",
+      "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+      "plan_code": "custom_plan_place",
+      "plan_interval": "monthly",
+      "active_customers_share": 0.009
+  },
+  {
+      "dt": "2025-02-25",
+      "amount_currency": "EUR",
+      "plan_id": "504cb319-8910-4175-9364-840028c39475",
+      "active_customers_count": 1,
+      "mrr": 799000.0,
+      "mrr_share": 0.0223,
+      "plan_name": "Silo",
+      "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+      "plan_code": "custom_plan_silo",
+      "plan_interval": "monthly",
+      "active_customers_share": 0.009
+  },
+  {
+      "dt": "2025-02-25",
+      "amount_currency": "EUR",
+      "plan_id": "8d39f27f-1112-43ea-a327-c9579e70eeb3",
+      "active_customers_count": 1,
+      "mrr": 790000.0,
+      "mrr_share": 0.022,
+      "plan_name": "Penny",
+      "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+      "plan_code": "custom_plan_penny",
+      "plan_interval": "monthly",
+      "active_customers_share": 0.009
+  }
+]

--- a/spec/graphql/resolvers/data_api/mrrs/plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/mrrs/plans_resolver_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::DataApi::Mrrs::PlansResolver, type: :graphql do
+  let(:required_permission) { "data_api:view" }
+  let(:query) do
+    <<~GQL
+      query($currency: CurrencyEnum) {
+        dataApiMrrsPlans(currency: $currency) {
+          collection {
+            amountCurrency
+            dt
+            planCode
+            planId
+            planInterval
+            planName
+            activeCustomersCount
+            activeCustomersShare
+            mrr
+            mrrShare
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/mrrs_plans.json") }
+
+  around { |test| lago_premium!(&test) }
+
+  before do
+    stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/mrrs/#{organization.id}/plans")
+      .to_return(status: 200, body: body_response, headers: {})
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "data_api:view"
+
+  it "returns a list of mrrs plans" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:
+    )
+
+    mrrs_response = result["data"]["dataApiMrrsPlans"]
+    expect(mrrs_response["collection"].first).to include(
+      {
+        "dt" => "2025-02-25",
+        "amountCurrency" => "EUR",
+        "planId" => "8f550d3e-1234-4f4d-a752-61b0f98a9ef7",
+        "activeCustomersCount" => "1",
+        "mrr" => 1000000.0,
+        "mrrShare" => 0.0279,
+        "planName" => "Tondr",
+        "planCode" => "custom_plan_tondr",
+        "planInterval" => "monthly",
+        "activeCustomersShare" => 0.009
+      }
+    )
+  end
+end

--- a/spec/graphql/types/data_api/mrrs/plans/object_spec.rb
+++ b/spec/graphql/types/data_api/mrrs/plans/object_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::DataApi::Mrrs::Plans::Object do
+  subject { described_class }
+
+  it do
+    expect(subject.graphql_name).to eq("DataApiMrrPlan")
+    expect(subject).to have_field(:amount_currency).of_type("CurrencyEnum!")
+    expect(subject).to have_field(:dt).of_type("ISO8601Date!")
+    expect(subject).to have_field(:plan_code).of_type("String!")
+    expect(subject).to have_field(:plan_id).of_type("ID!")
+    expect(subject).to have_field(:plan_interval).of_type("PlanInterval!")
+    expect(subject).to have_field(:plan_name).of_type("String!")
+    expect(subject).to have_field(:active_customers_count).of_type("BigInt!")
+    expect(subject).to have_field(:active_customers_share).of_type("Float!")
+    expect(subject).to have_field(:mrr).of_type("Float!")
+    expect(subject).to have_field(:mrr_share).of_type("Float!")
+  end
+end

--- a/spec/services/data_api/mrrs/plans_service_spec.rb
+++ b/spec/services/data_api/mrrs/plans_service_spec.rb
@@ -2,15 +2,15 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::RevenueStreams::PlansService, type: :service do
+RSpec.describe DataApi::Mrrs::PlansService, type: :service do
   let(:service) { described_class.new(organization, **params) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }
-  let(:body_response) { File.read("spec/fixtures/lago_data_api/revenue_streams_plans.json") }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/mrrs_plans.json") }
   let(:params) { {} }
 
   before do
-    stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/revenue_streams/#{organization.id}/plans")
+    stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/mrrs/#{organization.id}/plans")
       .to_return(status: 200, body: body_response, headers: {})
   end
 
@@ -27,23 +27,22 @@ RSpec.describe DataApi::RevenueStreams::PlansService, type: :service do
     context "when licence is premium" do
       around { |test| lago_premium!(&test) }
 
-      it "returns expected revenue streams plans" do
+      it "returns expected mrrs plans" do
         expect(service_call).to be_success
-        expect(service_call.revenue_streams_plans.count).to eq(4)
-        expect(service_call.revenue_streams_plans.first).to eq(
+        expect(service_call.mrrs_plans.count).to eq(4)
+        expect(service_call.mrrs_plans.first).to eq(
           {
-            "plan_id" => "8d39f27f-8371-43ea-a327-c9579e70eeb3",
+            "dt" => "2025-02-25",
             "amount_currency" => "EUR",
-            "plan_code" => "custom_plan_penny",
-            "customers_count" => 1,
-            "gross_revenue_amount_cents" => 120735293,
-            "net_revenue_amount_cents" => 120735293,
+            "plan_id" => "8f550d3e-1234-4f4d-a752-61b0f98a9ef7",
+            "active_customers_count" => 1,
+            "mrr" => 1000000.0,
+            "mrr_share" => 0.0279,
+            "plan_name" => "Tondr",
             "organization_id" => "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
-            "plan_name" => "Penny",
+            "plan_code" => "custom_plan_tondr",
             "plan_interval" => "monthly",
-            "customers_share" => 0.0055,
-            "gross_revenue_share" => 0.1148,
-            "net_revenue_share" => 0.1148
+            "active_customers_share" => 0.009
           }
         )
       end

--- a/spec/services/data_api/revenue_streams/customers_service_spec.rb
+++ b/spec/services/data_api/revenue_streams/customers_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DataApi::RevenueStreams::CustomersService, type: :service do
     context "when licence is premium" do
       around { |test| lago_premium!(&test) }
 
-      it "returns expected revenue streams" do
+      it "returns expected revenue streams customers" do
         expect(service_call).to be_success
         expect(service_call.revenue_streams_customers.count).to eq(4)
         expect(service_call.revenue_streams_customers.first).to eq(


### PR DESCRIPTION
**Context**

A lot of users ain’t using our analytics feature because it’s not detailed enough. Thus, we are revamping the Analytics dashboard.

**Description**

This pull request introduces a new feature to query mrrs plans of an organization using GraphQL.
It requests the `lago-data` api service and returns mrrs per plan for an organization.