### PR TITLE
Feat(multientities): assign billing_entity_id when creating fees

### DIFF
--- a/app/services/fees/add_on_service.rb
+++ b/app/services/fees/add_on_service.rb
@@ -2,6 +2,8 @@
 
 module Fees
   class AddOnService < BaseService
+    Result = BaseResult[:fee]
+
     def initialize(invoice:, applied_add_on:)
       @invoice = invoice
       @applied_add_on = applied_add_on
@@ -45,9 +47,6 @@ module Fees
     private
 
     attr_reader :invoice, :applied_add_on
-
-    # do we really need these customer and organization?
-    # delegate :customer, :organization, to: :invoice
 
     def already_billed?
       existing_fee = invoice.fees.find_by(applied_add_on_id: applied_add_on.id)

--- a/app/services/fees/add_on_service.rb
+++ b/app/services/fees/add_on_service.rb
@@ -15,7 +15,8 @@ module Fees
 
       new_fee = Fee.new(
         invoice:,
-        organization_id: organization.id,
+        organization_id: invoice.organization_id,
+        billing_entity_id: invoice.billing_entity_id,
         applied_add_on:,
         amount_cents:,
         precise_amount_cents: amount_cents.to_d,
@@ -45,7 +46,8 @@ module Fees
 
     attr_reader :invoice, :applied_add_on
 
-    delegate :customer, :organization, to: :invoice
+    # do we really need these customer and organization?
+    # delegate :customer, :organization, to: :invoice
 
     def already_billed?
       existing_fee = invoice.fees.find_by(applied_add_on_id: applied_add_on.id)

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -52,7 +52,6 @@ module Fees
 
     delegate :billable_metric, to: :charge
     delegate :subscription, to: :event
-    # delegate :organization, to: :customer
 
     def create_fee(properties:, charge_filter: nil)
       ActiveRecord::Base.transaction do

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -52,7 +52,7 @@ module Fees
 
     delegate :billable_metric, to: :charge
     delegate :subscription, to: :event
-    delegate :organization, to: :customer
+    # delegate :organization, to: :customer
 
     def create_fee(properties:, charge_filter: nil)
       ActiveRecord::Base.transaction do
@@ -66,7 +66,8 @@ module Fees
         fee = Fee.new(
           subscription:,
           charge:,
-          organization_id: organization.id,
+          organization_id: customer.organization_id,
+          billing_entity_id: customer.billing_entity_id,
           amount_cents: charge_model_result.amount,
           precise_amount_cents: charge_model_result.precise_amount,
           amount_currency: subscription.plan.amount_currency,

--- a/app/services/fees/init_from_adjusted_charge_fee_service.rb
+++ b/app/services/fees/init_from_adjusted_charge_fee_service.rb
@@ -2,6 +2,8 @@
 
 module Fees
   class InitFromAdjustedChargeFeeService < ::BaseService
+    Result = BaseResult[:fee]
+
     def initialize(adjusted_fee:, boundaries:, properties:)
       @adjusted_fee = adjusted_fee
       @boundaries = boundaries
@@ -23,7 +25,6 @@ module Fees
     attr_reader :adjusted_fee, :boundaries, :properties
 
     delegate :charge, :charge_filter, :invoice, :subscription, to: :adjusted_fee
-    # delegate :organization, to: :invoice
 
     def compute_amount
       adjusted_fee_result = BaseService::Result.new

--- a/app/services/fees/init_from_adjusted_charge_fee_service.rb
+++ b/app/services/fees/init_from_adjusted_charge_fee_service.rb
@@ -23,7 +23,7 @@ module Fees
     attr_reader :adjusted_fee, :boundaries, :properties
 
     delegate :charge, :charge_filter, :invoice, :subscription, to: :adjusted_fee
-    delegate :organization, to: :invoice
+    # delegate :organization, to: :invoice
 
     def compute_amount
       adjusted_fee_result = BaseService::Result.new
@@ -67,7 +67,8 @@ module Fees
 
       Fee.new(
         invoice:,
-        organization_id: organization.id,
+        organization_id: invoice.organization_id,
+        billing_entity_id: invoice.billing_entity_id,
         subscription:,
         charge:,
         amount_cents:,

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -24,7 +24,8 @@ module Fees
 
           fee = Fee.new(
             invoice:,
-            organization_id: organization.id,
+            organization_id: invoice.organization_id,
+            billing_entity_id: invoice.billing_entity_id,
             add_on:,
             invoice_display_name: fee[:invoice_display_name].presence,
             description: fee[:description] || add_on.description,

--- a/app/services/fees/paid_credit_service.rb
+++ b/app/services/fees/paid_credit_service.rb
@@ -18,7 +18,8 @@ module Fees
 
       new_fee = Fee.new(
         invoice:,
-        organization_id: organization.id,
+        organization_id: invoice.organization_id,
+        billing_entity_id: invoice.billing_entity_id,
         fee_type: :credit,
         invoiceable_type: "WalletTransaction",
         invoiceable: wallet_transaction,

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -35,13 +35,14 @@ module Fees
 
     attr_reader :invoice, :subscription, :boundaries, :context
 
-    delegate :customer, :organization, to: :invoice
+    delegate :customer, to: :invoice
     delegate :previous_subscription, :plan, to: :subscription
 
     def initialize_fee(new_amount_cents, new_precise_amount_cents)
       base_fee = Fee.new(
         invoice:,
-        organization_id: organization.id,
+        organization_id: invoice.organization_id,
+        billing_entity_id: invoice.billing_entity_id,
         subscription:,
         amount_cents: new_amount_cents,
         precise_amount_cents: new_precise_amount_cents.to_d,

--- a/spec/services/fees/add_on_service_spec.rb
+++ b/spec/services/fees/add_on_service_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Fees::AddOnService do
     described_class.new(invoice:, applied_add_on:)
   end
 
-  let(:customer) { create(:customer) }
-  let(:organization) { customer.organization }
+  let(:billing_entity) { create(:billing_entity) }
+  let(:organization) { billing_entity.organization }
+  let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:applied_add_on) { create(:applied_add_on, customer:) }
 
@@ -24,23 +25,22 @@ RSpec.describe Fees::AddOnService do
 
       created_fee = result.fee
 
-      aggregate_failures do
-        expect(created_fee.id).not_to be_nil
-        expect(created_fee.invoice_id).to eq(invoice.id)
-        expect(created_fee.organization_id).to eq(organization.id)
-        expect(created_fee.applied_add_on_id).to eq(applied_add_on.id)
-        expect(created_fee.amount_cents).to eq(200)
-        expect(created_fee.precise_amount_cents).to eq(200.0)
-        expect(created_fee.amount_currency).to eq("EUR")
-        expect(created_fee.units).to eq(1)
-        expect(created_fee.events_count).to be_nil
-        expect(created_fee.payment_status).to eq("pending")
+      expect(created_fee.id).not_to be_nil
+      expect(created_fee.invoice_id).to eq(invoice.id)
+      expect(created_fee.organization_id).to eq(organization.id)
+      expect(created_fee.billing_entity_id).to eq(billing_entity.id)
+      expect(created_fee.applied_add_on_id).to eq(applied_add_on.id)
+      expect(created_fee.amount_cents).to eq(200)
+      expect(created_fee.precise_amount_cents).to eq(200.0)
+      expect(created_fee.amount_currency).to eq("EUR")
+      expect(created_fee.units).to eq(1)
+      expect(created_fee.events_count).to be_nil
+      expect(created_fee.payment_status).to eq("pending")
 
-        expect(created_fee.taxes_amount_cents).to eq(40)
-        expect(created_fee.taxes_precise_amount_cents).to eq(40.0)
-        expect(created_fee.taxes_rate).to eq(20.0)
-        expect(created_fee.applied_taxes.count).to eq(1)
-      end
+      expect(created_fee.taxes_amount_cents).to eq(40)
+      expect(created_fee.taxes_precise_amount_cents).to eq(40.0)
+      expect(created_fee.taxes_rate).to eq(20.0)
+      expect(created_fee.applied_taxes.count).to eq(1)
     end
 
     context "when fee already exists on the period" do

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
   subject(:fee_service) { described_class.new(charge:, event:, billing_at: event.timestamp, estimate:) }
 
-  let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity) }
+  let(:organization) { billing_entity.organization }
   let(:billable_metric) { create(:billable_metric, organization:) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }
@@ -65,36 +66,35 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
     it "creates a fee" do
       result = fee_service.call
 
-      aggregate_failures do
-        expect(result).to be_success
+      expect(result).to be_success
 
-        expect(result.fees.count).to eq(1)
-        expect(result.fees.first).to have_attributes(
-          subscription:,
-          organization_id: organization.id,
-          charge:,
-          amount_cents: 10,
-          precise_amount_cents: 10.0,
-          amount_currency: "EUR",
-          fee_type: "charge",
-          pay_in_advance: true,
-          invoiceable: charge,
-          units: 9,
-          properties: Hash,
-          events_count: 1,
-          charge_filter: nil,
-          pay_in_advance_event_id: event.id,
-          pay_in_advance_event_transaction_id: event.transaction_id,
-          payment_status: "pending",
-          unit_amount_cents: 1,
-          precise_unit_amount: 0.01111111111,
+      expect(result.fees.count).to eq(1)
+      expect(result.fees.first).to have_attributes(
+        subscription:,
+        organization_id: organization.id,
+        billing_entity_id: billing_entity.id,
+        charge:,
+        amount_cents: 10,
+        precise_amount_cents: 10.0,
+        amount_currency: "EUR",
+        fee_type: "charge",
+        pay_in_advance: true,
+        invoiceable: charge,
+        units: 9,
+        properties: Hash,
+        events_count: 1,
+        charge_filter: nil,
+        pay_in_advance_event_id: event.id,
+        pay_in_advance_event_transaction_id: event.transaction_id,
+        payment_status: "pending",
+        unit_amount_cents: 1,
+        precise_unit_amount: 0.01111111111,
 
-          taxes_rate: 20.0,
-          taxes_amount_cents: 2,
-          taxes_precise_amount_cents: 2.0
-        )
-        expect(result.fees.first.applied_taxes.count).to eq(1)
-      end
+        taxes_rate: 20.0,
+        taxes_amount_cents: 2,
+        taxes_precise_amount_cents: 2.0
+      )
+      expect(result.fees.first.applied_taxes.count).to eq(1)
     end
 
     it "delivers a webhook" do
@@ -136,34 +136,34 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
       it "creates fees" do
         result = fee_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
+        expect(result).to be_success
 
-          expect(result.fees.count).to eq(1)
-          expect(result.fees.first).to have_attributes(
-            subscription:,
-            charge:,
-            amount_cents: 10,
-            precise_amount_cents: 10.0,
-            amount_currency: "EUR",
-            fee_type: "charge",
-            pay_in_advance: true,
-            invoiceable: charge,
-            units: 9,
-            properties: Hash,
-            events_count: 1,
-            charge_filter: nil,
-            pay_in_advance_event_id: event.id,
-            pay_in_advance_event_transaction_id: event.transaction_id,
-            payment_status: "pending",
-            unit_amount_cents: 1,
-            precise_unit_amount: 0.01111111111,
-            taxes_rate: 10.0,
-            taxes_amount_cents: 1,
-            taxes_precise_amount_cents: 1.0
-          )
-          expect(result.fees.first.applied_taxes.count).to eq(2)
-        end
+        expect(result.fees.count).to eq(1)
+        expect(result.fees.first).to have_attributes(
+          subscription:,
+          charge:,
+          organization_id: organization.id,
+          billing_entity_id: billing_entity.id,
+          amount_cents: 10,
+          precise_amount_cents: 10.0,
+          amount_currency: "EUR",
+          fee_type: "charge",
+          pay_in_advance: true,
+          invoiceable: charge,
+          units: 9,
+          properties: Hash,
+          events_count: 1,
+          charge_filter: nil,
+          pay_in_advance_event_id: event.id,
+          pay_in_advance_event_transaction_id: event.transaction_id,
+          payment_status: "pending",
+          unit_amount_cents: 1,
+          precise_unit_amount: 0.01111111111,
+          taxes_rate: 10.0,
+          taxes_amount_cents: 1,
+          taxes_precise_amount_cents: 1.0
+        )
+        expect(result.fees.first.applied_taxes.count).to eq(2)
       end
 
       context "when there is error received from the provider" do

--- a/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
+++ b/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService, type: :service do
     )
   end
   let(:organization) { invoice.organization }
+  let(:billing_entity) { organization.default_billing_entity }
   let(:invoice) { create(:invoice, status: :draft) }
   let(:invoice_subscription) { create(:invoice_subscription, invoice:, subscription:) }
 
@@ -64,6 +65,7 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService, type: :service do
       expect(result.fee).to have_attributes(
         id: nil,
         organization_id: organization.id,
+        billing_entity_id: billing_entity.id,
         invoice:,
         subscription:,
         charge:,

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Fees::OneOffService do
   end
 
   let(:invoice) { create(:invoice, organization:, customer:) }
-  let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity) }
+  let(:organization) { billing_entity.organization }
   let(:customer) { create(:customer, organization:) }
   let(:tax) { create(:tax, organization:) }
   let(:tax2) { create(:tax, organization:, applied_to_organization: false) }
@@ -42,41 +43,41 @@ RSpec.describe Fees::OneOffService do
       first_fee = result.fees[0]
       second_fee = result.fees[1]
 
-      aggregate_failures do
-        expect(first_fee).to have_attributes(
-          id: String,
-          organization_id: organization.id,
-          invoice_id: invoice.id,
-          add_on_id: add_on_first.id,
-          description: "desc-123",
-          unit_amount_cents: 1200,
-          precise_unit_amount: 12,
-          units: 2,
-          amount_cents: 2400,
-          precise_amount_cents: 2400.0,
-          amount_currency: "EUR",
-          fee_type: "add_on",
-          payment_status: "pending"
-        )
-        expect(first_fee.taxes.map(&:code)).to contain_exactly(tax2.code)
+      expect(first_fee).to have_attributes(
+        id: String,
+        organization_id: organization.id,
+        billing_entity_id: billing_entity.id,
+        invoice_id: invoice.id,
+        add_on_id: add_on_first.id,
+        description: "desc-123",
+        unit_amount_cents: 1200,
+        precise_unit_amount: 12,
+        units: 2,
+        amount_cents: 2400,
+        precise_amount_cents: 2400.0,
+        amount_currency: "EUR",
+        fee_type: "add_on",
+        payment_status: "pending"
+      )
+      expect(first_fee.taxes.map(&:code)).to contain_exactly(tax2.code)
 
-        expect(second_fee).to have_attributes(
-          id: String,
-          organization_id: organization.id,
-          invoice_id: invoice.id,
-          add_on_id: add_on_second.id,
-          description: add_on_second.description,
-          unit_amount_cents: 400,
-          precise_unit_amount: 4,
-          units: 1,
-          amount_cents: 400,
-          precise_amount_cents: 400.0,
-          amount_currency: "EUR",
-          fee_type: "add_on",
-          payment_status: "pending"
-        )
-        expect(second_fee.taxes.map(&:code)).to contain_exactly(tax.code)
-      end
+      expect(second_fee).to have_attributes(
+        id: String,
+        organization_id: organization.id,
+        billing_entity_id: billing_entity.id,
+        invoice_id: invoice.id,
+        add_on_id: add_on_second.id,
+        description: add_on_second.description,
+        unit_amount_cents: 400,
+        precise_unit_amount: 4,
+        units: 1,
+        amount_cents: 400,
+        precise_amount_cents: 400.0,
+        amount_currency: "EUR",
+        fee_type: "add_on",
+        payment_status: "pending"
+      )
+      expect(second_fee.taxes.map(&:code)).to contain_exactly(tax.code)
     end
 
     context "when add_on_code is invalid" do
@@ -121,23 +122,21 @@ RSpec.describe Fees::OneOffService do
 
         first_fee = result.fees[0]
 
-        aggregate_failures do
-          expect(first_fee).to have_attributes(
-            id: String,
-            invoice_id: invoice.id,
-            add_on_id: add_on_first.id,
-            description: "desc-123",
-            unit_amount_cents: 1200,
-            precise_unit_amount: 12,
-            units: 2,
-            amount_cents: 2400,
-            precise_amount_cents: 2400.0,
-            amount_currency: "EUR",
-            fee_type: "add_on",
-            payment_status: "pending"
-          )
-          expect(first_fee.taxes.map(&:code)).to contain_exactly(tax2.code)
-        end
+        expect(first_fee).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          add_on_id: add_on_first.id,
+          description: "desc-123",
+          unit_amount_cents: 1200,
+          precise_unit_amount: 12,
+          units: 2,
+          amount_cents: 2400,
+          precise_amount_cents: 2400.0,
+          amount_currency: "EUR",
+          fee_type: "add_on",
+          payment_status: "pending"
+        )
+        expect(first_fee.taxes.map(&:code)).to contain_exactly(tax2.code)
       end
     end
 
