### PR TITLE
Feat add timeout

### DIFF
--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -12,7 +12,8 @@ module Invoices
 
     retry_on Sequenced::SequenceError
     retry_on BaseService::ThrottlingError, wait: :polynomially_longer, attempts: 25
-    retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6, jitter: 0.75
+    retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 15, jitter: 0.75
+    retry_on ActiveRecord::LockWaitTimeout, PG::LockNotAvailable, wait: :exponentially_longer, attempts: 15
 
     unique :until_executed, on_conflict: :log
 

--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -18,6 +18,7 @@ module Credits
       wallet_credit = WalletCredit.from_amount_cents(wallet:, amount_cents:)
 
       ActiveRecord::Base.transaction do
+        ActiveRecord::Base.connection.execute("SET LOCAL lock_timeout = '10s'")
         wallet_transaction = WalletTransactions::CreateService.call!(
           wallet:,
           wallet_credit:,


### PR DESCRIPTION
## Context

This PR addresses a PostgreSQL lock_timeout issue when applying prepaid credits to invoices. Under certain conditions, concurrent updates to the same wallet record caused lock contention and job failures.

