### PR TITLE
feat: add wallet transaction details

### DIFF
--- a/app/graphql/resolvers/wallet_transaction_resolver.rb
+++ b/app/graphql/resolvers/wallet_transaction_resolver.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class WalletTransactionResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description "Query a single wallet transaction"
+
+    argument :id, ID, required: true, description: "Unique ID of the wallet transaction"
+
+    type Types::WalletTransactions::Object, null: true
+
+    def resolve(id:)
+      current_organization.wallet_transactions.includes(:invoice).find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: "wallet_transaction")
+    end
+  end
+end

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -70,6 +70,7 @@ module Types
       field :integration_salesforce_syncable, GraphQL::Types::Boolean, null: false
       field :integration_syncable, GraphQL::Types::Boolean, null: false
       field :payable_type, GraphQL::Types::String, null: false
+      field :payments, [Types::Payments::Object], null: true
       field :tax_provider_voidable, GraphQL::Types::Boolean, null: false
 
       def payable_type
@@ -78,6 +79,10 @@ module Types
 
       def applied_taxes
         object.applied_taxes.order(tax_rate: :desc)
+      end
+
+      def payments
+        object.payments.order(updated_at: :desc)
       end
 
       def integration_syncable

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -73,6 +73,7 @@ module Types
     field :tax, resolver: Resolvers::TaxResolver
     field :taxes, resolver: Resolvers::TaxesResolver
     field :wallet, resolver: Resolvers::WalletResolver
+    field :wallet_transaction, resolver: Resolvers::WalletTransactionResolver
     field :wallet_transactions, resolver: Resolvers::WalletTransactionsResolver
     field :wallets, resolver: Resolvers::WalletsResolver
     field :webhook_endpoint, resolver: Resolvers::WebhookEndpointResolver

--- a/app/graphql/types/wallet_transactions/object.rb
+++ b/app/graphql/types/wallet_transactions/object.rb
@@ -16,9 +16,18 @@ module Types
       field :transaction_type, Types::WalletTransactions::TransactionTypeEnum, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :failed_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :invoice, Types::Invoices::Object, null: true
       field :metadata, [Types::WalletTransactions::MetadataObject], null: true
       field :settled_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      def invoice
+        return object.invoice if object.invoice_id.present?
+
+        fee = Fee.find_by(invoiceable_id: object.id, invoiceable_type: "WalletTransaction")
+        fee&.invoice
+      end
     end
   end
 end

--- a/app/jobs/invoices/prepaid_credit_job.rb
+++ b/app/jobs/invoices/prepaid_credit_job.rb
@@ -7,10 +7,15 @@ module Invoices
     retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6
     unique :until_executed, on_conflict: :log
 
-    def perform(invoice)
+    def perform(invoice, payment_status = :succeeded)  # Default to :succeeded for old jobs
       wallet_transaction = invoice.fees.find_by(fee_type: "credit")&.invoiceable
