### PR TITLE
fix(bug): Stripe payment intent creation payload

### DIFF
--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -128,7 +128,6 @@ module PaymentProviders
             amount: payment.amount_cents,
             currency: payment.amount_currency.downcase,
             customer: provider_customer.provider_customer_id,
-            payment_method: stripe_payment_method,
             payment_method_types: provider_customer.provider_payment_methods,
             confirm: true,
             off_session: off_session?,
@@ -137,7 +136,13 @@ module PaymentProviders
             description: reference,
             metadata: enriched_metadata
           }
-          payload.merge!(customer_balance_fields) if provider_customer.provider_payment_methods == ["customer_balance"]
+
+          if provider_customer.provider_payment_methods == ["customer_balance"]
+            payload.merge!(customer_balance_fields)
+          else
+            payload[:payment_method] = stripe_payment_method
+          end
+
           payload
         end
 

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service
                 funding_type: "bank_transfer"
               }
             }
-          )
+          ).tap { |p| p.delete(:payment_method) }
         end
 
         context "when currency is EUR" do
@@ -422,6 +422,7 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service
                 }
               }
             )
+
             expect(payment_intent_payload).to eq(expected_payload)
           end
         end


### PR DESCRIPTION
when payload includes payment_method_data, it is not allowed to include payment_method as well.