@@ -193,48 +192,46 @@ RSpec.describe Fees::OneOffService do
         first_fee = result.fees[0]
         second_fee = result.fees[1]
 
-        aggregate_failures do
-          expect(result).to be_success
+        expect(result).to be_success
 
-          expect(first_fee).to have_attributes(
-            id: String,
-            invoice_id: invoice.id,
-            add_on_id: add_on_first.id,
-            description: "desc-123",
-            unit_amount_cents: 1200,
-            precise_unit_amount: 12,
-            units: 2,
-            amount_cents: 2400,
-            amount_currency: "EUR",
-            fee_type: "add_on",
-            payment_status: "pending",
-            taxes_rate: 10,
-            taxes_base_rate: 1.0
-          )
-          expect(first_fee.applied_taxes.first.amount_cents).to eq(240)
-          expect(first_fee.applied_taxes.first.precise_amount_cents).to eq(240.0)
+        expect(first_fee).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          add_on_id: add_on_first.id,
+          description: "desc-123",
+          unit_amount_cents: 1200,
+          precise_unit_amount: 12,
+          units: 2,
+          amount_cents: 2400,
+          amount_currency: "EUR",
+          fee_type: "add_on",
+          payment_status: "pending",
+          taxes_rate: 10,
+          taxes_base_rate: 1.0
+        )
+        expect(first_fee.applied_taxes.first.amount_cents).to eq(240)
+        expect(first_fee.applied_taxes.first.precise_amount_cents).to eq(240.0)
 
