### PR TITLE
feat(invoice-preview): Support previews for simulated termination, upgrade or downgrade of subscription

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -275,6 +275,7 @@ module Api
           :billing_time,
           :subscription_at,
           subscriptions: [
+            :terminated_at,
             external_ids: []
           ],
           coupons: [

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -275,6 +275,7 @@ module Api
           :billing_time,
           :subscription_at,
           subscriptions: [
+            :plan_code,
             :terminated_at,
             external_ids: []
           ],

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -213,6 +213,16 @@ module Api
           )
         end
 
+        if preview_params[:subscriptions] && !preview_params.to_h[:subscriptions].is_a?(Hash)
+          return render(
+            json: {
+              status: 400,
+              error: "subscriptions_must_be_an_object"
+            },
+            status: :bad_request
+          )
+        end
+
         result = Invoices::PreviewContextService.call(
           organization: current_organization,
           params: preview_params.to_h.deep_symbolize_keys

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -67,6 +67,18 @@ class Charge < ApplicationRecord
     charge_model == charge.charge_model && properties == charge.properties
   end
 
+  # NOTE: If same charge is NOT included in upgraded plan we still want to bill it. However if new plan is using
+  # the same charge it should not be billed since it is recurring and will be billed at the end of period
+  def included_in_next_subscription?(subscription)
+    return false if subscription.next_subscription.nil?
+
+    next_subscription_charges = subscription.next_subscription.plan.charges
+
+    return false if next_subscription_charges.blank?
+
+    next_subscription_charges.pluck(:billable_metric_id).include?(billable_metric_id)
+  end
+
   private
 
   def validate_amount

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -117,7 +117,7 @@ class Subscription < ApplicationRecord
   end
 
   def next_subscription
-    next_subscriptions.not_canceled.order(created_at: :desc).first
+    next_subscriptions.reject(&:canceled?).max_by(&:created_at)
   end
 
   def already_billed?

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -2,6 +2,8 @@
 
 module CreditNotes
   class CreateService < BaseService
+    Result = BaseResult[:credit_note]
+
     def initialize(invoice:, **args)
       @invoice = invoice
       args = args.with_indifferent_access
@@ -12,6 +14,7 @@ module CreditNotes
       @refund_amount_cents = args[:refund_amount_cents] || 0
 
       @automatic = args.key?(:automatic) ? args[:automatic] : false
+      @context = args[:context]
 
       super
     end
@@ -22,7 +25,7 @@ module CreditNotes
       return result.not_allowed_failure!(code: "invalid_type_or_status") unless valid_type_or_status?
 
       ActiveRecord::Base.transaction do
-        result.credit_note = CreditNote.create!(
+        result.credit_note = CreditNote.new(
           customer: invoice.customer,
           invoice:,
           issuing_date:,
@@ -38,6 +41,8 @@ module CreditNotes
           status: invoice.status
         )
 
+        credit_note.save! if context != :preview
+
         create_items
         result.raise_if_error!
 
@@ -49,10 +54,15 @@ module CreditNotes
         credit_note.credit_status = "available" if credit_note.credited?
         credit_note.refund_status = "pending" if credit_note.refunded?
 
-        credit_note.update!(
+        credit_note.assign_attributes(
           total_amount_cents: credit_note.credit_amount_cents + credit_note.refund_amount_cents,
           balance_amount_cents: credit_note.credit_amount_cents
         )
+
+        return result if context == :preview
+
+        credit_note.save!
+
         if wallet_credit
           WalletTransactions::VoidService.call(wallet: associated_wallet,
             wallet_credit:, credit_note_id: credit_note.id)
@@ -91,7 +101,8 @@ module CreditNotes
       :description,
       :credit_amount_cents,
       :refund_amount_cents,
-      :automatic
+      :automatic,
+      :context
 
     delegate :credit_note, to: :result
     delegate :customer, to: :invoice
@@ -130,7 +141,7 @@ module CreditNotes
         )
         break unless valid_item?(item)
 
-        item.save!
+        item.save! unless context == :preview
       end
     end
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -135,19 +135,7 @@ module Invoices
       charge.billable_metric.recurring? &&
         subscription.terminated? &&
         subscription.upgraded? &&
-        charge_included_in_next_subscription?(charge, subscription)
-    end
-
-    # NOTE: If same charge is NOT included in upgraded plan we still want to bill it. However if new plan is using
-    # the same charge it should not be billed since it is recurring and will be billed at the end of period
-    def charge_included_in_next_subscription?(charge, subscription)
-      return false if subscription.next_subscription.nil?
-
-      next_subscription_charges = subscription.next_subscription.plan.charges
-
-      return false if next_subscription_charges.blank?
-
-      next_subscription_charges.pluck(:billable_metric_id).include?(charge.billable_metric_id)
+        charge.included_in_next_subscription?(subscription)
     end
 
     def should_create_recurring_non_invoiceable_fees?(subscription)

--- a/app/services/invoices/preview/build_subscription_service.rb
+++ b/app/services/invoices/preview/build_subscription_service.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Preview
+    class BuildSubscriptionService < BaseService
+      Result = BaseResult[:subscriptions]
+
+      def initialize(customer:, params:)
+        @customer = customer
+        @params = params.presence || {}
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: "customer") unless customer
+        return result.not_found_failure!(resource: "plan") unless plan
+
+        result.subscriptions = [build_subscription]
+        result
+      end
+
+      private
+
+      attr_reader :customer, :params
+
+      delegate :organization, to: :customer
+
+      def build_subscription
+        Subscription.new(
+          customer:,
+          plan:,
+          subscription_at: params[:subscription_at].presence || Time.current,
+          started_at: params[:subscription_at].presence || Time.current,
+          billing_time:,
+          created_at: params[:subscription_at].presence || Time.current,
+          updated_at: Time.current
+        )
+      end
+
+      def billing_time
+        if Subscription::BILLING_TIME.include?(params[:billing_time]&.to_sym)
+          params[:billing_time]
+        else
+          "calendar"
+        end
+      end
+
+      def plan
+        @plan ||= organization.plans.find_by(code: params[:plan_code])
+      end
+    end
+  end
+end

--- a/app/services/invoices/preview/credits_service.rb
+++ b/app/services/invoices/preview/credits_service.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Preview
+    class CreditsService < BaseService
+      Result = BaseResult[:credits]
+
+      def initialize(invoice:, terminated_subscription: nil)
+        @invoice = invoice
+        @terminated_subscription = terminated_subscription
+        super
+      end
+
+      def call
+        result.credits = credits_from_terminated_subscription + persisted_credits
+        result
+      end
+
+      private
+
+      attr_accessor :invoice, :terminated_subscription
+
+      def persisted_credits
+        Credits::CreditNoteService
+          .call!(invoice:, context: :preview)
+          .credits
+      end
+
+      def credits_from_terminated_subscription
+        return [] unless terminated_subscription&.plan&.pay_in_advance?
+
+        credit_note = generate_credit_note
+        return [] unless credit_note
+
+        credit_amount = [credit_note.balance_amount_cents, invoice.total_amount_cents].min
+        return [] unless credit_amount.positive?
+        credit = Credit.new(
+          invoice:,
+          credit_note:,
+          amount_cents: credit_amount,
+          amount_currency: invoice.currency,
+          before_taxes: false
+        )
+
+        invoice.credit_notes_amount_cents += credit.amount_cents
+        [credit]
+      end
+
+      def generate_credit_note
+        return unless terminated_subscription.plan.pay_in_advance?
+
+        CreditNotes::CreateFromTermination.call!(
+          subscription: terminated_subscription,
+          reason: "order_cancellation",
+          context: :preview
+        ).credit_note
+      end
+    end
+  end
+end

--- a/app/services/invoices/preview/credits_service.rb
+++ b/app/services/invoices/preview/credits_service.rb
@@ -34,6 +34,7 @@ module Invoices
 
         credit_amount = [credit_note.balance_amount_cents, invoice.total_amount_cents].min
         return [] unless credit_amount.positive?
+
         credit = Credit.new(
           invoice:,
           credit_note:,

--- a/app/services/invoices/preview/subscription_plan_change_service.rb
+++ b/app/services/invoices/preview/subscription_plan_change_service.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Preview
+    class SubscriptionPlanChangeService < BaseService
+      Result = BaseResult[:subscriptions]
+
+      def initialize(current_subscription:, target_plan_code:)
+        @current_subscription = current_subscription
+        @target_plan_code = target_plan_code
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: "subscription") unless current_subscription
+        return result.not_found_failure!(resource: "plan") unless target_plan
+
+        if target_plan.id == current_subscription.plan_id
+          return result.single_validation_failure!(
+            error_code: "new_plan_should_be_different_from_existing_plan"
+          )
+        end
+
+        result.subscriptions = [terminated_current_subscription, new_subscription].compact
+        result
+      end
+
+      private
+
+      attr_reader :current_subscription, :target_plan_code, :context
+
+      delegate :organization, :customer, to: :current_subscription
+
+      def terminated_current_subscription
+        current_subscription.terminated_at = termination_date
+        current_subscription.status = :terminated
+
+        current_subscription
+      end
+
+      def new_subscription
+        return unless target_plan.pay_in_advance?
+
+        Subscription.new(
+          customer:,
+          plan: target_plan,
+          name: target_plan.name,
+          external_id: current_subscription.external_id,
+          previous_subscription_id: current_subscription.id,
+          subscription_at: current_subscription.subscription_at,
+          billing_time: current_subscription.billing_time,
+          ending_at: current_subscription.ending_at,
+          status: :active,
+          started_at: upgrade? ? Time.current : termination_date
+        )
+      end
+
+      def termination_date
+        @termination_date ||= if upgrade?
+          Time.current
+        else
+          Subscriptions::DatesService
+            .new_instance(current_subscription, Time.current, current_usage: true)
+            .end_of_period + 1.day
+        end
+      end
+
+      def upgrade?
+        target_plan.yearly_amount_cents >= current_subscription.plan.yearly_amount_cents
+      end
+
+      def target_plan
+        @target_plan ||= organization.plans.find_by(code: target_plan_code)
+      end
+    end
+  end
+end

--- a/app/services/invoices/preview/subscription_termination_service.rb
+++ b/app/services/invoices/preview/subscription_termination_service.rb
@@ -21,7 +21,7 @@ module Invoices
           )
         end
 
