### PR TITLE
Fix Invoices::PrepaidCreditJob queueing to ensure uniqueness

### DIFF
--- a/app/jobs/invoices/prepaid_credit_job.rb
+++ b/app/jobs/invoices/prepaid_credit_job.rb
@@ -7,6 +7,13 @@ module Invoices
     retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6
     unique :until_executed, on_conflict: :log
 
+    def lock_key_arguments
+      invoice = arguments.first
+      payment_status = arguments.second || :succeeded
+
+      [invoice, payment_status.to_sym]
+    end
+
     def perform(invoice, payment_status = :succeeded)  # Default to :succeeded for old jobs
       wallet_transaction = invoice.fees.find_by(fee_type: "credit")&.invoiceable
 

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -82,7 +82,7 @@ module Invoices
       return unless invoice.invoice_type&.to_sym == :credit
       return unless %i[succeeded failed].include?(payment_status.to_sym)
 
-      Invoices::PrepaidCreditJob.perform_later(invoice, payment_status)
+      Invoices::PrepaidCreditJob.perform_later(invoice, payment_status.to_sym)
     end
 
     def valid_metadata_count?(metadata:)

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Invoices::UpdateService do
 
         it "calls Invoices::PrepaidCreditJob with the correct arguments" do
           result
-          expect(Invoices::PrepaidCreditJob).to have_received(:perform_later).with(invoice, "succeeded")
+          expect(Invoices::PrepaidCreditJob).to have_received(:perform_later).with(invoice, :succeeded)
         end
       end
 
@@ -236,7 +236,7 @@ RSpec.describe Invoices::UpdateService do
 
         it "calls Invoices::PrepaidCreditJob with the correct arguments" do
           result
-          expect(Invoices::PrepaidCreditJob).to have_received(:perform_later).with(invoice, "failed")
+          expect(Invoices::PrepaidCreditJob).to have_received(:perform_later).with(invoice, :failed)
         end
       end
     end


### PR DESCRIPTION
Invoices::PrepaidCreditJob must but unique to avoid incorrect wallet balances... a bug was introduced where payment_status is a string value while by default it is a symbol. This mess up the uniqueness of the job
  and caused duplicated processing, hence incorrect wallet balances.