### PR TITLE
feat(data): Add analytics_dashboards organization flag

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -91,6 +91,7 @@ class Organization < ApplicationRecord
     preview
     multi_entities_pro
     multi_entities_enterprise
+    analytics_dashboards
   ].freeze
   PREMIUM_INTEGRATIONS = INTEGRATIONS - %w[anrok]
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -4617,6 +4617,7 @@ enum IntegrationItemTypeEnum {
 }
 
 enum IntegrationTypeEnum {
+  analytics_dashboards
   anrok
   api_permissions
   auto_dunning
@@ -6702,6 +6703,7 @@ input PlanOverridesInput {
 }
 
 enum PremiumIntegrationTypeEnum {
+  analytics_dashboards
   api_permissions
   auto_dunning
   beta_payment_authorization

--- a/schema.json
+++ b/schema.json
@@ -21871,6 +21871,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "analytics_dashboards",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -32577,6 +32583,12 @@
             },
             {
               "name": "multi_entities_enterprise",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "analytics_dashboards",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
+++ b/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Types::Integrations::PremiumIntegrationTypeEnum do
       preview
       multi_entities_pro
       multi_entities_enterprise
+      analytics_dashboards
     ]
   end
 


### PR DESCRIPTION
The goal of this PR is to add a new flag `analytics_dashboards` to the organization object.

This premium integration will be used to display new analytics dashboards.