### PR TITLE
fix(fees): Fix advance fees query

### DIFF
--- a/app/services/events/pay_in_advance_service.rb
+++ b/app/services/events/pay_in_advance_service.rb
@@ -51,7 +51,7 @@ module Events
     end
 
     def already_processed?
-      Fee.from_organization(event.organization).where(pay_in_advance_event_transaction_id: event.transaction_id).exists?
+      Fee.from_organization_pay_in_advance(event.organization).where(pay_in_advance_event_transaction_id: event.transaction_id).exists?
     end
 
     def can_create_fee?

--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -46,8 +46,8 @@ module Invoices
       # NOTE: filter all active/terminated subscriptions having non-invoiceable fees not yet attached to an invoice
       @subscriptions ||= organization.subscriptions
         .where(
-          id: Fee.from_organization(organization)
-            .where(invoice_id: nil, payment_status: :succeeded)
+          id: Fee.from_organization_pay_in_advance(organization)
+            .where(payment_status: :succeeded)
             .where("succeeded_at <= ?", billing_at)
             .joins(:subscription)
             .where(subscriptions: {


### PR DESCRIPTION
- Do not use the scope `from_organization` that will search for all fees for the organization, especially for the add_on. We're only interested for `in_advance` fees here