### PR TITLE
Feat invoice preview minor improvements

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -117,7 +117,7 @@ class Subscription < ApplicationRecord
   end
 
   def next_subscription
-    next_subscriptions.not_canceled.order(created_at: :desc).first
+    next_subscriptions.reject(&:canceled?).max_by(&:created_at)
   end
 
   def already_billed?

--- a/app/services/invoices/preview/credits_service.rb
+++ b/app/services/invoices/preview/credits_service.rb
@@ -34,6 +34,7 @@ module Invoices
 
         credit_amount = [credit_note.balance_amount_cents, invoice.total_amount_cents].min
         return [] unless credit_amount.positive?
+
         credit = Credit.new(
           invoice:,
           credit_note:,

--- a/app/services/invoices/preview/subscription_plan_change_service.rb
+++ b/app/services/invoices/preview/subscription_plan_change_service.rb
@@ -35,6 +35,13 @@ module Invoices
         current_subscription.terminated_at = termination_date
         current_subscription.status = :terminated
 
+        if current_subscription.next_subscription
+          current_subscription.next_subscription.assign_attributes(
+            status: :canceled,
+            canceled_at: Time.current
+          )
+        end
+
         current_subscription
       end
 

--- a/app/services/invoices/preview/subscription_termination_service.rb
+++ b/app/services/invoices/preview/subscription_termination_service.rb
@@ -33,6 +33,13 @@ module Invoices
           terminated_at:
         )
 
+        if current_subscription.next_subscription
+          current_subscription.next_subscription.assign_attributes(
+            status: :canceled,
+            canceled_at: Time.current
+          )
+        end
+
         result.subscriptions = [current_subscription]
         result
       end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -20,6 +20,7 @@ module Invoices
       return result.not_found_failure!(resource: "customer") unless customer
       return result.not_found_failure!(resource: "subscription") if subscriptions.empty?
       return result.not_allowed_failure!(code: "premium_integration_missing") if persisted_subscriptions && !organization.preview_enabled?
+      return result unless terminate_allowed?
       return result unless currencies_aligned?
       return result unless billing_times_aligned?
 
@@ -83,6 +84,15 @@ module Invoices
       end
 
       true
+    end
+
+    def terminate_allowed?
+      return true unless subscription_context == :terminated
+      return true if subscriptions.size == 1 && persisted_subscriptions
+
+      result.single_validation_failure!(error_code: "terminate_unavailable")
+
+      false
     end
 
     def end_of_periods

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -12,6 +12,11 @@ FactoryBot.define do
       status { :pending }
     end
 
+    trait :canceled do
+      status { :canceled }
+      canceled_at { Time.current }
+    end
+
     trait :terminated do
       status { :terminated }
       started_at { 1.month.ago }

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -617,4 +617,22 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe "#next_subscription" do
+    subject { subscription.next_subscription }
+
+    let(:subscription) { build_stubbed(:subscription, next_subscriptions:) }
+
+    let(:next_subscriptions) do
+      [
+        build_stubbed(:subscription, :canceled),
+        build_stubbed(:subscription, created_at: 1.day.ago),
+        build_stubbed(:subscription, created_at: 2.days.ago)
+      ]
+    end
+
+    it "returns most recently non-canceled next subscription" do
+      expect(subject).to eq next_subscriptions.second
+    end
+  end
 end

--- a/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
@@ -29,7 +29,16 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
     end
 
     context "when current subscription and matching plan are present" do
-      let!(:current_subscription) { create(:subscription, plan: current_plan, organization:) }
+      let!(:current_subscription) do
+        create(
+          :subscription,
+          plan: current_plan,
+          organization:,
+          next_subscriptions: [next_subscription]
+        )
+      end
+
+      let(:next_subscription) { create(:subscription, organization:) }
       let(:current_plan) { create(:plan, organization:) }
       let(:organization) { create(:organization) }
       let(:target_plan_code) { target_plan.code }
@@ -44,8 +53,12 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
             .to match(base: ["new_plan_should_be_different_from_existing_plan"])
         end
 
-        it "does not change persist any changes to the current subscription" do
+        it "does not persist any changes to the current subscription" do
           expect { subject }.not_to change { current_subscription.reload.attributes }
+        end
+
+        it "does not persist any changes to the next subscription" do
+          expect { subject }.not_to change { next_subscription.reload.attributes }
         end
 
         it "does not create any subscription" do
@@ -74,10 +87,19 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
               expect(subscriptions.second)
                 .to be_new_record
                 .and have_attributes(status: "active", started_at: Time.current, name: target_plan.name)
