### PR TITLE
feat(multi-entities): create billing entity with full data...

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -40,6 +40,7 @@ class BillingEntity < ApplicationRecord
   enum :document_numbering, DOCUMENT_NUMBERINGS
 
   default_scope -> { kept }
+  scope :active, -> { kept.where(archived_at: nil) }
 
   validates :code,
     uniqueness: {

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -52,6 +52,7 @@ class BillingEntity < ApplicationRecord
   validates :document_locale, language_code: true
   validates :email, email: true, if: :email?
   validates :invoice_footer, length: {maximum: 600}
+  validates :document_number_prefix, length: {minimum: 1, maximum: 10}, allow_nil: true, on: :create
   validates :document_number_prefix, length: {minimum: 1, maximum: 10}, on: :update
   validates :invoice_grace_period, numericality: {greater_than_or_equal_to: 0}
   validates :net_payment_term, numericality: {greater_than_or_equal_to: 0}
@@ -65,6 +66,10 @@ class BillingEntity < ApplicationRecord
   validate :validate_email_settings
 
   after_create :generate_document_number_prefix
+
+  def country=(value)
+    super(value&.upcase)
+  end
 
   def document_number_prefix=(value)
     super(value&.upcase)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -11,6 +11,12 @@ class Organization < ApplicationRecord
     "payment_receipt.created"
   ].freeze
 
+  MULTI_ENTITIES_MAX = {
+    default: 1,
+    pro: 2,
+    enterprise: Float::INFINITY
+  }.freeze
+
   has_many :api_keys
   has_many :billing_entities
   has_many :memberships
@@ -210,10 +216,10 @@ class Organization < ApplicationRecord
   end
 
   def remaining_billing_entities
-    return Float::INFINITY if multi_entities_enterprise_enabled?
-    return 2 - billing_entities.count if multi_entities_pro_enabled?
+    return MULTI_ENTITIES_MAX[:enterprise] if multi_entities_enterprise_enabled?
+    return MULTI_ENTITIES_MAX[:pro] - billing_entities.active.count if multi_entities_pro_enabled?
 
-    0
+    MULTI_ENTITIES_MAX[:default] - billing_entities.active.count
   end
 end
 

--- a/app/services/billing_entities/create_service.rb
+++ b/app/services/billing_entities/create_service.rb
@@ -13,19 +13,109 @@ module BillingEntities
     def call
       return result.forbidden_failure! unless organization.can_create_billing_entity?
 
-      billing_entity = organization.billing_entities.create!(
-        name: params[:name],
-        code: params[:code]
-      )
+      billing_entity = organization.billing_entities.new(create_attributes)
+
+      ActiveRecord::Base.transaction do
+        billing_entity.invoice_footer = billing_config[:invoice_footer]
+        billing_entity.document_locale = billing_config[:document_locale] if billing_config[:document_locale]
+
+        handle_eu_tax_management(billing_entity)
+        handle_base64_logo(billing_entity)
+
+        if License.premium?
+          # NOTE: multi entities is already a premium feature... so this is always true
+          billing_entity.invoice_grace_period = billing_config[:invoice_grace_period] if billing_config[:invoice_grace_period]
+          billing_entity.timezone = params[:timezone] if params[:timezone]
+          billing_entity.email_settings = params[:email_settings] if params[:email_settings]
+        end
+
+        billing_entity.save!
+      end
+
+      track_billing_entity_created(billing_entity)
 
       result.billing_entity = billing_entity
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      result.fail_with_error!(e)
     end
 
     private
 
     attr_reader :organization, :params
+
+    def create_attributes
+      @create_attributes ||= params.slice(
+        *%I[
+          address_line1
+          address_line2
+          city
+          code
+          country
+          default_currency
+          document_number_prefix
+          document_numbering
+          email
+          finalize_zero_amount_invoice
+          legal_name
+          legal_number
+          name
+          net_payment_term
+          state
+          tax_identification_number
+          vat_rate
+          zipcode
+        ]
+      )
+    end
+
+    def billing_config
+      @billing_config ||= params[:billing_configuration]&.to_h || {}
+    end
+
+    def handle_base64_logo(billing_entity)
+      return if params[:logo].blank?
+
+      base64_data = params[:logo].split(",")
+      data = base64_data.second
+      decoded_base_64_data = Base64.decode64(data)
+
+      # NOTE: data:image/png;base64, should give image/png content_type
+      content_type = base64_data.first.split(";").first.split(":").second
+
+      billing_entity.logo.attach(
+        io: StringIO.new(decoded_base_64_data),
+        filename: "logo",
+        content_type:
+      )
+    end
+
+    def handle_eu_tax_management(billing_entity)
+      return if params[:eu_tax_management].blank?
+
+      unless billing_entity.eu_vat_eligible?
+        result.single_validation_failure!(error_code: "billing_entity_must_be_in_eu", field: :eu_tax_management)
+          .raise_if_error!
+      end
+
+      # FIXME: update the service to rename the params use billing_entity instead of organization
+      Taxes::AutoGenerateService.call(organization: billing_entity)
+
+      billing_entity.eu_tax_management = params[:eu_tax_management]
+    end
+
+    def track_billing_entity_created(billing_entity)
+      SegmentTrackJob.perform_later(
+        membership_id: CurrentContext.membership,
+        event: "billing_entity_created",
+        properties: {
+          billing_entity_code: billing_entity.code,
+          billing_entity_name: billing_entity.name,
+          organization_id: billing_entity.organization_id
+        }
+      )
+    end
   end
 end

