### PR TITLE
Feat(multientities): Add support of billing_entity filter in invoices query

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -43,6 +43,7 @@ module Api
       end
 
       def index
+        billing_entity = current_organization.all_billing_entities.find_by!(code: params[:billing_entity_code]) if params[:billing_entity_code].present?
         result = InvoicesQuery.call(
           organization: current_organization,
           pagination: {
@@ -53,6 +54,7 @@ module Api
           filters: {
             amount_from: params[:amount_from],
             amount_to: params[:amount_to],
+            billing_entity_id: billing_entity&.id,
             currency: params[:currency],
             customer_external_id: params[:external_customer_id],
             invoice_type: params[:invoice_type],
@@ -81,6 +83,8 @@ module Api
         else
           render_error_response(result)
         end
+      rescue ActiveRecord::RecordNotFound => e
+        not_found_error(resource: e.model)
       end
 
       def download

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -11,6 +11,7 @@ module Resolvers
 
     argument :amount_from, Integer, required: false
     argument :amount_to, Integer, required: false
+    argument :billing_entity_id, ID, required: false
     argument :currency, Types::CurrencyEnum, required: false
     argument :customer_external_id, String, required: false
     argument :customer_id, ID, required: false, description: "Uniq ID of the customer"
@@ -33,6 +34,7 @@ module Resolvers
     def resolve( # rubocop:disable Metrics/ParameterLists
       amount_from: nil,
       amount_to: nil,
+      billing_entity_id: nil,
       currency: nil,
       customer_external_id: nil,
       customer_id: nil,
@@ -57,6 +59,7 @@ module Resolvers
         filters: {
           amount_from:,
           amount_to:,
+          billing_entity_id:,
           currency:,
           customer_external_id:,
           customer_id:,

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -11,6 +11,7 @@ class InvoicesQuery < BaseQuery
       default_order: {issuing_date: :desc, created_at: :desc}
     )
 
+    invoices = with_billing_entity_id(invoices) if filters.billing_entity_id.present?
     invoices = with_currency(invoices) if filters.currency
     invoices = with_customer_external_id(invoices) if filters.customer_external_id
     invoices = with_customer_id(invoices) if filters.customer_id.present?
@@ -55,6 +56,10 @@ class InvoicesQuery < BaseQuery
       customer_external_id_cont: search_term,
       customer_email_cont: search_term
     )
+  end
+
+  def with_billing_entity_id(scope)
+    scope.where(billing_entity_id: filters.billing_entity_id)
   end
 
   def with_currency(scope)

--- a/schema.graphql
+++ b/schema.graphql
@@ -7424,6 +7424,7 @@ type Query {
   invoices(
     amountFrom: Int
     amountTo: Int
+    billingEntityId: ID
     currency: CurrencyEnum
     customerExternalId: String
 

--- a/schema.json
+++ b/schema.json
@@ -38235,6 +38235,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "billingEntityId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "currency",
                   "description": null,
                   "type": {

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -11,14 +11,16 @@ RSpec.describe InvoicesQuery, type: :query do
   let(:pagination) { nil }
   let(:search_term) { nil }
   let(:filters) { nil }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let(:organization) { create(:organization) }
+  let(:billing_entity1) { organization.default_billing_entity }
+  let(:billing_entity2) { create(:billing_entity, organization:) }
   let(:customer_first) { create(:customer, organization:, name: "Rick Sanchez", firstname: "RickFirst", lastname: "SanchezLast", email: "pickle@hotmail.com") }
   let(:customer_second) { create(:customer, organization:, name: "Morty Smith", firstname: "MortyFirst", lastname: "SmithLast", email: "ilovejessica@gmail.com") }
   let(:invoice_first) do
     create(
       :invoice,
       organization:,
+      billing_entity: billing_entity1,
       status: "finalized",
       payment_status: "succeeded",
       customer: customer_first,
@@ -30,6 +32,7 @@ RSpec.describe InvoicesQuery, type: :query do
     create(
       :invoice,
       organization:,
+      billing_entity: billing_entity1,
       status: "finalized",
       payment_status: "pending",
       customer: customer_second,
@@ -41,6 +44,7 @@ RSpec.describe InvoicesQuery, type: :query do
     create(
       :invoice,
       organization:,
+      billing_entity: billing_entity1,
       status: "finalized",
       payment_status: "failed",
       payment_overdue: true,
@@ -53,6 +57,7 @@ RSpec.describe InvoicesQuery, type: :query do
     create(
       :invoice,
       organization:,
+      billing_entity: billing_entity2,
       status: "draft",
       payment_status: "pending",
       customer: customer_second,
@@ -65,6 +70,7 @@ RSpec.describe InvoicesQuery, type: :query do
       :invoice,
       :credit,
       organization:,
+      billing_entity: billing_entity2,
       status: "draft",
       payment_status: "pending",
       customer: customer_first,
@@ -76,6 +82,7 @@ RSpec.describe InvoicesQuery, type: :query do
       :invoice,
       :dispute_lost,
       organization:,
+      billing_entity: billing_entity2,
       payment_status: "pending",
       customer: customer_first,
       number: "6666666666"
@@ -785,6 +792,15 @@ RSpec.describe InvoicesQuery, type: :query do
           expect(returned_ids).to include(invoice_second.id)
         end
       end
+    end
+  end
+
+  context "when filtering by billing_entity_id" do
+    let(:filters) { {billing_entity_id: billing_entity1.id} }
+
+    it "returns invoices for the specified billing entity" do
+      expect(returned_ids).to include(invoice_first.id, invoice_second.id, invoice_third.id)
+      expect(returned_ids).not_to include(invoice_fourth.id, invoice_fifth.id, invoice_sixth.id)
     end
   end
 end

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -644,7 +644,6 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         end
       end
     end
-
   end
 
   describe "PUT /api/v1/invoices/:id/refresh" do

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -600,6 +600,51 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         end
       end
     end
+
+    context "when invoices are created in multiple billing entities" do
+      let(:billing_entity2) { create(:billing_entity, organization:) }
+      let(:params) { {} }
+
+      let(:invoice1) { create(:invoice, :self_billed, customer:, organization:) }
+      let(:invoice2) { create(:invoice, :self_billed, customer:, organization:, billing_entity: billing_entity2) }
+
+      before do
+        invoice1
+        invoice2
+      end
+
+      it "returns all invoices when not filtering by billing entity" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(2)
+        expect(json[:invoices].pluck(:lago_id)).to match_array([invoice1.id, invoice2.id])
+      end
+
+      context "when filtering by billing entity" do
+        let(:params) { {billing_entity_code: billing_entity2.code} }
+
+        it "returns invoices for the specified billing entity" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:invoices].count).to eq(1)
+          expect(json[:invoices].first[:lago_id]).to eq(invoice2.id)
+        end
+
+        context "when billing entity does not exist" do
+          let(:params) { {billing_entity_code: "non_existent_code"} }
+
+          it "returns a not found error" do
+            subject
+
+            expect(response).to have_http_status(:not_found)
+            expect(json[:code]).to eq("BillingEntity_not_found")
+          end
+        end
+      end
+    end
+
   end
 
   describe "PUT /api/v1/invoices/:id/refresh" do


### PR DESCRIPTION
## Context

We need a possibility to filter invoices by billing_entity in Graphql resolver and in api endpoint

## Description

Added billing_entity param to invoice_resolver and invoice#index action
Added billing_entity_id filter in Invoices query