-      Wallets::ApplyPaidCreditsService.call(wallet_transaction:)
-      Invoices::FinalizeOpenCreditService.call(invoice:)
+
+      if payment_status.to_sym == :succeeded
+        Wallets::ApplyPaidCreditsService.call(wallet_transaction:)
+        Invoices::FinalizeOpenCreditService.call(invoice:)
+      elsif payment_status.to_sym == :failed
+        WalletTransactions::MarkAsFailedService.new(wallet_transaction:).call
+      end
     end
   end
 end

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -11,7 +11,8 @@ class WalletTransaction < ApplicationRecord
 
   STATUSES = [
     :pending,
-    :settled
+    :settled,
+    :failed
   ].freeze
 
   TRANSACTION_STATUSES = [
@@ -46,6 +47,12 @@ class WalletTransaction < ApplicationRecord
   def unit_amount_cents
     wallet.rate_amount * wallet.currency_for_balance.subunit_to_unit
   end
+
+  def mark_as_failed!(timestamp = Time.zone.now)
+    return if failed?
+
+    update!(status: :failed, failed_at: timestamp)
+  end
 end
 
 # == Schema Information
@@ -55,6 +62,7 @@ end
 #  id                                  :uuid             not null, primary key
 #  amount                              :decimal(30, 5)   default(0.0), not null
 #  credit_amount                       :decimal(30, 5)   default(0.0), not null
+#  failed_at                           :datetime
 #  invoice_requires_successful_payment :boolean          default(FALSE), not null
 #  metadata                            :jsonb
 #  settled_at                          :datetime

--- a/app/serializers/v1/wallet_transaction_serializer.rb
+++ b/app/serializers/v1/wallet_transaction_serializer.rb
@@ -13,6 +13,7 @@ module V1
         amount: model.amount,
         credit_amount: model.credit_amount,
         settled_at: model.settled_at&.iso8601,
+        failed_at: model.failed_at&.iso8601,
         created_at: model.created_at.iso8601,
         invoice_requires_successful_payment: model.invoice_requires_successful_payment?,
         metadata: model.metadata

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -80,9 +80,9 @@ module Invoices
 
     def handle_prepaid_credits(payment_status)
       return unless invoice.invoice_type&.to_sym == :credit
-      return unless payment_status&.to_sym == :succeeded
+      return unless %i[succeeded failed].include?(payment_status.to_sym)
 
-      Invoices::PrepaidCreditJob.perform_later(invoice)
+      Invoices::PrepaidCreditJob.perform_later(invoice, payment_status)
     end
 
     def valid_metadata_count?(metadata:)

--- a/app/services/wallet_transactions/mark_as_failed_service.rb
+++ b/app/services/wallet_transactions/mark_as_failed_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module WalletTransactions
+  class MarkAsFailedService < BaseService
+    def initialize(wallet_transaction:)
+      @wallet_transaction = wallet_transaction
+      super()
+    end
+
+    def call
+      return result unless wallet_transaction
+      return result if wallet_transaction.status == "failed"
+
+      ActiveRecord::Base.transaction do
+        wallet_transaction.mark_as_failed!
+      end
+      SendWebhookJob.perform_later("wallet_transaction.updated", wallet_transaction)
+      result.wallet_transaction = wallet_transaction
+      result
+    end
+
+    private
+
+    attr_reader :wallet_transaction
+  end
+end

--- a/app/services/wallet_transactions/mark_as_failed_service.rb
+++ b/app/services/wallet_transactions/mark_as_failed_service.rb
@@ -4,16 +4,14 @@ module WalletTransactions
   class MarkAsFailedService < BaseService
     def initialize(wallet_transaction:)
       @wallet_transaction = wallet_transaction
-      super()
+      super
     end
 
     def call
       return result unless wallet_transaction
       return result if wallet_transaction.status == "failed"
 
-      ActiveRecord::Base.transaction do
-        wallet_transaction.mark_as_failed!
-      end
+      wallet_transaction.mark_as_failed!
       SendWebhookJob.perform_later("wallet_transaction.updated", wallet_transaction)
       result.wallet_transaction = wallet_transaction
       result

--- a/db/migrate/20250318093216_add_failed_at_to_wallet_transactions.rb
+++ b/db/migrate/20250318093216_add_failed_at_to_wallet_transactions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddFailedAtToWalletTransactions < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+  def change
+    add_column :wallet_transactions, :failed_at, :datetime
+  end
+end

--- a/db/migrate/20250318175216_mark_pending_wallet_transactions_as_failed.rb
+++ b/db/migrate/20250318175216_mark_pending_wallet_transactions_as_failed.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class MarkPendingWalletTransactionsAsFailed < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    # Update transactions using the latest `updated_at` from failed payments (if available)
+    safety_assured do
+      execute <<~SQL.squish
+        UPDATE wallet_transactions wt
+        SET status = 2,
+            failed_at = (
+                SELECT MAX(p.updated_at)
+                FROM fees f
+                INNER JOIN invoices i ON i.id = f.invoice_id
+                INNER JOIN payments p ON p.payable_id = i.id
+                WHERE f.invoiceable_id = wt.id
+                  AND f.invoiceable_type = 'WalletTransaction'
+                  AND i.payment_status = 2
+                  AND p.payable_payment_status = 'failed'
+            )
+        WHERE wt.status = 0
+          AND EXISTS (
+                SELECT 1
+                FROM fees f
+                INNER JOIN invoices i ON i.id = f.invoice_id
+                INNER JOIN payments p ON p.payable_id = i.id
+                WHERE f.invoiceable_id = wt.id
+                  AND f.invoiceable_type = 'WalletTransaction'
+                  AND i.payment_status = 2
+                  AND p.payable_payment_status = 'failed'
+            );
+      SQL
+    end
+
+    # Then update transactions using `invoices.updated_at` if no failed payment exists
+    safety_assured do
+      execute <<~SQL.squish
+        UPDATE wallet_transactions wt
+        SET status = 2,
+            failed_at = (
+                SELECT MAX(i.updated_at)
+                FROM fees f
+                INNER JOIN invoices i ON i.id = f.invoice_id
+                WHERE f.invoiceable_id = wt.id
+                  AND f.invoiceable_type = 'WalletTransaction'
+                  AND i.payment_status = 2
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM payments p
+                      WHERE p.payable_id = i.id
+                  )
+            )
+        WHERE wt.status = 0
+          AND EXISTS (
+              SELECT 1
+              FROM fees f
+              INNER JOIN invoices i ON i.id = f.invoice_id
+              WHERE f.invoiceable_id = wt.id
+                AND f.invoiceable_type = 'WalletTransaction'
+                AND i.payment_status = 2
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM payments p
+                    WHERE p.payable_id = i.id
+                )
+          );
+      SQL
+    end
+  end
+
+  def down
+    # do nothing
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_10_213734) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_18_175216) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1380,6 +1380,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_10_213734) do
     t.boolean "invoice_requires_successful_payment", default: false, null: false
     t.jsonb "metadata", default: []
     t.uuid "credit_note_id"
