### PR TITLE
Feat(multientities): update discarded customers to be assigned to a billing entity

### DIFF
--- a/db/migrate/20250402135038_assign_discarded_customers_to_billing_entities.rb
+++ b/db/migrate/20250402135038_assign_discarded_customers_to_billing_entities.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AssignDiscardedCustomersToBillingEntities < ActiveRecord::Migration[7.2]
+  def up
+    Customer.with_discarded.where("billing_entity_id != organization_id").or(Customer.with_discarded.where(billing_entity_id: nil)).find_in_batches(batch_size: 1000) do |batch|
+      Customer.with_discarded.where(id: batch.pluck(:id))
+        .update_all("billing_entity_id = organization_id") # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  def down
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6248,7 +6248,6 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250402135038'),
-('20250402133749'),
 ('20250402113844'),
 ('20250325162648'),
 ('20250325145324'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6247,6 +6247,8 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250402135038'),
+('20250402133749'),
 ('20250402113844'),
 ('20250325162648'),
 ('20250325145324'),


### PR DESCRIPTION
## Context

When data-exports are created, they include invoices that might  belong to descarded customers. When these customers are serialized, these customers should have billing_entity_id

Also Adding null: false for  customers table will require consistent data

Note: this job is done as a migration, because the original Customers migration was done as a migration. Also the amount of discarded customers is really low - ~5k on US, and they already were updated manually
