### PR TITLE
fix(aggregator-items): Fix empty cursor in aggregator items service

### DIFF
--- a/app/services/integrations/aggregator/items_service.rb
+++ b/app/services/integrations/aggregator/items_service.rb
@@ -61,9 +61,8 @@ module Integrations
 
       def params
         {
-          limit: LIMIT,
-          cursor:
-        }
+          limit: LIMIT
+        }.merge(cursor.present? ? {cursor:} : {})
       end
     end
   end

--- a/spec/graphql/mutations/integration_items/fetch_items_spec.rb
+++ b/spec/graphql/mutations/integration_items/fetch_items_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Mutations::IntegrationItems::FetchItems, type: :graphql do
     allow(Integrations::Aggregator::SyncService).to receive(:new).and_return(sync_service)
     allow(sync_service).to receive(:call).and_return(true)
 
-    stub_request(:get, "https://api.nango.dev/v1/netsuite/items?cursor=&limit=450")
+    stub_request(:get, "https://api.nango.dev/v1/netsuite/items?limit=450")
       .to_return(status: 200, body: items_response, headers: {})
 
     integration_item

--- a/spec/services/integrations/aggregator/items_service_spec.rb
+++ b/spec/services/integrations/aggregator/items_service_spec.rb
@@ -10,17 +10,13 @@ RSpec.describe Integrations::Aggregator::ItemsService do
   describe ".call" do
     let(:lago_client) { instance_double(LagoHttpClient::Client) }
     let(:items_endpoint) { "https://api.nango.dev/v1/netsuite/items" }
+    let(:params) { {limit: 450} }
+
     let(:headers) do
       {
         "Connection-Id" => integration.connection_id,
         "Authorization" => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
         "Provider-Config-Key" => "netsuite-tba"
-      }
-    end
-    let(:params) do
-      {
-        limit: 450,
-        cursor: ""
       }
     end
 
@@ -59,6 +55,31 @@ RSpec.describe Integrations::Aggregator::ItemsService do
 
     it "returns the path" do
       expect(subject).to eq(action_path)
+    end
+  end
+
+  describe "#params" do
+    subject(:params_call) { items_service.__send__(:params) }
+
+    context "when cursor is not present" do
+      let(:params) { {limit: 450} }
+
+      it "returns the params" do
+        expect(subject).to eq(params)
+      end
+    end
+
+    context "when cursor is present" do
+      let(:params) { {limit: 450, cursor:} }
+      let(:cursor) { "cursor" }
+
+      before do
+        items_service.instance_variable_set(:@cursor, cursor)
+      end
+
+      it "returns the params with cursor" do
+        expect(subject).to eq(params)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

`cursor` param sent to xero can't be blank anymore.

## Description

This PR fixes the API call with blank `cursor` so that we're not sending it in that case.