### PR TITLE
feat(multi-entities): Organizations' first billing entity matches its id with the organization_id

### DIFF
--- a/app/services/billing_entities/create_service.rb
+++ b/app/services/billing_entities/create_service.rb
@@ -15,6 +15,7 @@ module BillingEntities
 
       billing_entity = organization.billing_entities.new(create_attributes)
       ActiveRecord::Base.transaction do
+        billing_entity.id = params[:id] if params[:id]
         billing_entity.invoice_footer = billing_config[:invoice_footer]
         billing_entity.document_locale = billing_config[:document_locale] if billing_config[:document_locale]
 

--- a/app/services/organizations/create_service.rb
+++ b/app/services/organizations/create_service.rb
@@ -19,6 +19,10 @@ module Organizations
         if params[:document_numbering]
           params[:document_numbering] = "per_billing_entity" if params[:document_numbering] == "per_organization"
         end
+
+        # NOTE: ensure first billing entity has the same id as the organization to ease the migration to multi entities.
+        params[:id] = organization.id
+
         params[:code] = params[:name]&.parameterize(separator: "_") if params[:code].blank?
         BillingEntities::CreateService.call(organization: organization, params: params)
       end

--- a/db/migrate/20250325145324_assign_customers_to_billing_entities.rb
+++ b/db/migrate/20250325145324_assign_customers_to_billing_entities.rb
@@ -1,13 +1,17 @@
+# frozen_string_literal: true
+
 class AssignCustomersToBillingEntities < ActiveRecord::Migration[7.2]
   def change
     # NOTE: ensure first billing entity has the same id as the organization to ease the migration to multi entities.
     BillingEntity.where("id != organization_id").find_in_batches(batch_size: 1000) do |batch|
-      BillingEntity.where(id: batch.pluck(:id)).update_all("id = organization_id")
+      BillingEntity.where(id: batch.pluck(:id))
+        .update_all("id = organization_id") # rubocop:disable Rails/SkipsModelValidations
     end
 
     # NOTE: Update all customers to have the same billing_entity_id as organization_id
     Customer.where("billing_entity_id != organization_id").or(Customer.where(billing_entity_id: nil)).find_in_batches(batch_size: 1000) do |batch|
-      Customer.where(id: batch.pluck(:id)).update_all("billing_entity_id = organization_id")
+      Customer.where(id: batch.pluck(:id))
+        .update_all("billing_entity_id = organization_id") # rubocop:disable Rails/SkipsModelValidations
     end
   end
 end

--- a/db/migrate/20250325145324_assign_customers_to_billing_entities.rb
+++ b/db/migrate/20250325145324_assign_customers_to_billing_entities.rb
@@ -1,0 +1,13 @@
+class AssignCustomersToBillingEntities < ActiveRecord::Migration[7.2]
+  def change
+    # NOTE: ensure first billing entity has the same id as the organization to ease the migration to multi entities.
+    BillingEntity.where("id != organization_id").find_in_batches(batch_size: 1000) do |batch|
+      BillingEntity.where(id: batch.pluck(:id)).update_all("id = organization_id")
+    end
+
+    # NOTE: Update all customers to have the same billing_entity_id as organization_id
+    Customer.where("billing_entity_id != organization_id").or(Customer.where(billing_entity_id: nil)).find_in_batches(batch_size: 1000) do |batch|
+      Customer.where(id: batch.pluck(:id)).update_all("billing_entity_id = organization_id")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_24_125056) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_25_145324) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/spec/services/billing_entities/create_service_spec.rb
+++ b/spec/services/billing_entities/create_service_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe BillingEntities::CreateService, type: :service do
         expect(result.billing_entity.timezone).to eq("UTC")
         expect(result.billing_entity.email_settings).to be_empty
       end
+
+      context "when an id is provided in the params hash" do
+        it "creates a billing entity with the provided id" do
+          params[:id] = organization.id
+
+          expect(result).to be_success
+          expect(result.billing_entity.id).to eq(organization.id)
+        end
+      end
     end
   end
 

--- a/spec/services/organizations/create_service_spec.rb
+++ b/spec/services/organizations/create_service_spec.rb
@@ -42,10 +42,13 @@ RSpec.describe Organizations::CreateService, type: :service do
           expect { service_result }.to change(BillingEntity, :count).by(1)
 
           billing_entity = service_result.organization.billing_entities.first
-          expect(billing_entity).to have_attributes(organization: service_result.organization,
+          expect(billing_entity).to have_attributes(
+            id: service_result.organization.id,
+            organization: service_result.organization,
             name: service_result.organization.name,
             code: service_result.organization.name.parameterize(separator: "_"),
-            document_numbering: "per_customer")
+            document_numbering: "per_customer"
+          )
         end
       end
 
@@ -62,10 +65,13 @@ RSpec.describe Organizations::CreateService, type: :service do
           expect { service_result }.to change(BillingEntity, :count).by(1)
 
           billing_entity = service_result.organization.billing_entities.first
-          expect(billing_entity).to have_attributes(organization: service_result.organization,
+          expect(billing_entity).to have_attributes(
+            id: service_result.organization.id,
+            organization: service_result.organization,
             name: service_result.organization.name,
             code: "this_code_will_be_used_for_billing_entity",
-            document_numbering: "per_billing_entity")
+            document_numbering: "per_billing_entity"
+          )
         end
       end
     end


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

 ## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

 ## Description

in order to facilitate the migration to multi entities, the first billing entity id for each organization will match the organization id. This will allow us migrate data in a performant way and reduces the risks of migration issues.

Also, a migration is included to:
1. update all billing entity record ids not matching the organization id
2. update all customer's billing_entity_id not matching the organization_id