-        if parsed_terminated_at.to_date.past?
+        if parsed_terminated_at.past?
           return result.single_validation_failure!(
             error_code: "cannot_be_in_past",
             field: :terminated_at

--- a/app/services/invoices/preview/subscription_termination_service.rb
+++ b/app/services/invoices/preview/subscription_termination_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Preview
+    class SubscriptionTerminationService < BaseService
+      Result = BaseResult[:subscriptions]
+
+      def initialize(current_subscription:, terminated_at:)
+        @current_subscription = current_subscription
+        @terminated_at = terminated_at
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: "subscription") unless current_subscription
+
+        unless parsed_terminated_at
+          return result.single_validation_failure!(
+            error_code: "invalid_timestamp",
+            field: :terminated_at
+          )
+        end
+
+        if parsed_terminated_at.to_date.past?
+          return result.single_validation_failure!(
+            error_code: "cannot_be_in_past",
+            field: :terminated_at
+          )
+        end
+
+        current_subscription.assign_attributes(
+          status: :terminated,
+          terminated_at:
+        )
+
+        result.subscriptions = [current_subscription]
+        result
+      end
+
+      private
+
+      attr_reader :current_subscription, :terminated_at
+
+      def parsed_terminated_at
+        return unless Utils::Datetime.valid_format?(terminated_at)
+
+        Time.zone.parse(terminated_at)
+      end
+    end
+  end
+end

--- a/app/services/invoices/preview/subscriptions_service.rb
+++ b/app/services/invoices/preview/subscriptions_service.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Preview
+    class SubscriptionsService < BaseService
+      Result = BaseResult[:subscriptions]
+
+      def initialize(organization:, customer:, params:)
+        @organization = organization
+        @customer = customer
+        @params = params
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: "customer") unless customer
+
+        result.subscriptions = handle_subscriptions
+        result
+      rescue ActiveRecord::RecordNotFound => exception
+        result.not_found_failure!(resource: exception.model.demodulize.underscore)
+        result
+      end
+
+      private
+
+      attr_reader :params, :organization, :customer
+
+      def handle_subscriptions
+        return handle_customer_subscriptions if external_ids.any?
+
+        plan ? [build_subscription] : []
+      end
+
+      def handle_customer_subscriptions
+        terminated_at ? terminate_subscriptions : customer_subscriptions
+      end
+
+      def terminate_subscriptions
+        return [] unless valid_termination?
+
+        customer_subscriptions.map do |subscription|
+          subscription.terminated_at = terminated_at
+          subscription.status = :terminated
+          subscription
+        end
+      end
+
+      def build_subscription
+        Subscription.new(
+          customer: customer,
+          plan:,
+          subscription_at: params[:subscription_at].presence || Time.current,
+          started_at: params[:subscription_at].presence || Time.current,
+          billing_time:,
+          created_at: params[:subscription_at].presence || Time.current,
+          updated_at: Time.current
+        )
+      end
+
+      def billing_time
+        if Subscription::BILLING_TIME.include?(params[:billing_time]&.to_sym)
+          params[:billing_time]
+        else
+          "calendar"
+        end
+      end
+
+      def customer_subscriptions
+        @customer_subscriptions ||= customer
+          .subscriptions
+          .active
+          .where(external_id: external_ids)
+      end
+
+      def valid_termination?
+        if customer_subscriptions.size > 1
+          result.single_validation_failure!(
+            error_code: "only_one_subscription_allowed_for_termination",
+            field: :subscriptions
+          )
+        end
+
+        if parsed_terminated_at&.to_date&.past?
+          result.single_validation_failure!(
+            error_code: "cannot_be_in_past",
+            field: :terminated_at
+          )
+        end
+
+        result.success?
+      end
+
+      def parsed_terminated_at
+        if Utils::Datetime.valid_format?(terminated_at)
+          Time.zone.parse(terminated_at)
+        else
+          result.single_validation_failure!(error_code: "invalid_timestamp", field: :terminated_at)
+          nil
+        end
+      end
+
+      def terminated_at
+        params.dig(:subscriptions, :terminated_at)
+      end
+
+      def external_ids
+        Array(params.dig(:subscriptions, :external_ids))
+      end
+
+      def plan
+        organization.plans.find_by!(code: params[:plan_code])
+      end
+    end
+  end
+end

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -152,9 +152,7 @@ module Invoices
     end
 
     def add_charge_fees
-      return unless persisted_subscriptions
-
-      subscriptions.map do |subscription|
+      subscriptions.select(&:persisted?).map do |subscription|
         boundaries = boundaries(subscription)
 
         charges = []

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -223,10 +223,10 @@ module Invoices
     end
 
     def create_credit_note_credits
-      credit_result = Credits::CreditNoteService.call(invoice:, context: :preview)
-      credit_result.raise_if_error!
+      terminated_subscription = subscriptions.find(&:terminated?)
+      credits = Preview::CreditsService.call!(invoice:, terminated_subscription:).credits
 
-      invoice.total_amount_cents -= credit_result.credits.sum(&:amount_cents)
+      invoice.total_amount_cents -= credits.sum(&:amount_cents)
     end
 
     def create_applied_prepaid_credits

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -128,7 +128,10 @@ module Invoices
     end
 
     def issuing_date
