### PR TITLE
feat(preauth): Get latest payment method from Stripe if not found locally

### DIFF
--- a/app/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service.rb
+++ b/app/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  module Stripe
+    class RetrieveLatestPaymentMethodService < BaseService
+      Result = BaseResult[:payment_method_id]
+
+      def initialize(provider_customer:)
+        @provider_customer = provider_customer
+        super
+      end
+
+      def call
+        # We use limit: 10 just in case for some (wrong) reason the customer has a very high number of payment method
+        list = ::Stripe::Customer.list_payment_methods(provider_customer.provider_customer_id, {limit: 10}, api_key:)
+        result.payment_method_id = list.data.filter { _1.type == "card" }.max_by { _1.created }.id
+        result
+      end
+
+      private
+
+      attr_reader :provider_customer, :payment_method_id
+
+      def api_key
+        provider_customer.payment_provider.secret_key
+      end
+    end
+  end
+end

--- a/app/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service.rb
+++ b/app/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service.rb
@@ -11,15 +11,39 @@ module PaymentProviderCustomers
       end
 
       def call
-        # We use limit: 10 just in case for some (wrong) reason the customer has a very high number of payment method
-        list = ::Stripe::Customer.list_payment_methods(provider_customer.provider_customer_id, {limit: 10}, api_key:)
-        result.payment_method_id = list.data.filter { _1.type == "card" }.max_by { _1.created }.id
+        # First, we try to get the customer default payment method
+        payment_method_id = begin
+          customer = ::Stripe::Customer.retrieve(provider_customer.provider_customer_id, request_options)
+          customer["invoice_settings"]["default_payment_method"]
+        rescue
+          nil
+        end
+
+        # If no default, we'll try to get the latest card
+        if payment_method_id.blank?
+          payment_method_id = begin
+            # We use limit: 10 just in case for some (wrong) reason the customer has a very high number of payment method
+            list = ::Stripe::Customer.list_payment_methods(provider_customer.provider_customer_id, {limit: 10}, request_options)
+            list.data.filter { _1.type == "card" }.max_by { _1.created }.id
+          rescue
+            nil
+          end
+        end
+
+        result.payment_method_id = payment_method_id
         result
       end
 
       private
 
-      attr_reader :provider_customer, :payment_method_id
+      attr_reader :provider_customer
+
+      def request_options
+        {
+          api_key:,
+          stripe_version: "2024-09-30.acacia"
+        }
+      end
 
       def api_key
         provider_customer.payment_provider.secret_key

--- a/app/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service.rb
+++ b/app/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service.rb
@@ -12,6 +12,7 @@ module PaymentProviderCustomers
 
       def call
         # First, we try to get the customer default payment method
+        # We swallow all errors to run the second solution
         payment_method_id = begin
           customer = ::Stripe::Customer.retrieve(provider_customer.provider_customer_id, request_options)
           customer["invoice_settings"]["default_payment_method"]
@@ -20,6 +21,7 @@ module PaymentProviderCustomers
         end
 
         # If no default, we'll try to get the latest card
+        # We also swallow all errors because this is "best effort". If no payment method is found, the caller service will handle it
         if payment_method_id.blank?
           payment_method_id = begin
             # We use limit: 10 just in case for some (wrong) reason the customer has a very high number of payment method
@@ -41,7 +43,7 @@ module PaymentProviderCustomers
       def request_options
         {
           api_key:,
-          stripe_version: "2024-09-30.acacia"
+          stripe_version: "2024-09-30.acacia" # temporarily hardcoded until Lago fixes version
         }
       end
 

--- a/app/services/payment_providers/stripe/payments/authorize_service.rb
+++ b/app/services/payment_providers/stripe/payments/authorize_service.rb
@@ -72,7 +72,7 @@ module PaymentProviders
             {
               api_key:,
               idempotency_key: "auth-#{provider_customer.id}-#{unique_id}",
-              stripe_version: "2024-09-30.acacia"
+              stripe_version: "2024-09-30.acacia" # temporarily hardcoded until Lago fixes version
             }
           )
         end

--- a/app/services/payment_providers/stripe/payments/authorize_service.rb
+++ b/app/services/payment_providers/stripe/payments/authorize_service.rb
@@ -10,6 +10,7 @@ module PaymentProviders
           @amount = amount
           @currency = currency
           @provider_customer = provider_customer
+          @payment_method_id = provider_customer.payment_method_id
           @unique_id = unique_id
           @metadata = metadata
 
@@ -17,8 +18,17 @@ module PaymentProviders
         end
 
         def call
