### PR TITLE
feat(pdf): Add env var to disable generating pdfs

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -22,6 +22,7 @@ guard :rspec, cmd: "bundle exec rspec" do
   watch("app/services/base_service.rb") { "spec/services/" }
   watch("app/jobs/application_job.rb") { "spec/jobs/" }
   watch("app/models/application_record.rb") { "spec/models/" }
+  watch("app/mailers/application_mailer.rb") { "spec/mailers/" }
   watch("app/serializers/model_serializer.rb") { "spec/serializers/" }
   watch("app/graphql/lago_api_schema.rb") { "spec/graphql/" }
   watch(%r{^spec/.+_spec\.rb$})

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -10,5 +10,6 @@ class ApplicationMailer < ActionMailer::Base
   def set_shared_variables
     @show_lago_logo = true
     @lago_logo_url = "https://assets.getlago.com/lago-logo-email.png"
+    @pdfs_enabled = !ActiveModel::Type::Boolean.new.cast(ENV["LAGO_DISABLE_PDF_GENERATION"])
   end
 end

--- a/app/mailers/credit_note_mailer.rb
+++ b/app/mailers/credit_note_mailer.rb
@@ -12,8 +12,10 @@ class CreditNoteMailer < ApplicationMailer
     return if @organization.email.blank?
     return if @customer.email.blank?
 
-    @credit_note.file.open do |file|
-      attachments["credit_note-#{@credit_note.number}.pdf"] = file.read
+    if @pdfs_enabled
+      @credit_note.file.open do |file|
+        attachments["credit_note-#{@credit_note.number}.pdf"] = file.read
+      end
     end
 
     I18n.with_locale(@customer.preferred_document_locale) do

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -15,8 +15,10 @@ class InvoiceMailer < ApplicationMailer
 
     I18n.locale = @customer.preferred_document_locale
 
-    @invoice.file.open do |file|
-      attachments["invoice-#{@invoice.number}.pdf"] = file.read
+    if @pdfs_enabled
+      @invoice.file.open do |file|
+        attachments["invoice-#{@invoice.number}.pdf"] = file.read
+      end
     end
 
     I18n.with_locale(@customer.preferred_document_locale) do

--- a/app/mailers/payment_receipt_mailer.rb
+++ b/app/mailers/payment_receipt_mailer.rb
@@ -20,10 +20,12 @@ class PaymentReceiptMailer < ApplicationMailer
 
     I18n.locale = @customer.preferred_document_locale
 
-    @payment_receipt.file.open { |file| attachments["receipt-#{@payment_receipt.number}.pdf"] = file.read }
+    if @pdfs_enabled
+      @payment_receipt.file.open { |file| attachments["receipt-#{@payment_receipt.number}.pdf"] = file.read }
 
-    @invoices.each do |invoice|
-      invoice.file.open { |file| attachments["invoice-#{invoice.number}.pdf"] = file.read }
+      @invoices.each do |invoice|
+        invoice.file.open { |file| attachments["invoice-#{invoice.number}.pdf"] = file.read }
+      end
     end
 
     I18n.with_locale(@customer.preferred_document_locale) do

--- a/app/services/payment_receipts/generate_pdf_service.rb
+++ b/app/services/payment_receipts/generate_pdf_service.rb
@@ -49,6 +49,8 @@ module PaymentReceipts
     end
 
     def should_generate_pdf?
+      return false if ActiveModel::Type::Boolean.new.cast(ENV["LAGO_DISABLE_PDF_GENERATION"])
+
       context == "admin" || payment_receipt.file.blank?
     end
   end

--- a/app/views/credit_note_mailer/created.slim
+++ b/app/views/credit_note_mailer/created.slim
@@ -33,14 +33,16 @@ table cellpadding="0" cellspacing="0" style="width: 100%; padding: 24px 0; borde
             = I18n.t('email.credit_note.created.issue_date')
           td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: right; color: #19212e; white-space: nowrap;"
             = I18n.l(@credit_note.issuing_date, format: :default)