--- a/app/services/billing_entities/create_service.rb
+++ b/app/services/billing_entities/create_service.rb
@@ -99,8 +99,7 @@ module BillingEntities
           .raise_if_error!
       end
 
-      # FIXME: update the service to rename the params use billing_entity instead of organization
-      Taxes::AutoGenerateService.call(organization: billing_entity)
+      Taxes::AutoGenerateService.call(organization:)
 
       billing_entity.eu_tax_management = params[:eu_tax_management]
     end

--- a/app/services/billing_entities/create_service.rb
+++ b/app/services/billing_entities/create_service.rb
@@ -23,7 +23,6 @@ module BillingEntities
         handle_base64_logo(billing_entity)
 
         if License.premium?
-          # NOTE: multi entities is already a premium feature... so this is always true
           billing_entity.invoice_grace_period = billing_config[:invoice_grace_period] if billing_config[:invoice_grace_period]
           billing_entity.timezone = params[:timezone] if params[:timezone]
           billing_entity.email_settings = params[:email_settings] if params[:email_settings]

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -191,6 +191,14 @@ RSpec.describe BillingEntity, type: :model do
     end
   end
 
+  describe "#country=" do
+    it "upcases country" do
+      billing_entity.country = "us"
+
+      expect(billing_entity.country).to eq "US"
+    end
+  end
+
   describe "#document_number_prefix=" do
     it "upcases the value" do
       billing_entity.document_number_prefix = "abc-1234"

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe BillingEntity, type: :model do
     end
   end
 
+  describe "Scopes" do
+    let(:active_billing_entity) { create(:billing_entity) }
+    let(:archived_billing_entity) { create(:billing_entity, :archived) }
+
+    before do
+      active_billing_entity
+      archived_billing_entity
+    end
+
+    it "returns active billing entities" do
+      expect(described_class.active).to eq [active_billing_entity]
+    end
+  end
+
   describe "Validations" do
     let(:billing_entity) { build(:billing_entity) }
 

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -57,8 +57,10 @@ RSpec.describe BillingEntity, type: :model do
       archived_billing_entity
     end
 
-    it "returns active billing entities" do
-      expect(described_class.active).to eq [active_billing_entity]
+    describe ".active" do
+      it "returns active billing entities" do
+        expect(described_class.active).to eq [active_billing_entity]
+      end
     end
   end
 

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -69,6 +69,11 @@ RSpec.describe BillingEntity, type: :model do
       expect(billing_entity).to be_valid
     end
 
+    it { is_expected.to validate_length_of(:document_number_prefix).is_at_least(1).is_at_most(10).on(:update) }
+
+    it { is_expected.to allow_value(nil).for(:document_number_prefix).on(:create) }
+    it { is_expected.to validate_length_of(:document_number_prefix).is_at_least(1).is_at_most(10).on(:create) }
+
     it "is not valid without name" do
       billing_entity.name = nil
       expect(billing_entity).not_to be_valid

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -243,13 +243,21 @@ RSpec.describe Organization, type: :model do
     end
   end
 
-  describe "#can_create_more_billing_entity?" do
+  describe "#can_create_billing_entity?" do
     subject { organization.can_create_billing_entity? }
 
     around { |test| lago_premium!(&test) }
 
     context "when no premium multi entities integration is enabled" do
-      it { is_expected.to eq(false) }
+      it { is_expected.to eq(true) }
+
+      context "when organization has one active billing entity" do
+        before do
+          create(:billing_entity, organization:)
+        end
+
+        it { is_expected.to eq(false) }
+      end
     end
 
     context "when the premium multi_entities_pro integration is enabled" do
@@ -265,6 +273,14 @@ RSpec.describe Organization, type: :model do
         end
 
         it { is_expected.to eq(false) }
+      end
+
+      context "when organization has archived billing entities" do
+        before do
+          create_list(:billing_entity, 2, :archived, organization:)
+        end
+
+        it { is_expected.to eq true }
       end
     end
 

--- a/spec/services/billing_entities/create_service_spec.rb
+++ b/spec/services/billing_entities/create_service_spec.rb
@@ -42,6 +42,124 @@ RSpec.describe BillingEntities::CreateService, type: :service do
         expect(result.billing_entity.name).to eq("Billing Entity")
       end
 
