### PR TITLE
fix(invoice): Fix refundable amount

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -302,9 +302,7 @@ class Invoice < ApplicationRecord
     return 0 if version_number < CREDIT_NOTES_MIN_VERSION || draft?
     return 0 if !payment_succeeded? && total_paid_amount_cents == total_amount_cents
 
-    amount = total_paid_amount_cents - credit_notes.sum("refund_amount_cents + credit_amount_cents") -
-      credits.where(before_taxes: false).sum(:amount_cents) -
-      prepaid_credit_amount_cents
+    amount = total_paid_amount_cents - credit_notes.sum("refund_amount_cents + credit_amount_cents")
     amount = amount.negative? ? 0 : amount
 
     return [amount, associated_active_wallet&.balance_cents || 0].min if credit?

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1625,7 +1625,7 @@ RSpec.describe Invoice, type: :model do
 
       context "when total amount is not equal to paid amount" do
         it "returns the correct refundable amount" do
-          expect(invoice.refundable_amount_cents).to eq(700)
+          expect(invoice.refundable_amount_cents).to eq(900)
         end
       end
     end
@@ -1636,7 +1636,7 @@ RSpec.describe Invoice, type: :model do
       let(:payment_status) { :succeeded }
 
       it "returns the correct refundable amount" do
-        expect(invoice.refundable_amount_cents).to eq(700)
+        expect(invoice.refundable_amount_cents).to eq(900)
       end
     end
 


### PR DESCRIPTION
## Context

Fix wrong calculation on max refund amount when an invoice got credits and prepaid credits on it.

## Description

Fix `Invoice#refundable_amount_cents` method to not include credits and prepaid credits.