### PR TITLE
Fix(multientities): add billing_entity_id to cache key for analytics

### DIFF
--- a/app/models/analytics/gross_revenue.rb
+++ b/app/models/analytics/gross_revenue.rb
@@ -122,6 +122,7 @@ module Analytics
           "gross-revenue",
           Date.current.strftime("%Y-%m-%d"),
           organization_id,
+          args[:billing_entity_id],
           args[:external_customer_id],
           args[:currency],
           args[:months]

--- a/app/models/analytics/invoice_collection.rb
+++ b/app/models/analytics/invoice_collection.rb
@@ -89,6 +89,7 @@ module Analytics
           "invoice-collection",
           Date.current.strftime("%Y-%m-%d"),
           organization_id,
+          args[:billing_entity_id],
           args[:external_customer_id],
           args[:currency],
           args[:months]

--- a/app/models/analytics/invoiced_usage.rb
+++ b/app/models/analytics/invoiced_usage.rb
@@ -93,6 +93,7 @@ module Analytics
           "invoiced-usage",
           Date.current.strftime("%Y-%m-%d"),
           organization_id,
+          args[:billing_entity_id],
           args[:currency],
           args[:months]
         ].join("/")

--- a/app/models/analytics/mrr.rb
+++ b/app/models/analytics/mrr.rb
@@ -192,6 +192,7 @@ module Analytics
           "mrr",
           Date.current.strftime("%Y-%m-%d"),
           organization_id,
+          args[:billing_entity_id],
           args[:currency],
           args[:months]
         ].join("/")

--- a/app/models/analytics/overdue_balance.rb
+++ b/app/models/analytics/overdue_balance.rb
@@ -88,6 +88,7 @@ module Analytics
           "overdue-balance",
           Date.current.strftime("%Y-%m-%d"),
           organization_id,
+          args[:billing_entity_id],
           args[:external_customer_id],
           args[:currency],
           args[:months]

--- a/spec/models/analytics/gross_revenue_spec.rb
+++ b/spec/models/analytics/gross_revenue_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Analytics::GrossRevenue, type: :model do
     subject(:gross_revenue_cache_key) { described_class.cache_key(organization_id, **args) }
 
     let(:organization_id) { SecureRandom.uuid }
+    let(:billing_entity_id) { SecureRandom.uuid }
     let(:external_customer_id) { "customer_01" }
     let(:currency) { "EUR" }
     let(:months) { 12 }
@@ -14,7 +15,7 @@ RSpec.describe Analytics::GrossRevenue, type: :model do
 
     context "with no arguments" do
       let(:args) { {} }
-      let(:cache_key) { "gross-revenue/#{date}/#{organization_id}///" }
+      let(:cache_key) { "gross-revenue/#{date}/#{organization_id}////" }
 
       it "returns the cache key" do
         expect(gross_revenue_cache_key).to eq(cache_key)
@@ -25,11 +26,22 @@ RSpec.describe Analytics::GrossRevenue, type: :model do
       let(:args) { {external_customer_id:, currency:, months:} }
 
       let(:cache_key) do
-        "gross-revenue/#{date}/#{organization_id}/#{external_customer_id}/#{currency}/#{months}"
+        "gross-revenue/#{date}/#{organization_id}//#{external_customer_id}/#{currency}/#{months}"
       end
 
       it "returns the cache key" do
         expect(gross_revenue_cache_key).to eq(cache_key)
+      end
+
+      context "with billing entity id" do
+        let(:args) { {external_customer_id:, currency:, months:, billing_entity_id:} }
+        let(:cache_key) do
+          "gross-revenue/#{date}/#{organization_id}/#{billing_entity_id}/#{external_customer_id}/#{currency}/#{months}"
+        end
+
+        it "returns the cache key" do
+          expect(gross_revenue_cache_key).to eq(cache_key)
+        end
       end
     end
 
@@ -37,7 +49,7 @@ RSpec.describe Analytics::GrossRevenue, type: :model do
       let(:args) { {external_customer_id:} }
 
       let(:cache_key) do
-        "gross-revenue/#{date}/#{organization_id}/#{external_customer_id}//"
+        "gross-revenue/#{date}/#{organization_id}//#{external_customer_id}//"
       end
 
       it "returns the cache key" do
