### PR TITLE
misc(invoice-preview): Refactor subscription handling logic

### DIFF
--- a/app/services/invoices/preview/build_subscription_service.rb
+++ b/app/services/invoices/preview/build_subscription_service.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Preview
+    class BuildSubscriptionService < BaseService
+      Result = BaseResult[:subscriptions]
+
+      def initialize(customer:, params:)
+        @customer = customer
+        @params = params.presence || {}
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: "customer") unless customer
+        return result.not_found_failure!(resource: "plan") unless plan
+
+        result.subscriptions = [build_subscription]
+        result
+      end
+
+      private
+
+      attr_reader :customer, :params
+
+      delegate :organization, to: :customer
+
+      def build_subscription
+        Subscription.new(
+          customer:,
+          plan:,
+          subscription_at: params[:subscription_at].presence || Time.current,
+          started_at: params[:subscription_at].presence || Time.current,
+          billing_time:,
+          created_at: params[:subscription_at].presence || Time.current,
+          updated_at: Time.current
+        )
+      end
+
+      def billing_time
+        if Subscription::BILLING_TIME.include?(params[:billing_time]&.to_sym)
+          params[:billing_time]
+        else
+          "calendar"
+        end
+      end
+
+      def plan
+        @plan ||= organization.plans.find_by(code: params[:plan_code])
+      end
+    end
+  end
+end

--- a/app/services/invoices/preview/subscription_termination_service.rb
+++ b/app/services/invoices/preview/subscription_termination_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Preview
+    class SubscriptionTerminationService < BaseService
+      Result = BaseResult[:subscriptions]
+
+      def initialize(current_subscription:, terminated_at:)
+        @current_subscription = current_subscription
+        @terminated_at = terminated_at
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: "subscription") unless current_subscription
+
+        unless parsed_terminated_at
+          return result.single_validation_failure!(
+            error_code: "invalid_timestamp",
+            field: :terminated_at
+          )
+        end
+
+        if parsed_terminated_at.to_date.past?
+          return result.single_validation_failure!(
+            error_code: "cannot_be_in_past",
+            field: :terminated_at
+          )
+        end
+
+        current_subscription.assign_attributes(
+          status: :terminated,
+          terminated_at:
+        )
+
+        result.subscriptions = [current_subscription]
+        result
+      end
+
+      private
+
+      attr_reader :current_subscription, :terminated_at
+
+      def parsed_terminated_at
+        return unless Utils::Datetime.valid_format?(terminated_at)
+
+        Time.zone.parse(terminated_at)
+      end
+    end
+  end
+end

