### PR TITLE
feat(payments): Save payment method on successful payment (stripe only)

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -108,6 +108,7 @@ end
 #  payment_provider_customer_id :uuid
 #  payment_provider_id          :uuid
 #  provider_payment_id          :string
+#  provider_payment_method_id   :string
 #
 # Indexes
 #

--- a/app/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service.rb
@@ -5,7 +5,26 @@ module PaymentProviders
     module Webhooks
       class PaymentIntentSucceededService < BaseService
         def call
-          update_payment_status! "succeeded"
+          @result = update_payment_status! "succeeded"
+          update_provider_payment_method_data
+          result
+        end
+
+        private
+
+        def update_provider_payment_method_data
+          latest_charge = event.data.object.charges.data.last
+          data = {
+            id: event.data.object.payment_method,
+            type: latest_charge.payment_method_details.type
+          }
+          if data[:type] == "card"
+            data[:brand] = latest_charge.payment_method_details.card.brand
+            data[:last4] = latest_charge.payment_method_details.card.last4
+          end
+
+          # NOTE: `result.payment was set by the service handling update_payment_status!
+          result.payment.update(provider_payment_method_data: data)
         end
       end
     end

--- a/app/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service.rb
@@ -6,25 +6,16 @@ module PaymentProviders
       class PaymentIntentSucceededService < BaseService
         def call
           @result = update_payment_status! "succeeded"
-          update_provider_payment_method_data
-          result
-        end
 
-        private
-
-        def update_provider_payment_method_data
-          latest_charge = event.data.object.charges.data.last
-          data = {
-            id: event.data.object.payment_method,
-            type: latest_charge.payment_method_details.type
-          }
-          if data[:type] == "card"
-            data[:brand] = latest_charge.payment_method_details.card.brand
-            data[:last4] = latest_charge.payment_method_details.card.last4
+          payment = Payment.find_by(provider_payment_id: event.data.object.id)
+          if payment
+            ::Payments::UpdatePaymentMethodDataService.call!(
+              payment:,
+              payment_method_id: event.data.object.payment_method
+            )
           end
 
-          # NOTE: `result.payment was set by the service handling update_payment_status!
-          result.payment.update(provider_payment_method_data: data)
+          result
         end
       end
     end

--- a/app/services/payments/update_payment_method_data_service.rb
+++ b/app/services/payments/update_payment_method_data_service.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Payments
+  class UpdatePaymentMethodDataService < BaseService
+    Result = BaseResult[:payment]
+
+    def initialize(payment:, payment_method_id:)
+      @payment = payment
+      @payment_provider = payment.payment_provider
+      @provider_payment_method_id = payment_method_id
+
+      super
+    end
+
+    def call
+      data = case payment_provider.type
+      when PaymentProviders::StripeProvider.to_s
+        retrieve_stripe_payment_method_data
+      else
+        raise NotImplementedError, "Service not implemented for #{payment_provider.payment_type}"
+      end
+
+      payment.update!(provider_payment_method_data: data)
+
+      result.payment = payment
+      result
+    end
+
+    private
+
+    attr_reader :payment, :payment_provider, :provider_payment_method_id
+
+    def retrieve_stripe_payment_method_data
+      pm = ::Stripe::PaymentMethod.retrieve(provider_payment_method_id, {
+        api_key: payment_provider.secret_key,
+        stripe_version: "2024-09-30.acacia" # TODO: Remove when freezing version at the project level
+      })
+
+      data = {
+        id: provider_payment_method_id,
+        type: pm.type
+      }
+
+      if pm.respond_to?(:card)
+        data[:last4] = pm.card.last4
+        data[:brand] = pm.card.display_brand
+      end
+
+      data
+    end
+  end
+end

--- a/app/services/payments/update_payment_method_data_service.rb
+++ b/app/services/payments/update_payment_method_data_service.rb
@@ -20,7 +20,8 @@ module Payments
         raise NotImplementedError, "Service not implemented for #{payment_provider.payment_type}"
       end
 
-      payment.update!(provider_payment_method_data: data)
+      id = data.delete(:id)
+      payment.update!(provider_payment_method_id: id, provider_payment_method_data: data)
 
       result.payment = payment
       result

