### PR TITLE
spec(dunning): Add scenario tests for dunning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,10 @@ Style/FrozenStringLiteralComment:
 Performance/CaseWhenSplat:
   Enabled: true
 
+Rails/ApplicationJob:
+  Exclude:
+    - 'spec/support/jobs/**/*'
+
 Rails/InverseOf:
   Description: 'Checks for associations where the inverse cannot be determined automatically.'
   Enabled: false

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -88,7 +88,7 @@ module PaymentProviders
         end
 
         def update_payment_method_id
-          result = ::Stripe::Customer.retrieve(
+          stripe_customer = ::Stripe::Customer.retrieve(
             provider_customer.provider_customer_id,
             {api_key: payment_provider.secret_key}
           )
@@ -96,9 +96,9 @@ module PaymentProviders
           # TODO: stripe customer should be updated/deleted
           # TODO: deliver error webhook
           # TODO(payment): update payment status
-          return if result.deleted?
+          return if stripe_customer.deleted?
 
-          if (payment_method_id = result.invoice_settings.default_payment_method || result.default_source)
+          if (payment_method_id = stripe_customer.invoice_settings.default_payment_method || stripe_customer.default_source)
             provider_customer.update!(payment_method_id:)
           end
         end

--- a/spec/fixtures/stripe/payment_intent_failed_card_declined.json
+++ b/spec/fixtures/stripe/payment_intent_failed_card_declined.json
@@ -1,0 +1,310 @@
+{
+  "error": {
+    "advice_code": "try_again_later",
+    "charge": "ch_3QwwOwQ8iJWBZFaM2NuTw8mv",
+    "code": "card_declined",
+    "decline_code": "generic_decline",
+    "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+    "message": "Your card was declined.",
+    "payment_intent": {
+      "id": "pi_3QwwOwQ8iJWBZFaM2eEGbwPE",
+      "object": "payment_intent",
+      "amount": 8404,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": {}
+      },
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {
+        "object": "list",
+        "data": [
+          {
+            "id": "ch_3QwwOwQ8iJWBZFaM2NuTw8mv",
+            "object": "charge",
+            "amount": 8404,
+            "amount_captured": 0,
+            "amount_refunded": 0,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": "FR",
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": "adadwa@adw.coo",
+              "name": "Testing Stripe",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "JULIEN",
+            "captured": false,
+            "created": 1740621638,
+            "currency": "usd",
+            "customer": "cus_RqdXlBPlUJcVEr",
+            "description": "Hooli - Invoice HOO-CAAB-020-002",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_balance_transaction": null,
+            "failure_code": "card_declined",
+            "failure_message": "Your card was declined.",
+            "fraud_details": {},
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "invoice_type": "subscription",
+              "lago_customer_id": "599fb683-48da-4a30-bc5d-a1f0dc489598",
+              "invoice_issuing_date": "2025-02-27",
+              "lago_invoice_id": "95bde9bb-bbfb-4d41-a407-ea4fede7a134"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "advice_code": "try_again_later",
+              "network_advice_code": null,
+              "network_decline_code": null,
+              "network_status": "declined_by_network",
+              "reason": "generic_decline",
+              "risk_level": "normal",
+              "risk_score": 33,
+              "seller_message": "The bank did not return any further details with this decline.",
+              "type": "issuer_declined"
+            },
+            "paid": false,
+            "payment_intent": "pi_3QwwOwQ8iJWBZFaM2eEGbwPE",
+            "payment_method": "pm_1QwwGpQ8iJWBZFaMc5BLs95R",
+            "payment_method_details": {
+              "card": {
+                "amount_authorized": null,
+                "authorization_code": null,
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "exp_month": 12,
+                "exp_year": 2028,
+                "extended_authorization": {
+                  "status": "disabled"
+                },
+                "fingerprint": "pmIfA8TCefcd72yD",
+                "funding": "credit",
+                "incremental_authorization": {
+                  "status": "unavailable"
+                },
+                "installments": null,
+                "last4": "0341",
+                "mandate": null,
+                "multicapture": {
+                  "status": "unavailable"
+                },
+                "network": "visa",
+                "network_token": {
+                  "used": false
+                },
+                "network_transaction_id": "112109731026556",
+                "overcapture": {
+                  "maximum_amount_capturable": 8404,
+                  "status": "unavailable"
+                },
+                "regulated_status": "unregulated",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "radar_options": {},
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": null,
+            "refunded": false,
+            "refunds": {
+              "object": "list",
+              "data": [],
+              "has_more": false,
+              "total_count": 0,
+              "url": "/v1/charges/ch_3QwwOwQ8iJWBZFaM2NuTw8mv/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": null,
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "failed",
+            "transfer_data": null,
+            "transfer_group": null
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/charges?payment_intent=pi_3QwwOwQ8iJWBZFaM2eEGbwPE"
+      },
+      "client_secret": "pi_3Q**********************_******_*********************CfRX",
+      "confirmation_method": "automatic",
+      "created": 1740621638,
+      "currency": "usd",
+      "customer": "cus_RqdXlBPlUJcVEr",
+      "description": "Hooli - Invoice HOO-CAAB-020-002",
+      "invoice": null,
+      "last_payment_error": {
+        "advice_code": "try_again_later",
+        "charge": "ch_3QwwOwQ8iJWBZFaM2NuTw8mv",
+        "code": "card_declined",
+        "decline_code": "generic_decline",
+        "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+        "message": "Your card was declined.",
+        "payment_method": {
+          "id": "pm_1QwwGpQ8iJWBZFaMc5BLs95R",
+          "object": "payment_method",
+          "allow_redisplay": "always",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": "FR",
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": "adadwa@adw.coo",
+            "name": "Testing Stripe",
+            "phone": null
+          },
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": null,
+              "address_postal_code_check": null,
+              "cvc_check": "pass"
+            },
+            "country": "US",
+            "display_brand": "visa",
+            "exp_month": 12,
+            "exp_year": 2028,
+            "fingerprint": "pmIfA8TCefcd72yD",
+            "funding": "credit",
+            "generated_from": null,
+            "last4": "0341",
+            "networks": {
+              "available": [
+                "visa"
+              ],
+              "preferred": null
+            },
+            "regulated_status": "unregulated",
+            "three_d_secure_usage": {
+              "supported": true
+            },
+            "wallet": null
+          },
+          "created": 1740621135,
+          "customer": "cus_RqdXlBPlUJcVEr",
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+        },
+        "type": "card_error"
+      },
+      "latest_charge": "ch_3QwwOwQ8iJWBZFaM2NuTw8mv",
+      "livemode": false,
+      "metadata": {
+        "invoice_type": "subscription",
+        "lago_customer_id": "599fb683-48da-4a30-bc5d-a1f0dc489598",
+        "invoice_issuing_date": "2025-02-27",
+        "lago_invoice_id": "95bde9bb-bbfb-4d41-a407-ea4fede7a134"
+      },
+      "next_action": null,
+      "on_behalf_of": null,
+      "payment_method": null,
+      "payment_method_configuration_details": null,
+      "payment_method_options": {
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "setup_future_usage": null,
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "requires_payment_method",
+      "transfer_data": null,
+      "transfer_group": null
+    },
+    "payment_method": {
+      "id": "pm_1QwwGpQ8iJWBZFaMc5BLs95R",
+      "object": "payment_method",
+      "allow_redisplay": "always",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": "FR",
+          "line1": null,
+          "line2": null,
+          "postal_code": null,
+          "state": null
+        },
+        "email": "adadwa@adw.coo",
+        "name": "Testing Stripe",
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": null,
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "display_brand": "visa",
+        "exp_month": 12,
+        "exp_year": 2028,
+        "fingerprint": "pmIfA8TCefcd72yD",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "0341",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "regulated_status": "unregulated",
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1740621135,
+      "customer": "cus_RqdXlBPlUJcVEr",
+      "livemode": false,
+      "metadata": {},
+      "type": "card"
+    },
+    "request_log_url": "https://dashboard.stripe.com/test/logs/req_6GkSUWdWIhdhKz?t=1740621638",
+    "type": "card_error"
+  }
+}

--- a/spec/scenarios/credit_note_spec.rb
+++ b/spec/scenarios/credit_note_spec.rb
@@ -350,7 +350,7 @@ describe "Create credit note Scenarios", :scenarios, type: :request do
 
         it "solves the rounding issue" do
           #  create a one off invoice with two addons and small amounts as feed
-          create_one_off_invoice(customer, add_ons)
+          create_one_off_invoice(customer, add_ons, taxes: [tax.code])
           # invoice amount should be with taxes calculated on items sum:
           invoice = customer.invoices.order(:created_at).last
           expect(invoice.total_amount_cents).to eq(163_99)
@@ -466,7 +466,7 @@ describe "Create credit note Scenarios", :scenarios, type: :request do
 
         it "solves the rounding issue" do
           #  create a one off invoice with two addons and small amounts as feed
-          create_one_off_invoice(customer, add_ons)
+          create_one_off_invoice(customer, add_ons, taxes: [tax.code])
           # invoice amount should be with taxes calculated on items sum:
           invoice = customer.invoices.order(:created_at).last
           expect(invoice.total_amount_cents).to eq(327_98)

--- a/spec/scenarios/customers/create_partner_and_run_billing_spec.rb
+++ b/spec/scenarios/customers/create_partner_and_run_billing_spec.rb
@@ -136,7 +136,7 @@ describe "Create partner and run billing Scenarios", :scenarios, type: :request 
         inv.number.gsub("#{organization.document_number_prefix}-202406-", "")
       end.uniq.sort).to eq(["003", "004"])
     end
