### PR TITLE
misc(wallet): Reduce number of queries to flag refresh

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -217,8 +217,6 @@ class Customer < ApplicationRecord
   end
 
   def flag_wallets_for_refresh
-    return unless wallets.active.any?
-
     wallets.active.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
   end
 

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -702,8 +702,8 @@ RSpec.describe Customer, type: :model do
 
   describe "#flag_wallets_for_refresh" do
     context "without any wallets" do
-      it "returns nil" do
-        expect(customer.flag_wallets_for_refresh).to be_nil
+      it "returns 0" do
+        expect(customer.flag_wallets_for_refresh).to be_zero
       end
     end
 


### PR DESCRIPTION
## Context

Today, flagging a wallet for refresh leads to two queries (one to check the presence of active wallet, one to flag the wallets), when only one is necessary.

## Description

This PR removes the check of active wallets as the update query will simply do nothing if no active wallets exists.