### PR TITLE
misc(retry-jobs): Adjust jitter to increase spread between repeating jobs

### DIFF
--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -12,7 +12,7 @@ module Invoices
 
     retry_on Sequenced::SequenceError
     retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
-    retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6
+    retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6, jitter: 0.75
 
     unique :until_executed, on_conflict: :log
 


### PR DESCRIPTION
## Context

We had a batch of 600 failed jobs trying to update 3 wallets which lead to jobs failing with `ActiveRecord::StaleObjectError: Attempted to update a stale object: Wallet.` exception.
We're trying to increase `jitter` for job retries to order to increase spread between jobs retries and see if that it's enough to mitigate the issue.

This value should increase spread by 10 times on 3rd attempt.

## Description

Increase job jitter
