### PR TITLE
fix(payment): Dont update payment method if payment not found

### DIFF
--- a/app/jobs/payments/update_payment_method_data_job.rb
+++ b/app/jobs/payments/update_payment_method_data_job.rb
@@ -6,8 +6,7 @@ module Payments
 
     retry_on ::Stripe::RateLimitError, wait: :polynomially_longer, attempts: 5
 
-    def perform(provider_payment_id:, provider_payment_method_id:)
-      payment = ::Payment.find_by!(provider_payment_id: provider_payment_id)
+    def perform(payment:, provider_payment_method_id:)
       ::Payments::UpdatePaymentMethodDataService.call!(payment:, provider_payment_method_id:)
     end
   end

--- a/app/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service.rb
@@ -7,10 +7,12 @@ module PaymentProviders
         def call
           @result = update_payment_status! "succeeded"
 
-          ::Payments::UpdatePaymentMethodDataJob.perform_later(
-            provider_payment_id: event.data.object.id,
-            provider_payment_method_id: event.data.object.payment_method
-          )
+          if result.payment
+            ::Payments::UpdatePaymentMethodDataJob.perform_later(
+              payment: result.payment,
+              provider_payment_method_id: event.data.object.payment_method
+            )
+          end
 
           result
         end

--- a/spec/jobs/payments/update_payment_method_data_job_spec.rb
+++ b/spec/jobs/payments/update_payment_method_data_job_spec.rb
@@ -3,29 +3,15 @@
 require "rails_helper"
 
 RSpec.describe Payments::UpdatePaymentMethodDataJob, type: :job do
-  let(:provider_payment_id) { "pi_123" }
+  let(:payment) { create(:payment) }
   let(:provider_payment_method_id) { "pm_001" }
 
   it "calls the service" do
-    create(:payment, provider_payment_id:)
-
     allow(Payments::UpdatePaymentMethodDataService)
-      .to receive(:call!).with(payment: Payment, provider_payment_method_id:).and_return(BaseService::Result.new)
+      .to receive(:call!).with(payment:, provider_payment_method_id:).and_return(BaseService::Result.new)
 
-    described_class.perform_now(provider_payment_id: "pi_123", provider_payment_method_id:)
+    described_class.perform_now(payment:, provider_payment_method_id:)
 
     expect(Payments::UpdatePaymentMethodDataService).to have_received(:call!)
-  end
-
-  context "when payment is not found" do
-    it "does not call the service" do
-      allow(Payments::UpdatePaymentMethodDataService).to receive(:call!)
-
-      expect {
-        described_class.perform_now(provider_payment_id: "pi_123", provider_payment_method_id:)
-      }.to raise_error(ActiveRecord::RecordNotFound)
-
-      expect(Payments::UpdatePaymentMethodDataService).not_to have_received(:call!)
-    end
   end
 end


### PR DESCRIPTION
## Description

See https://github.com/getlago/lago-api/pull/3381

If the initial service updating the payment method (which might also create payment if not found doesn't return a payment), ignore the next job.

What I got wrong initially is that I assumed if no payment was found in the end, the service was raising an error. It doesn't.

https://github.com/getlago/lago-api/blob/953b92a96de74ab613479dd4db1d5e85977d9d47/app/services/invoices/payments/stripe_service.rb#L16-L28

https://github.com/getlago/lago-api/blob/953b92a96de74ab613479dd4db1d5e85977d9d47/app/services/payment_requests/payments/stripe_service.rb#L32-L42