-          expect(second_fee).to have_attributes(
-            id: String,
-            invoice_id: invoice.id,
-            add_on_id: add_on_second.id,
-            description: add_on_second.description,
-            unit_amount_cents: 400,
-            precise_unit_amount: 4,
-            units: 1,
-            amount_cents: 400,
-            precise_amount_cents: 400.0,
-            amount_currency: "EUR",
-            fee_type: "add_on",
-            payment_status: "pending",
-            taxes_rate: 15,
-            taxes_base_rate: 1.0
-          )
-          expect(second_fee.applied_taxes.first.amount_cents).to eq(60)
-          expect(second_fee.applied_taxes.first.precise_amount_cents).to eq(60.0)
+        expect(second_fee).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          add_on_id: add_on_second.id,
+          description: add_on_second.description,
+          unit_amount_cents: 400,
+          precise_unit_amount: 4,
+          units: 1,
+          amount_cents: 400,
+          precise_amount_cents: 400.0,
+          amount_currency: "EUR",
+          fee_type: "add_on",
+          payment_status: "pending",
+          taxes_rate: 15,
+          taxes_base_rate: 1.0
+        )
+        expect(second_fee.applied_taxes.first.amount_cents).to eq(60)
+        expect(second_fee.applied_taxes.first.precise_amount_cents).to eq(60.0)
 
