### PR TITLE
feat: Add deleted records to customers and plans resolvers

### DIFF
--- a/app/graphql/resolvers/customers_resolver.rb
+++ b/app/graphql/resolvers/customers_resolver.rb
@@ -15,6 +15,7 @@ module Resolvers
     argument :search_term, String, required: false
 
     argument :account_type, [Types::Customers::AccountTypeEnum], required: false
+    argument :with_deleted, Boolean, required: false
 
     type Types::Customers::Object.collection_type, null: false
 
@@ -26,7 +27,7 @@ module Resolvers
           page: args[:page],
           limit: args[:limit]
         },
-        filters: args.slice(:account_type)
+        filters: args.slice(:account_type, :with_deleted)
       )
 
       result.customers

--- a/app/graphql/resolvers/plans_resolver.rb
+++ b/app/graphql/resolvers/plans_resolver.rb
@@ -12,13 +12,17 @@ module Resolvers
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
     argument :search_term, String, required: false
+    argument :with_deleted, Boolean, required: false
 
     type Types::Plans::Object.collection_type, null: false
 
-    def resolve(page: nil, limit: nil, search_term: nil)
+    def resolve(page: nil, limit: nil, search_term: nil, with_deleted: nil)
       result = PlansQuery.call(
         organization: current_organization,
         search_term:,
+        filters: {
+          with_deleted:
+        },
         pagination: {
           page:,
           limit:

--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -11,6 +11,7 @@ class CustomersQuery < BaseQuery
     customers = apply_consistent_ordering(customers)
 
     customers = with_account_type(customers) if filters.account_type.present?
+    customers = customers.with_discarded if filters.with_deleted
 
     result.customers = customers
     result

--- a/app/queries/plans_query.rb
+++ b/app/queries/plans_query.rb
@@ -9,6 +9,7 @@ class PlansQuery < BaseQuery
     plans = apply_consistent_ordering(plans)
 
     plans = exclude_pending_deletion(plans) unless filters.include_pending_deletion
+    plans = plans.with_discarded if filters.with_deleted
 
     result.plans = plans
     result

--- a/schema.graphql
+++ b/schema.graphql
@@ -6998,7 +6998,7 @@ type Query {
   """
   Query customers of an organization
   """
-  customers(accountType: [CustomerAccountTypeEnum!], limit: Int, page: Int, searchTerm: String): CustomerCollection!
+  customers(accountType: [CustomerAccountTypeEnum!], limit: Int, page: Int, searchTerm: String, withDeleted: Boolean): CustomerCollection!
 
   """
   Query monthly recurring revenues of an organization
@@ -7288,7 +7288,7 @@ type Query {
   """
   Query plans of an organization
   """
-  plans(limit: Int, page: Int, searchTerm: String): PlanCollection!
+  plans(limit: Int, page: Int, searchTerm: String, withDeleted: Boolean): PlanCollection!
 
   """
   Query a single subscription of an organization

--- a/schema.json
+++ b/schema.json
@@ -35116,6 +35116,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "withDeleted",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },
@@ -37345,6 +37357,18 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "withDeleted",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null,


### PR DESCRIPTION
We want to be able to display deleted customers and plans on the UI.
The goal of this PR is to add a `with_deleted` filter to these resolvers so that we can filter on it.