-table cellpadding="0" cellspacing="0" style="width: 100%; padding: 24px 0; border-bottom: 1px solid #d9dee7;"
-  tr
-    td
-      table cellpadding="0" cellspacing="0" style="margin: auto"
-        tr
-          td style="padding-right: 8px;"
-            svg height="16px" width="16px" fill="#006CFA" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" style="padding-top: 4px"
-              path d="M12.705 10.27C12.5176 10.0838 12.2642 9.97921 12 9.97921C11.7358 9.97921 11.4824 10.0838 11.295 10.27L8.99999 12.75V1C8.99999 0.734784 8.89463 0.48043 8.7071 0.292893C8.51956 0.105357 8.26521 0 7.99999 0C7.73477 0 7.48042 0.105357 7.29288 0.292893C7.10535 0.48043 6.99999 0.734784 6.99999 1V12.755L4.70499 10.255C4.51763 10.0688 4.26417 9.96421 3.99999 9.96421C3.7358 9.96421 3.48235 10.0688 3.29499 10.255C3.19898 10.3482 3.12265 10.4597 3.07053 10.583C3.0184 10.7062 2.99155 10.8387 2.99155 10.9725C2.99155 11.1063 3.0184 11.2388 3.07053 11.362C3.12265 11.4853 3.19898 11.5968 3.29499 11.69L6.93999 15.54C7.22124 15.8209 7.60249 15.9787 7.99999 15.9787C8.39749 15.9787 8.77874 15.8209 9.05999 15.54L12.705 11.69C12.7987 11.597 12.8731 11.4864 12.9239 11.3646C12.9746 11.2427 13.0008 11.112 13.0008 10.98C13.0008 10.848 12.9746 10.7173 12.9239 10.5954C12.8731 10.4736 12.7987 10.363 12.705 10.27Z"
-          td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; color: #19212e;"
-            a style="text-decoration: none" href=@credit_note.file_url
-              = I18n.t('email.credit_note.created.download')
+
+- if @pdfs_enabled
+  table cellpadding="0" cellspacing="0" style="width: 100%; padding: 24px 0; border-bottom: 1px solid #d9dee7;"
+    tr
+      td
+        table cellpadding="0" cellspacing="0" style="margin: auto"
+          tr
+            td style="padding-right: 8px;"
+              svg height="16px" width="16px" fill="#006CFA" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" style="padding-top: 4px"
+                path d="M12.705 10.27C12.5176 10.0838 12.2642 9.97921 12 9.97921C11.7358 9.97921 11.4824 10.0838 11.295 10.27L8.99999 12.75V1C8.99999 0.734784 8.89463 0.48043 8.7071 0.292893C8.51956 0.105357 8.26521 0 7.99999 0C7.73477 0 7.48042 0.105357 7.29288 0.292893C7.10535 0.48043 6.99999 0.734784 6.99999 1V12.755L4.70499 10.255C4.51763 10.0688 4.26417 9.96421 3.99999 9.96421C3.7358 9.96421 3.48235 10.0688 3.29499 10.255C3.19898 10.3482 3.12265 10.4597 3.07053 10.583C3.0184 10.7062 2.99155 10.8387 2.99155 10.9725C2.99155 11.1063 3.0184 11.2388 3.07053 11.362C3.12265 11.4853 3.19898 11.5968 3.29499 11.69L6.93999 15.54C7.22124 15.8209 7.60249 15.9787 7.99999 15.9787C8.39749 15.9787 8.77874 15.8209 9.05999 15.54L12.705 11.69C12.7987 11.597 12.8731 11.4864 12.9239 11.3646C12.9746 11.2427 13.0008 11.112 13.0008 10.98C13.0008 10.848 12.9746 10.7173 12.9239 10.5954C12.8731 10.4736 12.7987 10.363 12.705 10.27Z"
+            td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; color: #19212e;"
+              a style="text-decoration: none" href=@credit_note.file_url
+                = I18n.t('email.credit_note.created.download')

--- a/app/views/invoice_mailer/finalized.slim
+++ b/app/views/invoice_mailer/finalized.slim
@@ -23,14 +23,16 @@ table cellpadding="0" cellspacing="0" style="width: 100%; padding: 24px 0; borde
             = I18n.t('email.invoice.finalized.issue_date')
           td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: right; color: #19212e; white-space: nowrap;"
             = I18n.l(@invoice.issuing_date, format: :default)