+
+              expect(next_subscription).to have_attributes(
+                canceled_at: Time.current,
+                status: "canceled"
+              )
             end
 
-            it "does not change persist any changes to the current subscription" do
+            it "does not persist any changes to the current subscription" do
               expect { subject }.not_to change { current_subscription.reload.attributes }
+            end
+
+            it "does not persist any changes to the next subscription" do
+              expect { subject }.not_to change { next_subscription.reload.attributes }
             end
 
             it "does not create any subscription" do
@@ -99,10 +121,19 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
               expect(subscriptions.second)
                 .to be_new_record
                 .and have_attributes(status: "active", started_at: start_of_next_billing_period, name: target_plan.name)
+
+              expect(next_subscription).to have_attributes(
+                canceled_at: Time.current,
+                status: "canceled"
+              )
             end
 
-            it "does not change persist any changes to the current subscription" do
+            it "does not persist any changes to the current subscription" do
               expect { subject }.not_to change { current_subscription.reload.attributes }
+            end
+
+            it "does not persist any changes to the next subscription" do
+              expect { subject }.not_to change { next_subscription.reload.attributes }
             end
 
             it "does not create any subscription" do
@@ -123,10 +154,19 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
 
               expect(subscriptions.first)
                 .to have_attributes(status: "terminated", terminated_at: Time.current)
+
+              expect(next_subscription).to have_attributes(
+                canceled_at: Time.current,
+                status: "canceled"
+              )
             end
 
-            it "does not change persist any changes to the current subscription" do
+            it "does not persist any changes to the current subscription" do
               expect { subject }.not_to change { current_subscription.reload.attributes }
+            end
+
+            it "does not persist any changes to the next subscription" do
+              expect { subject }.not_to change { next_subscription.reload.attributes }
             end
 
             it "does not create any subscription" do
@@ -144,10 +184,19 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
 
               expect(subscriptions.first)
                 .to have_attributes(status: "terminated", terminated_at: start_of_next_billing_period)
+
+              expect(next_subscription).to have_attributes(
+                canceled_at: Time.current,
+                status: "canceled"
+              )
             end
 
-            it "does not change persist any changes to the current subscription" do
+            it "does not persist any changes to the current subscription" do
               expect { subject }.not_to change { current_subscription.reload.attributes }
+            end
+
+            it "does not persist any changes to the next subscription" do
+              expect { subject }.not_to change { next_subscription.reload.attributes }
             end
 
             it "does not create any subscription" do

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -74,6 +74,29 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
       end
 
+      context "when terminate action not applicable" do
+        let(:subscription) do
+          build(
+            :subscription,
+            customer:,
+            plan:,
+            billing_time:,
+            status: "terminated",
+            subscription_at: timestamp,
+            terminated_at: timestamp,
+            started_at: timestamp,
+            created_at: timestamp
+          )
+        end
+
+        it "returns an error if subscription is not persisted" do
+          result = preview_service.call
+
+          expect(result).not_to be_success
+          expect(result.error.messages[:base]).to include("terminate_unavailable")
+        end
+      end
+
       context "when billing periods do not match" do
         let(:customer) { create(:customer, organization:) }
         let(:plan1) { create(:plan, organization:, interval: "monthly") }

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -74,29 +74,6 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
       end
 
-      context "when terminate action not applicable" do
-        let(:subscription) do
-          build(
-            :subscription,
-            customer:,
-            plan:,
-            billing_time:,
-            status: "terminated",
-            subscription_at: timestamp,
-            terminated_at: timestamp,
-            started_at: timestamp,
-            created_at: timestamp
-          )
-        end
-
-        it "returns an error if subscription is not persisted" do
-          result = preview_service.call
-
-          expect(result).not_to be_success
-          expect(result.error.messages[:base]).to include("terminate_unavailable")
-        end
-      end
-
       context "when billing periods do not match" do
         let(:customer) { create(:customer, organization:) }
         let(:plan1) { create(:plan, organization:, interval: "monthly") }
@@ -551,6 +528,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
 
                 expect(result).to be_success
                 expect(result.invoice.subscriptions.size).to eq(2)
+                expect(result.invoice.credits.length).to eq(1)
+                expect(result.invoice.credits.first.amount_cents).to eq(9)
                 expect(result.invoice.fees.length).to eq(1)
                 expect(result.invoice.invoice_type).to eq("subscription")
                 expect(result.invoice.issuing_date.to_s).to eq("2024-03-29")


### PR DESCRIPTION
## Description

Attach credits from credit notes to the preview invoice.
Switch `Subscription#next_subscription` to use array iteration for record finding.
Update logic for simulated subscription termination to also cancel next subscription.