+    t.datetime "failed_at"
     t.index ["credit_note_id"], name: "index_wallet_transactions_on_credit_note_id"
     t.index ["invoice_id"], name: "index_wallet_transactions_on_invoice_id"
     t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -4711,6 +4711,7 @@ type Invoice {
   paymentDueDate: ISO8601Date!
   paymentOverdue: Boolean!
   paymentStatus: InvoicePaymentStatusTypeEnum!
+  payments: [Payment!]
   prepaidCreditAmountCents: BigInt!
   progressiveBillingCreditAmountCents: BigInt!
   refundableAmountCents: BigInt!
@@ -7307,6 +7308,16 @@ type Query {
   ): Wallet
 
   """
+  Query a single wallet transaction
+  """
+  walletTransaction(
+    """
+    Unique ID of the wallet transaction
+    """
+    id: ID!
+  ): WalletTransaction
+
+  """
   Query wallet transactions
   """
   walletTransactions(
@@ -9296,7 +9307,9 @@ type WalletTransaction {
   amount: String!
   createdAt: ISO8601DateTime!
   creditAmount: String!
+  failedAt: ISO8601DateTime
   id: ID!
+  invoice: Invoice
   invoiceRequiresSuccessfulPayment: Boolean!
   metadata: [WalletTransactionMetadataObject!]
   settledAt: ISO8601DateTime
@@ -9333,6 +9346,7 @@ type WalletTransactionMetadataObject {
 }
 
 enum WalletTransactionStatusEnum {
+  failed
   pending
   settled
 }

--- a/schema.json
+++ b/schema.json
@@ -22667,6 +22667,26 @@
               "args": []
             },
             {
+              "name": "payments",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Payment",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "prepaidCreditAmountCents",
               "description": null,
               "type": {
@@ -36998,6 +37018,35 @@
               ]
             },
             {
+              "name": "walletTransaction",
+              "description": "Query a single wallet transaction",
+              "type": {
+                "kind": "OBJECT",
+                "name": "WalletTransaction",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Unique ID of the wallet transaction",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "walletTransactions",
               "description": "Query wallet transactions",
               "type": {
@@ -46400,6 +46449,18 @@
               "args": []
             },
             {
+              "name": "failedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -46410,6 +46471,18 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "invoice",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Invoice",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -46697,6 +46770,12 @@
             },
             {
               "name": "settled",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "failed",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/resolvers/wallet_transaction_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_transaction_resolver_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::WalletTransactionResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($id: ID!) {
+        walletTransaction(id: $id) {
+          id
+          status
+          amount
+          transactionType
+          failedAt
+          invoice {
+            id
+            totalAmountCents
+            payments {
+              id
+              amountCents
+              amountCurrency
+            }
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:wallet) { create(:wallet, customer:) }
+  let(:wallet_transaction) { create(:wallet_transaction, wallet:, status: :failed, failed_at: Time.current) }
+  let(:invoice) { create(:invoice) }
+  let(:fee) { create(:fee, invoice:, invoiceable: wallet_transaction, invoiceable_type: "WalletTransaction") }
+  let(:payment) { create(:payment, payable: invoice, amount_cents: 1000, amount_currency: "EUR") }
+
+  it "returns a single wallet transaction with its invoice and payments" do
+    fee
+    payment
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+      variables: {id: wallet_transaction.id}
+    )
+
+    transaction_response = result["data"]["walletTransaction"]
+    invoice_response = transaction_response["invoice"]
+    payments_response = invoice_response["payments"]
+
+    expect(transaction_response["id"]).to eq(wallet_transaction.id.to_s)
+    expect(transaction_response["status"]).to eq(wallet_transaction.status)
+    expect(transaction_response["failedAt"]).not_to be_nil
+    expect(transaction_response["amount"]).to eq(wallet_transaction.amount.to_s)
+    expect(transaction_response["transactionType"]).to eq(wallet_transaction.transaction_type)
+    expect(invoice_response["id"]).to eq(invoice.id.to_s)
+    expect(invoice_response["totalAmountCents"].to_i).to eq(invoice.total_amount_cents)
+    expect(payments_response).not_to be_empty
+    expect(payments_response.first["id"]).to eq(payment.id.to_s)
+    expect(payments_response.first["amountCents"].to_i).to eq(payment.amount_cents)
+    expect(payments_response.first["amountCurrency"]).to eq(payment.amount_currency)
+  end
+
+  context "without current organization" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        query:,
+        variables: {id: wallet_transaction.id}
+      )
+
+      expect_graphql_error(result:, message: "Missing organization id")
+    end
+  end
+
+  context "when not a member of the organization" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: create(:organization),
+        query:,
+        variables: {id: wallet_transaction.id}
+      )
+
+      expect_graphql_error(result:, message: "Not in organization")
+    end
+  end
+
+  context "when transaction does not exist" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {id: "123456"}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Types::Invoices::Object do
   subject { described_class }
 
-  it do
+  it "has the expected fields with correct types" do
     expect(subject).to have_field(:customer).of_type("Customer!")
 
     expect(subject).to have_field(:id).of_type("ID!")
@@ -64,5 +64,6 @@ RSpec.describe Types::Invoices::Object do
     expect(subject).to have_field(:integration_hubspot_syncable).of_type("Boolean!")
     expect(subject).to have_field(:integration_salesforce_syncable).of_type("Boolean!")
     expect(subject).to have_field(:integration_syncable).of_type("Boolean!")
+    expect(subject).to have_field(:payments).of_type("[Payment!]")
   end
 end

--- a/spec/graphql/types/wallet_transactions/object_spec.rb
+++ b/spec/graphql/types/wallet_transactions/object_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Types::WalletTransactions::Object do
   subject { described_class }
 
-  it do
+  it "has the expected fields with correct types" do
     expect(subject).to have_field(:wallet).of_type("Wallet")
 
     expect(subject).to have_field(:amount).of_type("String!")
@@ -16,8 +16,11 @@ RSpec.describe Types::WalletTransactions::Object do
     expect(subject).to have_field(:transaction_type).of_type("WalletTransactionTransactionTypeEnum!")
 
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:failed_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:settled_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+
     expect(subject).to have_field(:metadata).of_type("[WalletTransactionMetadataObject!]")
+    expect(subject).to have_field(:invoice).of_type("Invoice")
   end
 end

--- a/spec/jobs/invoices/prepaid_credit_job_spec.rb
+++ b/spec/jobs/invoices/prepaid_credit_job_spec.rb
@@ -62,4 +62,13 @@ RSpec.describe Invoices::PrepaidCreditJob, type: :job do
       }.to have_enqueued_job(described_class)
     end
   end
+
+  context "when payment fails" do
+    it "marks the wallet transaction as failed" do
+      allow(WalletTransactions::MarkAsFailedService).to receive(:new).and_call_original
+      described_class.perform_now(invoice, :failed)
+      expect(WalletTransactions::MarkAsFailedService).to have_received(:new).with(wallet_transaction: wallet_transaction)
+      expect(wallet_transaction.reload.status).to eq("failed")
+    end
+  end
 end

--- a/spec/models/wallet_transaction_spec.rb
+++ b/spec/models/wallet_transaction_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WalletTransaction, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:wallet) }
+    it { is_expected.to belong_to(:invoice).optional }
+    it { is_expected.to belong_to(:credit_note).optional }
+  end
+
+  describe "enums" do
+    it "defines expected enum values" do
+      expect(described_class.defined_enums).to include(
+        "status" => hash_including("pending", "settled", "failed"),
+        "transaction_status" => hash_including("purchased", "granted", "voided", "invoiced"),
+        "transaction_type" => hash_including("inbound", "outbound"),
+        "source" => hash_including("manual", "interval", "threshold")
+      )
+    end
+  end
+
+  describe "#mark_as_failed!" do
+    let(:transaction) { create(:wallet_transaction, status: :pending) }
+
+    it "marks the transaction as failed" do
+      expect { transaction.mark_as_failed! }
+        .to change(transaction, :status).from("pending").to("failed")
+        .and change(transaction, :failed_at).from(nil)
+    end
+  end
+end

--- a/spec/scenarios/wallets/topup_with_open_invoices_spec.rb
+++ b/spec/scenarios/wallets/topup_with_open_invoices_spec.rb
@@ -108,7 +108,7 @@ describe "Wallet Transaction with invoice after payment", :scenarios, type: :req
         expect(invoice.file?).to be false
 
         wt.reload
-        expect(wt.status).to eq "pending"
+        expect(wt.status).to eq "failed"
         expect(wt.settled_at).to be_nil
 
         wallet.reload

--- a/spec/serializers/v1/wallet_transaction_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_serializer_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe ::V1::WalletTransactionSerializer do
         "amount" => wallet_transaction.amount.to_s,
         "credit_amount" => wallet_transaction.credit_amount.to_s,
         "settled_at" => wallet_transaction.settled_at&.iso8601,
+        "failed_at" => wallet_transaction.failed_at&.iso8601,
         "created_at" => wallet_transaction.created_at.iso8601,
-        "invoice_requires_successful_payment" => wallet_transaction.invoice_requires_successful_payment,
+        "invoice_requires_successful_payment" => wallet_transaction.invoice_requires_successful_payment?,
         "metadata" => wallet_transaction.metadata
       )
     end

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Invoices::UpdateService do
       end
     end
 
