### PR TITLE
feat(preauth): Prepare Stripe Authorization for recent versions

### DIFF
--- a/app/services/payment_providers/stripe/payments/authorize_service.rb
+++ b/app/services/payment_providers/stripe/payments/authorize_service.rb
@@ -60,11 +60,17 @@ module PaymentProviders
               customer: provider_customer.provider_customer_id,
               payment_method: provider_customer.payment_method_id,
               description: "Pre-authorization for subscription",
-              metadata:
+              metadata:,
+              return_url: payment_provider.success_redirect_url,
+              automatic_payment_methods: {
+                enabled: true,
+                allow_redirects: "never"
+              }
             },
             {
               api_key:,
-              idempotency_key: "auth-#{provider_customer.id}-#{unique_id}"
+              idempotency_key: "auth-#{provider_customer.id}-#{unique_id}",
+              stripe_version: "2024-09-30.acacia"
             }
           )
         end


### PR DESCRIPTION
## Description

More recent version of stripe require some parameter to be set differently for SetupIntent and PaymentIntent.

https://docs.stripe.com/upgrades#2023-08-16

Keep in mind this feature is beta and enabled for only one customer (no breaking change by forcing the version here).