--- a/spec/services/invoices/preview/build_subscription_service_spec.rb
+++ b/spec/services/invoices/preview/build_subscription_service_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::Preview::BuildSubscriptionService, type: :service do
+  describe ".call" do
+    subject(:result) { described_class.call(customer:, params:) }
+
+    let(:subscriptions) { result.subscriptions }
+
+    context "when customer is missing" do
+      let(:customer) { nil }
+      let(:params) { {} }
+
+      it "fails with customer not found error" do
+        expect(result).to be_failure
+        expect(result.error.error_code).to eq("customer_not_found")
+      end
+
+      it "does not create any subscription" do
+        expect { subject }.not_to change(Subscription, :count)
+      end
+    end
+
+    context "when customer is present" do
+      let(:customer) { create(:customer) }
+
+      context "when plan matching code exists in the customer's organization" do
+        let(:plan) { create(:plan, organization: customer.organization) }
+
+        let(:params) do
+          {
+            plan_code: plan&.code,
+            billing_time:,
+            subscription_at: subscription_at&.iso8601
+          }
+        end
+
+        context "when valid billing time and subscribed at are provided" do
+          let(:billing_time) { Subscription::BILLING_TIME.sample.to_s }
+          let(:subscription_at) { generate(:past_date) }
+
+          let(:expected_attributes) do
+            {
+              billing_time:,
+              plan:,
+              customer:,
+              subscription_at: subscription_at.change(usec: 0),
+              started_at: subscription_at.change(usec: 0)
+            }
+          end
+
+          it "returns array containing new subscription with provided inputs" do
+            expect(result).to be_success
+            expect(subscriptions).to contain_exactly Subscription
+
+            expect(subscriptions.first)
+              .to be_new_record
+              .and have_attributes(expected_attributes)
+          end
+
+          it "does not create any subscription" do
+            expect { subject }.not_to change(Subscription, :count)
+          end
+        end
+
+        context "when invalid or empty billing time and subscribed at are provided" do
+          let(:billing_time) { "non-existing-time" }
+          let(:subscription_at) { nil }
+
+          let(:expected_attributes) do
+            {
+              billing_time: "calendar",
+              plan:,
+              customer:,
+              subscription_at: Time.current,
+              started_at: Time.current
+            }
+          end
+
+          before { freeze_time }
+
+          it "returns array containing new subscription with defaults" do
+            expect(result).to be_success
+            expect(subscriptions).to contain_exactly Subscription
+
+            expect(subscriptions.first)
+              .to be_new_record
+              .and have_attributes(expected_attributes)
+          end
+
+          it "does not create any subscription" do
+            expect { subject }.not_to change(Subscription, :count)
+          end
+        end
+      end
+
+      context "when plan matching code does not exist in the customer's organization" do
+        let(:params) { {plan_code: create(:plan).code} }
+
+        it "fails with plan not found error" do
+          expect(result).to be_failure
+          expect(result.error.error_code).to eq("plan_not_found")
+        end
+
+        it "does not create any subscription" do
+          expect { subject }.not_to change(Subscription, :count)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/preview/subscription_termination_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_termination_service_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::Preview::SubscriptionTerminationService, type: :service do
+  describe ".call" do
+    subject(:result) do
+      described_class.call(current_subscription:, terminated_at: terminated_at&.to_s)
+    end
+
+    let(:subscriptions) { result.subscriptions }
+
+    context "when current subscription is missing" do
+      let(:current_subscription) { nil }
+      let(:terminated_at) { nil }
+
+      it "fails with subscription not found error" do
+        expect(result).to be_failure
+        expect(result.error.error_code).to eq("subscription_not_found")
+      end
+    end
+
+    context "when current subscription is present" do
+      let(:current_subscription) { create(:subscription) }
+
+      context "when termination at is a valid timestamp" do
+        context "when timestamp is in the past" do
+          let(:terminated_at) { generate(:past_date) }
+
+          it "fails with past timestamp error" do
+            expect(result).to be_failure
+            expect(result.error.messages).to match(terminated_at: ["cannot_be_in_past"])
+          end
+
+          it "does not change persist any changes to the current subscription" do
+            expect { subject }.not_to change { current_subscription.reload.attributes }
+          end
+        end
+
+        context "when timestamp is today" do
+          let(:terminated_at) { Time.current }
+
+          it "returns result with subscriptions marked as terminated" do
+            expect(result).to be_success
+            expect(subscriptions).to contain_exactly current_subscription
+
+            expect(subscriptions.first).to have_attributes(
+              terminated_at: terminated_at.change(usec: 0),
+              status: "terminated"
+            )
+          end
+
+          it "does not change persist any changes to the current subscription" do
+            expect { subject }.not_to change { current_subscription.reload.attributes }
+          end
+        end
+
+        context "when timestamp is in future" do
+          let(:terminated_at) { generate(:future_date) }
+
+          it "returns result with subscriptions marked as terminated" do
+            expect(result).to be_success
+            expect(subscriptions).to contain_exactly current_subscription
+
+            expect(subscriptions.first).to have_attributes(
+              terminated_at: terminated_at.change(usec: 0),
+              status: "terminated"
+            )
+          end
+
+          it "does not change persist any changes to the current subscription" do
+            expect { subject }.not_to change { current_subscription.reload.attributes }
+          end
+        end
+      end
+
+      context "when termination at is not a valid timestamp" do
+        let(:terminated_at) { "2025" }
+
+        it "fails with invalid timestamp error" do
+          expect(result).to be_failure
+          expect(result.error.messages).to match(terminated_at: ["invalid_timestamp"])
+        end
+
+        it "does not change persist any changes to the current subscription" do
+          expect { subject }.not_to change { current_subscription.reload.attributes }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/preview/subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/subscriptions_service_spec.rb
@@ -3,160 +3,121 @@
 RSpec.describe Invoices::Preview::SubscriptionsService, type: :service do
   let(:result) { described_class.call(organization:, customer:, params:) }
 
