### PR TITLE
fix(invoice-preview): Fix bugs

### DIFF
--- a/app/services/invoices/preview/subscription_termination_service.rb
+++ b/app/services/invoices/preview/subscription_termination_service.rb
@@ -30,7 +30,7 @@ module Invoices
 
         current_subscription.assign_attributes(
           status: :terminated,
-          terminated_at:
+          terminated_at: parsed_terminated_at.end_of_day
         )
 
         result.subscriptions = [current_subscription]

--- a/app/services/invoices/preview/subscription_termination_service.rb
+++ b/app/services/invoices/preview/subscription_termination_service.rb
@@ -21,7 +21,7 @@ module Invoices
           )
         end
 
-        if parsed_terminated_at.to_date.past?
+        if parsed_terminated_at.past?
           return result.single_validation_failure!(
             error_code: "cannot_be_in_past",
             field: :terminated_at
@@ -30,7 +30,7 @@ module Invoices
 
         current_subscription.assign_attributes(
           status: :terminated,
-          terminated_at: parsed_terminated_at.end_of_day
+          terminated_at:
         )
 
         result.subscriptions = [current_subscription]

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -152,9 +152,7 @@ module Invoices
     end
 
     def add_charge_fees
-      return unless persisted_subscriptions
-
-      subscriptions.map do |subscription|
+      subscriptions.select(&:persisted?).map do |subscription|
         boundaries = boundaries(subscription)
 
         charges = []

--- a/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
@@ -68,8 +68,11 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
               expect(result).to be_success
               expect(subscriptions).to match_array [current_subscription, Subscription]
 
-              expect(subscriptions.first)
-                .to have_attributes(status: "terminated", terminated_at: Time.current)
+              expect(subscriptions.first).to have_attributes(
+                status: "terminated",
+                next_subscription: Subscription,
+                terminated_at: Time.current
+              )
 
               expect(subscriptions.second)
                 .to be_new_record
@@ -93,8 +96,11 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
               expect(result).to be_success
               expect(subscriptions).to match_array [current_subscription, Subscription]
 
-              expect(subscriptions.first)
-                .to have_attributes(status: "terminated", terminated_at: start_of_next_billing_period)
+              expect(subscriptions.first).to have_attributes(
+                status: "terminated",
+                next_subscription: Subscription,
+                terminated_at: start_of_next_billing_period
+              )
 
               expect(subscriptions.second)
                 .to be_new_record
@@ -121,8 +127,11 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
               expect(result).to be_success
               expect(subscriptions).to contain_exactly current_subscription
 
-              expect(subscriptions.first)
-                .to have_attributes(status: "terminated", terminated_at: Time.current)
+              expect(subscriptions.first).to have_attributes(
+                status: "terminated",
+                next_subscription: Subscription,
+                terminated_at: Time.current
+              )
             end
 
             it "does not persist any changes to the current subscription" do
@@ -142,8 +151,11 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
               expect(result).to be_success
               expect(subscriptions).to contain_exactly current_subscription
 
-              expect(subscriptions.first)
-                .to have_attributes(status: "terminated", terminated_at: start_of_next_billing_period)
+              expect(subscriptions.first).to have_attributes(
+                status: "terminated",
+                next_subscription: Subscription,
+                terminated_at: start_of_next_billing_period
+              )
             end
 
             it "does not persist any changes to the current subscription" do

--- a/spec/services/invoices/preview/subscription_termination_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_termination_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Invoices::Preview::SubscriptionTerminationService, type: :service
             expect(subscriptions).to contain_exactly current_subscription
 
             expect(subscriptions.first).to have_attributes(
-              terminated_at: terminated_at.change(usec: 0),
+              terminated_at: terminated_at.end_of_day,
               status: "terminated"
             )
           end
@@ -63,7 +63,7 @@ RSpec.describe Invoices::Preview::SubscriptionTerminationService, type: :service
             expect(subscriptions).to contain_exactly current_subscription
 
             expect(subscriptions.first).to have_attributes(
-              terminated_at: terminated_at.change(usec: 0),
+              terminated_at: terminated_at.end_of_day,
               status: "terminated"
             )
           end

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -484,7 +484,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
 
           context "with upgraded subscription" do
             let(:timestamp) { Time.zone.parse("29 Mar 2024") }
-            let(:plan_new) { create(:plan, organization:, interval: "monthly", amount_cents: 200, pay_in_advance: true) }
+            let(:plan_new) { create(:plan, charges:, organization:, interval: "monthly", amount_cents: 200, pay_in_advance: true) }
             let(:subscriptions) { [terminated_subscription, upgrade_subscription] }
             let(:terminated_subscription) do
               create(
@@ -509,6 +509,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 created_at: timestamp
               )
             end
+
+            let(:charges) { [build(:standard_charge)] }
 
             before do
               BillSubscriptionJob.perform_now(


### PR DESCRIPTION
## Description

Prevent charge fees generation for non-persisted subscriptions.
Adjust subscription termination to always happen in the end of day.
Ensure that upgraded/downgraded subscription always has reference to new subscription.
