### PR TITLE
feat(stripe): Add lago_payment_id to payment intent metadata

### DIFF
--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -115,6 +115,14 @@ module PaymentProviders
           )
         end
 
+        def enriched_metadata
+          metadata.merge(
+            {
+              lago_payment_id: payment.id
+            }
+          )
+        end
+
         def payment_intent_payload
           payload = {
             amount: payment.amount_cents,
@@ -127,7 +135,7 @@ module PaymentProviders
             return_url: success_redirect_url,
             error_on_requires_action: error_on_requires_action?,
             description: reference,
-            metadata: metadata
+            metadata: enriched_metadata
           }
           payload.merge!(customer_balance_fields) if provider_customer.provider_payment_methods == ["customer_balance"]
           payload

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service
     {
       lago_customer_id: customer.id,
       lago_invoice_id: invoice.id,
+      lago_payment_id: payment.id,
       invoice_issuing_date: invoice.issuing_date.iso8601,
       invoice_type: invoice.invoice_type
     }


### PR DESCRIPTION
## Description

In our app you can do `Payment.find_by(provider_payment_id: "pi_xxx")` but with the API you must pass the primary key.

Nobody asked for it but as I was working with Payments and Stripe, I thought it would be useful. WDYT?