-table cellpadding="0" cellspacing="0" style="width: 100%; padding: 24px 0; border-bottom: 1px solid #d9dee7;"
-  tr
-    td
-      table cellpadding="0" cellspacing="0" style="margin: auto"
-        tr
-          td style="padding-right: 8px;"
-            svg height="16px" width="16px" fill="#006CFA" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" style="padding-top: 4px"
-              path d="M12.705 10.27C12.5176 10.0838 12.2642 9.97921 12 9.97921C11.7358 9.97921 11.4824 10.0838 11.295 10.27L8.99999 12.75V1C8.99999 0.734784 8.89463 0.48043 8.7071 0.292893C8.51956 0.105357 8.26521 0 7.99999 0C7.73477 0 7.48042 0.105357 7.29288 0.292893C7.10535 0.48043 6.99999 0.734784 6.99999 1V12.755L4.70499 10.255C4.51763 10.0688 4.26417 9.96421 3.99999 9.96421C3.7358 9.96421 3.48235 10.0688 3.29499 10.255C3.19898 10.3482 3.12265 10.4597 3.07053 10.583C3.0184 10.7062 2.99155 10.8387 2.99155 10.9725C2.99155 11.1063 3.0184 11.2388 3.07053 11.362C3.12265 11.4853 3.19898 11.5968 3.29499 11.69L6.93999 15.54C7.22124 15.8209 7.60249 15.9787 7.99999 15.9787C8.39749 15.9787 8.77874 15.8209 9.05999 15.54L12.705 11.69C12.7987 11.597 12.8731 11.4864 12.9239 11.3646C12.9746 11.2427 13.0008 11.112 13.0008 10.98C13.0008 10.848 12.9746 10.7173 12.9239 10.5954C12.8731 10.4736 12.7987 10.363 12.705 10.27Z"
-          td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; color: #19212e;"
-            a style="text-decoration: none" href=@invoice.file_url
-              = I18n.t('email.invoice.finalized.download')
+
+- if @pdfs_enabled
+  table cellpadding="0" cellspacing="0" style="width: 100%; padding: 24px 0; border-bottom: 1px solid #d9dee7;"
+    tr
+      td
+        table cellpadding="0" cellspacing="0" style="margin: auto"
+          tr
+            td style="padding-right: 8px;"
+              svg height="16px" width="16px" fill="#006CFA" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" style="padding-top: 4px"
+                path d="M12.705 10.27C12.5176 10.0838 12.2642 9.97921 12 9.97921C11.7358 9.97921 11.4824 10.0838 11.295 10.27L8.99999 12.75V1C8.99999 0.734784 8.89463 0.48043 8.7071 0.292893C8.51956 0.105357 8.26521 0 7.99999 0C7.73477 0 7.48042 0.105357 7.29288 0.292893C7.10535 0.48043 6.99999 0.734784 6.99999 1V12.755L4.70499 10.255C4.51763 10.0688 4.26417 9.96421 3.99999 9.96421C3.7358 9.96421 3.48235 10.0688 3.29499 10.255C3.19898 10.3482 3.12265 10.4597 3.07053 10.583C3.0184 10.7062 2.99155 10.8387 2.99155 10.9725C2.99155 11.1063 3.0184 11.2388 3.07053 11.362C3.12265 11.4853 3.19898 11.5968 3.29499 11.69L6.93999 15.54C7.22124 15.8209 7.60249 15.9787 7.99999 15.9787C8.39749 15.9787 8.77874 15.8209 9.05999 15.54L12.705 11.69C12.7987 11.597 12.8731 11.4864 12.9239 11.3646C12.9746 11.2427 13.0008 11.112 13.0008 10.98C13.0008 10.848 12.9746 10.7173 12.9239 10.5954C12.8731 10.4736 12.7987 10.363 12.705 10.27Z"
+            td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; color: #19212e;"
+              a style="text-decoration: none" href=@invoice.file_url
+                = I18n.t('email.invoice.finalized.download')

