### PR TITLE
feat(taxes): Add jobs to update EU Taxes

### DIFF
--- a/app/jobs/taxes/update_all_eu_taxes_job.rb
+++ b/app/jobs/taxes/update_all_eu_taxes_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Taxes
+  class UpdateAllEuTaxesJob < ApplicationJob
+    queue_as "default"
+
+    def perform
+      Organization.where(eu_tax_management: true).find_each do |org|
+        ::Taxes::UpdateOrganizationEuTaxesJob.perform_later(org)
+      end
+    end
+  end
+end

--- a/app/jobs/taxes/update_organization_eu_taxes_job.rb
+++ b/app/jobs/taxes/update_organization_eu_taxes_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Taxes
+  class UpdateOrganizationEuTaxesJob < ApplicationJob
+    queue_as "default"
+
+    def perform(organization)
+      Taxes::AutoGenerateService.call!(organization:)
+    end
+  end
+end

--- a/spec/jobs/taxes/update_all_eu_taxes_job_spec.rb
+++ b/spec/jobs/taxes/update_all_eu_taxes_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Taxes::UpdateAllEuTaxesJob, type: :job do
+  subject { described_class.perform_now }
+
+  let(:organization) { create(:organization, eu_tax_management: true) }
+
+  describe ".perform" do
+    it "enqueues a job for organization with EU Tax Management" do
+      create(:organization, eu_tax_management: false)
+
+      expect { subject }.to have_enqueued_job(::Taxes::UpdateOrganizationEuTaxesJob).with(organization).exactly(:once)
+    end
+  end
+end

--- a/spec/jobs/taxes/update_organization_eu_taxes_job_spec.rb
+++ b/spec/jobs/taxes/update_organization_eu_taxes_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Taxes::UpdateOrganizationEuTaxesJob, type: :job do
+  let(:organization) { create(:organization) }
+
+  describe ".perform" do
+    let(:organization) { create(:organization, api_keys: []) }
+    let(:result) { BaseService::Result.new }
+
+    it "calls the subscriptions biller service" do
+      allow(Taxes::AutoGenerateService).to receive(:call!)
+
+      described_class.perform_now(organization)
+
+      expect(Taxes::AutoGenerateService).to have_received(:call!).with(organization:)
+    end
+  end
+end

--- a/spec/services/taxes/auto_generate_service_spec.rb
+++ b/spec/services/taxes/auto_generate_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Taxes::AutoGenerateService, type: :service do
 
     it "updates eu taxes for organization" do
       auto_generate_service.call
-      organization.taxes.update_all(rate: 99)
+      organization.taxes.update_all(rate: 99) # rubocop:disable Rails/SkipsModelValidations
       expect(organization.taxes.pluck(:rate)).to all eq 99
 
       auto_generate_service.call

--- a/spec/services/taxes/auto_generate_service_spec.rb
+++ b/spec/services/taxes/auto_generate_service_spec.rb
@@ -11,7 +11,17 @@ RSpec.describe Taxes::AutoGenerateService, type: :service do
     it "creates eu taxes for organization" do
       auto_generate_service.call
 
-      expect(Tax.count).to eq(46) # EU taxes + 2 defaults
+      expect(organization.taxes.count).to eq(46) # EU taxes + 2 defaults
+    end
+
+    it "updates eu taxes for organization" do
+      auto_generate_service.call
+      organization.taxes.update_all(rate: 99)
+      expect(organization.taxes.pluck(:rate)).to all eq 99
+
+      auto_generate_service.call
+      expect(organization.taxes.count).to eq(46) # No new taxes created
+      expect(organization.taxes.pluck(:rate)).to all(be < 99)
     end
   end
 end


### PR DESCRIPTION
## Context

The EU Tax Management integration generate taxes [from a json file](https://github.com/getlago/lago-api/blob/main/lib/lago_eu_vat/lago_eu_vat/eu_vat_rates.json). These taxes should be updated with we update the file.

Related recent changes: https://github.com/getlago/lago-api/pull/3356

## Description

The existing service already takes care of updating the existing taxes (see new spec added). This PR only adds jobs to run the update.

When the file is updated, we should add a job to the migration or enqueue it from the console, or even make a rake console.

What's your preference?