@@ -47,7 +59,16 @@ RSpec.describe Analytics::GrossRevenue, type: :model do
 
     context "with currency" do
       let(:args) { {currency:} }
-      let(:cache_key) { "gross-revenue/#{date}/#{organization_id}//#{currency}/" }
+      let(:cache_key) { "gross-revenue/#{date}/#{organization_id}///#{currency}/" }
+
+      it "returns the cache key" do
+        expect(gross_revenue_cache_key).to eq(cache_key)
+      end
+    end
+
+    context "with billing entity id" do
+      let(:args) { {billing_entity_id:} }
+      let(:cache_key) { "gross-revenue/#{date}/#{organization_id}/#{billing_entity_id}///" }
 
       it "returns the cache key" do
         expect(gross_revenue_cache_key).to eq(cache_key)

--- a/spec/models/analytics/invoice_collection_spec.rb
+++ b/spec/models/analytics/invoice_collection_spec.rb
@@ -8,13 +8,14 @@ RSpec.describe Analytics::InvoiceCollection, type: :model do
 
     let(:organization_id) { SecureRandom.uuid }
     let(:external_customer_id) { "customer_01" }
+    let(:billing_entity_id) { SecureRandom.uuid }
     let(:currency) { "EUR" }
     let(:months) { 12 }
     let(:date) { Date.current.strftime("%Y-%m-%d") }
 
     context "with no arguments" do
       let(:args) { {} }
-      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}///" }
+      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}////" }
 
       it "returns the cache key" do
         expect(invoice_collection_cache_key).to eq(cache_key)
@@ -25,11 +26,22 @@ RSpec.describe Analytics::InvoiceCollection, type: :model do
       let(:args) { {external_customer_id:, currency:, months:} }
 
       let(:cache_key) do
-        "invoice-collection/#{date}/#{organization_id}/#{external_customer_id}/#{currency}/#{months}"
+        "invoice-collection/#{date}/#{organization_id}//#{external_customer_id}/#{currency}/#{months}"
       end
 
       it "returns the cache key" do
         expect(invoice_collection_cache_key).to eq(cache_key)
+      end
+
+      context "with billing entity id" do
+        let(:args) { {external_customer_id:, currency:, months:, billing_entity_id:} }
+        let(:cache_key) do
+          "invoice-collection/#{date}/#{organization_id}/#{billing_entity_id}/#{external_customer_id}/#{currency}/#{months}"
+        end
+
+        it "returns the cache key" do
+          expect(invoice_collection_cache_key).to eq(cache_key)
+        end
       end
     end
 
@@ -37,7 +49,7 @@ RSpec.describe Analytics::InvoiceCollection, type: :model do
       let(:args) { {months:} }
 
       let(:cache_key) do
-        "invoice-collection/#{date}/#{organization_id}///#{months}"
+        "invoice-collection/#{date}/#{organization_id}////#{months}"
       end
 
       it "returns the cache key" do
@@ -47,7 +59,16 @@ RSpec.describe Analytics::InvoiceCollection, type: :model do
 
     context "with currency" do
       let(:args) { {currency:} }
-      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}//#{currency}/" }
+      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}///#{currency}/" }
+
+      it "returns the cache key" do
+        expect(invoice_collection_cache_key).to eq(cache_key)
+      end
+    end
+
+    context "with billing_entity_id" do
+      let(:args) { {billing_entity_id:} }
+      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}/#{billing_entity_id}///" }
 
       it "returns the cache key" do
         expect(invoice_collection_cache_key).to eq(cache_key)

--- a/spec/models/analytics/invoiced_usage_spec.rb
+++ b/spec/models/analytics/invoiced_usage_spec.rb
@@ -7,13 +7,14 @@ RSpec.describe Analytics::InvoicedUsage, type: :model do
     subject(:invoiced_usage_cache_key) { described_class.cache_key(organization_id, **args) }
 
     let(:organization_id) { SecureRandom.uuid }
+    let(:billing_entity_id) { SecureRandom.uuid }
     let(:currency) { "EUR" }
     let(:months) { 12 }
     let(:date) { Date.current.strftime("%Y-%m-%d") }
 
     context "with no arguments" do
       let(:args) { {} }
