### PR TITLE
Feat(multientities): serialize billing_entity_code in API

### DIFF
--- a/app/serializers/v1/billing_entity_serializer.rb
+++ b/app/serializers/v1/billing_entity_serializer.rb
@@ -26,14 +26,6 @@ module V1
         document_number_prefix: model.document_number_prefix,
         tax_identification_number: model.tax_identification_number,
         finalize_zero_amount_invoice: model.finalize_zero_amount_invoice,
-        billing_configuration:
-      }
-    end
-
-    private
-
-    def billing_configuration
-      {
         invoice_footer: model.invoice_footer,
         invoice_grace_period: model.invoice_grace_period,
         document_locale: model.document_locale

--- a/app/serializers/v1/credit_note_serializer.rb
+++ b/app/serializers/v1/credit_note_serializer.rb
@@ -5,6 +5,7 @@ module V1
     def serialize
       payload = {
         lago_id: model.id,
+        billing_entity_code: model.invoice.billing_entity.code,
         sequential_id: model.sequential_id,
         number: model.number,
         lago_invoice_id: model.invoice_id,

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -5,6 +5,7 @@ module V1
     def serialize
       payload = {
         lago_id: model.id,
+        billing_entity_code: model.billing_entity.code,
         external_id: model.external_id,
         account_type: model.account_type,
         name: model.name,

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -5,6 +5,7 @@ module V1
     def serialize
       payload = {
         lago_id: model.id,
+        billing_entity_code: model.billing_entity.code,
         sequential_id: model.sequential_id,
         number: model.number,
         issuing_date: model.issuing_date&.iso8601,

--- a/app/services/invoices/preview_context_service.rb
+++ b/app/services/invoices/preview_context_service.rb
@@ -4,8 +4,9 @@ module Invoices
   class PreviewContextService < BaseService
     Result = BaseResult[:customer, :subscriptions, :applied_coupons]
 
-    def initialize(organization:, params:)
+    def initialize(organization:, params:, billing_entity: nil)
       @organization = organization
+      @billing_entity = billing_entity || organization.default_billing_entity
       @params = params.presence || {}
       super
     end
@@ -34,7 +35,7 @@ module Invoices
 
     private
 
-    attr_reader :params, :organization
+    attr_reader :params, :organization, :billing_entity
 
     def subscription_params
       params.slice(:billing_time, :plan_code, :subscription_at, :subscriptions)
@@ -46,7 +47,7 @@ module Invoices
       customer = if customer_params.key?(:external_id)
         organization.customers.find_by!(external_id: customer_params[:external_id])
       else
-        organization.customers.new(created_at: Time.current, updated_at: Time.current)
+        organization.customers.new(created_at: Time.current, updated_at: Time.current, billing_entity:)
       end
 
       customer.assign_attributes(

--- a/spec/serializers/v1/billing_entity_serializer_spec.rb
+++ b/spec/serializers/v1/billing_entity_serializer_spec.rb
@@ -32,10 +32,8 @@ RSpec.describe V1::BillingEntitySerializer, type: :serializer do
     expect(billing_entity_serialized.fetch("document_number_prefix")).to eq(billing_entity.document_number_prefix)
     expect(billing_entity_serialized.fetch("tax_identification_number")).to eq(billing_entity.tax_identification_number)
     expect(billing_entity_serialized.fetch("finalize_zero_amount_invoice")).to eq(billing_entity.finalize_zero_amount_invoice)
-    expect(billing_entity_serialized.fetch("billing_configuration")).to match(hash_including(
-      "invoice_footer" => billing_entity.invoice_footer,
-      "invoice_grace_period" => billing_entity.invoice_grace_period,
-      "document_locale" => billing_entity.document_locale
-    ))
+    expect(billing_entity_serialized.fetch("invoice_footer")).to eq(billing_entity.invoice_footer)
+    expect(billing_entity_serialized.fetch("invoice_grace_period")).to eq(billing_entity.invoice_grace_period)
+    expect(billing_entity_serialized.fetch("document_locale")).to eq(billing_entity.document_locale)
   end
 end

--- a/spec/serializers/v1/credit_note_serializer_spec.rb
+++ b/spec/serializers/v1/credit_note_serializer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe V1::CreditNoteSerializer, type: :serializer do
 
     expect(result["credit_note"]).to include(
       "lago_id" => credit_note.id,
+      "billing_entity_code" => credit_note.invoice.billing_entity.code,
       "sequential_id" => credit_note.sequential_id,
       "number" => credit_note.number,
       "lago_invoice_id" => credit_note.invoice_id,

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe ::V1::CustomerSerializer do
 
     aggregate_failures do
       expect(result["customer"]["lago_id"]).to eq(customer.id)
+      expect(result["customer"]["billing_entity_code"]).to eq(customer.billing_entity.code)
       expect(result["customer"]["external_id"]).to eq(customer.external_id)
       expect(result["customer"]["account_type"]).to eq(customer.account_type)
       expect(result["customer"]["name"]).to eq(customer.name)

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe ::V1::InvoiceSerializer do
     aggregate_failures do
       expect(result["invoice"]).to include(
         "lago_id" => invoice.id,
+        "billing_entity_code" => invoice.billing_entity.code,
         "sequential_id" => invoice.sequential_id,
         "number" => invoice.number,
         "issuing_date" => invoice.issuing_date.iso8601,

--- a/spec/services/invoices/preview_context_service_spec.rb
+++ b/spec/services/invoices/preview_context_service_spec.rb
@@ -142,16 +142,29 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
         let(:expected_attributes) do
           params[:customer].tap do |hash|
             hash[:integration_customers] = array_including(IntegrationCustomers::AnrokCustomer)
+            hash[:billing_entity_id] = organization.default_billing_entity.id
           end
         end
 
         before { create(:anrok_integration, organization:, code: "code") }
 
-        it "returns new customer build from params including integration customers" do
+        it "returns new customer build from params including integration customers and default billing_entity" do
           expect(subject)
             .to be_present
             .and be_new_record
             .and have_attributes(expected_attributes)
+        end
+
+        context "when passing billing_entity" do
+          let(:billing_entity) { create(:billing_entity, organization:) }
+          let(:result) { described_class.call(organization:, params:, billing_entity:) }
+
+          it "returns new customer build with provided billing_entity" do
+            expect(subject)
+              .to be_present
+              .and be_new_record
+              .and have_attributes({billing_entity_id: billing_entity.id})
+          end
         end
       end
 


### PR DESCRIPTION
## Context

Include billing_entity code in:
- invoice serialized object
- customer serialized object
- credit_note serialized object

## Note:
needed to update also `Invoices::PreviewContextService` as customer should always be build with billing entity (the `null: false` on billing_entity_id will be added later)
