### PR TITLE
misc(GraphQL): add `has_*` attributes to plan object as replacement of `*_count` attributes

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -6658,7 +6658,12 @@ type Plan {
   customersCount: Int!
   description: String
   draftInvoicesCount: Int!
+  hasActiveSubscriptions: Boolean!
+  hasCharges: Boolean!
+  hasCustomers: Boolean!
+  hasDraftInvoices: Boolean!
   hasOverriddenPlans: Boolean
+  hasSubscriptions: Boolean!
   id: ID!
   interval: PlanInterval!
   invoiceDisplayName: String

--- a/schema.json
+++ b/schema.json
@@ -32136,12 +32136,92 @@
               "args": []
             },
             {
+              "name": "hasActiveSubscriptions",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "hasCharges",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "hasCustomers",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "hasDraftInvoices",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "hasOverriddenPlans",
               "description": null,
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "hasSubscriptions",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/resolvers/plan_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_resolver_spec.rb
@@ -3,6 +3,16 @@
 require "rails_helper"
 
 RSpec.describe Resolvers::PlanResolver, type: :graphql do
+  subject(:result) do
+    execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:,
+      variables: {planId: plan.id}
+    )
+  end
+
   let(:required_permission) { "plans:view" }
   let(:query) do
     <<~GQL
