### PR TITLE
fix(invoices): improve organization numbering performances

### DIFF
--- a/app/jobs/database_migrations/fix_invoices_organization_sequential_id_job.rb
+++ b/app/jobs/database_migrations/fix_invoices_organization_sequential_id_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class FixInvoicesOrganizationSequentialIdJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      Organization.per_organization.find_each do |organization|
+        last_organization_sequential_id = organization.invoices.maximum(:organization_sequential_id) || 0
+        invoices_count = organization.invoices.non_self_billed.with_generated_number.count
+
+        next if last_organization_sequential_id == invoices_count
+
+        last_invoice = organization.invoices.non_self_billed.with_generated_number.order(created_at: :desc).limit(1)
+        last_invoice.update_all(organization_sequential_id: invoices_count) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -446,7 +446,7 @@ class Invoice < ApplicationRecord
       organization_sequential_id = organization
         .invoices
         .non_self_billed
-        .maximum(:organization_sequential_id)
+        .maximum(:organization_sequential_id) || 0
 
       # NOTE: Start with the most recent sequential id and find first available sequential id that haven't occurred
       loop do

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -443,18 +443,10 @@ class Invoice < ApplicationRecord
       transaction: true,
       timeout_seconds: 10.seconds
     ) do
-      # If previous invoice had different numbering, base sequential id is the total number of invoices
-      organization_sequential_id = if switched_from_customer_numbering?
-        organization.invoices.non_self_billed.with_generated_number.count
-      else
-        organization
-          .invoices
-          .non_self_billed
-          .where.not(organization_sequential_id: 0)
-          .order(organization_sequential_id: :desc)
-          .limit(1)
-          .pick(:organization_sequential_id) || 0
-      end
+      organization_sequential_id = organization
+        .invoices
+        .non_self_billed
+        .maximum(:organization_sequential_id)
 
       # NOTE: Start with the most recent sequential id and find first available sequential id that haven't occurred
       loop do
@@ -468,14 +460,6 @@ class Invoice < ApplicationRecord
     raise(SequenceError, "Unable to acquire lock on the database") unless result
 
     result
-  end
-
-  def switched_from_customer_numbering?
-    last_invoice = organization.invoices.non_self_billed.order(created_at: :desc).with_generated_number.first
-
-    return false unless last_invoice
-
-    last_invoice&.organization_sequential_id&.zero?
   end
 
   def status_changed_to_finalized?

--- a/app/services/organizations/update_invoice_numbering_service.rb
+++ b/app/services/organizations/update_invoice_numbering_service.rb
@@ -16,8 +16,12 @@ module Organizations
       return result if organization.document_numbering == document_numbering
 
       if organization.per_customer? && document_numbering == "per_organization"
-        organization_invoices_count = organization.invoices.non_self_billed.with_generated_number.count
-        organization.invoices.order(created_at: :desc).first&.update!(organization_sequential_id: organization_invoices_count)
+        last_invoice = organization.invoices.non_self_billed.with_generated_number.order(created_at: :desc).first
+
+        if last_invoice
+            organization_invoices_count = organization.invoices.non_self_billed.with_generated_number.count
+            last_invoice.update!(organization_sequential_id: organization_invoices_count)
+        end
       end
 
       organization.document_numbering = document_numbering

--- a/app/services/organizations/update_invoice_numbering_service.rb
+++ b/app/services/organizations/update_invoice_numbering_service.rb
@@ -19,8 +19,8 @@ module Organizations
         last_invoice = organization.invoices.non_self_billed.with_generated_number.order(created_at: :desc).first
 
         if last_invoice
-            organization_invoices_count = organization.invoices.non_self_billed.with_generated_number.count
-            last_invoice.update!(organization_sequential_id: organization_invoices_count)
+          organization_invoices_count = organization.invoices.non_self_billed.with_generated_number.count
+          last_invoice.update!(organization_sequential_id: organization_invoices_count)
         end
       end
 

