### PR TITLE
fix(dunning): adapt refund logic with dunning

### DIFF
--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -81,16 +81,16 @@ module CreditNotes
       def payment
         return @payment if defined?(@payment)
 
-        @payment = if credit_note.invoice.payments.where(status: 'succeeded').present?
-          credit_note.invoice.payments.where(status: 'succeeded').order(created_at: :desc).first
+        @payment = if credit_note.invoice.payments.where(status: "succeeded").present?
+          credit_note.invoice.payments.where(status: "succeeded").order(created_at: :desc).first
         else
-          Payment.where(payable_type: 'PaymentRequest')
+          Payment.where(payable_type: "PaymentRequest")
             .joins("INNER JOIN invoices_payment_requests ON invoices_payment_requests.payment_request_id = payments.payable_id")
             .joins("INNER JOIN payment_requests ON payment_requests.id = invoices_payment_requests.payment_request_id")
             .where("invoices_payment_requests.invoice_id = ?", credit_note.invoice_id)
-            .where(payments: { status: 'succeeded' })
-            .where(payment_requests: { customer_id: credit_note.customer_id })
-            .where(payment_requests: { payment_status: 1 }) # 1 is succeeded
+            .where(payments: {status: "succeeded"})
+            .where(payment_requests: {customer_id: credit_note.customer_id})
+            .where(payment_requests: {payment_status: 1}) # 1 is succeeded
             .order("payments.created_at DESC")
             .first
         end

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -79,7 +79,21 @@ module CreditNotes
       end
 
       def payment
-        @payment ||= credit_note.invoice.payments.order(created_at: :desc).first
+        return @payment if defined?(@payment)
+
+        @payment = if credit_note.invoice.payments.where(status: 'succeeded').present?
+          credit_note.invoice.payments.where(status: 'succeeded').order(created_at: :desc).first
+        else
+          Payment.where(payable_type: 'PaymentRequest')
+            .joins("INNER JOIN invoices_payment_requests ON invoices_payment_requests.payment_request_id = payments.payable_id")
+            .joins("INNER JOIN payment_requests ON payment_requests.id = invoices_payment_requests.payment_request_id")
+            .where("invoices_payment_requests.invoice_id = ?", credit_note.invoice_id)
+            .where(payments: { status: 'succeeded' })
+            .where(payment_requests: { customer_id: credit_note.customer_id })
+            .where(payment_requests: { payment_status: 1 }) # 1 is succeeded
+            .order("payments.created_at DESC")
+            .first
+        end
       end
 
       def stripe_api_key

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -81,14 +81,14 @@ module CreditNotes
       def payment
         return @payment if defined?(@payment)
 
-        @payment = if credit_note.invoice.payments.where(status: "succeeded").present?
-          credit_note.invoice.payments.where(status: "succeeded").order(created_at: :desc).first
+        @payment = if credit_note.invoice.payments.succeeded.present?
+          credit_note.invoice.payments.succeeded.order(created_at: :desc).first
         else
           Payment.where(payable_type: "PaymentRequest")
             .joins("INNER JOIN invoices_payment_requests ON invoices_payment_requests.payment_request_id = payments.payable_id")
             .joins("INNER JOIN payment_requests ON payment_requests.id = invoices_payment_requests.payment_request_id")
             .where("invoices_payment_requests.invoice_id = ?", credit_note.invoice_id)
-            .where(payments: {status: "succeeded"})
+            .where(payments: {payable_payment_status: "succeeded"})
             .where(payment_requests: {customer_id: credit_note.customer_id})
             .where(payment_requests: {payment_status: 1}) # 1 is succeeded
             .order("payments.created_at DESC")

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
       payment_provider_customer: stripe_customer,
       amount_cents: 200,
       amount_currency: "CHF",
-      status: 'succeeded',
+      status: "succeeded",
       payable: credit_note.invoice
     )
   end
@@ -86,7 +86,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
       )
     end
 
-    context 'with a payment request for an invoice' do
+    context "with a payment request for an invoice" do
       let(:payment_request) { create(:payment_request, payment_status: 1, customer: credit_note.customer) }
       let(:applied_payment_request) { create(:payment_request_applied_invoice, payment_request:, invoice: credit_note.invoice) }
       let(:payment) do
@@ -96,7 +96,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
           payment_provider_customer: stripe_customer,
           amount_cents: 200,
           amount_currency: "CHF",
-          status: 'succeeded',
+          status: "succeeded",
           payable: payment_request
         )
       end

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
       payment_provider_customer: stripe_customer,
       amount_cents: 200,
       amount_currency: "CHF",
-      status: "succeeded",
+      payable_payment_status: "succeeded",
       payable: credit_note.invoice
     )
   end
@@ -96,7 +96,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
           payment_provider_customer: stripe_customer,
           amount_cents: 200,
           amount_currency: "CHF",
-          status: "succeeded",
+          payable_payment_status: "succeeded",
           payable: payment_request
         )
       end


### PR DESCRIPTION
## Context

Refund logic does not work with dunning campaign

## Description

Currently credit note refund logic works only if payment intent is created with the initial invoice and if it is successful.

However, with dunning campaign, initial payment can be failed, but there can be separate payment request which covers invoice.

This case was not supported and with refund we were linking invalid failed payment.

This PR fixes described case.
