### PR TITLE
feat(avalara-integration): add support for avalara mapping

### DIFF
--- a/app/models/integration_collection_mappings/avalara_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/avalara_collection_mapping.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module IntegrationCollectionMappings
+  class AvalaraCollectionMapping < BaseCollectionMapping
+  end
+end
+
+# == Schema Information
+#
+# Table name: integration_collection_mappings
+#
+#  id             :uuid             not null, primary key
+#  mapping_type   :integer          not null
+#  settings       :jsonb            not null
+#  type           :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  integration_id :uuid             not null
+#
+# Indexes
+#
+#  index_int_collection_mappings_on_mapping_type_and_int_id  (mapping_type,integration_id) UNIQUE
+#  index_integration_collection_mappings_on_integration_id   (integration_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (integration_id => integrations.id)
+#

--- a/app/models/integration_mappings/avalara_mapping.rb
+++ b/app/models/integration_mappings/avalara_mapping.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module IntegrationMappings
+  class AvalaraMapping < BaseMapping
+  end
+end
+
+# == Schema Information
+#
+# Table name: integration_mappings
+#
+#  id             :uuid             not null, primary key
+#  mappable_type  :string           not null
+#  settings       :jsonb            not null
+#  type           :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  integration_id :uuid             not null
+#  mappable_id    :uuid             not null
+#
+# Indexes
+#
+#  index_integration_mappings_on_integration_id  (integration_id)
+#  index_integration_mappings_on_mappable        (mappable_type,mappable_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (integration_id => integrations.id)
+#

--- a/app/services/integration_collection_mappings/factory.rb
+++ b/app/services/integration_collection_mappings/factory.rb
@@ -12,6 +12,8 @@ module IntegrationCollectionMappings
         IntegrationCollectionMappings::NetsuiteCollectionMapping
       when "Integrations::AnrokIntegration"
         IntegrationCollectionMappings::AnrokCollectionMapping
+      when "Integrations::AvalaraIntegration"
+        IntegrationCollectionMappings::AvalaraCollectionMapping
       when "Integrations::XeroIntegration"
         IntegrationCollectionMappings::XeroCollectionMapping
       else

--- a/app/services/integration_mappings/factory.rb
+++ b/app/services/integration_mappings/factory.rb
@@ -12,6 +12,8 @@ module IntegrationMappings
         IntegrationMappings::NetsuiteMapping
       when "Integrations::AnrokIntegration"
         IntegrationMappings::AnrokMapping
+      when "Integrations::AvalaraIntegration"
+        IntegrationMappings::AvalaraMapping
       when "Integrations::XeroIntegration"
         IntegrationMappings::XeroMapping
       else


### PR DESCRIPTION
## Context

Currently Lago adds integration with tax provider Avalara.

## Description

This PR adds models and base support for mapping. In Lago, _single-table-inheritance_ is used for storing mapping data, so this PR only handles new models and factory classes
