### PR TITLE
feat(regroup_fee): Use current month boundaries for AdvanceCharges invoices

### DIFF
--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -114,9 +114,7 @@ module Invoices
         datetime: billing_at, # this is an int we need to convert it
         skip_charges: true
       ) do |invoice|
-        Invoices::CreateInvoiceSubscriptionService
-          .call(invoice:, subscriptions:, timestamp: billing_at.to_i, invoicing_reason: :in_advance_charge_periodic)
-          .raise_if_error!
+        Invoices::CreateAdvanceChargesInvoiceSubscriptionService.call!(invoice:, subscriptions:, timestamp: billing_at)
       end
 
       invoice_result.raise_if_error!

--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -114,7 +114,12 @@ module Invoices
         datetime: billing_at, # this is an int we need to convert it
         skip_charges: true
       ) do |invoice|
-        Invoices::CreateAdvanceChargesInvoiceSubscriptionService.call!(invoice:, subscriptions:, timestamp: billing_at)
+        Invoices::CreateAdvanceChargesInvoiceSubscriptionService.call!(
+          invoice:,
+          subscriptions_with_fees: subscriptions,
+          all_subscriptions: subscriptions + initial_subscriptions,
+          timestamp: billing_at
+        )
       end
 
       invoice_result.raise_if_error!

--- a/app/services/invoices/create_advance_charges_invoice_subscription_service.rb
+++ b/app/services/invoices/create_advance_charges_invoice_subscription_service.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Invoices
+  class CreateAdvanceChargesInvoiceSubscriptionService < BaseService
+    Result = BaseResult
+
+    def initialize(invoice:, timestamp:, subscriptions:)
+      @invoice = invoice
+      @timestamp = timestamp
+      @subscriptions = subscriptions
+
+      super
+    end
+
+    # Since the `advance_charges` invoice only have charges by design,
+    # we apply the `charges_(from|to)_date for both charges and subscriptions period
+    # See https://github.com/getlago/lago-api/pull/3327 for details
+    def call
+      latest_subscription = subscriptions.max_by(&:started_at)
+      boundaries = calculate_boundaries(latest_subscription)
+
+      subscriptions.each do |subscription|
+        invoice.invoice_subscriptions << InvoiceSubscription.create!(
+          invoice:,
+          subscription:,
+          timestamp:,
+          from_datetime: boundaries[:from],
+          to_datetime: boundaries[:to],
+          charges_from_datetime: boundaries[:from],
+          charges_to_datetime: boundaries[:to],
+          recurring: false,
+          invoicing_reason: :in_advance_charge_periodic
+        )
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :invoice, :timestamp, :subscriptions
+
+    def calculate_boundaries(subscription)
+      date_service = Subscriptions::DatesService.new_instance(subscription, timestamp, current_usage: false)
+
+      {
+        from: date_service.charges_from_datetime,
+        to: date_service.charges_to_datetime
+      }
+    end
+  end
+end

--- a/app/services/invoices/create_invoice_subscription_service.rb
+++ b/app/services/invoices/create_invoice_subscription_service.rb
@@ -54,8 +54,10 @@ module Invoices
     def impacted_subscriptions
       @impacted_subscriptions ||= if refresh
         subscriptions
+      elsif recurring
+        subscriptions.select(&:active?).uniq(&:id)
       else
-        (recurring ? subscriptions.select(&:active?) : subscriptions).uniq(&:id)
+        subscriptions.uniq(&:id)
       end
     end
 

--- a/spec/scenarios/invoices/advance_charges_dates_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_dates_spec.rb
@@ -36,8 +36,8 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
     create(:standard_charge, regroup_paid_fees: "invoice", pay_in_advance: true, invoiceable: false, prorated: true, billable_metric:, plan: plan_upgrade, properties: {amount: bm_amount.to_s, grouped_by: nil})
   end
 
