### PR TITLE
fix(permissions): Fix permissions in integrations resolver

### DIFF
--- a/app/graphql/resolvers/integrations_resolver.rb
+++ b/app/graphql/resolvers/integrations_resolver.rb
@@ -5,7 +5,7 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
-    REQUIRED_PERMISSION = "organization:integrations:view"
+    REQUIRED_PERMISSION = %w[organization:integrations:view customers:view]
 
     description "Query organization's integrations"
 

--- a/spec/graphql/resolvers/integrations_resolver_spec.rb
+++ b/spec/graphql/resolvers/integrations_resolver_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::IntegrationsResolver, type: :graphql do
-  let(:required_permission) { "organization:integrations:view" }
+  let(:required_permission) { "customers:view" }
   let(:query) do
     <<~GQL
       query {
@@ -29,7 +29,7 @@ RSpec.describe Resolvers::IntegrationsResolver, type: :graphql do
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
-  it_behaves_like "requires permission", "organization:integrations:view"
+  it_behaves_like "requires permission", %w[customers:view organization:integrations:view]
 
   context "when type is present" do
     let(:query) do


### PR DESCRIPTION
## Context

Account manager role not see the Anrok connection on a customer under "information" tab.

## Description

This PR adds `customers:view` permission to GQL `IntegrationsResolver` so users with the manager role can see all the integrations not just payment providers.