--- a/app/services/organizations/update_invoice_numbering_service.rb
+++ b/app/services/organizations/update_invoice_numbering_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Organizations
+  class UpdateInvoiceNumberingService < BaseService
+    Result = BaseResult[:organization]
+
+    def initialize(organization:, document_numbering:)
+      @organization = organization
+      @document_numbering = document_numbering
+      super
+    end
+
+    def call
+      result.organization = organization
+
+      return result if organization.document_numbering == document_numbering
+
+      if organization.per_customer? && document_numbering == "per_organization"
+        organization_invoices_count = organization.invoices.non_self_billed.with_generated_number.count
+        organization.invoices.order(created_at: :desc).first&.update!(organization_sequential_id: organization_invoices_count)
+      end
+
+      organization.document_numbering = document_numbering
+
+      result
+    end
+
+    private
+
+    attr_reader :organization, :document_numbering
+  end
+end

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -59,7 +59,7 @@ module Organizations
         if params.key?(:document_numbering)
           Organizations::UpdateInvoiceNumberingService.call(
             organization:,
-            document_numbering: params[:document_numbering],
+            document_numbering: params[:document_numbering]
           )
         end
 

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -25,7 +25,6 @@ module Organizations
       organization.state = params[:state] if params.key?(:state)
       organization.country = params[:country]&.upcase if params.key?(:country)
       organization.default_currency = params[:default_currency]&.upcase if params.key?(:default_currency)
-      organization.document_numbering = params[:document_numbering] if params.key?(:document_numbering)
       organization.document_number_prefix = params[:document_number_prefix] if params.key?(:document_number_prefix)
       organization.finalize_zero_amount_invoice = params[:finalize_zero_amount_invoice] if params.key?(:finalize_zero_amount_invoice)
 
@@ -54,6 +53,13 @@ module Organizations
           Organizations::UpdateInvoicePaymentDueDateService.call(
             organization:,
             net_payment_term: params[:net_payment_term]
+          )
+        end
+
+        if params.key?(:document_numbering)
+          Organizations::UpdateInvoiceNumberingService.call(
+            organization:,
+            document_numbering: params[:document_numbering],
           )
         end
 

--- a/db/migrate/20250403093628_ensure_organization_last_invoice_got_organization_sequential_id.rb
+++ b/db/migrate/20250403093628_ensure_organization_last_invoice_got_organization_sequential_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class EnsureOrganizationLastInvoiceGotOrganizationSequentialId < ActiveRecord::Migration[7.2]
+  def change
+    DatabaseMigrations::FixInvoicesOrganizationSequentialIdJob.perform_later
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6249,6 +6249,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250402135038'),
 ('20250402113844'),
