### PR TITLE
fix: fix credit note applied taxes

### DIFF
--- a/app/services/invoices/aggregate_amounts_and_taxes_from_fees.rb
+++ b/app/services/invoices/aggregate_amounts_and_taxes_from_fees.rb
@@ -43,7 +43,7 @@ module Invoices
           amount_currency: t.amount_currency,
 
           amount_cents: applied_taxes.sum(&:amount_cents),
-          fees_amount_cents: applied_taxes.sum(&:amount_cents),
+          fees_amount_cents: applied_taxes.sum { |at| at.fee.sub_total_excluding_taxes_amount_cents },
           taxable_base_amount_cents: applied_taxes.sum { |at| at.fee.taxes_base_rate * at.fee.sub_total_excluding_taxes_amount_cents }
         )
       end

--- a/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
+++ b/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Invoices::AggregateAmountsAndTaxesFromFees, type: :service do
     expect(applied_tax_5.tax_description).to eq tax_5.description
     expect(applied_tax_5.tax_rate).to eq tax_5.rate
     expect(applied_tax_5.amount_cents).to eq(9 + 16)
+    expect(applied_tax_5.fees_amount_cents).to eq(200 + 120)
     expect(applied_tax_5.taxable_base_amount_cents).to eq(200 + 120)
 
     applied_tax_12 = invoice.applied_taxes.find { |at| at.tax_code == tax_12.code }
@@ -42,6 +43,7 @@ RSpec.describe Invoices::AggregateAmountsAndTaxesFromFees, type: :service do
     expect(applied_tax_12.tax_description).to eq tax_12.description
     expect(applied_tax_12.tax_rate).to eq tax_12.rate
     expect(applied_tax_12.amount_cents).to eq(2 + 11)
+    expect(applied_tax_12.fees_amount_cents).to eq(120 + 50)
     expect(applied_tax_12.taxable_base_amount_cents).to eq(120 + 50)
   end
 end


### PR DESCRIPTION
## Context

For in advance invoice applied tax objects had invalid data

## Description

This PR fixes creation of applied tax for in advance invoice
