### PR TITLE
Fix: overdue invoices should not include invoices not ready to be paid

### DIFF
--- a/app/services/dunning_campaigns/process_attempt_service.rb
+++ b/app/services/dunning_campaigns/process_attempt_service.rb
@@ -72,6 +72,7 @@ module DunningCampaigns
       customer
         .invoices
         .payment_overdue
+        .where(ready_for_payment_processing: true)
         .where(currency: dunning_campaign_threshold.currency)
     end
   end


### PR DESCRIPTION
Together AI have an error when triggering `DunningCampaigns::ProcessAttemptJob`: `BaseService::MethodNotAllowedFailure: invoices_not_ready_for_payment_processing`
this happens because when selecting overdue invoices, we do not filter invoices that are ready for payment processing.

- Added filter invoices to be ready_to_be_processed when filtering invoices for dunning_campaign process_attempt