### PR TITLE
fix(clickhouse): Use from_datetime for prorated unique count

### DIFF
--- a/app/services/events/stores/clickhouse/unique_count_query.rb
+++ b/app/services/events/stores/clickhouse/unique_count_query.rb
@@ -291,7 +291,7 @@ module Events
                     if(timestamp < toDateTime64(:from_datetime, 3, 'UTC'), toDateTime64(:from_datetime, 3, 'UTC'), timestamp),
                     if(
                       (leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 3, 'UTC')) OVER (PARTITION BY property ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) < toDateTime64(:from_datetime, 3, 'UTC'),
-                      toDateTime64(:to_datetime, 3, 'UTC'),
+                      toDateTime64(:from_datetime, 3, 'UTC'),
                       leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 3, 'UTC')) OVER (PARTITION BY property ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
                     ),
                     :timezone


### PR DESCRIPTION
When the following event is older than the start of the period, we use the start date of the period as the reference instead of the end date of the period, as previously set.