-    context "when invoice type is credit and new payment_status is succeeded" do
+    context "when invoice type is credit" do
       let(:subscription) { create(:subscription, customer: invoice.customer) }
       let(:wallet) { create(:wallet, customer: invoice.customer, balance: 10.0, credits_balance: 10.0) }
       let(:wallet_transaction) do
@@ -222,10 +222,22 @@ RSpec.describe Invoices::UpdateService do
         invoice.update(invoice_type: "credit")
       end
 
-      it "calls Invoices::PrepaidCreditJob" do
-        result
+      context "when payment_status is succeeded" do
+        let(:update_args) { {payment_status: "succeeded"} }
 
-        expect(Invoices::PrepaidCreditJob).to have_received(:perform_later).with(invoice)
+        it "calls Invoices::PrepaidCreditJob with the correct arguments" do
+          result
+          expect(Invoices::PrepaidCreditJob).to have_received(:perform_later).with(invoice, "succeeded")
+        end
+      end
+
+      context "when payment_status is failed" do
+        let(:update_args) { {payment_status: "failed"} }
+
+        it "calls Invoices::PrepaidCreditJob with the correct arguments" do
+          result
+          expect(Invoices::PrepaidCreditJob).to have_received(:perform_later).with(invoice, "failed")
+        end
       end
     end
 