-          expect(invoice.reload.error_details.count).to eq(0)
-        end
+        expect(invoice.reload.error_details.count).to eq(0)
       end
 
       context "when there is tax deduction" do
@@ -257,48 +254,46 @@ RSpec.describe Fees::OneOffService do
           first_fee = result.fees[0]
           second_fee = result.fees[1]
 
-          aggregate_failures do
-            expect(result).to be_success
+          expect(result).to be_success
 
-            expect(first_fee).to have_attributes(
-              id: String,
-              invoice_id: invoice.id,
-              add_on_id: add_on_first.id,
-              description: "desc-123",
-              unit_amount_cents: 1200,
-              precise_unit_amount: 12,
-              units: 2,
-              amount_cents: 2400,
-              amount_currency: "EUR",
-              fee_type: "add_on",
-              payment_status: "pending",
-              taxes_rate: 10,
-              taxes_base_rate: 0.8
-            )
-            expect(first_fee.applied_taxes.first.amount_cents).to eq(192)
-            expect(first_fee.applied_taxes.first.precise_amount_cents).to eq(192.0)
+          expect(first_fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            add_on_id: add_on_first.id,
+            description: "desc-123",
+            unit_amount_cents: 1200,
+            precise_unit_amount: 12,
+            units: 2,
+            amount_cents: 2400,
+            amount_currency: "EUR",
+            fee_type: "add_on",
+            payment_status: "pending",
+            taxes_rate: 10,
+            taxes_base_rate: 0.8
+          )
+          expect(first_fee.applied_taxes.first.amount_cents).to eq(192)
+          expect(first_fee.applied_taxes.first.precise_amount_cents).to eq(192.0)
 