-  describe "#call" do
+  describe ".call" do
     subject { result.subscriptions }
 
-    let(:organization) { create(:organization) }
-    let(:customer) { create(:customer, organization:) }
-
-    context "when customer is missing" do
+    context "when organization is missing" do
+      let(:organization) { nil }
       let(:customer) { nil }
       let(:params) { {} }
 
-      it "returns a failed result with customer not found error" do
-        expect(result).not_to be_success
+      it "fails with organization not found error" do
+        expect(result).to be_failure
+        expect(result.error.error_code).to eq("organization_not_found")
+      end
+    end
+
+    context "when customer is missing" do
+      let(:organization) { create(:organization) }
+      let(:customer) { nil }
+      let(:params) { {} }
+
+      it "fails with customer not found error" do
+        expect(result).to be_failure
         expect(result.error.error_code).to eq("customer_not_found")
       end
     end
 
-    context "when external_ids are provided" do
-      let!(:subscriptions) { create_pair(:subscription, customer:) }
-      let(:subscription_ids) { subscriptions.map(&:external_id) }
+    context "when customer and organization are present" do
+      let(:organization) { create(:organization) }
+      let(:customer) { create(:customer, organization:) }
 
-      context "when terminated at is not provided" do
+      context "when external_ids are provided" do
+        let!(:subscriptions) { create_pair(:subscription, customer:) }
+        let(:subscription_ids) { subscriptions.map(&:external_id) }
+
+        context "when terminated at is not provided" do
+          let(:params) do
+            {
+              subscriptions: {
+                external_ids: subscriptions.map(&:external_id)
+              }
+            }
+          end
+
+          it "returns persisted customer subscriptions" do
+            expect(result).to be_success
+            expect(subject.pluck(:external_id)).to match_array subscriptions.map(&:external_id)
+          end
+        end
+
+        context "when terminated at is provided" do
+          let(:terminated_at) { generate(:future_date) }
+
+          let(:params) do
+            {
+              subscriptions: {
+                external_ids: external_ids,
+                terminated_at: terminated_at.to_s
+              }
+            }
+          end
+
+          context "when multiple subscriptions passed" do
+            let(:external_ids) { subscriptions.map(&:external_id) }
+
+            it "fails with multiple subscriptions error" do
+              expect(result).to be_failure
+
+              expect(result.error.messages)
+                .to match(subscriptions: ["only_one_subscription_allowed_for_termination"])
+            end
+          end
+
+          context "when single subscription passed" do
+            let(:external_ids) { [subscriptions.first.external_id] }
+
+            it "returns result with subscriptions marked as terminated" do
+              expect(result).to be_success
+
+              expect(subject).to all(
+                be_a(Subscription)
+                  .and(have_attributes(
+                    terminated_at: terminated_at.change(usec: 0),
+                    status: "terminated"
+                  ))
+              )
+            end
+          end
+        end
+      end
+
+      context "when external_ids are not provided" do
         let(:params) do
           {
-            subscriptions: {
-              external_ids: subscriptions.map(&:external_id)
-            }
+            billing_time:,
+            plan_code: plan.code,
+            subscription_at: subscription_at.iso8601
           }
         end
 
