### PR TITLE
feat(stripe): Update payment method in a job

### DIFF
--- a/app/jobs/payments/update_payment_method_data_job.rb
+++ b/app/jobs/payments/update_payment_method_data_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Payments
+  class UpdatePaymentMethodDataJob < ApplicationJob
+    queue_as "default"
+
+    def perform(provider_payment_id:, provider_payment_method_id:)
+      payment = ::Payment.find_by!(provider_payment_id: provider_payment_id)
+      ::Payments::UpdatePaymentMethodDataService.call!(payment:, provider_payment_method_id:)
+    end
+  end
+end

--- a/app/jobs/payments/update_payment_method_data_job.rb
+++ b/app/jobs/payments/update_payment_method_data_job.rb
@@ -4,6 +4,8 @@ module Payments
   class UpdatePaymentMethodDataJob < ApplicationJob
     queue_as "default"
 
+    retry_on ::Stripe::RateLimitError, wait: :exponentially_longer, attempts: 5
+
     def perform(provider_payment_id:, provider_payment_method_id:)
       payment = ::Payment.find_by!(provider_payment_id: provider_payment_id)
       ::Payments::UpdatePaymentMethodDataService.call!(payment:, provider_payment_method_id:)

--- a/app/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service.rb
@@ -7,13 +7,10 @@ module PaymentProviders
         def call
           @result = update_payment_status! "succeeded"
 
-          payment = Payment.find_by(provider_payment_id: event.data.object.id)
-          if payment
-            ::Payments::UpdatePaymentMethodDataService.call!(
-              payment:,
-              payment_method_id: event.data.object.payment_method
-            )
-          end
+          ::Payments::UpdatePaymentMethodDataJob.perform_later(
+            provider_payment_id: event.data.object.id,
+            provider_payment_method_id: event.data.object.payment_method
+          )
 
           result
         end

--- a/app/services/payments/update_payment_method_data_service.rb
+++ b/app/services/payments/update_payment_method_data_service.rb
@@ -4,10 +4,10 @@ module Payments
   class UpdatePaymentMethodDataService < BaseService
     Result = BaseResult[:payment]
 
-    def initialize(payment:, payment_method_id:)
+    def initialize(payment:, provider_payment_method_id:)
       @payment = payment
       @payment_provider = payment.payment_provider
-      @provider_payment_method_id = payment_method_id
+      @provider_payment_method_id = provider_payment_method_id
 
       super
     end

--- a/spec/jobs/payments/update_payment_method_data_job_spec.rb
+++ b/spec/jobs/payments/update_payment_method_data_job_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Payments::UpdatePaymentMethodDataJob, type: :job do
+  let(:provider_payment_id) { "pi_123" }
+  let(:provider_payment_method_id) { "pm_001" }
+
+  it "calls the create service" do
+    create(:payment, provider_payment_id:)
+
+    allow(Payments::UpdatePaymentMethodDataService)
+      .to receive(:call!).with(payment: Payment, provider_payment_method_id:).and_return(BaseService::Result.new)
+
+    described_class.perform_now(provider_payment_id: "pi_123", provider_payment_method_id:)
+
+    expect(Payments::UpdatePaymentMethodDataService).to have_received(:call!)
+  end
+end

--- a/spec/jobs/payments/update_payment_method_data_job_spec.rb
+++ b/spec/jobs/payments/update_payment_method_data_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Payments::UpdatePaymentMethodDataJob, type: :job do
   let(:provider_payment_id) { "pi_123" }
   let(:provider_payment_method_id) { "pm_001" }
 
-  it "calls the create service" do
+  it "calls the service" do
     create(:payment, provider_payment_id:)
 
     allow(Payments::UpdatePaymentMethodDataService)
@@ -15,5 +15,17 @@ RSpec.describe Payments::UpdatePaymentMethodDataJob, type: :job do
     described_class.perform_now(provider_payment_id: "pi_123", provider_payment_method_id:)
 
     expect(Payments::UpdatePaymentMethodDataService).to have_received(:call!)
+  end
+
+  context "when payment is not found" do
+    it "does not call the service" do
+      allow(Payments::UpdatePaymentMethodDataService).to receive(:call!)
+
+      expect {
+        described_class.perform_now(provider_payment_id: "pi_123", provider_payment_method_id:)
+      }.to raise_error(ActiveRecord::RecordNotFound)
+
+      expect(Payments::UpdatePaymentMethodDataService).not_to have_received(:call!)
+    end
   end
 end

--- a/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService
     File.read(path)
   end
 
+  before do
+    allow(::Payments::UpdatePaymentMethodDataJob).to receive(:perform_later)
+      .and_invoke(->(args) { ::Payments::UpdatePaymentMethodDataJob.perform_now(**args) })
+  end
+
   ["2020-08-27", "2022-11-15", "2024-09-30.acacia"].each do |fixtures_version|
     context "when payment intent event (api_version: #{fixtures_version})" do
       let(:fixtures_version) { fixtures_version }

--- a/spec/services/payments/update_payment_method_data_service_spec.rb
+++ b/spec/services/payments/update_payment_method_data_service_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Payments::UpdatePaymentMethodDataService, type: :service do
-  subject(:service) { described_class.new(payment:, payment_method_id:) }
+  subject(:service) { described_class.new(payment:, provider_payment_method_id:) }
 
-  let(:payment_method_id) { "pm_1R2DFsQ8iJWBZFaMw3LLbR0r" }
+  let(:provider_payment_method_id) { "pm_1R2DFsQ8iJWBZFaMw3LLbR0r" }
 
   describe "#call" do
     context "with Stripe" do


### PR DESCRIPTION
## Description

I was hesitant to make it async but it's better for retries.

Note that `update_payment_status` might raise a not found error if the webhook arrived before the `payment._provider_payment_id` is updated in the DB, which will retry the HandleEventJob. 

So when `UpdatePaymentMethodDataJob` is dispatched, we're guaranteed that payment is updated... until the implementation of `update_payment_status` changes 😄 