### PR TITLE
feat(event): Add metadata in kafka payload

### DIFF
--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -63,7 +63,10 @@ module Events
           precise_total_amount_cents: event.precise_total_amount_cents.present? ? event.precise_total_amount_cents.to_s : "0.0",
           properties: event.properties,
           ingested_at: Time.zone.now.iso8601[...-1],
-          source: "http_ruby"
+          source: "http_ruby",
+          source_metadata: {
+            api_post_processed: !organization.clickhouse_events_store?
+          }
         }.to_json
       )
     end


### PR DESCRIPTION
## Description

This PR adds a new `source_metadata` collection attribute to the events payload sent to Kafka.
For now, this it will contains a new `api_post_processed` boolean flag to allow the events-processor to identify if the events should be sent-back to API for in advance billing