### PR TITLE
misc(processor): Change config for refresh

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -168,7 +168,7 @@ module Clockwork
   end
 
   # NOTE: Enable wallets and lifetime usage refresh from the events-processor
-  if ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"].present?
+  if ENV["LAGO_REDIS_STORE_URL"].present?
     every(1.minute, "schedule:refresh_flagged_subscriptions") do
       Clock::ConsumeSubscriptionRefreshedQueueJob
         .set(sentry: {"slug" => "lago_refresh_flagged_subscriptions", "cron" => "*/1 * * * *"})


### PR DESCRIPTION
## Description

This PR changes the variable used to check if the refresh from events processor is enable on wallet and lifetime usage from `LAGO_KAFKA_BOOTSTRAP_SERVERS` to `LAGO_REDIS_STORE_URL`.
This reason behind this is that the Kafka config is not defined on clock service