### PR TITLE
Feat(multientities): add billing_entity to invoices#preview

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -223,8 +223,15 @@ module Api
           )
         end
 
+        billing_entity_resolver = BillingEntities::ResolveService.call(
+          organization: current_organization, billing_entity_code: params[:billing_entity_code]
+        )
+        return render_error_response(billing_entity_resolver) unless billing_entity_resolver.success?
+        billing_entity = billing_entity_resolver.billing_entity
+
         result = Invoices::PreviewContextService.call(
           organization: current_organization,
+          billing_entity: billing_entity,
           params: preview_params.to_h.deep_symbolize_keys
         )
         return render_error_response(result) unless result.success?

--- a/app/services/invoices/preview_context_service.rb
+++ b/app/services/invoices/preview_context_service.rb
@@ -4,9 +4,9 @@ module Invoices
   class PreviewContextService < BaseService
     Result = BaseResult[:customer, :subscriptions, :applied_coupons]
 
-    def initialize(organization:, params:, billing_entity: nil)
+    def initialize(organization:, billing_entity:, params:)
       @organization = organization
-      @billing_entity = billing_entity || organization.default_billing_entity
+      @billing_entity = billing_entity
       @params = params.presence || {}
       super
     end


### PR DESCRIPTION
## Context

When querying `invoices#preview` endpoint, a billing_entity_code might be provided - in this case we should create a preview for customer from this billing_entity. Otherwise a default billing_entity should be used.

Since customer.external_id stays uniq within org, if customer.external_id is provided, we're ignoring billing_entity when looking for a customer
