### PR TITLE
fix(preview-invoices): rescue more transient error in preview mode and apply zero taxes

### DIFF
--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -270,7 +270,7 @@ module Invoices
       else
         apply_zero_tax
       end
-    rescue BaseService::ThrottlingError
+    rescue BaseService::ThrottlingError, Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError
       apply_zero_tax
     end
 


### PR DESCRIPTION
## Context

Preview feature fetches taxes in sync mode. If any transient network error appears, we should rescue it and apply zero taxes.