### PR TITLE
Feat(multientities): Add support of billing_entity filter in credit_notes query

### DIFF
--- a/app/contracts/queries/customers_query_filters_contract.rb
+++ b/app/contracts/queries/customers_query_filters_contract.rb
@@ -5,6 +5,7 @@ module Queries
     params do
       required(:filters).hash do
         optional(:account_type).array(:string, included_in?: Customer::ACCOUNT_TYPES.values)
+        optional(:billing_entity_ids).maybe { array(:string, format?: Regex::UUID) }
       end
 
       optional(:search_term).maybe(:string)

--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -94,7 +94,7 @@ module Api
 
       def index
         billing_entities = current_organization.billing_entities.where(code: params[:billing_entity_codes]) if params[:billing_entity_codes].present?
-        return not_found_error(resource: "billing_entity") if params[:billing_entity_codes].present? && billing_entities.blank?
+        return not_found_error(resource: "billing_entity") if params[:billing_entity_codes].present? && billing_entities.count != params[:billing_entity_codes].count
 
         result = CreditNotesQuery.call(
           organization: current_organization,

--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -93,6 +93,7 @@ module Api
       end
 
       def index
+        billing_entity = current_organization.billing_entities.find_by!(code: params[:billing_entity_code]) if params[:billing_entity_code].present?
         result = CreditNotesQuery.call(
           organization: current_organization,
           pagination: {
@@ -103,6 +104,7 @@ module Api
           filters: {
             amount_from: params[:amount_from],
             amount_to: params[:amount_to],
+            billing_entity_id: billing_entity&.id,
             credit_status: params[:credit_status],
             currency: params[:currency],
             customer_external_id: params[:external_customer_id],
@@ -128,6 +130,8 @@ module Api
         else
           render_error_response(result)
         end
+      rescue ActiveRecord::RecordNotFound => e
+        not_found_error(resource: e.model)
       end
 
       def estimate

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -36,7 +36,7 @@ module Api
 
       def index
         billing_entities = current_organization.all_billing_entities.where(code: params[:billing_entity_codes]) if params[:billing_entity_codes].present?
-        return not_found_error(resource: "billing_entity") if params[:billing_entity_codes].present? && billing_entities.blank?
+        return not_found_error(resource: "billing_entity") if params[:billing_entity_codes].present? && billing_entities.count != params[:billing_entity_codes].count
 
         result = CustomersQuery.call(
           organization: current_organization,

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -35,13 +35,14 @@ module Api
       end
 
       def index
+        billing_entity = current_organization.all_billing_entities.find_by!(code: params[:billing_entity_code]) if params[:billing_entity_code].present?
         result = CustomersQuery.call(
           organization: current_organization,
           pagination: {
             page: params[:page],
             limit: params[:per_page] || PER_PAGE
           },
-          filters: params.slice(:account_type)
+          filters: params.slice(:account_type).merge(billing_entity_id: billing_entity&.id)
         )
 
         if result.success?
@@ -57,6 +58,8 @@ module Api
         else
           render_error_response(result)
         end
+      rescue ActiveRecord::RecordNotFound => e
+        not_found_error(resource: e.model)
       end
 
       def show

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -44,7 +44,7 @@ module Api
 
       def index
         billing_entities = current_organization.all_billing_entities.where(code: params[:billing_entity_codes]) if params[:billing_entity_codes].present?
-        return not_found_error(resource: "billing_enitity") if params[:billing_entity_codes].present? && billing_entities.blank?
+        return not_found_error(resource: "billing_entity") if params[:billing_entity_codes].present? && billing_entities.count != params[:billing_entity_codes].count
 
         result = InvoicesQuery.call(
           organization: current_organization,

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -43,7 +43,9 @@ module Api
       end
 
       def index
-        billing_entity = current_organization.all_billing_entities.find_by!(code: params[:billing_entity_code]) if params[:billing_entity_code].present?
+        billing_entities = current_organization.all_billing_entities.where(code: params[:billing_entity_codes]) if params[:billing_entity_codes].present?
+        return not_found_error(resource: "billing_enitity") if params[:billing_entity_codes].present? && billing_entities.blank?
+
         result = InvoicesQuery.call(
           organization: current_organization,
           pagination: {
@@ -54,7 +56,7 @@ module Api
           filters: {
             amount_from: params[:amount_from],
             amount_to: params[:amount_to],
-            billing_entity_id: billing_entity&.id,
+            billing_entity_ids: billing_entities&.ids,
             currency: params[:currency],
             customer_external_id: params[:external_customer_id],
             invoice_type: params[:invoice_type],
@@ -83,8 +85,6 @@ module Api
         else
           render_error_response(result)
         end
-      rescue ActiveRecord::RecordNotFound => e
-        not_found_error(resource: e.model)
       end
 
       def download

--- a/app/graphql/resolvers/credit_notes_resolver.rb
+++ b/app/graphql/resolvers/credit_notes_resolver.rb
@@ -16,6 +16,7 @@ module Resolvers
 
     argument :amount_from, Integer, required: false
     argument :amount_to, Integer, required: false
+    argument :billing_entity_id, ID, required: false
     argument :credit_status, [Types::CreditNotes::CreditStatusTypeEnum], required: false
     argument :currency, Types::CurrencyEnum, required: false
     argument :customer_external_id, String, required: false
@@ -36,6 +37,7 @@ module Resolvers
         filters: {
           amount_from: args[:amount_from],
           amount_to: args[:amount_to],
+          billing_entity_id: args[:billing_entity_id],
           credit_status: args[:credit_status],
           currency: args[:currency],
           customer_external_id: args[:customer_external_id],

--- a/app/graphql/resolvers/credit_notes_resolver.rb
+++ b/app/graphql/resolvers/credit_notes_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
     argument :amount_from, Integer, required: false
     argument :amount_to, Integer, required: false
-    argument :billing_entity_id, ID, required: false
+    argument :billing_entity_ids, [ID], required: false
     argument :credit_status, [Types::CreditNotes::CreditStatusTypeEnum], required: false
     argument :currency, Types::CurrencyEnum, required: false
     argument :customer_external_id, String, required: false
@@ -37,7 +37,7 @@ module Resolvers
         filters: {
           amount_from: args[:amount_from],
           amount_to: args[:amount_to],
-          billing_entity_id: args[:billing_entity_id],
+          billing_entity_ids: args[:billing_entity_ids],
           credit_status: args[:credit_status],
           currency: args[:currency],
           customer_external_id: args[:customer_external_id],

--- a/app/graphql/resolvers/customers_resolver.rb
+++ b/app/graphql/resolvers/customers_resolver.rb
@@ -15,7 +15,7 @@ module Resolvers
     argument :search_term, String, required: false
 
     argument :account_type, [Types::Customers::AccountTypeEnum], required: false
-    argument :billing_entity_id, ID, required: false
+    argument :billing_entity_ids, [ID], required: false
     argument :with_deleted, Boolean, required: false
 
     type Types::Customers::Object.collection_type, null: false
@@ -28,7 +28,7 @@ module Resolvers
           page: args[:page],
           limit: args[:limit]
         },
-        filters: args.slice(:account_type, :billing_entity_id, :with_deleted)
+        filters: args.slice(:account_type, :billing_entity_ids, :with_deleted)
       )
 
       result.customers

--- a/app/graphql/resolvers/customers_resolver.rb
+++ b/app/graphql/resolvers/customers_resolver.rb
@@ -15,6 +15,7 @@ module Resolvers
     argument :search_term, String, required: false
 
     argument :account_type, [Types::Customers::AccountTypeEnum], required: false
+    argument :billing_entity_id, ID, required: false
     argument :with_deleted, Boolean, required: false
 
     type Types::Customers::Object.collection_type, null: false
@@ -27,7 +28,7 @@ module Resolvers
           page: args[:page],
           limit: args[:limit]
         },
-        filters: args.slice(:account_type, :with_deleted)
+        filters: args.slice(:account_type, :billing_entity_id, :with_deleted)
       )
 
       result.customers

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -11,7 +11,7 @@ module Resolvers
 
     argument :amount_from, Integer, required: false
     argument :amount_to, Integer, required: false
-    argument :billing_entity_id, ID, required: false
+    argument :billing_entity_ids, [ID], required: false
     argument :currency, Types::CurrencyEnum, required: false
     argument :customer_external_id, String, required: false
     argument :customer_id, ID, required: false, description: "Uniq ID of the customer"
@@ -34,7 +34,7 @@ module Resolvers
     def resolve( # rubocop:disable Metrics/ParameterLists
       amount_from: nil,
       amount_to: nil,
-      billing_entity_id: nil,
+      billing_entity_ids: nil,
       currency: nil,
       customer_external_id: nil,
       customer_id: nil,
@@ -59,7 +59,7 @@ module Resolvers
         filters: {
           amount_from:,
           amount_to:,
-          billing_entity_id:,
+          billing_entity_ids:,
           currency:,
           customer_external_id:,
           customer_id:,

--- a/app/queries/credit_notes_query.rb
+++ b/app/queries/credit_notes_query.rb
@@ -8,7 +8,7 @@ class CreditNotesQuery < BaseQuery
     credit_notes = paginate(credit_notes)
     credit_notes = apply_consistent_ordering(credit_notes)
 
-    credit_notes = with_billing_entity_id(credit_notes) if filters.billing_entity_id.present?
+    credit_notes = with_billing_entity_ids(credit_notes) if filters.billing_entity_ids.present?
     credit_notes = with_currency(credit_notes) if filters.currency.present?
     credit_notes = with_customer_external_id(credit_notes) if filters.customer_external_id
     credit_notes = with_customer_id(credit_notes) if filters.customer_id.present?
@@ -105,8 +105,8 @@ class CreditNotesQuery < BaseQuery
       })
   end
 
-  def with_billing_entity_id(scope)
-    scope.joins(:invoice).where(invoices: {billing_entity_id: filters.billing_entity_id})
+  def with_billing_entity_ids(scope)
+    scope.joins(:invoice).where(invoices: {billing_entity_id: filters.billing_entity_ids})
   end
 
   def issuing_date_from

--- a/app/queries/credit_notes_query.rb
+++ b/app/queries/credit_notes_query.rb
@@ -8,6 +8,7 @@ class CreditNotesQuery < BaseQuery
     credit_notes = paginate(credit_notes)
     credit_notes = apply_consistent_ordering(credit_notes)
 
+    credit_notes = with_billing_entity_id(credit_notes) if filters.billing_entity_id.present?
     credit_notes = with_currency(credit_notes) if filters.currency.present?
     credit_notes = with_customer_external_id(credit_notes) if filters.customer_external_id
     credit_notes = with_customer_id(credit_notes) if filters.customer_id.present?
@@ -102,6 +103,10 @@ class CreditNotesQuery < BaseQuery
       .where(invoices: {
         self_billed: ActiveModel::Type::Boolean.new.cast(filters.self_billed)
       })
+  end
+
+  def with_billing_entity_id(scope)
+    scope.joins(:invoice).where(invoices: {billing_entity_id: filters.billing_entity_id})
   end
 
   def issuing_date_from

--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -11,7 +11,7 @@ class CustomersQuery < BaseQuery
     customers = apply_consistent_ordering(customers)
 
     customers = with_account_type(customers) if filters.account_type.present?
-    customers = with_billing_entity_id(customers) if filters.billing_entity_id.present?
+    customers = with_billing_entity_ids(customers) if filters.billing_entity_ids.present?
     customers = customers.with_discarded if filters.with_deleted
 
     result.customers = customers
@@ -46,7 +46,7 @@ class CustomersQuery < BaseQuery
     scope.where(account_type: filters.account_type)
   end
 
-  def with_billing_entity_id(scope)
-    scope.where(billing_entity_id: filters.billing_entity_id)
+  def with_billing_entity_ids(scope)
+    scope.where(billing_entity_id: filters.billing_entity_ids)
   end
 end

--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -11,6 +11,7 @@ class CustomersQuery < BaseQuery
     customers = apply_consistent_ordering(customers)
 
     customers = with_account_type(customers) if filters.account_type.present?
+    customers = with_billing_entity_id(customers) if filters.billing_entity_id.present?
     customers = customers.with_discarded if filters.with_deleted
 
     result.customers = customers
@@ -43,5 +44,9 @@ class CustomersQuery < BaseQuery
 
   def with_account_type(scope)
     scope.where(account_type: filters.account_type)
+  end
+
+  def with_billing_entity_id(scope)
+    scope.where(billing_entity_id: filters.billing_entity_id)
   end
 end

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -11,7 +11,7 @@ class InvoicesQuery < BaseQuery
       default_order: {issuing_date: :desc, created_at: :desc}
     )
 
-    invoices = with_billing_entity_id(invoices) if filters.billing_entity_id.present?
+    invoices = with_billing_entity_ids(invoices) if filters.billing_entity_ids.present?
     invoices = with_currency(invoices) if filters.currency
     invoices = with_customer_external_id(invoices) if filters.customer_external_id
     invoices = with_customer_id(invoices) if filters.customer_id.present?
@@ -58,8 +58,8 @@ class InvoicesQuery < BaseQuery
     )
   end
 
-  def with_billing_entity_id(scope)
-    scope.where(billing_entity_id: filters.billing_entity_id)
+  def with_billing_entity_ids(scope)
+    scope.where(billing_entity_id: filters.billing_entity_ids)
   end
 
   def with_currency(scope)

--- a/schema.graphql
+++ b/schema.graphql
@@ -7147,7 +7147,7 @@ type Query {
   creditNotes(
     amountFrom: Int
     amountTo: Int
-    billingEntityId: ID
+    billingEntityIds: [ID!]
     creditStatus: [CreditNoteCreditStatusEnum!]
     currency: CurrencyEnum
     customerExternalId: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -7249,7 +7249,7 @@ type Query {
   """
   Query customers of an organization
   """
-  customers(accountType: [CustomerAccountTypeEnum!], billingEntityId: ID, limit: Int, page: Int, searchTerm: String, withDeleted: Boolean): CustomerCollection!
+  customers(accountType: [CustomerAccountTypeEnum!], billingEntityIds: [ID!], limit: Int, page: Int, searchTerm: String, withDeleted: Boolean): CustomerCollection!
 
   """
   Query monthly recurring revenues of an organization
@@ -7434,7 +7434,7 @@ type Query {
   invoices(
     amountFrom: Int
     amountTo: Int
-    billingEntityId: ID
+    billingEntityIds: [ID!]
     currency: CurrencyEnum
     customerExternalId: String
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -7147,6 +7147,7 @@ type Query {
   creditNotes(
     amountFrom: Int
     amountTo: Int
+    billingEntityId: ID
     creditStatus: [CreditNoteCreditStatusEnum!]
     currency: CurrencyEnum
     customerExternalId: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -7249,7 +7249,7 @@ type Query {
   """
   Query customers of an organization
   """
-  customers(accountType: [CustomerAccountTypeEnum!], limit: Int, page: Int, searchTerm: String, withDeleted: Boolean): CustomerCollection!
+  customers(accountType: [CustomerAccountTypeEnum!], billingEntityId: ID, limit: Int, page: Int, searchTerm: String, withDeleted: Boolean): CustomerCollection!
 
   """
   Query monthly recurring revenues of an organization

--- a/schema.json
+++ b/schema.json
@@ -36013,12 +36013,20 @@
                   "deprecationReason": null
                 },
                 {
-                  "name": "billingEntityId",
+                  "name": "billingEntityIds",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -36780,12 +36780,20 @@
                   "deprecationReason": null
                 },
                 {
-                  "name": "billingEntityId",
+                  "name": "billingEntityIds",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,
@@ -38363,12 +38371,20 @@
                   "deprecationReason": null
                 },
                 {
-                  "name": "billingEntityId",
+                  "name": "billingEntityIds",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -36780,6 +36780,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "billingEntityId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "withDeleted",
                   "description": null,
                   "type": {

--- a/schema.json
+++ b/schema.json
@@ -36013,6 +36013,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "billingEntityId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "creditStatus",
                   "description": null,
                   "type": {

--- a/spec/contracts/queries/customers_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/customers_query_filters_contract_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe Queries::CustomersQueryFiltersContract, type: :contract do
     end
   end
 
+  context "when filtering by billing entity ids" do
+    let(:filters) { {billing_entity_ids: ["123e4567-e89b-12d3-a456-426614174000"]} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
   context "when search_term is provided and valid" do
     let(:search_term) { "valid_search_term" }
 
@@ -45,5 +53,7 @@ RSpec.describe Queries::CustomersQueryFiltersContract, type: :contract do
 
     it_behaves_like "an invalid filter", :account_type, nil, ["must be an array"]
     it_behaves_like "an invalid filter", :account_type, %w[random], {0 => ["must be one of: customer, partner"]}
+    it_behaves_like "an invalid filter", :billing_entity_ids, SecureRandom.uuid, ["must be an array"]
+    it_behaves_like "an invalid filter", :billing_entity_ids, %w[random], {0 => ["is in invalid format"]}
   end
 end

--- a/spec/graphql/resolvers/credit_notes_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes_resolver_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe Resolvers::CreditNotesResolver, type: :graphql do
     let(:query) do
       <<~GQL
         query {
-          creditNotes(limit: 5, billingEntityId: "#{billing_entity.id}") {
+          creditNotes(limit: 5, billingEntityIds: ["#{billing_entity.id}"]) {
             collection { id }
             metadata { currentPage, totalCount }
           }

--- a/spec/graphql/resolvers/credit_notes_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes_resolver_spec.rb
@@ -249,4 +249,34 @@ RSpec.describe Resolvers::CreditNotesResolver, type: :graphql do
       expect(result["data"]["creditNotes"]["metadata"]["totalCount"]).to eq(1)
     end
   end
+
+  context "when filtering by billing_entity_id" do
+    let(:billing_entity) { create(:billing_entity, organization:) }
+    let(:matching_credit_note) { create(:credit_note, customer:, invoice: create(:invoice, billing_entity:)) }
+    let(:non_matching_credit_note) { create(:credit_note, customer:) }
+
+    let(:query) do
+      <<~GQL
+        query {
+          creditNotes(limit: 5, billingEntityId: "#{billing_entity.id}") {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    before do
+      matching_credit_note
+      non_matching_credit_note
+    end
+
+    it "returns credit notes with matching billing entity id" do
+      expect(response_collection.count).to eq(1)
+      expect(response_collection.first["id"]).to eq(matching_credit_note.id)
+
+      expect(result["data"]["creditNotes"]["metadata"]["currentPage"]).to eq(1)
+      expect(result["data"]["creditNotes"]["metadata"]["totalCount"]).to eq(1)
+    end
+  end
 end

--- a/spec/graphql/resolvers/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers_resolver_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Resolvers::CustomersResolver, type: :graphql do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
+  let(:billing_entity1) { organization.default_billing_entity }
+  let(:billing_entity2) { create(:billing_entity, organization:) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
@@ -90,6 +92,45 @@ RSpec.describe Resolvers::CustomersResolver, type: :graphql do
 
       expect(invoices_response["metadata"]["currentPage"]).to eq(1)
       expect(invoices_response["metadata"]["totalCount"]).to eq(1)
+    end
+  end
+
+  context "when filtering by billing_entity_id" do
+    let(:customer) { create(:customer, organization:, billing_entity: billing_entity1) }
+    let(:customer2) { create(:customer, organization:, billing_entity: billing_entity2) }
+
+    let(:query) do
+      <<~GQL
+        query($billingEntityId: ID) {
+          customers(limit: 5, billingEntityId: $billingEntityId) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    before do
+      customer
+      customer2
+    end
+
+    it "returns all customers for the specified billing entity" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {billingEntityId: billing_entity2.id}
+      )
+
+      customers_response = result["data"]["customers"]
+
+      expect(customers_response["collection"].count).to eq(1)
+      expect(customers_response["collection"].first["id"]).to eq(customer2.id)
+
+      expect(customers_response["metadata"]["currentPage"]).to eq(1)
+      expect(customers_response["metadata"]["totalCount"]).to eq(1)
     end
   end
 

--- a/spec/graphql/resolvers/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers_resolver_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe Resolvers::CustomersResolver, type: :graphql do
 
     let(:query) do
       <<~GQL
-        query($billingEntityId: ID) {
-          customers(limit: 5, billingEntityId: $billingEntityId) {
+        query($billingEntityIds: [ID!]) {
+          customers(limit: 5, billingEntityIds: $billingEntityIds) {
             collection { id }
             metadata { currentPage, totalCount }
           }
@@ -121,7 +121,7 @@ RSpec.describe Resolvers::CustomersResolver, type: :graphql do
         current_organization: organization,
         permissions: required_permission,
         query:,
-        variables: {billingEntityId: billing_entity2.id}
+        variables: {billingEntityIds: [billing_entity2.id]}
       )
 
       customers_response = result["data"]["customers"]

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -583,7 +583,7 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
     let(:query) do
       <<~GQL
         query {
-          invoices(limit: 5, billingEntityId: "#{billing_entity2.id}") {
+          invoices(limit: 5, billingEntityIds: ["#{billing_entity2.id}"]) {
             collection { id }
             metadata { currentPage, totalCount }
           }

--- a/spec/queries/credit_notes_query_spec.rb
+++ b/spec/queries/credit_notes_query_spec.rb
@@ -376,7 +376,6 @@ RSpec.describe CreditNotesQuery, type: :query do
     end
   end
 
-
   context "when search term filter applied" do
     context "with term matching credit note by id" do
       let(:search_term) { matching_credit_note.id.first(10) }

--- a/spec/queries/credit_notes_query_spec.rb
+++ b/spec/queries/credit_notes_query_spec.rb
@@ -378,6 +378,22 @@ RSpec.describe CreditNotesQuery, type: :query do
       expect(result).to be_success
       expect(result.credit_notes.pluck(:id)).to contain_exactly matching_credit_note.id
     end
+
+    context "when matching credit notes from more than one billing_entity" do
+      let(:billing_entity_2) { create(:billing_entity, organization:) }
+      let(:filters) { {billing_entity_ids: [billing_entity.id, billing_entity_2.id]} }
+
+      let(:matching_credit_note_2) { create(:credit_note, customer:, invoice: create(:invoice, billing_entity: billing_entity_2)) }
+
+      before do
+        matching_credit_note_2
+      end
+
+      it "returns credit notes with matching billing entity ids" do
+        expect(result).to be_success
+        expect(result.credit_notes.pluck(:id)).to contain_exactly(matching_credit_note.id, matching_credit_note_2.id)
+      end
+    end
   end
 
   context "when search term filter applied" do

--- a/spec/queries/credit_notes_query_spec.rb
+++ b/spec/queries/credit_notes_query_spec.rb
@@ -362,13 +362,17 @@ RSpec.describe CreditNotesQuery, type: :query do
     end
   end
 
-  context "when billing entity id filter applied" do
+  context "when billing entity ids filter applied" do
     let(:billing_entity) { create(:billing_entity, organization:) }
-    let(:filters) { {billing_entity_id: billing_entity.id} }
+    let(:filters) { {billing_entity_ids: [billing_entity.id]} }
 
-    let!(:matching_credit_note) { create(:credit_note, customer:, invoice: create(:invoice, billing_entity:)) }
+    let(:matching_credit_note) { create(:credit_note, customer:, invoice: create(:invoice, billing_entity:)) }
+    let(:other_credit_note) { create(:credit_note, customer:, invoice: create(:invoice, organization:)) }
 
-    before { create(:credit_note, customer:, invoice: create(:invoice, organization:)) }
+    before do
+      matching_credit_note
+      other_credit_note
+    end
 
     it "returns credit notes with matching billing entity id" do
       expect(result).to be_success

--- a/spec/queries/credit_notes_query_spec.rb
+++ b/spec/queries/credit_notes_query_spec.rb
@@ -362,6 +362,21 @@ RSpec.describe CreditNotesQuery, type: :query do
     end
   end
 
+  context "when billing entity id filter applied" do
+    let(:billing_entity) { create(:billing_entity, organization:) }
+    let(:filters) { {billing_entity_id: billing_entity.id} }
+
+    let!(:matching_credit_note) { create(:credit_note, customer:, invoice: create(:invoice, billing_entity:)) }
+
+    before { create(:credit_note, customer:, invoice: create(:invoice, organization:)) }
+
+    it "returns credit notes with matching billing entity id" do
+      expect(result).to be_success
+      expect(result.credit_notes.pluck(:id)).to contain_exactly matching_credit_note.id
+    end
+  end
+
+
   context "when search term filter applied" do
     context "with term matching credit note by id" do
       let(:search_term) { matching_credit_note.id.first(10) }

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe CustomersQuery, type: :query do
   end
 
   context "when filtering by billing_entity_id" do
-    let(:filters) { {billing_entity_id: billing_entity2.id} }
+    let(:filters) { {billing_entity_ids: [billing_entity2.id]} }
 
     it "returns customers for the specified billing entity" do
       expect(returned_ids.count).to eq(1)

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -11,14 +11,15 @@ RSpec.describe CustomersQuery, type: :query do
   let(:pagination) { nil }
   let(:search_term) { nil }
   let(:filters) { {} }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let(:organization) { create(:organization) }
+  let(:billing_entity1) { organization.default_billing_entity }
+  let(:billing_entity2) { create(:billing_entity, organization:) }
 
   let(:customer_first) do
-    create(:customer, organization:, name: "defgh", firstname: "John", lastname: "Doe", legal_name: "Legalname", external_id: "11", email: "1@example.com")
+    create(:customer, organization:, name: "defgh", firstname: "John", lastname: "Doe", legal_name: "Legalname", external_id: "11", email: "1@example.com", billing_entity: billing_entity1)
   end
   let(:customer_second) do
-    create(:customer, organization:, name: "abcde", firstname: "Jane", lastname: "Smith", legal_name: "other name", external_id: "22", email: "2@example.com")
+    create(:customer, organization:, name: "abcde", firstname: "Jane", lastname: "Smith", legal_name: "other name", external_id: "22", email: "2@example.com", billing_entity: billing_entity1)
   end
   let(:customer_third) do
     create(
@@ -30,7 +31,8 @@ RSpec.describe CustomersQuery, type: :query do
       firstname: "Mary",
       lastname: "Johnson",
       legal_name: "Company name",
-      name: "presuv"
+      name: "presuv",
+      billing_entity: billing_entity2
     )
   end
 
@@ -64,6 +66,15 @@ RSpec.describe CustomersQuery, type: :query do
       expect(returned_ids.count).to eq(2)
       expect(returned_ids).to include customer_first.id
       expect(returned_ids).to include customer_second.id
+    end
+  end
+
+  context "when filtering by billing_entity_id" do
+    let(:filters) { {billing_entity_id: billing_entity2.id} }
+
+    it "returns customers for the specified billing entity" do
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).to include(customer_third.id)
     end
   end
 

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -796,7 +796,7 @@ RSpec.describe InvoicesQuery, type: :query do
   end
 
   context "when filtering by billing_entity_id" do
-    let(:filters) { {billing_entity_id: billing_entity1.id} }
+    let(:filters) { {billing_entity_ids: [billing_entity1.id]} }
 
     it "returns invoices for the specified billing entity" do
       expect(returned_ids).to include(invoice_first.id, invoice_second.id, invoice_third.id)

--- a/spec/requests/api/v1/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes_controller_spec.rb
@@ -459,12 +459,16 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
       end
     end
 
-    context "with billing entity code filter" do
-      let(:params) { {billing_entity_code: billing_entity.code} }
+    context "with billing entity codes filter" do
+      let(:params) { {billing_entity_codes: [billing_entity.code]} }
       let(:billing_entity) { create(:billing_entity, organization:) }
-      let!(:matching_credit_note) { create(:credit_note, customer:, invoice: create(:invoice, billing_entity:)) }
+      let(:matching_credit_note) { create(:credit_note, customer:, invoice: create(:invoice, billing_entity:)) }
+      let(:other_credit_note) { create(:credit_note, customer:) }
 
-      before { create(:credit_note, customer:) }
+      before do
+        matching_credit_note
+        other_credit_note
+      end
 
       it "returns credit notes with matching billing entity code" do
         subject
@@ -474,13 +478,13 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
       end
 
       context "when billing entity code is not found" do
-        let(:params) { {billing_entity_code: "non_existent_code"} }
+        let(:params) { {billing_entity_codes: [SecureRandom.uuid]} }
 
         it "returns an error" do
           subject
 
           expect(response).to have_http_status(:not_found)
-          expect(json[:code]).to eq("BillingEntity_not_found")
+          expect(json[:code]).to eq("billing_entity_not_found")
         end
       end
     end

--- a/spec/requests/api/v1/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes_controller_spec.rb
@@ -477,8 +477,8 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         expect(json[:credit_notes].pluck(:lago_id)).to contain_exactly matching_credit_note.id
       end
 
-      context "when billing entity code is not found" do
-        let(:params) { {billing_entity_codes: [SecureRandom.uuid]} }
+      context "when one of billing entity codes is not found" do
+        let(:params) { {billing_entity_codes: [billing_entity.code, SecureRandom.uuid]} }
 
         it "returns an error" do
           subject

--- a/spec/requests/api/v1/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes_controller_spec.rb
@@ -458,6 +458,32 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         expect(json[:credit_notes].pluck(:lago_id)).to contain_exactly matching_credit_note.id
       end
     end
+
+    context "with billing entity code filter" do
+      let(:params) { {billing_entity_code: billing_entity.code} }
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let!(:matching_credit_note) { create(:credit_note, customer:, invoice: create(:invoice, billing_entity:)) }
+
+      before { create(:credit_note, customer:) }
+
+      it "returns credit notes with matching billing entity code" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:credit_notes].pluck(:lago_id)).to contain_exactly matching_credit_note.id
+      end
+
+      context "when billing entity code is not found" do
+        let(:params) { {billing_entity_code: "non_existent_code"} }
+
+        it "returns an error" do
+          subject
+
+          expect(response).to have_http_status(:not_found)
+          expect(json[:code]).to eq("BillingEntity_not_found")
+        end
+      end
+    end
   end
 
   describe "POST /api/v1/credit_notes" do

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -374,7 +374,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     context "when filtering by billing_entity_code" do
       let(:billing_entity) { create(:billing_entity, organization:) }
       let(:customer) { create(:customer, organization:, billing_entity:) }
-      let(:params) { {billing_entity_code: billing_entity.code} }
+      let(:params) { {billing_entity_codes: [billing_entity.code]} }
 
       before { customer }
 
@@ -387,13 +387,13 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       end
 
       context "when billing entity does not exist" do
-        let(:params) { {billing_entity_code: "non_existent_code"} }
+        let(:params) { {billing_entity_codes: ["non_existent_code"]} }
 
         it "returns a not found error" do
           subject
 
           expect(response).to have_http_status(:not_found)
-          expect(json[:code]).to eq("BillingEntity_not_found")
+          expect(json[:code]).to eq("billing_entity_not_found")
         end
       end
     end

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -386,8 +386,8 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         expect(json[:customers].first[:lago_id]).to eq(customer.id)
       end
 
-      context "when billing entity does not exist" do
-        let(:params) { {billing_entity_codes: ["non_existent_code"]} }
+      context "when one of billing entities does not exist" do
+        let(:params) { {billing_entity_codes: [billing_entity.code, "non_existent_code"]} }
 
         it "returns a not found error" do
           subject

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -370,6 +370,33 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         expect(json[:customers].first[:lago_id]).to eq(partner.id)
       end
     end
+
+    context "when filtering by billing_entity_code" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:customer) { create(:customer, organization:, billing_entity:) }
+      let(:params) { {billing_entity_code: billing_entity.code} }
+
+      before { customer }
+
+      it "returns customers for the specified billing entity" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:customers].count).to eq(1)
+        expect(json[:customers].first[:lago_id]).to eq(customer.id)
+      end
+
+      context "when billing entity does not exist" do
+        let(:params) { {billing_entity_code: "non_existent_code"} }
+
+        it "returns a not found error" do
+          subject
+
+          expect(response).to have_http_status(:not_found)
+          expect(json[:code]).to eq("BillingEntity_not_found")
+        end
+      end
+    end
   end
 
   describe "GET /api/v1/customers/:customer_id" do

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -622,7 +622,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       end
 
       context "when filtering by billing entity" do
-        let(:params) { {billing_entity_code: billing_entity2.code} }
+        let(:params) { {billing_entity_codes: [billing_entity2.code]} }
 
         it "returns invoices for the specified billing entity" do
           subject
@@ -633,13 +633,13 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         end
 
         context "when billing entity does not exist" do
-          let(:params) { {billing_entity_code: "non_existent_code"} }
+          let(:params) { {billing_entity_codes: [SecureRandom.uuid]} }
 
           it "returns a not found error" do
             subject
 
             expect(response).to have_http_status(:not_found)
-            expect(json[:code]).to eq("BillingEntity_not_found")
+            expect(json[:code]).to eq("billing_enitity_not_found")
           end
         end
       end

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -632,14 +632,14 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
           expect(json[:invoices].first[:lago_id]).to eq(invoice2.id)
         end
 
-        context "when billing entity does not exist" do
-          let(:params) { {billing_entity_codes: [SecureRandom.uuid]} }
+        context "when one of billing entities does not exist" do
+          let(:params) { {billing_entity_codes: [billing_entity2.code, SecureRandom.uuid]} }
 
           it "returns a not found error" do
             subject
 
             expect(response).to have_http_status(:not_found)
-            expect(json[:code]).to eq("billing_enitity_not_found")
+            expect(json[:code]).to eq("billing_entity_not_found")
           end
         end
       end


### PR DESCRIPTION
## Context

We need a possibility to filter credit_notes by billing_entity in Graphql resolver and in api endpoint

## Description

Added billing_entity param to credit_notes_resolver and credit_notes#index action
Added billing_entity_id filter in CreditNotes query