### PR TITLE
feat(LifetimeUsage): Add lifetime_usage premium integration 

### DIFF
--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -50,7 +50,7 @@ module Types
       end
 
       def lifetime_usage
-        return nil unless object.plan.usage_thresholds.any?
+        return nil unless object.plan.usage_thresholds.any? || object.organization.lifetime_usage_enabled?
 
         object.lifetime_usage
       end

--- a/app/jobs/clock/refresh_lifetime_usages_job.rb
+++ b/app/jobs/clock/refresh_lifetime_usages_job.rb
@@ -19,7 +19,7 @@ module Clock
     def perform
       return unless License.premium?
 
-      LifetimeUsage.joins(:organization).merge(Organization.with_progressive_billing_support).needs_recalculation.find_each do |ltu|
+      LifetimeUsage.joins(:organization).merge(Organization.with_progressive_billing_support.or(Organization.with_lifetime_usage_support)).needs_recalculation.find_each do |ltu|
         LifetimeUsages::RecalculateAndCheckJob.perform_later(ltu)
       end
     end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -79,6 +79,7 @@ class Organization < ApplicationRecord
     anrok
     xero
     progressive_billing
+    lifetime_usage
     hubspot
     auto_dunning
     revenue_analytics

--- a/app/services/lifetime_usages/flag_refresh_from_invoice_service.rb
+++ b/app/services/lifetime_usages/flag_refresh_from_invoice_service.rb
@@ -9,7 +9,7 @@ module LifetimeUsages
 
     def call
       return result unless invoice.subscription?
-      return result unless has_plan_usage_thresholds?
+      return result unless should_flag_refresh_from_invoice?
 
       result.lifetime_usages = []
 
@@ -31,8 +31,8 @@ module LifetimeUsages
 
     attr_reader :invoice
 
-    def has_plan_usage_thresholds?
-      invoice.subscriptions.any? { |s| s.plan.usage_thresholds.any? }
+    def should_flag_refresh_from_invoice?
+      invoice.organization.lifetime_usage_enabled? || invoice.subscriptions.any? { |s| s.plan.usage_thresholds.any? }
     end
   end
 end

--- a/app/services/lifetime_usages/flag_refresh_from_subscription_service.rb
+++ b/app/services/lifetime_usages/flag_refresh_from_subscription_service.rb
@@ -9,7 +9,7 @@ module LifetimeUsages
 
     def call
       return result unless subscription.active?
-      return result unless subscription.plan.usage_thresholds.any?
+      return result unless should_flag_refresh_from_subscription?
 
       lifetime_usage = subscription.lifetime_usage
       lifetime_usage ||= subscription.build_lifetime_usage(organization: subscription.organization)
@@ -26,5 +26,9 @@ module LifetimeUsages
     private
 
     attr_reader :subscription
