### PR TITLE
fix: make json parsing more resilient

### DIFF
--- a/lib/lago_http_client/lago_http_client/http_error.rb
+++ b/lib/lago_http_client/lago_http_client/http_error.rb
@@ -16,6 +16,8 @@ module LagoHttpClient
 
     def json_message
       JSON.parse(error_body)
+    rescue JSON::ParserError
+      {}
     end
   end
 end


### PR DESCRIPTION
## Context

When parsing json and converting to ruby hash, we want to be more resilient to parsing errors

## Description

This PR returns empty hash, for invalid json
