### PR TITLE
chore(spec): Add HINT when gql query use snake_case

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,3 +7,9 @@ def pp(*args)
     ap arg, {sort_vars: false, sort_keys: false, indent: -2}
   end
 end
+
+def pps(*args)
+  pp "--------------------------------------"
+  pp(*args)
+  pp "--------------------------------------"
+end

--- a/spec/support/graphql_helper.rb
+++ b/spec/support/graphql_helper.rb
@@ -30,10 +30,18 @@ module GraphQLHelper
       }
     )
 
-    LagoApiSchema.execute(
+    res = LagoApiSchema.execute(
       query,
       **args
     )
+
+    res["errors"]&.each do |e|
+      if e.dig("extensions", "code") == "undefinedField" && e.dig("extensions", "fieldName").match?(/_/)
+        pps "HINT: GraphQL field name should use camelCase even if its declaration is snake_case."
+      end
+    end
+
+    res
   end
 
   def expect_graphql_error(result:, message:)


### PR DESCRIPTION
## Description

I have spent a few minutes understanding why my code didn't work and it turned out that I used `bcc_emails` instead of `bccEmail`. I remember doing the same mistake a while back.

We directly access `res["data"]` so the error is pretty cryptic. I think we could add nicer error message for next time.