### PR TITLE
misc(http-client): Add response headers to http error

### DIFF
--- a/lib/lago_http_client/lago_http_client/client.rb
+++ b/lib/lago_http_client/lago_http_client/client.rb
@@ -114,7 +114,7 @@ module LagoHttpClient
     attr_reader :http_client
 
     def raise_error(response)
-      raise(::LagoHttpClient::HttpError.new(response.code, response.body, uri))
+      raise(::LagoHttpClient::HttpError.new(response.code, response.body, uri, response_headers: response.to_hash))
     end
   end
 end

--- a/lib/lago_http_client/lago_http_client/client.rb
+++ b/lib/lago_http_client/lago_http_client/client.rb
@@ -114,7 +114,9 @@ module LagoHttpClient
     attr_reader :http_client
 
     def raise_error(response)
-      raise(::LagoHttpClient::HttpError.new(response.code, response.body, uri, response_headers: response.to_hash))
+      raise(
+        ::LagoHttpClient::HttpError.new(response.code, response.body, uri, response_headers: response.each_header.to_h)
+      )
     end
   end
 end

--- a/lib/lago_http_client/lago_http_client/http_error.rb
+++ b/lib/lago_http_client/lago_http_client/http_error.rb
@@ -2,16 +2,17 @@
 
 module LagoHttpClient
   class HttpError < StandardError
-    attr_reader :error_code, :error_body, :uri
+    attr_reader :error_code, :error_body, :uri, :response_headers
 
-    def initialize(code, body, uri)
+    def initialize(code, body, uri, response_headers: {})
       @error_code = code
       @error_body = body
       @uri = uri
+      @response_headers = response_headers
     end
 
     def message
-      "HTTP #{error_code} - URI: #{uri}.\nError: #{error_body}"
+      "HTTP #{error_code} - URI: #{uri}.\nError: #{error_body}\nResponse headers: #{response_headers}"
     end
 
     def json_message


### PR DESCRIPTION
## Description

This PR adds response headers to `LagoHttpClient::HttpError` which will help us to debug requests made to external integrations services.