### PR TITLE
fix(invoice-preview): Add charge duration to boundaries during preview generation

### DIFF
--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -94,7 +94,8 @@ module Invoices
         to_datetime: date_service.to_datetime,
         charges_from_datetime: date_service.charges_from_datetime,
         charges_to_datetime: date_service.charges_to_datetime,
-        timestamp: billing_time
+        timestamp: billing_time,
+        charges_duration: date_service.charges_duration_in_days
       }
     end
 

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -550,9 +550,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
           end
 
           context "with charge fees" do
-            let(:billable_metric) do
-              create(:billable_metric, aggregation_type: "count_agg")
-            end
+            let(:billable_metric) { create(:unique_count_billable_metric) }
+
             let(:charge) do
               create(
                 :standard_charge,
@@ -561,10 +560,10 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 properties: {amount: "12.66"}
               )
             end
+
             let(:events) do
-              create_list(
+              create_pair(
                 :event,
-                2,
                 organization:,
                 subscription:,
                 customer:,
@@ -574,7 +573,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             end
 
             before do
-              events if subscription
+              events
               charge
               Rails.cache.clear
             end
@@ -588,11 +587,11 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 expect(result.invoice.fees.length).to eq(2)
                 expect(result.invoice.invoice_type).to eq("subscription")
                 expect(result.invoice.issuing_date.to_s).to eq("2024-04-30")
-                expect(result.invoice.fees_amount_cents).to eq(2632)
-                expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(2632)
-                expect(result.invoice.taxes_amount_cents).to eq(1316)
-                expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(3948)
-                expect(result.invoice.total_amount_cents).to eq(3948)
+                expect(result.invoice.fees_amount_cents).to eq(1366)
+                expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(1366)
+                expect(result.invoice.taxes_amount_cents).to eq(683)
+                expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(2049)
+                expect(result.invoice.total_amount_cents).to eq(2049)
               end
             end
           end

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -550,8 +550,9 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
           end
 
           context "with charge fees" do
-            let(:billable_metric) { create(:unique_count_billable_metric) }
-
+            let(:billable_metric) do
+              create(:billable_metric, aggregation_type: "count_agg")
+            end
             let(:charge) do
               create(
                 :standard_charge,
@@ -560,10 +561,10 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 properties: {amount: "12.66"}
               )
             end
-
             let(:events) do
-              create_pair(
+              create_list(
                 :event,
+                2,
                 organization:,
                 subscription:,
                 customer:,
@@ -573,7 +574,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             end
 
             before do
-              events
+              events if subscription
               charge
               Rails.cache.clear
             end
@@ -587,11 +588,11 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 expect(result.invoice.fees.length).to eq(2)
                 expect(result.invoice.invoice_type).to eq("subscription")
                 expect(result.invoice.issuing_date.to_s).to eq("2024-04-30")
-                expect(result.invoice.fees_amount_cents).to eq(1366)
-                expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(1366)
-                expect(result.invoice.taxes_amount_cents).to eq(683)
-                expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(2049)
-                expect(result.invoice.total_amount_cents).to eq(2049)
+                expect(result.invoice.fees_amount_cents).to eq(2632)
+                expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(2632)
+                expect(result.invoice.taxes_amount_cents).to eq(1316)
+                expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(3948)
+                expect(result.invoice.total_amount_cents).to eq(3948)
               end
             end
           end


### PR DESCRIPTION
## Context

Invoice preview generation logic was missing charge duration property in boundaries which lead to invalid calculations on charge fees.

## Description

Add `charges_duration` to boundaries and adjust tests.