-      let(:cache_key) { "invoiced-usage/#{date}/#{organization_id}//" }
+      let(:cache_key) { "invoiced-usage/#{date}/#{organization_id}///" }
 
       it "returns the cache key" do
         expect(invoiced_usage_cache_key).to eq(cache_key)
@@ -24,11 +25,22 @@ RSpec.describe Analytics::InvoicedUsage, type: :model do
       let(:args) { {currency:, months:} }
 
       let(:cache_key) do
-        "invoiced-usage/#{date}/#{organization_id}/#{currency}/#{months}"
+        "invoiced-usage/#{date}/#{organization_id}//#{currency}/#{months}"
       end
 
       it "returns the cache key" do
         expect(invoiced_usage_cache_key).to eq(cache_key)
+      end
+
+      context "with billing entity id" do
+        let(:args) { {currency:, months:, billing_entity_id:} }
+        let(:cache_key) do
+          "invoiced-usage/#{date}/#{organization_id}/#{billing_entity_id}/#{currency}/#{months}"
+        end
+
+        it "returns the cache key" do
+          expect(invoiced_usage_cache_key).to eq(cache_key)
+        end
       end
     end
 
@@ -36,7 +48,7 @@ RSpec.describe Analytics::InvoicedUsage, type: :model do
       let(:args) { {months:} }
 
       let(:cache_key) do
-        "invoiced-usage/#{date}/#{organization_id}//#{months}"
+        "invoiced-usage/#{date}/#{organization_id}///#{months}"
       end
 
       it "returns the cache key" do
@@ -46,7 +58,16 @@ RSpec.describe Analytics::InvoicedUsage, type: :model do
 
     context "with currency" do
       let(:args) { {currency:} }
-      let(:cache_key) { "invoiced-usage/#{date}/#{organization_id}/#{currency}/" }
+      let(:cache_key) { "invoiced-usage/#{date}/#{organization_id}//#{currency}/" }
+
+      it "returns the cache key" do
+        expect(invoiced_usage_cache_key).to eq(cache_key)
+      end
+    end
+
+    context "with billing_entity_id" do
+      let(:args) { {billing_entity_id:} }
+      let(:cache_key) { "invoiced-usage/#{date}/#{organization_id}/#{billing_entity_id}//" }
 
       it "returns the cache key" do
         expect(invoiced_usage_cache_key).to eq(cache_key)

--- a/spec/models/analytics/mrr_spec.rb
+++ b/spec/models/analytics/mrr_spec.rb
@@ -7,13 +7,14 @@ RSpec.describe Analytics::Mrr, type: :model do
     subject(:mrr_cache_key) { described_class.cache_key(organization_id, **args) }
 
     let(:organization_id) { SecureRandom.uuid }
+    let(:billing_entity_id) { SecureRandom.uuid }
     let(:currency) { "EUR" }
     let(:months) { 12 }
     let(:date) { Date.current.strftime("%Y-%m-%d") }
 
     context "with no arguments" do
       let(:args) { {} }
-      let(:cache_key) { "mrr/#{date}/#{organization_id}//" }
+      let(:cache_key) { "mrr/#{date}/#{organization_id}///" }
 
       it "returns the cache key" do
         expect(mrr_cache_key).to eq(cache_key)
@@ -24,17 +25,28 @@ RSpec.describe Analytics::Mrr, type: :model do
       let(:args) { {currency:, months:} }
 
       let(:cache_key) do
-        "mrr/#{date}/#{organization_id}/#{currency}/#{months}"
+        "mrr/#{date}/#{organization_id}//#{currency}/#{months}"
       end
 
       it "returns the cache key" do
         expect(mrr_cache_key).to eq(cache_key)
       end
+
+      context "with billing_entity_id" do
+        let(:args) { {billing_entity_id:, currency:, months:} }
+        let(:cache_key) do
+          "mrr/#{date}/#{organization_id}/#{billing_entity_id}/#{currency}/#{months}"
+        end
+
+        it "returns the cache key" do
+          expect(mrr_cache_key).to eq(cache_key)
+        end
+      end
     end
 
     context "with months" do
       let(:args) { {months:} }
