### PR TITLE
Fix charge update service params

### DIFF
--- a/app/services/charges/update_service.rb
+++ b/app/services/charges/update_service.rb
@@ -4,7 +4,7 @@ module Charges
   class UpdateService < BaseService
     def initialize(charge:, params:, cascade_options: {})
       @charge = charge
-      @params = params
+      @params = params.to_h.deep_symbolize_keys
       @cascade_options = cascade_options
       @cascade = cascade_options[:cascade]
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -122,7 +122,7 @@ module Plans
         if child_charge
           Charges::UpdateJob.perform_later(
             charge: child_charge,
-            params: payload_charge,
+            params: payload_charge.deep_stringify_keys,
             cascade_options: {
               cascade: true,
               parent_filters: charge.filters.map(&:attributes),

--- a/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
@@ -236,7 +236,9 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver, type: :graph
         }
       )
 
-      charge_usage = result["data"]["customerPortalCustomerUsage"]["chargesUsage"][0]
+      charge_usage = result["data"]["customerPortalCustomerUsage"]["chargesUsage"].find do |usage|
+        usage["billableMetric"]["code"] == metric.code
+      end
       filters_usage = charge_usage["filters"]
 
       aggregate_failures do

--- a/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver, type: :graphql do
+  let(:now) { Time.zone.now }
   let(:query) do
     <<~GQL
       query($subscriptionId: ID!) {
@@ -43,7 +44,7 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver, type: :graph
       :subscription,
       plan:,
       customer:,
-      started_at: Time.zone.now - 2.years
+      started_at: now - 2.years
     )
   end
   let(:plan) { create(:plan, interval: "monthly") }
@@ -102,7 +103,7 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver, type: :graph
       customer:,
       subscription:,
       code: metric.code,
-      timestamp: Time.zone.now
+      timestamp: now - 1.hour
     )
 
     create_list(
@@ -112,7 +113,7 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver, type: :graph
       customer:,
       subscription:,
       code: sum_metric.code,
-      timestamp: Time.zone.now,
+      timestamp: now - 1.hour,
       properties: {
         agent_name: "frodo",
         cloud: "aws",
@@ -135,10 +136,10 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver, type: :graph
     usage_response = result["data"]["customerPortalCustomerUsage"]
 
     aggregate_failures do
-      expect(usage_response["fromDatetime"]).to eq(Time.current.beginning_of_month.iso8601)
-      expect(usage_response["toDatetime"]).to eq(Time.current.end_of_month.iso8601)
+      expect(usage_response["fromDatetime"]).to eq(now.beginning_of_month.iso8601)
+      expect(usage_response["toDatetime"]).to eq(now.end_of_month.iso8601)
       expect(usage_response["currency"]).to eq("EUR")
-      expect(usage_response["issuingDate"]).to eq(Time.zone.today.end_of_month.iso8601)
+      expect(usage_response["issuingDate"]).to eq(now.to_date.end_of_month.iso8601)
       expect(usage_response["amountCents"]).to eq("405")
       expect(usage_response["totalAmountCents"]).to eq("405")
       expect(usage_response["taxesAmountCents"]).to eq("0")
@@ -211,7 +212,7 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver, type: :graph
         customer:,
         subscription:,
         code: metric.code,
-        timestamp: Time.zone.now,
+        timestamp: now - 1.hour,
         properties: {cloud: "aws"}
       )
 
@@ -221,7 +222,7 @@ RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver, type: :graph
         customer:,
         subscription:,
         code: metric.code,
-        timestamp: Time.zone.now,
+        timestamp: now - 1.hour,
         properties: {cloud: "google"}
       )
     end


### PR DESCRIPTION
## Context
 
While executing the Charges::UpdateJob, we noticed that some data — specifically the properties key inside params — was being lost. This happened because payload_charge was passed to perform_later with symbol keys (:key), and ActiveJob/Sidekiq serializes job arguments using JSON, which does not handle deeply nested symbol keys properly. As a result, some nested data like properties was silently dropped during serialization.

## Description

This PR ensures that payload_charge is passed to the job using .deep_stringify_keys, making the entire structure JSON-safe before enqueueing the job. Additionally, inside the Charges::UpdateService, params are converted back to symbolized keys using .to_h.deep_symbolize_keys 