-      billing_time.in_time_zone(customer.applicable_timezone).to_date
+      return @issuing_date if defined?(@issuing_date)
+
+      date = billing_time.in_time_zone(customer.applicable_timezone).to_date
+      @issuing_date = date + customer.applicable_invoice_grace_period.days
     end
 
     def payment_due_date

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -217,6 +217,7 @@ module Invoices
       terminated_subscription = subscriptions.find(&:terminated?)
       credits = Preview::CreditsService.call!(invoice:, terminated_subscription:).credits
 
+      invoice.credits << credits
       invoice.total_amount_cents -= credits.sum(&:amount_cents)
     end
 

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -151,12 +151,11 @@ module Subscriptions
 
       # NOTE: When downgrading a subscription, we keep the current one active
       #       until the next billing day. The new subscription will become active at this date
-      Subscription.create!(
+      current_subscription.next_subscriptions.create!(
         customer:,
         plan: params.key?(:plan_overrides) ? override_plan(plan) : plan,
         name:,
         external_id: current_subscription.external_id,
-        previous_subscription_id: current_subscription.id,
         subscription_at: current_subscription.subscription_at,
         status: :pending,
         billing_time: current_subscription.billing_time,

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -12,6 +12,11 @@ FactoryBot.define do
       status { :pending }
     end
 
+    trait :canceled do
+      status { :canceled }
+      canceled_at { Time.current }
+    end
+
     trait :terminated do
       status { :terminated }
       started_at { 1.month.ago }

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -573,4 +573,52 @@ RSpec.describe Charge, type: :model do
       end
     end
   end
+
+  describe "#included_in_next_subscription?" do
+    subject { charge.included_in_next_subscription?(subscription) }
+
+    let(:charge) { create(:standard_charge) }
+    let(:subscription) { create(:subscription, next_subscriptions:) }
+
+    context "when subscription has next subscription" do
+      let(:next_subscriptions) { [create(:subscription, plan: next_plan)] }
+      let(:next_plan) { build(:plan, charges:) }
+
+      context "when next subscription's plan has charges" do
+        let(:charges) { [create(:standard_charge, billable_metric:)] }
+
+        context "when next plan charges includes charge billable metric" do
+          let(:billable_metric) { charge.billable_metric }
+
+          it "returns true" do
+            expect(subject).to be true
+          end
+        end
+
+        context "when next plan charges does not include charge billable metric" do
+          let(:billable_metric) { create(:billable_metric) }
+
+          it "returns false" do
+            expect(subject).to be false
+          end
+        end
+      end
+
+      context "when next subscription's plan has no charges" do
+        let(:charges) { [] }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+    end
+
+    context "when subscription has no next subscription" do
+      let(:next_subscriptions) { [] }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -554,4 +554,67 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe "#adjusted_boundaries" do
+    let(:timestamp) { Time.zone.parse("30 Mar 2024") }
+    let(:billing_date) { Time.zone.parse("15 May 2024") }
+    let(:date_service) { Subscriptions::DatesService.new_instance(subscription, billing_date) }
+    let(:plan) { create(:plan, amount_cents: 100) }
+    let(:status) { "active" }
+    let(:terminated_at) { nil }
+    let(:subscription) do
+      create(
+        :subscription,
+        billing_time: "calendar",
+        started_at: timestamp,
+        created_at: timestamp,
+        status:,
+        terminated_at:,
+        subscription_at: timestamp,
+        plan:
+      )
+    end
+    let(:default_boundaries) do
+      {
+        from_datetime: date_service.from_datetime,
+        to_datetime: date_service.to_datetime,
+        charges_from_datetime: date_service.charges_from_datetime,
+        charges_to_datetime: date_service.charges_to_datetime,
+        timestamp: billing_date
+      }
+    end
+
+    context "with active subscription" do
+      let(:billing_date) { Time.zone.parse("01 Jun 2024") }
+
+      it "returns default boundaries" do
+        expect(subscription.adjusted_boundaries(billing_date, default_boundaries)).to eq(default_boundaries)
+      end
+    end
+
+    context "with termination on non billing day" do
+      let(:status) { "terminated" }
+      let(:terminated_at) { billing_date }
+
+      it "returns default boundaries" do
+        expect(subscription.adjusted_boundaries(billing_date, default_boundaries)).to eq(default_boundaries)
+      end
+    end
+
+    context "with termination on billing day without invoice for previous period" do
+      let(:status) { "terminated" }
+      let(:billing_date) { Time.zone.parse("01 Jun 2024") }
+      let(:terminated_at) { billing_date }
+
+      it "returns new boundaries based on previous billing period" do
+        new_boundaries = subscription.adjusted_boundaries(billing_date, default_boundaries)
+
+        expect(new_boundaries).not_to eq(default_boundaries)
+        expect(new_boundaries[:from_datetime].iso8601).to eq("2024-05-01T00:00:00Z")
+        expect(new_boundaries[:to_datetime].iso8601).to eq("2024-05-31T23:59:59Z")
+        expect(new_boundaries[:charges_from_datetime].iso8601).to eq("2024-05-01T00:00:00Z")
+        expect(new_boundaries[:charges_to_datetime].iso8601).to eq("2024-05-31T23:59:59Z")
+      end
+    end
+  end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -617,4 +617,22 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe "#next_subscription" do
+    subject { subscription.next_subscription }
+
+    let(:subscription) { build_stubbed(:subscription, next_subscriptions:) }
+
+    let(:next_subscriptions) do
+      [
+        build_stubbed(:subscription, :canceled),
+        build_stubbed(:subscription, created_at: 1.day.ago),
+        build_stubbed(:subscription, created_at: 2.days.ago)
+      ]
+    end
+
+    it "returns most recently non-canceled next subscription" do
+      expect(subject).to eq next_subscriptions.second
+    end
+  end
 end

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -1137,7 +1137,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       end
     end
 
-    context "when params have invalid structure" do
+    context "when coupons have invalid type" do
       let(:preview_params) do
         {
           coupons: {
@@ -1150,6 +1150,20 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         subject
         expect(response).to have_http_status(:bad_request)
         expect(json[:error]).to eq "coupons_must_be_an_array"
+      end
+    end
+
+    context "when subscriptions have invalid type" do
+      let(:preview_params) do
+        {
+          subscriptions: []
+        }
+      end
+
+      it "returns a bad request error" do
+        subject
+        expect(response).to have_http_status(:bad_request)
+        expect(json[:error]).to eq "subscriptions_must_be_an_object"
       end
     end
   end

--- a/spec/services/invoices/preview/build_subscription_service_spec.rb
+++ b/spec/services/invoices/preview/build_subscription_service_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::Preview::BuildSubscriptionService, type: :service do
+  describe ".call" do
+    subject(:result) { described_class.call(customer:, params:) }
+
+    let(:subscriptions) { result.subscriptions }
+
+    context "when customer is missing" do
+      let(:customer) { nil }
+      let(:params) { {} }
+
+      it "fails with customer not found error" do
+        expect(result).to be_failure
+        expect(result.error.error_code).to eq("customer_not_found")
+      end
+
+      it "does not create any subscription" do
+        expect { subject }.not_to change(Subscription, :count)
+      end
+    end
+
+    context "when customer is present" do
+      let(:customer) { create(:customer) }
+
+      context "when plan matching code exists in the customer's organization" do
+        let(:plan) { create(:plan, organization: customer.organization) }
+
+        let(:params) do
+          {
+            plan_code: plan&.code,
+            billing_time:,
+            subscription_at: subscription_at&.iso8601
+          }
+        end
+
+        context "when valid billing time and subscribed at are provided" do
+          let(:billing_time) { Subscription::BILLING_TIME.sample.to_s }
+          let(:subscription_at) { generate(:past_date) }
+
+          let(:expected_attributes) do
+            {
+              billing_time:,
+              plan:,
+              customer:,
+              subscription_at: subscription_at.change(usec: 0),
+              started_at: subscription_at.change(usec: 0)
+            }
+          end
+
+          it "returns array containing new subscription with provided inputs" do
+            expect(result).to be_success
+            expect(subscriptions).to contain_exactly Subscription
+
+            expect(subscriptions.first)
+              .to be_new_record
+              .and have_attributes(expected_attributes)
+          end
+
+          it "does not create any subscription" do
+            expect { subject }.not_to change(Subscription, :count)
+          end
+        end
+
+        context "when invalid or empty billing time and subscribed at are provided" do
+          let(:billing_time) { "non-existing-time" }
+          let(:subscription_at) { nil }
+
+          let(:expected_attributes) do
+            {
+              billing_time: "calendar",
+              plan:,
+              customer:,
+              subscription_at: Time.current,
+              started_at: Time.current
+            }
+          end
+
+          before { freeze_time }
+
+          it "returns array containing new subscription with defaults" do
+            expect(result).to be_success
+            expect(subscriptions).to contain_exactly Subscription
+
+            expect(subscriptions.first)
+              .to be_new_record
+              .and have_attributes(expected_attributes)
+          end
+
+          it "does not create any subscription" do
+            expect { subject }.not_to change(Subscription, :count)
+          end
+        end
+      end
+
+      context "when plan matching code does not exist in the customer's organization" do
+        let(:params) { {plan_code: create(:plan).code} }
+
+        it "fails with plan not found error" do
+          expect(result).to be_failure
+          expect(result.error.error_code).to eq("plan_not_found")
+        end
+
+        it "does not create any subscription" do
+          expect { subject }.not_to change(Subscription, :count)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/preview/credits_service_spec.rb
+++ b/spec/services/invoices/preview/credits_service_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::Preview::CreditsService, type: :service do
+  describe ".call" do
+    subject(:result) { described_class.call(invoice:, terminated_subscription:) }
+
+    let(:credits) { result.credits.map { |c| c.attributes.symbolize_keys } }
+
+    let(:customer) { create(:customer) }
+    let(:organization) { customer.organization }
+    let(:invoice) { build(:invoice, customer:, organization:, total_amount_cents: 10_000) }
+
+    let(:credit_notes) do
+      create_pair(
+        :credit_note,
+        customer:,
+        invoice: build(:invoice, customer:, organization:)
+      )
+    end
+
+    let(:expected_credits_from_customer) do
+      credit_notes.map do |note|
+        hash_including(
+          amount_cents: note.total_amount_cents,
+          amount_currency: note.total_amount_currency
+        )
+      end
+    end
+
+    context "when terminated_subscription is present" do
+      let(:plan) { create(:plan, organization:, pay_in_advance:, amount_cents: 10_000) }
+
+      let(:subscription) do
+        create(
+          :subscription,
+          organization:,
+          customer:,
+          plan:,
+          subscription_at: Time.zone.parse("2025-02-01"),
+          started_at: Time.zone.parse("2025-02-01")
+        )
+      end
+
+      let(:terminated_subscription) do
+        subscription.tap do |sub|
+          sub.assign_attributes(
+            status: :terminated,
+            terminated_at: Time.zone.parse("15-02-2025")
+          )
+        end
+      end
+
+      before do
+        BillSubscriptionJob.perform_now(
+          [subscription],
+          Time.zone.parse("2025-02-01").to_i,
+          invoicing_reason: :subscription_starting
+        )
+
+        credit_notes
+      end
+
+      context "when subscription has a credit note" do
+        let(:pay_in_advance) { true }
+
+        let(:expected_credits_from_subscription) do
+          [
+            hash_including(
+              amount_cents: 4643,
+              amount_currency: "EUR"
+            )
+          ]
+        end
+
+        it "returns credits generated from subscription and customer credit notes" do
+          expect(result).to be_success
+          expect(credits).to match_array expected_credits_from_customer + expected_credits_from_subscription
+        end
+      end
+
+      context "when subscription has no credit note" do
+        let(:pay_in_advance) { false }
+
+        it "returns credits generated from customer's credit notes" do
+          expect(result).to be_success
+          expect(credits).to match_array expected_credits_from_customer
+        end
+      end
+    end
+
+    context "when terminated_subscription is missing" do
+      let(:terminated_subscription) { nil }
+
+      before { credit_notes }
+
+      it "returns credits generated from customer's credit notes" do
+        expect(result).to be_success
+        expect(credits).to match_array expected_credits_from_customer
+      end
+    end
+  end
+end

--- a/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
@@ -68,8 +68,11 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
               expect(result).to be_success
               expect(subscriptions).to match_array [current_subscription, Subscription]
 
-              expect(subscriptions.first)
-                .to have_attributes(status: "terminated", terminated_at: Time.current)
+              expect(subscriptions.first).to have_attributes(
+                status: "terminated",
+                next_subscription: Subscription,
+                terminated_at: Time.current
+              )
 
               expect(subscriptions.second)
                 .to be_new_record
@@ -93,8 +96,11 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
               expect(result).to be_success
               expect(subscriptions).to match_array [current_subscription, Subscription]
 
-              expect(subscriptions.first)
-                .to have_attributes(status: "terminated", terminated_at: start_of_next_billing_period)
+              expect(subscriptions.first).to have_attributes(
+                status: "terminated",
+                next_subscription: Subscription,
+                terminated_at: start_of_next_billing_period
+              )
 
               expect(subscriptions.second)
                 .to be_new_record
@@ -121,8 +127,11 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
               expect(result).to be_success
               expect(subscriptions).to contain_exactly current_subscription
 
-              expect(subscriptions.first)
-                .to have_attributes(status: "terminated", terminated_at: Time.current)
+              expect(subscriptions.first).to have_attributes(
+                status: "terminated",
+                next_subscription: Subscription,
+                terminated_at: Time.current
+              )
             end
 
             it "does not persist any changes to the current subscription" do
@@ -142,8 +151,11 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
               expect(result).to be_success
               expect(subscriptions).to contain_exactly current_subscription
 
-              expect(subscriptions.first)
-                .to have_attributes(status: "terminated", terminated_at: start_of_next_billing_period)
+              expect(subscriptions.first).to have_attributes(
+                status: "terminated",
+                next_subscription: Subscription,
+                terminated_at: start_of_next_billing_period
+              )
             end
 
             it "does not persist any changes to the current subscription" do

--- a/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
             .to match(base: ["new_plan_should_be_different_from_existing_plan"])
         end
 
-        it "does not change persist any changes to the current subscription" do
+        it "does not persist any changes to the current subscription" do
           expect { subject }.not_to change { current_subscription.reload.attributes }
         end
 
@@ -76,7 +76,7 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
                 .and have_attributes(status: "active", started_at: Time.current, name: target_plan.name)
             end
 
-            it "does not change persist any changes to the current subscription" do
+            it "does not persist any changes to the current subscription" do
               expect { subject }.not_to change { current_subscription.reload.attributes }
             end
 
@@ -101,7 +101,7 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
                 .and have_attributes(status: "active", started_at: start_of_next_billing_period, name: target_plan.name)
             end
 
-            it "does not change persist any changes to the current subscription" do
+            it "does not persist any changes to the current subscription" do
               expect { subject }.not_to change { current_subscription.reload.attributes }
             end
 
@@ -125,7 +125,7 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
                 .to have_attributes(status: "terminated", terminated_at: Time.current)
             end
 
-            it "does not change persist any changes to the current subscription" do
+            it "does not persist any changes to the current subscription" do
               expect { subject }.not_to change { current_subscription.reload.attributes }
             end
 
@@ -146,7 +146,7 @@ RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service 
                 .to have_attributes(status: "terminated", terminated_at: start_of_next_billing_period)
             end
 
-            it "does not change persist any changes to the current subscription" do
+            it "does not persist any changes to the current subscription" do
               expect { subject }.not_to change { current_subscription.reload.attributes }
             end
 

--- a/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service do
+  describe ".call" do
+    subject(:result) { described_class.call(current_subscription:, target_plan_code:) }
+
+    let(:subscriptions) { result.subscriptions }
+
+    context "when current subscription is missing" do
+      let(:current_subscription) { nil }
+      let(:target_plan_code) { nil }
+
+      it "fails with subscription not found error" do
+        expect(result).to be_failure
+        expect(result.error.error_code).to eq("subscription_not_found")
+      end
+    end
+
+    context "when plan matching code does not exist" do
+      let(:current_subscription) { create(:subscription) }
+      let(:target_plan_code) { "non-existing-code" }
+
+      it "fails with plan not found error" do
+        expect(result).to be_failure
+        expect(result.error.error_code).to eq("plan_not_found")
+      end
+    end
+
+    context "when current subscription and matching plan are present" do
+      let!(:current_subscription) { create(:subscription, plan: current_plan, organization:) }
+      let(:current_plan) { create(:plan, organization:) }
+      let(:organization) { create(:organization) }
+      let(:target_plan_code) { target_plan.code }
+
+      context "when target plan is the same as current subscription's plan" do
+        let(:target_plan) { current_plan }
+
+        it "fails with invalid target plan error" do
+          expect(result).to be_failure
+
+          expect(result.error.messages)
+            .to match(base: ["new_plan_should_be_different_from_existing_plan"])
+        end
+
+        it "does not change persist any changes to the current subscription" do
+          expect { subject }.not_to change { current_subscription.reload.attributes }
+        end
+
+        it "does not create any subscription" do
+          expect { subject }.not_to change(Subscription, :count)
+        end
+      end
+
+      context "when target plan is not the same as current subscription's plan" do
+        let(:target_plan) { create(:plan, organization:, pay_in_advance:, amount_cents:) }
+
+        before { travel_to Time.zone.parse("05-02-2025 12:34:56") }
+
+        context "when target plan is pay in advance" do
+          let(:pay_in_advance) { true }
+
+          context "when target plan is same price or more expensive" do
+            let(:amount_cents) { current_plan.amount_cents }
+
+            it "returns array containing terminated current and new subscriptions" do
+              expect(result).to be_success
+              expect(subscriptions).to match_array [current_subscription, Subscription]
+
+              expect(subscriptions.first)
+                .to have_attributes(status: "terminated", terminated_at: Time.current)
+
+              expect(subscriptions.second)
+                .to be_new_record
+                .and have_attributes(status: "active", started_at: Time.current, name: target_plan.name)
+            end
+
+            it "does not change persist any changes to the current subscription" do
+              expect { subject }.not_to change { current_subscription.reload.attributes }
+            end
+
+            it "does not create any subscription" do
+              expect { subject }.not_to change(Subscription, :count)
+            end
+          end
+
+          context "when target plan is cheaper" do
+            let(:amount_cents) { current_plan.amount_cents - 1 }
+            let(:start_of_next_billing_period) { Time.zone.parse("01-03-2025").end_of_day }
+
+            it "returns array containing terminated current and new subscriptions" do
+              expect(result).to be_success
+              expect(subscriptions).to match_array [current_subscription, Subscription]
+
+              expect(subscriptions.first)
+                .to have_attributes(status: "terminated", terminated_at: start_of_next_billing_period)
+
+              expect(subscriptions.second)
+                .to be_new_record
+                .and have_attributes(status: "active", started_at: start_of_next_billing_period, name: target_plan.name)
+            end
+
+            it "does not change persist any changes to the current subscription" do
+              expect { subject }.not_to change { current_subscription.reload.attributes }
+            end
+
+            it "does not create any subscription" do
+              expect { subject }.not_to change(Subscription, :count)
+            end
+          end
+        end
+
+        context "when target plan is not pay in advance" do
+          let(:pay_in_advance) { false }
+
+          context "when target plan is same price or more expensive" do
+            let(:amount_cents) { current_plan.amount_cents }
+
+            it "returns array containing terminated current subscription" do
+              expect(result).to be_success
+              expect(subscriptions).to contain_exactly current_subscription
+
+              expect(subscriptions.first)
+                .to have_attributes(status: "terminated", terminated_at: Time.current)
+            end
+
+            it "does not change persist any changes to the current subscription" do
+              expect { subject }.not_to change { current_subscription.reload.attributes }
+            end
+
+            it "does not create any subscription" do
+              expect { subject }.not_to change(Subscription, :count)
+            end
+          end
+
+          context "when target plan is cheaper" do
+            let(:amount_cents) { current_plan.amount_cents - 1 }
+            let(:start_of_next_billing_period) { Time.zone.parse("01-03-2025").end_of_day }
+
+            it "returns array containing terminated current subscription" do
+              expect(result).to be_success
+              expect(subscriptions).to contain_exactly current_subscription
+
+              expect(subscriptions.first)
+                .to have_attributes(status: "terminated", terminated_at: start_of_next_billing_period)
+            end
+
+            it "does not change persist any changes to the current subscription" do
+              expect { subject }.not_to change { current_subscription.reload.attributes }
+            end
+
+            it "does not create any subscription" do
+              expect { subject }.not_to change(Subscription, :count)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/preview/subscription_termination_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_termination_service_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::Preview::SubscriptionTerminationService, type: :service do
+  describe ".call" do
+    subject(:result) do
+      described_class.call(current_subscription:, terminated_at: terminated_at&.to_s)
+    end
+
+    let(:subscriptions) { result.subscriptions }
+
+    context "when current subscription is missing" do
+      let(:current_subscription) { nil }
+      let(:terminated_at) { nil }
+
+      it "fails with subscription not found error" do
+        expect(result).to be_failure
+        expect(result.error.error_code).to eq("subscription_not_found")
+      end
+    end
+
+    context "when current subscription is present" do
+      let(:current_subscription) { create(:subscription) }
+
+      context "when termination at is a valid timestamp" do
+        context "when timestamp is in the past" do
+          let(:terminated_at) { generate(:past_date) }
+
+          it "fails with past timestamp error" do
+            expect(result).to be_failure
+            expect(result.error.messages).to match(terminated_at: ["cannot_be_in_past"])
+          end
+
+          it "does not change persist any changes to the current subscription" do
+            expect { subject }.not_to change { current_subscription.reload.attributes }
+          end
+        end
+
+        context "when timestamp is today" do
+          let(:terminated_at) { Time.current }
+
+          it "returns result with subscriptions marked as terminated" do
+            expect(result).to be_success
+            expect(subscriptions).to contain_exactly current_subscription
+
+            expect(subscriptions.first).to have_attributes(
+              terminated_at: terminated_at.change(usec: 0),
+              status: "terminated"
+            )
+          end
+
+          it "does not change persist any changes to the current subscription" do
+            expect { subject }.not_to change { current_subscription.reload.attributes }
+          end
+        end
+
+        context "when timestamp is in future" do
+          let(:terminated_at) { generate(:future_date) }
+
+          it "returns result with subscriptions marked as terminated" do
+            expect(result).to be_success
+            expect(subscriptions).to contain_exactly current_subscription
+
+            expect(subscriptions.first).to have_attributes(
+              terminated_at: terminated_at.change(usec: 0),
+              status: "terminated"
+            )
+          end
+
+          it "does not change persist any changes to the current subscription" do
+            expect { subject }.not_to change { current_subscription.reload.attributes }
+          end
+        end
+      end
+
+      context "when termination at is not a valid timestamp" do
+        let(:terminated_at) { "2025" }
+
+        it "fails with invalid timestamp error" do
+          expect(result).to be_failure
+          expect(result.error.messages).to match(terminated_at: ["invalid_timestamp"])
+        end
+
+        it "does not change persist any changes to the current subscription" do
+          expect { subject }.not_to change { current_subscription.reload.attributes }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/preview/subscription_termination_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_termination_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Invoices::Preview::SubscriptionTerminationService, type: :service
             expect(result.error.messages).to match(terminated_at: ["cannot_be_in_past"])
           end
 
-          it "does not change persist any changes to the current subscription" do
+          it "does not persist any changes to the current subscription" do
             expect { subject }.not_to change { current_subscription.reload.attributes }
           end
         end
@@ -50,7 +50,7 @@ RSpec.describe Invoices::Preview::SubscriptionTerminationService, type: :service
             )
           end
 
-          it "does not change persist any changes to the current subscription" do
+          it "does not persist any changes to the current subscription" do
             expect { subject }.not_to change { current_subscription.reload.attributes }
           end
         end
@@ -68,7 +68,7 @@ RSpec.describe Invoices::Preview::SubscriptionTerminationService, type: :service
             )
           end
 
-          it "does not change persist any changes to the current subscription" do
+          it "does not persist any changes to the current subscription" do
             expect { subject }.not_to change { current_subscription.reload.attributes }
           end
         end
@@ -82,7 +82,7 @@ RSpec.describe Invoices::Preview::SubscriptionTerminationService, type: :service
           expect(result.error.messages).to match(terminated_at: ["invalid_timestamp"])
         end
 
-        it "does not change persist any changes to the current subscription" do
+        it "does not persist any changes to the current subscription" do
           expect { subject }.not_to change { current_subscription.reload.attributes }
         end
       end

--- a/spec/services/invoices/preview/subscription_termination_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_termination_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Invoices::Preview::SubscriptionTerminationService, type: :service
 
       context "when termination at is a valid timestamp" do
         context "when timestamp is in the past" do
-          let(:terminated_at) { generate(:past_date) }
+          let(:terminated_at) { Time.current - 1.second }
 
           it "fails with past timestamp error" do
             expect(result).to be_failure
@@ -37,17 +37,12 @@ RSpec.describe Invoices::Preview::SubscriptionTerminationService, type: :service
           end
         end
 
-        context "when timestamp is today" do
+        context "when timestamp is current time" do
           let(:terminated_at) { Time.current }
 
-          it "returns result with subscriptions marked as terminated" do
-            expect(result).to be_success
-            expect(subscriptions).to contain_exactly current_subscription
-
-            expect(subscriptions.first).to have_attributes(
-              terminated_at: terminated_at.change(usec: 0),
-              status: "terminated"
-            )
+          it "fails with past timestamp error" do
+            expect(result).to be_failure
+            expect(result.error.messages).to match(terminated_at: ["cannot_be_in_past"])
           end
 
           it "does not persist any changes to the current subscription" do
@@ -56,7 +51,7 @@ RSpec.describe Invoices::Preview::SubscriptionTerminationService, type: :service
         end
 
         context "when timestamp is in future" do
-          let(:terminated_at) { generate(:future_date) }
+          let(:terminated_at) { Time.current + 1.second }
 
           it "returns result with subscriptions marked as terminated" do
             expect(result).to be_success

--- a/spec/services/invoices/preview/subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/subscriptions_service_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+RSpec.describe Invoices::Preview::SubscriptionsService, type: :service do
+  let(:result) { described_class.call(organization:, customer:, params:) }
+
+  describe "#call" do
+    subject { result.subscriptions }
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+
+    context "when customer is missing" do
+      let(:customer) { nil }
+      let(:params) { {} }
+
+      it "returns a failed result with customer not found error" do
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq("customer_not_found")
+      end
+    end
+
+    context "when external_ids are provided" do
+      let!(:subscriptions) { create_pair(:subscription, customer:) }
+      let(:subscription_ids) { subscriptions.map(&:external_id) }
+
+      context "when terminated at is not provided" do
+        let(:params) do
+          {
+            subscriptions: {
+              external_ids: subscriptions.map(&:external_id)
+            }
+          }
+        end
+
+        it "returns persisted customer subscriptions" do
+          expect(subject.pluck(:external_id)).to match_array subscriptions.map(&:external_id)
+        end
+      end
+
+      context "when terminated at is provided" do
+        let(:external_ids) { [subscriptions.first.external_id] }
+        let(:terminated_at) { generate(:future_date) }
+
+        let(:params) do
+          {
+            subscriptions: {
+              external_ids: external_ids,
+              terminated_at: terminated_at.to_s
+            }
+          }
+        end
+
+        context "when invalid timestamp provided" do
+          let(:terminated_at) { "2025" }
+
+          it "returns a failed result with invalid timestamp error" do
+            expect(result).not_to be_success
+            expect(result.error.messages).to match(terminated_at: ["invalid_timestamp"])
+          end
+        end
+
+        context "when past timestamp provided" do
+          let(:terminated_at) { generate(:past_date) }
+
+          it "returns a failed result with past timestamp error" do
+            expect(result).not_to be_success
+            expect(result.error.messages).to match(terminated_at: ["cannot_be_in_past"])
+          end
+        end
+
+        context "when multiple subscriptions passed" do
+          let(:external_ids) { subscriptions.map(&:external_id) }
+
+          it "returns a failed result with multiple subscriptions error" do
+            expect(result).not_to be_success
+
+            expect(result.error.messages)
+              .to match(subscriptions: ["only_one_subscription_allowed_for_termination"])
+          end
+        end
+
+        context "when all validations passed" do
+          it "returns result with subscriptions marked as terminated" do
+            expect(subject).to all(
+              be_a(Subscription)
+                .and(have_attributes(
+                  terminated_at: terminated_at.change(usec: 0),
+                  status: "terminated"
+                ))
+            )
+          end
+        end
+      end
+    end
+
+    context "when external_ids are not provided" do
+      let(:params) do
+        {
+          billing_time:,
+          plan_code: plan&.code,
+          subscription_at: subscription_at&.iso8601
+        }
+      end
+
+      context "when plan matching provided code exists" do
+        let(:plan) { create(:plan, organization:) }
+
+        before { freeze_time }
+
+        context "when billing time and subscription date are present" do
+          let(:subscription_at) { generate(:past_date) }
+          let(:billing_time) { "anniversary" }
+
+          it "returns new subscription with provided params" do
+            expect(subject)
+              .to all(
+                be_a(Subscription)
+                  .and(have_attributes(
+                    customer:,
+                    plan:,
+                    subscription_at: subscription_at,
+                    started_at: subscription_at,
+                    billing_time: params[:billing_time]
+                  ))
+              )
+          end
+        end
+
+        context "when billing time and subscription date are missing" do
+          let(:subscription_at) { nil }
+          let(:billing_time) { nil }
+
+          it "returns new subscription with default values for subscription date and billing time" do
+            expect(subject)
+              .to all(
+                be_a(Subscription)
+                  .and(have_attributes(
+                    customer:,
+                    plan:,
+                    subscription_at: Time.current,
+                    started_at: Time.current,
+                    billing_time: "calendar"
+                  ))
+              )
+          end
+        end
+      end
+
+      context "when plan matching provided code does not exist" do
+        let(:plan) { nil }
+        let(:subscription_at) { nil }
+        let(:billing_time) { nil }
+
+        it "returns nil" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.error_code).to eq("plan_not_found")
+
+          expect(subject).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/preview/subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/subscriptions_service_spec.rb
@@ -37,17 +37,61 @@ RSpec.describe Invoices::Preview::SubscriptionsService, type: :service do
         let(:subscription_ids) { subscriptions.map(&:external_id) }
 
         context "when terminated at is not provided" do
-          let(:params) do
-            {
-              subscriptions: {
-                external_ids: subscriptions.map(&:external_id)
+          context "when plan code is present" do
+            let(:params) do
+              {
+                subscriptions: {
+                  external_ids:,
+                  plan_code: target_plan.code
+                }
               }
-            }
+            end
+
+            let(:target_plan) { create(:plan, organization:, pay_in_advance: true) }
+
+            context "when multiple subscriptions passed" do
+              let(:external_ids) { subscriptions.map(&:external_id) }
+
+              it "fails with multiple subscriptions error" do
+                expect(result).to be_failure
+
+                expect(result.error.messages)
+                  .to match(subscriptions: ["only_one_subscription_allowed_for_plan_change"])
+              end
+            end
+
+            context "when single subscription passed" do
+              let(:external_ids) { [subscriptions.first.external_id] }
+
+              before { freeze_time }
+
+              it "returns result with subscriptions marked as terminated and new subscription" do
+                expect(result).to be_success
+                expect(subject).to match_array [subscriptions.first, Subscription]
+
+                expect(subject.first)
+                  .to have_attributes(status: "terminated", terminated_at: Time.current)
+
+                expect(subject.second)
+                  .to be_new_record
+                  .and have_attributes(status: "active", started_at: Time.current, name: target_plan.name)
+              end
+            end
           end
 
-          it "returns persisted customer subscriptions" do
-            expect(result).to be_success
-            expect(subject.pluck(:external_id)).to match_array subscriptions.map(&:external_id)
+          context "when plan code is missing" do
+            let(:params) do
+              {
+                subscriptions: {
+                  external_ids: subscriptions.map(&:external_id)
+                }
+              }
+            end
+
+            it "returns persisted customer subscriptions" do
+              expect(result).to be_success
+              expect(subject.pluck(:external_id)).to match_array subscriptions.map(&:external_id)
+            end
           end
         end
 

--- a/spec/services/invoices/preview/subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/subscriptions_service_spec.rb
@@ -3,160 +3,121 @@
 RSpec.describe Invoices::Preview::SubscriptionsService, type: :service do
   let(:result) { described_class.call(organization:, customer:, params:) }
 
-  describe "#call" do
+  describe ".call" do
     subject { result.subscriptions }
 
-    let(:organization) { create(:organization) }
-    let(:customer) { create(:customer, organization:) }
-
-    context "when customer is missing" do
+    context "when organization is missing" do
+      let(:organization) { nil }
       let(:customer) { nil }
       let(:params) { {} }
 
-      it "returns a failed result with customer not found error" do
-        expect(result).not_to be_success
+      it "fails with organization not found error" do
+        expect(result).to be_failure
+        expect(result.error.error_code).to eq("organization_not_found")
+      end
+    end
+
+    context "when customer is missing" do
+      let(:organization) { create(:organization) }
+      let(:customer) { nil }
+      let(:params) { {} }
+
+      it "fails with customer not found error" do
+        expect(result).to be_failure
         expect(result.error.error_code).to eq("customer_not_found")
       end
     end
 
-    context "when external_ids are provided" do
-      let!(:subscriptions) { create_pair(:subscription, customer:) }
-      let(:subscription_ids) { subscriptions.map(&:external_id) }
+    context "when customer and organization are present" do
+      let(:organization) { create(:organization) }
+      let(:customer) { create(:customer, organization:) }
 
-      context "when terminated at is not provided" do
+      context "when external_ids are provided" do
+        let!(:subscriptions) { create_pair(:subscription, customer:) }
+        let(:subscription_ids) { subscriptions.map(&:external_id) }
+
+        context "when terminated at is not provided" do
+          let(:params) do
+            {
+              subscriptions: {
+                external_ids: subscriptions.map(&:external_id)
+              }
+            }
+          end
+
+          it "returns persisted customer subscriptions" do
+            expect(result).to be_success
+            expect(subject.pluck(:external_id)).to match_array subscriptions.map(&:external_id)
+          end
+        end
+
+        context "when terminated at is provided" do
+          let(:terminated_at) { generate(:future_date) }
+
+          let(:params) do
+            {
+              subscriptions: {
+                external_ids: external_ids,
+                terminated_at: terminated_at.to_s
+              }
+            }
+          end
+
+          context "when multiple subscriptions passed" do
+            let(:external_ids) { subscriptions.map(&:external_id) }
+
+            it "fails with multiple subscriptions error" do
+              expect(result).to be_failure
+
+              expect(result.error.messages)
+                .to match(subscriptions: ["only_one_subscription_allowed_for_termination"])
+            end
+          end
+
+          context "when single subscription passed" do
+            let(:external_ids) { [subscriptions.first.external_id] }
+
+            it "returns result with subscriptions marked as terminated" do
+              expect(result).to be_success
+
+              expect(subject).to all(
+                be_a(Subscription)
+                  .and(have_attributes(
+                    terminated_at: terminated_at.change(usec: 0),
+                    status: "terminated"
+                  ))
+              )
+            end
+          end
+        end
+      end
+
+      context "when external_ids are not provided" do
         let(:params) do
           {
-            subscriptions: {
-              external_ids: subscriptions.map(&:external_id)
-            }
+            billing_time:,
+            plan_code: plan.code,
+            subscription_at: subscription_at.iso8601
           }
         end
 
-        it "returns persisted customer subscriptions" do
-          expect(subject.pluck(:external_id)).to match_array subscriptions.map(&:external_id)
-        end
-      end
-
-      context "when terminated at is provided" do
-        let(:external_ids) { [subscriptions.first.external_id] }
-        let(:terminated_at) { generate(:future_date) }
-
-        let(:params) do
-          {
-            subscriptions: {
-              external_ids: external_ids,
-              terminated_at: terminated_at.to_s
-            }
-          }
-        end
-
-        context "when invalid timestamp provided" do
-          let(:terminated_at) { "2025" }
-
-          it "returns a failed result with invalid timestamp error" do
-            expect(result).not_to be_success
-            expect(result.error.messages).to match(terminated_at: ["invalid_timestamp"])
-          end
-        end
-
-        context "when past timestamp provided" do
-          let(:terminated_at) { generate(:past_date) }
-
-          it "returns a failed result with past timestamp error" do
-            expect(result).not_to be_success
-            expect(result.error.messages).to match(terminated_at: ["cannot_be_in_past"])
-          end
-        end
-
-        context "when multiple subscriptions passed" do
-          let(:external_ids) { subscriptions.map(&:external_id) }
-
-          it "returns a failed result with multiple subscriptions error" do
-            expect(result).not_to be_success
-
-            expect(result.error.messages)
-              .to match(subscriptions: ["only_one_subscription_allowed_for_termination"])
-          end
-        end
-
-        context "when all validations passed" do
-          it "returns result with subscriptions marked as terminated" do
-            expect(subject).to all(
-              be_a(Subscription)
-                .and(have_attributes(
-                  terminated_at: terminated_at.change(usec: 0),
-                  status: "terminated"
-                ))
-            )
-          end
-        end
-      end
-    end
-
-    context "when external_ids are not provided" do
-      let(:params) do
-        {
-          billing_time:,
-          plan_code: plan&.code,
-          subscription_at: subscription_at&.iso8601
-        }
-      end
-
-      context "when plan matching provided code exists" do
         let(:plan) { create(:plan, organization:) }
+        let(:subscription_at) { generate(:past_date) }
+        let(:billing_time) { "anniversary" }
 
-        before { freeze_time }
+        it "returns new subscription with provided params" do
+          expect(result).to be_success
+          expect(subject).to contain_exactly Subscription
 
-        context "when billing time and subscription date are present" do
-          let(:subscription_at) { generate(:past_date) }
-          let(:billing_time) { "anniversary" }
-
-          it "returns new subscription with provided params" do
-            expect(subject)
-              .to all(
-                be_a(Subscription)
-                  .and(have_attributes(
-                    customer:,
-                    plan:,
-                    subscription_at: subscription_at,
-                    started_at: subscription_at,
-                    billing_time: params[:billing_time]
-                  ))
-              )
-          end
-        end
-
-        context "when billing time and subscription date are missing" do
-          let(:subscription_at) { nil }
-          let(:billing_time) { nil }
-
-          it "returns new subscription with default values for subscription date and billing time" do
-            expect(subject)
-              .to all(
-                be_a(Subscription)
-                  .and(have_attributes(
-                    customer:,
-                    plan:,
-                    subscription_at: Time.current,
-                    started_at: Time.current,
-                    billing_time: "calendar"
-                  ))
-              )
-          end
-        end
-      end
-
-      context "when plan matching provided code does not exist" do
-        let(:plan) { nil }
-        let(:subscription_at) { nil }
-        let(:billing_time) { nil }
-
-        it "returns nil" do
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::NotFoundFailure)
-          expect(result.error.error_code).to eq("plan_not_found")
-
-          expect(subject).to be_nil
+          expect(subject.first)
+            .to be_new_record
+            .and have_attributes(
+              customer:,
+              plan:,
+              subscription_at: subscription_at.change(usec: 0),
+              started_at: subscription_at.change(usec: 0),
+              billing_time:
+            )
         end
       end
     end

--- a/spec/services/invoices/preview_context_service_spec.rb
+++ b/spec/services/invoices/preview_context_service_spec.rb
@@ -182,50 +182,29 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
       }
     end
 