-            expect(second_fee).to have_attributes(
-              id: String,
-              invoice_id: invoice.id,
-              add_on_id: add_on_second.id,
-              description: add_on_second.description,
-              unit_amount_cents: 400,
-              precise_unit_amount: 4,
-              units: 1,
-              amount_cents: 400,
-              precise_amount_cents: 400.0,
-              amount_currency: "EUR",
-              fee_type: "add_on",
-              payment_status: "pending",
-              taxes_rate: 15,
-              taxes_base_rate: 0.8
-            )
-            expect(second_fee.applied_taxes.first.amount_cents).to eq(48)
-            expect(second_fee.applied_taxes.first.precise_amount_cents).to eq(48.0)
+          expect(second_fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            add_on_id: add_on_second.id,
+            description: add_on_second.description,
+            unit_amount_cents: 400,
+            precise_unit_amount: 4,
+            units: 1,
+            amount_cents: 400,
+            precise_amount_cents: 400.0,
+            amount_currency: "EUR",
+            fee_type: "add_on",
+            payment_status: "pending",
+            taxes_rate: 15,
+            taxes_base_rate: 0.8
+          )
+          expect(second_fee.applied_taxes.first.amount_cents).to eq(48)
+          expect(second_fee.applied_taxes.first.precise_amount_cents).to eq(48.0)
 
