### PR TITLE
fix(redis): increase timeouts and retry counts, and reconnect counts, add retry_jitter to avoid lock contention

### DIFF
--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -4,8 +4,11 @@ ActiveJob::Uniqueness.configure do |config|
   config.lock_ttl = 1.hour
 
   config.redlock_options = {
-    retry_count: 0,
-    redis_timeout: 5
+    retry_count: 3,
+    redis_timeout: 5,
+    retry_delay: 200,
+    # random delay to avoid lock contention
+    retry_jitter: 50
   }
 
   if ENV["REDIS_PASSWORD"].present? && !ENV["REDIS_PASSWORD"].empty?
@@ -16,6 +19,6 @@ ActiveJob::Uniqueness.configure do |config|
       host = [host, uri.query].join("?")
     end
 
-    config.redlock_servers = [RedisClient.new(url: "#{uri.scheme}://:#{ENV["REDIS_PASSWORD"]}@#{host}:#{uri.port}", reconnect_attempts: 2)]
+    config.redlock_servers = [RedisClient.new(url: "#{uri.scheme}://:#{ENV["REDIS_PASSWORD"]}@#{host}:#{uri.port}", reconnect_attempts: 4)]
   end
 end


### PR DESCRIPTION
## Context

Lago's RedisClient is currently configured to `reconnect_attempts` just 2 times, and redlock's `retry_count` is set to 0.

if Lago tries to connect to Redis and the connection is not stable at the time of the connection, this will result in an error such as:
```
{"level":"error","event":"enqueue","status":"error","job":"Invoices::Payments::CreateJob","queue":"default","exception":{"class":"Redlock::LockAcquisitionError","message":"failed to acquire lock on 'Too many Redis errors prevented lock acquisition:\nRedisClient::ConnectionError: Broken pipe (rediss://redis-host:6379)'"}}
{"level":"error","event":"perform","status":"error","job":"BillSubscriptionJob","duration":557.02,"job_id":"ce1323cb-64e3-4a08-a81e-420fd6e3d345","queue":"billing","exception":{"class":"Redlock::LockAcquisitionError","message":"failed to acquire lock on 'Too many Redis errors prevented lock acquisition:\nRedisClient::ConnectionError: Broken pipe (rediss://redis-host:6379)'"}}
```

these errors will then lead to weird behaviour in the Lago front end and API, such as showing random errors like:
`This invoice contains a tax error`

## Description

This PR optimizes the defaults and helps Lago successfully handle these, thus increasing reliability, specifically it:

- increases `reconnect_attempts` from 2 to 4, so more reconnect attempts are tried in case of failure.
- increase `retry_count` from 0 to 3, so more redlock retries attempts are tried in case of failure.
- add a `retry_delay` of 200ms, to wait a bit before trying to reconnect instead of trying immediately.
- add a `retry_jitter` of 50ms, to help avoid lock contention and increase reliability.

This should result in more reliable Redis connections, with really no downsize.
