### PR TITLE
fix(invoice-preview): Params parsing and grace period being ignored

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -213,6 +213,16 @@ module Api
           )
         end
 
+        if preview_params[:subscriptions] && !preview_params.to_h[:subscriptions].is_a?(Hash)
+          return render(
+            json: {
+              status: 400,
+              error: "subscriptions_must_be_an_object"
+            },
+            status: :bad_request
+          )
+        end
+
         result = Invoices::PreviewContextService.call(
           organization: current_organization,
           params: preview_params.to_h.deep_symbolize_keys

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -128,7 +128,10 @@ module Invoices
     end
 
     def issuing_date
-      billing_time.in_time_zone(customer.applicable_timezone).to_date
+      return @issuing_date if defined?(@issuing_date)
+
+      date = billing_time.in_time_zone(customer.applicable_timezone).to_date
+      @issuing_date = date + customer.applicable_invoice_grace_period.days
     end
 
     def payment_due_date

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -1137,7 +1137,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       end
     end
 
-    context "when params have invalid structure" do
+    context "when coupons have invalid type" do
       let(:preview_params) do
         {
           coupons: {
@@ -1150,6 +1150,20 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         subject
         expect(response).to have_http_status(:bad_request)
         expect(json[:error]).to eq "coupons_must_be_an_array"
+      end
+    end
+
+    context "when subscriptions have invalid type" do
+      let(:preview_params) do
+        {
+          subscriptions: []
+        }
+      end
+
+      it "returns a bad request error" do
+        subject
+        expect(response).to have_http_status(:bad_request)
+        expect(json[:error]).to eq "subscriptions_must_be_an_object"
       end
     end
   end

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -383,6 +383,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
 
         context "with in advance billing in the future" do
+          let(:organization) { create(:organization, invoice_grace_period: 2) }
           let(:plan) { create(:plan, organization:, interval: "monthly", pay_in_advance: true) }
           let(:subscription) do
             build(
@@ -404,7 +405,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               expect(result.invoice.subscriptions.first).to eq(subscription)
               expect(result.invoice.fees.length).to eq(1)
               expect(result.invoice.invoice_type).to eq("subscription")
-              expect(result.invoice.issuing_date.to_s).to eq("2024-03-31")
+              expect(result.invoice.issuing_date.to_s).to eq("2024-04-02")
               expect(result.invoice.fees_amount_cents).to eq(3)
               expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(3)
               expect(result.invoice.taxes_amount_cents).to eq(2)
@@ -846,7 +847,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
 
         context "with multiple persisted subscriptions" do
-          let(:customer) { create(:customer, organization:) }
+          let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
           let(:plan1) { create(:plan, organization:, interval: "monthly") }
           let(:plan2) { create(:plan, organization:, interval: "monthly") }
           let(:subscriptions) { [subscription1, subscription2] }
@@ -883,7 +884,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               expect(result.invoice.subscriptions.map { |s| s.id }).to match_array([subscription1.id, subscription2.id])
               expect(result.invoice.fees.length).to eq(2)
               expect(result.invoice.invoice_type).to eq("subscription")
-              expect(result.invoice.issuing_date.to_s).to eq("2024-04-30")
+              expect(result.invoice.issuing_date.to_s).to eq("2024-05-03")
               expect(result.invoice.fees_amount_cents).to eq(200)
               expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(200)
               expect(result.invoice.taxes_amount_cents).to eq(100)


### PR DESCRIPTION
## Description

Add support for grace period for invoice preview.
Handle invalid params type for gracefully.
