### PR TITLE
feat(multi-entities) Invoices services with billing entities

### DIFF
--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -14,6 +14,7 @@ module Invoices
       ActiveRecord::Base.transaction do
         invoice = Invoice.create!(
           organization: customer.organization,
+          billing_entity: customer.billing_entity,
           customer:,
           issuing_date:,
           payment_due_date:,

--- a/app/services/invoices/create_generating_service.rb
+++ b/app/services/invoices/create_generating_service.rb
@@ -21,6 +21,7 @@ module Invoices
         invoice = Invoice.create!(
           id: invoice_id || SecureRandom.uuid,
           organization:,
+          billing_entity: customer.billing_entity,
           customer:,
           invoice_type:,
           currency:,

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -25,6 +25,7 @@ module Invoices
 
       @invoice = Invoice.new(
         organization:,
+        billing_entity:,
         customer:,
         invoice_type: :subscription,
         currency: first_subscription.plan.amount_currency,
@@ -51,6 +52,7 @@ module Invoices
 
     attr_accessor :customer, :subscriptions, :invoice, :applied_coupons, :first_subscription, :persisted_subscriptions, :subscription_context
     delegate :organization, to: :customer
+    delegate :billing_entity, to: :customer
 
     def fetch_context
       return :terminated if subscriptions.any?(&:terminated?)

--- a/db/migrate/20250325162648_assign_invoices_to_billing_entities.rb
+++ b/db/migrate/20250325162648_assign_invoices_to_billing_entities.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AssignInvoicesToBillingEntities < ActiveRecord::Migration[7.2]
+  def change
+    Invoice.find_in_batches(batch_size: 1000) do |batch|
+      Invoice.where(id: batch.pluck(:id))
+        .update_all("billing_entity_id = organization_id") # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_24_125056) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_25_162648) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/spec/services/billing_entities/resolve_service_spec.rb
+++ b/spec/services/billing_entities/resolve_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe BillingEntities::ResolveService do
     it "returns not found failure" do
       expect(result).to be_failure
       expect(result.error).to be_a(BaseService::NotFoundFailure)
+      expect(result.error.resource).to eq("billing_entity")
       expect(result.error.error_code).to eq("billing_entity_not_found")
     end
   end
@@ -42,6 +43,7 @@ RSpec.describe BillingEntities::ResolveService do
       it "returns not found failure" do
         expect(result).to be_failure
         expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("billing_entity")
         expect(result.error.error_code).to eq("billing_entity_not_found")
       end
     end

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -25,27 +25,25 @@ RSpec.describe Invoices::AddOnService, type: :service do
     it "creates an invoice" do
       result = invoice_service.create
 
-      aggregate_failures do
-        expect(result).to be_success
+      expect(result).to be_success
 
-        expect(result.invoice.subscriptions.first).to be_nil
-        expect(result.invoice).to have_attributes(
-          issuing_date: datetime.to_date,
-          invoice_type: "add_on",
-          payment_status: "pending",
-          currency: "EUR",
-          fees_amount_cents: 200,
-          sub_total_excluding_taxes_amount_cents: 200,
-          taxes_amount_cents: 40,
-          taxes_rate: 20,
-          sub_total_including_taxes_amount_cents: 240,
-          total_amount_cents: 240
-        )
+      expect(result.invoice.subscriptions.first).to be_nil
+      expect(result.invoice).to have_attributes(
+        issuing_date: datetime.to_date,
+        invoice_type: "add_on",
+        payment_status: "pending",
+        currency: "EUR",
+        fees_amount_cents: 200,
+        sub_total_excluding_taxes_amount_cents: 200,
+        taxes_amount_cents: 40,
+        taxes_rate: 20,
+        sub_total_including_taxes_amount_cents: 240,
+        total_amount_cents: 240
+      )
 
-        expect(result.invoice.applied_taxes.count).to eq(1)
+      expect(result.invoice.applied_taxes.count).to eq(1)
 
-        expect(result.invoice).to be_finalized
-      end
+      expect(result.invoice).to be_finalized
     end
 
     it "enqueues a SendWebhookJob" do

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe Invoices::AddOnService, type: :service do
 
       expect(result.invoice.subscriptions.first).to be_nil
       expect(result.invoice).to have_attributes(
+        organization: organization,
+        billing_entity: customer.billing_entity,
         issuing_date: datetime.to_date,
         invoice_type: "add_on",
         payment_status: "pending",

--- a/spec/services/invoices/create_generating_service_spec.rb
+++ b/spec/services/invoices/create_generating_service_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Invoices::CreateGeneratingService, type: :service do
       expect(result.invoice).to be_generating
       expect(result.invoice.organization).to eq(customer.organization)
       expect(result.invoice.customer).to eq(customer)
+      expect(result.invoice.billing_entity).to eq(customer.billing_entity)
       expect(result.invoice).to be_one_off
       expect(result.invoice.currency).to eq(currency)
       expect(result.invoice.timezone).to eq(customer.applicable_timezone)

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -84,6 +84,8 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
 
       expect(result).to be_success
       expect(result.invoice).to be_a(Invoice)
+      expect(result.invoice.organization).to eq(organization)
+      expect(result.invoice.billing_entity).to eq(customer.billing_entity)
       expect(result.invoice.total_paid_amount_cents).to eq(0)
       expect(result.invoice.prepaid_credit_amount_cents).to eq(0)
 

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -104,6 +104,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             result = preview_service.call
 
             expect(result).to be_success
+            expect(result.invoice.organization).to eq(organization)
+            expect(result.invoice.billing_entity).to eq(customer.billing_entity)
             expect(result.invoice.subscriptions.first).to eq(subscription)
             expect(result.invoice.fees.length).to eq(1)
             expect(result.invoice.invoice_type).to eq("subscription")
@@ -139,6 +141,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               result = preview_service.call
 
               expect(result).to be_success
+              expect(result.invoice.organization).to eq(organization)
+              expect(result.invoice.billing_entity).to eq(customer.billing_entity)
               expect(result.invoice.subscriptions.first).to eq(subscription)
               expect(result.invoice.fees.length).to eq(1)
               expect(result.invoice.invoice_type).to eq("subscription")
@@ -188,6 +192,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 result = preview_service.call
 
                 expect(result).to be_success
+                expect(result.invoice.organization).to eq(organization)
+                expect(result.invoice.billing_entity).to eq(customer.billing_entity)
                 expect(result.invoice.subscriptions.first).to eq(subscription)
                 expect(result.invoice.fees.length).to eq(2)
                 expect(result.invoice.invoice_type).to eq("subscription")
@@ -402,6 +408,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               result = preview_service.call
 
               expect(result).to be_success
+              expect(result.invoice.organization).to eq(organization)
+              expect(result.invoice.billing_entity).to eq(customer.billing_entity)
               expect(result.invoice.subscriptions.first).to eq(subscription)
               expect(result.invoice.fees.length).to eq(1)
               expect(result.invoice.invoice_type).to eq("subscription")
@@ -437,6 +445,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               result = preview_service.call
 
               expect(result).to be_success
+              expect(result.invoice.organization).to eq(organization)
+              expect(result.invoice.billing_entity).to eq(customer.billing_entity)
               expect(result.invoice.subscriptions.first).to eq(subscription)
               expect(result.invoice.fees.length).to eq(1)
               expect(result.invoice.invoice_type).to eq("subscription")
@@ -574,6 +584,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               result = described_class.new(customer:, subscriptions: [subscription], applied_coupons: [applied_coupon]).call
 
               expect(result).to be_success
+              expect(result.invoice.organization).to eq(organization)
+              expect(result.invoice.billing_entity).to eq(customer.billing_entity)
               expect(result.invoice.subscriptions.first).to eq(subscription)
               expect(result.invoice.fees.length).to eq(1)
               expect(result.invoice.invoice_type).to eq("subscription")
@@ -610,6 +622,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               result = preview_service.call
 
               expect(result).to be_success
+              expect(result.invoice.organization).to eq(organization)
+              expect(result.invoice.billing_entity).to eq(customer.billing_entity)
               expect(result.invoice.subscriptions.first).to eq(subscription)
               expect(result.invoice.fees.length).to eq(1)
               expect(result.invoice.invoice_type).to eq("subscription")
@@ -703,6 +717,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 result = preview_service.call
 
                 expect(result).to be_success
+                expect(result.invoice.organization).to eq(organization)
+                expect(result.invoice.billing_entity).to eq(customer.billing_entity)
                 expect(result.invoice.subscriptions.first).to eq(subscription)
                 expect(result.invoice.fees.length).to eq(1)
                 expect(result.invoice.invoice_type).to eq("subscription")
@@ -778,6 +794,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             result = preview_service.call
 
             expect(result).to be_success
+            expect(result.invoice.organization).to eq(organization)
+            expect(result.invoice.billing_entity).to eq(customer.billing_entity)
             expect(result.invoice.subscriptions.first).to eq(subscription)
             expect(result.invoice.fees.length).to eq(1)
             expect(result.invoice.invoice_type).to eq("subscription")
@@ -811,6 +829,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               result = preview_service.call
 
               expect(result).to be_success
+              expect(result.invoice.organization).to eq(organization)
+              expect(result.invoice.billing_entity).to eq(customer.billing_entity)
               expect(result.invoice.subscriptions.first).to eq(subscription)
               expect(result.invoice.fees.length).to eq(1)
               expect(result.invoice.invoice_type).to eq("subscription")
@@ -858,6 +878,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 result = preview_service.call
 
                 expect(result).to be_success
+                expect(result.invoice.organization).to eq(organization)
+                expect(result.invoice.billing_entity).to eq(customer.billing_entity)
                 expect(result.invoice.subscriptions.first).to eq(subscription)
                 expect(result.invoice.fees.length).to eq(2)
                 expect(result.invoice.invoice_type).to eq("subscription")
@@ -907,6 +929,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               result = preview_service.call
 
               expect(result).to be_success
+              expect(result.invoice.organization).to eq(organization)
+              expect(result.invoice.billing_entity).to eq(customer.billing_entity)
               expect(result.invoice.subscriptions.map { |s| s.id }).to match_array([subscription1.id, subscription2.id])
               expect(result.invoice.fees.length).to eq(2)
               expect(result.invoice.invoice_type).to eq("subscription")


### PR DESCRIPTION
This PR depends on https://github.com/getlago/lago-api/pull/3377 that needs to be merged first.

## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

## Description

On invoice generation assign customer's billing entity reference.

Also assign all existing Invoices to the organization default billing entity (matching the organization_id). This is needed to later implement and populate the billing_entity_sequential_id for each invoice.