-  context "when subscription is renewed" do
-    it "generates an invoice with the correct charges" do
+  context "when subscription is upgraded, renewed and terminated" do
+    it do
       travel_to(DateTime.new(2024, 6, 5, 10)) do
         create_subscription(
           {
@@ -169,6 +169,82 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
 
       # Note: if a fee is marked as paid after the last subscription with THIS external_id was terminated
       #     it will never be attached to an invoice
+    end
+  end
+
+  context "when subscription is upgraded but new sub has no events" do
+    it do
+      travel_to(DateTime.new(2024, 6, 5, 10)) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: external_subscription_id,
+            plan_code: plan.code
+          }
+        )
+        perform_billing
+        expect(customer.invoices.count).to eq(1)
+      end
+
+      initial_subscription = customer.subscriptions.sole
+      fees = []
+
+      # Create an event but keep it unpaid
+      travel_to(DateTime.new(2024, 6, 12, 10)) do
+        fees << send_card_event!("card_1")
+        expect(initial_subscription.fees.charge.where(invoice_id: nil).count).to eq(1)
+      end
+
+      upgraded_subscription = nil
+      # Upgrade the subscription (so previous one is terminated)
+      travel_to(DateTime.new(2024, 7, 7, 10)) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: external_subscription_id,
+            plan_code: plan_upgrade.code
+          }
+        )
+
+        upgraded_subscription = customer.subscriptions.where.not(id: initial_subscription.id).sole
+
+        expect(initial_subscription.reload).to be_terminated
+        expect(customer.invoices.count).to eq(2) # initial sub invoice + upgraded sub invoice
+        expect(upgraded_subscription.fees.charge.count).to eq 0
+      end
+
+      # In october, the fee from initial sub is finally marked as paid
+      travel_to(DateTime.new(2024, 10, 2, 10)) do
+        fees.each do |fee_id|
+          update_fee(fee_id, payment_status: :succeeded)
+        end
+      end
+
+      # In november, this fee should be added to the advance_charge invoice
+      travel_to(DateTime.new(2024, 11, 1, 10)) do
+        perform_billing
+        invoice = customer.invoices.where(invoice_type: :advance_charges).sole
+        invoice_fees = invoice.fees.order(:created_at)
+
+        # Notice that the periods in the fees relate to the CREATION of the fees
+        expect(invoice_fees.first.properties).to eq({
+          "timestamp" => "2024-06-12T10:00:00.000Z",
+          "to_datetime" => "2024-06-30T23:59:59.999Z",
+          "from_datetime" => "2024-06-05T00:00:00.000Z",
+          "charges_duration" => 30,
+          "charges_to_datetime" => "2024-06-30T23:59:59.999Z",
+          "charges_from_datetime" => "2024-06-05T10:00:00.000Z"
+        })
+
+        invoice_periods = billing_periods_hash(invoice)
+        expect(invoice_periods).to all include({
+          subscription_from_datetime: "2024-10-01T00:00:00Z",
+          subscription_to_datetime: "2024-10-31T23:59:59Z",
+          charges_from_datetime: "2024-10-01T00:00:00Z",
+          charges_to_datetime: "2024-10-31T23:59:59Z",
+          invoicing_reason: "in_advance_charge_periodic"
+        })
+      end
     end
   end
 end

--- a/spec/scenarios/invoices/advance_charges_dates_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_dates_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+  let(:tax_rate) { 20 }
+  let(:billable_metric) { create(:unique_count_billable_metric, organization:, code: "cards", recurring: true) }
+  let(:plan) { create(:plan, organization:, pay_in_advance: true, amount_cents: 49) }
+  let(:plan_upgrade) { create(:plan, organization:, pay_in_advance: true, amount_cents: 259) }
+  let(:external_subscription_id) { "sub_#{SecureRandom.hex}" }
+  let(:bm_amount) { 30.12 }
+
+  def send_card_event!(item_id = SecureRandom.uuid)
+    create_event({
+      code: billable_metric.code,
+      transaction_id: "tr_#{SecureRandom.hex(10)}",
+      external_customer_id: customer.external_id,
+      external_subscription_id:,
+      properties: {item_id:}
+    })
+  end
+
+  before do
+    create(:tax, organization:, rate: tax_rate)
+    create(:standard_charge, regroup_paid_fees: "invoice", pay_in_advance: true, invoiceable: false, prorated: true, billable_metric:, plan:, properties: {amount: bm_amount.to_s, grouped_by: nil})
+    create(:standard_charge, regroup_paid_fees: "invoice", pay_in_advance: true, invoiceable: false, prorated: true, billable_metric:, plan: plan_upgrade, properties: {amount: bm_amount.to_s, grouped_by: nil})
+  end
+
+  context "when subscription is renewed" do
+    it "generates an invoice with the correct charges" do
+      travel_to(DateTime.new(2024, 6, 5, 10)) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: external_subscription_id,
+            plan_code: plan.code
+          }
+        )
+        perform_billing
+        expect(customer.invoices.count).to eq(1)
+      end
+
+      initial_subscription = customer.subscriptions.sole
+
+      # Create an event but keep it unpaid
+      travel_to(DateTime.new(2024, 6, 12, 10)) do
+        send_card_event! "card_1"
+        expect(initial_subscription.fees.charge.where(invoice_id: nil).count).to eq(1)
+      end
+
+      upgraded_subscription = nil
+      # Upgrade the subscription (so previous one is terminated)
+      travel_to(DateTime.new(2024, 7, 7, 10)) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: external_subscription_id,
+            plan_code: plan_upgrade.code
+          }
+        )
+
+        upgraded_subscription = customer.subscriptions.where.not(id: initial_subscription.id).sole
+        pp({
+          upgraded_subscription: upgraded_subscription.id,
+          initial_subscription: initial_subscription.id
+        })
+        expect(initial_subscription.reload).to be_terminated
+        expect(customer.invoices.count).to eq(2) # initial sub invoice + upgraded sub invoice
+        expect(upgraded_subscription.fees.charge.count).to eq 0
+      end
+
+      # Create an event but keep it unpaid
+      travel_to(DateTime.new(2024, 7, 22, 10)) do
+        send_card_event! "card_2"
+        # one fee for each subscription
+        expect(initial_subscription.fees.charge.where(invoice_id: nil).count).to eq(1)
+        expect(upgraded_subscription.fees.charge.where(invoice_id: nil).count).to eq(1)
+      end
+
+      # In october, both fees are finally marked as paid
+      travel_to(DateTime.new(2024, 10, 2, 10)) do
+        [initial_subscription, upgraded_subscription].each do |subscription|
+          subscription.fees.charge.where(invoice_id: nil).each do |fee|
+            update_fee(fee, payment_status: :succeeded)
+          end
+        end
+      end
+
+      # In november, these fees should be added to the advance_charge invoice
+      travel_to(DateTime.new(2024, 11, 1, 10)) do
+        perform_billing
+        invoice = customer.invoices.where(invoice_type: :advance_charges).sole
+        expect(invoice.fees.count).to eq(2)
+        pp(::V1::InvoiceSerializer.new(
+          invoice,
+          root_name: "invoice", includes: [:billing_periods]
+        ).serialize[:billing_periods])
+      end
+    end
+  end
+end