-    update_overdue_balance
+    perform_overdue_balance_update
 
     # check payments
     expect(partner.invoices.map(&:payments).flatten).to be_empty

--- a/spec/scenarios/dunning/campaign_v1_spec.rb
+++ b/spec/scenarios/dunning/campaign_v1_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Dunning Campaign v1", :scenarios, type: :request do
+  let(:webhook_url) { "https://test.co/lago" }
+  let(:organization) do
+    create(:organization,
+      name: "JC AI",
+      premium_integrations: %w[auto_dunning],
+      email_settings: [],
+      webhook_url:)
+  end
+
+  let(:dunning_campaign) do
+    create(:dunning_campaign, organization:,
+      applied_to_organization: true, max_attempts: 2, days_between_attempts: 2)
+  end
+  let(:dunning_campaign_threshold) do
+    create(:dunning_campaign_threshold, dunning_campaign:, amount_cents: 150_00, currency: "EUR")
+  end
+  let(:stripe_cus_id) { "cus_123456789" }
+  let(:stripe_pm_id) { "pm_123456" }
+
+  let(:stripe_provider) { create(:stripe_provider, organization:) }
+  let(:customer) { create(:customer, organization:, payment_provider: :stripe, payment_provider_code: stripe_provider.code, net_payment_term: 2) }
+  let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider: stripe_provider, provider_customer_id: stripe_cus_id) }
+
+  let(:external_subscription_id) { "sub_overdue-dunning-campaign-v1" }
+  let(:plan) { create(:plan, organization:, pay_in_advance: true, amount_cents: 149_00) }
+  let!(:addon) { create(:add_on, organization:) }
+
+  let(:webhooks_sent) { [] }
+
+  let(:stripe_customer_response) do
+    File.read("spec/fixtures/stripe/customer_retrieve_response.json")
+  end
+  # TODO: this is part of another PR coming soon https://github.com/getlago/lago-api/pull/3345
+  let(:stripe_payment_method_response) do
+    {
+      id: stripe_pm_id,
+      object: "payment_method",
+      allow_redisplay: "always",
+      billing_details: {
+        address: {
+          city: nil,
+          country: "FR",
+          line1: nil,
+          line2: nil,
+          postal_code: nil,
+          state: nil
+        },
+        email: "awdawd@desf.com",
+        name: "Testing Stripe",
+        phone: nil
+      },
+      card: {
+        brand: "visa",
+        checks: {
+          address_line1_check: nil,
+          address_postal_code_check: nil,
+          cvc_check: "pass"
+        },
+        country: "US",
+        display_brand: "visa",
+        exp_month: 12,
+        exp_year: 2028,
+        fingerprint: "8TOiB4cGytYxCweY",
+        funding: "credit",
+        generated_from: nil,
+        last4: "4242",
+        networks: {
+          available: [
+            "visa"
+          ],
+          preferred: nil
+        },
+        regulated_status: "unregulated",
+        three_d_secure_usage: {
+          supported: true
+        },
+        wallet: nil
+      },
+      created: 1741878064,
+      customer: stripe_cus_id,
+      livemode: false,
+      metadata: {},
+      type: "card"
+    }
+  end
+  let(:stripe_payment_intent_response) do
+    File.read("spec/fixtures/stripe/payment_intent_failed_card_declined.json")
+  end
+
+  # TODO: make it a test metadata `:scenarios, type: :request, premium: true`
+  around { |test| lago_premium!(&test) }
+
+  before do
+    stub_pdf_generation
+    stripe_customer
+    dunning_campaign_threshold
+
+    stub_request(:post, webhook_url).with do |req|
+      webhooks_sent << JSON.parse(req.body)
+      true
+    end.and_return(status: 200)
+
+    stub_request(:get, "https://api.stripe.com/v1/customers/#{stripe_customer.provider_customer_id}")
+      .and_return(status: 200, body: stripe_customer_response)
+    stub_request(:get, "https://api.stripe.com/v1/customers/#{stripe_customer.provider_customer_id}/payment_methods/pm_123456")
+      .and_return(status: 200, body: stripe_payment_method_response.to_json)
+    stub_request(:post, "https://api.stripe.com/v1/payment_intents")
+      .and_return(status: 402, body: stripe_payment_intent_response)
+    stub_request(:post, "https://api.stripe.com/v1/checkout/sessions")
+      .and_return(status: 200, body: {url: "https://stripe.com/checkout/session/cs_test_123"}.to_json)
+  end
+
+  it do
+    travel_to(DateTime.new(2025, 1, 1, 10)) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: external_subscription_id,
+          plan_code: plan.code
+        }
+      )
+      perform_billing
+
+      expect(webhooks_sent.map { _1["webhook_type"] }).to eq(%w[
+        subscription.started
+        invoice.created
+        invoice.generated
+        invoice.payment_failure
+      ])
+      invoice = customer.invoices.sole
+      expect(invoice.payment_status).to eq("failed")
+      expect(invoice.payment_due_date).to eq(Date.new(2025, 1, 3))
+    end
+
+    # The day after payment_due_date, the invoice should be marked as overdue
+    travel_to(DateTime.new(2025, 1, 4, 13)) do
+      perform_overdue_balance_update
+
+      invoice = customer.invoices.sole
+      expect(invoice).to be_payment_overdue
+      expect(customer.overdue_balance_cents).to eq(149_00)
+
+      # Performing dunning has no effect because the threshold is 150 and we have only 149 overdue
+      perform_dunning
+      expect(customer.payment_requests.count).to eq(0)
+    end
+
+    # Create a one-off invoice to reach the threshold
+    travel_to(DateTime.new(2025, 1, 4, 18)) do
+      create_one_off_invoice(customer, [addon], units: 3)
+      perform_all_enqueued_jobs
+
+      oneoff = customer.invoices.one_off.sole
+      expect(oneoff.payment_status).to eq("failed")
+      expect(oneoff.payment_due_date).to eq(Date.new(2025, 1, 6))
+    end
+
+    travel_to(DateTime.new(2025, 1, 7, 10)) do
+      perform_overdue_balance_update
+      expect(customer.invoices.one_off.sole).to be_payment_overdue
+
+      expect(ActionMailer::Base.deliveries.count).to eq(0)
+      perform_dunning
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.subject).to eq "Your overdue balance from JC AI"
+
+      pr = customer.payment_requests.sole
+      expect(pr.amount_cents).to eq(155_00)
+
+      # TODO Simulate webhook payment failed received
+    end
+
+    # The next 2 days nothing happens
+    [DateTime.new(2025, 1, 8, 10), DateTime.new(2025, 1, 9, 10)].each do |date|
+      travel_to(date) do
+        perform_overdue_balance_update
+        perform_dunning
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+      end
+    end
+
+    # The next day nothing happens
+    travel_to(DateTime.new(2025, 1, 10, 10)) do
+      perform_overdue_balance_update
+      perform_dunning
+      expect(ActionMailer::Base.deliveries.count).to eq(2)
+
+      expect(customer.payment_requests.reload.map(&:amount_cents)).to eq([155_00, 155_00])
+    end
+
+    # This is over
+    travel_to(DateTime.new(2025, 1, 13, 13)) do
+      perform_overdue_balance_update
+      perform_dunning
+      expect(ActionMailer::Base.deliveries.count).to eq(2)
+    end
+  end
+end

