### PR TITLE
chore(gems): require `pry` for development and test env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,6 +117,7 @@ group :development, :test do
   gem "rubocop-rspec", require: false
   gem "rubocop-thread_safety", require: false
   gem "awesome_print"
+  gem "pry"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -988,6 +988,7 @@ DEPENDENCIES
   paper_trail
   parallel
   pg
+  pry
   puma (~> 6.5)
   rack-cors
   rails (~> 7.2)


### PR DESCRIPTION
## Description

1. Add `binding.pry` somewhere
1. Attach docker `docker attach lago_api_dev` 
  (see https://github.com/getlago/lago/pull/473)
1. In another window, run your rspec test and enjoy 🌟 