--- a/spec/scenarios/invoices/recurring_fees_spec.rb
+++ b/spec/scenarios/invoices/recurring_fees_spec.rb
@@ -87,7 +87,7 @@ describe "Recurring fee invoice inclusion after upgrade", :scenarios, type: :req
       )
 
       # Step 5: Mark the original fee as succeeded
-      update_fee(fee, {fee: {payment_status: "succeeded"}})
+      update_fee(fee, {payment_status: "succeeded"})
       expect(fee.reload.payment_status).to eq("succeeded")
 
       # Step 6: Verify the fee is included in the end-of-period invoice

--- a/spec/scenarios/invoices/recurring_fees_spec.rb
+++ b/spec/scenarios/invoices/recurring_fees_spec.rb
@@ -87,7 +87,7 @@ describe "Recurring fee invoice inclusion after upgrade", :scenarios, type: :req
       )
 
       # Step 5: Mark the original fee as succeeded
-      update_fee(fee, {payment_status: "succeeded"})
+      update_fee(fee.id, {payment_status: "succeeded"})
       expect(fee.reload.payment_status).to eq("succeeded")
 
       # Step 6: Verify the fee is included in the end-of-period invoice

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -161,8 +161,8 @@ module ScenariosHelper
 
   ### Fees
 
-  def update_fee(fee, params)
-    put_with_token(organization, "/api/v1/fees/#{fee.id}", {fee: params})
+  def update_fee(fee_id, params)
+    put_with_token(organization, "/api/v1/fees/#{fee_id}", {fee: params})
   end
 
   def perform_billing

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -162,7 +162,7 @@ module ScenariosHelper
   ### Fees
 
   def update_fee(fee, params)
-    put_with_token(organization, "/api/v1/fees/#{fee.id}", params)
+    put_with_token(organization, "/api/v1/fees/#{fee.id}", {fee: params})
   end
 
   def perform_billing


### PR DESCRIPTION
## Context

`advance_charges` invoices will regroup all **non invoiceable fees paid within the last period**. 

Invoice billing periods are normally related to the fee periods but in this case, you can have a fee created in June paid only in November so we want to recompute the periods.

The second issue is that the `DateService` is designed to work active or "recently terminated" subscription. In this case we try to compute dates for a fees long after the subscription is terminated which results in wrong dates (`to` date being before `from` date for instance). This bug is NOT fixed. Even if it was, the Date service would still compute date related to the subscription when the fee is created which is **not what we want in this specific case**. 

## Description

This fixed is inspired by this first attempt by @vincent-pochet : https://github.com/getlago/lago-api/pull/3285

Note that this invoice only has charge fees by design, so subscription fee.

For `advance_charges` and only for these invoices, I created a new service to create the `InvoiceSubscription` model. We grab the most recent subscription to compute correct boundaries and apply them to all InvoiceSubscriptions.


This invoice is special! See other corner case recently fixed: https://github.com/getlago/lago-api/pull/3153