-          unless provider_customer.payment_method_id
-            return result.single_validation_failure!(field: :payment_method_id, error_code: "customer_has_no_payment_method")
+          if payment_method_id.blank?
+            # If the customer doesn't have a payment_method_id on Lago, we check on Stripe before returning the error,
+            # because it could be that it was just added and the webhook wasn't processed yet
+            # The preauth api call requires a payment_method_id
+            latest_id = PaymentProviderCustomers::Stripe::RetrieveLatestPaymentMethodService.call!(provider_customer:).payment_method_id
+
+            if latest_id
+              @payment_method_id = latest_id
+            else
+              return result.single_validation_failure!(field: :payment_method_id, error_code: "customer_has_no_payment_method")
+            end
           end
 
           pi = create_payment_intent
@@ -50,7 +60,7 @@ module PaymentProviders
                 }
               },
               customer: provider_customer.provider_customer_id,
-              payment_method: provider_customer.payment_method_id,
+              payment_method: payment_method_id,
               description: "Pre-authorization for subscription",
               metadata:,
               return_url: payment_provider.success_redirect_url,
@@ -67,7 +77,7 @@ module PaymentProviders
           )
         end
 
-        attr_reader :amount, :currency, :provider_customer, :unique_id, :metadata
+        attr_reader :amount, :currency, :provider_customer, :payment_method_id, :unique_id, :metadata
       end
     end
   end

--- a/spec/fixtures/stripe/customer_list_no_payment_methods.json
+++ b/spec/fixtures/stripe/customer_list_no_payment_methods.json
@@ -1,0 +1,6 @@
+{
+  "object": "list",
+  "data": [],
+  "has_more": false,
+  "url": "/v1/customers/cus_Rw5Qso78STEap3/payment_methods"
+}

--- a/spec/fixtures/stripe/customer_list_payment_methods.json
+++ b/spec/fixtures/stripe/customer_list_payment_methods.json
@@ -1,0 +1,108 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "pm_1R2EmOQ8iJWBZFaMKJHOwcvP",
+      "object": "payment_method",
+      "allow_redisplay": "always",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": null,
+          "line1": null,
+          "line2": null,
+          "postal_code": null,
+          "state": null
+        },
+        "email": null,
+        "name": null,
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": null,
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "display_brand": "visa",
+        "exp_month": 12,
+        "exp_year": 2028,
+        "fingerprint": "pmIfA8TCefcd72yD",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "0341",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "regulated_status": "unregulated",
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1741883924,
+      "customer": "cus_Rw5Qso78STEap3",
+      "livemode": false,
+      "metadata": {},
+      "radar_options": {},
+      "type": "card"
+    },
+    {
+      "id": "pm_1R2DFsQ8iJWBZFaMw3LLbR0r",
+      "object": "payment_method",
+      "allow_redisplay": "always",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": "FR",
+          "line1": null,
+          "line2": null,
+          "postal_code": null,
+          "state": null
+        },
+        "email": "awdawd@desf.com",
+        "name": "Testing Stripe",
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": null,
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "display_brand": "visa",
+        "exp_month": 12,
+        "exp_year": 2028,
+        "fingerprint": "8TOiB4cGytYxCweY",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "regulated_status": "unregulated",
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1741878064,
+      "customer": "cus_Rw5Qso78STEap3",
+      "livemode": false,
+      "metadata": {},
+      "type": "card"
+    }
+  ],
+  "has_more": false,
+  "url": "/v1/customers/cus_Rw5Qso78STEap3/payment_methods"
+}

--- a/spec/fixtures/stripe/customer_no_default_payment_method.json
+++ b/spec/fixtures/stripe/customer_no_default_payment_method.json
@@ -1,0 +1,32 @@
+{
+  "id": "cus_Rw5Qso78STEap3",
+  "object": "customer",
+  "address": null,
+  "balance": 0,
+  "created": 1741878032,
+  "currency": null,
+  "default_source": null,
+  "delinquent": false,
+  "description": null,
+  "discount": null,
+  "email": "awdawd@desf.com",
+  "invoice_prefix": "D0821665",
+  "invoice_settings": {
+    "custom_fields": null,
+    "default_payment_method": null,
+    "footer": null,
+    "rendering_options": null
+  },
+  "livemode": false,
+  "metadata": {
+    "customer_id": "cust_new_auth_no_card",
+    "lago_customer_id": "e4674f68-a7ba-4ce8-95e9-981f346b49d7"
+  },
+  "name": "Julien FTP Stripe",
+  "next_invoice_sequence": 1,
+  "phone": null,
+  "preferred_locales": [],
+  "shipping": null,
+  "tax_exempt": "none",
+  "test_clock": null
+}

