### PR TITLE
chore(CI) - Enable knapsack-pro

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -76,6 +76,6 @@ jobs:
         run: bin/rails db:schema:dump:clickhouse
       - name: Run tests
         run: bundle exec rake knapsack_pro:queue:rspec
+        continue-on-error: true
       - name: retry failed tests
         run: bundle exec rspec --only-failures
-        if: ${{ failure() }}

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -30,8 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [5]
-        ci_node_index: [0, 1, 2, 3, 4]
+        ci_node_total: [8]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
       RAILS_ENV: test
       DATABASE_URL: "postgres://lago:lago@localhost:5432/lago"

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -27,7 +27,11 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [2]
+        ci_node_index: [0, 1]
     env:
       RAILS_ENV: test
       DATABASE_URL: "postgres://lago:lago@localhost:5432/lago"
@@ -45,6 +49,10 @@ jobs:
       LAGO_CLICKHOUSE_USERNAME: ""
       LAGO_CLICKHOUSE_PASSWORD: "password"
       LAGO_KAFKA_EVENTS_CHARGED_IN_ADVANCE_TOPIC: events_charged_in_advance
+      KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
+      KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+      KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+      KNAPSACK_PRO_LOG_LEVEL: info
 
     steps:
       - name: Checkout code
@@ -67,4 +75,4 @@ jobs:
       - name: Dump Clickhouse database schema
         run: bin/rails db:schema:dump:clickhouse
       - name: Run tests
-        run: bundle exec rspec
+        run: bundle exec rake knapsack_pro:queue:rspec

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -76,5 +76,8 @@ jobs:
         run: bin/rails db:migrate:clickhouse
       - name: Dump Clickhouse database schema
         run: bin/rails db:schema:dump:clickhouse
-      - name: Run tests & retry failed tests
-        run: bundle exec rake knapsack_pro:queue:rspec || bundle exec rspec --only-failures
+      - name: Run tests
+        run: bundle exec rake knapsack_pro:queue:rspec
+        continue-on-error: true
+      - name: retry failed tests
+        run: bundle exec rspec --only-failures

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -30,8 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [2]
-        ci_node_index: [0, 1]
+        ci_node_total: [5]
+        ci_node_index: [0, 1, 2, 3, 4]
     env:
       RAILS_ENV: test
       DATABASE_URL: "postgres://lago:lago@localhost:5432/lago"

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -76,3 +76,6 @@ jobs:
         run: bin/rails db:schema:dump:clickhouse
       - name: Run tests
         run: bundle exec rake knapsack_pro:queue:rspec
+      - name: retry failed tests
+        run: bundle exec rspec --only-failures
+        if: ${{ failure() }}

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -32,6 +32,7 @@ jobs:
       matrix:
         ci_node_total: [8]
         ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
+
     env:
       RAILS_ENV: test
       DATABASE_URL: "postgres://lago:lago@localhost:5432/lago"
@@ -75,8 +76,5 @@ jobs:
         run: bin/rails db:migrate:clickhouse
       - name: Dump Clickhouse database schema
         run: bin/rails db:schema:dump:clickhouse
-      - name: Run tests
-        run: bundle exec rake knapsack_pro:queue:rspec
-        continue-on-error: true
-      - name: retry failed tests
-        run: bundle exec rspec --only-failures
+      - name: Run tests & retry failed tests
+        run: bundle exec rake knapsack_pro:queue:rspec || bundle exec rspec --only-failures

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -52,6 +52,7 @@ jobs:
       KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
       KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
       KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+      KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
       KNAPSACK_PRO_LOG_LEVEL: info
 
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem "newrelic_rpm"
 gem "opentelemetry-exporter-otlp"
 gem "opentelemetry-instrumentation-all"
 gem "opentelemetry-sdk"
-gem 'stackprof', require: false
+gem "stackprof", require: false
 gem "sentry-rails", require: false
 gem "sentry-ruby", require: false
 gem "sentry-sidekiq", require: false
@@ -119,6 +119,7 @@ group :development, :test do
   gem "rubocop-thread_safety", require: false
   gem "awesome_print"
   gem "pry"
+  gem "knapsack_pro", "~> 8.1"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,6 +365,8 @@ GEM
       karafka-core (>= 2.4.0, < 2.5.0)
       roda (~> 3.68, >= 3.69)
       tilt (~> 2.0)
+    knapsack_pro (8.1.0)
+      rake
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     listen (3.9.0)
@@ -980,6 +982,7 @@ DEPENDENCIES
   karafka (~> 2.4.17)
   karafka-testing
   karafka-web (~> 0.10.4)
+  knapsack_pro (~> 8.1)
   lago-expression!
   lograge
   logstash-event

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require "knapsack_pro"
+
+# Custom Knapsack Pro config here
+KnapsackPro::Adapters::RSpecAdapter.bind
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] = "test"
 require_relative "../config/environment"


### PR DESCRIPTION
This PR enables knapsack-pro. It splits up our CI pipeline into 8 nodes and runs now in 3 minutes instead of 15.