--- a/db/migrate/20250324125056_add_provider_payment_method_id_to_payments.rb
+++ b/db/migrate/20250324125056_add_provider_payment_method_id_to_payments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProviderPaymentMethodIdToPayments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :payments, :provider_payment_method_id, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_24_122757) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_24_125056) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1190,6 +1190,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_24_122757) do
     t.enum "payment_type", default: "provider", null: false, enum_type: "payment_type"
     t.string "reference"
     t.jsonb "provider_payment_method_data", default: {}, null: false
+    t.string "provider_payment_method_id"
     t.index ["invoice_id"], name: "index_payments_on_invoice_id"
     t.index ["payable_id", "payable_type"], name: "index_payments_on_payable_id_and_payable_type", unique: true, where: "((payable_payment_status = ANY (ARRAY['pending'::payment_payable_payment_status, 'processing'::payment_payable_payment_status])) AND (payment_type = 'provider'::payment_type))"
     t.index ["payable_type", "payable_id"], name: "index_payments_on_payable_type_and_payable_id"

--- a/spec/fixtures/stripe/retrieve_payment_method.json
+++ b/spec/fixtures/stripe/retrieve_payment_method.json
@@ -1,0 +1,50 @@
+{
+  "id": "pm_1R2DFsQ8iJWBZFaMw3LLbR0r",
+  "object": "payment_method",
+  "allow_redisplay": "always",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": "FR",
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": "awdawd@desf.com",
+    "name": "Testing Stripe",
+    "phone": null
+  },
+  "card": {
+    "brand": "visa",
+    "checks": {
+      "address_line1_check": null,
+      "address_postal_code_check": null,
+      "cvc_check": "pass"
+    },
+    "country": "US",
+    "display_brand": "visa",
+    "exp_month": 12,
+    "exp_year": 2028,
+    "fingerprint": "8TOiB4cGytYxCweY",
+    "funding": "credit",
+    "generated_from": null,
+    "last4": "4242",
+    "networks": {
+      "available": [
+        "visa"
+      ],
+      "preferred": null
+    },
+    "regulated_status": "unregulated",
+    "three_d_secure_usage": {
+      "supported": true
+    },
+    "wallet": null
+  },
+  "created": 1741878064,
+  "customer": "cus_Rw5Qso78STEap3",
+  "livemode": false,
+  "metadata": {},
+  "type": "card"
+}

