### PR TITLE
fix(tax-provider): do not call tax provider when invoice is zero amount or without fees

### DIFF
--- a/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
+++ b/app/jobs/invoices/provider_taxes/pull_taxes_and_apply_job.rb
@@ -7,6 +7,7 @@ module Invoices
 
       retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
       retry_on LagoHttpClient::HttpError, wait: :polynomially_longer, attempts: 6
+      retry_on OpenSSL::SSL::SSLError, wait: :polynomially_longer, attempts: 6
       retry_on Net::ReadTimeout, wait: :polynomially_longer, attempts: 6
 
       def perform(invoice:)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -388,6 +388,12 @@ class Invoice < ApplicationRecord
     I18n.t("invoice.document_name")
   end
 
+  def should_apply_provider_tax?
+    should_finalize_invoice = Invoices::TransitionToFinalStatusService.new(invoice: self).should_finalize_invoice?
+
+    fees.any? && should_finalize_invoice
+  end
+
   private
 
   def should_assign_sequential_id?

--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -12,7 +12,7 @@ module Invoices
     def call
       if should_apply_fee_taxes?
         invoice.fees.each do |fee|
-          taxes_result = if provider_taxes && customer_provider_taxation?
+          taxes_result = if provider_taxes && customer_provider_taxation? && invoice.should_apply_provider_tax?
             Fees::ApplyProviderTaxesService.call(fee:, fee_taxes: fee_taxes(fee))
           else
             Fees::ApplyTaxesService.call(fee:)

--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -29,7 +29,7 @@ module Invoices
         invoice.fees_amount_cents - invoice.progressive_billing_credit_amount_cents - invoice.coupons_amount_cents
       )
 
-      taxes_result = if customer_provider_taxation?
+      taxes_result = if customer_provider_taxation? && invoice.fees.any?
         Invoices::ApplyProviderTaxesService.call(invoice:, provider_taxes:)
       else
         Invoices::ApplyTaxesService.call(invoice:)

--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -29,7 +29,7 @@ module Invoices
         invoice.fees_amount_cents - invoice.progressive_billing_credit_amount_cents - invoice.coupons_amount_cents
       )
 
-      taxes_result = if customer_provider_taxation? && invoice.fees.any?
+      taxes_result = if customer_provider_taxation? && invoice.should_apply_provider_tax?
         Invoices::ApplyProviderTaxesService.call(invoice:, provider_taxes:)
       else
         Invoices::ApplyTaxesService.call(invoice:)

--- a/app/services/invoices/compute_taxes_and_totals_service.rb
+++ b/app/services/invoices/compute_taxes_and_totals_service.rb
@@ -12,7 +12,7 @@ module Invoices
     def call
       return result.not_found_failure!(resource: "invoice") unless invoice
 
-      if customer_provider_taxation?
+      if customer_provider_taxation? && invoice.fees.any?
         invoice.status = "pending" if finalizing
         invoice.tax_status = "pending"
         invoice.save!

--- a/app/services/invoices/compute_taxes_and_totals_service.rb
+++ b/app/services/invoices/compute_taxes_and_totals_service.rb
@@ -12,7 +12,7 @@ module Invoices
     def call
       return result.not_found_failure!(resource: "invoice") unless invoice
 
-      if customer_provider_taxation? && invoice.fees.any?
+      if customer_provider_taxation? && invoice.should_apply_provider_tax?
         invoice.status = "pending" if finalizing
         invoice.tax_status = "pending"
         invoice.save!

--- a/app/services/invoices/transition_to_final_status_service.rb
+++ b/app/services/invoices/transition_to_final_status_service.rb
@@ -19,10 +19,6 @@ module Invoices
       result
     end
 
-    private
-
-    attr_reader :invoice, :customer, :organization
-
     def should_finalize_invoice?
       return true unless invoice.fees_amount_cents.zero?
       customer_setting = customer.finalize_zero_amount_invoice
@@ -32,5 +28,9 @@ module Invoices
         customer_setting == "finalize"
       end
     end
+
+    private
+
+    attr_reader :invoice, :customer, :organization
   end
 end

--- a/spec/graphql/mutations/invoices/finalize_spec.rb
+++ b/spec/graphql/mutations/invoices/finalize_spec.rb
@@ -47,9 +47,39 @@ RSpec.describe Mutations::Invoices::Finalize, type: :graphql do
   context "with tax provider" do
     let(:integration) { create(:anrok_integration, organization:) }
     let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+    let(:timestamp) { Time.zone.now.beginning_of_month }
+    let(:subscription) do
+      create(
+        :subscription,
+        customer:,
+        subscription_at: Time.current - 3.months,
+        started_at: Time.current - 3.months,
+        created_at: Time.current - 3.months
+      )
+    end
+    let(:date_service) do
+      Subscriptions::DatesService.new_instance(
+        subscription,
+        Time.zone.at(timestamp),
+        current_usage: false
+      )
+    end
+    let(:invoice_subscription) do
+      create(
+        :invoice_subscription,
+        subscription:,
+        invoice:,
+        timestamp:,
+        from_datetime: date_service.from_datetime,
+        to_datetime: date_service.to_datetime,
+        charges_from_datetime: date_service.charges_from_datetime,
+        charges_to_datetime: date_service.charges_to_datetime
+      )
+    end
 
     before do
       integration_customer