+('20250403093628'),
 ('20250325162648'),
 ('20250325145324'),
 ('20250324125056'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6247,9 +6247,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250403093628'),
 ('20250402135038'),
 ('20250402113844'),
-('20250403093628'),
 ('20250325162648'),
 ('20250325145324'),
 ('20250324125056'),

--- a/spec/jobs/database_migrations/fix_invoices_organization_sequential_id_job_spec.rb
+++ b/spec/jobs/database_migrations/fix_invoices_organization_sequential_id_job_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DatabaseMigrations::FixInvoicesOrganizationSequentialIdJob do
+  subject(:perform_job) { described_class.perform_now }
+
+  let(:organization) { create(:organization, document_numbering: :per_organization) }
+
+  context "when maximum sequential_id matches invoice count" do
+    it "does not change the last invoice" do
+      invoice_1 = create(:invoice, organization:, organization_sequential_id: 1)
+      invoice_2 = create(:invoice, organization:, organization_sequential_id: 2)
+
+      expect { perform_job }
+        .to not_change { invoice_1.reload.organization_sequential_id }
+        .and not_change { invoice_2.reload.organization_sequential_id }
+    end
+  end
+
+  context "when maximum sequential_id does not match invoice count" do
+    it "updates the last invoice sequential_id" do
+      invoice_1 = create(:invoice, organization:, organization_sequential_id: 1, created_at: 2.days.ago)
+      invoice_2 = create(:invoice, organization:, organization_sequential_id: 0, created_at: 1.day.ago)
+
+      expect { perform_job }
+        .to change { invoice_2.reload.organization_sequential_id }.to(2)
+        .and not_change { invoice_1.reload.organization_sequential_id }
+    end
+
+    it "does not consider self-billed invoices" do
+      invoice_1 = create(:invoice, organization:, organization_sequential_id: 0, created_at: 2.days.ago)
+      invoice_2 = create(:invoice, :self_billed, organization:, organization_sequential_id: 0, created_at: 1.day.ago)
+
+      expect { perform_job }
+        .to change { invoice_1.reload.organization_sequential_id }.to(1)
+        .and not_change { invoice_2.reload.organization_sequential_id }
+    end
+
+    it "does not consider draft invoices" do
+      invoice_1 = create(:invoice, organization:, organization_sequential_id: 0, created_at: 2.days.ago)
+      invoice_2 = create(:invoice, :draft, organization:, organization_sequential_id: 0, created_at: 1.day.ago)
+
+      expect { perform_job }
+        .to change { invoice_1.reload.organization_sequential_id }.to(1)
+        .and not_change { invoice_2.reload.organization_sequential_id }
+    end
+  end
+
+  context "when organization has no invoices" do
+    it "does nothing" do
+      expect { perform_job }.not_to raise_error
+    end
+  end
+
+  context "when organization is on per_customer document_numbering" do
+    let(:organization) { create(:organization, document_numbering: :per_customer) }
+
+    it "does not change any invoices" do
+      invoice = create(:invoice, organization:, organization_sequential_id: 0)
+
+      expect { perform_job }
+        .not_to change { invoice.reload.organization_sequential_id }
+    end
+  end
+end

--- a/spec/scenarios/invoices/invoice_numbering_spec.rb
+++ b/spec/scenarios/invoices/invoice_numbering_spec.rb
@@ -113,7 +113,7 @@ describe "Invoice Numbering Scenario", :scenarios, type: :request, transaction: 
 
     # NOTE: October 19th: Switching to per_organization numbering and Bill subscription
     travel_to(DateTime.new(2023, 10, 19, 12, 12)) do
-      result = update_organization(document_numbering: "per_organization", document_number_prefix: "ORG-11")
+      update_organization(document_numbering: "per_organization", document_number_prefix: "ORG-11")
 
       perform_billing
 

--- a/spec/scenarios/invoices/invoice_numbering_spec.rb
+++ b/spec/scenarios/invoices/invoice_numbering_spec.rb
@@ -113,7 +113,7 @@ describe "Invoice Numbering Scenario", :scenarios, type: :request, transaction: 
 
     # NOTE: October 19th: Switching to per_organization numbering and Bill subscription
     travel_to(DateTime.new(2023, 10, 19, 12, 12)) do
-      organization.update!(document_numbering: "per_organization", document_number_prefix: "ORG-11")
+      result = update_organization(document_numbering: "per_organization", document_number_prefix: "ORG-11")
 
       perform_billing
 
@@ -129,7 +129,7 @@ describe "Invoice Numbering Scenario", :scenarios, type: :request, transaction: 
 
     # NOTE: November 19th: Switching to per_customer numbering and Bill subscription
     travel_to(DateTime.new(2023, 11, 19, 12, 12)) do
-      organization.update!(document_numbering: "per_customer")
+      update_organization(document_numbering: "per_customer")
 
       perform_billing
 
@@ -185,7 +185,7 @@ describe "Invoice Numbering Scenario", :scenarios, type: :request, transaction: 
 
     # NOTE: December 19th: Switching to per_organization numbering and Bill subscription
     travel_to(DateTime.new(2023, 12, 19, 12, 12)) do
-      organization.update!(document_numbering: "per_organization")
+      update_organization(document_numbering: "per_organization")
 
       perform_billing
 
@@ -291,7 +291,7 @@ describe "Invoice Numbering Scenario", :scenarios, type: :request, transaction: 
 
       # NOTE: October 1st: Switching to per_organization numbering and Bill subscription
       travel_to(DateTime.new(2023, 9, 30, 23, 10)) do
-        organization.update!(document_numbering: "per_organization", document_number_prefix: "ORG-11")
+        update_organization(document_numbering: "per_organization", document_number_prefix: "ORG-11")
 
         perform_billing
 
@@ -812,7 +812,7 @@ describe "Invoice Numbering Scenario", :scenarios, type: :request, transaction: 
 
       # NOTE: October 19th: Switching to per_organization numbering and Bill subscription
       travel_to(DateTime.new(2023, 10, 19, 12, 12)) do
-        organization.update!(document_numbering: "per_organization", document_number_prefix: "ORG-11")
+        update_organization(document_numbering: "per_organization", document_number_prefix: "ORG-11")
 
         perform_billing
 
@@ -828,7 +828,7 @@ describe "Invoice Numbering Scenario", :scenarios, type: :request, transaction: 
 
       # NOTE: November 19th: Switching to per_customer numbering and Bill subscription
       travel_to(DateTime.new(2023, 11, 19, 12, 12)) do
-        organization.update!(document_numbering: "per_customer")
+        update_organization(document_numbering: "per_customer")
 
         perform_billing
 
@@ -844,7 +844,7 @@ describe "Invoice Numbering Scenario", :scenarios, type: :request, transaction: 
 
       # NOTE: December 19th: Switching to per_organization numbering and Bill subscription
       travel_to(DateTime.new(2023, 12, 19, 12, 12)) do
-        organization.update!(document_numbering: "per_organization")
+        update_organization(document_numbering: "per_organization")
 
         perform_billing
 

--- a/spec/services/organizations/update_invoice_numbering_service_spec.rb
+++ b/spec/services/organizations/update_invoice_numbering_service_spec.rb
@@ -37,12 +37,11 @@ RSpec.describe Organizations::UpdateInvoiceNumberingService, type: :service do
 
       before do
         invoice1
-        invoice2 
+        invoice2
         invoice3
         self_billed_invoice
         voided_invoice
       end
-      
 
       it "updates the organization sequential id for the latest invoice" do
         expect {
@@ -72,4 +71,4 @@ RSpec.describe Organizations::UpdateInvoiceNumberingService, type: :service do
       end
     end
   end
-end 
+end

--- a/spec/services/organizations/update_invoice_numbering_service_spec.rb
+++ b/spec/services/organizations/update_invoice_numbering_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Organizations::UpdateInvoiceNumberingService, type: :service do
+  subject(:update_service) { described_class.new(organization:, document_numbering:) }
+
+  let(:organization) { create(:organization, document_numbering: "per_customer") }
+  let(:document_numbering) { "per_organization" }
+
+  describe "#call" do
+    it "updates the organization's document_numbering" do
+      result = update_service.call
+
+      expect(result).to be_success
+      expect(result.organization.per_organization?).to be_truthy
+    end
+
+    context "when document_numbering is not changing" do
+      let(:document_numbering) { "per_customer" }
+
+      it "returns early without making changes" do
+        result = update_service.call
+
+        expect(result).to be_success
+        expect(result.organization.per_customer?).to be_truthy
+      end
+    end
+
+    context "when changing from per_customer to per_organization" do
+      let(:customer) { create(:customer, organization:) }
+      let(:invoice1) { create(:invoice, customer:, organization:, status: "finalized", self_billed: false) }
+      let(:invoice2) { create(:invoice, customer:, organization:, status: "finalized", self_billed: false) }
+      let(:invoice3) { create(:invoice, customer:, organization:, status: "draft", self_billed: false) }
+      let(:voided_invoice) { create(:invoice, customer:, organization:, status: "voided", self_billed: false) }
+      let(:self_billed_invoice) { create(:invoice, customer:, organization:, status: "finalized", self_billed: true) }
+
+      before do
+        invoice1
+        invoice2 
+        invoice3
+        self_billed_invoice
+        voided_invoice
+      end
+      
+
+      it "updates the organization sequential id for the latest invoice" do
+        expect {
+          update_service.call
+        }.to change { voided_invoice.reload.organization_sequential_id }.to(3)
+
+        expect(organization.per_organization?).to be_truthy
+      end
+
+      it "only counts non-self-billed invoices with generated numbers" do
+        result = update_service.call
+
+        expect(result).to be_success
+        expect(voided_invoice.reload.organization_sequential_id).to eq(3)
+      end
+    end
+
+    context "when changing from per_organization to per_customer" do
+      let(:organization) { create(:organization, document_numbering: "per_organization") }
+      let(:document_numbering) { "per_customer" }
+
+      it "updates the organization's document_numbering without other changes" do
+        result = update_service.call
+
+        expect(result).to be_success
+        expect(result.organization.per_customer?).to be_truthy
+      end
+    end
+  end
+end 

--- a/spec/services/organizations/update_invoice_numbering_service_spec.rb
+++ b/spec/services/organizations/update_invoice_numbering_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Organizations::UpdateInvoiceNumberingService, type: :service do
       result = update_service.call
 
       expect(result).to be_success
-      expect(result.organization.per_organization?).to be_truthy
+      expect(result.organization).to be_per_organization
     end
 
     context "when document_numbering is not changing" do
@@ -23,7 +23,7 @@ RSpec.describe Organizations::UpdateInvoiceNumberingService, type: :service do
         result = update_service.call
 
         expect(result).to be_success
-        expect(result.organization.per_customer?).to be_truthy
+        expect(result.organization).to be_per_customer
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe Organizations::UpdateInvoiceNumberingService, type: :service do
           update_service.call
         }.to change { voided_invoice.reload.organization_sequential_id }.to(3)
 
-        expect(organization.per_organization?).to be_truthy
+        expect(organization).to be_per_organization
       end
 
       it "only counts non-self-billed invoices with generated numbers" do
@@ -68,7 +68,7 @@ RSpec.describe Organizations::UpdateInvoiceNumberingService, type: :service do
         result = update_service.call
 
         expect(result).to be_success
-        expect(result.organization.per_customer?).to be_truthy
+        expect(result.organization).to be_per_customer
       end
     end
   end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module ScenariosHelper
+  ### Organizations
+
+  def update_organization(params)
+    put_with_token(organization, "/api/v1/organizations", {organization: params})
+  end
+
   ### Billable metrics
 
   def create_metric(params)


### PR DESCRIPTION
- The way we were assigning organization sequential id was not efficient and doing a lot of queries
- We removed the `switched_from_customer_numbering?`
  - This should be done when the user update the organization to `per_organization` numbering

```ruby
# Instead of doing
organization
  .invoices
  .non_self_billed
   .where.not(organization_sequential_id: 0)
   .order(organization_sequential_id: :desc)
   .limit(1)
   .pick(:organization_sequential_id) || 0

# Just do
organization
  .invoices
  .non_self_billed
  .maximum(:organization_sequential_id) || 0
``` 

- Change the organization update logic when we change the document numbering

```ruby
if params.key?(:document_numbering)
  Organizations::UpdateInvoiceNumberingService.call(
    organization:,
    document_numbering: params[:document_numbering]
   )
end
```

- Create a new service `Organizations::UpdateInvoiceNumberingService` that will assign the last org sequential id to the last invoice created when changed to `per_organization`. So we don't need to check for all invoices whats the count.
- Use api calls to update the organization in the scenarios so it covers all the cases


⚠️ Before deploying : 

- [x] Make sure that no organizations are in a middle state (upgrading from `per_customer` to `per_organization`), if its the case, assign the last organization sequential id to the last invoice
- [x] QA has to be done by @nudded @ancorcruz 