--- a/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
+++ b/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WalletTransactions::MarkAsFailedService, type: :service do
+  subject(:service) { described_class.new(wallet_transaction:) }
+
+  let(:wallet_transaction) { create(:wallet_transaction, status: "pending") }
+
+  describe ".call" do
+    context "when wallet_transaction is nil" do
+      let(:wallet_transaction) { nil }
+
+      it "returns an empty result" do
+        result = service.call
+        expect(result.wallet_transaction).to be_nil
+      end
+    end
+
+    context "when wallet_transaction is already failed" do
+      let(:wallet_transaction) { create(:wallet_transaction, status: "failed") }
+
+      it "does not change the wallet_transaction status" do
+        expect { service.call }.not_to change(wallet_transaction, :status)
+      end
+
+      it "does not enqueue a SendWebhookJob" do
+        expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+      end
+    end
+
+    context "when wallet_transaction is not failed" do
+      it "updates the wallet_transaction status to failed" do
+        expect {
+          service.call
+        }.to change { wallet_transaction.reload.status }.from("pending").to("failed")
+      end
+
+      it "enqueues a SendWebhookJob with appropriate arguments" do
+        expect {
+          service.call
+        }.to have_enqueued_job(SendWebhookJob).with("wallet_transaction.updated", wallet_transaction)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR enhances the handling of WalletTransactions by introducing support for failed transactions and improving GraphQL access to transaction data. The changes provide better visibility into payment failures and their impact on invoices.

## Description

GraphQL Changes

- Added WalletTransactionResolver to allow retrieving a single wallet transaction.
- Linked payments to an invoice 
- Added failed_at and linked invoice to WalletTransaction for better tracking of failed transactions.

Backend Changes

- Introduced a new failed status for WalletTransaction to reflect payment failures.
- Added failed_at timestamp to store when a transaction fails.
- Updated logic to handle payment failures:
- When a payment fails, the corresponding WalletTransaction is now marked as failed with the failed_at timestamp.|

 ## Ongoing Refactor
 Working on a separate PR to refactor how we retrieve the invoice for a WalletTransaction so we always have invoice_id in transaction instead of searching on the fees