-            expect(invoice.reload.error_details.count).to eq(0)
-          end
+          expect(invoice.reload.error_details.count).to eq(0)
         end
       end
 
@@ -311,14 +306,12 @@ RSpec.describe Fees::OneOffService do
         it "returns tax error" do
           result = one_off_service.create
 
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error.code).to eq("tax_error")
-            expect(result.error.error_message).to eq("taxDateTooFarInFuture")
+          expect(result).not_to be_success
+          expect(result.error.code).to eq("tax_error")
+          expect(result.error.error_message).to eq("taxDateTooFarInFuture")
 
-            expect(invoice.reload.error_details.count).to eq(1)
-            expect(invoice.reload.error_details.first.details["tax_error"]).to eq("taxDateTooFarInFuture")
-          end
+          expect(invoice.reload.error_details.count).to eq(1)
+          expect(invoice.reload.error_details.first.details["tax_error"]).to eq("taxDateTooFarInFuture")
         end
 
         context "with api limit error" do
@@ -330,16 +323,14 @@ RSpec.describe Fees::OneOffService do
           it "returns and store proper error details" do
             result = one_off_service.create
 
-            aggregate_failures do
-              expect(result).not_to be_success
-              expect(result.error.code).to eq("tax_error")
-              expect(result.error.error_message).to eq("validationError")
+            expect(result).not_to be_success
+            expect(result.error.code).to eq("tax_error")
+            expect(result.error.error_message).to eq("validationError")
 
-              expect(invoice.reload.error_details.count).to eq(1)
-              expect(invoice.reload.error_details.first.details["tax_error"]).to eq("validationError")
-              expect(invoice.reload.error_details.first.details["tax_error_message"])
-                .to eq("You've exceeded your API limit of 10 per second")
-            end
+            expect(invoice.reload.error_details.count).to eq(1)
+            expect(invoice.reload.error_details.first.details["tax_error"]).to eq("validationError")
+            expect(invoice.reload.error_details.first.details["tax_error_message"])
+              .to eq("You've exceeded your API limit of 10 per second")
           end
         end
       end

--- a/spec/services/fees/paid_credit_service_spec.rb
+++ b/spec/services/fees/paid_credit_service_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Fees::PaidCreditService do
 
   let(:customer) { create(:customer) }
   let(:organization) { customer.organization }
+  let(:billing_entity) { customer.billing_entity }
   let(:invoice) { create(:invoice, organization:) }
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:, rate_amount: "1.00") }
@@ -27,6 +28,7 @@ RSpec.describe Fees::PaidCreditService do
         id: String,
         fee_type: "credit",
         organization_id: organization.id,
+        billing_entity_id: billing_entity.id,
         invoice_id: invoice.id,
         invoiceable_type: "WalletTransaction",
         invoiceable_id: wallet_transaction.id,

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Fees::SubscriptionService do
     )
   end
 
-  let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity) }
+  let(:organization) { billing_entity.organization }
   let(:customer) { create(:customer, organization:) }
   let(:tax) { create(:tax, organization:, rate: 20) }
   let(:started_at) { Time.zone.parse("2022-01-01 00:01") }
@@ -58,6 +59,7 @@ RSpec.describe Fees::SubscriptionService do
       expect(result.fee).to have_attributes(
         id: String,
         organization_id: organization.id,
+        billing_entity_id: billing_entity.id,
         invoice_id: invoice.id,
         amount_cents: 100,
         precise_amount_cents: 100.0,


### PR DESCRIPTION
## Context

Third part of multientities implementation includes passing billing_entity_id to fees

## Description

- updated services that create fees to populate billing_entity_id for fee
- removed calls to organization while creating fees