-    context "when plan matching provided code exists" do
+    context "with valid params" do
       let(:plan) { create(:plan, organization:) }
+      let(:subscription_at) { generate(:past_date) }
+      let(:billing_time) { "anniversary" }
 
       before { freeze_time }
 
-      context "when billing time and subscription date are present" do
-        let(:subscription_at) { generate(:past_date) }
-        let(:billing_time) { "anniversary" }
-
-        it "returns new subscription with provided params" do
-          expect(subject)
-            .to all(
-              be_a(Subscription)
-                .and(have_attributes(
-                  customer:,
-                  plan:,
-                  subscription_at: subscription_at,
-                  started_at: subscription_at,
-                  billing_time: params[:billing_time]
-                ))
-            )
-        end
-      end
-
-      context "when billing time and subscription date are missing" do
-        let(:subscription_at) { nil }
-        let(:billing_time) { nil }
-
-        it "returns new subscription with default values for subscription date and billing time" do
-          expect(subject)
-            .to all(
-              be_a(Subscription).and(have_attributes(
+      it "returns new subscription with provided params" do
+        expect(subject)
+          .to all(
+            be_a(Subscription)
+              .and(have_attributes(
                 customer:,
                 plan:,
-                subscription_at: Time.current,
-                started_at: Time.current,
-                billing_time: "calendar"
+                subscription_at: subscription_at,
+                started_at: subscription_at,
+                billing_time: params[:billing_time]
               ))
-            )
-        end
+          )
       end
     end
 
-    context "when plan matching provided code does not exist" do
+    context "with invalid params" do
       let(:plan) { nil }
       let(:subscription_at) { nil }
       let(:billing_time) { nil }
@@ -236,28 +215,6 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
         expect(result.error.error_code).to eq("plan_not_found")
 
         expect(subject).to be_nil
-      end
-    end
-
-    context "when subscriptions are fetched from the database" do
-      let(:subscription1) { create(:subscription, customer:) }
-      let(:subscription2) { create(:subscription, customer:) }
-      let(:params) do
-        {
-          customer: {external_id: customer.external_id},
-          subscriptions: {
-            external_ids: [subscription1.external_id, subscription2.external_id]
-          }
-        }
-      end
-
-      before do
-        subscription1
-        subscription2
-      end
-
-      it "returns subscriptions that are persisted" do
-        expect(subject.pluck(:external_id)).to eq([subscription1.external_id, subscription2.external_id])
       end
     end
   end

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -383,6 +383,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
 
         context "with in advance billing in the future" do
+          let(:organization) { create(:organization, invoice_grace_period: 2) }
           let(:plan) { create(:plan, organization:, interval: "monthly", pay_in_advance: true) }
           let(:subscription) do
             build(
@@ -404,7 +405,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               expect(result.invoice.subscriptions.first).to eq(subscription)
               expect(result.invoice.fees.length).to eq(1)
               expect(result.invoice.invoice_type).to eq("subscription")
-              expect(result.invoice.issuing_date.to_s).to eq("2024-03-31")
+              expect(result.invoice.issuing_date.to_s).to eq("2024-04-02")
               expect(result.invoice.fees_amount_cents).to eq(3)
               expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(3)
               expect(result.invoice.taxes_amount_cents).to eq(2)
@@ -846,7 +847,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
 
         context "with multiple persisted subscriptions" do
-          let(:customer) { create(:customer, organization:) }
+          let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
           let(:plan1) { create(:plan, organization:, interval: "monthly") }
           let(:plan2) { create(:plan, organization:, interval: "monthly") }
           let(:subscriptions) { [subscription1, subscription2] }
@@ -883,7 +884,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               expect(result.invoice.subscriptions.map { |s| s.id }).to match_array([subscription1.id, subscription2.id])
               expect(result.invoice.fees.length).to eq(2)
               expect(result.invoice.invoice_type).to eq("subscription")
-              expect(result.invoice.issuing_date.to_s).to eq("2024-04-30")
+              expect(result.invoice.issuing_date.to_s).to eq("2024-05-03")
               expect(result.invoice.fees_amount_cents).to eq(200)
               expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(200)
               expect(result.invoice.taxes_amount_cents).to eq(100)

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -528,6 +528,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
 
                 expect(result).to be_success
                 expect(result.invoice.subscriptions.size).to eq(2)
+                expect(result.invoice.credits.length).to eq(1)
+                expect(result.invoice.credits.first.amount_cents).to eq(9)
                 expect(result.invoice.fees.length).to eq(1)
                 expect(result.invoice.invoice_type).to eq("subscription")
                 expect(result.invoice.issuing_date.to_s).to eq("2024-03-29")

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -484,7 +484,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
 
           context "with upgraded subscription" do
             let(:timestamp) { Time.zone.parse("29 Mar 2024") }
-            let(:plan_new) { create(:plan, organization:, interval: "monthly", amount_cents: 200, pay_in_advance: true) }
+            let(:plan_new) { create(:plan, charges:, organization:, interval: "monthly", amount_cents: 200, pay_in_advance: true) }
             let(:subscriptions) { [terminated_subscription, upgrade_subscription] }
             let(:terminated_subscription) do
               create(
@@ -509,6 +509,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 created_at: timestamp
               )
             end
+
+            let(:charges) { [build(:standard_charge)] }
 
             before do
               BillSubscriptionJob.perform_now(


### PR DESCRIPTION
## Context

Add support for generating invoice preview simulating termination, upgrade and downgrade of existing subscriptions.

## Description

Following PRs were already reviewed and this feature branch does not
contain any change outside of these PRS:
-https://github.com/getlago/lago-api/pull/3257
-https://github.com/getlago/lago-api/pull/3265
-https://github.com/getlago/lago-api/pull/3277
-https://github.com/getlago/lago-api/pull/3275
-https://github.com/getlago/lago-api/pull/3296
-https://github.com/getlago/lago-api/pull/3297
-https://github.com/getlago/lago-api/pull/3318
-https://github.com/getlago/lago-api/pull/3328
-https://github.com/getlago/lago-api/pull/3335