--- a/spec/support/jobs/mock_stripe_webhook_event_job.rb
+++ b/spec/support/jobs/mock_stripe_webhook_event_job.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Jobs
+  class MockStripeWebhookEventJob < ActiveJob::Base
+    def perform(organization, request_body, response_body)
+      @organization = organization
+      @request_body = request_body.deep_symbolize_keys
+      @response_body = response_body.deep_symbolize_keys
+
+      @status = @response_body[:error] ? "failed" : "succeeded"
+
+      # NOTE: Update Payment in our database because `PaymentRequests::Payments::StripeService.update_payment_status`
+      #       relies on Payment.find_by(provider_payment_id: stripe_payment.id)
+      lago_payment_id = @request_body[:metadata][:lago_payment_id]
+      Payment.find(lago_payment_id).update!(provider_payment_id: payment_intent_id)
+
+      result = PaymentProviders::Stripe::HandleEventService.call(
+        organization:,
+        event_json: build_event.to_json
+      )
+      result.raise_if_error!
+    end
+
+    def build_event
+      {
+        id: "evt_#{SecureRandom.hex(10)}",
+        object: "event",
+        created: Time.current.to_i,
+        type: (status == "succeeded") ? "payment_intent.succeeded" : "payment_intent.payment_failed",
+        data: {
+          object: {
+            id: payment_intent_id,
+            object: "payment_intent",
+            status: status.to_s,
+            metadata: request_body[:metadata]
+          }
+        }
+      }
+    end
+
+    private
+
+    attr_reader :organization, :request_body, :status, :response_body
+
+    def payment_intent_id
+      response_body.dig(:error, :payment_intent, :id)
+    end
+  end
+end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -72,7 +72,7 @@ module ScenariosHelper
     invoice.reload
   end
 
