### PR TITLE
fix(regroup_fees): Compute taxable_base_amount_cents on applied taxes

### DIFF
--- a/spec/scenarios/invoices/advance_charges_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_spec.rb
@@ -64,6 +64,7 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
 
         advance_charges_invoice = customer.invoices.where(invoice_type: :advance_charges).sole
         expect(advance_charges_invoice.fees_amount_cents).to eq(2008 + 1908 + 1807)
+        expect(advance_charges_invoice.applied_taxes.first.taxable_base_amount_cents).to eq(2008 + 1908 + 1807)
       end
 
       travel_to(DateTime.new(2024, 7, 10, 10)) do
@@ -88,6 +89,7 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
         expect(advance_charges_invoice.fees_amount_cents).to eq 18373
 
         expect(advance_charges_invoice.sub_total_excluding_taxes_amount_cents).to eq 18373 # == fees_amount_cents
+        expect(advance_charges_invoice.applied_taxes.first.taxable_base_amount_cents).to eq(18373)
         expect(advance_charges_invoice.sub_total_including_taxes_amount_cents).to eq 22047 # == fees_amount_cents + taxes_amount_cents == total_amount_cents
 
         expect(advance_charges_invoice.coupons_amount_cents).to eq 0

--- a/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
+++ b/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
@@ -35,11 +35,13 @@ RSpec.describe Invoices::AggregateAmountsAndTaxesFromFees, type: :service do
     expect(applied_tax_5.tax_description).to eq tax_5.description
     expect(applied_tax_5.tax_rate).to eq tax_5.rate
     expect(applied_tax_5.amount_cents).to eq(9 + 16)
+    expect(applied_tax_5.taxable_base_amount_cents).to eq(200 + 120)
 
     applied_tax_12 = invoice.applied_taxes.find { |at| at.tax_code == tax_12.code }
     expect(applied_tax_12.tax_name).to eq tax_12.name
     expect(applied_tax_12.tax_description).to eq tax_12.description
     expect(applied_tax_12.tax_rate).to eq tax_12.rate
     expect(applied_tax_12.amount_cents).to eq(2 + 11)
+    expect(applied_tax_12.taxable_base_amount_cents).to eq(120 + 50)
   end
 end


### PR DESCRIPTION
This pull request includes changes to fix the calculation of taxable base amounts in the regroup_fees invoice.
The aim is to compute the value based on the fees having the specified taxes.


![Screenshot 2025-03-31 at 17 17 58](https://github.com/user-attachments/assets/39f18f4b-500e-4f60-8200-9185624ab625)