-      let(:cache_key) { "mrr/#{date}/#{organization_id}//#{months}" }
+      let(:cache_key) { "mrr/#{date}/#{organization_id}///#{months}" }
 
       it "returns the cache key" do
         expect(mrr_cache_key).to eq(cache_key)
@@ -43,7 +55,16 @@ RSpec.describe Analytics::Mrr, type: :model do
 
     context "with currency" do
       let(:args) { {currency:} }
-      let(:cache_key) { "mrr/#{date}/#{organization_id}/#{currency}/" }
+      let(:cache_key) { "mrr/#{date}/#{organization_id}//#{currency}/" }
+
+      it "returns the cache key" do
+        expect(mrr_cache_key).to eq(cache_key)
+      end
+    end
+
+    context "with billing_entity_id" do
+      let(:args) { {billing_entity_id:} }
+      let(:cache_key) { "mrr/#{date}/#{organization_id}/#{billing_entity_id}//" }
 
       it "returns the cache key" do
         expect(mrr_cache_key).to eq(cache_key)

--- a/spec/models/analytics/overdue_balance_spec.rb
+++ b/spec/models/analytics/overdue_balance_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Analytics::OverdueBalance, type: :model do
     subject(:overdue_balance_cache_key) { described_class.cache_key(organization_id, **args) }
 
     let(:organization_id) { SecureRandom.uuid }
+    let(:billing_entity_id) { SecureRandom.uuid }
     let(:external_customer_id) { "customer_01" }
     let(:currency) { "EUR" }
     let(:months) { 12 }
@@ -14,7 +15,7 @@ RSpec.describe Analytics::OverdueBalance, type: :model do
 
     context "with no arguments" do
       let(:args) { {} }
-      let(:cache_key) { "overdue-balance/#{date}/#{organization_id}///" }
+      let(:cache_key) { "overdue-balance/#{date}/#{organization_id}////" }
 
       it "returns the cache key" do
         expect(overdue_balance_cache_key).to eq(cache_key)
@@ -25,11 +26,22 @@ RSpec.describe Analytics::OverdueBalance, type: :model do
       let(:args) { {external_customer_id:, currency:, months:} }
 
       let(:cache_key) do
-        "overdue-balance/#{date}/#{organization_id}/#{external_customer_id}/#{currency}/#{months}"
+        "overdue-balance/#{date}/#{organization_id}//#{external_customer_id}/#{currency}/#{months}"
       end
 
       it "returns the cache key" do
         expect(overdue_balance_cache_key).to eq(cache_key)
+      end
+
+      context "with billing_entity_id" do
+        let(:args) { {billing_entity_id:, external_customer_id:, currency:, months:} }
+        let(:cache_key) do
+          "overdue-balance/#{date}/#{organization_id}/#{billing_entity_id}/#{external_customer_id}/#{currency}/#{months}"
+        end
+
+        it "returns the cache key" do
+          expect(overdue_balance_cache_key).to eq(cache_key)
+        end
       end
     end
 
@@ -37,7 +49,7 @@ RSpec.describe Analytics::OverdueBalance, type: :model do
       let(:args) { {external_customer_id:} }
 
       let(:cache_key) do
-        "overdue-balance/#{date}/#{organization_id}/#{external_customer_id}//"
+        "overdue-balance/#{date}/#{organization_id}//#{external_customer_id}//"
       end
 
       it "returns the cache key" do
@@ -47,7 +59,16 @@ RSpec.describe Analytics::OverdueBalance, type: :model do
 
     context "with currency" do
       let(:args) { {currency:} }
-      let(:cache_key) { "overdue-balance/#{date}/#{organization_id}//#{currency}/" }
+      let(:cache_key) { "overdue-balance/#{date}/#{organization_id}///#{currency}/" }
+
+      it "returns the cache key" do
+        expect(overdue_balance_cache_key).to eq(cache_key)
+      end
+    end
+
+    context "with billing_entity_id" do
+      let(:args) { {billing_entity_id:} }
+      let(:cache_key) { "overdue-balance/#{date}/#{organization_id}/#{billing_entity_id}///" }
 
       it "returns the cache key" do
         expect(overdue_balance_cache_key).to eq(cache_key)


### PR DESCRIPTION
## Context

When caching analytics, billing_entity_id should be taken into account