--- a/app/views/payment_receipt_mailer/created.slim
+++ b/app/views/payment_receipt_mailer/created.slim
@@ -18,6 +18,9 @@ table style="width: 100%; border-collapse: collapse;"
   - @invoices.each do |invoice|
     tr style="border-bottom: 1px solid #d9dee7;"
       td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: left; padding-right: 16px; white-space: nowrap; padding: 16px 0;"
-        = link_to invoice.number, invoice.file_url, {style: "text-decoration: none; color: #006cfa"}
+        - if @pdfs_enabled
+          = link_to invoice.number, invoice.file_url, {style: "text-decoration: none; color: #006cfa"}
+        - else
+          = invoice.number
       td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: right; color: #19212e; white-space: nowrap; padding: 16px 0;"
         = MoneyHelper.format(invoice.total_amount)

--- a/app/views/payment_request_mailer/requested.slim
+++ b/app/views/payment_request_mailer/requested.slim
@@ -35,6 +35,9 @@ table style="width: 100%; border-collapse: collapse;"
   - @invoices.each do |invoice|
     tr style="border-bottom: 1px solid #d9dee7;"
       td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: left; padding-right: 16px; white-space: nowrap; padding: 16px 0;"
-        = link_to invoice.number, invoice.file_url, {style: "text-decoration: none; color: #006cfa"}
+        - if @pdfs_enabled
+          = link_to invoice.number, invoice.file_url, {style: "text-decoration: none; color: #006cfa"}
+        - else
+          = invoice.number
       td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: right; color: #19212e; white-space: nowrap; padding: 16px 0;"
         = MoneyHelper.format(invoice.total_due_amount)

--- a/spec/mailers/credit_note_mailer_spec.rb
+++ b/spec/mailers/credit_note_mailer_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe CreditNoteMailer, type: :mailer do
       expect(mailer.attachments.first.filename).to eq("credit_note-#{credit_note.number}.pdf")
     end
 
+    context "when pdfs are disabled" do
+      before { ENV["LAGO_DISABLE_PDF_GENERATION"] = "true" }
+
+      it "does not attach the pdf" do
+        mailer = credit_note_mailer.with(credit_note:).created
+
+        expect(mailer.attachments).to be_empty
+      end
+    end
+
     context "with no pdf file" do
       let(:pdf_service) { instance_double(CreditNotes::GenerateService) }
 

--- a/spec/mailers/invoice_mailer_spec.rb
+++ b/spec/mailers/invoice_mailer_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe InvoiceMailer, type: :mailer do
       expect(mailer.attachments.first.filename).to eq("invoice-#{invoice.number}.pdf")
     end
 
+    context "when pdfs are disabled" do
+      before { ENV["LAGO_DISABLE_PDF_GENERATION"] = "true" }
+
+      it "does not attach the pdf" do
+        mailer = invoice_mailer.with(invoice:).finalized
+
+        expect(mailer.attachments).to be_empty
+      end
+    end
+
     context "with no pdf file" do
       let(:pdf_service) { instance_double(Invoices::GeneratePdfService) }
 

--- a/spec/mailers/payment_receipt_mailer_spec.rb
+++ b/spec/mailers/payment_receipt_mailer_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe PaymentReceiptMailer, type: :mailer do
       expect(mailer.attachments.first.filename).to eq("receipt-#{payment_receipt.number}.pdf")
     end
 
+    context "when pdfs are disabled" do
+      before { ENV["LAGO_DISABLE_PDF_GENERATION"] = "true" }
+
+      it "does not attach the pdf" do
+        mailer = payment_receipt_mailer.with(payment_receipt:).created
+
+        expect(mailer.attachments).to be_empty
+      end
+    end
+
     context "with no pdf file" do
       let(:pdf_service) { instance_double(PaymentReceipts::GeneratePdfService) }
 


### PR DESCRIPTION
## Context

Some clients don't need pdfs of invoices, credit notes and payment receipts.

## Description

This PR adds and ENV var to disable generation pdfs: `LAGO_DISABLE_PDF_GENERATION`
