### PR TITLE
feat(payment_providers): Add MoneyHash

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -74,4 +74,19 @@ class WebhooksController < ApplicationController
   def adyen_params
     params["notificationItems"]&.first&.dig("NotificationRequestItem")&.permit!
   end
+
+  def moneyhash
+    result = InboundWebhooks::CreateService.call(
+      organization_id: params[:organization_id],
+      webhook_source: :moneyhash,
+      code: params[:code].presence,
+      payload: JSON.parse(request.body.read),
+      signature: request.headers["MoneyHash-Signature"],
+      event_type: params[:type]
+    )
+
+    return head(:bad_request) unless result.success?
+
+    head(:ok)
+  end
 end

--- a/app/graphql/mutations/payment_providers/moneyhash/base.rb
+++ b/app/graphql/mutations/payment_providers/moneyhash/base.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Mutations
+  module PaymentProviders
+    module Moneyhash
+      class Base < BaseMutation
+        include AuthenticableApiUser
+        include RequiredOrganization
+
+        def resolve(**args)
+          result = ::PaymentProviders::MoneyhashService
+            .new(context[:current_user])
+            .create_or_update(**args.merge(organization: current_organization))
+
+          result.success? ? result.moneyhash_provider : result_error(result)
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/payment_providers/moneyhash/create.rb
+++ b/app/graphql/mutations/payment_providers/moneyhash/create.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mutations
+  module PaymentProviders
+    module Moneyhash
+      class Create < Base
+        REQUIRED_PERMISSION = "organization:integrations:create"
+
+        graphql_name "AddMoneyhashPaymentProvider"
+        description "Add Moneyhash payment provider"
+
+        input_object_class Types::PaymentProviders::MoneyhashInput
+
+        type Types::PaymentProviders::Moneyhash
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/payment_providers/moneyhash/update.rb
+++ b/app/graphql/mutations/payment_providers/moneyhash/update.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mutations
+  module PaymentProviders
+    module Moneyhash
+      class Update < Base
+        REQUIRED_PERMISSION = "organization:integrations:update"
+
+        graphql_name "UpdateMoneyhashPaymentProvider"
+        description "Update Moneyhash payment provider"
+
+        input_object_class Types::PaymentProviders::UpdateInput
+
+        type Types::PaymentProviders::Moneyhash
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/payment_providers_resolver.rb
+++ b/app/graphql/resolvers/payment_providers_resolver.rb
@@ -33,6 +33,8 @@ module Resolvers
         PaymentProviders::GocardlessProvider.to_s
       when "cashfree"
         PaymentProviders::CashfreeProvider.to_s
+      when "moneyhash"
+        PaymentProviders::MoneyhashProvider.to_s
       else
         raise(NotImplementedError)
       end

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -125,7 +125,7 @@ module Types
         object.active_subscriptions.count
       end
 
-      def provider_customer
+      def provider_customer # rubocop:disable GraphQL/ResolverMethodLength
         case object&.payment_provider&.to_sym
         when :stripe
           object.stripe_customer
@@ -135,6 +135,8 @@ module Types
           object.cashfree_customer
         when :adyen
           object.adyen_customer
+        when :moneyhash
+          object.moneyhash_customer
         end
       end
 

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -50,11 +50,13 @@ module Types
     field :add_adyen_payment_provider, mutation: Mutations::PaymentProviders::Adyen::Create
     field :add_cashfree_payment_provider, mutation: Mutations::PaymentProviders::Cashfree::Create
     field :add_gocardless_payment_provider, mutation: Mutations::PaymentProviders::Gocardless::Create
+    field :add_moneyhash_payment_provider, mutation: Mutations::PaymentProviders::Moneyhash::Create
     field :add_stripe_payment_provider, mutation: Mutations::PaymentProviders::Stripe::Create
 
     field :update_adyen_payment_provider, mutation: Mutations::PaymentProviders::Adyen::Update
     field :update_cashfree_payment_provider, mutation: Mutations::PaymentProviders::Cashfree::Update
     field :update_gocardless_payment_provider, mutation: Mutations::PaymentProviders::Gocardless::Update
+    field :update_moneyhash_payment_provider, mutation: Mutations::PaymentProviders::Moneyhash::Update
     field :update_stripe_payment_provider, mutation: Mutations::PaymentProviders::Stripe::Update
 
     field :destroy_payment_provider, mutation: Mutations::PaymentProviders::Destroy

--- a/app/graphql/types/payment_providers/moneyhash.rb
+++ b/app/graphql/types/payment_providers/moneyhash.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Types
+  module PaymentProviders
+    class Moneyhash < Types::BaseObject
+      graphql_name "MoneyhashProvider"
+
+      field :api_key, String, null: true, permission: "organization:integrations:view"
+      field :code, String, null: false
+      field :flow_id, String, null: true, permission: "organization:integrations:view"
+      field :id, ID, null: false
+      field :name, String, null: false
+      field :success_redirect_url, String, null: true, permission: "organization:integrations:view"
+
+      # NOTE: Api key is a sensitive information. It should not be sent back to the
+      #       front end application. Instead we send an obfuscated value
+      def api_key
+        "#{"•" * 8}…#{object.api_key[-3..]}"
+      end
+    end
+  end
+end

--- a/app/graphql/types/payment_providers/moneyhash_input.rb
+++ b/app/graphql/types/payment_providers/moneyhash_input.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module PaymentProviders
+    class MoneyhashInput < BaseInputObject
+      description "Moneyhash input arguments"
+
+      argument :api_key, String, required: true
+      argument :code, String, required: true
+      argument :flow_id, String, required: true
+      argument :name, String, required: true
+      argument :success_redirect_url, String, required: false
+    end
+  end
+end

--- a/app/graphql/types/payment_providers/object.rb
+++ b/app/graphql/types/payment_providers/object.rb
@@ -8,7 +8,8 @@ module Types
       possible_types Types::PaymentProviders::Adyen,
         Types::PaymentProviders::Gocardless,
         Types::PaymentProviders::Stripe,
-        Types::PaymentProviders::Cashfree
+        Types::PaymentProviders::Cashfree,
+        Types::PaymentProviders::Moneyhash
 
       def self.resolve_type(object, _context)
         case object.class.to_s
@@ -20,6 +21,8 @@ module Types
           Types::PaymentProviders::Gocardless
         when "PaymentProviders::CashfreeProvider"
           Types::PaymentProviders::Cashfree
+        when "PaymentProviders::MoneyhashProvider"
+          Types::PaymentProviders::Moneyhash
         else
           raise "Unexpected Payment provider type: #{object.inspect}"
         end

--- a/app/graphql/types/payment_providers/update_input.rb
+++ b/app/graphql/types/payment_providers/update_input.rb
@@ -6,6 +6,7 @@ module Types
       description "Update input arguments"
 
       argument :code, String, required: false
+      argument :flow_id, String, required: false
       argument :id, ID, required: true
       argument :name, String, required: false
       argument :success_redirect_url, String, required: false

--- a/app/jobs/invoices/payments/moneyhash_create_job.rb
+++ b/app/jobs/invoices/payments/moneyhash_create_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Payments
+    class MoneyhashCreateJob < ApplicationJob
+      queue_as "providers"
+
+      unique :until_executed
+
+      retry_on Faraday::ConnectionFailed, wait: :polynomially_longer, attempts: 6
+
+      def perform(invoice)
+        result = Invoices::Payments::MoneyhashService.new(invoice).create
+        result.raise_if_error!
+      end
+    end
+  end
+end

--- a/app/jobs/payment_provider_customers/moneyhash_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/moneyhash_checkout_url_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class MoneyhashCheckoutUrlJob < ApplicationJob
+    queue_as :providers
+
+    retry_on ActiveJob::DeserializationError
+
+    def perform(moneyhash_customer)
+      result = PaymentProviderCustomers::MoneyhashService.new(moneyhash_customer).generate_checkout_url
+      result.raise_if_error!
+    end
+  end
+end

--- a/app/jobs/payment_provider_customers/moneyhash_create_job.rb
+++ b/app/jobs/payment_provider_customers/moneyhash_create_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class MoneyhashCreateJob < ApplicationJob
+    queue_as :providers
+
+    retry_on ActiveJob::DeserializationError
+
+    def perform(moneyhash_customer)
+      result = PaymentProviderCustomers::MoneyhashService.new(moneyhash_customer).create
+
+      result.raise_if_error!
+    end
+  end
+end

--- a/app/jobs/payment_providers/moneyhash/handle_event_job.rb
+++ b/app/jobs/payment_providers/moneyhash/handle_event_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Moneyhash
+    class HandleEventJob < ApplicationJob
+      queue_as "providers"
+
+      def perform(organization:, event_json:)
+        result = ::PaymentProviders::MoneyhashService.new.handle_event(organization:, event_json:)
+        result.raise_if_error!
+      end
+    end
+  end
+end

--- a/app/jobs/payment_requests/payments/moneyhash_create_job.rb
+++ b/app/jobs/payment_requests/payments/moneyhash_create_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PaymentRequests
+  module Payments
+    class MoneyhashCreateJob < ApplicationJob
+      queue_as "providers"
+
+      unique :until_executed
+
+      def perform(payable)
+        result = PaymentRequests::Payments::MoneyhashService.new(payable).create
+        result.raise_if_error!
+      end
+    end
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -75,8 +75,9 @@ class Customer < ApplicationRecord
   has_one :xero_customer, class_name: "IntegrationCustomers::XeroCustomer"
   has_one :hubspot_customer, class_name: "IntegrationCustomers::HubspotCustomer"
   has_one :salesforce_customer, class_name: "IntegrationCustomers::SalesforceCustomer"
+  has_one :moneyhash_customer, class_name: "PaymentProviderCustomers::MoneyhashCustomer"
 
-  PAYMENT_PROVIDERS = %w[stripe gocardless cashfree adyen].freeze
+  PAYMENT_PROVIDERS = %w[stripe gocardless cashfree adyen moneyhash].freeze
 
   default_scope -> { kept }
   sequenced scope: ->(customer) { customer.organization.customers.with_discarded },
@@ -170,6 +171,8 @@ class Customer < ApplicationRecord
       cashfree_customer
     when :adyen
       adyen_customer
+    when :moneyhash
+      moneyhash_customer
     end
   end
 

--- a/app/models/payment_provider_customers/moneyhash_customer.rb
+++ b/app/models/payment_provider_customers/moneyhash_customer.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class MoneyhashCustomer < BaseCustomer
+    settings_accessors :payment_method_id
+
+    # extract MoneyHash's billing data from customer
+    def mh_billing_data
+      {}.tap do |billing_data|
+        billing_data[:name] = customer.name if customer.name.present?
+        billing_data[:first_name] = customer.firstname if customer.firstname.present?
+        billing_data[:last_name] = customer.lastname if customer.lastname.present?
+        billing_data[:email] = customer.email if customer.email.present?
+        billing_data[:phone_number] = customer.phone if customer.phone.present?
+        billing_data[:address] = customer.address_line1 if customer.address_line1.present?
+        billing_data[:address1] = customer.address_line2 if customer.address_line2.present?
+        billing_data[:city] = customer.city if customer.city.present?
+        billing_data[:state] = customer.state if customer.state.present?
+        billing_data[:country] = customer.country if customer.country.present?
+        billing_data[:postal_code] = customer.zipcode if customer.zipcode.present?
+      end
+    end
+
+    # extract all possible custom_fields from moneyhash_customer
+    def mh_custom_fields
+      {
+        # connection
+        lago_mh_connection_id: payment_provider.id,
+        lago_mh_connection_code: payment_provider.code,
+        # customer
+        lago_customer_id: customer.id,
+        lago_customer_external_id: customer.external_id.to_s,
+        lago_customer_name: customer.name.to_s,
+        lago_customer_currency: customer.currency.to_s,
+        lago_customer_legal_name: customer.legal_name.to_s,
+        lago_customer_legal_number: customer.legal_number.to_s,
+        lago_customer_tax_identification_number: customer.tax_identification_number.to_s,
+        lago_customer_provider_customer_id: provider_customer_id.to_s,
+        # organization
+        lago_organization_id: customer.organization.id
+      }
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: payment_provider_customers
+#
+#  id                   :uuid             not null, primary key
+#  deleted_at           :datetime
+#  settings             :jsonb            not null
+#  type                 :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  customer_id          :uuid             not null
+#  payment_provider_id  :uuid
+#  provider_customer_id :string
+#
+# Indexes
+#
+#  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE WHERE (deleted_at IS NULL)
+#  index_payment_provider_customers_on_payment_provider_id   (payment_provider_id)
+#  index_payment_provider_customers_on_provider_customer_id  (provider_customer_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (payment_provider_id => payment_providers.id)
+#

--- a/app/models/payment_providers/moneyhash_provider.rb
+++ b/app/models/payment_providers/moneyhash_provider.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  class MoneyhashProvider < BaseProvider
+    SUCCESS_REDIRECT_URL = "https://moneyhash.io/"
+
+    # Lago payment_status -> MoneyHash statuses mapping
+    PROCESSING_STATUSES = %w[PENDING PENDING_AUTHENTICATION UNPROCESSED].freeze
+    SUCCESS_STATUSES = %w[SUCCESSFUL PROCESSED].freeze
+    FAILED_STATUSES = %w[FAILED].freeze
+
+    # MoneyHash payment status -> Lago payable_payment_status mapping
+    PAYABLE_PAYMENT_STATUS_MAP = {
+      "PENDING" => "pending",
+      "PENDING_AUTHENTICATION" => "pending",
+      "UNPROCESSED" => "pending",
+      "SUCCESSFUL" => "succeeded",
+      "PROCESSED" => "succeeded",
+      "FAILED" => "failed"
+    }.freeze
+
+    validates :api_key, presence: true
+    validates :flow_id, presence: true, length: {maximum: 20}
+
+    secrets_accessors :api_key, :signature_key
+    settings_accessors :flow_id
+
+    def self.api_base_url
+      if Rails.env.production?
+        "https://web.moneyhash.io"
+      else
+        "https://staging-web.moneyhash.io"
+      end
+    end
+
+    def webhook_end_point
+      URI.join(
+        ENV["LAGO_API_URL"],
+        "webhooks/moneyhash/#{organization_id}?code=#{URI.encode_www_form_component(code)}"
+      )
+    end
+
+    def environment
+      if Rails.env.production? && live_prefix.present?
+        :live
+      else
+        :test
+      end
+    end
+
+    def payment_type
+      "moneyhash"
+    end
+
+    def payable_payment_status(mh_status)
+      PAYABLE_PAYMENT_STATUS_MAP[mh_status]
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: payment_providers
+#
+#  id              :uuid             not null, primary key
+#  code            :string           not null
+#  deleted_at      :datetime
+#  name            :string           not null
+#  secrets         :string
+#  settings        :jsonb            not null
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid             not null
+#
+# Indexes
+#
+#  index_payment_providers_on_code_and_organization_id  (code,organization_id) UNIQUE WHERE (deleted_at IS NULL)
+#  index_payment_providers_on_organization_id           (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -80,6 +80,9 @@ module V1
       when :adyen
         configuration[:provider_customer_id] = model.adyen_customer&.provider_customer_id
         configuration.merge!(model.adyen_customer&.settings&.symbolize_keys || {})
+      when :moneyhash
+        configuration[:provider_customer_id] = model.moneyhash_customer&.provider_customer_id
+        configuration.merge!(model.moneyhash_customer&.settings&.symbolize_keys || {})
       end
 
       configuration

--- a/app/services/inbound_webhooks/process_service.rb
+++ b/app/services/inbound_webhooks/process_service.rb
@@ -3,7 +3,8 @@
 module InboundWebhooks
   class ProcessService < BaseService
     WEBHOOK_HANDLER_SERVICES = {
-      stripe: PaymentProviders::Stripe::HandleIncomingWebhookService
+      stripe: PaymentProviders::Stripe::HandleIncomingWebhookService,
+      moneyhash: PaymentProviders::Moneyhash::HandleIncomingWebhookService
     }
 
     def initialize(inbound_webhook:)

--- a/app/services/inbound_webhooks/validate_payload_service.rb
+++ b/app/services/inbound_webhooks/validate_payload_service.rb
@@ -3,7 +3,8 @@
 module InboundWebhooks
   class ValidatePayloadService < BaseService
     WEBHOOK_SOURCES = {
-      stripe: PaymentProviders::Stripe::ValidateIncomingWebhookService
+      stripe: PaymentProviders::Stripe::ValidateIncomingWebhookService,
+      moneyhash: PaymentProviders::Moneyhash::ValidateIncomingWebhookService
     }
 
     def initialize(organization_id:, code:, payload:, webhook_source:, signature:)

