### PR TITLE
Fix(wallet-balance): Fail if failed to fetch full current usage while updating wallet

### DIFF
--- a/app/jobs/wallets/refresh_ongoing_balance_job.rb
+++ b/app/jobs/wallets/refresh_ongoing_balance_job.rb
@@ -11,7 +11,7 @@ module Wallets
     def perform(wallet)
       return unless wallet.ready_to_be_refreshed?
 
-      Wallets::Balance::RefreshOngoingService.call(wallet:)
+      Wallets::Balance::RefreshOngoingService.call!(wallet:)
     end
   end
 end

--- a/app/services/wallets/balance/refresh_ongoing_service.rb
+++ b/app/services/wallets/balance/refresh_ongoing_service.rb
@@ -10,7 +10,9 @@ module Wallets
 
       def call
         usage_amount_cents = customer.active_subscriptions.map do |subscription|
-          invoice = ::Invoices::CustomerUsageService.call(customer:, subscription:).invoice
+          customer_usage_result = ::Invoices::CustomerUsageService.call(customer:, subscription:)
+          return customer_usage_result if customer_usage_result.failure?
+          invoice = customer_usage_result.invoice
 
           {
             total_usage_amount_cents: invoice.total_amount.to_f * wallet.ongoing_balance.currency.subunit_to_unit,


### PR DESCRIPTION
This PR fixes a bug:
- when updating wallet balance
- we fail to fetch taxes
- result of `Invoices::CustomerUsageService` is not checked if it's success
- we update wallet without correctly calculated current usage invoice (total_amount_cents in this case is 0)

After the fix:
- when updating wallet balance
- we fail to fetch taxes
- we return a failed result from the service `Wallets::Balance::RefreshOngoingService`
- Job `Wallets::RefreshOngoingBalance` raises an exception