--- a/spec/fixtures/stripe/webhooks/payment_intent_succeeded-2020-08-27.json
+++ b/spec/fixtures/stripe/webhooks/payment_intent_succeeded-2020-08-27.json
@@ -1,18 +1,18 @@
 {
-  "id": "evt_3Qu0oXQ8iJWBZFaM2POll434",
+  "id": "evt_3R3dvoQ8iJWBZFaM0Wh4E44o",
   "object": "event",
   "api_version": "2020-08-27",
-  "created": 1739923617,
+  "created": 1742218937,
   "data": {
     "object": {
-      "id": "pi_3Qu0oXQ8iJWBZFaM2cc2RG6D",
+      "id": "pi_3R3dvoQ8iJWBZFaM0uu1G1rx",
       "object": "payment_intent",
-      "amount": 9995,
+      "amount": 3897,
       "amount_capturable": 0,
       "amount_details": {
         "tip": {}
       },
-      "amount_received": 9995,
+      "amount_received": 3897,
       "application": null,
       "application_fee_amount": null,
       "automatic_payment_methods": null,
@@ -23,34 +23,34 @@
         "object": "list",
         "data": [
           {
-            "id": "ch_3Qu0oXQ8iJWBZFaM2mejOQKg",
+            "id": "ch_3R3dvoQ8iJWBZFaM0NhAbztB",
             "object": "charge",
-            "amount": 9995,
-            "amount_captured": 9995,
+            "amount": 3897,
+            "amount_captured": 3897,
             "amount_refunded": 0,
             "application": null,
             "application_fee": null,
             "application_fee_amount": null,
-            "balance_transaction": "txn_3Qu0oXQ8iJWBZFaM2dA7i3aQ",
+            "balance_transaction": "txn_3R3dvoQ8iJWBZFaM0vIgoQgO",
             "billing_details": {
               "address": {
                 "city": null,
-                "country": "US",
+                "country": "FR",
                 "line1": null,
                 "line2": null,
-                "postal_code": "45678",
+                "postal_code": null,
                 "state": null
               },
-              "email": "julienbourdeau@hey.com",
+              "email": "awdawd@desf.com",
               "name": "Testing Stripe",
               "phone": null
             },
             "calculated_statement_descriptor": "JULIEN",
             "captured": true,
-            "created": 1739923617,
+            "created": 1742218936,
             "currency": "usd",
-            "customer": "cus_RnWzeE8gaYbSve",
-            "description": "Hooli - Invoice HOO-CAAB-010-001",
+            "customer": "cus_Rw5Qso78STEap3",
+            "description": "Hooli - Invoice HOO-CAAB-028-004",
             "destination": null,
             "dispute": null,
             "disputed": false,
@@ -61,8 +61,10 @@
             "invoice": null,
             "livemode": false,
             "metadata": {
-              "lago_payment_request_id": "a587e552-36bc-4334-81f2-abcbf034ad3f",
-              "lago_payable_type": "PaymentRequest"
+              "invoice_type": "one_off",
+              "lago_customer_id": "e4674f68-a7ba-4ce8-95e9-981f346b49d7",
+              "invoice_issuing_date": "2025-03-17",
+              "lago_invoice_id": "5ccdc601-18a5-4f22-a8e7-a53ca18e1f00"
             },
             "on_behalf_of": null,
             "order": null,
@@ -73,22 +75,22 @@
               "network_status": "approved_by_network",
               "reason": null,
               "risk_level": "normal",
-              "risk_score": 14,
+              "risk_score": 49,
               "seller_message": "Payment complete.",
               "type": "authorized"
             },
             "paid": true,
-            "payment_intent": "pi_3Qu0oXQ8iJWBZFaM2cc2RG6D",
+            "payment_intent": "pi_3R3dvoQ8iJWBZFaM0uu1G1rx",
             "payment_method": "pm_1R2DFsQ8iJWBZFaMw3LLbR0r",
             "payment_method_details": {
               "card": {
-                "amount_authorized": 9995,
+                "amount_authorized": 3897,
                 "authorization_code": null,
                 "brand": "visa",
                 "checks": {
                   "address_line1_check": null,
-                  "address_postal_code_check": "pass",
-                  "cvc_check": "pass"
+                  "address_postal_code_check": null,
+                  "cvc_check": null
                 },
                 "country": "US",
                 "exp_month": 12,
@@ -113,7 +115,7 @@
                 },
                 "network_transaction_id": "568479105665299",
                 "overcapture": {
-                  "maximum_amount_capturable": 9995,
+                  "maximum_amount_capturable": 3897,
                   "status": "unavailable"
                 },
                 "regulated_status": "unregulated",
@@ -125,14 +127,14 @@
             "radar_options": {},
             "receipt_email": null,
             "receipt_number": null,
-            "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xUXNPODZROGlKV0JaRmFNKKLB1L0GMgZyY5dzQos6LBYmPDJ2CJS8Ofst88nIYdxk7dQPCLdbAkTKJVa3ly3jF3irJxsp03NFOUjj",
+            "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xUXNPODZROGlKV0JaRmFNKLnN4L4GMgZG_ZU7Occ6LBa2vkaCb0vmYUzyS_hCt6KVClQQn57DEam-9o5grpM2ZtQsdc7xMPJsKpwG",
             "refunded": false,
             "refunds": {
               "object": "list",
               "data": [],
               "has_more": false,
               "total_count": 0,
-              "url": "/v1/charges/ch_3Qu0oXQ8iJWBZFaM2mejOQKg/refunds"
+              "url": "/v1/charges/ch_3R3dvoQ8iJWBZFaM0NhAbztB/refunds"
             },
             "review": null,
             "shipping": null,
@@ -147,21 +149,23 @@
         ],
         "has_more": false,
         "total_count": 1,
-        "url": "/v1/charges?payment_intent=pi_3Qu0oXQ8iJWBZFaM2cc2RG6D"
+        "url": "/v1/charges?payment_intent=pi_3R3dvoQ8iJWBZFaM0uu1G1rx"
       },
-      "client_secret": "pi_3Qu0oXQ8iJWBZFaM2cc2RG6D_secret_wV73MVI9F0SNoZNeODtkLsOKc",
+      "client_secret": "pi_3R3dvoQ8iJWBZFaM0uu1G1rx_secret_qADOJoHblKMdHbpS73aZEncpt",
       "confirmation_method": "automatic",
-      "created": 1739923617,
+      "created": 1742218936,
       "currency": "usd",
-      "customer": "cus_RnWzeE8gaYbSve",
-      "description": "Hooli - Invoice HOO-CAAB-010-001",
+      "customer": "cus_Rw5Qso78STEap3",
+      "description": "Hooli - Invoice HOO-CAAB-028-004",
       "invoice": null,
       "last_payment_error": null,
-      "latest_charge": "ch_3Qu0oXQ8iJWBZFaM2mejOQKg",
+      "latest_charge": "ch_3R3dvoQ8iJWBZFaM0NhAbztB",
       "livemode": false,
       "metadata": {
-        "lago_payment_request_id": "a587e552-36bc-4334-81f2-abcbf034ad3f",
-        "lago_payable_type": "PaymentRequest"
+        "invoice_type": "one_off",
+        "lago_customer_id": "e4674f68-a7ba-4ce8-95e9-981f346b49d7",
+        "invoice_issuing_date": "2025-03-17",
+        "lago_invoice_id": "5ccdc601-18a5-4f22-a8e7-a53ca18e1f00"
       },
       "next_action": null,
       "on_behalf_of": null,
@@ -194,10 +198,10 @@
     }
   },
   "livemode": false,
-  "pending_webhooks": 1,
+  "pending_webhooks": 3,
   "request": {
-    "id": "req_STTo2yGuTiiuNq",
-    "idempotency_key": "payment-31e11fc4-60a4-467f-8661-1f24f410fbe0"
+    "id": "req_O6QX7CMLkdywUG",
+    "idempotency_key": "payment-086e04f0-7459-41d2-ab66-8795f2c0ff9e"
   },
   "type": "payment_intent.succeeded"
 }