+
+    def should_flag_refresh_from_subscription?
+      subscription.organization.lifetime_usage_enabled? || subscription.plan.usage_thresholds.any?
+    end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4631,6 +4631,7 @@ enum IntegrationTypeEnum {
   from_email
   hubspot
   issue_receipts
+  lifetime_usage
   manual_payments
   multi_entities_enterprise
   multi_entities_pro
@@ -6722,6 +6723,7 @@ enum PremiumIntegrationTypeEnum {
   from_email
   hubspot
   issue_receipts
+  lifetime_usage
   manual_payments
   multi_entities_enterprise
   multi_entities_pro

--- a/schema.json
+++ b/schema.json
@@ -21893,6 +21893,12 @@
               "deprecationReason": null
             },
             {
+              "name": "lifetime_usage",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "hubspot",
               "description": null,
               "isDeprecated": false,
@@ -32703,6 +32709,12 @@
             },
             {
               "name": "progressive_billing",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lifetime_usage",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
+++ b/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Types::Integrations::PremiumIntegrationTypeEnum do
       netsuite
       okta
       progressive_billing
+      lifetime_usage
       revenue_analytics
       revenue_share
       salesforce

--- a/spec/scenarios/lifetime_usages/without_progressive_billing_spec.rb
+++ b/spec/scenarios/lifetime_usages/without_progressive_billing_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Lifetime usage without progressive billing", :time_travel, :scenarios, type: :request do
+  around { |test| lago_premium!(&test) }
+
+  let(:organization) { create(:organization, webhook_url: nil, email_settings: [], premium_integrations: ["lifetime_usage"]) }
+  let(:plan) { create(:plan, organization: organization, interval: "monthly", amount_cents: 31_00, pay_in_advance: false) }
+
+  let(:customer) { create(:customer, organization: organization) }
+  let(:billable_metric) { create(:billable_metric, organization: organization, field_name: "total", aggregation_type: "sum_agg") }
+  let(:charge) { create(:charge, plan: plan, billable_metric: billable_metric, charge_model: "standard", properties: {"amount" => "0.01"}) }
+
+  before do
+    charge
+  end
+
+  it "calculates lifetime usage" do
+    create_subscription(
+      {
+        external_customer_id: customer.external_id,
+        external_id: customer.external_id,
+        plan_code: plan.code
+      }
+    )
+    subscription = customer.subscriptions.first
+
+    lifetime_usage = subscription.lifetime_usage
+    expect(lifetime_usage).not_to be_nil
+
+    pass_time 4.days
+
+    ingest_event(subscription, billable_metric, 1000000)
+
+    expect(lifetime_usage.reload.current_usage_amount_cents).to eq(1_000_000)
+    expect(Invoice.count).to eq(0)
+
+    pass_time 1.day
+
+    ingest_event(subscription, billable_metric, 1000000)
+    expect(lifetime_usage.reload.current_usage_amount_cents).to eq(2_000_000)
+    expect(Invoice.count).to eq(0)
+
+    pass_time 29.days
+
+    expect(Invoice.count).to eq(1)
+
+    invoice = Invoice.sole
+
+    expect(invoice.total_amount_cents).to eq(31_00 + 2_000_000)
+    expect(invoice.invoice_type).to eq("subscription")
+  end
+end

--- a/spec/scenarios/lifetime_usages/without_progressive_billing_spec.rb
+++ b/spec/scenarios/lifetime_usages/without_progressive_billing_spec.rb
@@ -5,18 +5,19 @@ require "rails_helper"
 describe "Lifetime usage without progressive billing", :time_travel, :scenarios, type: :request do
   around { |test| lago_premium!(&test) }
 
-  let(:organization) { create(:organization, webhook_url: nil, email_settings: [], premium_integrations: ["lifetime_usage"]) }
+  let(:organization) { create(:organization, webhook_url: nil, email_settings: [], premium_integrations: ["lifetime_usage", "progressive_billing"]) }
   let(:plan) { create(:plan, organization: organization, interval: "monthly", amount_cents: 31_00, pay_in_advance: false) }
 
   let(:customer) { create(:customer, organization: organization) }
   let(:billable_metric) { create(:billable_metric, organization: organization, field_name: "total", aggregation_type: "sum_agg") }
   let(:charge) { create(:charge, plan: plan, billable_metric: billable_metric, charge_model: "standard", properties: {"amount" => "0.01"}) }
+  let(:threshold_amount_cents) { 1000 }
 
   before do
     charge
   end
 
-  it "calculates lifetime usage" do
+  it "calculates lifetime usage without generating invoices" do
     create_subscription(
       {
         external_customer_id: customer.external_id,
@@ -50,5 +51,57 @@ describe "Lifetime usage without progressive billing", :time_travel, :scenarios,
 
     expect(invoice.total_amount_cents).to eq(31_00 + 2_000_000)
     expect(invoice.invoice_type).to eq("subscription")
+  end
+
+  it "calculates lifetime usage and does not issue progressive billing invoices once added to the plan" do
+    create_subscription(
+      {
+        external_customer_id: customer.external_id,
+        external_id: customer.external_id,
+        plan_code: plan.code
+      }
+    )
+    subscription = customer.subscriptions.first
+
+    lifetime_usage = subscription.lifetime_usage
+    expect(lifetime_usage).not_to be_nil
+
+    pass_time 4.days
+
+    ingest_event(subscription, billable_metric, 1000000)
+
+    expect(lifetime_usage.reload.current_usage_amount_cents).to eq(1_000_000)
+    expect(Invoice.count).to eq(0)
+
+    pass_time 1.day
+
+    ingest_event(subscription, billable_metric, 1000000)
+    expect(lifetime_usage.reload.current_usage_amount_cents).to eq(2_000_000)
+    expect(Invoice.count).to eq(0)
+
+    pass_time 29.days
+
+    expect(Invoice.count).to eq(1)
+
+    invoice = Invoice.sole
+
+    expect(invoice.total_amount_cents).to eq(31_00 + 2_000_000)
+    expect(invoice.invoice_type).to eq("subscription")
+
+    pass_time 1.day
+    update_plan(plan, usage_thresholds: [
+      {
+        amount_cents: threshold_amount_cents
+      }
+    ])
+
+    pass_time 2.days
+
+    expect(Invoice.count).to eq(1)
+
+    ingest_event(subscription, billable_metric, 1000000)
+    expect(lifetime_usage.reload.current_usage_amount_cents).to eq(1_000_000)
+    expect(lifetime_usage.reload.invoiced_usage_amount_cents).to eq(2_000_000)
+    expect(Invoice.count).to eq(1)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,6 +108,8 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:deletion)
   end
 
+  config.include_context "with Time travel enabled", :time_travel
+
   config.before do |example|
     ActiveJob::Base.queue_adapter.enqueued_jobs.clear
     DatabaseCleaner.strategy = :transaction

--- a/spec/support/shared_context/time_travel.rb
+++ b/spec/support/shared_context/time_travel.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+PassedTime = Struct.new(:days)
+
+RSpec.shared_context "with Time travel enabled" do
+  # Standard time on which all things start
+  # can simply be overriden via a let(:time0) {} in your own spec!
+  let(:time0) { DateTime.new(2022, 12, 1) }
+  let(:passed_time) { PassedTime.new(0) }
+
+  before do
+    passed_time.days = 0
+    travel_to time0
+  end
+
+  def pass_time(amount)
+    amount_of_days = amount / 1.day
+    amount_of_days.times do |i|
+      perform_billing
+      travel_to time0 + passed_time.days + i.day
+    end
+    perform_billing
+    passed_time.days += amount_of_days
+  end
+end


### PR DESCRIPTION
## Description

Some customers want the lifetime usage of a subscription to always be refreshed for all subscriptions. (Even if the plan does not include progressive billing thresholds). This new premium integration enables that.

