### PR TITLE
fix(payments): Fix payment of a one time payment request

### DIFF
--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -30,11 +30,10 @@ module PaymentRequests
       end
 
       def update_payment_status(organization_id:, status:, stripe_payment:)
-        # TODO: do we have one-time payments for payment requests?
-        payment = if stripe_payment.metadata[:payment_type] == "one-time"
-          create_payment(stripe_payment)
-        else
-          Payment.find_by(provider_payment_id: stripe_payment.id)
+        payment = Payment.find_by(provider_payment_id: stripe_payment.id)
+
+        if !payment && stripe_payment.metadata[:payment_type] == "one-time"
+          payment = create_payment(stripe_payment)
         end
 
         unless payment


### PR DESCRIPTION
## Context

There was a bug when a payment for payment request was initiated via clicking a payment link in an email.
In that case we were creating a new payment instead of finding an existing one by payment provider id.
That new payment was not created due to a unique index on `provider_payment_id` and `payment_provider_id`.

## Description

This PR fixes the described issue by fixing `Invoices::Payments::StripeService#update_payment_status` method implementation.