### PR TITLE
feat(wallet-transactions): Add generate payment url endpoint

### DIFF
--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -63,6 +63,23 @@ module Api
         )
       end
 
+      def payment_url
+        wallet_transaction = current_organization.wallet_transactions.find_by(id: params[:id])
+        result = ::WalletTransactions::Payments::GeneratePaymentUrlService.call(wallet_transaction:)
+
+        if result.success?
+          render(
+            json: ::V1::PaymentProviders::WalletTransactionPaymentSerializer.new(
+              wallet_transaction,
+              root_name: "wallet_transaction_payment_details",
+              payment_url: result.payment_url
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
       private
 
       def input_params

--- a/app/serializers/v1/payment_providers/wallet_transaction_payment_serializer.rb
+++ b/app/serializers/v1/payment_providers/wallet_transaction_payment_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module V1
+  module PaymentProviders
+    class WalletTransactionPaymentSerializer < ModelSerializer
+      def serialize
+        {
+          lago_customer_id: customer.id,
+          external_customer_id: customer.external_id,
+          payment_provider: customer.payment_provider,
+          lago_wallet_transaction_id: model.id,
+          payment_url: options[:payment_url]
+        }
+      end
+
+      private
+
+      def customer
+        @customer ||= model.invoice.customer
+      end
+    end
+  end
+end

--- a/app/services/wallet_transactions/payments/generate_payment_url_service.rb
+++ b/app/services/wallet_transactions/payments/generate_payment_url_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module WalletTransactions
+  module Payments
+    class GeneratePaymentUrlService < BaseService
+      def initialize(wallet_transaction:)
+        @wallet_transaction = wallet_transaction
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: "wallet_transaction") unless wallet_transaction
+
+        unless wallet_transaction.purchased?
+          return result.single_validation_failure!(error_code: "wallet_transaction_not_purchased")
+        end
+
+        if wallet_transaction.settled?
+          return result.single_validation_failure!(error_code: "wallet_transaction_already_settled")
+        end
+
+        unless invoice
+          return result.single_validation_failure!(error_code: "wallet_transaction_has_no_attached_invoice")
+        end
+
+        ::Invoices::Payments::GeneratePaymentUrlService.call(invoice:)
+      end
+
+      private
+
+      attr_reader :wallet_transaction
+
+      delegate :invoice, to: :wallet_transaction, allow_nil: true
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,7 +75,9 @@ Rails.application.routes.draw do
       resources :payments, only: %i[create index show]
       resources :plans, param: :code, code: /.*/
       resources :taxes, param: :code, code: /.*/
-      resources :wallet_transactions, only: %i[create show]
+      resources :wallet_transactions, only: %i[create show] do
+        post :payment_url, on: :member
+      end
       get "/wallets/:id/wallet_transactions", to: "wallet_transactions#index"
       resources :wallets, only: %i[create update show index]
       delete "/wallets/:id", to: "wallets#terminate"

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -75,5 +75,20 @@ FactoryBot.define do
     trait :with_skipped_invoice_custom_section_selections do
       skip_invoice_custom_sections { true }
     end
+
+    trait :with_stripe_payment_provider do
+      payment_provider { "stripe" }
+      payment_provider_code { Faker::Lorem.word }
+
+      after(:create) do |customer|
+        payment_provider = build(
+          :stripe_provider,
+          organization: customer.organization,
+          code: customer.payment_provider_code
+        )
+
+        create(:stripe_customer, customer:, payment_provider:)
+      end
+    end
   end
 end

--- a/spec/factories/wallet_transactions.rb
+++ b/spec/factories/wallet_transactions.rb
@@ -13,5 +13,13 @@ FactoryBot.define do
       status { "failed" }
       failed_at { Time.current }
     end
+
+    trait :with_invoice do
+      transient do
+        customer { association(:customer) }
+      end
+
+      invoice { association(:invoice, customer:, organization: customer.organization) }
+    end
   end
 end

--- a/spec/serializers/v1/payment_providers/wallet_transaction_payment_serializer_spec.rb
+++ b/spec/serializers/v1/payment_providers/wallet_transaction_payment_serializer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe V1::PaymentProviders::WalletTransactionPaymentSerializer do
+  subject(:serializer) { described_class.new(wallet_transaction, options) }
+
+  let(:wallet_transaction) { create(:wallet_transaction, :with_invoice) }
+  let(:options) do
+    {"payment_url" => "https://example.com"}.with_indifferent_access
+  end
+
+  it "serializes the object" do
+    result = JSON.parse(serializer.to_json)
+
+    expect(result["data"]["lago_customer_id"]).to eq(wallet_transaction.invoice.customer.id)
+    expect(result["data"]["external_customer_id"]).to eq(wallet_transaction.invoice.customer.external_id)
+    expect(result["data"]["payment_provider"]).to eq(wallet_transaction.invoice.customer.payment_provider)
+    expect(result["data"]["lago_wallet_transaction_id"]).to eq(wallet_transaction.id)
+    expect(result["data"]["payment_url"]).to eq("https://example.com")
+  end
+end

--- a/spec/services/wallet_transactions/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/wallet_transactions/payments/generate_payment_url_service_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe WalletTransactions::Payments::GeneratePaymentUrlService do
+  describe ".call" do
+    subject(:result) { described_class.call(wallet_transaction:) }
+
+    context "when wallet transaction does not exist" do
+      let(:wallet_transaction) { nil }
+
+      it "fails with wallet transaction not found error" do
+        expect(result).to be_failure
+        expect(result.error.error_code).to eq("wallet_transaction_not_found")
+      end
+    end
+
+    context "when wallet transaction exists" do
+      let(:wallet_transaction) { build(:wallet_transaction, status:, transaction_status:) }
+
+      context "when transactions status is purchased" do
+        let(:transaction_status) { "purchased" }
+        let(:status) { nil }
+
+        context "when transaction is already settled" do
+          let(:status) { "settled" }
+
+          it "fails with wallet transaction already settled error" do
+            expect(result).to be_failure
+            expect(result.error.messages).to match(base: ["wallet_transaction_already_settled"])
+          end
+        end
+
+        context "when transaction is not settled" do
+          let(:status) { WalletTransaction::STATUSES.excluding(:settled).sample }
+
+          context "when transaction's invoice is missing" do
+            it "fails with no attached invoice error" do
+              expect(result).to be_failure
+              expect(result.error.messages).to match(base: ["wallet_transaction_has_no_attached_invoice"])
+            end
+          end
+
+          context "when transaction's invoice is present" do
+            let(:wallet_transaction) do
+              create(:wallet_transaction, :with_invoice, status:, transaction_status:, customer:)
+            end
+
+            let(:customer) { create(:customer, :with_stripe_payment_provider) }
+            let(:checkout_url) { "https://example.com" }
+
+            before do
+              allow(::Stripe::Checkout::Session).to receive(:create).and_return({"url" => checkout_url})
+
+              allow(Invoices::Payments::GeneratePaymentUrlService)
+                .to receive(:call).with(invoice: wallet_transaction.invoice).and_call_original
+            end
+
+            it "calls Invoices::Payments::GeneratePaymentUrlService" do
+              subject
+
+              expect(Invoices::Payments::GeneratePaymentUrlService)
+                .to have_received(:call)
+                .with(invoice: wallet_transaction.invoice)
+
+              expect(result).to be_success
+              expect(result.payment_url).to eq checkout_url
+            end
+          end
+        end
+      end
+
+      context "when transactions status is not purchased" do
+        let(:transaction_status) { WalletTransaction::TRANSACTION_STATUSES.excluding(:purchased).sample }
+        let(:status) { nil }
+
+        it "fails with wallet transaction not purchased error" do
+          expect(result).to be_failure
+          expect(result.error.messages).to match(base: ["wallet_transaction_not_purchased"])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Allow to generate payment url for failed or pending wallet transactions.

## Description

Add `payment_url` endpoint for wallet transactions.