-  def create_one_off_invoice(customer, addons)
+  def create_one_off_invoice(customer, addons, taxes: [], units: 1)
     create_invoice_params = {
       external_customer_id: customer.external_id,
       currency: "EUR",
@@ -84,11 +84,9 @@ module ScenariosHelper
         add_on_id: fee.id,
         add_on_code: fee.code,
         name: fee.name,
-        units: 1,
+        units:,
         unit_amount_cents: fee.amount_cents,
-        tax_codes: [
-          tax.code
-        ]
+        tax_codes: taxes
       }
       create_invoice_params[:fees].push(fee_addon_params)
     end
@@ -203,8 +201,13 @@ module ScenariosHelper
     perform_all_enqueued_jobs
   end
 
-  def update_overdue_balance
+  def perform_overdue_balance_update
     Clock::MarkInvoicesAsPaymentOverdueJob.perform_later
+    perform_all_enqueued_jobs
+  end
+
+  def perform_dunning
+    Clock::ProcessDunningCampaignsJob.perform_later
     perform_all_enqueued_jobs
   end
 end


### PR DESCRIPTION
This PR adds a new scenario test for dunning campaign.

The interesting part are:
* mocking stripe at the HTTP level 
* simulating the reception of the Stripe webhooks
* testing emails sent
* testing Lago webhook sent by "logging" them rathen than mocking job

The new jobs in `spec/support/jobs/` extend `ActiveJob::Base` instead of `ApplicationJob` because they are NOT jobs from the applications but fake jobs only meant to be run in spec to help mock behavior. 