--- a/app/services/invoices/payments/moneyhash_service.rb
+++ b/app/services/invoices/payments/moneyhash_service.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Payments
+    class MoneyhashService < BaseService
+      include Customers::PaymentProviderFinder
+
+      def initialize(invoice = nil)
+        @invoice = invoice
+
+        super(nil)
+      end
+
+      def update_payment_status(organization_id:, provider_payment_id:, status:, metadata: {})
+        payment_obj = Payment.find_or_initialize_by(provider_payment_id: provider_payment_id)
+        payment = if payment_obj.persisted?
+          payment_obj
+        else
+          create_payment(provider_payment_id:, metadata:)
+        end
+
+        return handle_missing_payment(organization_id, metadata) unless payment
+
+        result.payment = payment
+        result.invoice = payment.payable
+        return result if payment.payable.payment_succeeded?
+
+        payment_status = payment.payment_provider.determine_payment_status(status)
+        payable_payment_status = payment.payment_provider.payable_payment_status(status)
+
+        payment.update!(status: payment_status, payable_payment_status:)
+
+        update_invoice_payment_status(payment_status: payable_payment_status, processing: payment_status == :processing)
+
+        result
+      rescue BaseService::FailedResult => e
+        result.fail_with_error!(e)
+      end
+
+      def generate_payment_url
+        return result unless should_process_payment?
+        response = client.post_with_response(payment_url_params, headers)
+        moneyhash_result = JSON.parse(response.body)
+
+        return result unless moneyhash_result
+
+        moneyhash_result_data = moneyhash_result["data"]
+        result.payment_url = "#{moneyhash_result_data["embed_url"]}?lago_request=generate_payment_url"
+        result
+      rescue LagoHttpClient::HttpError => e
+        deliver_error_webhook(e)
+        result.service_failure!(code: e.error_code, message: e.message)
+      end
+
+      private
+
+      attr_accessor :invoice
+
+      delegate :organization, :customer, to: :invoice
+
+      def handle_missing_payment(organization_id, metadata)
+        return result unless metadata&.key?("lago_payable_id")
+
+        invoice = Invoice.find_by(id: metadata["lago_payable_id"], organization_id:)
+        return result if invoice.nil?
+        return result if invoice.payment_failed?
+
+        result.not_found_failure!(resource: "moneyhash_payment")
+      end
+
+      def update_invoice_payment_status(payment_status:, deliver_webhook: true, processing: false)
+        result = Invoices::UpdateService.call(
+          invoice: invoice.presence || @result.invoice,
+          params: {
+            payment_status:,
+            ready_for_payment_processing: !processing && payment_status.to_sym != :succeeded
+          },
+          webhook_notification: deliver_webhook
+        )
+        result.raise_if_error!
+      end
+
+      def increment_payment_attempts
+        invoice.update!(payment_attempts: invoice.payment_attempts + 1)
+      end
+
+      def create_payment(provider_payment_id:, metadata:)
+        @invoice ||= Invoice.find_by(id: metadata["lago_payable_id"])
+        unless @invoice
+          result.not_found_failure!(resource: "invoice")
+          return
+        end
+        increment_payment_attempts
+        Payment.new(
+          payable: invoice,
+          payment_provider_id: moneyhash_payment_provider.id,
+          payment_provider_customer_id: customer.moneyhash_customer.id,
+          amount_cents: invoice.total_amount_cents,
+          amount_currency: invoice.currency&.upcase,
+          provider_payment_id:
+        )
+      end
+
+      def should_process_payment?
+        return false if invoice.payment_succeeded? || invoice.voided?
+        return false if moneyhash_payment_provider.blank?
+
+        customer&.moneyhash_customer&.provider_customer_id
+      end
+
+      def client
+        @client || LagoHttpClient::Client.new("#{::PaymentProviders::MoneyhashProvider.api_base_url}/api/v1.1/payments/intent/")
+      end
+
+      def headers
+        {
+          "Content-Type" => "application/json",
+          "x-Api-Key" => moneyhash_payment_provider.api_key
+        }
+      end
+
+      def moneyhash_payment_provider
+        @moneyhash_payment_provider ||= payment_provider(customer)
+      end
+
+      def payment_url_params
+        params = {
+          amount: invoice.total_due_amount_cents.div(100).to_f,
+          amount_currency: invoice.currency.upcase,
+          flow_id: moneyhash_payment_provider.flow_id,
+          billing_data: invoice.customer.moneyhash_customer.mh_billing_data,
+          customer: invoice.customer.moneyhash_customer.provider_customer_id,
+          webhook_url: moneyhash_payment_provider.webhook_end_point,
+          merchant_initiated: false,
+          custom_fields: {
+            # payable
+            lago_payable_id: invoice.id,
+            lago_payable_type: invoice.class.name,
+            lago_payable_invoice_type: invoice.invoice_type,
+            # mit flag
+            lago_mit: false,
+            # service
+            lago_mh_service: "Invoices::Payments::MoneyhashService",
+            # request
+            lago_request: "generate_payment_url"
+          }
+        }
+
+        params[:custom_fields].merge!(customer.moneyhash_customer.mh_custom_fields)
+
+        # Include subscription data for subscription invoices
+        if invoice.invoice_type == "subscription"
+          params[:custom_fields].merge!(
+            lago_plan_id: invoice.subscriptions&.first&.plan_id.to_s,
+            lago_subscription_external_id: invoice.subscriptions&.first&.external_id.to_s
+          )
+        end
+
+        # Tokenize card if the customer doesn't have a saved one
+        if customer.moneyhash_customer.provider_customer_id.blank?
+          params.merge!(
+            tokenize_card: true,
+            payment_type: "UNSCHEDULED",
+            recurring_data: {
+              agreement_id: customer.id
+            }
+          )
+        end
+
+        params
+      end
+
+      def deliver_error_webhook(moneyhash_error)
+        DeliverErrorWebhookService.call_async(invoice, {
+          provider_customer_id: customer.moneyhash_customer.provider_customer_id,
+          provider_error: {
+            message: moneyhash_error.message,
+            error_code: moneyhash_error.error_code
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/services/invoices/payments/payment_providers/factory.rb
+++ b/app/services/invoices/payments/payment_providers/factory.rb
@@ -18,6 +18,8 @@ module Invoices
             Invoices::Payments::GocardlessService
           when "cashfree"
             Invoices::Payments::CashfreeService
+          when "moneyhash"
+            Invoices::Payments::MoneyhashService
           else
             raise(NotImplementedError)
           end

--- a/app/services/payment_provider_customers/factory.rb
+++ b/app/services/payment_provider_customers/factory.rb
@@ -16,6 +16,8 @@ module PaymentProviderCustomers
         PaymentProviderCustomers::CashfreeService
       when "PaymentProviderCustomers::AdyenCustomer"
         PaymentProviderCustomers::AdyenService
+      when "PaymentProviderCustomers::MoneyhashCustomer"
+        PaymentProviderCustomers::MoneyhashService
       else
         raise(NotImplementedError)
       end

--- a/app/services/payment_provider_customers/moneyhash_service.rb
+++ b/app/services/payment_provider_customers/moneyhash_service.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class MoneyhashService < BaseService
+    include Customers::PaymentProviderFinder
+
+    def initialize(moneyhash_customer = nil)
+      @moneyhash_customer = moneyhash_customer
+
+      super(nil)
+    end
+
+    def create
+      result.moneyhash_customer = moneyhash_customer
+      return result if moneyhash_customer.provider_customer_id?
+      moneyhash_result = create_moneyhash_customer
+
+      return result if !result.success?
+
+      provider_customer_id = begin
+        moneyhash_result["data"]["id"]
+      rescue
+        ""
+      end
+
+      moneyhash_customer.update!(
+        provider_customer_id: provider_customer_id
+      )
+      deliver_success_webhook
+      result.moneyhash_customer = moneyhash_customer
+      checkout_url_result = generate_checkout_url
+      return result unless checkout_url_result.success?
+      result.checkout_url = checkout_url_result.checkout_url
+      result
+    end
+
+    def update
+      result
+    end
+
+    def generate_checkout_url(send_webhook: true)
+      return result.not_found_failure!(resource: "moneyhash_payment_provider") unless moneyhash_payment_provider
+      return result.not_found_failure!(resource: "moneyhash_customer") unless moneyhash_customer
+
+      response = checkout_url_client.post_with_response(checkout_url_params, headers)
+      moneyhash_result = JSON.parse(response.body)
+
+      return result unless moneyhash_result
+
+      result.checkout_url = "#{moneyhash_result["data"]["embed_url"]}?lago_request=generate_checkout_url"
+
+      if send_webhook
+        SendWebhookJob.perform_now(
+          "customer.checkout_url_generated",
+          customer,
+          checkout_url: result.checkout_url
+        )
+      end
+      result
+    rescue LagoHttpClient::HttpError => e
+      deliver_error_webhook(e)
+      result.service_failure!(code: e.error_code, message: e.message)
+    end
+
+    def update_payment_method(organization_id:, customer_id:, payment_method_id:, metadata: {})
+      customer = PaymentProviderCustomers::MoneyhashCustomer.find_by(customer_id: customer_id)
+      return handle_missing_customer(organization_id, metadata) unless customer
+
+      customer.payment_method_id = payment_method_id
+      customer.save!
+
+      result.moneyhash_customer = customer
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_accessor :moneyhash_customer, :customer
+
+    delegate :customer, to: :moneyhash_customer
+
+    def customers_client
+      @customers_client || LagoHttpClient::Client.new("#{PaymentProviders::MoneyhashProvider.api_base_url}/api/v1.1/customers/")
+    end
+
+    def checkout_url_client
+      @checkout_url_client || LagoHttpClient::Client.new("#{::PaymentProviders::MoneyhashProvider.api_base_url}/api/v1.1/payments/intent/")
+    end
+
+    def api_key
+      moneyhash_payment_provider.secret_key
+    end
+
+    def moneyhash_payment_provider
+      @moneyhash_payment_provider ||= payment_provider(customer)
+    end
+
+    def create_moneyhash_customer
+      customer_params = {
+        type: customer&.customer_type&.upcase,
+        first_name: customer&.firstname,
+        last_name: customer&.lastname,
+        email: customer&.email,
+        phone_number: customer&.phone,
+        tax_id: customer&.tax_identification_number&.to_i&.to_s,
+        address: [customer&.address_line1, customer&.address_line2].compact.join(" "),
+        contact_person_name: (customer&.name.presence || [customer&.firstname, customer&.lastname].compact.join(" ")).presence,
+        company_name: customer&.legal_name,
+        custom_fields: {
+          # service
+          lago_mh_service: "PaymentProviderCustomers::MoneyhashService",
+          # request
+          lago_request: "create_moneyhash_customer"
+        }
+      }.compact
+
+      customer_params[:custom_fields].merge!(moneyhash_customer.mh_custom_fields)
+
+      response = customers_client.post_with_response(customer_params, headers)
+      JSON.parse(response.body)
+    rescue LagoHttpClient::HttpError => e
+      deliver_error_webhook(e)
+      nil
+    end
+
+    def deliver_error_webhook(moneyhash_error)
+      SendWebhookJob.perform_later(
+        "customer.payment_provider_error",
+        customer,
+        provider_error: {
+          message: moneyhash_error.message,
+          error_code: moneyhash_error.error_code
+        }
+      )
+    end
+
+    def deliver_success_webhook
+      SendWebhookJob.perform_later(
+        "customer.payment_provider_created",
+        customer
+      )
+    end
+
+    def headers
+      {
+        "Content-Type" => "application/json",
+        "x-Api-Key" => moneyhash_payment_provider.api_key
+      }
+    end
+
+    def checkout_url_params
+      params = {
+        amount: 5.0,
+        amount_currency: customer.currency.presence || "USD",
+        flow_id: moneyhash_payment_provider.flow_id,
+        billing_data: moneyhash_customer.mh_billing_data,
+        customer: moneyhash_customer.provider_customer_id,
+        webhook_url: moneyhash_payment_provider.webhook_end_point,
+        merchant_initiated: false,
+        tokenize_card: true,
+        payment_type: "UNSCHEDULED",
+        recurring_data: {
+          agreement_id: moneyhash_customer.customer_id
+        },
+        custom_fields: {
+          # mit flag
+          lago_mit: false,
+          # service
+          lago_mh_service: "PaymentProviderCustomers::MoneyhashService",
+          # request
+          lago_request: "generate_checkout_url"
+        }
+      }
+
+      params[:custom_fields].merge!(moneyhash_customer.mh_custom_fields)
+
+      params
+    end
+
+    def handle_missing_customer(organization_id, metadata)
+      # NOTE: this is a silent failure, we return result directly if lago_customer_id is not present or Customer is not found
+      return result unless metadata&.key?("lago_customer_id")
+      return result if Customer.find_by(id: metadata["lago_customer_id"], organization_id:).nil?
+
+      # fail only when certain that moneyhash customer is not found (after finding the customer)
+      result.not_found_failure!(resource: "moneyhash_customer")
+    end
+  end
+end

--- a/app/services/payment_providers/create_customer_factory.rb
+++ b/app/services/payment_providers/create_customer_factory.rb
@@ -16,6 +16,8 @@ module PaymentProviders
         PaymentProviders::Gocardless::Customers::CreateService
       when "stripe"
         PaymentProviders::Stripe::Customers::CreateService
+      when "moneyhash"
+        PaymentProviders::Moneyhash::Customers::CreateService
       end
     end
   end

--- a/app/services/payment_providers/create_payment_factory.rb
+++ b/app/services/payment_providers/create_payment_factory.rb
@@ -16,6 +16,8 @@ module PaymentProviders
         PaymentProviders::Gocardless::Payments::CreateService
       when :stripe
         PaymentProviders::Stripe::Payments::CreateService
+      when :moneyhash
+        PaymentProviders::Moneyhash::Payments::CreateService
       end
     end
   end

--- a/app/services/payment_providers/moneyhash/base_service.rb
+++ b/app/services/payment_providers/moneyhash/base_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Moneyhash
+    class BaseService < BaseService
+      def initialize(payment_provider)
+        @payment_provider = payment_provider
+
+        super
+      end
+
+      protected
+
+      attr_reader :payment_provider
+
+      delegate :organization, :organization_id, to: :payment_provider
+
+      def api_key
+        payment_provider.api_key
+      end
+
+      def deliver_error_webhook(action:, error:)
+        SendWebhookJob.perform_later(
+          "payment_provider.error",
+          payment_provider,
+          provider_error: {
+            source: "moneyhash",
+            action: action,
+            message: error.message,
+            code: error.code
+          }
+        )
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/moneyhash/customers/create_service.rb
+++ b/app/services/payment_providers/moneyhash/customers/create_service.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Moneyhash
+    module Customers
+      class CreateService < BaseService
+        def initialize(customer:, payment_provider_id:, params:, async: true)
+          @customer = customer
+          @payment_provider_id = payment_provider_id
+          @params = params || {}
+          @async = async
+
+          super
+        end
+
+        def call
+          provider_customer = PaymentProviderCustomers::MoneyhashCustomer.find_by(customer_id: customer.id)
+          provider_customer ||= PaymentProviderCustomers::MoneyhashCustomer.new(customer_id: customer.id, payment_provider_id:)
+
+          if params.key?(:provider_customer_id)
+            provider_customer.provider_customer_id = params[:provider_customer_id].presence
+          end
+
+          if params.key?(:sync_with_provider)
+            provider_customer.sync_with_provider = params[:sync_with_provider].presence
+          end
+
+          provider_customer.save!
+
+          result.provider_customer = provider_customer
+
+          if should_create_provider_customer?
+            create_customer_on_provider_service(async)
+          elsif should_generate_checkout_url?
+            generate_checkout_url(async)
+          end
+
+          result
+        rescue ActiveRecord::RecordInvalid => e
+          result.record_validation_failure!(record: e.record)
+        end
+
+        private
+
+        attr_accessor :customer, :payment_provider_id, :params, :async
+
+        delegate :organization, to: :customer
+
+        def create_customer_on_provider_service(async)
+          return PaymentProviderCustomers::MoneyhashCreateJob.perform_later(result.provider_customer) if async
+
+          PaymentProviderCustomers::MoneyhashCreateJob.perform_now(result.provider_customer)
+        end
+
+        def generate_checkout_url(async)
+          return PaymentProviderCustomers::MoneyhashCheckoutUrlJob.perform_later(result.provider_customer) if async
+
+          PaymentProviderCustomers::MoneyhashCheckoutUrlJob.perform_now(result.provider_customer)
+        end
+
+        def should_create_provider_customer?
+          # NOTE: the customer does not exists on the service provider
+          # and the customer id was not removed from the customer
+          # customer sync with provider setting is set to true
+          !result.provider_customer.provider_customer_id? &&
+            !result.provider_customer.provider_customer_id_previously_changed? &&
+            result.provider_customer.sync_with_provider.present?
+        end
+
+        def should_generate_checkout_url?
+          !result.provider_customer.id_previously_changed?(from: nil) && # it was not created but updated
+            result.provider_customer.provider_customer_id_previously_changed? &&
+            result.provider_customer.provider_customer_id? &&
+            result.provider_customer.sync_with_provider.blank?
+        end
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/moneyhash/handle_incoming_webhook_service.rb
+++ b/app/services/payment_providers/moneyhash/handle_incoming_webhook_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Moneyhash
+    class HandleIncomingWebhookService < BaseService
+      extend Forwardable
+
+      def initialize(inbound_webhook:)
+        @inbound_webhook = inbound_webhook
+
+        super
+      end
+
+      def call
+        organization = Organization.find_by(id: @inbound_webhook.organization_id)
+        return result.service_failure!(code: "webhook_error", message: "Organization not found") unless organization
+
+        payment_provider_result = PaymentProviders::FindService.call(
+          organization_id: @inbound_webhook.organization_id,
+          code: @inbound_webhook.code,
+          payment_provider_type: "moneyhash"
+        )
+
+        return handle_payment_provider_failure(payment_provider_result) unless payment_provider_result.success?
+
+        PaymentProviders::Moneyhash::HandleEventJob.perform_later(organization:, event_json: @inbound_webhook.payload)
+        result.event = @inbound_webhook.payload
+        result
+      end
+
+      private
+
+      def_delegators :@inbound_webhook, :organization, :payload
+
+      def handle_payment_provider_failure(payment_provider_result)
+        return payment_provider_result unless payment_provider_result.error.is_a?(BaseService::ServiceFailure)
+        result.service_failure!(code: "webhook_error", message: payment_provider_result.error.error_message)
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/moneyhash/payments/create_service.rb
+++ b/app/services/payment_providers/moneyhash/payments/create_service.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Moneyhash
+    module Payments
+      class CreateService < BaseService
+        include ::Customers::PaymentProviderFinder
+
+        def initialize(payment:, reference:, metadata:)
+          @payment = payment
+          @invoice = payment.payable
+          @provider_customer = payment.payment_provider_customer
+
+          super
+        end
+
+        def call
+          result.payment = payment
+
+          moneyhash_result = create_moneyhash_payment
+
+          payment.provider_payment_id = moneyhash_result.dig("data", "id")
+          payment.status = moneyhash_result.dig("data", "status") || moneyhash_result.dig("data", "active_transaction", "status") || "PENDING"
+          payment.payable_payment_status = payment.payment_provider&.determine_payment_status(payment.status)
+          payment.save!
+
+          result.payment = payment
+          result
+        end
+
+        private
+
+        attr_reader :payment, :invoice, :provider_customer
+
+        delegate :customer, to: :invoice
+
+        def create_moneyhash_payment
+          payment_params = {
+            amount: payment.amount_cents.div(100).to_f,
+            amount_currency: payment.amount_currency.upcase,
+            flow_id: moneyhash_payment_provider.flow_id,
+            billing_data: provider_customer.mh_billing_data,
+            customer: provider_customer.provider_customer_id,
+            webhook_url: moneyhash_payment_provider.webhook_end_point,
+            payment_type: "UNSCHEDULED",
+            merchant_initiated: true,
+            recurring_data: {
+              agreement_id: customer.id
+            },
+            card_token: provider_customer.payment_method_id,
+            custom_fields: {
+              # plan/subscription
+              lago_plan_id: invoice.subscriptions&.first&.plan_id.to_s,
+              lago_subscription_external_id: invoice.subscriptions&.first&.external_id.to_s,
+              # payable
+              lago_payable_id: invoice.id,
+              lago_payable_type: invoice.class.name,
+              lago_payable_invoice_type: invoice.invoice_type.to_s,
+              # mit flag
+              lago_mit: true,
+              # service
+              lago_mh_service: "PaymentProviders::Moneyhash::Payments::CreateService",
+              # request
+              lago_request: "invoice_automatic_payment"
+            }
+          }
+
+          payment_params[:custom_fields].merge!(provider_customer.mh_custom_fields)
+
+          headers = {
+            "Content-Type" => "application/json",
+            "x-Api-Key" => moneyhash_payment_provider.api_key
+          }
+
+          response = client.post_with_response(payment_params, headers)
+          JSON.parse(response.body)
+        rescue LagoHttpClient::HttpError => e
+          prepare_failed_result(e, reraise: true)
+        end
+
+        def client
+          @client || LagoHttpClient::Client.new("#{::PaymentProviders::MoneyhashProvider.api_base_url}/api/v1.1/payments/intent/")
+        end
+
+        def moneyhash_payment_provider
+          @moneyhash_payment_provider ||= payment_provider(provider_customer.customer)
+        end
+
+        def prepare_failed_result(error, reraise: false)
+          result.error_message = error.error_body
+          result.error_code = error.error_code
+          result.reraise = reraise
+
+          payment.update!(status: :failed, payable_payment_status: :failed)
+
+          result.service_failure!(code: "moneyhash_error", message: "#{error.error_code}: #{error.error_body}")
+        end
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/moneyhash/validate_incoming_webhook_service.rb
+++ b/app/services/payment_providers/moneyhash/validate_incoming_webhook_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "openssl"
+require "base64"
+
+module PaymentProviders
+  module Moneyhash
+    class ValidateIncomingWebhookService < BaseService
+      def initialize(payload:, signature:, payment_provider:)
+        @payload = payload
+        @signature = signature
+        @provider = payment_provider
+
+        super
+      end
+
+      def call
+        # extract timestamp and v3_signature from signature
+        timestamp, v3_signature = signature.split(",").each_with_object({}) do |part, hash|
+          key, value = part.split("=")
+          hash[key] = value if %w[t v3].include?(key)
+        end.values_at("t", "v3")
+
+        # validate signature
+        secret = webhook_secret
+        decoded_body = Base64.strict_encode64(payload.to_json)
+
+        to_sign = "#{decoded_body}#{timestamp}"
+
+        calculated_signature = OpenSSL::HMAC.hexdigest("SHA256", secret, to_sign)
+
+        if calculated_signature != v3_signature
+          result.service_failure!(code: "webhook_error", message: "Invalid signature")
+        end
+
+        result
+      end
+
+      private
+
+      attr_reader :payload, :signature, :provider
+
+      def webhook_secret
+        provider.signature_key
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/moneyhash_service.rb
+++ b/app/services/payment_providers/moneyhash_service.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  class MoneyhashService < BaseService
+    INTENT_WEBHOOKS_EVENTS = %w[intent.processed intent.time_expired].freeze
+    TRANSACTION_WEBHOOKS_EVENTS = %w[transaction.purchase.failed transaction.purchase.pending_authentication transaction.purchase.successful].freeze
+    CARD_WEBHOOKS_EVENTS = %w[card_token.created card_token.updated card_token.deleted].freeze
+    ALLOWED_WEBHOOK_EVENTS = (INTENT_WEBHOOKS_EVENTS + TRANSACTION_WEBHOOKS_EVENTS + CARD_WEBHOOKS_EVENTS).freeze
+
+    PAYMENT_SERVICE_CLASS_MAP = {
+      "Invoice" => Invoices::Payments::MoneyhashService,
+      "PaymentRequest" => PaymentRequests::Payments::MoneyhashService
+    }.freeze
+
+    def create_or_update(**args)
+      payment_provider_result = PaymentProviders::FindService.call(
+        organization_id: args[:organization].id,
+        code: args[:code],
+        id: args[:id],
+        payment_provider_type: "moneyhash"
+      )
+
+      @moneyhash_provider = if payment_provider_result.success?
+        payment_provider_result.payment_provider
+      else
+        PaymentProviders::MoneyhashProvider.new(
+          organization_id: args[:organization].id,
+          code: args[:code]
+        )
+      end
+
+      old_code = moneyhash_provider.code
+      moneyhash_provider.api_key = args[:api_key] if args.key?(:api_key)
+      moneyhash_provider.code = args[:code] if args.key?(:code)
+      moneyhash_provider.name = args[:name] if args.key?(:name)
+      moneyhash_provider.flow_id = args[:flow_id] if args.key?(:flow_id)
+
+      if moneyhash_provider.signature_key.blank?
+        signature_result = get_signature_key
+        return signature_result unless signature_result.success?
+        moneyhash_provider.signature_key = signature_result.signature_key
+      end
+
+      moneyhash_provider.save(validate: false)
+
+      if payment_provider_code_changed?(moneyhash_provider, old_code, args)
+        moneyhash_provider.customers.update_all(payment_provider_code: args[:code]) # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      result.moneyhash_provider = moneyhash_provider
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    def handle_event(organization:, event_json:)
+      @event_json = event_json
+      @event_code = event_json["type"]
+      @organization = organization
+
+      unless ALLOWED_WEBHOOK_EVENTS.include?(@event_code)
+        return result.service_failure!(
+          code: "webhook_error",
+          message: "Invalid moneyhash event code: #{@event_code}"
+        )
+      end
+      event_handlers.fetch(@event_code, method(:default_handler)).call
+    end
+
+    def event_to_payment_status(event_code)
+      # MH's event -> MH's payment status
+      case event_code
+      when "intent.processed", "transaction.purchase.successful"
+        "SUCCESSFUL"
+      when "intent.time_expired", "transaction.purchase.failed"
+        "FAILED"
+      when "transaction.purchase.pending_authentication"
+        "PENDING"
+      end
+    end
+
+    attr_reader :moneyhash_provider
+
+    private
+
+    def get_signature_key
+      response = LagoHttpClient::Client.new(
+        "#{::PaymentProviders::MoneyhashProvider.api_base_url}/api/v1/organizations/get-webhook-signature-key/"
+      ).get(
+        headers: {
+          "X-Api-Key" => moneyhash_provider.api_key
+        }
+      )
+      result.signature_key = response["data"]["webhook_signature_secret"]
+      result
+    rescue LagoHttpClient::HttpError => e
+      result.service_failure!(code: "moneyhash_error", message: "#{e.error_code}: #{e.error_body}")
+    end
+
+    def event_handlers
+      {
+        "intent.processed" => method(:handle_intent_event),
+        "intent.time_expired" => method(:handle_intent_event),
+        "transaction.purchase.failed" => method(:handle_transaction_event),
+        "transaction.purchase.pending_authentication" => method(:handle_transaction_event),
+        "transaction.purchase.successful" => method(:handle_transaction_event),
+        "card_token.created" => method(:handle_card_event),
+        "card_token.updated" => method(:handle_card_event),
+        "card_token.deleted" => method(:handle_card_event)
+      }
+    end
+
+    def handle_intent_event
+      if INTENT_WEBHOOKS_EVENTS.include?(@event_code)
+        payment_service_klass(@event_json)
+          .new.update_payment_status(
+            organization_id: @organization.id,
+            provider_payment_id: @event_json.dig("data", "intent_id"),
+            status: event_to_payment_status(@event_code),
+            metadata: @event_json.dig("data", "intent", "custom_fields")
+          ).raise_if_error!
+      end
+    end
+
+    def handle_transaction_event
+      if TRANSACTION_WEBHOOKS_EVENTS.include?(@event_code)
+        payment_service_klass(@event_json)
+          .new.update_payment_status(
+            organization_id: @organization.id,
+            provider_payment_id: @event_json.dig("intent", "id"),
+            status: event_to_payment_status(@event_code),
+            metadata: @event_json.dig("intent", "custom_fields")
+          ).raise_if_error!
+      end
+    end
+
+    def handle_card_event
+      service = PaymentProviderCustomers::MoneyhashService.new
+
+      case @event_code
+      when "card_token.deleted"
+        payment_method_id = @event_json.dig("data", "card_token", "id")
+        customer_id = @event_json.dig("data", "card_token", "custom_fields", "lago_customer_id")
+        customer = PaymentProviderCustomers::MoneyhashCustomer.find_by(customer_id: customer_id)
+
+        selected_payment_method_id = (customer&.payment_method_id&.present? && (customer&.payment_method_id == payment_method_id)) ? nil : customer&.payment_method_id
+        service
+          .update_payment_method(
+            organization_id: @organization.id,
+            customer_id: customer_id,
+            payment_method_id: selected_payment_method_id,
+            metadata: @event_json.dig("data", "card_token", "custom_fields")
+          ).raise_if_error!
+
+      when "card_token.created", "card_token.updated"
+        service
+          .update_payment_method(
+            organization_id: @organization.id,
+            customer_id: @event_json.dig("data", "card_token", "custom_fields", "lago_customer_id"),
+            payment_method_id: @event_json.dig("data", "card_token", "id"),
+            metadata: @event_json.dig("data", "card_token", "custom_fields")
+          ).raise_if_error!
+      end
+    end
+
+    def payment_service_klass(event_json)
+      payable_type = event_json.dig("intent", "custom_fields", "lago_payable_type") || "Invoice"
+      PAYMENT_SERVICE_CLASS_MAP.fetch(payable_type) do
+        raise NameError, "Invalid lago_payable_type: #{payable_type}"
+      end
+    end
+
+    def default_handler
+      result.service_failure!(
+        code: "webhook_error",
+        message: "No handler for event code: #{@event_code}"
+      )
+    end
+  end
+end

--- a/app/services/payment_requests/payments/moneyhash_service.rb
+++ b/app/services/payment_requests/payments/moneyhash_service.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+module PaymentRequests
+  module Payments
+    class MoneyhashService < BaseService
+      include Customers::PaymentProviderFinder
+
+      def initialize(payable = nil)
+        @payable = payable
+
+        super(nil)
+      end
+
+      def create
+        result.payable = payable
+        return result.not_found_failure!(resource: "moneyhash_customer") if customer&.moneyhash_customer&.provider_customer_id.blank?
+        return result.not_found_failure!(resource: "payment_method") if moneyhash_payment_method.nil?
+        return result unless should_process_payment?
+
+        unless payable.total_amount_cents.positive?
+          update_payable_payment_status(payment_status: :succeeded)
+          return result
+        end
+
+        payable.increment_payment_attempts!
+
+        moneyhash_result = create_moneyhash_payment
+        return result unless moneyhash_result
+        mh_status = moneyhash_result.dig("data", "status")
+
+        payment = Payment.new(
+          payable: payable,
+          payment_provider_id: moneyhash_payment_provider.id,
+          payment_provider_customer_id: customer.moneyhash_customer.id,
+          amount_cents: payable.amount_cents,
+          amount_currency: payable.currency&.upcase,
+          provider_payment_id: moneyhash_result.dig("data", "id"),
+          status: moneyhash_payment_provider.determine_payment_status(mh_status)
+        )
+
+        payment.save!
+
+        payable_payment_status = moneyhash_payment_provider.payable_payment_status(mh_status)
+
+        update_payable_payment_status(
+          payment_status: payable_payment_status,
+          processing: payment.status == "pending"
+        )
+        update_invoices_payment_status(
+          payment_status: payable_payment_status,
+          processing: payment.status == "pending"
+        )
+        result.payment = payment
+        result.payable_payment_status = payable_payment_status
+        result
+      end
+
+      def update_payment_status(organization_id:, provider_payment_id:, status:, metadata: {})
+        payment_obj = Payment.find_or_initialize_by(provider_payment_id: provider_payment_id)
+        payment = if payment_obj.persisted?
+          payment_obj
+        else
+          create_payment(provider_payment_id:, metadata:)
+        end
+
+        return handle_missing_payment(organization_id, metadata) unless payment
+
+        result.payment = payment
+        result.payable = payment.payable
+        return result if payment.payable.payment_succeeded?
+        payment.update!(status: moneyhash_payment_provider.determine_payment_status(status))
+
+        processing = status == "pending"
+        payment_status = moneyhash_payment_provider.payable_payment_status(status)
+        update_payable_payment_status(payment_status:, processing:)
+        update_invoices_payment_status(payment_status:, processing:)
+
+        PaymentRequestMailer.with(payment_request: payment.payable).requested.deliver_later if result.payable.payment_failed?
+        result
+      rescue BaseService::FailedResult => e
+        PaymentRequestMailer.with(payment_request: payment.payable).requested.deliver_later if result.payable.payment_failed?
+        result.fail_with_error!(e)
+      end
+
+      private
+
+      attr_accessor :payable
+
+      delegate :organization, :customer, to: :payable
+
+      def handle_missing_payment(organization_id, metadata)
+        return result unless metadata&.key?("lago_payable_id")
+        payment_request = PaymentRequest.find_by(id: metadata["lago_payable_id"], organization_id:)
+        return result unless payment_request
+        return result if payment_request.payment_failed?
+
+        result.not_found_failure!(resource: "moneyhash_payment")
+      end
+
+      def create_payment(provider_payment_id:, metadata:)
+        @payable = payable || PaymentRequest.find_by(id: metadata["lago_payable_id"])
+
+        unless payable
+          result.not_found_failure!(resource: "payment_request")
+          return
+        end
+
+        payable.increment_payment_attempts!
+
+        Payment.new(
+          payable:,
+          payment_provider_id: moneyhash_payment_provider.id,
+          payment_provider_customer_id: customer.moneyhash_customer.id,
+          amount_cents: payable.total_amount_cents,
+          amount_currency: payable.currency&.upcase,
+          provider_payment_id:
+        )
+      end
+
+      def moneyhash_payment_method
+        customer.moneyhash_customer.payment_method_id
+      end
+
+      def should_process_payment?
+        return false if payable.payment_succeeded?
+        return false if moneyhash_payment_provider.blank?
+
+        !!customer&.moneyhash_customer&.provider_customer_id
+      end
+
+      def client
+        @client || LagoHttpClient::Client.new("#{::PaymentProviders::MoneyhashProvider.api_base_url}/api/v1.1/payments/intent/")
+      end
+
+      def headers
+        {
+          "Content-Type" => "application/json",
+          "x-Api-Key" => moneyhash_payment_provider.api_key
+        }
+      end
+
+      def moneyhash_payment_provider
+        @moneyhash_payment_provider ||= payment_provider(customer)
+      end
+
+      def create_moneyhash_payment
+        payment_params = {
+          amount: payable.total_amount_cents.div(100).to_f,
+          amount_currency: payable.currency.upcase,
+          flow_id: moneyhash_payment_provider.flow_id,
+          billing_data: customer.moneyhash_customer.mh_billing_data,
+          customer: customer.moneyhash_customer.provider_customer_id,
+          webhook_url: moneyhash_payment_provider.webhook_end_point,
+          merchant_initiated: true,
+          payment_type: "UNSCHEDULED",
+          card_token: moneyhash_payment_method,
+          recurring_data: {
+            agreement_id: customer.id
+          },
+          custom_fields: {
+            # plan/subscription
+            lago_plan_id: payable&.invoices&.first&.subscriptions&.first&.plan_id.to_s,
+            lago_subscription_external_id: payable&.invoices&.first&.subscriptions&.first&.external_id.to_s,
+            # payable
+            lago_payable_id: payable.id,
+            lago_payable_type: payable.class.name,
+            # mit flag
+            lago_mit: true,
+            # service
+            lago_mh_service: "PaymentRequests::Payments::MoneyhashService",
+            # request
+            lago_request: "create_payment_request"
+          }
+        }
+
+        payment_params[:custom_fields].merge!(payable.customer.moneyhash_customer.mh_custom_fields)
+
+        response = client.post_with_response(payment_params, headers)
+        JSON.parse(response.body)
+      rescue LagoHttpClient::HttpError => e
+        deliver_error_webhook(e)
+        update_payable_payment_status(payment_status: :failed, deliver_webhook: false)
+        nil
+      end
+
+      def update_payable_payment_status(payment_status:, deliver_webhook: true, processing: false)
+        UpdateService.call(
+          payable: result.payable,
+          params: {
+            payment_status:,
+            ready_for_payment_processing: !processing && payment_status.to_sym != :succeeded
+          },
+          webhook_notification: deliver_webhook
+        ).raise_if_error!
+      end
+
+      def update_invoices_payment_status(payment_status:, deliver_webhook: true, processing: false)
+        result.payable.invoices.each do |invoice|
+          Invoices::UpdateService.call(
+            invoice: invoice,
+            params: {
+              payment_status:,
+              ready_for_payment_processing: !processing && payment_status.to_sym != :succeeded
+            },
+            webhook_notification: deliver_webhook
+          ).raise_if_error!
+        end
+      end
+
+      def deliver_error_webhook(moneyhash_error)
+        DeliverErrorWebhookService.call_async(payable, {
+          provider_customer_id: customer.moneyhash_customer.provider_customer_id,
+          provider_error: {
+            message: moneyhash_error.message,
+            error_code: moneyhash_error.error_code
+          }
+        })
+      end
+    end
+  end
+end

--- a/app/services/payment_requests/payments/payment_providers/factory.rb
+++ b/app/services/payment_requests/payments/payment_providers/factory.rb
@@ -18,6 +18,8 @@ module PaymentRequests
             PaymentRequests::Payments::CashfreeService
           when "gocardless"
             PaymentRequests::Payments::GocardlessService
+          when "moneyhash"
+            PaymentRequests::Payments::MoneyhashService
           else
             raise(NotImplementedError)
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ Rails.application.routes.draw do
     post "cashfree/:organization_id", to: "webhooks#cashfree", on: :collection, as: :cashfree
     post "gocardless/:organization_id", to: "webhooks#gocardless", on: :collection, as: :gocardless
     post "adyen/:organization_id", to: "webhooks#adyen", on: :collection, as: :adyen
+    post "moneyhash/:organization_id", to: "webhooks#moneyhash", on: :collection, as: :moneyhash
   end
 
   namespace :admin do

--- a/schema.graphql
+++ b/schema.graphql
@@ -64,6 +64,22 @@ input AddGocardlessPaymentProviderInput {
   successRedirectUrl: String
 }
 
+"""
+Moneyhash input arguments
+"""
+input AddMoneyhashPaymentProviderInput {
+  apiKey: String!
+
+  """
+  A unique identifier for the client performing the mutation.
+  """
+  clientMutationId: String
+  code: String!
+  flowId: String!
+  name: String!
+  successRedirectUrl: String
+}
+
 type AddOn {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
@@ -5070,6 +5086,15 @@ type Metadata {
   totalPages: Int!
 }
 
+type MoneyhashProvider {
+  apiKey: String
+  code: String!
+  flowId: String
+  id: ID!
+  name: String!
+  successRedirectUrl: String
+}
+
 type Mrr {
   amountCents: BigInt
   currency: CurrencyEnum
@@ -5131,6 +5156,16 @@ type Mutation {
     """
     input: AddGocardlessPaymentProviderInput!
   ): GocardlessProvider
+
+  """
+  Add Moneyhash payment provider
+  """
+  addMoneyhashPaymentProvider(
+    """
+    Parameters for AddMoneyhashPaymentProvider
+    """
+    input: AddMoneyhashPaymentProviderInput!
+  ): MoneyhashProvider
 
   """
   Add Stripe API keys to the organization
@@ -6201,6 +6236,16 @@ type Mutation {
   ): Membership
 
   """
+  Update Moneyhash payment provider
+  """
+  updateMoneyhashPaymentProvider(
+    """
+    Parameters for UpdateMoneyhashPaymentProvider
+    """
+    input: UpdateMoneyhashPaymentProviderInput!
+  ): MoneyhashProvider
+
+  """
   Update Netsuite integration
   """
   updateNetsuiteIntegration(
@@ -6488,7 +6533,7 @@ type PaymentCollection {
   metadata: CollectionMetadata!
 }
 
-union PaymentProvider = AdyenProvider | CashfreeProvider | GocardlessProvider | StripeProvider
+union PaymentProvider = AdyenProvider | CashfreeProvider | GocardlessProvider | MoneyhashProvider | StripeProvider
 
 """
 PaymentProviderCollection type
@@ -6812,6 +6857,7 @@ enum ProviderTypeEnum {
   adyen
   cashfree
   gocardless
+  moneyhash
   stripe
 }
 
@@ -8658,6 +8704,7 @@ input UpdateAdyenPaymentProviderInput {
   """
   clientMutationId: String
   code: String
+  flowId: String
   id: ID!
   name: String
   successRedirectUrl: String
@@ -8723,6 +8770,7 @@ input UpdateCashfreePaymentProviderInput {
   """
   clientMutationId: String
   code: String
+  flowId: String
   id: ID!
   name: String
   successRedirectUrl: String
@@ -8896,6 +8944,7 @@ input UpdateGocardlessPaymentProviderInput {
   """
   clientMutationId: String
   code: String
+  flowId: String
   id: ID!
   name: String
   successRedirectUrl: String
@@ -9006,6 +9055,21 @@ input UpdateMembershipInput {
   clientMutationId: String
   id: ID!
   role: MembershipRole!
+}
+
+"""
+Update input arguments
+"""
+input UpdateMoneyhashPaymentProviderInput {
+  """
+  A unique identifier for the client performing the mutation.
+  """
+  clientMutationId: String
+  code: String
+  flowId: String
+  id: ID!
+  name: String
+  successRedirectUrl: String
 }
 
 """
@@ -9145,6 +9209,7 @@ input UpdateStripePaymentProviderInput {
   """
   clientMutationId: String
   code: String
+  flowId: String
   id: ID!
   name: String
   successRedirectUrl: String

--- a/schema.json
+++ b/schema.json
@@ -382,6 +382,105 @@
           "enumValues": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "AddMoneyhashPaymentProviderInput",
+          "description": "Moneyhash input arguments",
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "apiKey",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "flowId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "successRedirectUrl",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
           "kind": "OBJECT",
           "name": "AddOn",
           "description": null,
@@ -25556,6 +25655,101 @@
         },
         {
           "kind": "OBJECT",
+          "name": "MoneyhashProvider",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "apiKey",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "flowId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "successRedirectUrl",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Mrr",
           "description": null,
           "interfaces": [],
@@ -25770,6 +25964,35 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "AddGocardlessPaymentProviderInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "addMoneyhashPaymentProvider",
+              "description": "Add Moneyhash payment provider",
+              "type": {
+                "kind": "OBJECT",
+                "name": "MoneyhashProvider",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for AddMoneyhashPaymentProvider",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "AddMoneyhashPaymentProviderInput",
                       "ofType": null
                     }
                   },
@@ -28920,6 +29143,35 @@
               ]
             },
             {
+              "name": "updateMoneyhashPaymentProvider",
+              "description": "Update Moneyhash payment provider",
+              "type": {
+                "kind": "OBJECT",
+                "name": "MoneyhashProvider",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "input",
+                  "description": "Parameters for UpdateMoneyhashPaymentProvider",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "UpdateMoneyhashPaymentProviderInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "updateNetsuiteIntegration",
               "description": "Update Netsuite integration",
               "type": {
@@ -30546,6 +30798,11 @@
             {
               "kind": "OBJECT",
               "name": "GocardlessProvider",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "MoneyhashProvider",
               "ofType": null
             },
             {
@@ -33824,6 +34081,12 @@
             },
             {
               "name": "adyen",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "moneyhash",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -42077,6 +42340,18 @@
               "deprecationReason": null
             },
             {
+              "name": "flowId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -42470,6 +42745,18 @@
           "inputFields": [
             {
               "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "flowId",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -43841,6 +44128,18 @@
               "deprecationReason": null
             },
             {
+              "name": "flowId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -44532,6 +44831,93 @@
                   "name": "MembershipRole",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateMoneyhashPaymentProviderInput",
+          "description": "Update input arguments",
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "flowId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "successRedirectUrl",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -45600,6 +45986,18 @@
           "inputFields": [
             {
               "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "flowId",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/spec/factories/payment_provider_customers.rb
+++ b/spec/factories/payment_provider_customers.rb
@@ -25,4 +25,10 @@ FactoryBot.define do
 
     provider_customer_id { SecureRandom.uuid }
   end
+
+  factory :moneyhash_customer, class: "PaymentProviderCustomers::MoneyhashCustomer" do
+    customer
+
+    provider_customer_id { SecureRandom.uuid }
+  end
 end

--- a/spec/factories/payment_providers.rb
+++ b/spec/factories/payment_providers.rb
@@ -80,4 +80,25 @@ FactoryBot.define do
       success_redirect_url { Faker::Internet.url }
     end
   end
+
+  factory :moneyhash_provider, class: "PaymentProviders::MoneyhashProvider" do
+    organization
+    type { "PaymentProviders::MoneyhashProvider" }
+    name { "MoneyHash" }
+    code { "moneyhash_#{SecureRandom.uuid}" }
+
+    secrets do
+      {api_key:}.to_json
+    end
+
+    settings do
+      {success_redirect_url:, flow_id:}
+    end
+
+    transient do
+      api_key { SecureRandom.uuid }
+      success_redirect_url { Faker::Internet.url }
+      flow_id { SecureRandom.uuid[0..19] }
+    end
+  end
 end

--- a/spec/fixtures/moneyhash/card_token.created.json
+++ b/spec/fixtures/moneyhash/card_token.created.json
@@ -1,0 +1,42 @@
+{
+  "type": "card_token.created",
+  "data": {
+    "intent_id": "Z0e5lo9",
+    "card_token": {
+      "id": "419cb5f7-20fc-4571-a64d-4a64f0a0412f",
+      "hashid": "gMRXKaZ",
+      "brand": "Visa",
+      "card_holder_name": "Kevin Smith",
+      "bin": "111100",
+      "last_4": "0000",
+      "issuer": "test",
+      "expiry_month": "02",
+      "expiry_year": "26",
+      "country": null,
+      "type": null,
+      "custom_fields": {
+        "lago_mit": false,
+        "lago_plan_id": "de95fd5d-3349-4439-a5d0-18b42b8551d1",
+        "lago_mh_service": "Invoices::Payments::MoneyhashService",
+        "lago_payable_id": "23fd1f3c-922c-4928-b40b-c8a31e4d6664",
+        "lago_customer_id": "53c14b65-3406-4b1b-9d49-77fb389ee92e",
+        "lago_payable_type": "Invoice",
+        "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414",
+        "lago_subscription_external_id": "69f64026-69eb-4836-b1bd-9323d9f7d892"
+      },
+      "provider_token_data": [
+        {
+          "last_4": "0000",
+          "service_provider_id": "gQJnWwZ",
+          "pay_in_method": "gqYGvEg",
+          "provider_specific_data": {
+            "token_id": "test_token"
+          }
+        }
+      ],
+      "requires_cvv": true,
+      "fingerprint": "d795b7befe90eaf9d91a9d563f446487c69f06c3a35374289a385d40709a82f0b14ebe7c24139e19aaca6f3661ec1a3715d92e51a5b099880acb66b39a621dc5",
+      "vault_region": "default"
+    }
+  }
+}

--- a/spec/fixtures/moneyhash/card_token.deleted.json
+++ b/spec/fixtures/moneyhash/card_token.deleted.json
@@ -1,0 +1,26 @@
+{
+  "type": "card_token.deleted",
+  "data": {
+    "intent_id": "ZBv8DkZ",
+    "card_token": {
+      "id": "bf05e221-1305-44cb-ac04-f227f0a8b67a",
+      "hashid": "gERzJPZ",
+      "brand": "Visa",
+      "card_holder_name": "Kevin Smith",
+      "bin": "111100",
+      "last_4": "0000",
+      "issuer": "test",
+      "expiry_month": "02",
+      "expiry_year": "26",
+      "country": null,
+      "type": null,
+      "custom_fields": {
+        "lago_customer_id": "2f2f4867-1ac9-4529-b03b-4f7133897b82"
+      },
+      "provider_token_data": [],
+      "requires_cvv": true,
+      "fingerprint": "d795b7befe90eaf9d91a9d563f446487c69f06c3a35374289a385d40709a82f0b14ebe7c24139e19aaca6f3661ec1a3715d92e51a5b099880acb66b39a621dc5",
+      "vault_region": "default"
+    }
+  }
+}

--- a/spec/fixtures/moneyhash/card_token.updated.json
+++ b/spec/fixtures/moneyhash/card_token.updated.json
@@ -1,0 +1,40 @@
+{
+  "type": "card_token.updated",
+  "data": {
+    "intent_id": "LW0prGg",
+    "card_token": {
+      "id": "419cb5f7-20fc-4571-a64d-4a64f0a0412f",
+      "hashid": "gMRXKaZ",
+      "brand": "Visa",
+      "card_holder_name": "Kevin Smith",
+      "bin": "111100",
+      "last_4": "0000",
+      "issuer": "test",
+      "expiry_month": "02",
+      "expiry_year": "26",
+      "country": null,
+      "type": null,
+      "custom_fields": {
+        "lago_mit": false,
+        "lago_mh_service": "Invoices::Payments::MoneyhashService",
+        "lago_payable_id": "713ba385-5686-4a52-b5f6-a9b678ef4535",
+        "lago_customer_id": "53c14b65-3406-4b1b-9d49-77fb389ee92e",
+        "lago_payable_type": "Invoice",
+        "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414"
+      },
+      "provider_token_data": [
+        {
+          "last_4": "0000",
+          "service_provider_id": "gQJnWwZ",
+          "pay_in_method": "gqYGvEg",
+          "provider_specific_data": {
+            "token_id": "test_token"
+          }
+        }
+      ],
+      "requires_cvv": true,
+      "fingerprint": "d795b7befe90eaf9d91a9d563f446487c69f06c3a35374289a385d40709a82f0b14ebe7c24139e19aaca6f3661ec1a3715d92e51a5b099880acb66b39a621dc5",
+      "vault_region": "default"
+    }
+  }
+}

--- a/spec/fixtures/moneyhash/checkout_url_response.json
+++ b/spec/fixtures/moneyhash/checkout_url_response.json
@@ -1,0 +1,67 @@
+{
+  "status": {
+    "code": 200,
+    "message": "success",
+    "errors": []
+  },
+  "data": {
+    "embed_url": "https://stg-embed.moneyhash.io/embed/payment/LYPoo59",
+    "id": "LYPoo59",
+    "status": "UNPROCESSED",
+    "amount": 50.0,
+    "amount_currency": "USD",
+    "type": "Payin",
+    "account": "lgaxEBL",
+    "custom_fields": {
+      "lago_mit": false,
+      "lago_customer_id": "2f2f4867-1ac9-4529-b03b-4f7133897b82",
+      "lago_request": "generate_checkout_url",
+      "lago_provider_customer_id": "d835774d-7839-48b2-9161-aaae81eb3b89",
+      "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414"
+    },
+    "billing_data": {
+      "first_name": "mustafa",
+      "last_name": "eid",
+      "email": "test@email.com",
+      "phone_number": "+201064610000"
+    },
+    "transaction_provider_fields": {},
+    "active_transaction": null,
+    "transactions_history": [],
+    "flow": "xgXlXgX",
+    "flow_data": {
+      "id": "xgXlXgX",
+      "version": 1,
+      "sequence": null
+    },
+    "is_live": false,
+    "created": "today",
+    "template": null,
+    "merchant_reference": null,
+    "customer": "d835774d-7839-48b2-9161-aaae81eb3b89",
+    "state": "INTENT_FORM",
+    "state_details": {
+      "embed_url": "https://stg-embed.moneyhash.io/embed/payment/LYPoo59"
+    },
+    "customer_last_used_payment_method": "CARD",
+    "last_used_method": {
+      "id": "CARD",
+      "type": "payment_method"
+    },
+    "payment_status": {
+      "status": "NO_AUTHORIZE_ATTEMPTS",
+      "balances": {
+        "total_authorized": "0.00",
+        "total_voided": "0.00",
+        "available_to_void": "0.00",
+        "total_captured": "0.00",
+        "available_to_capture": "0.00",
+        "total_refunded": "0.00",
+        "available_to_refund": "0.00"
+      }
+    }
+  },
+  "count": 1,
+  "next": null,
+  "previous": null
+}

--- a/spec/fixtures/moneyhash/create_customer.json
+++ b/spec/fixtures/moneyhash/create_customer.json
@@ -1,0 +1,31 @@
+{
+  "status": { "code": 200, "message": "success", "errors": [] },
+  "data": {
+    "id": "dc98b896-c008-4446-97b8-8af852f476ef",
+    "type": "INDIVIDUAL",
+    "name": "Legal00x3 Customer",
+    "first_name": "Legal00x3",
+    "last_name": "Customer",
+    "email": "test@mh.io",
+    "phone_number": "+201087654321",
+    "description": null,
+    "custom_fields": null,
+    "company_name": "legal name cust00x3",
+    "tax_id": 76543456,
+    "tax_rate": null,
+    "address": "first line addr",
+    "national_id": null,
+    "contact_person_name": "legal name cust00x3 - Legal00x3 Customer",
+    "birth_date": null,
+    "is_live": false,
+    "wallets": {},
+    "created_during_a_payment": false,
+    "webhook_url": null,
+    "last_used_payment_method": null,
+    "last_used_method": {},
+    "custom_webhook_headers": {}
+  },
+  "count": 1,
+  "next": null,
+  "previous": null
+}

--- a/spec/fixtures/moneyhash/intent.processed.json
+++ b/spec/fixtures/moneyhash/intent.processed.json
@@ -1,0 +1,442 @@
+{
+  "type": "intent.processed",
+  "intent_type": "PAYMENT",
+  "data": {
+    "intent_id": "g6Q6QJL",
+    "intent": {
+      "id": "g6Q6QJL",
+      "status": "PROCESSED",
+      "amount": 5,
+      "amount_currency": "USD",
+      "type": "Payin",
+      "account": "lgaxEBL",
+      "custom_fields": {
+        "lago_mh_connection_id": "ee0e4bd6-fad0-483c-8865-6314df1199ea",
+        "lago_mh_connection_code": "salah-demo",
+        "lago_mit": true,
+        "lago_customer_id": "46275968-4805-44e2-a181-e587b4c13b19",
+        "lago_external_customer_id": "cust_external_id_xxx1",
+        "lago_provider_customer_id": "1f3e6132-85d7-4c35-81e1-0c302f056d34",
+        "lago_payable_id": "727bb6ca-9a31-458e-ac05-98bf48967387",
+        "lago_payable_type": "Invoice",
+        "lago_plan_id": "",
+        "lago_subscription_external_id": "",
+        "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414",
+        "lago_mh_service": "PaymentProviders::Moneyhash::Payments::CreateService",
+        "lago_invoice_type": "one_off",
+        "lago_request": "invoice_automatic_payment"
+      },
+      "billing_data": {
+        "first_name": "salah",
+        "last_name": "salah",
+        "email": null,
+        "phone_number": "+201087654321"
+      },
+      "active_transaction": {
+        "id": "af6395fe-617c-480e-864e-2de6d2e6828f",
+        "custom_fields": {
+          "lago_mh_connection_id": "ee0e4bd6-fad0-483c-8865-6314df1199ea",
+          "lago_mh_connection_code": "salah-demo",
+          "lago_mit": true,
+          "lago_customer_id": "46275968-4805-44e2-a181-e587b4c13b19",
+          "lago_external_customer_id": "cust_external_id_xxx1",
+          "lago_provider_customer_id": "1f3e6132-85d7-4c35-81e1-0c302f056d34",
+          "lago_payable_id": "727bb6ca-9a31-458e-ac05-98bf48967387",
+          "lago_payable_type": "Invoice",
+          "lago_plan_id": "",
+          "lago_subscription_external_id": "",
+          "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414",
+          "lago_mh_service": "PaymentProviders::Moneyhash::Payments::CreateService",
+          "lago_invoice_type": "one_off",
+          "lago_request": "invoice_automatic_payment"
+        },
+        "created": "2025-03-13T23:52:45.201012Z",
+        "status": "SUCCESSFUL",
+        "amount": "5.00",
+        "amount_currency": "USD",
+        "billing_data": {
+          "name": "salah salah",
+          "first_name": "salah",
+          "last_name": "salah",
+          "email": null,
+          "phone_number": "+201087654321",
+          "address": null,
+          "address1": null,
+          "apartment": null,
+          "floor": null,
+          "building": null,
+          "street": null,
+          "city": null,
+          "state": null,
+          "country": null,
+          "postal_code": null,
+          "mobile_wallet_number": null
+        },
+        "external_action_message": [],
+        "payment_method": "CARD",
+        "payment_method_name": "Card",
+        "custom_form_answers": null,
+        "custom_message": "",
+        "account": "lgaxEBL",
+        "provider_transaction_fields": {
+          "checkoutdotcom_payment_id": null,
+          "checkoutdotcom_payment_auth_code": null,
+          "checkoutdotcom_increase_auth_code": null,
+          "checkoutdotcom_increase_auth_action_id": null,
+          "checkoutdotcom_acquirer_reference_number": null,
+          "checkoutdotcom_processing_object": null,
+          "checkoutdotcom_operation_fields": {}
+        },
+        "provider_signature_match": false,
+        "service_provider": "gQJnWwZ",
+        "method": {
+          "id": "gqYGvEg",
+          "display_name": "CheckoutDotCom - Card",
+          "service_provider": {
+            "id": "gQJnWwZ",
+            "display_name": "Checkout.com"
+          }
+        },
+        "operations": [
+          {
+            "id": "9JzpB79",
+            "type": "purchase",
+            "status": "successful",
+            "amount": {
+              "value": 5,
+              "currency": "USD"
+            },
+            "latest_status": {
+              "id": "gl2pKo9",
+              "value": "successful",
+              "code": "6000",
+              "provider_error_code": null,
+              "provider_error_message": null,
+              "message": "Successful",
+              "localized_message": "Successful"
+            },
+            "statuses": [
+              {
+                "id": "ZBzOvWZ",
+                "value": "pending",
+                "code": "8000",
+                "provider_error_code": null,
+                "provider_error_message": null,
+                "message": "Pending",
+                "localized_message": "Pending",
+                "created": "2025-03-13 23:52:45.236134+00:00"
+              },
+              {
+                "id": "gl2pKo9",
+                "value": "successful",
+                "code": "6000",
+                "provider_error_code": null,
+                "provider_error_message": null,
+                "message": "Successful",
+                "localized_message": "Successful",
+                "created": "2025-03-13 23:52:45.354504+00:00"
+              }
+            ],
+            "refund_type": null,
+            "custom_fields": null,
+            "extra": {},
+            "rrn": null,
+            "arn": null,
+            "authorization_code": null
+          }
+        ],
+        "fraud_decision": null,
+        "device_check": null,
+        "paying_card_token": {
+          "id": "60cd8d40-3acd-41b4-b5ab-62ce4eceb12d",
+          "hashid": "ZONbEpg",
+          "brand": "Visa",
+          "card_holder_name": "Kevin Smith",
+          "bin": "111100",
+          "last_4": "0000",
+          "issuer": "test",
+          "expiry_month": "02",
+          "expiry_year": "26",
+          "country": null,
+          "type": null,
+          "custom_fields": {
+            "lago_mh_connection_id": "ee0e4bd6-fad0-483c-8865-6314df1199ea",
+            "lago_mh_connection_code": "salah-demo",
+            "lago_mit": true,
+            "lago_customer_id": "46275968-4805-44e2-a181-e587b4c13b19",
+            "lago_external_customer_id": "cust_external_id_xxx1",
+            "lago_provider_customer_id": "1f3e6132-85d7-4c35-81e1-0c302f056d34",
+            "lago_payable_id": "727bb6ca-9a31-458e-ac05-98bf48967387",
+            "lago_payable_type": "Invoice",
+            "lago_plan_id": "",
+            "lago_subscription_external_id": "",
+            "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414",
+            "lago_mh_service": "PaymentProviders::Moneyhash::Payments::CreateService",
+            "lago_invoice_type": "one_off",
+            "lago_request": "invoice_automatic_payment"
+          },
+          "provider_token_data": [
+            {
+              "last_4": "0000",
+              "service_provider_id": "gQJnWwZ",
+              "pay_in_method": "gqYGvEg",
+              "provider_specific_data": {
+                "token_id": "test_token"
+              }
+            }
+          ],
+          "requires_cvv": true,
+          "fingerprint": "d795b7befe90eaf9d91a9d563f446487c69f06c3a35374289a385d40709a82f0b14ebe7c24139e19aaca6f3661ec1a3715d92e51a5b099880acb66b39a621dc5",
+          "vault_region": "default"
+        },
+        "authorization_code": null,
+        "payment_method_details": {
+          "type": "CARD",
+          "data": null,
+          "provider_data": null
+        },
+        "merchant_reference": null,
+        "provider_unique_reference": {
+          "key": "checkoutdotcom_payment_id",
+          "value": null
+        },
+        "authentication_data": null,
+        "trx_rrn": null,
+        "full_capture": true,
+        "ip": {
+          "ip": {
+            "ip_address": null,
+            "country": {
+              "iso_code": null,
+              "name": null
+            }
+          }
+        }
+      },
+      "transactions_count": 1,
+      "transactions_history": [
+        {
+          "id": "af6395fe-617c-480e-864e-2de6d2e6828f",
+          "custom_fields": {
+            "lago_mit": true,
+            "lago_plan_id": "",
+            "lago_request": "invoice_automatic_payment",
+            "lago_mh_service": "PaymentProviders::Moneyhash::Payments::CreateService",
+            "lago_payable_id": "727bb6ca-9a31-458e-ac05-98bf48967387",
+            "lago_customer_id": "46275968-4805-44e2-a181-e587b4c13b19",
+            "lago_invoice_type": "one_off",
+            "lago_payable_type": "Invoice",
+            "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414",
+            "lago_mh_connection_id": "ee0e4bd6-fad0-483c-8865-6314df1199ea",
+            "lago_mh_connection_code": "salah-demo",
+            "lago_external_customer_id": "cust_external_id_xxx1",
+            "lago_provider_customer_id": "1f3e6132-85d7-4c35-81e1-0c302f056d34",
+            "lago_subscription_external_id": ""
+          },
+          "created": "2025-03-13T23:52:45.201012Z",
+          "status": "SUCCESSFUL",
+          "amount": "5.00",
+          "amount_currency": "USD",
+          "billing_data": {
+            "name": "salah salah",
+            "first_name": "salah",
+            "last_name": "salah",
+            "email": null,
+            "phone_number": "+201087654321",
+            "address": null,
+            "address1": null,
+            "apartment": null,
+            "floor": null,
+            "building": null,
+            "street": null,
+            "city": null,
+            "state": null,
+            "country": null,
+            "postal_code": null,
+            "mobile_wallet_number": null
+          },
+          "external_action_message": [],
+          "payment_method": "CARD",
+          "payment_method_name": "Card",
+          "custom_form_answers": null,
+          "custom_message": "",
+          "account": "lgaxEBL",
+          "provider_transaction_fields": {
+            "checkoutdotcom_payment_id": null,
+            "checkoutdotcom_payment_auth_code": null,
+            "checkoutdotcom_increase_auth_code": null,
+            "checkoutdotcom_increase_auth_action_id": null,
+            "checkoutdotcom_acquirer_reference_number": null,
+            "checkoutdotcom_processing_object": null,
+            "checkoutdotcom_operation_fields": {}
+          },
+          "provider_signature_match": false,
+          "service_provider": "gQJnWwZ",
+          "method": {
+            "id": "gqYGvEg",
+            "display_name": "CheckoutDotCom - Card",
+            "service_provider": {
+              "id": "gQJnWwZ",
+              "display_name": "Checkout.com"
+            }
+          },
+          "operations": [
+            {
+              "id": "9JzpB79",
+              "type": "purchase",
+              "status": "successful",
+              "amount": {
+                "value": 5,
+                "currency": "USD"
+              },
+              "latest_status": {
+                "id": "gl2pKo9",
+                "value": "successful",
+                "code": "6000",
+                "provider_error_code": null,
+                "provider_error_message": null,
+                "message": "Successful",
+                "localized_message": "Successful"
+              },
+              "statuses": [
+                {
+                  "id": "ZBzOvWZ",
+                  "value": "pending",
+                  "code": "8000",
+                  "provider_error_code": null,
+                  "provider_error_message": null,
+                  "message": "Pending",
+                  "localized_message": "Pending",
+                  "created": "2025-03-13 23:52:45.236134+00:00"
+                },
+                {
+                  "id": "gl2pKo9",
+                  "value": "successful",
+                  "code": "6000",
+                  "provider_error_code": null,
+                  "provider_error_message": null,
+                  "message": "Successful",
+                  "localized_message": "Successful",
+                  "created": "2025-03-13 23:52:45.354504+00:00"
+                }
+              ],
+              "refund_type": null,
+              "custom_fields": null,
+              "extra": {},
+              "rrn": null,
+              "arn": null,
+              "authorization_code": null
+            }
+          ],
+          "fraud_decision": null,
+          "device_check": null,
+          "paying_card_token": {
+            "id": "60cd8d40-3acd-41b4-b5ab-62ce4eceb12d",
+            "hashid": "ZONbEpg",
+            "brand": "Visa",
+            "card_holder_name": "Kevin Smith",
+            "bin": "111100",
+            "last_4": "0000",
+            "issuer": "test",
+            "expiry_month": "02",
+            "expiry_year": "26",
+            "country": null,
+            "type": null,
+            "custom_fields": {
+              "lago_mh_connection_id": "ee0e4bd6-fad0-483c-8865-6314df1199ea",
+              "lago_mh_connection_code": "salah-demo",
+              "lago_mit": true,
+              "lago_customer_id": "46275968-4805-44e2-a181-e587b4c13b19",
+              "lago_external_customer_id": "cust_external_id_xxx1",
+              "lago_provider_customer_id": "1f3e6132-85d7-4c35-81e1-0c302f056d34",
+              "lago_payable_id": "727bb6ca-9a31-458e-ac05-98bf48967387",
+              "lago_payable_type": "Invoice",
+              "lago_plan_id": "",
+              "lago_subscription_external_id": "",
+              "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414",
+              "lago_mh_service": "PaymentProviders::Moneyhash::Payments::CreateService",
+              "lago_invoice_type": "one_off",
+              "lago_request": "invoice_automatic_payment"
+            },
+            "provider_token_data": [
+              {
+                "last_4": "0000",
+                "service_provider_id": "gQJnWwZ",
+                "pay_in_method": "gqYGvEg",
+                "provider_specific_data": {
+                  "token_id": "test_token"
+                }
+              }
+            ],
+            "requires_cvv": true,
+            "fingerprint": "d795b7befe90eaf9d91a9d563f446487c69f06c3a35374289a385d40709a82f0b14ebe7c24139e19aaca6f3661ec1a3715d92e51a5b099880acb66b39a621dc5",
+            "vault_region": "default"
+          },
+          "authorization_code": null,
+          "payment_method_details": {
+            "type": "CARD",
+            "data": null,
+            "provider_data": null
+          },
+          "merchant_reference": null,
+          "provider_unique_reference": {
+            "key": "checkoutdotcom_payment_id",
+            "value": null
+          },
+          "authentication_data": null,
+          "trx_rrn": null,
+          "full_capture": true,
+          "ip": {
+            "ip": {
+              "ip_address": null,
+              "country": {
+                "iso_code": null,
+                "name": null
+              }
+            }
+          }
+        }
+      ],
+      "method": {
+        "display_name": "CheckoutDotCom - Card",
+        "id": "gqYGvEg"
+      },
+      "flow": "xgXlXgX",
+      "flow_data": {
+        "id": "xgXlXgX",
+        "version": 1,
+        "sequence": {
+          "id": 29319,
+          "alias": "RrPGuUx-Untitled Trigger",
+          "last_action": {
+            "id": 49432,
+            "alias": "vAZSwgB-Payment Provider"
+          }
+        }
+      },
+      "is_live": false,
+      "created": "2025-03-13T23:52:44.967714Z",
+      "merchant_reference": null,
+      "ip": {
+        "ip_address": null,
+        "country": {
+          "iso_code": null,
+          "name": null
+        }
+      },
+      "payment_status": {
+        "status": "CAPTURED",
+        "balances": {
+          "total_authorized": "5.00",
+          "total_voided": "0.00",
+          "available_to_void": "0.00",
+          "total_captured": "5.00",
+          "available_to_capture": "0.00",
+          "total_refunded": "0.00",
+          "available_to_refund": "5.00"
+        }
+      }
+    }
+  },
+  "api_version": "1.1"
+}

--- a/spec/fixtures/moneyhash/intent.time_expired.json
+++ b/spec/fixtures/moneyhash/intent.time_expired.json
@@ -1,0 +1,64 @@
+{
+  "type": "intent.time_expired",
+  "intent_type": "PAYMENT",
+  "data": {
+    "intent_id": "9J0x2Dg",
+    "intent": {
+      "id": "9J0x2Dg",
+      "status": "TIME_EXPIRED",
+      "amount": 6.77,
+      "amount_currency": "USD",
+      "type": "Payin",
+      "account": "lgaxEBL",
+      "custom_fields": {
+        "lago_mit": false,
+        "lago_plan_id": "de95fd5d-3349-4439-a5d0-18b42b8551d1",
+        "lago_mh_service": "Invoices::Payments::MoneyhashService",
+        "lago_payable_id": "b42828c5-ae57-4716-8281-3317fed01042",
+        "lago_customer_id": "e6676e85-9e4f-4fb5-bd2f-590a9c170d0e",
+        "lago_payable_type": "Invoice",
+        "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414",
+        "lago_subscription_external_id": "7373a747-b6ab-44f2-b6cd-0662b73cbfcb"
+      },
+      "billing_data": {
+        "first_name": "Ahmed",
+        "last_name": "Shahwan",
+        "email": "a.shahwan@moneyhash.io",
+        "phone_number": "+201087654321"
+      },
+      "active_transaction": null,
+      "transactions_count": 0,
+      "transactions_history": [],
+      "method": {},
+      "flow": "xgXlXgX",
+      "flow_data": {
+        "id": "xgXlXgX",
+        "version": 1,
+        "sequence": null
+      },
+      "is_live": false,
+      "created": "2025-03-11T11:21:02.267317Z",
+      "merchant_reference": null,
+      "ip": {
+        "ip_address": "196.150.203.149",
+        "country": {
+          "iso_code": "EG",
+          "name": "Egypt"
+        }
+      },
+      "payment_status": {
+        "status": "EXPIRED",
+        "balances": {
+          "total_authorized": "0.00",
+          "total_voided": "0.00",
+          "available_to_void": "0.00",
+          "total_captured": "0.00",
+          "available_to_capture": "0.00",
+          "total_refunded": "0.00",
+          "available_to_refund": "0.00"
+        }
+      }
+    }
+  },
+  "api_version": "1.1"
+}

--- a/spec/fixtures/moneyhash/recurring_mit_payment_failure_response.json
+++ b/spec/fixtures/moneyhash/recurring_mit_payment_failure_response.json
@@ -1,0 +1,11 @@
+{
+  "status": {
+    "code": 400,
+    "message": "",
+    "errors": [{ "card_token": "This field may not be null." }]
+  },
+  "data": {},
+  "count": null,
+  "next": null,
+  "previous": null
+}

--- a/spec/fixtures/moneyhash/recurring_mit_payment_payload.json
+++ b/spec/fixtures/moneyhash/recurring_mit_payment_payload.json
@@ -1,0 +1,29 @@
+{
+  "amount": 10,
+  "amount_currency": "USD",
+  "billing_data": {
+    "email": "a.shahwan@moneyhash.io",
+    "first_name": "Ahmed",
+    "last_name": "Shahwan",
+    "phone_number": "+201087654321"
+  },
+  "custom_fields": {
+    "lago_customer_id": "e6676e85-9e4f-4fb5-bd2f-590a9c170d0e",
+    "lago_external_customer_id": "ext_cust_004",
+    "lago_mh_service": "PaymentProviders::Moneyhash::Payments::CreateService",
+    "lago_mit": true,
+    "lago_payable_id": "15fb51fb-586f-42bd-8e39-620d539d4e79",
+    "lago_payable_type": "Invoice",
+    "lago_plan_id": "de95fd5d-3349-4439-a5d0-18b42b8551d1",
+    "lago_provider_customer_id": "c4fc7f2f-e46b-42d1-842b-c246cf1a597d",
+    "lago_subscription_external_id": "7373a747-b6ab-44f2-b6cd-0662b73cbfcb"
+  },
+  "customer": "c4fc7f2f-e46b-42d1-842b-c246cf1a597d",
+  "card_token": "card_token_001",
+  "flow_id": "xgXlXgX",
+  "merchant_initiated": true,
+  "recurring_data": {
+    "agreement_id": "7373a747-b6ab-44f2-b6cd-0662b73cbfcb"
+  },
+  "webhook_url": "https://29c9-196-150-203-149.ngrok-free.app/webhooks/moneyhash/1f6edf98-9eb4-4baf-8c64-7c6be9d0b414?code=mh-lago"
+}

--- a/spec/fixtures/moneyhash/recurring_mit_payment_success_response.json
+++ b/spec/fixtures/moneyhash/recurring_mit_payment_success_response.json
@@ -1,0 +1,426 @@
+{
+  "status": {
+    "code": 200,
+    "message": "success",
+    "errors": []
+  },
+  "data": {
+    "embed_url": "https://stg-embed.moneyhash.io/embed/payment/ZdBEBXL",
+    "id": "ZdBEBXL",
+    "status": "PROCESSED",
+    "amount": 10.0,
+    "amount_currency": "USD",
+    "type": "Payin",
+    "account": "lgaxEBL",
+    "custom_fields": {
+      "lago_customer_id": "a7a7deae-ca21-4c9b-bd3e-18f31bb358f8",
+      "lago_external_customer_id": "test_lago10",
+      "lago_mh_service": "PaymentProviders::Moneyhash::Payments::CreateService",
+      "lago_mit": true,
+      "lago_payable_id": "962256eb-dc4b-4339-b8b1-b4b888ab984a",
+      "lago_payable_type": "Invoice",
+      "lago_plan_id": "de95fd5d-3349-4439-a5d0-18b42b8551d1",
+      "lago_provider_customer_id": "f8be4051-d93e-4307-a1d3-b9d59c01a7c5",
+      "lago_subscription_external_id": "81c781e8-6361-4cf2-8c66-bdfde9fe842f"
+    },
+    "billing_data": {
+      "first_name": "Ahmed",
+      "last_name": "Shahwan",
+      "email": "a.shahwan@moneyhash.io",
+      "phone_number": "+201087654321"
+    },
+    "transaction_provider_fields": {
+      "checkoutdotcom_payment_id": null,
+      "checkoutdotcom_payment_auth_code": null,
+      "checkoutdotcom_increase_auth_code": null,
+      "checkoutdotcom_increase_auth_action_id": null,
+      "checkoutdotcom_acquirer_reference_number": null,
+      "checkoutdotcom_processing_object": null,
+      "checkoutdotcom_operation_fields": {}
+    },
+    "active_transaction": {
+      "id": "d7156e7f-ef0b-4fa2-a862-cb1c1f758a5c",
+      "custom_fields": {
+        "lago_customer_id": "a7a7deae-ca21-4c9b-bd3e-18f31bb358f8",
+        "lago_external_customer_id": "test_lago10",
+        "lago_mh_service": "PaymentProviders::Moneyhash::Payments::CreateService",
+        "lago_mit": true,
+        "lago_payable_id": "962256eb-dc4b-4339-b8b1-b4b888ab984a",
+        "lago_payable_type": "Invoice",
+        "lago_plan_id": "de95fd5d-3349-4439-a5d0-18b42b8551d1",
+        "lago_provider_customer_id": "f8be4051-d93e-4307-a1d3-b9d59c01a7c5",
+        "lago_subscription_external_id": "81c781e8-6361-4cf2-8c66-bdfde9fe842f"
+      },
+      "created": "2025-03-12T08:56:40.181596Z",
+      "status": "SUCCESSFUL",
+      "amount": 10.0,
+      "amount_currency": "USD",
+      "billing_data": {
+        "name": "Ahmed Shahwan",
+        "first_name": "Ahmed",
+        "last_name": "Shahwan",
+        "email": "a.shahwan@moneyhash.io",
+        "phone_number": "+201087654321",
+        "address": null,
+        "address1": null,
+        "apartment": null,
+        "floor": null,
+        "building": null,
+        "street": null,
+        "city": null,
+        "state": null,
+        "country": null,
+        "postal_code": null,
+        "mobile_wallet_number": null
+      },
+      "external_action_message": [],
+      "payment_method": "CARD",
+      "payment_method_name": "Card",
+      "custom_form_answers": null,
+      "custom_message": "",
+      "account": "lgaxEBL",
+      "provider_transaction_fields": {
+        "checkoutdotcom_payment_id": null,
+        "checkoutdotcom_payment_auth_code": null,
+        "checkoutdotcom_increase_auth_code": null,
+        "checkoutdotcom_increase_auth_action_id": null,
+        "checkoutdotcom_acquirer_reference_number": null,
+        "checkoutdotcom_processing_object": null,
+        "checkoutdotcom_operation_fields": {}
+      },
+      "provider_signature_match": false,
+      "service_provider": "gQJnWwZ",
+      "method": {
+        "id": "gqYGvEg",
+        "display_name": "CheckoutDotCom - Card",
+        "service_provider": {
+          "id": "gQJnWwZ",
+          "display_name": "Checkout.com"
+        }
+      },
+      "operations": [
+        {
+          "id": "gMK40Q9",
+          "type": "purchase",
+          "status": "successful",
+          "amount": {
+            "value": 10,
+            "currency": "USD"
+          },
+          "latest_status": {
+            "id": "Z1m4xrZ",
+            "value": "successful",
+            "code": "6000",
+            "provider_error_code": null,
+            "provider_error_message": null,
+            "message": "Successful",
+            "localized_message": "Successful"
+          },
+          "statuses": [
+            {
+              "id": "LPoNjr9",
+              "value": "pending",
+              "code": "8000",
+              "provider_error_code": null,
+              "provider_error_message": null,
+              "message": "Pending",
+              "localized_message": "Pending",
+              "created": "2025-03-12 08:56:40.223232+00:00"
+            },
+            {
+              "id": "Z1m4xrZ",
+              "value": "successful",
+              "code": "6000",
+              "provider_error_code": null,
+              "provider_error_message": null,
+              "message": "Successful",
+              "localized_message": "Successful",
+              "created": "2025-03-12 08:56:40.342989+00:00"
+            }
+          ],
+          "refund_type": null,
+          "custom_fields": null,
+          "extra": {},
+          "rrn": null,
+          "arn": null,
+          "authorization_code": null
+        }
+      ],
+      "fraud_decision": null,
+      "device_check": null,
+      "paying_card_token": {
+        "id": "41fbf0e5-c8d8-4ca8-9b11-c0afdf631af7",
+        "hashid": "ZGxOdA9",
+        "brand": "Visa",
+        "card_holder_name": "Kevin Smith",
+        "bin": "111100",
+        "last_4": "0000",
+        "issuer": "test",
+        "expiry_month": "02",
+        "expiry_year": "26",
+        "country": null,
+        "type": null,
+        "custom_fields": {
+          "lago_customer_id": "a7a7deae-ca21-4c9b-bd3e-18f31bb358f8",
+          "lago_external_customer_id": "test_lago10",
+          "lago_mh_service": "PaymentProviders::Moneyhash::Payments::CreateService",
+          "lago_mit": true,
+          "lago_payable_id": "962256eb-dc4b-4339-b8b1-b4b888ab984a",
+          "lago_payable_type": "Invoice",
+          "lago_plan_id": "de95fd5d-3349-4439-a5d0-18b42b8551d1",
+          "lago_provider_customer_id": "f8be4051-d93e-4307-a1d3-b9d59c01a7c5",
+          "lago_subscription_external_id": "81c781e8-6361-4cf2-8c66-bdfde9fe842f"
+        },
+        "provider_token_data": [
+          {
+            "last_4": "0000",
+            "service_provider_id": "gQJnWwZ",
+            "pay_in_method": "gqYGvEg",
+            "provider_specific_data": {
+              "token_id": "test_token"
+            }
+          }
+        ],
+        "requires_cvv": true,
+        "fingerprint": "d795b7befe90eaf9d91a9d563f446487c69f06c3a35374289a385d40709a82f0b14ebe7c24139e19aaca6f3661ec1a3715d92e51a5b099880acb66b39a621dc5",
+        "vault_region": "default"
+      },
+      "authorization_code": null,
+      "payment_method_details": {
+        "type": "CARD",
+        "data": null,
+        "provider_data": null
+      },
+      "merchant_reference": null,
+      "provider_unique_reference": {
+        "key": "checkoutdotcom_payment_id",
+        "value": null
+      },
+      "authentication_data": null,
+      "trx_rrn": null,
+      "full_capture": true,
+      "ip": {
+        "ip": {
+          "ip_address": null,
+          "country": {
+            "iso_code": null,
+            "name": null
+          }
+        }
+      }
+    },
+    "transactions_history": [
+      {
+        "id": "d7156e7f-ef0b-4fa2-a862-cb1c1f758a5c",
+        "custom_fields": {
+          "lago_mit": true,
+          "lago_plan_id": "de95fd5d-3349-4439-a5d0-18b42b8551d1",
+          "lago_mh_service": "PaymentProviders::Moneyhash::Payments::CreateService",
+          "lago_payable_id": "962256eb-dc4b-4339-b8b1-b4b888ab984a",
+          "lago_customer_id": "a7a7deae-ca21-4c9b-bd3e-18f31bb358f8",
+          "lago_payable_type": "Invoice",
+          "lago_external_customer_id": "test_lago10",
+          "lago_provider_customer_id": "f8be4051-d93e-4307-a1d3-b9d59c01a7c5",
+          "lago_subscription_external_id": "81c781e8-6361-4cf2-8c66-bdfde9fe842f"
+        },
+        "created": "2025-03-12T08:56:40.181596Z",
+        "status": "SUCCESSFUL",
+        "amount": 10.0,
+        "amount_currency": "USD",
+        "billing_data": {
+          "name": "Ahmed Shahwan",
+          "first_name": "Ahmed",
+          "last_name": "Shahwan",
+          "email": "a.shahwan@moneyhash.io",
+          "phone_number": "+201087654321",
+          "address": null,
+          "address1": null,
+          "apartment": null,
+          "floor": null,
+          "building": null,
+          "street": null,
+          "city": null,
+          "state": null,
+          "country": null,
+          "postal_code": null,
+          "mobile_wallet_number": null
+        },
+        "external_action_message": [],
+        "payment_method": "CARD",
+        "payment_method_name": "Card",
+        "custom_form_answers": null,
+        "custom_message": "",
+        "account": "lgaxEBL",
+        "provider_transaction_fields": {
+          "checkoutdotcom_payment_id": null,
+          "checkoutdotcom_payment_auth_code": null,
+          "checkoutdotcom_increase_auth_code": null,
+          "checkoutdotcom_increase_auth_action_id": null,
+          "checkoutdotcom_acquirer_reference_number": null,
+          "checkoutdotcom_processing_object": null,
+          "checkoutdotcom_operation_fields": {}
+        },
+        "provider_signature_match": false,
+        "service_provider": "gQJnWwZ",
+        "method": {
+          "id": "gqYGvEg",
+          "display_name": "CheckoutDotCom - Card",
+          "service_provider": {
+            "id": "gQJnWwZ",
+            "display_name": "Checkout.com"
+          }
+        },
+        "operations": [
+          {
+            "id": "gMK40Q9",
+            "type": "purchase",
+            "status": "successful",
+            "amount": {
+              "value": 10,
+              "currency": "USD"
+            },
+            "latest_status": {
+              "id": "Z1m4xrZ",
+              "value": "successful",
+              "code": "6000",
+              "provider_error_code": null,
+              "provider_error_message": null,
+              "message": "Successful",
+              "localized_message": "Successful"
+            },
+            "statuses": [
+              {
+                "id": "LPoNjr9",
+                "value": "pending",
+                "code": "8000",
+                "provider_error_code": null,
+                "provider_error_message": null,
+                "message": "Pending",
+                "localized_message": "Pending",
+                "created": "2025-03-12 08:56:40.223232+00:00"
+              },
+              {
+                "id": "Z1m4xrZ",
+                "value": "successful",
+                "code": "6000",
+                "provider_error_code": null,
+                "provider_error_message": null,
+                "message": "Successful",
+                "localized_message": "Successful",
+                "created": "2025-03-12 08:56:40.342989+00:00"
+              }
+            ],
+            "refund_type": null,
+            "custom_fields": null,
+            "extra": {},
+            "rrn": null,
+            "arn": null,
+            "authorization_code": null
+          }
+        ],
+        "fraud_decision": null,
+        "device_check": null,
+        "paying_card_token": {
+          "id": "41fbf0e5-c8d8-4ca8-9b11-c0afdf631af7",
+          "hashid": "ZGxOdA9",
+          "brand": "Visa",
+          "card_holder_name": "Kevin Smith",
+          "bin": "111100",
+          "last_4": "0000",
+          "issuer": "test",
+          "expiry_month": "02",
+          "expiry_year": "26",
+          "country": null,
+          "type": null,
+          "custom_fields": {
+            "lago_customer_id": "a7a7deae-ca21-4c9b-bd3e-18f31bb358f8",
+            "lago_external_customer_id": "test_lago10",
+            "lago_mh_service": "PaymentProviders::Moneyhash::Payments::CreateService",
+            "lago_mit": true,
+            "lago_payable_id": "962256eb-dc4b-4339-b8b1-b4b888ab984a",
+            "lago_payable_type": "Invoice",
+            "lago_plan_id": "de95fd5d-3349-4439-a5d0-18b42b8551d1",
+            "lago_provider_customer_id": "f8be4051-d93e-4307-a1d3-b9d59c01a7c5",
+            "lago_subscription_external_id": "81c781e8-6361-4cf2-8c66-bdfde9fe842f"
+          },
+          "provider_token_data": [
+            {
+              "last_4": "0000",
+              "service_provider_id": "gQJnWwZ",
+              "pay_in_method": "gqYGvEg",
+              "provider_specific_data": {
+                "token_id": "test_token"
+              }
+            }
+          ],
+          "requires_cvv": true,
+          "fingerprint": "d795b7befe90eaf9d91a9d563f446487c69f06c3a35374289a385d40709a82f0b14ebe7c24139e19aaca6f3661ec1a3715d92e51a5b099880acb66b39a621dc5",
+          "vault_region": "default"
+        },
+        "authorization_code": null,
+        "payment_method_details": {
+          "type": "CARD",
+          "data": null,
+          "provider_data": null
+        },
+        "merchant_reference": null,
+        "provider_unique_reference": {
+          "key": "checkoutdotcom_payment_id",
+          "value": null
+        },
+        "authentication_data": null,
+        "trx_rrn": null,
+        "full_capture": true,
+        "ip": {
+          "ip": {
+            "ip_address": null,
+            "country": {
+              "iso_code": null,
+              "name": null
+            }
+          }
+        }
+      }
+    ],
+    "flow": "xgXlXgX",
+    "flow_data": {
+      "id": "xgXlXgX",
+      "version": 1,
+      "sequence": {
+        "id": 29319,
+        "alias": "RrPGuUx-Untitled Trigger",
+        "last_action": {
+          "id": 49432,
+          "alias": "vAZSwgB-Payment Provider"
+        }
+      }
+    },
+    "is_live": false,
+    "created": "today",
+    "template": null,
+    "merchant_reference": null,
+    "customer": "f8be4051-d93e-4307-a1d3-b9d59c01a7c5",
+    "state": "INTENT_PROCESSED",
+    "state_details": "{\"transaction\": {\"id\": \"d7156e7f-ef0b-4fa2-a862-cb1c1f758a5c\", \"custom_fields\": {\"lago_customer_id\": \"a7a7deae-ca21-4c9b-bd3e-18f31bb358f8\", \"lago_external_customer_id\": \"test_lago10\", \"lago_mh_service\": \"PaymentProviders::Moneyhash::Payments::CreateService\", \"lago_mit\": true, \"lago_payable_id\": \"962256eb-dc4b-4339-b8b1-b4b888ab984a\", \"lago_payable_type\": \"Invoice\", \"lago_plan_id\": \"de95fd5d-3349-4439-a5d0-18b42b8551d1\", \"lago_provider_customer_id\": \"f8be4051-d93e-4307-a1d3-b9d59c01a7c5\", \"lago_subscription_external_id\": \"81c781e8-6361-4cf2-8c66-bdfde9fe842f\"}, \"created\": \"2025-03-12T08:56:40.181596Z\", \"status\": \"SUCCESSFUL\", \"amount\": 10.0, \"amount_currency\": \"USD\", \"billing_data\": {\"name\": \"Ahmed Shahwan\", \"first_name\": \"Ahmed\", \"last_name\": \"Shahwan\", \"email\": \"a.shahwan@moneyhash.io\", \"phone_number\": \"+201087654321\", \"address\": null, \"address1\": null, \"apartment\": null, \"floor\": null, \"building\": null, \"street\": null, \"city\": null, \"state\": null, \"country\": null, \"postal_code\": null, \"mobile_wallet_number\": null}, \"external_action_message\": [], \"payment_method\": \"CARD\", \"payment_method_name\": \"Card\", \"custom_form_answers\": null, \"custom_message\": \"\", \"account\": \"lgaxEBL\", \"provider_transaction_fields\": {\"checkoutdotcom_payment_id\": null, \"checkoutdotcom_payment_auth_code\": null, \"checkoutdotcom_increase_auth_code\": null, \"checkoutdotcom_increase_auth_action_id\": null, \"checkoutdotcom_acquirer_reference_number\": null, \"checkoutdotcom_processing_object\": null, \"checkoutdotcom_operation_fields\": {}}, \"provider_signature_match\": false, \"service_provider\": \"gQJnWwZ\", \"method\": {\"id\": \"gqYGvEg\", \"display_name\": \"CheckoutDotCom - Card\", \"service_provider\": {\"id\": \"gQJnWwZ\", \"display_name\": \"Checkout.com\"}}, \"operations\": [{\"id\": \"gMK40Q9\", \"type\": \"purchase\", \"status\": \"successful\", \"amount\": {\"value\": 10, \"currency\": \"USD\"}, \"latest_status\": {\"id\": \"Z1m4xrZ\", \"value\": \"successful\", \"code\": \"6000\", \"provider_error_code\": null, \"provider_error_message\": null, \"message\": \"Successful\", \"localized_message\": \"Successful\"}, \"statuses\": [{\"id\": \"LPoNjr9\", \"value\": \"pending\", \"code\": \"8000\", \"provider_error_code\": null, \"provider_error_message\": null, \"message\": \"Pending\", \"localized_message\": \"Pending\", \"created\": \"2025-03-12 08:56:40.223232+00:00\"}, {\"id\": \"Z1m4xrZ\", \"value\": \"successful\", \"code\": \"6000\", \"provider_error_code\": null, \"provider_error_message\": null, \"message\": \"Successful\", \"localized_message\": \"Successful\", \"created\": \"2025-03-12 08:56:40.342989+00:00\"}], \"refund_type\": null, \"custom_fields\": null, \"extra\": {}, \"rrn\": null, \"arn\": null, \"authorization_code\": null}], \"fraud_decision\": null, \"device_check\": null, \"paying_card_token\": {\"id\": \"41fbf0e5-c8d8-4ca8-9b11-c0afdf631af7\", \"hashid\": \"ZGxOdA9\", \"brand\": \"Visa\", \"card_holder_name\": \"Kevin Smith\", \"bin\": \"111100\", \"last_4\": \"0000\", \"issuer\": \"test\", \"expiry_month\": \"02\", \"expiry_year\": \"26\", \"country\": null, \"type\": null, \"custom_fields\": {\"lago_customer_id\": \"a7a7deae-ca21-4c9b-bd3e-18f31bb358f8\", \"lago_external_customer_id\": \"test_lago10\", \"lago_mh_service\": \"PaymentProviders::Moneyhash::Payments::CreateService\", \"lago_mit\": true, \"lago_payable_id\": \"962256eb-dc4b-4339-b8b1-b4b888ab984a\", \"lago_payable_type\": \"Invoice\", \"lago_plan_id\": \"de95fd5d-3349-4439-a5d0-18b42b8551d1\", \"lago_provider_customer_id\": \"f8be4051-d93e-4307-a1d3-b9d59c01a7c5\", \"lago_subscription_external_id\": \"81c781e8-6361-4cf2-8c66-bdfde9fe842f\"}, \"provider_token_data\": [{\"last_4\": \"0000\", \"service_provider_id\": \"gQJnWwZ\", \"pay_in_method\": \"gqYGvEg\", \"provider_specific_data\": {\"token_id\": \"test_token\"}}], \"requires_cvv\": true, \"fingerprint\": \"d795b7befe90eaf9d91a9d563f446487c69f06c3a35374289a385d40709a82f0b14ebe7c24139e19aaca6f3661ec1a3715d92e51a5b099880acb66b39a621dc5\", \"vault_region\": \"default\"}, \"authorization_code\": null, \"payment_method_details\": {\"type\": \"CARD\", \"data\": null, \"provider_data\": null}, \"merchant_reference\": null, \"provider_unique_reference\": {\"key\": \"checkoutdotcom_payment_id\", \"value\": null}, \"authentication_data\": null, \"trx_rrn\": null, \"full_capture\": true, \"ip\": {\"ip\": {\"ip_address\": null, \"country\": {\"iso_code\": null, \"name\": null}}}, \"localized_status\": \"SUCCESSFUL\", \"trx_status\": \"purchase.successful\", \"type\": \"payin\"}, \"product_items_data\": null, \"shipping_data\": null, \"amount\": \"10.00USD\"}",
+    "customer_last_used_payment_method": "CARD",
+    "last_used_method": {
+      "type": "saved_card",
+      "id": "ZGxOdA9"
+    },
+    "payment_status": {
+      "status": "CAPTURED",
+      "balances": {
+        "total_authorized": "10.00",
+        "total_voided": "0.00",
+        "available_to_void": "0.00",
+        "total_captured": "10.00",
+        "available_to_capture": "0.00",
+        "total_refunded": "0.00",
+        "available_to_refund": "10.00"
+      }
+    }
+  },
+  "count": 1,
+  "next": null,
+  "previous": null
+}

--- a/spec/fixtures/moneyhash/transaction.purchase.failed.json
+++ b/spec/fixtures/moneyhash/transaction.purchase.failed.json
@@ -1,0 +1,160 @@
+{
+  "type": "transaction.purchase.failed",
+  "status_id": "Zv2kmzZ",
+  "operation_id": "Z0kD6Dg",
+  "intent": {
+    "id": "LVR0VXL",
+    "created": "2025-03-11 00:04:17.347506+00:00",
+    "custom_fields": {
+      "lago_mit": false,
+      "lago_mh_service": "Invoices::Payments::MoneyhashService",
+      "lago_payable_id": "2b618048-af9e-48f5-b188-f38642eef389",
+      "lago_customer_id": "53c14b65-3406-4b1b-9d49-77fb389ee92e",
+      "lago_payable_type": "Invoice",
+      "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414"
+    },
+    "split_data": [],
+    "custom_form_answers": null,
+    "amount": {
+      "value": 5,
+      "currency": "USD"
+    },
+    "flow_data": {
+      "id": "xgXlXgX",
+      "version": 1,
+      "sequence": null
+    },
+    "payment_status": {
+      "status": "AUTHORIZE_ATTEMPT_FAILED",
+      "balances": {
+        "total_authorized": "0.00",
+        "total_voided": "0.00",
+        "available_to_void": "0.00",
+        "total_captured": "0.00",
+        "available_to_capture": "0.00",
+        "total_refunded": "0.00",
+        "available_to_refund": "0.00"
+      }
+    }
+  },
+  "account": {
+    "id": "lgaxEBL"
+  },
+  "transaction": {
+    "type": "payment",
+    "id": "2414609b-8c3f-4298-8879-c9daa244a039",
+    "created": "2025-03-11 00:04:33.864332+00:00",
+    "status": "purchase.failed",
+    "billing_data": {
+      "name": "Legal00x3 Customer",
+      "first_name": "Legal00x3",
+      "last_name": "Customer",
+      "email": "test@mh.io",
+      "phone_number": "+201087654321",
+      "address": null,
+      "address1": null,
+      "apartment": null,
+      "floor": null,
+      "building": null,
+      "street": null,
+      "city": null,
+      "state": null,
+      "country": null,
+      "postal_code": null,
+      "mobile_wallet_number": null
+    },
+    "external_action_message": [],
+    "provider_transaction_fields": {
+      "checkoutdotcom_payment_id": null,
+      "checkoutdotcom_payment_auth_code": null,
+      "checkoutdotcom_increase_auth_code": null,
+      "checkoutdotcom_increase_auth_action_id": null,
+      "checkoutdotcom_acquirer_reference_number": null,
+      "checkoutdotcom_processing_object": null,
+      "checkoutdotcom_operation_fields": {}
+    },
+    "provider_unique_reference": {
+      "key": "checkoutdotcom_payment_id",
+      "value": null
+    },
+    "operations": [
+      {
+        "id": "Z0kD6Dg",
+        "type": "purchase",
+        "status": "failed",
+        "amount": {
+          "value": 5,
+          "currency": "USD"
+        },
+        "latest_status": {
+          "id": "Zv2kmzZ",
+          "value": "failed",
+          "code": "7000",
+          "provider_error_code": null,
+          "provider_error_message": null,
+          "message": "A generic payment processing error occurred.",
+          "localized_message": "A generic payment processing error occurred."
+        },
+        "statuses": [
+          {
+            "id": "Zo2p0Vg",
+            "value": "pending",
+            "code": "8000",
+            "provider_error_code": null,
+            "provider_error_message": null,
+            "message": "Pending",
+            "localized_message": "Pending",
+            "created": "2025-03-11 00:04:33.903421+00:00"
+          },
+          {
+            "id": "Zv2kmzZ",
+            "value": "failed",
+            "code": "7000",
+            "provider_error_code": null,
+            "provider_error_message": null,
+            "message": "A generic payment processing error occurred.",
+            "localized_message": "A generic payment processing error occurred.",
+            "created": "2025-03-11 00:04:34.016913+00:00"
+          }
+        ],
+        "refund_type": null,
+        "custom_fields": null,
+        "extra": {},
+        "rrn": null,
+        "arn": null,
+        "authorization_code": null
+      }
+    ],
+    "fraud_decision": null,
+    "device_check": null,
+    "custom_message": "",
+    "method": {
+      "id": "gqYGvEg",
+      "display_name": "CheckoutDotCom - Card",
+      "service_provider": {
+        "id": "gQJnWwZ",
+        "display_name": "Checkout.com"
+      }
+    },
+    "payment_method_details": {
+      "type": "CARD",
+      "data": null,
+      "provider_data": null
+    },
+    "authentication_data": null,
+    "paying_card_token": null,
+    "authorization_code": null,
+    "merchant_reference": null,
+    "shipping_data": null,
+    "trx_rrn": null,
+    "ip": {
+      "ip_address": "196.150.203.149",
+      "country": {
+        "iso_code": "EG",
+        "name": "Egypt"
+      }
+    },
+    "full_capture": false
+  },
+  "api_version": "1.1"
+}

--- a/spec/fixtures/moneyhash/transaction.purchase.pending_authentication.json
+++ b/spec/fixtures/moneyhash/transaction.purchase.pending_authentication.json
@@ -1,0 +1,164 @@
+{
+  "type": "transaction.purchase.pending_authentication",
+  "status_id": "1LkmkZr",
+  "operation_id": "4L2GvgE",
+  "intent": {
+    "id": "wgjowZJ",
+    "created": "2025-02-26 20:31:54.673799+00:00",
+    "custom_fields": {
+      "lago_mit": false,
+      "lago_plan_id": "de95fd5d-3349-4439-a5d0-18b42b8551d1",
+      "lago_mh_service": "Invoices::Payments::MoneyhashService",
+      "lago_payable_id": "23fd1f3c-922c-4928-b40b-c8a31e4d6664",
+      "lago_customer_id": "53c14b65-3406-4b1b-9d49-77fb389ee92e",
+      "lago_payable_type": "Invoice",
+      "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414",
+      "lago_subscription_external_id": "69f64026-69eb-4836-b1bd-9323d9f7d892"
+    },
+    "split_data": [],
+    "custom_form_answers": null,
+    "amount": { "value": 50, "currency": "USD" },
+    "flow_data": null,
+    "payment_status": {
+      "status": "AUTHORIZE_ATTEMPT_PENDING",
+      "balances": {
+        "total_authorized": 0,
+        "total_voided": 0,
+        "available_to_void": 0,
+        "total_captured": 0,
+        "available_to_capture": 0,
+        "total_refunded": 0,
+        "available_to_refund": 0
+      }
+    }
+  },
+  "account": { "id": "YVglAZx" },
+  "transaction": {
+    "type": "payment",
+    "id": "e2a009af-af3c-4068-b254-2a5f140dc733",
+    "created": "2025-02-26 20:31:57.152967+00:00",
+    "status": "purchase.pending_authentication",
+    "billing_data": {
+      "name": null,
+      "first_name": null,
+      "last_name": null,
+      "email": null,
+      "phone_number": null,
+      "address": null,
+      "address1": null,
+      "apartment": null,
+      "floor": null,
+      "building": null,
+      "street": null,
+      "city": null,
+      "state": null,
+      "country": null,
+      "postal_code": null,
+      "mobile_wallet_number": null
+    },
+    "external_action_message": [],
+    "provider_transaction_fields": {
+      "hyperpay_checkout_id": null,
+      "hyperpay_transaction_id": "8ac7a4a19542d70b019543f5b42725d6",
+      "hyperpay_merchant_transaction_id": "e2a009afaf3c4068",
+      "hyperpay_result_details_object": {
+        "TermID": "71F00820",
+        "OrderID": "8316384413",
+        "AuthCode": "f2e7a815c3",
+        "ProcStatus": "0",
+        "ConnectorTxID1": "8ac7a4a19542d70b019543f5b42725d6",
+        "ConnectorTxID2": "8ac7a4a1",
+        "ConnectorTxID3": "42d70b019543f5b42725d6",
+        "AcquirerResponse": "00",
+        "ExtendedDescription": "Successfully processed",
+        "EXTERNAL_SYSTEM_LINK": "https://csi-test.retaildecisions.com/RS60/TransDetail.aspx?oid=000194001101S2E20110926045038668&support=Link+to+Risk+Details",
+        "clearingInstituteName": "NCB BANK"
+      },
+      "extended_error_description": null
+    },
+    "provider_unique_reference": {
+      "key": "hyperpay_checkout_id",
+      "value": null
+    },
+    "operations": [
+      {
+        "id": "4L2GvgE",
+        "type": "purchase",
+        "status": "pending_authentication",
+        "amount": { "value": 50, "currency": "USD" },
+        "latest_status": {
+          "id": "1LkmkZr",
+          "value": "pending_authentication",
+          "code": "8001",
+          "provider_error_code": null,
+          "provider_error_message": null,
+          "message": "Pending Authentication",
+          "localized_message": "Pending Authentication"
+        },
+        "statuses": [
+          {
+            "id": "GgqzyZx",
+            "value": "pending",
+            "code": "8000",
+            "provider_error_code": null,
+            "provider_error_message": null,
+            "message": "Pending",
+            "localized_message": "Pending",
+            "created": "2025-02-26 20:31:57.204039+00:00"
+          },
+          {
+            "id": "1LkmkZr",
+            "value": "pending_authentication",
+            "code": "8001",
+            "provider_error_code": null,
+            "provider_error_message": null,
+            "message": "Pending Authentication",
+            "localized_message": "Pending Authentication",
+            "created": "2025-02-26 20:32:11.034455+00:00"
+          }
+        ],
+        "refund_type": null,
+        "custom_fields": null,
+        "extra": {},
+        "rrn": null,
+        "arn": null,
+        "authorization_code": null
+      }
+    ],
+    "fraud_decision": null,
+    "device_check": null,
+    "custom_message": "",
+    "method": {
+      "id": "lgbY0LB",
+      "display_name": "Hyperpay - Card",
+      "service_provider": { "id": "8LVnmLr", "display_name": "HyperPay" }
+    },
+    "payment_method_details": {
+      "type": "CARD",
+      "data": {
+        "bin": "411111",
+        "type": null,
+        "brand": "VISA",
+        "issuer": null,
+        "last_4": "1111",
+        "country": null,
+        "expiry_year": "2025",
+        "expiry_month": "05",
+        "card_holder_name": "ahmed shahhwan"
+      },
+      "provider_data": null
+    },
+    "authentication_data": null,
+    "paying_card_token": null,
+    "authorization_code": null,
+    "merchant_reference": null,
+    "shipping_data": null,
+    "trx_rrn": null,
+    "ip": {
+      "ip_address": "127.0.0.1",
+      "country": { "iso_code": null, "name": null }
+    },
+    "full_capture": false
+  },
+  "api_version": "1.1"
+}

--- a/spec/fixtures/moneyhash/transaction.purchase.successful.json
+++ b/spec/fixtures/moneyhash/transaction.purchase.successful.json
@@ -1,0 +1,197 @@
+{
+  "type": "transaction.purchase.successful",
+  "status_id": "9z2l4n9",
+  "operation_id": "94eK1qL",
+  "intent": {
+    "id": "LY0a5W9",
+    "created": "2025-03-10 17:44:35.192694+00:00",
+    "custom_fields": {
+      "lago_mit": false,
+      "lago_plan_id": "de95fd5d-3349-4439-a5d0-18b42b8551d1",
+      "lago_mh_service": "Invoices::Payments::MoneyhashService",
+      "lago_payable_id": "23fd1f3c-922c-4928-b40b-c8a31e4d6664",
+      "lago_customer_id": "53c14b65-3406-4b1b-9d49-77fb389ee92e",
+      "lago_payable_type": "Invoice",
+      "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414",
+      "lago_subscription_external_id": "69f64026-69eb-4836-b1bd-9323d9f7d892"
+    },
+    "split_data": [],
+    "custom_form_answers": null,
+    "amount": {
+      "value": 7.1,
+      "currency": "USD"
+    },
+    "flow_data": {
+      "id": "xgXlXgX",
+      "version": 1,
+      "sequence": null
+    },
+    "payment_status": {
+      "status": "CAPTURED",
+      "balances": {
+        "total_authorized": "7.10",
+        "total_voided": "0.00",
+        "available_to_void": "0.00",
+        "total_captured": "7.10",
+        "available_to_capture": "0.00",
+        "total_refunded": "0.00",
+        "available_to_refund": "7.10"
+      }
+    }
+  },
+  "account": {
+    "id": "lgaxEBL"
+  },
+  "transaction": {
+    "type": "payment",
+    "id": "0f6d9298-5346-49e4-8043-f3899bedbdb1",
+    "created": "2025-03-10 17:44:44.588034+00:00",
+    "status": "purchase.successful",
+    "billing_data": {
+      "name": "Legal00x3 Customer",
+      "first_name": "Legal00x3",
+      "last_name": "Customer",
+      "email": "test@mh.io",
+      "phone_number": "+201087654321",
+      "address": null,
+      "address1": null,
+      "apartment": null,
+      "floor": null,
+      "building": null,
+      "street": null,
+      "city": null,
+      "state": null,
+      "country": null,
+      "postal_code": null,
+      "mobile_wallet_number": null
+    },
+    "external_action_message": [],
+    "provider_transaction_fields": {
+      "checkoutdotcom_payment_id": null,
+      "checkoutdotcom_payment_auth_code": null,
+      "checkoutdotcom_increase_auth_code": null,
+      "checkoutdotcom_increase_auth_action_id": null,
+      "checkoutdotcom_acquirer_reference_number": null,
+      "checkoutdotcom_processing_object": null,
+      "checkoutdotcom_operation_fields": {}
+    },
+    "provider_unique_reference": {
+      "key": "checkoutdotcom_payment_id",
+      "value": null
+    },
+    "operations": [
+      {
+        "id": "94eK1qL",
+        "type": "purchase",
+        "status": "successful",
+        "amount": {
+          "value": 7.1,
+          "currency": "USD"
+        },
+        "latest_status": {
+          "id": "9z2l4n9",
+          "value": "successful",
+          "code": "6000",
+          "provider_error_code": null,
+          "provider_error_message": null,
+          "message": "Successful",
+          "localized_message": "Successful"
+        },
+        "statuses": [
+          {
+            "id": "gy2BVQZ",
+            "value": "pending",
+            "code": "8000",
+            "provider_error_code": null,
+            "provider_error_message": null,
+            "message": "Pending",
+            "localized_message": "Pending",
+            "created": "2025-03-10 17:44:44.642478+00:00"
+          },
+          {
+            "id": "9z2l4n9",
+            "value": "successful",
+            "code": "6000",
+            "provider_error_code": null,
+            "provider_error_message": null,
+            "message": "Successful",
+            "localized_message": "Successful",
+            "created": "2025-03-10 17:44:44.778054+00:00"
+          }
+        ],
+        "refund_type": null,
+        "custom_fields": null,
+        "extra": {},
+        "rrn": null,
+        "arn": null,
+        "authorization_code": null
+      }
+    ],
+    "fraud_decision": null,
+    "device_check": null,
+    "custom_message": "",
+    "method": {
+      "id": "gqYGvEg",
+      "display_name": "CheckoutDotCom - Card",
+      "service_provider": {
+        "id": "gQJnWwZ",
+        "display_name": "Checkout.com"
+      }
+    },
+    "payment_method_details": {
+      "type": "CARD",
+      "data": null,
+      "provider_data": null
+    },
+    "authentication_data": null,
+    "paying_card_token": {
+      "id": "419cb5f7-20fc-4571-a64d-4a64f0a0412f",
+      "hashid": "gMRXKaZ",
+      "brand": "Visa",
+      "card_holder_name": "Kevin Smith",
+      "bin": "111100",
+      "last_4": "0000",
+      "issuer": "test",
+      "expiry_month": "02",
+      "expiry_year": "26",
+      "country": null,
+      "type": null,
+      "custom_fields": {
+        "lago_mit": false,
+        "lago_plan_id": "de95fd5d-3349-4439-a5d0-18b42b8551d1",
+        "lago_mh_service": "Invoices::Payments::MoneyhashService",
+        "lago_payable_id": "23fd1f3c-922c-4928-b40b-c8a31e4d6664",
+        "lago_customer_id": "53c14b65-3406-4b1b-9d49-77fb389ee92e",
+        "lago_payable_type": "Invoice",
+        "lago_organization_id": "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414",
+        "lago_subscription_external_id": "69f64026-69eb-4836-b1bd-9323d9f7d892"
+      },
+      "provider_token_data": [
+        {
+          "last_4": "0000",
+          "service_provider_id": "gQJnWwZ",
+          "pay_in_method": "gqYGvEg",
+          "provider_specific_data": {
+            "token_id": "test_token"
+          }
+        }
+      ],
+      "requires_cvv": true,
+      "fingerprint": "d795b7befe90eaf9d91a9d563f446487c69f06c3a35374289a385d40709a82f0b14ebe7c24139e19aaca6f3661ec1a3715d92e51a5b099880acb66b39a621dc5",
+      "vault_region": "default"
+    },
+    "authorization_code": null,
+    "merchant_reference": null,
+    "shipping_data": null,
+    "trx_rrn": null,
+    "ip": {
+      "ip_address": "196.150.203.149",
+      "country": {
+        "iso_code": "EG",
+        "name": "Egypt"
+      }
+    },
+    "full_capture": true
+  },
+  "api_version": "1.1"
+}

--- a/spec/fixtures/moneyhash/webhook_signature_response.json
+++ b/spec/fixtures/moneyhash/webhook_signature_response.json
@@ -1,0 +1,13 @@
+{
+  "status": {
+    "code": 200,
+    "message": "success",
+    "errors": []
+  },
+  "data": {
+    "webhook_signature_secret": "oVZo2bro-a7UBN3k9QFlsSz6cN_Zrdt9KCWk4_5q2lo="
+  },
+  "count": 1,
+  "next": null,
+  "previous": null
+}

--- a/spec/models/payment_provider_customers/moneyhash_customer_spec.rb
+++ b/spec/models/payment_provider_customers/moneyhash_customer_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviderCustomers::MoneyhashCustomer, type: :model do
+  subject(:moneyhash_customer) { described_class.new(attributes) }
+
+  let(:attributes) {}
+
+  describe "#payment_method_id" do
+    subject(:customer_payment_method_id) { moneyhash_customer.payment_method_id }
+
+    let(:moneyhash_customer) { FactoryBot.build_stubbed(:moneyhash_customer) }
+    let(:payment_method_id) { SecureRandom.uuid }
+
+    before { moneyhash_customer.payment_method_id = payment_method_id }
+
+    it "returns the payment method id" do
+      expect(customer_payment_method_id).to eq payment_method_id
+    end
+  end
+
+  describe "#require_provider_payment_id?" do
+    it { expect(moneyhash_customer).to be_require_provider_payment_id }
+  end
+end

--- a/spec/models/payment_providers/moneyhash_provider_spec.rb
+++ b/spec/models/payment_providers/moneyhash_provider_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::MoneyhashProvider, type: :model do
+  subject(:moneyhash_provider) { build(:moneyhash_provider, attributes) }
+
+  let(:attributes) {}
+
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:api_key) }
+  it { is_expected.to validate_presence_of(:flow_id) }
+  it { is_expected.to validate_length_of(:flow_id).is_at_most(20) }
+
+  describe "validations" do
+    it "validates uniqueness of the code" do
+      expect(moneyhash_provider).to validate_uniqueness_of(:code).scoped_to(:organization_id)
+    end
+  end
+
+  describe "#api_key" do
+    let(:api_key) { SecureRandom.uuid }
+
+    before { moneyhash_provider.api_key = api_key }
+
+    it "returns the api key" do
+      expect(moneyhash_provider.api_key).to eq api_key
+    end
+  end
+
+  describe "#flow_id" do
+    let(:flow_id) { "test_flow_id" }
+
+    before { moneyhash_provider.flow_id = flow_id }
+
+    it "returns the flow id" do
+      expect(moneyhash_provider.flow_id).to eq flow_id
+    end
+  end
+
+  describe ".api_base_url" do
+    context "when in production environment" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+      end
+
+      it "returns production URL" do
+        expect(described_class.api_base_url).to eq("https://web.moneyhash.io")
+      end
+    end
+
+    context "when in non-production environment" do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(false)
+      end
+
+      it "returns staging URL" do
+        expect(described_class.api_base_url).to eq("https://staging-web.moneyhash.io")
+      end
+    end
+  end
+
+  describe "#webhook_end_point" do
+    let(:organization_id) { SecureRandom.uuid }
+    let(:code) { "test_code" }
+    let(:lago_api_url) { "https://api.getlago.com" }
+
+    before do
+      moneyhash_provider.organization_id = organization_id
+      moneyhash_provider.code = code
+      allow(ENV).to receive(:[]).with("LAGO_API_URL").and_return(lago_api_url)
+    end
+
+    it "returns the correct webhook endpoint URL" do
+      expected_url = "#{lago_api_url}/webhooks/moneyhash/#{organization_id}?code=#{code}"
+      expect(moneyhash_provider.webhook_end_point.to_s).to eq(expected_url)
+    end
+  end
+end

--- a/spec/services/invoices/payments/moneyhash_service_spec.rb
+++ b/spec/services/invoices/payments/moneyhash_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::Payments::MoneyhashService do
+  subject(:moneyhash_service) { described_class.new(invoice) }
+
+  let(:invoice) { create(:invoice, organization:, customer:, invoice_type: :subscription, payment_status: :pending) }
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
+  let(:moneyhash_customer) { create(:moneyhash_customer, customer:, payment_provider: moneyhash_provider) }
+
+  let(:intent_processed_json) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/intent.processed.json"))) }
+  let(:provider_payment_id) { intent_processed_json.dig("data", "id") }
+
+  let(:mh_provider_service) { PaymentProviders::MoneyhashService.new }
+
+  let(:payment_url_response) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/checkout_url_response.json"))) }
+
+  describe "#update_payment_status" do
+    before do
+      intent_processed_json["data"]["intent"]["custom_fields"]["lago_payable_id"] = invoice.id
+
+      moneyhash_provider
+      moneyhash_customer
+    end
+
+    it "creates a payment and updates the invoice payment status" do
+      result = moneyhash_service.update_payment_status(
+        organization_id: organization.id,
+        provider_payment_id: intent_processed_json.dig("data", "intent_id"),
+        status: mh_provider_service.event_to_payment_status(intent_processed_json.dig("type")),
+        metadata: intent_processed_json.dig("data", "intent", "custom_fields")
+      ).raise_if_error!
+
+      expect(result).to be_success
+      expect(result.payment.status).to eq("succeeded")
+      expect(result.payment.provider_payment_id).to eq(intent_processed_json.dig("data", "intent_id"))
+      expect(result.payment.payable_payment_status).to eq("succeeded")
+      expect(result.invoice.payment_status).to eq("succeeded")
+      expect(result.invoice.payment_attempts).to eq(1)
+    end
+  end
+
+  describe "#generate_payment_url" do
+    let(:response) { instance_double(Net::HTTPOK) }
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+    let(:endpoint) { "#{PaymentProviders::MoneyhashProvider.api_base_url}/api/v1.1/payments/intent/" }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response).and_return(response)
+      allow(response).to receive(:body).and_return(payment_url_response.to_json.to_s)
+
+      moneyhash_provider
+      moneyhash_customer
+    end
+
+    it "generates the payment url" do
+      result = moneyhash_service.generate_payment_url
+      expect(result).to be_success
+      expect(result.payment_url).to eq("#{payment_url_response.dig("data", "embed_url")}?lago_request=generate_payment_url")
+    end
+  end
+end

--- a/spec/services/invoices/payments/payment_providers/factory_spec.rb
+++ b/spec/services/invoices/payments/payment_providers/factory_spec.rb
@@ -39,5 +39,13 @@ RSpec.describe Invoices::Payments::PaymentProviders::Factory, type: :service do
         expect(factory_service.class.to_s).to eq("Invoices::Payments::CashfreeService")
       end
     end
+
+    context "when moneyhash" do
+      let(:payment_provider) { "moneyhash" }
+
+      it "returns correct class" do
+        expect(factory_service.class.to_s).to eq("Invoices::Payments::MoneyhashService")
+      end
+    end
   end
 end

--- a/spec/services/payment_provider_customers/moneyhash_service_spec.rb
+++ b/spec/services/payment_provider_customers/moneyhash_service_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviderCustomers::MoneyhashService, type: :service do
+  subject(:moneyhash_service) { described_class.new(moneyhash_customer) }
+
+  let(:customer) { create(:customer, name: customer_name, organization:) }
+  let(:moneyhash_provider) { create(:moneyhash_provider) }
+  let(:organization) { moneyhash_provider.organization }
+  let(:customer_name) { nil }
+
+  let(:moneyhash_customer) do
+    create(:moneyhash_customer, customer:, provider_customer_id: nil, payment_provider: moneyhash_provider)
+  end
+
+  describe "#create" do
+    context "when provider_customer_id is already present" do
+      before {
+        moneyhash_customer.update(provider_customer_id: SecureRandom.uuid)
+        allow(moneyhash_service).to receive(:create_moneyhash_customer) # rubocop:disable RSpec/SubjectStub
+      }
+
+      it "does not call moneyhash customers API" do
+        result = moneyhash_service.create
+        expect(result).to be_success
+        expect(moneyhash_service).not_to have_received(:create_moneyhash_customer) # rubocop:disable RSpec/SubjectStub
+      end
+    end
+
+    context "when provider_customer_id is not present" do
+      let(:moneyhash_result) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/create_customer.json"))) }
+      let(:checkout_url_response) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/checkout_url_response.json"))) }
+
+      let(:response) { instance_double(Net::HTTPOK) }
+      let(:lago_client) { instance_double(LagoHttpClient::Client) }
+      let(:endpoint) { "#{PaymentProviders::MoneyhashProvider.api_base_url}/api/v1.1/payments/intent/" }
+
+      before do
+        allow(moneyhash_service).to receive(:create_moneyhash_customer).and_return(moneyhash_result) # rubocop:disable RSpec/SubjectStub
+        allow(moneyhash_service).to receive(:deliver_success_webhook) # rubocop:disable RSpec/SubjectStub
+
+        allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+        allow(lago_client).to receive(:post_with_response).and_return(response)
+        allow(response).to receive(:body).and_return(checkout_url_response.to_json.to_s)
+      end
+
+      it "creates the moneyhash customer, checkout_url, and sends a success webhook" do
+        result = moneyhash_service.create
+        expect(result).to be_success
+        expect(moneyhash_customer.reload.provider_customer_id).to eq(moneyhash_result["data"]["id"])
+        expect(result.checkout_url).to eq("#{checkout_url_response["data"]["embed_url"]}?lago_request=generate_checkout_url")
+        expect(moneyhash_service).to have_received(:create_moneyhash_customer) # rubocop:disable RSpec/SubjectStub
+        expect(moneyhash_service).to have_received(:deliver_success_webhook) # rubocop:disable RSpec/SubjectStub
+      end
+    end
+
+    describe "#update" do
+      it "returns a success result" do
+        result = moneyhash_service.update
+        expect(result).to be_success
+      end
+    end
+
+    describe "#update_payment_method" do
+      let(:custom_fields) do
+        {
+          lago_mit: false,
+          lago_mh_service: "Invoices::Payments::MoneyhashService",
+          lago_payable_id: "b4e7e786-7716-4ca1-940d-3606ef971413",
+          lago_customer_id: "36cfbd82-167d-448e-8c0b-63269347f8ac",
+          lago_payable_type: "Invoice",
+          lago_organization_id: "1f6edf98-9eb4-4baf-8c64-7c6be9d0b414"
+        }.with_indifferent_access
+      end
+
+      let(:payment_method_id) { SecureRandom.uuid }
+
+      let(:moneyhash_customer) do
+        create(:moneyhash_customer, customer:, provider_customer_id: SecureRandom.uuid)
+      end
+
+      it "updates the payment method for existing customer" do
+        result = moneyhash_service.update_payment_method(
+          organization_id: organization.id,
+          customer_id: customer.id,
+          payment_method_id: payment_method_id,
+          metadata: custom_fields
+        )
+        expect(result).to be_success
+        expect(moneyhash_customer.reload.payment_method_id).to eq(payment_method_id)
+      end
+
+      it "deletes the payment method for existing customer" do
+        moneyhash_customer.update(payment_method_id: SecureRandom.uuid)
+
+        result = moneyhash_service.update_payment_method(
+          organization_id: organization.id,
+          customer_id: customer.id,
+          payment_method_id: nil
+        )
+        expect(result).to be_success
+        expect(moneyhash_customer.reload.payment_method_id).to be_nil
+      end
+
+      it "overrides the payment method for existing customer" do
+        moneyhash_customer.update(payment_method_id: SecureRandom.uuid)
+
+        result = moneyhash_service.update_payment_method(
+          organization_id: organization.id,
+          customer_id: customer.id,
+          payment_method_id: payment_method_id,
+          metadata: custom_fields
+        )
+        expect(result).to be_success
+        expect(moneyhash_customer.reload.payment_method_id).to eq(payment_method_id)
+      end
+
+      it "returns result directly when lago_customer_id is not present" do
+        custom_fields.delete("lago_customer_id")
+        result = moneyhash_service.update_payment_method(
+          organization_id: organization.id,
+          customer_id: customer.id,
+          payment_method_id: payment_method_id,
+          metadata: custom_fields
+        )
+
+        expect(result).to be_success
+      end
+
+      it "returns result directly when customer is not found" do
+        custom_fields["lago_customer_id"] = SecureRandom.uuid
+
+        result = moneyhash_service.update_payment_method(
+          organization_id: organization.id,
+          customer_id: SecureRandom.uuid,
+          payment_method_id: payment_method_id,
+          metadata: custom_fields
+        )
+
+        expect(result).to be_success
+      end
+
+      it "returns a failure when moneyhash customer is not found" do
+        customer = create(:customer, organization:)
+        custom_fields["lago_customer_id"] = customer.id
+
+        result = moneyhash_service.update_payment_method(
+          organization_id: organization.id,
+          customer_id: customer.id,
+          payment_method_id: payment_method_id,
+          metadata: custom_fields
+        )
+
+        expect(result).to be_failure
+        expect(result.error.to_s).to eq("moneyhash_customer_not_found")
+      end
+    end
+  end
+end

--- a/spec/services/payment_providers/moneyhash/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/handle_incoming_webhook_service_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Moneyhash::HandleIncomingWebhookService, type: :service do
+  subject(:result) { described_class.call(inbound_webhook:) }
+
+  let(:organization) { create(:organization) }
+  let(:code) { "mh-test" }
+  let(:moneyhash_provider) { create(:moneyhash_provider, code:, organization:) }
+  let(:intent_processed_payload) { JSON.parse(Rails.root.join("spec/fixtures/moneyhash/intent.processed.json").read) }
+  let(:inbound_webhook) { create :inbound_webhook, source: :moneyhash, organization:, code:, payload: intent_processed_payload }
+  let(:event_result) { intent_processed_payload }
+
+  it "checks the webhook" do
+    moneyhash_provider
+    expect(result).to be_success
+    expect(result.event).to eq(event_result)
+    expect(PaymentProviders::Moneyhash::HandleEventJob).to have_been_enqueued
+  end
+
+  context "when failing to find the provider" do
+    let(:inbound_webhook) { create :inbound_webhook, source: :moneyhash, organization:, code:, payload: "invalid" }
+
+    it "returns an error" do
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ServiceFailure)
+      expect(result.error.code).to eq("webhook_error")
+      expect(result.error.error_message).to eq("Payment provider not found")
+    end
+  end
+end

--- a/spec/services/payment_providers/moneyhash/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/payments/create_service_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Moneyhash::Payments::CreateService do
+  let(:organization) { create(:organization) }
+  let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:moneyhash_customer) { create(:moneyhash_customer, customer:, payment_provider: moneyhash_provider) }
+
+  let(:reference) { "1234567890" }
+  let(:metadata) { {} }
+
+  let(:invoice) { create(:invoice, organization:, customer:, invoice_type: :subscription) }
+  let(:payment) { create(:payment, payable: invoice, payment_provider: moneyhash_provider, payment_provider_customer: moneyhash_customer) }
+
+  let(:request_payload) { JSON.parse(File.read("spec/fixtures/moneyhash/recurring_mit_payment_payload.json")) }
+  let(:failure_response) { JSON.parse(File.read("spec/fixtures/moneyhash/recurring_mit_payment_failure_response.json")) }
+  let(:success_response) { JSON.parse(File.read("spec/fixtures/moneyhash/recurring_mit_payment_success_response.json")) }
+
+  describe "#call" do
+    it "succeeds for a successful payment of invoices" do
+      allow_any_instance_of(described_class).to receive(:create_moneyhash_payment).and_return(success_response) # rubocop:disable RSpec/AnyInstance
+      result = described_class.call(payment: payment, reference:, metadata:)
+      expect(result).to be_success
+      expect(result.payment.status).to eq("PROCESSED")
+      expect(result.payment.provider_payment_id).to eq(success_response.dig("data", "id"))
+      expect(result.payment.payable_payment_status).to eq("succeeded")
+    end
+
+    it "fails if error raised" do
+      allow_any_instance_of(described_class).to receive(:moneyhash_payment_provider).and_return(moneyhash_provider) # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(LagoHttpClient::Client).to receive(:post_with_response).and_raise(LagoHttpClient::HttpError.new(400, failure_response, "")) # rubocop:disable RSpec/AnyInstance
+      result = described_class.call(payment: payment, reference:, metadata:)
+      expect(result).to be_failure
+      expect(result.error_code).to eq(400)
+      expect(result.error_message).to eq(failure_response)
+      expect(payment.status).to eq("PENDING")
+      expect(payment.payable_payment_status).to eq("processing")
+    end
+  end
+end

--- a/spec/services/payment_providers/moneyhash/validate_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/validate_incoming_webhook_service_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::Moneyhash::ValidateIncomingWebhookService, type: :service do
+  subject(:result) do
+    described_class.call(payload:, signature:, payment_provider:)
+  end
+
+  let(:payload) { "webhook_payload" }
+  let(:signature) { "t=1743090080,v1=placeholder,v2=placeholder,v3=ca13480c8142f2f2b44822c764909027974e84b3e8c94457a314f129d8d60148" }
+  let(:payment_provider) { create(:moneyhash_provider, signature_key: "test_signature_key") }
+
+  it "return success when signature is valid" do
+    result = described_class.call(payload:, signature:, payment_provider:)
+    expect(result).to be_success
+  end
+
+  it "returns a service failure when signature is invalid" do
+    signature = "Moneyhash-Signature: t=1743090080,v1=placeholder,v2=placeholder,v3=invalid_signature"
+    result = described_class.call(payload:, signature:, payment_provider:)
+    expect(result).not_to be_success
+    expect(result.error).to be_a(BaseService::ServiceFailure)
+    expect(result.error.message).to eq("webhook_error: Invalid signature")
+  end
+end

--- a/spec/services/payment_providers/moneyhash_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash_service_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviders::MoneyhashService, type: :service do
+  let(:organization) { create(:organization) }
+  let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:moneyhash_customer) { create(:moneyhash_customer, customer:) }
+
+  describe "#create_or_update" do
+    let(:webhook_signature_response) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/webhook_signature_response.json"))) }
+
+    before do
+      allow_any_instance_of(LagoHttpClient::Client).to receive(:get).and_return(webhook_signature_response) # rubocop:disable RSpec/AnyInstance
+    end
+
+    it "creates a new moneyhash provider with the webhook signature key" do
+      result = described_class.new.create_or_update(organization:, code: "test_code", name: "test_name", flow_id: "test_flow_id")
+      expect(result).to be_success
+      expect(result.moneyhash_provider).to be_a(PaymentProviders::MoneyhashProvider)
+      expect(result.moneyhash_provider.signature_key).to eq(webhook_signature_response.dig("data", "webhook_signature_secret"))
+      expect(result.moneyhash_provider.code).to eq("test_code")
+      expect(result.moneyhash_provider.name).to eq("test_name")
+      expect(result.moneyhash_provider.flow_id).to eq("test_flow_id")
+    end
+
+    it "updates the existing moneyhash provider but leaves the signature key unchanged" do
+      moneyhash_provider.update!(signature_key: "same_signature_key")
+      result = described_class.new.create_or_update(organization:, code: moneyhash_provider.code, name: "updated_name", flow_id: "updated_flow_id")
+      expect(result).to be_success
+      expect(result.moneyhash_provider).to be_a(PaymentProviders::MoneyhashProvider)
+      expect(result.moneyhash_provider.signature_key).to eq("same_signature_key")
+      expect(result.moneyhash_provider.code).to eq(moneyhash_provider.code)
+      expect(result.moneyhash_provider.name).to eq("updated_name")
+      expect(result.moneyhash_provider.flow_id).to eq("updated_flow_id")
+    end
+  end
+
+  # Intent
+  # handle event - intent.processed <-
+  # handle event - intent.time_expired <-
+  describe "#handle_intent_event" do
+    let(:intent_processed_event_json) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/intent.processed.json"))) }
+    let(:intent_time_expired_event_json) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/intent.time_expired.json"))) }
+
+    # intent processed payment & invoice
+    let(:payment_processed) { create(:payment, payment_provider: moneyhash_provider, provider_payment_id: intent_processed_event_json.dig("data", "intent_id"), payable: invoice_processed) }
+    let(:invoice_processed) { create(:invoice, organization:, customer:) }
+
+    # intent time expired payment & invoice
+    let(:payment_time_expired) { create(:payment, payment_provider: moneyhash_provider, provider_payment_id: intent_time_expired_event_json.dig("data", "intent_id"), payable: invoice_time_expired) }
+    let(:invoice_time_expired) { create(:invoice, organization:, customer:) }
+
+    it "handles intent.processed event" do
+      intent_processed_event_json["data"]["intent"]["custom_fields"]["lago_payable_type"] = "Invoice"
+      intent_processed_event_json["data"]["intent"]["custom_fields"]["lago_payable_id"] = invoice_processed.id
+
+      payment_processed
+      result = described_class.new.handle_event(organization:, event_json: intent_processed_event_json)
+      payment_processed.reload
+      expect(result).to be_success
+      expect(payment_processed.status).to eq("succeeded")
+      expect(payment_processed.payable_payment_status).to eq("succeeded")
+      expect(payment_processed.payable.payment_status).to eq("succeeded")
+    end
+
+    it "handles intent.time_expired event" do
+      intent_time_expired_event_json["data"]["intent"]["custom_fields"]["lago_payable_type"] = "Invoice"
+      intent_time_expired_event_json["data"]["intent"]["custom_fields"]["lago_payable_id"] = invoice_time_expired.id
+
+      payment_time_expired
+      result = described_class.new.handle_event(organization:, event_json: intent_time_expired_event_json)
+      payment_time_expired.reload
+      expect(result).to be_success
+      expect(payment_time_expired.status).to eq("failed")
+      expect(payment_time_expired.payable_payment_status).to eq("failed")
+      expect(payment_time_expired.payable.payment_status).to eq("failed")
+    end
+  end
+
+  # Transaction
+  # handle event - transaction.purchase.successful <-
+  # handle event - transaction.purchase.pending_authentication <-
+  # handle event - transaction.purchase.failed <-
+  describe "#handle_transaction_event" do
+    let(:transaction_successful_event_json) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/transaction.purchase.successful.json"))) }
+    let(:transaction_pending_authentication_event_json) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/transaction.purchase.pending_authentication.json"))) }
+    let(:transaction_failed_event_json) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/transaction.purchase.failed.json"))) }
+
+    # transaction successful payment & invoice
+    let(:payment) { create(:payment, payment_provider: moneyhash_provider, provider_payment_id: transaction_successful_event_json.dig("intent", "id"), payable: invoice) }
+    let(:invoice) { create(:invoice, organization:, customer:) }
+
+    # transaction pending authentication payment & invoice
+    let(:payment_pending_authentication) { create(:payment, payment_provider: moneyhash_provider, provider_payment_id: transaction_pending_authentication_event_json.dig("intent", "id"), payable: invoice_pending_authentication) }
+    let(:invoice_pending_authentication) { create(:invoice, organization:, customer:) }
+
+    # transaction failed payment & invoice
+    let(:payment_failed) { create(:payment, payment_provider: moneyhash_provider, provider_payment_id: transaction_failed_event_json.dig("intent", "id"), payable: invoice_failed) }
+    let(:invoice_failed) { create(:invoice, organization:, customer:) }
+
+    before do
+      moneyhash_provider
+      moneyhash_customer
+      payment
+      payment_pending_authentication
+      payment_failed
+
+      transaction_successful_event_json["intent"]["custom_fields"]["lago_payable_type"] = "Invoice"
+      transaction_successful_event_json["intent"]["custom_fields"]["lago_payable_id"] = invoice.id
+      transaction_successful_event_json["intent"]["custom_fields"]["lago_customer_id"] = moneyhash_customer.customer_id
+
+      transaction_pending_authentication_event_json["intent"]["custom_fields"]["lago_payable_type"] = "Invoice"
+      transaction_pending_authentication_event_json["intent"]["custom_fields"]["lago_payable_id"] = invoice_pending_authentication.id
+      transaction_pending_authentication_event_json["intent"]["custom_fields"]["lago_customer_id"] = moneyhash_customer.customer_id
+
+      transaction_failed_event_json["intent"]["custom_fields"]["lago_payable_type"] = "Invoice"
+      transaction_failed_event_json["intent"]["custom_fields"]["lago_payable_id"] = invoice_failed.id
+      transaction_failed_event_json["intent"]["custom_fields"]["lago_customer_id"] = moneyhash_customer.customer_id
+    end
+
+    it "handles transaction.purchase.successful event" do
+      result = described_class.new.handle_event(organization:, event_json: transaction_successful_event_json)
+      payment.reload
+      expect(result).to be_success
+      expect(payment.status).to eq("succeeded")
+      expect(payment.payable_payment_status).to eq("succeeded")
+      expect(payment.payable.payment_status).to eq("succeeded")
+    end
+
+    it "handles transaction.purchase.pending_authentication event" do
+      result = described_class.new.handle_event(organization:, event_json: transaction_pending_authentication_event_json)
+      payment_pending_authentication.reload
+      expect(result).to be_success
+      expect(payment_pending_authentication.status).to eq("processing")
+      expect(payment_pending_authentication.payable_payment_status).to eq("pending")
+      expect(payment_pending_authentication.payable.payment_status).to eq("pending")
+    end
+
+    it "handles transaction.purchase.failed event" do
+      result = described_class.new.handle_event(organization:, event_json: transaction_failed_event_json)
+      payment_failed.reload
+      expect(result).to be_success
+      expect(payment_failed.status).to eq("failed")
+      expect(payment_failed.payable_payment_status).to eq("failed")
+      expect(payment_failed.payable.payment_status).to eq("failed")
+    end
+  end
+
+  # Card Token
+  # handle event - card_token.created <-
+  # handle event - card_token.updated <-
+  # handle event - card_token.deleted <-
+  describe "#handle_card_event" do
+    before do
+      moneyhash_provider
+      moneyhash_customer
+    end
+
+    it "handles card_token.created event" do
+      card_token_created_event_json = JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/card_token.created.json")))
+      card_token_created_event_json["data"]["card_token"]["custom_fields"]["lago_customer_id"] = moneyhash_customer.customer_id
+
+      result = described_class.new.handle_event(organization:, event_json: card_token_created_event_json)
+      expect(result).to be_success
+      moneyhash_customer.reload
+      expect(moneyhash_customer.payment_method_id).to eq(card_token_created_event_json.dig("data", "card_token", "id"))
+    end
+
+    it "handles card_token.updated event" do
+      card_token_updated_event_json = JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/card_token.updated.json")))
+      card_token_updated_event_json["data"]["card_token"]["custom_fields"]["lago_customer_id"] = moneyhash_customer.customer_id
+
+      result = described_class.new.handle_event(organization:, event_json: card_token_updated_event_json)
+      expect(result).to be_success
+      moneyhash_customer.reload
+      expect(moneyhash_customer.payment_method_id).to eq(card_token_updated_event_json.dig("data", "card_token", "id"))
+    end
+
+    it "handles card_token.deleted event" do
+      card_token_deleted_event_json = JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/card_token.deleted.json")))
+      card_token_deleted_event_json["data"]["card_token"]["custom_fields"]["lago_customer_id"] = moneyhash_customer.customer_id
+      moneyhash_customer.update!(payment_method_id: card_token_deleted_event_json.dig("data", "card_token", "id"))
+
+      result = described_class.new.handle_event(organization:, event_json: card_token_deleted_event_json)
+      expect(result).to be_success
+      moneyhash_customer.reload
+      expect(moneyhash_customer.payment_method_id).to be_nil
+    end
+
+    it "card_token.deleted event ignored if not the same card" do
+      card_token_deleted_event_json = JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/card_token.deleted.json")))
+      card_token_deleted_event_json["data"]["card_token"]["custom_fields"]["lago_customer_id"] = moneyhash_customer.customer_id
+      moneyhash_customer.update!(payment_method_id: "test_payment_id")
+
+      result = described_class.new.handle_event(organization:, event_json: card_token_deleted_event_json)
+      expect(result).to be_success
+      moneyhash_customer.reload
+      expect(moneyhash_customer.payment_method_id).to eq("test_payment_id")
+    end
+  end
+end

--- a/spec/services/payment_requests/payments/moneyhash_service_spec.rb
+++ b/spec/services/payment_requests/payments/moneyhash_service_spec.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentRequests::Payments::MoneyhashService do
+  subject(:moneyhash_service) { described_class.new(payable) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
+  let(:moneyhash_customer) { create(:moneyhash_customer, customer:, payment_provider: moneyhash_provider) }
+  let(:payable) do
+    create(
+      :payment_request,
+      organization:,
+      customer:,
+      amount_cents: 799,
+      amount_currency: "USD",
+      invoices: [invoice_1, invoice_2]
+    )
+  end
+
+  let(:invoice_1) do
+    create(
+      :invoice,
+      organization:,
+      customer:,
+      total_amount_cents: 200,
+      currency: "USD",
+      ready_for_payment_processing: true
+    )
+  end
+
+  let(:invoice_2) do
+    create(
+      :invoice,
+      organization:,
+      customer:,
+      total_amount_cents: 599,
+      currency: "USD",
+      ready_for_payment_processing: true
+    )
+  end
+
+  let(:payment_response_json) { JSON.parse(File.read(Rails.root.join("spec/fixtures/moneyhash/recurring_mit_payment_success_response.json"))) }
+  let(:provider_payment_id) { payment_response_json.dig("data", "id") }
+
+  describe "#create" do
+    before do
+      moneyhash_provider
+      moneyhash_customer
+      moneyhash_customer.update!(payment_method_id: "test_payment_method")
+    end
+
+    context "when moneyhash customer is missing provider customer id" do
+      before { moneyhash_customer.update!(provider_customer_id: nil) }
+
+      it "returns not found failure" do
+        result = moneyhash_service.create
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("moneyhash_customer")
+      end
+    end
+
+    context "when payment method is missing" do
+      before { moneyhash_customer.update!(payment_method_id: nil) }
+
+      it "returns not found failure" do
+        result = moneyhash_service.create
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("payment_method")
+      end
+    end
+
+    context "when payment should not be processed" do
+      context "when payment already succeeded" do
+        before { payable.update!(payment_status: :succeeded) }
+
+        it "returns success without payment" do
+          result = moneyhash_service.create
+
+          expect(result).to be_success
+          expect(result.payment).to be_nil
+        end
+      end
+
+      context "when moneyhash provider is missing" do
+        before { moneyhash_provider.destroy }
+
+        it "returns success without payment" do
+          result = moneyhash_service.create
+
+          expect(result).to be_success
+          expect(result.payment).to be_nil
+        end
+      end
+    end
+
+    context "when payment amount is zero" do
+      before { payable.update!(amount_cents: 0) }
+
+      it "marks payment as succeeded without processing" do
+        result = moneyhash_service.create
+
+        expect(result).to be_success
+        expect(result.payment).to be_nil
+        expect(payable.reload.payment_status).to eq("succeeded")
+      end
+    end
+
+    context "when payment should be processed" do
+      before do
+        allow_any_instance_of(LagoHttpClient::Client).to receive(:post_with_response) # rubocop:disable RSpec/AnyInstance
+          .and_return(OpenStruct.new(body: payment_response_json.to_json))
+      end
+
+      it "increments payment attempts, creates a payment and updates payment statuses for payable and invoices" do
+        result = moneyhash_service.create
+
+        expect(result).to be_success
+        expect(result.payment).to be_present
+        expect(result.payment.status).to eq("succeeded")
+        expect(result.payment.provider_payment_id).to eq(provider_payment_id)
+        expect(payable.reload.payment_status).to eq("succeeded")
+        payable.invoices.each do |invoice|
+          expect(invoice.payment_status).to eq("succeeded")
+        end
+      end
+
+      context "when API request fails" do
+        before do
+          allow_any_instance_of(LagoHttpClient::Client).to receive(:post_with_response) # rubocop:disable RSpec/AnyInstance
+            .and_raise(LagoHttpClient::HttpError.new(422, "error", "error_code"))
+        end
+
+        it "marks payment as failed" do
+          result = moneyhash_service.create
+
+          expect(result).to be_success
+          expect(result.payment).to be_nil
+          expect(payable.reload.payment_status).to eq("failed")
+          payable.invoices.each do |invoice|
+            expect(invoice.payment_status).to eq("pending")
+          end
+        end
+      end
+    end
+  end
+
+  describe "#update_payment_status" do
+    let(:payment) { create(:payment, payment_provider: moneyhash_provider, provider_payment_id:, payable:, amount_cents: payable.total_amount_cents, amount_currency: payable.currency) }
+
+    before do
+      moneyhash_provider
+      moneyhash_customer
+      payable
+      payment
+      payment_response_json["data"]["custom_fields"]["lago_payable_id"] = payable.id
+      payment_response_json["data"]["custom_fields"]["lago_payable_type"] = payable.class.name
+    end
+
+    context "when payment exists" do
+      it "updates payment, payable and invoices status" do
+        result = moneyhash_service.update_payment_status(
+          organization_id: organization.id,
+          provider_payment_id: payment_response_json.dig("data", "id"),
+          status: payment_response_json.dig("data", "status"),
+          metadata: payment_response_json.dig("data", "custom_fields")
+        )
+
+        expect(result).to be_success
+        expect(result.payment.status).to eq("succeeded")
+        expect(result.payment.provider_payment_id).to eq(payment_response_json.dig("data", "id"))
+        expect(result.payable.payment_status).to eq("succeeded")
+        [invoice_1, invoice_2].each do |invoice|
+          expect(invoice.reload.payment_status).to eq("succeeded")
+        end
+      end
+    end
+
+    context "when payment does not exist" do
+      let(:metadata) { {"lago_payable_id" => payable.id} }
+
+      it "creates a new payment" do
+        result = moneyhash_service.update_payment_status(
+          organization_id: organization.id,
+          provider_payment_id: "new_payment_id",
+          status: "SUCCESSFUL",
+          metadata:
+        )
+
+        expect(result).to be_success
+        expect(result.payment).to be_present
+        expect(result.payment.provider_payment_id).to eq("new_payment_id")
+        expect(result.payment.status).to eq("succeeded")
+        expect(result.payable.payment_status).to eq("succeeded")
+        [invoice_1, invoice_2].each do |invoice|
+          expect(invoice.reload.payment_status).to eq("succeeded")
+        end
+      end
+
+      context "when payable is not found" do
+        let(:metadata) { {"lago_payable_id" => "invalid_id"} }
+        let(:moneyhash_service) { described_class.new(nil) }
+
+        it "returns not found error" do
+          result = moneyhash_service.update_payment_status(
+            organization_id: organization.id,
+            provider_payment_id: "new_payment_id",
+            status: "SUCCESSFUL",
+            metadata:
+          )
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq("payment_request")
+        end
+      end
+    end
+
+    context "when payment already succeeded" do
+      before do
+        payable.update!(payment_status: :succeeded)
+        payment.update!(status: :succeeded)
+      end
+
+      it "does not update the status" do
+        result = moneyhash_service.update_payment_status(
+          organization_id: organization.id,
+          provider_payment_id: payment_response_json.dig("data", "id"),
+          status: "FAILED",
+          metadata: payment_response_json.dig("data", "custom_fields")
+        )
+
+        expect(result).to be_success
+        expect(payment.reload.status).to eq("succeeded")
+        expect(payable.reload.payment_status).to eq("succeeded")
+      end
+    end
+  end
+end

--- a/spec/services/payment_requests/payments/payment_providers/factory_spec.rb
+++ b/spec/services/payment_requests/payments/payment_providers/factory_spec.rb
@@ -39,5 +39,13 @@ RSpec.describe PaymentRequests::Payments::PaymentProviders::Factory, type: :serv
         expect(factory_service.class.to_s).to eq("PaymentRequests::Payments::GocardlessService")
       end
     end
+
+    context "when moneyhash" do
+      let(:payment_provider) { "moneyhash" }
+
+      it "returns correct class" do
+        expect(factory_service.class.to_s).to eq("PaymentRequests::Payments::MoneyhashService")
+      end
+    end
   end
 end


### PR DESCRIPTION
Re-opening [this PR](https://github.com/getlago/lago-api/pull/3117) to allow maintainer edits

## Feature Request

https://getlago.canny.io/feature-requests/p/integration-with-moneyhash-for-payment-orchestration

## Context

MoneyHash is a leading payment infrastructure software in Africa and the Middle East. Our biggest features are providing a superior payment orchestration for many payment providers in the region, smart payment routing among other features.

We have common customers, and it's a needed feature to have MoneyHash integrated into Lago.

This PR integrates MoneyHash as a payment provider for Lago's customers.

## Description

Integrate MoneyHash as a Payment Provider inside Lago

### **MoneyHash’s code inside Lago is mostly concerned with the following**

- CRUD a MoneyHash connection instance that contains the credentials needed to integrate Lago with MoneyHash
    - In the background, this operation includes getting MoneyHash’s organization’s `signature_key` through api and saving it to the connection representation (MoneyhashPorvider model).
        - Hence, creating a new moneyhash connection with invalid credentials will fail
    - signature_key is later used to verify the signature of MoneyHash’s incoming webhooks
- Sync customer creation with MoneyHash’s system
    - This creates a customer on MoneyHash’s end and save its ID on Lago’s MoneyhashCustomer instance
- Automatically generating a checkout_url and send it to the merchant’s webhook defined in Lago’s dashboard
    - This occurs after creating a customer, through Lago’s dashboard, that’s connected to a moneyhash connection and the ‘Create automatically this customer in MoneyHash’ was checked.
    - checkout_url should be sent to the end customer somehow to allow them to enter their card details and save it on MoneyHash’s side, for subsequent payments
- Automatic invoice payments on Lago’s end through MoneyHash’s system
    - This is done using the Customer’s saved card from the checkout_url
    - This occurs in the following situations
        - generating a one-off invoice for the customer
        - a new periodic invoice is generated for a subscription (customer’s plan)
        - an invoice that’s manually resent for collection through the dashboard
- Handle incoming webhooks from MoneyHash to
    - Create/Update/Delete a card_token for the customer
    - Update the payment status according to the `intent/operation_status` incoming webhooks
- Regenerate checkout_url for the customer through Lago’s API
    - just-in-case, the merchant can re-generate a checkout_url for the customer to save a new card

- Extra
    - generate a payment_url for a specific invoice for the customer to manually pay it
    - pay the PaymentRequests (bulk invoices payment) through MoneyHash’s


---
List any dependencies that are required.
NA