### PR TITLE
feat(stripe): Upgrading Stripe version

### DIFF
--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+STRIPE_API_VERSION = "2020-08-27"
+
+Stripe.api_version = STRIPE_API_VERSION


### PR DESCRIPTION
## Context

The version of the Stripe can be set in your Stripe account or passed in each requests. Versions are date strings with optional tags. 

Note that the API version is unrelated to the version of the gem. FYI we use 6.5.0, [latests version is 13.5.0](https://github.com/stripe/stripe-ruby).

With Lago, each customer use their own Stripe account which my use any version by default. We don't set the version explicitly but fortunately we use very stable features and our calls work in all version.

We intend to [save the payment method](https://github.com/getlago/lago-api/pull/3230) information when we receive the `payment_intent.succeeded` but for the first time, we experienced the difference between webhook versions. The `charges` array was removed: 

## Overview

**Our current version is `2020-08-27`.** We will upgrade to `2025-04-30.basil`.

The version is [set in the client](https://docs.stripe.com/sdks/set-version) during Rails boot so the client will set it explicitly for all requests.

```rb
Stripe.api_version = "2025-04-30.basil"
```

https://docs.stripe.com/changelog/basil


### Webhooks

**You cannot update the `api_version` of an existing WebhookEndpoint**. You must create a new WebhookEndpoint with the new version and delete the old one once you migrated. This is actually the best way to not have any downtime.

https://docs.stripe.com/webhooks/versioning

It means to set the version for all our customers, we'll need to recreate the endpoint for all organization. It's fine but before we upgrade the endpoint, we should move to a more recent version. We'll need to keep the fixtures virtually forever for the same reason we keep migrations.

See #3718

## The Plan

- [x] Create Integration tests calling the Stripe API for real 
        #3783
- [x] Refactor fixtures to handle multiple versions
        #3723
- [x] Add new fixtures for `2025-04-30.basil` 
        #3787
- [x] Ensure all webhook processing services are tested with all versions
        https://github.com/getlago/lago-api/pull/3799
- [x] **Fix Stripe version in initializer!** 🎉
        https://github.com/getlago/lago-api/pull/3823
- [ ] Upgrade the WebhookEndpoint to set the version
- [ ] Upgrade the `stripe` gem to latest version

Other related PRs

* Refactor webhooks #3718
