### PR TITLE
fix(job): Wrong retry strategy name

### DIFF
--- a/app/jobs/payments/update_payment_method_data_job.rb
+++ b/app/jobs/payments/update_payment_method_data_job.rb
@@ -4,7 +4,7 @@ module Payments
   class UpdatePaymentMethodDataJob < ApplicationJob
     queue_as "default"
 
-    retry_on ::Stripe::RateLimitError, wait: :exponentially_longer, attempts: 5
+    retry_on ::Stripe::RateLimitError, wait: :polynomially_longer, attempts: 5
 
     def perform(provider_payment_id:, provider_payment_method_id:)
       payment = ::Payment.find_by!(provider_payment_id: provider_payment_id)


### PR DESCRIPTION
## Description

```
RuntimeError: Couldn't determine a delay based on :exponentially_longer
```
