### PR TITLE
 fix(services): return valid Result in AutoGenerateService

### DIFF
--- a/app/services/taxes/auto_generate_service.rb
+++ b/app/services/taxes/auto_generate_service.rb
@@ -2,6 +2,8 @@
 
 module Taxes
   class AutoGenerateService < BaseService
+    Result = BaseResult
+
     def initialize(organization:)
       @organization = organization
       super
@@ -13,6 +15,8 @@ module Taxes
       end
 
       create_generic_taxes
+
+      result
     end
 
     private

--- a/spec/jobs/taxes/update_organization_eu_taxes_job_spec.rb
+++ b/spec/jobs/taxes/update_organization_eu_taxes_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Taxes::UpdateOrganizationEuTaxesJob, type: :job do
     let(:result) { BaseService::Result.new }
 
     it "calls the subscriptions biller service" do
-      allow(Taxes::AutoGenerateService).to receive(:call!)
+      allow(Taxes::AutoGenerateService).to receive(:call!).and_call_original
 
       described_class.perform_now(organization)
 


### PR DESCRIPTION
Sometimes you don't need the result of the service to return any data but all services MUST return a result.

How do you feel about an `EmptyResult` class. It avoid creating the same class multiple times.

Any idea for a better name?