@@ -10,10 +20,18 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
         plan(id: $planId) {
           id
           name
+          hasActiveSubscriptions
+          hasCharges
+          hasCustomers
+          hasDraftInvoices
+          hasOverriddenPlans
+          hasSubscriptions
+
           customersCount
           subscriptionsCount
           activeSubscriptionsCount
           draftInvoicesCount
+
           taxes { id rate }
           charges {
             id
@@ -48,12 +66,10 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
   let(:plan) { create(:plan, organization:) }
 
   let(:billable_metric) { create(:billable_metric, organization:) }
-  let(:charge) { create(:standard_charge, billable_metric:, plan:) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:) }
 
   before do
     customer
-    create_list(:subscription, 2, customer:, plan:)
     minimum_commitment
   end
 
@@ -62,26 +78,131 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
   it_behaves_like "requires permission", "plans:view"
 
   it "returns a single plan" do
-    result = execute_graphql(
-      current_user: membership.user,
-      current_organization: organization,
-      permissions: required_permission,
-      query:,
-      variables: {planId: plan.id}
-    )
-
     plan_response = result["data"]["plan"]
 
-    aggregate_failures do
-      expect(plan_response["id"]).to eq(plan.id)
-      expect(plan_response["subscriptionsCount"]).to eq(2)
+    expect(plan_response["id"]).to eq(plan.id)
+    expect(plan_response["hasCharges"]).to eq(false)
+    expect(plan_response["hasCustomers"]).to eq(false)
+    expect(plan_response["hasDraftInvoices"]).to eq(false)
+    expect(plan_response["hasActiveSubscriptions"]).to eq(false)
+    expect(plan_response["hasSubscriptions"]).to eq(false)
+
+    expect(plan_response["minimumCommitment"]).to include(
+      "id" => minimum_commitment.id,
+      "amountCents" => minimum_commitment.amount_cents.to_s,
+      "invoiceDisplayName" => minimum_commitment.invoice_display_name,
+      "taxes" => []
+    )
+  end
+
+  context "when plan has active subscriptions" do
+    before do
+      create_list(:subscription, 2, customer:, plan:)
+    end
+
+    it "returns true for has active subscriptions and subscriptions" do
+      plan_response = result["data"]["plan"]
+
+      expect(plan_response["hasCustomers"]).to eq(true)
+      expect(plan_response["hasActiveSubscriptions"]).to eq(true)
+      expect(plan_response["hasSubscriptions"]).to eq(true)
+
       expect(plan_response["customersCount"]).to eq(1)
-      expect(plan_response["minimumCommitment"]).to include(
-        "id" => minimum_commitment.id,
-        "amountCents" => minimum_commitment.amount_cents.to_s,
-        "invoiceDisplayName" => minimum_commitment.invoice_display_name,
-        "taxes" => []
-      )
+      expect(plan_response["subscriptionsCount"]).to eq(2)
+    end
+  end
+
+  context "when child plan has active subscriptions" do
+    before do
+      child_plan = create(:plan, organization:, parent: plan)
+      create(:subscription, customer:, plan: child_plan)
+    end
+
+    it "returns true for has active subscriptions and subscriptions" do
+      plan_response = result["data"]["plan"]
+
+      expect(plan_response["hasCustomers"]).to eq(true)
+      expect(plan_response["hasActiveSubscriptions"]).to eq(true)
+      expect(plan_response["hasSubscriptions"]).to eq(true)
+
+      expect(plan_response["customersCount"]).to eq(1)
+      expect(plan_response["subscriptionsCount"]).to eq(1)
+    end
+  end
+
+  context "when plan only has terminated subscriptions" do
+    before do
+      create(:subscription, :terminated, customer:, plan:)
+    end
+
+    it "returns true for has subscriptions but false for active subscriptions" do
+      plan_response = result["data"]["plan"]
+
+      expect(plan_response["hasCustomers"]).to eq(false)
+      expect(plan_response["hasActiveSubscriptions"]).to eq(false)
+      expect(plan_response["hasSubscriptions"]).to eq(true)
+
+      expect(plan_response["customersCount"]).to eq(0)
+      expect(plan_response["subscriptionsCount"]).to eq(1)
+    end
+  end
+
+  context "when child plan has terminated subscriptions" do
+    before do
+      child_plan = create(:plan, organization:, parent: plan)
+      create(:subscription, :terminated, customer:, plan: child_plan)
+    end
+
+    it "returns true for has subscriptions but false for active subscriptions" do
+      plan_response = result["data"]["plan"]
+
+      expect(plan_response["hasCustomers"]).to eq(false)
+      expect(plan_response["hasActiveSubscriptions"]).to eq(false)
+      expect(plan_response["hasSubscriptions"]).to eq(true)
+
+      expect(plan_response["customersCount"]).to eq(0)
+      expect(plan_response["subscriptionsCount"]).to eq(1)
+    end
+  end
+
+  context "when plan has charges" do
+    before do
+      create(:standard_charge, billable_metric:, plan:)
+    end
+
+    it "returns true for has charges" do
+      plan_response = result["data"]["plan"]
+
+      expect(plan_response["hasCharges"]).to eq(true)
+    end
+  end
+
+  context "when plan has draft invoices" do
+    before do
+      subscription = create(:subscription, customer:, plan:)
+      invoice = create(:invoice, :draft, customer:)
+      create(:invoice_subscription, subscription:, invoice:)
+    end
+
+    it "returns true for has draft invoices" do
+      plan_response = result["data"]["plan"]
+
+      expect(plan_response["hasDraftInvoices"]).to eq(true)
+    end
+  end
+
+  context "when child plan has draft invoices" do
+    before do
+      child_plan = create(:plan, organization:, parent: plan)
+      subscription = create(:subscription, :terminated, customer:, plan: child_plan)
+      invoice = create(:invoice, :draft, customer:)
+      create(:invoice_subscription, subscription:, invoice:)
+    end
+
+    it "returns true for has draft invoices" do
+      plan_response = result["data"]["plan"]
+
+      expect(plan_response["hasDraftInvoices"]).to eq(true)
     end
   end
 

--- a/spec/graphql/types/plans/object_spec.rb
+++ b/spec/graphql/types/plans/object_spec.rb
@@ -25,11 +25,18 @@ RSpec.describe Types::Plans::Object do
     expect(subject).to have_field(:taxes).of_type("[Tax!]")
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:usage_thresholds).of_type("[UsageThreshold!]")
+
+    expect(subject).to have_field(:has_active_subscriptions).of_type("Boolean!")
+    expect(subject).to have_field(:has_charges).of_type("Boolean!")
+    expect(subject).to have_field(:has_customers).of_type("Boolean!")
+    expect(subject).to have_field(:has_draft_invoices).of_type("Boolean!")
+    expect(subject).to have_field(:has_subscriptions).of_type("Boolean!")
+
     expect(subject).to have_field(:active_subscriptions_count).of_type("Int!")
     expect(subject).to have_field(:charges_count).of_type("Int!")
     expect(subject).to have_field(:customers_count).of_type("Int!")
     expect(subject).to have_field(:draft_invoices_count).of_type("Int!")
     expect(subject).to have_field(:subscriptions_count).of_type("Int!")
-    expect(subject).to have_field(:usage_thresholds).of_type("[UsageThreshold!]")
   end
 end


### PR DESCRIPTION
These methods will replace `*_count` methods as this ones are DB expensive and we don't need them anymore. It is enough to know if plan or its children plans has related objects nor the count of them, also, this is performant.

`*_count` attributes are deprecated and will be deleted after frontend does not require them anymore.