### PR TITLE
feat: Add section_type to InvoiceCustomSections to support different section types

### DIFF
--- a/app/graphql/resolvers/invoice_custom_sections_resolver.rb
+++ b/app/graphql/resolvers/invoice_custom_sections_resolver.rb
@@ -15,7 +15,7 @@ module Resolvers
     type Types::InvoiceCustomSections::Object.collection_type, null: true
 
     def resolve(page: nil, limit: nil)
-      current_organization.invoice_custom_sections
+      current_organization.manual_invoice_custom_sections
         .joins('LEFT JOIN invoice_custom_section_selections ON invoice_custom_sections.id = invoice_custom_section_selections.invoice_custom_section_id
                 AND invoice_custom_section_selections.customer_id is NULL')
         .order(

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -94,7 +94,7 @@ module Types
 
       field :finalize_zero_amount_invoice, Types::Customers::FinalizeZeroAmountInvoiceEnum, null: true, description: "Options for handling invoices with a zero total amount."
 
-      field :applicable_invoice_custom_sections, [Types::InvoiceCustomSections::Object], null: true, description: "Invoice custom sections applicable to the customer"
+      field :configurable_invoice_custom_sections, [Types::InvoiceCustomSections::Object], null: true, description: "Invoice custom sections manually configured by the customer"
       field :has_overwritten_invoice_custom_sections_selection, Boolean, null: true, description: "Define if the customer has custom invoice custom sections selection"
       field :skip_invoice_custom_sections, Boolean, null: true, description: "Skip invoice custom sections for the customer"
 
@@ -157,7 +157,7 @@ module Types
       end
 
       def has_overwritten_invoice_custom_sections_selection
-        !object.skip_invoice_custom_sections && object.selected_invoice_custom_sections.any?
+        !object.skip_invoice_custom_sections && object.manual_selected_invoice_custom_sections.any?
       end
     end
   end

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -94,7 +94,7 @@ module Types
 
       field :finalize_zero_amount_invoice, Types::Customers::FinalizeZeroAmountInvoiceEnum, null: true, description: "Options for handling invoices with a zero total amount."
 
-      field :configurable_invoice_custom_sections, [Types::InvoiceCustomSections::Object], null: true, description: "Invoice custom sections manually configured by the customer"
+      field :configurable_invoice_custom_sections, [Types::InvoiceCustomSections::Object], null: true, description: "Invoice custom sections manually configured for the customer"
       field :has_overwritten_invoice_custom_sections_selection, Boolean, null: true, description: "Define if the customer has custom invoice custom sections selection"
       field :skip_invoice_custom_sections, Boolean, null: true, description: "Skip invoice custom sections for the customer"
 

--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -54,7 +54,7 @@ module Types
       argument :exclude_from_dunning_campaign, Boolean, required: false
 
       # Invoice custom sections settings
-      argument :applicable_invoice_custom_section_ids, [ID], required: false
+      argument :configurable_invoice_custom_section_ids, [ID], required: false
       argument :skip_invoice_custom_sections, Boolean, required: false
     end
   end

--- a/app/models/invoice_custom_section.rb
+++ b/app/models/invoice_custom_section.rb
@@ -7,6 +7,10 @@ class InvoiceCustomSection < ApplicationRecord
   belongs_to :organization
   has_many :invoice_custom_section_selections, dependent: :destroy
 
+  SECTION_TYPES = {manual: "manual", system_generated: "system_generated"}.freeze
+  enum :section_type, SECTION_TYPES, default: :manual, prefix: :section_type
+  attribute :payment_type, :string
+
   validates :name, presence: true
   validates :code,
     presence: true,
@@ -30,6 +34,7 @@ end
 #  details         :string
 #  display_name    :string
 #  name            :string           not null
+#  section_type    :enum             default("manual"), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :uuid             not null
@@ -39,6 +44,7 @@ end
 #  idx_on_organization_id_deleted_at_225e3f789d               (organization_id,deleted_at)
 #  index_invoice_custom_sections_on_organization_id           (organization_id)
 #  index_invoice_custom_sections_on_organization_id_and_code  (organization_id,code) UNIQUE WHERE (deleted_at IS NULL)
+#  index_invoice_custom_sections_on_section_type              (section_type)
 #
 # Foreign Keys
 #

--- a/app/models/invoice_custom_section.rb
+++ b/app/models/invoice_custom_section.rb
@@ -9,7 +9,6 @@ class InvoiceCustomSection < ApplicationRecord
 
   SECTION_TYPES = {manual: "manual", system_generated: "system_generated"}.freeze
   enum :section_type, SECTION_TYPES, default: :manual, prefix: :section_type
-  attribute :payment_type, :string
 
   validates :name, presence: true
   validates :code,

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -63,6 +63,8 @@ class Organization < ApplicationRecord
 
   has_many :invoice_custom_sections
   has_many :invoice_custom_section_selections
+  has_many :manual_invoice_custom_sections, -> { where(section_type: :manual) }, class_name: "InvoiceCustomSection"
+  has_many :system_generated_invoice_custom_sections, -> { where(section_type: :system_generated) }, class_name: "InvoiceCustomSection"
   has_many :selected_invoice_custom_sections, through: :invoice_custom_section_selections, source: :invoice_custom_section
 
   has_one_attached :logo

--- a/app/services/customers/manage_invoice_custom_sections_service.rb
+++ b/app/services/customers/manage_invoice_custom_sections_service.rb
@@ -50,11 +50,16 @@ module Customers
 
     def assign_selected_sections
       # Note: when assigning organization's sections, an empty array will be sent
-      if section_ids.nil?
-        return customer.selected_invoice_custom_sections = customer.organization.invoice_custom_sections.where(code: section_codes)
+      selected_sections = if section_ids
+        customer.organization.invoice_custom_sections.where(id: section_ids)
+      elsif section_codes
+        customer.organization.invoice_custom_sections.where(code: section_codes)
+      else
+        InvoiceCustomSection.none
       end
 
-      customer.selected_invoice_custom_sections = customer.organization.invoice_custom_sections.where(id: section_ids)
+      system_generated_sections = customer.system_generated_invoice_custom_sections
+      customer.selected_invoice_custom_sections = selected_sections + system_generated_sections
     end
   end
 end

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -137,7 +137,7 @@ module Customers
         Customers::ManageInvoiceCustomSectionsService.call(
           customer:,
           skip_invoice_custom_sections: args[:skip_invoice_custom_sections],
-          section_ids: args[:applicable_invoice_custom_section_ids]
+          section_ids: args[:configurable_invoice_custom_section_ids]
         ).raise_if_error!
 
         customer.save!

--- a/db/migrate/20250403110833_add_section_type_to_invoice_custom_sections.rb
+++ b/db/migrate/20250403110833_add_section_type_to_invoice_custom_sections.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AddSectionTypeToInvoiceCustomSections < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    create_enum :invoice_custom_section_type, %w[manual system_generated]
+
+    safety_assured do
+      change_table :invoice_custom_sections, bulk: true do |t|
+        t.column :section_type, :enum, enum_type: "invoice_custom_section_type", null: true
+      end
+    end
+
+    # Backfill all existing rows as manual
+    InvoiceCustomSection.unscoped.in_batches(of: 10_000).update_all(section_type: "manual") # rubocop:disable Rails/SkipsModelValidations
+
+    safety_assured do
+      execute <<~SQL
+        ALTER TABLE invoice_custom_sections ALTER COLUMN section_type SET DEFAULT 'manual';
+      SQL
+      execute <<~SQL
+        ALTER TABLE invoice_custom_sections ALTER COLUMN section_type SET NOT NULL;
+      SQL
+    end
+  end
+
+  def down
+    change_table :invoice_custom_sections, bulk: true do |t|
+      t.remove :section_type
+    end
+
+    drop_enum :invoice_custom_section_type
+  end
+end

--- a/db/migrate/20250407202459_add_section_type_index_to_invoice_custom_sections.rb
+++ b/db/migrate/20250407202459_add_section_type_index_to_invoice_custom_sections.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddSectionTypeIndexToInvoiceCustomSections < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    add_index :invoice_custom_sections, :section_type, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :invoice_custom_sections, column: :section_type
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -256,6 +256,7 @@ DROP INDEX IF EXISTS public.index_invoice_subscriptions_on_charges_from_and_to_d
 DROP INDEX IF EXISTS public.index_invoice_subscriptions_boundaries;
 DROP INDEX IF EXISTS public.index_invoice_metadata_on_invoice_id_and_key;
 DROP INDEX IF EXISTS public.index_invoice_metadata_on_invoice_id;
+DROP INDEX IF EXISTS public.index_invoice_custom_sections_on_section_type;
 DROP INDEX IF EXISTS public.index_invoice_custom_sections_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_invoice_custom_sections_on_organization_id;
 DROP INDEX IF EXISTS public.index_invoice_custom_section_selections_on_organization_id;
@@ -612,6 +613,7 @@ DROP TYPE IF EXISTS public.tax_status;
 DROP TYPE IF EXISTS public.subscription_invoicing_reason;
 DROP TYPE IF EXISTS public.payment_type;
 DROP TYPE IF EXISTS public.payment_payable_payment_status;
+DROP TYPE IF EXISTS public.invoice_custom_section_type;
 DROP TYPE IF EXISTS public.inbound_webhook_status;
 DROP TYPE IF EXISTS public.entity_document_numbering;
 DROP TYPE IF EXISTS public.customer_type;
@@ -693,6 +695,16 @@ CREATE TYPE public.inbound_webhook_status AS ENUM (
     'processing',
     'succeeded',
     'failed'
+);
+
+
+--
+-- Name: invoice_custom_section_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.invoice_custom_section_type AS ENUM (
+    'manual',
+    'system_generated'
 );
 
 
@@ -1836,7 +1848,8 @@ CREATE TABLE public.invoice_custom_sections (
     organization_id uuid NOT NULL,
     deleted_at timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    section_type public.invoice_custom_section_type DEFAULT 'manual'::public.invoice_custom_section_type NOT NULL
 );
 
 
@@ -4439,6 +4452,13 @@ CREATE UNIQUE INDEX index_invoice_custom_sections_on_organization_id_and_code ON
 
 
 --
+-- Name: index_invoice_custom_sections_on_section_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_invoice_custom_sections_on_section_type ON public.invoice_custom_sections USING btree (section_type);
+
+
+--
 -- Name: index_invoice_metadata_on_invoice_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6247,6 +6267,8 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250407202459'),
+('20250403110833'),
 ('20250403093628'),
 ('20250402135038'),
 ('20250402113844'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -3422,7 +3422,7 @@ type Customer {
   city: String
 
   """
-  Invoice custom sections manually configured by the customer
+  Invoice custom sections manually configured for the customer
   """
   configurableInvoiceCustomSections: [InvoiceCustomSection!]
   country: CountryCode

--- a/schema.graphql
+++ b/schema.graphql
@@ -3408,11 +3408,6 @@ type Customer {
   addressLine1: String
   addressLine2: String
   anrokCustomer: AnrokCustomer
-
-  """
-  Invoice custom sections applicable to the customer
-  """
-  applicableInvoiceCustomSections: [InvoiceCustomSection!]
   applicableTimezone: TimezoneEnum!
   appliedAddOns: [AppliedAddOn!]
   appliedCoupons: [AppliedCoupon!]
@@ -3425,6 +3420,11 @@ type Customer {
   """
   canEditAttributes: Boolean!
   city: String
+
+  """
+  Invoice custom sections manually configured by the customer
+  """
+  configurableInvoiceCustomSections: [InvoiceCustomSection!]
   country: CountryCode
   createdAt: ISO8601DateTime!
   creditNotes: [CreditNote!]
@@ -9115,7 +9115,6 @@ input UpdateCustomerInput {
   accountType: CustomerAccountTypeEnum
   addressLine1: String
   addressLine2: String
-  applicableInvoiceCustomSectionIds: [ID!]
   appliedDunningCampaignId: ID
   billingConfiguration: CustomerBillingConfigurationInput
   billingEntityCode: String
@@ -9125,6 +9124,7 @@ input UpdateCustomerInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  configurableInvoiceCustomSectionIds: [ID!]
   country: CountryCode
   currency: CurrencyEnum
   customerType: CustomerTypeEnum

--- a/schema.json
+++ b/schema.json
@@ -14070,26 +14070,6 @@
               "args": []
             },
             {
-              "name": "applicableInvoiceCustomSections",
-              "description": "Invoice custom sections applicable to the customer",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "InvoiceCustomSection",
-                    "ofType": null
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
               "name": "applicableTimezone",
               "description": null,
               "type": {
@@ -14208,6 +14188,26 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "configurableInvoiceCustomSections",
+              "description": "Invoice custom sections manually configured by the customer",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "InvoiceCustomSection",
+                    "ofType": null
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -45603,7 +45603,7 @@
               "deprecationReason": null
             },
             {
-              "name": "applicableInvoiceCustomSectionIds",
+              "name": "configurableInvoiceCustomSectionIds",
               "description": null,
               "type": {
                 "kind": "LIST",

--- a/schema.json
+++ b/schema.json
@@ -14195,7 +14195,7 @@
             },
             {
               "name": "configurableInvoiceCustomSections",
-              "description": "Invoice custom sections manually configured by the customer",
+              "description": "Invoice custom sections manually configured for the customer",
               "type": {
                 "kind": "LIST",
                 "name": null,

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           billingConfiguration { id, documentLocale }
           metadata { id, key, value, displayInInvoice }
           taxes { code }
-          applicableInvoiceCustomSections { id }
+          configurableInvoiceCustomSections { id }
         }
       }
     GQL
@@ -79,7 +79,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
         }
       ],
       taxCodes: [tax.code],
-      applicableInvoiceCustomSectionIds: invoice_custom_sections.map(&:id)
+      configurableInvoiceCustomSectionIds: invoice_custom_sections.map(&:id)
     }
   end
 
@@ -135,7 +135,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
       expect(result_data["billingConfiguration"]["id"]).to eq("#{customer.id}-c0nf")
       expect(result_data["metadata"][0]["key"]).to eq("test-key")
       expect(result_data["taxes"][0]["code"]).to eq(tax.code)
-      expect(result_data["applicableInvoiceCustomSections"]).to match_array(invoice_custom_sections.map { |section| {"id" => section.id} })
+      expect(result_data["configurableInvoiceCustomSections"]).to match_array(invoice_custom_sections.map { |section| {"id" => section.id} })
       expect(result_data["billingEntity"]["code"]).to eq(billing_entity.code)
     end
   end

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
           appliedCoupons { id amountCents amountCurrency coupon { id name } }
           appliedAddOns { id amountCents amountCurrency addOn { id name } }
           taxes { id code name }
-          applicableInvoiceCustomSections { id name }
+          configurableInvoiceCustomSections { id name }
           creditNotes {
             id
             creditStatus
@@ -111,7 +111,7 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
       expect(customer_response["creditNotesBalanceAmountCents"]).to eq("120")
       expect(customer_response["hasOverwrittenInvoiceCustomSectionsSelection"]).to be true
       expect(customer_response["skipInvoiceCustomSections"]).to be false
-      expect(customer_response["applicableInvoiceCustomSections"].count).to eq(2)
+      expect(customer_response["configurableInvoiceCustomSections"].count).to eq(2)
     end
   end
 

--- a/spec/graphql/resolvers/invoice_custom_sections_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_custom_sections_resolver_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe Resolvers::InvoiceCustomSectionsResolver, type: :graphql do
       create(:invoice_custom_section, organization:, name: "c"),
       create(:invoice_custom_section, organization:, name: "a"),
       create(:invoice_custom_section, organization:, name: "z"),
-      create(:invoice_custom_section, organization:, name: "n")
+      create(:invoice_custom_section, organization:, name: "n"),
+      create(:invoice_custom_section, organization:, name: "not show", section_type: "system_generated"),
+      create(:invoice_custom_section, organization:, name: "not show2", section_type: "system_generated")
     ]
   end
 

--- a/spec/graphql/resolvers/invoice_custom_sections_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_custom_sections_resolver_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe Resolvers::InvoiceCustomSectionsResolver, type: :graphql do
       create(:invoice_custom_section, organization:, name: "a"),
       create(:invoice_custom_section, organization:, name: "z"),
       create(:invoice_custom_section, organization:, name: "n"),
-      create(:invoice_custom_section, organization:, name: "not show", section_type: "system_generated"),
-      create(:invoice_custom_section, organization:, name: "not show2", section_type: "system_generated")
+      create(:invoice_custom_section, organization:, name: "not show", section_type: "system_generated")
     ]
   end
 

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -82,5 +82,6 @@ RSpec.describe Types::Customers::Object do
     expect(subject).to have_field(:exclude_from_dunning_campaign).of_type("Boolean!")
     expect(subject).to have_field(:last_dunning_campaign_attempt).of_type("Int!")
     expect(subject).to have_field(:last_dunning_campaign_attempt_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:configurable_invoice_custom_sections).of_type("[InvoiceCustomSection!]")
   end
 end

--- a/spec/graphql/types/customers/update_customer_input_spec.rb
+++ b/spec/graphql/types/customers/update_customer_input_spec.rb
@@ -44,5 +44,8 @@ RSpec.describe Types::Customers::UpdateCustomerInput do
     expect(subject).to accept_argument(:applied_dunning_campaign_id).of_type("ID")
     expect(subject).to accept_argument(:exclude_from_dunning_campaign).of_type("Boolean")
     expect(subject).to accept_argument(:billing_entity_code).of_type("String")
+
+    expect(subject).to accept_argument(:configurable_invoice_custom_section_ids).of_type("[ID!]")
+    expect(subject).to accept_argument(:skip_invoice_custom_sections).of_type("Boolean")
   end
 end

--- a/spec/models/invoice_custom_section_spec.rb
+++ b/spec/models/invoice_custom_section_spec.rb
@@ -6,4 +6,17 @@ RSpec.describe InvoiceCustomSection, type: :model do
   subject(:invoice_custom_section) { create(:invoice_custom_section) }
 
   it { is_expected.to belong_to(:organization) }
+
+  describe "enums" do
+    it "defines section_type enum with correct values" do
+      expect(described_class.section_types).to eq(
+        "manual" => "manual",
+        "system_generated" => "system_generated"
+      )
+    end
+
+    it "has manual as the default section_type" do
+      expect(invoice_custom_section.section_type).to eq("manual")
+    end
+  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:daily_usages) }
   it { is_expected.to have_many(:invoice_custom_sections) }
   it { is_expected.to have_many(:invoice_custom_section_selections) }
+  it { is_expected.to have_many(:manual_invoice_custom_sections) }
+  it { is_expected.to have_many(:system_generated_invoice_custom_sections) }
   it { is_expected.to have_many(:selected_invoice_custom_sections) }
 
   it { is_expected.to have_one(:applied_dunning_campaign).conditions(applied_to_organization: true) }
@@ -408,6 +410,22 @@ RSpec.describe Organization, type: :model do
 
     it "returns the count of failed tax invoices" do
       expect(failed_tax_invoices_count).to eq(2)
+    end
+  end
+
+  describe "scoped invoice_custom_sections" do
+    let(:organization) { create(:organization) }
+    let(:manual_section) { create(:invoice_custom_section, organization:, section_type: :manual) }
+    let(:system_generated_section) { create(:invoice_custom_section, organization:, section_type: :system_generated) }
+
+    before do
+      manual_section
+      system_generated_section
+    end
+
+    it "returns the correct invoice custom sections for each scope" do
+      expect(organization.manual_invoice_custom_sections).to contain_exactly(manual_section)
+      expect(organization.system_generated_invoice_custom_sections).to contain_exactly(system_generated_section)
     end
   end
 end

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -465,7 +465,7 @@ RSpec.describe Customers::UpdateService, type: :service do
         let(:update_args) do
           {
             id: customer.id,
-            applicable_invoice_custom_section_ids: []
+            configurable_invoice_custom_section_ids: []
           }
         end
 
@@ -481,7 +481,7 @@ RSpec.describe Customers::UpdateService, type: :service do
         let(:update_args) do
           {
             id: customer.id,
-            applicable_invoice_custom_section_ids: invoice_custom_sections[1..2].map(&:id)
+            configurable_invoice_custom_section_ids: invoice_custom_sections[1..2].map(&:id)
           }
         end
 
@@ -496,7 +496,7 @@ RSpec.describe Customers::UpdateService, type: :service do
         let(:update_args) do
           {
             id: customer.id,
-            applicable_invoice_custom_section_ids: invoice_custom_sections[1..2].map(&:id)
+            configurable_invoice_custom_section_ids: invoice_custom_sections[1..2].map(&:id)
           }
         end
 
@@ -515,7 +515,7 @@ RSpec.describe Customers::UpdateService, type: :service do
           {
             id: customer.id,
             skip_invoice_custom_sections: true,
-            applicable_invoice_custom_section_ids: invoice_custom_sections[1..2].map(&:id)
+            configurable_invoice_custom_section_ids: invoice_custom_sections[1..2].map(&:id)
           }
         end
 


### PR DESCRIPTION
## Context

Currently, users have no way to include bank transfer instructions or other automatic content directly on invoices.

To support this in a clean and scalable way, we’re introducing a section_type enum to distinguish between different types of invoice custom sections `manual` and `system_generated`.

This PR focuses only on introducing the structure needed to support that functionality in future changes.

## Description

This PR introduces the following changes:

- Added a new section_type enum column to invoice_custom_sections:
  - manual: user-defined sections (default)
  - system_generated: will be used for auto-generated content (e.g., Stripe funding instructions)
- Updated InvoiceCustomSection model with enum declaration and default value.
- Added two scoped associations in Organization:
  - manual_invoice_custom_sections
  - system_generated_invoice_custom_sections
- Added corresponding model specs to ensure proper behavior of the enum and scoped associations.

No logic yet for auto-generating or assigning system-generated sections — that will come in a follow-up PR.