### PR TITLE
feat(processor): Add flag subscription refresh logic

### DIFF
--- a/app/jobs/clock/consume_subscription_refreshed_queue_job.rb
+++ b/app/jobs/clock/consume_subscription_refreshed_queue_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Clock::ConsumeSubscriptionRefreshedQueueJob < ApplicationJob
+  queue_as do
+    if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
+      :clock_worker
+    else
+      :clock
+    end
+  end
+
+  unique :until_executed, on_conflict: :log
+
+  def perform
+    Subscriptions::ConsumeSubscriptionRefreshedQueueService.call!
+  end
+end

--- a/app/jobs/subscriptions/flag_refreshed_job.rb
+++ b/app/jobs/subscriptions/flag_refreshed_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class FlagRefreshedJob < ApplicationJob
+    queue_as :events
+
+    def perform(subscription_id)
+      Subscriptions::FlagRefreshedService.call!(subscription_id)
+    end
+  end
+end

--- a/app/services/subscriptions/consume_subscription_refreshed_queue_service.rb
+++ b/app/services/subscriptions/consume_subscription_refreshed_queue_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class ConsumeSubscriptionRefreshedQueueService < BaseService
+    REDIS_STORE_NAME = "subscription_refreshed"
+    BATCH_SIZE = 100
+    PROCESSING_TIMEOUT = 1.minute
+
+    def call
+      start_time = Time.current
+
+      loop do
+        if Time.current - start_time > PROCESSING_TIMEOUT
+          # Avoid looping for ever if the producer is quicker than this consumer
+          break
+        end
+
+        values = redis_client.srandmember(REDIS_STORE_NAME, BATCH_SIZE)
+        break if values.blank?
+
+        values.each { |v| Subscriptions::FlagRefreshedJob.perform_later(v.split(":").last) }
+
+        redis_client.srem(REDIS_STORE_NAME, values) if values.present?
+      end
+
+      result
+    end
+
+    private
+
+    def redis_client
+      @redis_client ||= Redis.new(
+        url: "redis://#{ENV["LAGO_REDIS_STORE_URL"]}",
+        password: ENV["LAGO_REDIS_STORE_PASSWORD"].presence,
+        db: ENV["LAGO_REDIS_STORE_DB"]
+      )
+    end
+  end
+end

--- a/app/services/subscriptions/flag_refreshed_service.rb
+++ b/app/services/subscriptions/flag_refreshed_service.rb
@@ -1,0 +1,38 @@
+#  frozen_string_literal: true
+
+module Subscriptions
+  class FlagRefreshedService < BaseService
+    Result = BaseResult[:subscription_id]
+
+    def initialize(subscription_id)
+      @subscription_id = subscription_id
+      super
+    end
+
+    def call
+      flag_wallets_for_refresh
+      flag_lifetime_usage_for_refresh
+
+      result.subscription_id = subscription_id
+      result
+    end
+
+    private
+
+    attr_reader :subscription_id
+
+    def flag_wallets_for_refresh
+      Wallet
+        .active
+        .joins(:customer)
+        .where(customers: {id: Subscription.where(id: subscription_id).select(:customer_id)})
+        .update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    def flag_lifetime_usage_for_refresh
+      Subscription.where(id: subscription_id).includes(:lifetime_usage, plan: :usage_thresholds).find_each do
+        LifetimeUsages::FlagRefreshFromSubscriptionService.new(subscription: _1).call
+      end
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -166,4 +166,13 @@ module Clockwork
       .set(sentry: {"slug" => "lago_retry_inbound_webhooks", "cron" => "*/15 * * * *"})
       .perform_later
   end
+
+  # NOTE: Enable wallets and lifetime usage refresh from the events-processor
+  if ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"].present?
+    every(1.minute, "schedule:refresh_flagged_subscriptions") do
+      Clock::ConsumeSubscriptionRefreshedQueueJob
+        .set(sentry: {"slug" => "lago_refresh_flagged_subscriptions", "cron" => "*/1 * * * *"})
+        .perform_later
+    end
+  end
 end

--- a/spec/jobs/clock/consume_subscription_refreshed_queue_job_spec.rb
+++ b/spec/jobs/clock/consume_subscription_refreshed_queue_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Clock::ConsumeSubscriptionRefreshedQueueJob, type: :job do
+  subject(:refresh_jobs) { described_class }
+
+  describe "#perform" do
+    before { allow(Subscriptions::ConsumeSubscriptionRefreshedQueueService).to receive(:call!) }
+
+    it "consumes the subscription refresh requests from the queue" do
+      refresh_jobs.perform_now
+
+      expect(Subscriptions::ConsumeSubscriptionRefreshedQueueService).to have_received(:call!)
+    end
+  end
+end