+      invoice_subscription
     end
 
     it "returns pending invoice" do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1765,4 +1765,45 @@ RSpec.describe Invoice, type: :model do
       end
     end
   end
+
+  describe "should_apply_provider_tax?" do
+    let(:invoice) { create(:invoice, :subscription, subscriptions: [subscription]) }
+    let(:plan) { create(:plan) }
+    let(:subscription) { create(:subscription, plan:) }
+
+    let(:charge) { create(:standard_charge, plan:) }
+    let(:charge_fee) { create(:charge_fee, charge:, invoice:, amount: 100) }
+
+    before { charge_fee }
+
+    context "when there are fees with non zero amount" do
+      it { expect(invoice).to be_should_apply_provider_tax }
+    end
+
+    context "when there are no fees" do
+      let(:charge_fee) { nil }
+
+      it { expect(invoice).not_to be_should_apply_provider_tax }
+    end
+
+    context "when fees amount is zero with skip configuration" do
+      let(:charge_fee) { create(:charge_fee, charge:, invoice:, amount: 0) }
+
+      before do
+        invoice.customer.update!(finalize_zero_amount_invoice: "skip")
+      end
+
+      it { expect(invoice).not_to be_should_apply_provider_tax }
+    end
+
+    context "when fees amount is zero with finalize configuration" do
+      let(:charge_fee) { create(:charge_fee, charge:, invoice:, amount: 0) }
+
+      before do
+        invoice.customer.update!(finalize_zero_amount_invoice: "finalize")
+      end
+
+      it { expect(invoice).to be_should_apply_provider_tax }
+    end
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1767,23 +1767,25 @@ RSpec.describe Invoice, type: :model do
   end
 
   describe "should_apply_provider_tax?" do
+    subject { invoice.should_apply_provider_tax? }
+
     let(:invoice) { create(:invoice, :subscription, subscriptions: [subscription]) }
     let(:plan) { create(:plan) }
     let(:subscription) { create(:subscription, plan:) }
-
     let(:charge) { create(:standard_charge, plan:) }
-    let(:charge_fee) { create(:charge_fee, charge:, invoice:, amount: 100) }
 
     before { charge_fee }
 
     context "when there are fees with non zero amount" do
-      it { expect(invoice).to be_should_apply_provider_tax }
+      let(:charge_fee) { create(:charge_fee, charge:, invoice:, amount: 100) }
+
+      it { expect(subject).to be true }
     end
 
     context "when there are no fees" do
       let(:charge_fee) { nil }
 
-      it { expect(invoice).not_to be_should_apply_provider_tax }
+      it { expect(subject).to be false }
     end
 
     context "when fees amount is zero with skip configuration" do
@@ -1793,7 +1795,7 @@ RSpec.describe Invoice, type: :model do
         invoice.customer.update!(finalize_zero_amount_invoice: "skip")
       end
 
-      it { expect(invoice).not_to be_should_apply_provider_tax }
+      it { expect(subject).to be false }
     end
 
     context "when fees amount is zero with finalize configuration" do
@@ -1803,7 +1805,7 @@ RSpec.describe Invoice, type: :model do
         invoice.customer.update!(finalize_zero_amount_invoice: "finalize")
       end
 
-      it { expect(invoice).to be_should_apply_provider_tax }
+      it { expect(subject).to be true }
     end
   end
 end

--- a/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
+++ b/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
@@ -102,6 +102,24 @@ RSpec.describe Invoices::ComputeTaxesAndTotalsService, type: :service do
           expect(invoice.reload.tax_status).to eq("pending")
         end
       end
+
+      context "when there is no fees" do
+        let(:fee_subscription) { nil }
+        let(:fee_charge) { nil }
+        let(:result) { BaseService::Result.new }
+
+        before do
+          allow(Invoices::ComputeAmountsFromFees).to receive(:call)
+            .with(invoice:)
+            .and_return(result)
+        end
+
+        it "skips tax provider flow" do
+          totals_service.call
+
+          expect(Invoices::ComputeAmountsFromFees).to have_received(:call)
+        end
+      end
     end
 
     context "when there is NO tax provider" do


### PR DESCRIPTION
## Context

When invoice does not have any fee attached we don't want to make a request to the tax provider. In addition, if invoice `fees_amount_cents` is zero but customer property for finalizing zero amount invoices is set to `skip`, we also don't want to sync such invoice to Anrok.

## Description

In described scenario, expected flow should include using Lago defined taxes, which will anyway result in zero amounts even if Lago taxes are defined.

However, tax provider users usually does not define Lago taxes. 
