### PR TITLE
Feat(multientities): graphql create and update user with billing entity

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -128,6 +128,7 @@ module Api
           :external_salesforce_id,
           :finalize_zero_amount_invoice,
           :skip_invoice_custom_sections,
+          :billing_entity_code,
           integration_customers: [
             :id,
             :external_customer_id,

--- a/app/graphql/types/customers/create_customer_input.rb
+++ b/app/graphql/types/customers/create_customer_input.rb
@@ -31,6 +31,7 @@ module Types
       argument :url, String, required: false
       argument :zipcode, String, required: false
 
+      argument :billing_entity_code, String, required: false
       argument :shipping_address, Types::Customers::AddressInput, required: false
 
       argument :metadata, [Types::Customers::Metadata::Input], required: false

--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -30,6 +30,7 @@ module Types
       argument :url, String, required: false, permission: "customers:update"
       argument :zipcode, String, required: false, permission: "customers:update"
 
+      argument :billing_entity_code, String, required: false, permission: "customers:update"
       argument :shipping_address, Types::Customers::AddressInput, required: false, permission: "customers:update"
 
       argument :metadata, [Types::Customers::Metadata::Input], required: false, permission: "customers:update"

--- a/schema.graphql
+++ b/schema.graphql
@@ -2103,6 +2103,7 @@ input CreateCustomerInput {
   addressLine1: String
   addressLine2: String
   billingConfiguration: CustomerBillingConfigurationInput
+  billingEntityCode: String
   city: String
 
   """
@@ -9090,6 +9091,7 @@ input UpdateCustomerInput {
   applicableInvoiceCustomSectionIds: [ID!]
   appliedDunningCampaignId: ID
   billingConfiguration: CustomerBillingConfigurationInput
+  billingEntityCode: String
   city: String
 
   """

--- a/schema.json
+++ b/schema.json
@@ -8545,6 +8545,18 @@
               "deprecationReason": null
             },
             {
+              "name": "billingEntityCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "shippingAddress",
               "description": null,
               "type": {
@@ -45240,6 +45252,18 @@
             },
             {
               "name": "zipcode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billingEntityCode",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
   let(:required_permissions) { "customers:create" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
+  let(:billing_entity) { create(:billing_entity, organization:) }
   let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:tax) { create(:tax, organization:) }
 
@@ -35,6 +36,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           shippingAddress { addressLine1 city state }
           metadata { id, key, value, displayInInvoice }
           taxes { code }
+          billingEntity { code }
         }
       }
     GQL
@@ -78,6 +80,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           currency: "EUR",
           netPaymentTerm: 30,
           finalizeZeroAmountInvoice: "skip",
+          billingEntityCode: billing_entity.code,
           providerCustomer: {
             providerCustomerId: "cu_12345",
             providerPaymentMethods: ["card"]
@@ -130,6 +133,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
       expect(result_data["metadata"].count).to eq(1)
       expect(result_data["metadata"][0]["value"]).to eq("John Doe")
       expect(result_data["taxes"][0]["code"]).to eq(tax.code)
+      expect(result_data["billingEntity"]["code"]).to eq(billing_entity.code)
     end
   end
 

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
   let(:required_permissions) { "customers:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
+  let(:billing_entity) { create(:billing_entity, organization:) }
   let(:customer) { create(:customer, organization:, legal_name: nil) }
   let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:tax) { create(:tax, organization:) }
@@ -31,6 +32,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           canEditAttributes
           invoiceGracePeriod
           finalizeZeroAmountInvoice
+          billingEntity { code }
           providerCustomer { id, providerCustomerId, providerPaymentMethods }
           billingConfiguration { id, documentLocale }
           metadata { id, key, value, displayInInvoice }
@@ -61,6 +63,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
       currency: "USD",
       netPaymentTerm: 3,
       finalizeZeroAmountInvoice: "skip",
+      billingEntityCode: billing_entity.code,
       providerCustomer: {
         providerCustomerId: "cu_12345",
         providerPaymentMethods: %w[card sepa_debit]
@@ -133,6 +136,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
       expect(result_data["metadata"][0]["key"]).to eq("test-key")
       expect(result_data["taxes"][0]["code"]).to eq(tax.code)
       expect(result_data["applicableInvoiceCustomSections"]).to match_array(invoice_custom_sections.map { |section| {"id" => section.id} })
+      expect(result_data["billingEntity"]["code"]).to eq(billing_entity.code)
     end
   end
 

--- a/spec/graphql/types/customers/create_customer_input_spec.rb
+++ b/spec/graphql/types/customers/create_customer_input_spec.rb
@@ -39,5 +39,6 @@ RSpec.describe Types::Customers::CreateCustomerInput do
     expect(subject).to accept_argument(:integration_customers).of_type("[IntegrationCustomerInput!]")
     expect(subject).to accept_argument(:billing_configuration).of_type("CustomerBillingConfigurationInput")
     expect(subject).to accept_argument(:finalize_zero_amount_invoice).of_type("FinalizeZeroAmountInvoiceEnum")
+    expect(subject).to accept_argument(:billing_entity_code).of_type("String")
   end
 end

--- a/spec/graphql/types/customers/update_customer_input_spec.rb
+++ b/spec/graphql/types/customers/update_customer_input_spec.rb
@@ -43,5 +43,6 @@ RSpec.describe Types::Customers::UpdateCustomerInput do
 
     expect(subject).to accept_argument(:applied_dunning_campaign_id).of_type("ID")
     expect(subject).to accept_argument(:exclude_from_dunning_campaign).of_type("Boolean")
+    expect(subject).to accept_argument(:billing_entity_code).of_type("String")
   end
 end

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       expect(json[:customer][:currency]).to eq(create_params[:currency])
       expect(json[:customer][:external_salesforce_id]).to eq(create_params[:external_salesforce_id])
       expect(json[:customer][:account_type]).to eq("customer")
+      expect(json[:customer][:billing_entity_code]).to eq(organization.default_billing_entity.code)
     end
 
     context "with premium features" do
@@ -301,6 +302,24 @@ RSpec.describe Api::V1::CustomersController, type: :request do
 
           expect(json[:error_details][:invoice_custom_sections]).to include("skip_sections_and_selected_ids_sent_together")
         end
+      end
+    end
+
+    context "when billing_entity_code is provided" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:create_params) do
+        {
+          external_id: SecureRandom.uuid,
+          name: "Foo Bar",
+          billing_entity_code: billing_entity.code
+        }
+      end
+
+      it "creates customer associated to the provided billing_entity" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:customer][:billing_entity_code]).to eq(billing_entity.code)
       end
     end
   end


### PR DESCRIPTION
## Context

Update customer accepts billing_entity_id

## Description

Updated graphql inputs for create_customer and update_customer to receive billing_entity_id and send it to the services