--- a/spec/jobs/subscriptions/flag_refreshed_job_spec.rb
+++ b/spec/jobs/subscriptions/flag_refreshed_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::FlagRefreshedJob, type: :job do
+  describe "#perform" do
+    let(:subscription_id) { SecureRandom.uuid }
+
+    it "calls the subscriptions flag refreshed job" do
+      allow(Subscriptions::FlagRefreshedService).to receive(:call!)
+
+      described_class.perform_now(subscription_id)
+
+      expect(Subscriptions::FlagRefreshedService).to have_received(:call!)
+        .with(subscription_id)
+    end
+  end
+end

--- a/spec/services/subscriptions/consume_subscription_refreshed_queue_service_spec.rb
+++ b/spec/services/subscriptions/consume_subscription_refreshed_queue_service_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::ConsumeSubscriptionRefreshedQueueService do
+  subject(:flag_service) { described_class.new }
+
+  let(:redis_client) { instance_double(Redis) }
+
+  let(:values) { ["#{SecureRandom.uuid}:#{SecureRandom.uuid}", "#{SecureRandom.uuid}:#{SecureRandom.uuid}"] }
+  let(:loop_values) { [values, []] }
+
+  before do
+    allow(Redis).to receive(:new).and_return(redis_client)
+    allow(redis_client).to receive(:srandmember)
+      .with(described_class::REDIS_STORE_NAME, described_class::BATCH_SIZE)
+      .and_return(*loop_values)
+
+    allow(redis_client).to receive(:srem)
+  end
+
+  describe "#call" do
+    it "flags all subscriptions as refreshed" do
+      result = flag_service.call
+
+      expect(result).to be_success
+      expect(Subscriptions::FlagRefreshedJob).to have_been_enqueued.twice
+    end
+
+    context "with multiple batches" do
+      let(:loop_values) { [values, values, []] }
+
+      it "flags all subscriptions as refreshed" do
+        result = flag_service.call
+
+        expect(result).to be_success
+        expect(Subscriptions::FlagRefreshedJob).to have_been_enqueued.exactly(4).times
+      end
+    end
+
+    context "with no subscriptions" do
+      let(:loop_values) { [[]] }
+
+      it "does not flag any subscriptions as refreshed" do
+        result = flag_service.call
+
+        expect(result).to be_success
+        expect(Subscriptions::FlagRefreshedJob).not_to have_been_enqueued
+      end
+    end
+
+    context "when timeout is reached" do
+      let(:start_time) { Time.current }
+
+      before do
+        allow(Time).to receive(:current).and_return(
+          start_time,
+          start_time + described_class::PROCESSING_TIMEOUT + 1.second
+        )
+      end
+
+      it "flags all subscriptions as refreshed" do
+        result = flag_service.call
+
+        expect(result).to be_success
+        expect(Subscriptions::FlagRefreshedJob).not_to have_been_enqueued
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/flag_refreshed_service_spec.rb
+++ b/spec/services/subscriptions/flag_refreshed_service_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::FlagRefreshedService, type: :service do
+  subject(:flag_service) { described_class.new(subscription_id) }
+
+  let(:subscription_id) { subscription.id }
+
+  let(:plan) { create(:plan, organization: customer.organization) }
+  let(:threshold) { create(:usage_threshold, plan:) }
+
+  let(:customer) { create(:customer) }
+  let(:subscription) { create(:subscription, customer:, plan:) }
+  let(:wallet) { create(:wallet, customer:, ready_to_be_refreshed: false) }
+
+  before do
+    wallet
+    threshold
+  end
+
+  describe "#call" do
+    it "flags the wallets and usage for refresh" do
+      result = flag_service.call
+
+      expect(result).to be_success
+      expect(wallet.reload).to be_ready_to_be_refreshed
+      expect(subscription.reload.lifetime_usage).to be_recalculate_current_usage
+    end
+  end
+end


### PR DESCRIPTION
# Description

Related to https://github.com/getlago/lago/pull/500

This PR adds a new Redis consumer to flag subscription's lifetime usage records and customer's wallet for refresh.
The messages are pushed from the events-processor for every uniq subscriptions.