### PR TITLE
misc: Remove count attributes from BillableMetric graphQL type object

### DIFF
--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -23,12 +23,6 @@ module Types
 
       field :recurring, Boolean, null: false
 
-      # TODO: remove these count fields after frontend migration is completed
-      field :active_subscriptions_count, Integer, null: false
-      field :draft_invoices_count, Integer, null: false
-      field :plans_count, Integer, null: false
-      field :subscriptions_count, Integer, null: false
-
       field :has_active_subscriptions, Boolean, null: false
       field :has_draft_invoices, Boolean, null: false
       field :has_plans, Boolean, null: false
@@ -43,24 +37,6 @@ module Types
 
       field :integration_mappings, [Types::IntegrationMappings::Object], null: true do
         argument :integration_id, ID, required: false
-      end
-
-      def subscriptions_count
-        Subscription.where(plan_id: object.charges.select(:plan_id).distinct).count
-      end
-
-      def active_subscriptions_count
-        Subscription.active.where(plan_id: object.charges.select(:plan_id).distinct).count
-      end
-
-      def draft_invoices_count
-        Invoice.draft.where(id: object.charges
-          .joins(:fees)
-          .select(:invoice_id)).count
-      end
-
-      def plans_count
-        object.charges.distinct.count(:plan_id)
       end
 
       def has_active_subscriptions

--- a/schema.graphql
+++ b/schema.graphql
@@ -255,13 +255,11 @@ scalar BigInt
 Base billable metric
 """
 type BillableMetric {
-  activeSubscriptionsCount: Int!
   aggregationType: AggregationTypeEnum!
   code: String!
   createdAt: ISO8601DateTime!
   deletedAt: ISO8601DateTime
   description: String
-  draftInvoicesCount: Int!
   expression: String
   fieldName: String
   filters: [BillableMetricFilter!]
@@ -273,11 +271,9 @@ type BillableMetric {
   integrationMappings(integrationId: ID): [Mapping!]
   name: String!
   organization: Organization
-  plansCount: Int!
   recurring: Boolean!
   roundingFunction: RoundingFunctionEnum
   roundingPrecision: Int
-  subscriptionsCount: Int!
   updatedAt: ISO8601DateTime!
   weightedInterval: WeightedIntervalEnum
 }

--- a/schema.json
+++ b/schema.json
@@ -1989,22 +1989,6 @@
           "possibleTypes": null,
           "fields": [
             {
-              "name": "activeSubscriptionsCount",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
               "name": "aggregationType",
               "description": null,
               "type": {
@@ -2071,22 +2055,6 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "draftInvoicesCount",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -2278,22 +2246,6 @@
               "args": []
             },
             {
-              "name": "plansCount",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
               "name": "recurring",
               "description": null,
               "type": {
@@ -2328,22 +2280,6 @@
                 "kind": "SCALAR",
                 "name": "Int",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "subscriptionsCount",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/resolvers/billable_metric_resolver_spec.rb
+++ b/spec/graphql/resolvers/billable_metric_resolver_spec.rb
@@ -24,11 +24,6 @@ RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
           hasActiveSubscriptions
           hasDraftInvoices
           hasPlans
-
-          subscriptionsCount
-          activeSubscriptionsCount
-          draftInvoicesCount
-          plansCount
         }
       }
     GQL
@@ -50,10 +45,6 @@ RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
     expect(metric_response["hasActiveSubscriptions"]).to eq(false)
     expect(metric_response["hasDraftInvoices"]).to eq(false)
     expect(metric_response["hasPlans"]).to eq(false)
-
-    expect(metric_response["subscriptionsCount"]).to eq(0)
-    expect(metric_response["activeSubscriptionsCount"]).to eq(0)
-    expect(metric_response["draftInvoicesCount"]).to eq(0)
   end
 
   context "when billable metric has subscriptions" do
@@ -66,9 +57,6 @@ RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
       metric_response = graphql_request["data"]["billableMetric"]
       expect(metric_response["hasSubscriptions"]).to eq(true)
       expect(metric_response["hasActiveSubscriptions"]).to eq(false)
-
-      expect(metric_response["subscriptionsCount"]).to eq(1)
-      expect(metric_response["activeSubscriptionsCount"]).to eq(0)
     end
   end
 
@@ -85,9 +73,6 @@ RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
       metric_response = graphql_request["data"]["billableMetric"]
       expect(metric_response["hasSubscriptions"]).to eq(true)
       expect(metric_response["hasActiveSubscriptions"]).to eq(true)
-
-      expect(metric_response["subscriptionsCount"]).to eq(2)
-      expect(metric_response["activeSubscriptionsCount"]).to eq(1)
     end
   end
 
@@ -110,7 +95,6 @@ RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
     it "returns true for has draft invoices" do
       metric_response = graphql_request["data"]["billableMetric"]
       expect(metric_response["hasDraftInvoices"]).to eq(true)
-      expect(metric_response["draftInvoicesCount"]).to eq(1)
     end
   end
 
@@ -125,7 +109,6 @@ RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
     it "returns true for has plans" do
       metric_response = graphql_request["data"]["billableMetric"]
       expect(metric_response["hasPlans"]).to eq(true)
-      expect(metric_response["plansCount"]).to eq(2)
     end
   end
 

--- a/spec/graphql/types/billable_metrics/object_spec.rb
+++ b/spec/graphql/types/billable_metrics/object_spec.rb
@@ -28,10 +28,5 @@ RSpec.describe Types::BillableMetrics::Object do
     expect(subject).to have_field(:has_draft_invoices).of_type("Boolean!")
     expect(subject).to have_field(:has_plans).of_type("Boolean!")
     expect(subject).to have_field(:has_subscriptions).of_type("Boolean!")
-
-    expect(subject).to have_field(:active_subscriptions_count).of_type("Int!")
-    expect(subject).to have_field(:draft_invoices_count).of_type("Int!")
-    expect(subject).to have_field(:plans_count).of_type("Int!")
-    expect(subject).to have_field(:subscriptions_count).of_type("Int!")
   end
 end


### PR DESCRIPTION
## Context

We have 4 type of count attributes on the BM model.

* activeSubscriptionsCount
* draftInvoicesCount
* plansCount
* subscriptionsCount

Computation for these fields is quite DB expensive and impacts overall performance.

We have replaced the usage of these attributes with new "has_*" attributes. These new attributes return true when there are at least one record matching... these are performant queries for the usage intended and will reduce DB load and improve graphQL response times. 

## Description

This change remove the _count attributes from Billable Metric object type as it is not needed anymore.