### PR TITLE
fix(cashfree): wrong module name

### DIFF
--- a/app/services/payment_providers/create_payment_factory.rb
+++ b/app/services/payment_providers/create_payment_factory.rb
@@ -11,7 +11,7 @@ module PaymentProviders
       when :adyen
         PaymentProviders::Adyen::Payments::CreateService
       when :cashfree
-        PaymentProviders::Cachfree::Payments::CreateService
+        PaymentProviders::Cashfree::Payments::CreateService
       when :gocardless
         PaymentProviders::Gocardless::Payments::CreateService
       when :stripe


### PR DESCRIPTION
Typo in the module name but it has been [this way since the feature was added](https://github.com/getlago/lago-api/pull/2767/files#diff-5fdcae1d090ff3f90fb788278788fe3e73e3b46c1bf899379ee97c88c7848ccfR15-R16). This payment provider is "community maintained".

