### PR TITLE
refactor(eu_vat): store json in class const (so it's only read once at boot)

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -91,7 +91,7 @@ class BillingEntity < ApplicationRecord
   end
 
   def eu_vat_eligible?
-    country && LagoEuVat::Rate.new.countries_code.include?(country)
+    country && LagoEuVat::Rate.country_codes.include?(country)
   end
 
   private

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -150,7 +150,7 @@ class Organization < ApplicationRecord
   end
 
   def eu_vat_eligible?
-    country && LagoEuVat::Rate.new.countries_code.include?(country)
+    country && LagoEuVat::Rate.country_codes.include?(country)
   end
 
   def payment_provider(provider)

--- a/app/services/customers/eu_auto_taxes_service.rb
+++ b/app/services/customers/eu_auto_taxes_service.rb
@@ -63,7 +63,7 @@ module Customers
     end
 
     def eu_countries_code
-      LagoEuVat::Rate.new.countries_code
+      LagoEuVat::Rate.country_codes
     end
 
     def applicable_tax_exceptions(country_code:)
@@ -73,7 +73,7 @@ module Customers
     end
 
     def eu_country_exceptions(country_code:)
-      @eu_country_exceptions ||= LagoEuVat::Rate.new.country_rates(country_code:)[:exceptions]
+      @eu_country_exceptions ||= LagoEuVat::Rate.country_rates(country_code:)[:exceptions]
     end
 
     def should_apply_eu_taxes?

--- a/app/services/taxes/auto_generate_service.rb
+++ b/app/services/taxes/auto_generate_service.rb
@@ -4,14 +4,11 @@ module Taxes
   class AutoGenerateService < BaseService
     def initialize(organization:)
       @organization = organization
-      @lago_eu_vat = LagoEuVat::Rate.new
       super
     end
 
     def call
-      countries_code = lago_eu_vat.countries_code
-
-      countries_code.each do |country_code|
+      LagoEuVat::Rate.country_codes.each do |country_code|
         create_country_tax(country_code)
       end
 
@@ -20,10 +17,10 @@ module Taxes
 
     private
 
-    attr_reader :organization, :lago_eu_vat
+    attr_reader :organization
 
     def create_country_tax(country_code)
-      country_taxes = lago_eu_vat.country_rates(country_code:)
+      country_taxes = LagoEuVat::Rate.country_rates(country_code:)
 
       country_rates = country_taxes[:rates]
       tax_code = "lago_eu_#{country_code.downcase}_standard"

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -20,7 +20,7 @@ module Rails::ConsoleMethods
   def find(id)
     if /^gid/.match?(id)
       GlobalID::Locator.locate(id)
-    elsif EmailValidator::EMAIL_REGEXP.match?(id)
+    elsif Regex::EMAIL.match?(id)
       User.find_by email: id
     else
       raise "Don't know how to resolve this ¯\\_(ツ)_/¯. Please provide a valid email or Global ID."

--- a/lib/lago_eu_vat/lago_eu_vat/rate.rb
+++ b/lib/lago_eu_vat/lago_eu_vat/rate.rb
@@ -2,30 +2,29 @@
 
 module LagoEuVat
   class Rate
-    def initialize
+    COUNTRY_RATES = begin
       file_path = Rails.root.join("lib/lago_eu_vat/lago_eu_vat/eu_vat_rates.json")
       json_file = File.read(file_path)
-      @json_countries_rates = JSON.parse(json_file)["items"]
+      rates = JSON.parse(json_file)["items"]
+      rates.freeze
     end
 
-    def countries_code
-      json_countries_rates.map { |country_code, _| country_code }
-    end
-
-    def country_rates(country_code:)
-      # NOTE: country rates are ordered by date, so we select the most recent applicable
-      country_rates = json_countries_rates[country_code].select do |period|
-        Time.zone.now >= DateTime.parse(period["effective_from"])
+    class << self
+      def country_codes
+        COUNTRY_RATES.keys
       end
 
-      rates = country_rates.first.fetch("rates")
-      exceptions = country_rates.first.fetch("exceptions", [])
+      def country_rates(country_code:)
+        # NOTE: country rates are ordered by date, so we select the most recent applicable
+        country_rates = COUNTRY_RATES[country_code].select do |period|
+          Time.zone.now >= DateTime.parse(period["effective_from"])
+        end
 
-      {rates:, exceptions:}
+        rates = country_rates.first.fetch("rates")
+        exceptions = country_rates.first.fetch("exceptions", [])
+
+        {rates:, exceptions:}
+      end
     end
-
-    private
-
-    attr_reader :json_countries_rates
   end
 end

--- a/spec/lib/lago_eu_vat/rate_spec.rb
+++ b/spec/lib/lago_eu_vat/rate_spec.rb
@@ -3,27 +3,23 @@
 require "rails_helper"
 
 RSpec.describe LagoEuVat::Rate do
-  subject(:rates) { described_class.new }
+  subject { described_class }
 
-  describe ".countries_code" do
+  describe "#country_codes" do
     it "returns all EU country codes" do
-      countries_code = rates.countries_code
-
-      # NOTE: 28 in the original file but we removed BG manually
-      expect(countries_code.count).to eq(27)
+      # NOTE: 28 in the original file but we removed GB manually
+      expect(subject.country_codes.count).to eq(27)
     end
   end
 
-  describe ".country_rate" do
+  describe "#country_rate" do
     it "returns all applicable rates for a country" do
-      fr_taxes = rates.country_rates(country_code: "FR")
+      fr_taxes = subject.country_rates(country_code: "FR")
       fr_rates = fr_taxes[:rates]
       fr_exceptions = fr_taxes[:exceptions]
 
-      aggregate_failures do
-        expect(fr_rates["standard"]).to eq(20)
-        expect(fr_exceptions.count).to eq(5)
-      end
+      expect(fr_rates["standard"]).to eq(20)
+      expect(fr_exceptions.count).to eq(5)
     end
   end
 end

--- a/spec/services/taxes/auto_generate_service_spec.rb
+++ b/spec/services/taxes/auto_generate_service_spec.rb
@@ -11,9 +11,7 @@ RSpec.describe Taxes::AutoGenerateService, type: :service do
     it "creates eu taxes for organization" do
       auto_generate_service.call
 
-      aggregate_failures do
-        expect(Tax.count).to eq(46) # EU taxes + 2 defaults
-      end
+      expect(Tax.count).to eq(46) # EU taxes + 2 defaults
     end
   end
 end


### PR DESCRIPTION
## Description

As I was updating the rates (see #3352) I noticed we could improve the `LagoEuVat::Rate` class.

Instead of reading the json file every time we initialize the class, we now load it once when Rails is eager loading at boot.

The 2 methods are now class methods too.