--- a/spec/fixtures/stripe/customer_with_default_payment_method.json
+++ b/spec/fixtures/stripe/customer_with_default_payment_method.json
@@ -1,0 +1,32 @@
+{
+  "id": "cus_Rw5Qso78STEap3",
+  "object": "customer",
+  "address": null,
+  "balance": 0,
+  "created": 1741878032,
+  "currency": null,
+  "default_source": null,
+  "delinquent": false,
+  "description": null,
+  "discount": null,
+  "email": "awdawd@desf.com",
+  "invoice_prefix": "D0821665",
+  "invoice_settings": {
+    "custom_fields": null,
+    "default_payment_method": "pm_1R2DFsQ8iJWBZFaMw3LLbR0r",
+    "footer": null,
+    "rendering_options": null
+  },
+  "livemode": false,
+  "metadata": {
+    "customer_id": "cust_new_auth_no_card",
+    "lago_customer_id": "e4674f68-a7ba-4ce8-95e9-981f346b49d7"
+  },
+  "name": "Julien FTP Stripe",
+  "next_invoice_sequence": 1,
+  "phone": null,
+  "preferred_locales": [],
+  "shipping": null,
+  "tax_exempt": "none",
+  "test_clock": null
+}

--- a/spec/graphql/resolvers/memberships_resolver_spec.rb
+++ b/spec/graphql/resolvers/memberships_resolver_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Resolvers::MembershipsResolver, type: :graphql do
     memberships_response = result["data"]["memberships"]
 
     aggregate_failures do
-      expect(memberships_response["collection"].count).to eq(organization.memberships.count)
-      expect(memberships_response["collection"].first["id"]).to eq(membership.id)
+      expect(memberships_response["collection"].count).to eq(4)
+      expect(memberships_response["collection"].map { _1["id"] }).to include(membership.id)
 
       expect(memberships_response["metadata"]["currentPage"]).to eq(1)
       expect(memberships_response["metadata"]["totalCount"]).to eq(4)

--- a/spec/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviderCustomers::Stripe::RetrieveLatestPaymentMethodService, type: :service do
+  subject { described_class.new(provider_customer:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:provider_customer_id) { "cus_Rw5Qso78STEap3" }
+  let(:provider_customer) { create(:stripe_customer, customer:, provider_customer_id:, payment_provider: create(:stripe_provider, organization:), payment_method_id: nil) }
+
+  describe "#call" do
+    context "when customer has a default payment method in Stripe" do
+      it do
+        stub_request(:get, %r{/v1/customers/#{provider_customer_id}$}).and_return(
+          status: 200, body: File.read(Rails.root.join("spec/fixtures/stripe/customer_with_default_payment_method.json"))
+        )
+
+        result = subject.call
+        expect(result.payment_method_id).to eq "pm_1R2DFsQ8iJWBZFaMw3LLbR0r"
+      end
+    end
+
+    context "when customer has payment method in Stripe but no default" do
+      it do
+        stub_request(:get, %r{/v1/customers/#{provider_customer_id}$}).and_return(
+          status: 200, body: File.read(Rails.root.join("spec/fixtures/stripe/customer_no_default_payment_method.json"))
+        )
+        stub_request(:get, %r{/v1/customers/#{provider_customer_id}/payment_methods}).and_return(
+          status: 200, body: File.read(Rails.root.join("spec/fixtures/stripe/customer_list_payment_methods.json"))
+        )
+
+        result = subject.call
+        expect(result.payment_method_id).to eq "pm_1R2EmOQ8iJWBZFaMKJHOwcvP"
+      end
+    end
+
+    context "when customer has no payment method in Stripe" do
+      it do
+        stub_request(:get, %r{/v1/customers/#{provider_customer_id}$}).and_return(
+          status: 200, body: File.read(Rails.root.join("spec/fixtures/stripe/customer_no_default_payment_method.json"))
+        )
+        stub_request(:get, %r{/v1/customers/#{provider_customer_id}/payment_methods}).and_return(
+          status: 200, body: File.read(Rails.root.join("spec/fixtures/stripe/customer_list_no_payment_methods.json"))
+        )
+
+        result = subject.call
+        expect(result.payment_method_id).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Payments in Lago rely on Stripe to figure out the payment method, we don't pass it explicitly. For payment authorization, we must pass the payment method explicitly.

When a payment method is added to a stripe user, we receive a `setup_intent.succeeded` and save this payment method in Lago. 

It's possible that when creating a new subscription and making a pre-auth call, the webhook wasn't process yet. In this case, we'll try to find a payment method directly on Stripe.

First, we try the default payment.
Then, the most recent card.
Otherwise, fail.