### PR TITLE
fix: handle xero decimal cases

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/xero.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/xero.rb
@@ -8,6 +8,18 @@ module Integrations
           def initialize(integration_customer:, invoice:)
             super
           end
+
+          def item(fee)
+            base_item = super
+
+            if fee.precise_unit_amount.round(2) != fee.precise_unit_amount
+              base_item["units"] = 1
+              base_item.delete("precise_unit_amount")
+              base_item["amount_cents"] = fee.amount_cents
+            end
+
+            base_item
+          end
         end
       end
     end

--- a/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/xero_spec.rb
@@ -154,8 +154,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Xero do
             {
               "external_id" => "m2",
               "description" => charge_fee.invoice_name,
-              "units" => 2.0,
-              "precise_unit_amount" => 4.121212121233378,
+              "units" => 1,
+              "amount_cents" => charge_fee.amount_cents,
               "account_code" => "m22",
               "taxes_amount_cents" => 2
             },


### PR DESCRIPTION
## Context

Some billing systems, such as Xero, do not support precise_unit_amount values with more than two decimal places. Currently, we send the raw value, which can cause errors on the values presented on xero

This PR addresses that issue by adjusting the payload format specifically for the Xero integration.

## Description
Moves the item(fee) serialization logic into the Xero class, preserving the generic behavior in BasePayload.
When a precise_unit_amount has more than 2 decimal places:

- Sets "units" to 1
- Removes the "precise_unit_amount" field
- Adds "amount_cents" with the fee value excluding discounts and taxes

This logic is only applied to the Xero integration payload.