--- a/spec/fixtures/stripe/webhooks/payment_intent_succeeded-2022-11-15.json
+++ b/spec/fixtures/stripe/webhooks/payment_intent_succeeded-2022-11-15.json
@@ -1,0 +1,75 @@
+{
+  "id": "evt_3R3dvoQ8iJWBZFaM0Wh4E44o",
+  "object": "event",
+  "api_version": "2022-11-15",
+  "created": 1742218937,
+  "data": {
+    "object": {
+      "id": "pi_3R3dvoQ8iJWBZFaM0uu1G1rx",
+      "object": "payment_intent",
+      "amount": 3897,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {}
+      },
+      "amount_received": 3897,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "client_secret": "pi_3R3dvoQ8iJWBZFaM0uu1G1rx_secret_qADOJoHblKMdHbpS73aZEncpt",
+      "confirmation_method": "automatic",
+      "created": 1742218936,
+      "currency": "usd",
+      "customer": "cus_Rw5Qso78STEap3",
+      "description": "Hooli - Invoice HOO-CAAB-028-004",
+      "invoice": null,
+      "last_payment_error": null,
+      "latest_charge": "ch_3R3dvoQ8iJWBZFaM0NhAbztB",
+      "livemode": false,
+      "metadata": {
+        "invoice_type": "one_off",
+        "lago_customer_id": "e4674f68-a7ba-4ce8-95e9-981f346b49d7",
+        "invoice_issuing_date": "2025-03-17",
+        "lago_invoice_id": "5ccdc601-18a5-4f22-a8e7-a53ca18e1f00"
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": "pm_1R2DFsQ8iJWBZFaMw3LLbR0r",
+      "payment_method_configuration_details": null,
+      "payment_method_options": {
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        },
+        "crypto": {}
+      },
+      "payment_method_types": [
+        "card",
+        "crypto"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "succeeded",
+      "transfer_data": null,
+      "transfer_group": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 3,
+  "request": {
+    "id": "req_O6QX7CMLkdywUG",
+    "idempotency_key": "payment-086e04f0-7459-41d2-ab66-8795f2c0ff9e"
+  },
+  "type": "payment_intent.succeeded"
+}

--- a/spec/fixtures/stripe/webhooks/payment_intent_succeeded-2024-09-30.acacia.json
+++ b/spec/fixtures/stripe/webhooks/payment_intent_succeeded-2024-09-30.acacia.json
@@ -1,0 +1,75 @@
+{
+  "id": "evt_3R3dvoQ8iJWBZFaM0Wh4E44o",
+  "object": "event",
+  "api_version": "2024-09-30.acacia",
+  "created": 1742218937,
+  "data": {
+    "object": {
+      "id": "pi_3R3dvoQ8iJWBZFaM0uu1G1rx",
+      "object": "payment_intent",
+      "amount": 3897,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {}
+      },
+      "amount_received": 3897,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "client_secret": "pi_3R3dvoQ8iJWBZFaM0uu1G1rx_secret_qADOJoHblKMdHbpS73aZEncpt",
+      "confirmation_method": "automatic",
+      "created": 1742218936,
+      "currency": "usd",
+      "customer": "cus_Rw5Qso78STEap3",
+      "description": "Hooli - Invoice HOO-CAAB-028-004",
+      "invoice": null,
+      "last_payment_error": null,
+      "latest_charge": "ch_3R3dvoQ8iJWBZFaM0NhAbztB",
+      "livemode": false,
+      "metadata": {
+        "invoice_type": "one_off",
+        "lago_customer_id": "e4674f68-a7ba-4ce8-95e9-981f346b49d7",
+        "invoice_issuing_date": "2025-03-17",
+        "lago_invoice_id": "5ccdc601-18a5-4f22-a8e7-a53ca18e1f00"
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": "pm_1R2DFsQ8iJWBZFaMw3LLbR0r",
+      "payment_method_configuration_details": null,
+      "payment_method_options": {
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        },
+        "crypto": {}
+      },
+      "payment_method_types": [
+        "card",
+        "crypto"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "succeeded",
+      "transfer_data": null,
+      "transfer_group": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 3,
+  "request": {
+    "id": "req_O6QX7CMLkdywUG",
+    "idempotency_key": "payment-086e04f0-7459-41d2-ab66-8795f2c0ff9e"
+  },
+  "type": "payment_intent.succeeded"
+}

--- a/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
@@ -43,9 +43,8 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
         result = event_service.call
 
         expect(result).to be_success
-
+        expect(payment.reload.provider_payment_method_id).to eq "pm_1R2DFsQ8iJWBZFaMw3LLbR0r"
         expect(payment.reload.provider_payment_method_data).to eq({
-          "id" => "pm_1R2DFsQ8iJWBZFaMw3LLbR0r",
           "type" => "card",
           "brand" => "visa",
           "last4" => "4242"
@@ -85,8 +84,8 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
       result = event_service.call
 
       expect(result).to be_success
+      expect(payment.reload.provider_payment_method_id).to eq "pm_1R2DFsQ8iJWBZFaMw3LLbR0r"
       expect(payment.reload.provider_payment_method_data).to eq({
-        "id" => "pm_1R2DFsQ8iJWBZFaMw3LLbR0r",
         "type" => "card",
         "brand" => "visa",
         "last4" => "4242"

--- a/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
@@ -33,18 +33,18 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
           )
         ).and_call_original
 
-      create(:payment, provider_payment_id: event.data.object.id)
+      payment = create(:payment, provider_payment_id: event.data.object.id)
 
       result = event_service.call
 
       expect(result).to be_success
 
-      # expect(payment.reload.provider_payment_method_data).to eq({
-      #   "id" => "pm_1Qu0lNQ8iJWBZFaMkKPH3KFv",
-      #   "type" => "card",
-      #   "brand" => "visa",
-      #   "last4" => "4242"
-      # })
+      expect(payment.reload.provider_payment_method_data).to eq({
+        "id" => "pm_1Qu0lNQ8iJWBZFaMkKPH3KFv",
+        "type" => "card",
+        "brand" => "visa",
+        "last4" => "4242"
+      })
     end
   end
 
@@ -72,12 +72,12 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
       result = event_service.call
 
       expect(result).to be_success
-      # expect(payment.reload.provider_payment_method_data).to eq({
-      #   "id" => "pm_1Qu0lNQ8iJWBZFaMkKPH3KFv",
-      #   "type" => "card",
-      #   "brand" => "visa",
-      #   "last4" => "4242"
-      # })
+      expect(payment.reload.provider_payment_method_data).to eq({
+        "id" => "pm_1Qu0lNQ8iJWBZFaMkKPH3KFv",
+        "type" => "card",
+        "brand" => "visa",
+        "last4" => "4242"
+      })
     end
   end
 

--- a/spec/services/payments/update_payment_method_data_service_spec.rb
+++ b/spec/services/payments/update_payment_method_data_service_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Payments::UpdatePaymentMethodDataService, type: :service do
 
         result = service.call
 
+        expect(result.payment.provider_payment_method_id).to eq "pm_1R2DFsQ8iJWBZFaMw3LLbR0r"
         expect(result.payment.provider_payment_method_data).to eq({
-          "id" => "pm_1R2DFsQ8iJWBZFaMw3LLbR0r",
           "type" => "card",
           "brand" => "visa",
           "last4" => "4242"

--- a/spec/services/payments/update_payment_method_data_service_spec.rb
+++ b/spec/services/payments/update_payment_method_data_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Payments::UpdatePaymentMethodDataService, type: :service do
+  subject(:service) { described_class.new(payment:, payment_method_id:) }
+
+  let(:payment_method_id) { "pm_1R2DFsQ8iJWBZFaMw3LLbR0r" }
+
+  describe "#call" do
+    context "with Stripe" do
+      let(:payment) { create(:payment, payment_provider: create(:stripe_provider)) }
+
+      it "updates the payment method data" do
+        stub_request(:get, %r{/v1/payment_methods/pm_1R2DFsQ8iJWBZFaMw3LLbR0r$}).and_return(
+          status: 200, body: File.read(Rails.root.join("spec/fixtures/stripe/retrieve_payment_method.json"))
+        )
+
+        result = service.call
+
+        expect(result.payment.provider_payment_method_data).to eq({
+          "id" => "pm_1R2DFsQ8iJWBZFaMw3LLbR0r",
+          "type" => "card",
+          "brand" => "visa",
+          "last4" => "4242"
+        })
+      end
+    end
+
+    context "with any other provider" do
+      let(:payment) { create(:payment, payment_provider: create(:gocardless_provider)) }
+
+      it do
+        expect { service.call }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR reintroduce the work reverted in #3282 

I originally wanted to freeze the stripe version before re-introducing this feature but:
* I want to upgrade Stripe before we freeze the version
* you can't [update webhook endpoint](https://docs.stripe.com/webhooks/versioning), you need to handle both at some point, so let's handle both now.

## Description

We want to save some payment method details for a successful payment. This info will be reused in the Payment Receipt feature.

It's done with the webhook only because it needs to be done with the webhook for all payment happening outside Lago (like invoice payment url or "customer balance"). Instead of doing it multple times, we always rely on webhooks.

The card details are not part of all webhooks depending on the version so we call the Stripe API to get the details of the payment method.

We call the service synchronously because this will allow to dispatch jobs that rely on this info (like payment receipt 😬)
We could easily make this async if needed.

### Caching ?

We could introduce some cache because the payment method ID is unique but I'm not sure how often we'd hit the cache. I think a lot of customers have one or 2 invoice a month. Only few have a lot payments per months. We could be writing a lot of stuff to redis and by the time we need it (next month) it was removed.

```ruby
Rails.cache.fetch("pm-data-#{provider_payment_method_id}") do
  retrieve_stripe_payment_method_data
end
```
