### PR TITLE
Fix(multientities): ensure seeded organization is created with billing_entity

### DIFF
--- a/db/seeds/base.rb
+++ b/db/seeds/base.rb
@@ -10,6 +10,7 @@ user = User.create_with(password: "ILoveLago")
 organization = Organization.find_or_create_by!(name: "Hooli")
 organization.premium_integrations = Organization::PREMIUM_INTEGRATIONS
 organization.save!
+BillingEntity.find_or_create_by!(organization: organization, name: "Hooli", code: "hooli")
 ApiKey.find_or_create_by!(organization:)
 Membership.find_or_create_by!(user:, organization:, role: :admin)
 


### PR DESCRIPTION
Because in the seeds we create an Organization directly with ActiveRecord, not through the service, we have to manually create a BillingEntity for it