+      context "when creating billing entity with full data" do
+        let(:params) do
+          {
+            name: "Billing Entity",
+            code: "billing-entity",
+            address_line1: "Address Line 1",
+            address_line2: "Address Line 2",
+            city: "City",
+            country: "fr",
+            default_currency: "CHF",
+            document_number_prefix: "ENT-1234",
+            document_numbering: "per_customer",
+            email: "test@lago.com",
+            finalize_zero_amount_invoice: true,
+            legal_name: "Legal Name",
+            legal_number: "Legal Number",
+            net_payment_term: 90,
+            state: "State",
+            tax_identification_number: "EU123456789",
+            vat_rate: 1,
+            zipcode: "12345",
+            timezone: "Europe/Paris",
+            email_settings: ["invoice.finalized", "credit_note.created"],
+            billing_configuration: {
+              invoice_grace_period: 15,
+              invoice_footer: "Invoice Footer",
+              document_locale: "fr"
+            },
+            eu_tax_management: true,
+            logo: "data:image/png;base64,#{Base64.encode64(File.read("spec/factories/images/logo.png"))}"
+          }
+        end
+
+        before do
+          allow(Taxes::AutoGenerateService).to receive(:call)
+        end
+
+        it "creates a billing entity with full data" do
+          expect(result).to be_success
+          expect(result.billing_entity).to be_persisted
+          expect(result.billing_entity.name).to eq("Billing Entity")
+          expect(result.billing_entity.address_line1).to eq("Address Line 1")
+          expect(result.billing_entity.address_line2).to eq("Address Line 2")
+          expect(result.billing_entity.city).to eq("City")
+          expect(result.billing_entity.country).to eq("FR")
+          expect(result.billing_entity.default_currency).to eq("CHF")
+          expect(result.billing_entity.document_number_prefix).to eq("ENT-1234")
+          expect(result.billing_entity.document_numbering).to eq("per_customer")
+          expect(result.billing_entity.email).to eq("test@lago.com")
+          expect(result.billing_entity.finalize_zero_amount_invoice).to eq(true)
+          expect(result.billing_entity.legal_name).to eq("Legal Name")
+          expect(result.billing_entity.legal_number).to eq("Legal Number")
+          expect(result.billing_entity.net_payment_term).to eq(90)
+          expect(result.billing_entity.state).to eq("State")
+          expect(result.billing_entity.tax_identification_number).to eq("EU123456789")
+          expect(result.billing_entity.vat_rate).to eq(1)
+          expect(result.billing_entity.zipcode).to eq("12345")
+          expect(result.billing_entity.timezone).to eq("Europe/Paris")
+          expect(result.billing_entity.email_settings).to eq(["invoice.finalized", "credit_note.created"])
+          expect(result.billing_entity.invoice_grace_period).to eq(15)
+          expect(result.billing_entity.invoice_footer).to eq("Invoice Footer")
+          expect(result.billing_entity.document_locale).to eq("fr")
+          expect(result.billing_entity.eu_tax_management).to eq(true)
+          expect(result.billing_entity.logo).to be_attached
+          expect(Taxes::AutoGenerateService).to have_received(:call).with(organization: result.billing_entity)
+        end
+      end
+
+      context "when document_number_prefix is lowercase" do
+        it "converts document_number_prefix to uppercase" do
+          params[:document_number_prefix] = "abc"
+
+          expect(result).to be_success
+          expect(result.billing_entity.document_number_prefix).to eq("ABC")
+        end
+      end
+
+      context "when document_number_prefix is invalid" do
+        before { params[:document_number_prefix] = "aaaaaaaaaaaaaaa" }
+
+        it "returns an error" do
+          expect(result).to be_failure
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:document_number_prefix]).to eq(["value_is_too_long"])
+        end
+      end
+
+      context "when billing entity outside the EU and eu_tax_management is true" do
+        let(:tax_auto_generate_service) { instance_double(Taxes::AutoGenerateService) }
+
+        before do
+          params[:country] = "us"
+          params[:eu_tax_management] = true
+
+          allow(Taxes::AutoGenerateService).to receive(:new).and_return(tax_auto_generate_service)
+          allow(tax_auto_generate_service).to receive(:call)
+        end
+
+        it "returns an error" do
+          expect(result).to be_failure
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({eu_tax_management: ["billing_entity_must_be_in_eu"]})
+          expect(tax_auto_generate_service).not_to have_received(:call)
+        end
+      end
+
+      context "with validation errors" do
+        before do
+          params[:country] = "---"
+        end
+
+        it "returns an error" do
+          expect(result).to be_failure
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:country]).to eq(["not_a_valid_country_code"])
+        end
+      end
+
       context "when max billing entities limit is reached" do
         it "returns an error" do
           create(:billing_entity, organization:)

--- a/spec/services/billing_entities/create_service_spec.rb
+++ b/spec/services/billing_entities/create_service_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe BillingEntities::CreateService, type: :service do
           expect(result.billing_entity.document_locale).to eq("fr")
           expect(result.billing_entity.eu_tax_management).to eq(true)
           expect(result.billing_entity.logo).to be_attached
-          expect(Taxes::AutoGenerateService).to have_received(:call).with(organization: result.billing_entity)
+          expect(Taxes::AutoGenerateService).to have_received(:call).with(organization:)
         end
       end
 


### PR DESCRIPTION
  ## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

  ## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

  ## Description

BillingEntities::CreateService creates billing entities with all data...