-        it "returns persisted customer subscriptions" do
-          expect(subject.pluck(:external_id)).to match_array subscriptions.map(&:external_id)
-        end
-      end
-
-      context "when terminated at is provided" do
-        let(:external_ids) { [subscriptions.first.external_id] }
-        let(:terminated_at) { generate(:future_date) }
-
-        let(:params) do
-          {
-            subscriptions: {
-              external_ids: external_ids,
-              terminated_at: terminated_at.to_s
-            }
-          }
-        end
-
-        context "when invalid timestamp provided" do
-          let(:terminated_at) { "2025" }
-
-          it "returns a failed result with invalid timestamp error" do
-            expect(result).not_to be_success
-            expect(result.error.messages).to match(terminated_at: ["invalid_timestamp"])
-          end
-        end
-
-        context "when past timestamp provided" do
-          let(:terminated_at) { generate(:past_date) }
-
-          it "returns a failed result with past timestamp error" do
-            expect(result).not_to be_success
-            expect(result.error.messages).to match(terminated_at: ["cannot_be_in_past"])
-          end
-        end
-
-        context "when multiple subscriptions passed" do
-          let(:external_ids) { subscriptions.map(&:external_id) }
-
-          it "returns a failed result with multiple subscriptions error" do
-            expect(result).not_to be_success
-
-            expect(result.error.messages)
-              .to match(subscriptions: ["only_one_subscription_allowed_for_termination"])
-          end
-        end
-
-        context "when all validations passed" do
-          it "returns result with subscriptions marked as terminated" do
-            expect(subject).to all(
-              be_a(Subscription)
-                .and(have_attributes(
-                  terminated_at: terminated_at.change(usec: 0),
-                  status: "terminated"
-                ))
-            )
-          end
-        end
-      end
-    end
-
-    context "when external_ids are not provided" do
-      let(:params) do
-        {
-          billing_time:,
-          plan_code: plan&.code,
-          subscription_at: subscription_at&.iso8601
-        }
-      end
-
-      context "when plan matching provided code exists" do
         let(:plan) { create(:plan, organization:) }
+        let(:subscription_at) { generate(:past_date) }
+        let(:billing_time) { "anniversary" }
 
-        before { freeze_time }
+        it "returns new subscription with provided params" do
+          expect(result).to be_success
+          expect(subject).to contain_exactly Subscription
 
-        context "when billing time and subscription date are present" do
-          let(:subscription_at) { generate(:past_date) }
-          let(:billing_time) { "anniversary" }
-
-          it "returns new subscription with provided params" do
-            expect(subject)
-              .to all(
-                be_a(Subscription)
-                  .and(have_attributes(
-                    customer:,
-                    plan:,
-                    subscription_at: subscription_at,
-                    started_at: subscription_at,
-                    billing_time: params[:billing_time]
-                  ))
-              )
-          end
-        end
-
-        context "when billing time and subscription date are missing" do
-          let(:subscription_at) { nil }
-          let(:billing_time) { nil }
-
-          it "returns new subscription with default values for subscription date and billing time" do
-            expect(subject)
-              .to all(
-                be_a(Subscription)
-                  .and(have_attributes(
-                    customer:,
-                    plan:,
-                    subscription_at: Time.current,
-                    started_at: Time.current,
-                    billing_time: "calendar"
-                  ))
-              )
-          end
-        end
-      end
-
-      context "when plan matching provided code does not exist" do
-        let(:plan) { nil }
-        let(:subscription_at) { nil }
-        let(:billing_time) { nil }
-
-        it "returns nil" do
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::NotFoundFailure)
-          expect(result.error.error_code).to eq("plan_not_found")
-
-          expect(subject).to be_nil
+          expect(subject.first)
+            .to be_new_record
+            .and have_attributes(
+              customer:,
+              plan:,
+              subscription_at: subscription_at.change(usec: 0),
+              started_at: subscription_at.change(usec: 0),
+              billing_time:
+            )
         end
       end
     end


### PR DESCRIPTION
## Context

`SubscriptionsService` became even more complicated with brining support for upgrade/downgrade cases.
To better prepare for those changes breaking existing service into smaller, more focused on doing single thing services with better test coverage.
Extracted only refactoring part for easier review process. In next PR I'll add support for upgrade and downgrade cases.

## Description

Now `SubscriptionsService` responsible only for identifying context and calling another smaller service to produce proper data state.
