### PR TITLE
feat: Add Stripe funding instructions as system-generated invoice custom sections

### DIFF
--- a/app/jobs/payment_provider_customers/stripe_sync_funding_instructions_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_sync_funding_instructions_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class StripeSyncFundingInstructionsJob < ApplicationJob
+    queue_as :providers
+
+    retry_on ::Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
+    retry_on ::Stripe::APIError, wait: :polynomially_longer, attempts: 6
+    retry_on ::Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
+    retry_on ActiveJob::DeserializationError
+
+    def perform(stripe_customer)
+      result = PaymentProviderCustomers::Stripe::SyncFundingInstructionsService.new(stripe_customer).call
+      result.raise_if_error!
+    rescue BaseService::UnauthorizedFailure => e
+      Rails.logger.warn(e.message)
+    end
+  end
+end

--- a/app/jobs/payment_provider_customers/stripe_sync_funding_instructions_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_sync_funding_instructions_job.rb
@@ -12,8 +12,6 @@ module PaymentProviderCustomers
     def perform(stripe_customer)
       result = PaymentProviderCustomers::Stripe::SyncFundingInstructionsService.new(stripe_customer).call
       result.raise_if_error!
-    rescue BaseService::UnauthorizedFailure => e
-      Rails.logger.warn(e.message)
     end
   end
 end

--- a/app/jobs/payment_provider_customers/stripe_sync_funding_instructions_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_sync_funding_instructions_job.rb
@@ -12,6 +12,8 @@ module PaymentProviderCustomers
     def perform(stripe_customer)
       result = PaymentProviderCustomers::Stripe::SyncFundingInstructionsService.new(stripe_customer).call
       result.raise_if_error!
+    rescue BaseService::UnauthorizedFailure => e
+      Rails.logger.warn(e.message)
     end
   end
 end

--- a/app/services/invoice_custom_sections/funding_instructions_formatter_service.rb
+++ b/app/services/invoice_custom_sections/funding_instructions_formatter_service.rb
@@ -18,10 +18,10 @@ module InvoiceCustomSections
 
         case funding_data[:type]
         when "us_bank_transfer" then format_us_bank_transfer(lines, t)
-        when "mx_bank_transfer" then format_mx_bank_transfer(lines, t)
-        when "jp_bank_transfer" then format_jp_bank_transfer(lines, t)
-        when "gb_bank_transfer" then format_gb_bank_transfer(lines, t)
-        when "eu_bank_transfer" then format_eu_bank_transfer(lines, t)
+        when "mx_bank_transfer" then lines << format_mx_bank_transfer(t)
+        when "jp_bank_transfer" then lines << format_jp_bank_transfer(t)
+        when "gb_bank_transfer" then lines << format_gb_bank_transfer(t)
+        when "eu_bank_transfer" then lines << format_eu_bank_transfer(t)
         else
           result.service_failure!(
             code: "unsupported_funding_type",
@@ -45,54 +45,67 @@ module InvoiceCustomSections
         type = address[:type]&.to_sym
         details = address[type] || {}
 
-        case type
+        block = case type
         when :aba
-          lines << "US ACH, Domestic Wire"
-          lines << "#{t.call(:bank_name)}: #{details_or_default(details[:bank_name])}"
-          lines << "#{t.call(:account_number)}: #{details_or_default(details[:account_number])}"
-          lines << "#{t.call(:routing_number)}: #{details_or_default(details[:routing_number])}"
-          lines << ""
+          <<~TEXT
+            US ACH, Domestic Wire
+            #{t.call(:bank_name)}: #{details_or_default(details[:bank_name])}
+            #{t.call(:account_number)}: #{details_or_default(details[:account_number])}
+            #{t.call(:routing_number)}: #{details_or_default(details[:routing_number])}
+          TEXT
         when :swift
-          lines << "SWIFT"
-          lines << "#{t.call(:bank_name)}: #{details_or_default(details[:bank_name])}"
-          lines << "#{t.call(:account_number)}: #{details_or_default(details[:account_number])}"
-          lines << "#{t.call(:swift_code)}: #{details_or_default(details[:swift_code])}"
-          lines << ""
+          <<~TEXT
+            SWIFT
+            #{t.call(:bank_name)}: #{details_or_default(details[:bank_name])}
+            #{t.call(:account_number)}: #{details_or_default(details[:account_number])}
+            #{t.call(:swift_code)}: #{details_or_default(details[:swift_code])}
+          TEXT
         end
+
+        lines << block.strip if block
+        lines << "" if block
       end
     end
 
-    def format_mx_bank_transfer(lines, t)
+    def format_mx_bank_transfer(t)
       details = extract_details(:mx_bank_transfer)
-      lines << "#{t.call(:clabe)}: #{details_or_default(details[:clabe])}"
-      lines << "#{t.call(:bank_name)}: #{details_or_default(details[:bank_name])}"
-      lines << "#{t.call(:bank_code)}: #{details_or_default(details[:bank_code])}"
+      <<~TEXT.strip
+        #{t.call(:clabe)}: #{details_or_default(details[:clabe])}
+        #{t.call(:bank_name)}: #{details_or_default(details[:bank_name])}
+        #{t.call(:bank_code)}: #{details_or_default(details[:bank_code])}
+      TEXT
     end
 
-    def format_jp_bank_transfer(lines, t)
+    def format_jp_bank_transfer(t)
       details = extract_details(:jp_bank_transfer)
-      lines << "#{t.call(:bank_code)}: #{details_or_default(details[:bank_code])}"
-      lines << "#{t.call(:bank_name)}: #{details_or_default(details[:bank_name])}"
-      lines << "#{t.call(:branch_code)}: #{details_or_default(details[:branch_code])}"
-      lines << "#{t.call(:branch_name)}: #{details_or_default(details[:branch_name])}"
-      lines << "#{t.call(:account_type)}: #{details_or_default(details[:account_type])}"
-      lines << "#{t.call(:account_number)}: #{details_or_default(details[:account_number])}"
-      lines << "#{t.call(:account_holder_name)}: #{details_or_default(details[:account_holder_name])}"
+      <<~TEXT.strip
+        #{t.call(:bank_code)}: #{details_or_default(details[:bank_code])}
+        #{t.call(:bank_name)}: #{details_or_default(details[:bank_name])}
+        #{t.call(:branch_code)}: #{details_or_default(details[:branch_code])}
+        #{t.call(:branch_name)}: #{details_or_default(details[:branch_name])}
+        #{t.call(:account_type)}: #{details_or_default(details[:account_type])}
+        #{t.call(:account_number)}: #{details_or_default(details[:account_number])}
+        #{t.call(:account_holder_name)}: #{details_or_default(details[:account_holder_name])}
+      TEXT
     end
 
-    def format_gb_bank_transfer(lines, t)
+    def format_gb_bank_transfer(t)
       details = extract_details(:sort_code)
-      lines << "#{t.call(:account_number)}: #{details_or_default(details[:account_number])}"
-      lines << "#{t.call(:sort_code)}: #{details_or_default(details[:sort_code])}"
-      lines << "#{t.call(:account_holder_name)}: #{details_or_default(details[:account_holder_name])}"
+      <<~TEXT.strip
+        #{t.call(:account_number)}: #{details_or_default(details[:account_number])}
+        #{t.call(:sort_code)}: #{details_or_default(details[:sort_code])}
+        #{t.call(:account_holder_name)}: #{details_or_default(details[:account_holder_name])}
+      TEXT
     end
 
-    def format_eu_bank_transfer(lines, t)
+    def format_eu_bank_transfer(t)
       details = extract_details(:iban)
-      lines << "#{t.call(:bic)}: #{details_or_default(details[:bic])}"
-      lines << "#{t.call(:iban)}: #{details_or_default(details[:iban])}"
-      lines << "#{t.call(:country)}: #{details_or_default(details[:country])}"
-      lines << "#{t.call(:account_holder_name)}: #{details_or_default(details[:account_holder_name])}"
+      <<~TEXT.strip
+        #{t.call(:bic)}: #{details_or_default(details[:bic])}
+        #{t.call(:iban)}: #{details_or_default(details[:iban])}
+        #{t.call(:country)}: #{details_or_default(details[:country])}
+        #{t.call(:account_holder_name)}: #{details_or_default(details[:account_holder_name])}
+      TEXT
     end
 
     def extract_details(key)

--- a/app/services/invoice_custom_sections/funding_instructions_formatter_service.rb
+++ b/app/services/invoice_custom_sections/funding_instructions_formatter_service.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module InvoiceCustomSections
+  class FundingInstructionsFormatterService < BaseService
+    def initialize(funding_data:, locale:)
+      @funding_data = funding_data
+      @locale = locale
+      super
+    end
+
+    def call
+      I18n.with_locale(locale) do
+        lines = []
+        t = ->(key) { I18n.t("invoice.#{key}") }
+
+        lines << t.call(:bank_transfer_info)
+        lines << ""
+
+        case funding_data[:type]
+        when "us_bank_transfer" then format_us_bank_transfer(lines, t)
+        when "mx_bank_transfer" then format_mx_bank_transfer(lines, t)
+        when "jp_bank_transfer" then format_jp_bank_transfer(lines, t)
+        when "gb_bank_transfer" then format_gb_bank_transfer(lines, t)
+        when "eu_bank_transfer" then format_eu_bank_transfer(lines, t)
+        else
+          result.service_failure!(
+            code: "unsupported_funding_type",
+            message: "Funding type '#{funding_data[:type]}' is not supported"
+          )
+        end
+
+        result.details = lines.join("\n")
+        result
+      end
+    end
+
+    private
+
+    attr_reader :funding_data, :locale
+
+    def format_us_bank_transfer(lines, t)
+      addresses = funding_data[:financial_addresses] || []
+
+      addresses.each do |address|
+        type = address[:type]&.to_sym
+        details = address[type] || {}
+
+        case type
+        when :aba
+          lines << "US ACH, Domestic Wire"
+          lines << "#{t.call(:bank_name)}: #{details_or_default(details[:bank_name])}"
+          lines << "#{t.call(:account_number)}: #{details_or_default(details[:account_number])}"
+          lines << "#{t.call(:routing_number)}: #{details_or_default(details[:routing_number])}"
+          lines << ""
+        when :swift
+          lines << "SWIFT"
+          lines << "#{t.call(:bank_name)}: #{details_or_default(details[:bank_name])}"
+          lines << "#{t.call(:account_number)}: #{details_or_default(details[:account_number])}"
+          lines << "#{t.call(:swift_code)}: #{details_or_default(details[:swift_code])}"
+          lines << ""
+        end
+      end
+    end
+
+    def format_mx_bank_transfer(lines, t)
+      details = extract_details(:mx_bank_transfer)
+      lines << "#{t.call(:clabe)}: #{details_or_default(details[:clabe])}"
+      lines << "#{t.call(:bank_name)}: #{details_or_default(details[:bank_name])}"
+      lines << "#{t.call(:bank_code)}: #{details_or_default(details[:bank_code])}"
+    end
+
+    def format_jp_bank_transfer(lines, t)
+      details = extract_details(:jp_bank_transfer)
+      lines << "#{t.call(:bank_code)}: #{details_or_default(details[:bank_code])}"
+      lines << "#{t.call(:bank_name)}: #{details_or_default(details[:bank_name])}"
+      lines << "#{t.call(:branch_code)}: #{details_or_default(details[:branch_code])}"
+      lines << "#{t.call(:branch_name)}: #{details_or_default(details[:branch_name])}"
+      lines << "#{t.call(:account_type)}: #{details_or_default(details[:account_type])}"
+      lines << "#{t.call(:account_number)}: #{details_or_default(details[:account_number])}"
+      lines << "#{t.call(:account_holder_name)}: #{details_or_default(details[:account_holder_name])}"
+    end
+
+    def format_gb_bank_transfer(lines, t)
+      details = extract_details(:sort_code)
+      lines << "#{t.call(:account_number)}: #{details_or_default(details[:account_number])}"
+      lines << "#{t.call(:sort_code)}: #{details_or_default(details[:sort_code])}"
+      lines << "#{t.call(:account_holder_name)}: #{details_or_default(details[:account_holder_name])}"
+    end
+
+    def format_eu_bank_transfer(lines, t)
+      details = extract_details(:iban)
+      lines << "#{t.call(:bic)}: #{details_or_default(details[:bic])}"
+      lines << "#{t.call(:iban)}: #{details_or_default(details[:iban])}"
+      lines << "#{t.call(:country)}: #{details_or_default(details[:country])}"
+      lines << "#{t.call(:account_holder_name)}: #{details_or_default(details[:account_holder_name])}"
+    end
+
+    def extract_details(key)
+      funding_data[:financial_addresses]&.first&.dig(key) || {}
+    end
+
+    def details_or_default(value)
+      value.presence || "-"
+    end
+  end
+end

--- a/app/services/payment_provider_customers/stripe/sync_funding_instructions_service.rb
+++ b/app/services/payment_provider_customers/stripe/sync_funding_instructions_service.rb
@@ -41,7 +41,8 @@ module PaymentProviderCustomers
             code: unique_code,
             name: "Funding Instructions",
             display_name: I18n.t("invoice.pay_with_bank_transfer", locale: preferred_locale),
-            details: formatter.details
+            details: formatter.details,
+            section_type: :system_generated
           },
           selected: false
         ).invoice_custom_section

--- a/app/services/payment_provider_customers/stripe/sync_funding_instructions_service.rb
+++ b/app/services/payment_provider_customers/stripe/sync_funding_instructions_service.rb
@@ -32,7 +32,7 @@ module PaymentProviderCustomers
         Customers::ManageInvoiceCustomSectionsService.call(
           customer: customer,
           skip_invoice_custom_sections: false,
-          section_ids: [section_ids]
+          section_ids: section_ids
         )
       end
 

--- a/app/services/payment_provider_customers/stripe/sync_funding_instructions_service.rb
+++ b/app/services/payment_provider_customers/stripe/sync_funding_instructions_service.rb
@@ -98,14 +98,6 @@ module PaymentProviderCustomers
 
       def customer_currency
         currency = customer.currency || customer.organization.default_currency
-
-        if currency.blank?
-          return result.service_failure!(
-            code: "missing_currency",
-            message: "No currency found for customer or organization"
-          )
-        end
-
         currency.downcase
       end
 

--- a/app/services/payment_provider_customers/stripe/sync_funding_instructions_service.rb
+++ b/app/services/payment_provider_customers/stripe/sync_funding_instructions_service.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  module Stripe
+    class SyncFundingInstructionsService < BaseService
+      Result = BaseResult[:funding_instructions]
+
+      def initialize(stripe_customer)
+        @stripe_customer = stripe_customer
+        super
+      end
+
+      def call
+        return result unless eligible_for_funding_instructions?
+        funding_instructions = fetch_funding_instructions
+        create_invoice_section_with_funding_info(funding_instructions)
+        result
+      rescue ::Stripe::StripeError => e
+        result.service_failure!(code: "stripe_error", message: e.message)
+      end
+
+      private
+
+      attr_reader :stripe_customer
+      delegate :customer, to: :stripe_customer
+
+      def create_invoice_section_with_funding_info(funding_instructions)
+        funding_instructions.bank_transfer.to_hash
+        unique_code = "funding_instructions_#{customer.id}"
+
+        existing_section = customer.organization.system_generated_invoice_custom_sections.find_by(code: unique_code)
+
+        formatter = InvoiceCustomSections::FundingInstructionsFormatterService.call(
+          funding_data: funding_instructions.bank_transfer.to_hash,
+          locale: preferred_locale
+        )
+
+        invoice_custom_section = existing_section || InvoiceCustomSections::CreateService.call(
+          organization: customer.organization,
+          create_params: {
+            code: unique_code,
+            name: "Funding Instructions",
+            display_name: I18n.t("invoice.pay_with_bank_transfer", locale: preferred_locale),
+            details: formatter.details
+          },
+          selected: false
+        ).invoice_custom_section
+
+        return unless invoice_custom_section
+
+        all_section_ids = customer.selected_invoice_custom_sections.ids | [invoice_custom_section.id]
+        Customers::ManageInvoiceCustomSectionsService.call(
+          customer: customer,
+          skip_invoice_custom_sections: false,
+          section_ids: [all_section_ids]
+        )
+      end
+
+      def fetch_funding_instructions
+        ::Stripe::Customer.create_funding_instructions(
+          stripe_customer.provider_customer_id,
+          {
+            funding_type: "bank_transfer",
+            bank_transfer: funding_type_payload,
+            currency: customer_currency
+          },
+          {api_key: stripe_api_key}
+        )
+      end
+
+      def funding_type_payload
+        return eu_bank_transfer_payload if customer_currency == "eur"
+
+        {
+          "usd" => {type: "us_bank_transfer"},
+          "gbp" => {type: "gb_bank_transfer"},
+          "jpy" => {type: "jp_bank_transfer"},
+          "mxn" => {type: "mx_bank_transfer"}
+        }[customer_currency]
+      end
+
+      def eu_bank_transfer_payload
+        customer_country = customer.country || customer.organization.country
+
+        if customer_country.blank?
+          return result.service_failure!(
+            code: "missing_country",
+            message: "No country found for customer or organization to generate EU bank transfer payload"
+          )
+        end
+
+        {type: "eu_bank_transfer", eu_bank_transfer: {country: customer_country.upcase}}
+      end
+
+      def customer_currency
+        currency = customer.currency || customer.organization.default_currency
+
+        if currency.blank?
+          return result.service_failure!(
+            code: "missing_currency",
+            message: "No currency found for customer or organization"
+          )
+        end
+
+        currency.downcase
+      end
+
+      def preferred_locale
+        customer.preferred_document_locale
+      end
+
+      def stripe_api_key
+        stripe_customer.payment_provider.secret_key
+      end
+
+      def eligible_for_funding_instructions?
+        stripe_customer.provider_customer_id.present? &&
+          stripe_customer.provider_payment_methods&.include?("customer_balance") &&
+          !customer.system_generated_invoice_custom_sections.exists?(code: "funding_instructions_#{customer.id}")
+      end
+    end
+  end
+end

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -1,17 +1,28 @@
 ---
 de:
   invoice:
+    account_holder_name: Kontoinhaber
+    account_number: Kontonummer
+    account_type: Kontotyp
     all_subscriptions: Alle Abonnements
     all_usage_based_fees: Alle nutzungsabhängigen Gebühren
     already_paid: Bereits bezahlt
     amount: Betrag
     amount_with_tax: Betrag (inkl. Steuern)
     amount_without_tax: Betrag (ohne Steuern)
+    bank_code: Bankleitzahl
+    bank_name: Bankname
+    bank_transfer_info: Banküberweisungen können mehrere Werktage zur Bearbeitung benötigen. Um per Banküberweisung zu bezahlen, überweisen Sie den Betrag unter Verwendung der folgenden Bankdaten.
+    bic: BIC
     bill_from: Von
     bill_to: An
+    branch_code: Filialnummer
+    branch_name: Filialname
     breakdown: Aufschlüsselung
     breakdown_for_days: "%{breakdown_duration} für %{breakdown_total_duration} Tage"
     breakdown_of: Aufschlüsselung für %{fee_filter_display_name}
+    clabe: CLABE
+    country: Land
     coupons: Coupons
     credit_notes: Gutschriften
     date_from: Vom
@@ -29,6 +40,7 @@ de:
       flat_fee_for_the_first: Pauschalgebühr für die ersten %{to}
       flat_fee_for_the_last: Pauschalgebühr für %{from} und höher
       flat_fee_for_the_next: Pauschalgebühr für die nächsten %{from} bis %{to}
+    iban: IBAN
     invoice_number: Rechnungsnummer
     issue_date: Ausgabedatum
     item: Artikel
@@ -43,6 +55,7 @@ de:
       free_units_for_the_first: Gebühr pro Einheit für die ersten %{count}
     paid_invoice: Bezahlte Rechnung
     paid_tax_invoice: Bezahlte Steuerrechnung
+    pay_with_bank_transfer: Zahlung per Banküberweisung
     payment_term: Zahlungsfrist
     payment_term_days: "%{net_payment_term} Tage"
     percentage:
@@ -60,15 +73,18 @@ de:
     quarter: quartal
     quarterly: Vierteljährlich
     reached_usage_threshold: Diese progressive Rechnung wird erstellt, da Ihre kumulierte Nutzung %{usage_amount} erreicht hat und den Schwellenwert von %{threshold_amount} überschritten hat.
+    routing_number: Routing-Nummer
     see_breakdown: Siehe Aufschlüsselung für Gesamtübersicht
     self_billed:
       document_name: Gutschriftrechnung
       footer: Diese Gutschriftrechnung wurde vom Kunden im Namen des Partners mit dessen Zustimmung erstellt. Der Partner hat zugestimmt, keine eigene Rechnung für diese Transaktion auszustellen.
+    sort_code: Sortiercode
     sub_total: Zwischensumme
     sub_total_with_tax: Zwischensumme (inkl. Steuern)
     sub_total_without_tax: Zwischensumme (ohne Steuern)
     subscription: Abonnement
     subscription_interval: "%{plan_interval}es Abonnement - %{plan_name}"
+    swift_code: SWIFT-Code
     tax: Steuern
     tax_identification_number: 'Steuer ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% on %{amount})"

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -1,18 +1,29 @@
 ---
 en:
   invoice:
+    account_holder_name: Account holder name
+    account_number: Account number
+    account_type: Account type
     all_subscriptions: All Subscriptions
     all_usage_based_fees: All usage based fees
     already_paid: Already paid
     amount: Amount
     amount_with_tax: Amount (incl. tax)
     amount_without_tax: Amount (excl. tax)
+    bank_code: Bank code
+    bank_name: Bank name
+    bank_transfer_info: Bank transfers may take several business days to process. To pay via bank transfer, transfer funds using the following bank information.
+    bic: BIC
     bill_from: From
     bill_to: Bill to
+    branch_code: Branch code
+    branch_name: Branch name
     breakdown: Breakdown
     breakdown_for_days: Used %{breakdown_duration} out of %{breakdown_total_duration} days
     breakdown_of: Breakdown of %{fee_filter_display_name}
     charges_paid_in_advance: Charges paid in advance
+    clabe: CLABE
+    country: Country
     coupons: Coupons
     credit_notes: Credit notes
     date_from: From
@@ -30,6 +41,7 @@ en:
       flat_fee_for_the_first: Flat fee for first %{to}
       flat_fee_for_the_last: Flat fee for %{from} and above
       flat_fee_for_the_next: Flat fee for the next %{from} to %{to}
+    iban: IBAN
     invoice_number: Invoice Number
     issue_date: Issue Date
     item: Item
@@ -44,6 +56,7 @@ en:
       free_units_for_the_first: Free units for the first %{count}
     paid_invoice: Paid invoice
     paid_tax_invoice: Paid tax invoice
+    pay_with_bank_transfer: Pay with a bank transfer
     payment_term: Payment term
     payment_term_days: "%{net_payment_term} days"
     percentage:
@@ -61,15 +74,18 @@ en:
     quarter: quarter
     quarterly: Quarterly
     reached_usage_threshold: This progressive billing is generated because your cumulative usage has reached %{usage_amount}, exceeding the %{threshold_amount} threshold.
+    routing_number: Routing number
     see_breakdown: See breakdown for total unit
     self_billed:
       document_name: Self-billing invoice
       footer: This self-billing invoice was issued by the client on behalf of the partner, with their consent. The partner has agreed not to issue their own invoice for this transaction.
+    sort_code: Sort code
     sub_total: Subtotal
     sub_total_with_tax: Subtotal (incl. tax)
     sub_total_without_tax: Subtotal (excl. tax)
     subscription: Subscription
     subscription_interval: "%{plan_interval} subscription - %{plan_name}"
+    swift_code: SWIFT code
     tax: Tax
     tax_identification_number: 'Tax ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% on %{amount})"

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -1,17 +1,28 @@
 ---
 es:
   invoice:
+    account_holder_name: Nombre del titular de la cuenta
+    account_number: Número de cuenta
+    account_type: Tipo de cuenta
     all_subscriptions: Todos los suscripciones
     all_usage_based_fees: Todos los cargos basados en el uso
     already_paid: Ya pagado
     amount: Total (excl. impuestos)
     amount_with_tax: Total (impuestos incl.)
     amount_without_tax: Total (impuestos excl.)
+    bank_code: Código bancario
+    bank_name: Nombre del banco
+    bank_transfer_info: Las transferencias bancarias pueden tardar varios días hábiles en procesarse. Para pagar mediante transferencia bancaria, transfiere fondos utilizando la siguiente información bancaria.
+    bic: BIC
     bill_from: Emitida por
     bill_to: Factura destinada a
+    branch_code: Código de sucursal
+    branch_name: Nombre de la sucursal
     breakdown: Desglose
     breakdown_for_days: Utilizados %{breakdown_duration} de %{breakdown_total_duration} días
     breakdown_of: Desglose de %{fee_filter_display_name}
+    clabe: CLABE
+    country: País
     credit_notes: Notas de crédito
     date_from: Tarifas desde
     date_to: hasta
@@ -28,6 +39,7 @@ es:
       flat_fee_for_the_first: Tarifa fija para las %{to} primeras
       flat_fee_for_the_last: Tarifa fija para %{from} y superiores
       flat_fee_for_the_next: Tarifa fija para las siguientes de %{from} a %{to}
+    iban: IBAN
     invoice_number: Número de la factura
     issue_date: Fecha de emisión
     item: Ítem
@@ -42,6 +54,7 @@ es:
       free_units_for_the_first: Unidades gratuitas para las %{count} primeras
     paid_invoice: Factura pagada
     paid_tax_invoice: Factura fiscal pagada
+    pay_with_bank_transfer: Paga con transferencia bancaria
     payment_term: Plazo de pago neto
     payment_term_days: "%{net_payment_term} días"
     percentage:
@@ -59,15 +72,18 @@ es:
     quarter: trimestre
     quarterly: Trimestral
     reached_usage_threshold: Esta facturación progresiva se genera porque su uso acumulado ha alcanzado los %{usage_amount}, superando el umbral de %{threshold_amount}.
+    routing_number: Número de ruta
     see_breakdown: Consulte el desglose a continuación
     self_billed:
       document_name: Factura de autoliquidación
       footer: Esta factura de autoliquidación ha sido emitida por el cliente en nombre del socio, con su consentimiento. El socio ha aceptado no emitir su propia factura para esta transacción.
+    sort_code: Código de clasificación
     sub_total: Subtotal
     sub_total_with_tax: Subtotal (impuestos incl.)
     sub_total_without_tax: Subtotal (impuestos excl.)
     subscription: Suscripción
     subscription_interval: Suscripción %{plan_interval} - %{plan_name}
+    swift_code: Código SWIFT
     tax: Impuesto
     tax_identification_number: 'ID del impuesto: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% sobre %{amount})"

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -1,17 +1,28 @@
 ---
 fr:
   invoice:
+    account_holder_name: Nom du titulaire du compte
+    account_number: Numéro de compte
+    account_type: Type de compte
     all_subscriptions: Tous les abonnements
     all_usage_based_fees: Tous les frais de consommation
     already_paid: Déjà payé
     amount: Montant
     amount_with_tax: Montant (TTC)
     amount_without_tax: Montant (HT)
+    bank_code: Code banque
+    bank_name: Nom de la banque
+    bank_transfer_info: Les virements bancaires peuvent prendre plusieurs jours ouvrables pour être traités. Pour payer par virement bancaire, transférez des fonds en utilisant les informations bancaires suivantes.
+    bic: BIC
     bill_from: De
     bill_to: Facturé à
+    branch_code: Code guichet
+    branch_name: Nom de l'agence
     breakdown: Détails de consommation
     breakdown_for_days: "%{breakdown_duration} sur %{breakdown_total_duration} jours"
     breakdown_of: Détails de consommation de %{fee_filter_display_name}
+    clabe: CLABE
+    country: Pays
     coupons: Réduction(s)
     credit_notes: Avoir(s)
     date_from: Du
@@ -29,6 +40,7 @@ fr:
       flat_fee_for_the_first: Frais fixes pour les %{to} premières
       flat_fee_for_the_last: Frais fixes pour %{from} et plus
       flat_fee_for_the_next: Frais fixes pour les suivantes de %{from} à %{to}
+    iban: IBAN
     invoice_number: Nº de facture
     issue_date: Date d'émission
     item: Article
@@ -43,6 +55,7 @@ fr:
       free_units_for_the_first: Unités gratuites pour les premiers %{count}
     paid_invoice: Facture payée
     paid_tax_invoice: Facture fiscale payée
+    pay_with_bank_transfer: Payer par virement bancaire
     payment_term: Délai de paiement
     payment_term_days: "%{net_payment_term} jours"
     percentage:
@@ -60,15 +73,18 @@ fr:
     quarter: trimestre
     quarterly: trimestriellement
     reached_usage_threshold: Cette facturation progressive est générée car votre usage cumulé a atteint %{usage_amount}, dépassant le seuil de %{threshold_amount}.
+    routing_number: Numéro de routage
     see_breakdown: Consultez le détail ci-après
     self_billed:
       document_name: Facture d'autofacturation
       footer: Cette facture d'autofacturation a été émise par le client au nom du partenaire, avec son consentement. Le partenaire a accepté de ne pas établir sa propre facture pour cette transaction.
+    sort_code: Code de tri
     sub_total: Sous total
     sub_total_with_tax: Sous total (TTC)
     sub_total_without_tax: Sous total (HT)
     subscription: Abonnement
     subscription_interval: Abonnement %{plan_interval} - %{plan_name}
+    swift_code: Code SWIFT
     tax: TVA
     tax_identification_number: 'ID fiscal: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% sur %{amount})"

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -1,17 +1,28 @@
 ---
 it:
   invoice:
+    account_holder_name: Nome del titolare del conto
+    account_number: Numero di conto
+    account_type: Tipo di conto
     all_subscriptions: Tutti gli abbonamenti
     all_usage_based_fees: Tutte le tariffe basate sull'utilizzo
     already_paid: Già pagato
     amount: Importo
     amount_with_tax: Importo (incl. tasse)
     amount_without_tax: Importo (escl. tasse)
+    bank_code: Codice banca
+    bank_name: Nome della banca
+    bank_transfer_info: I bonifici bancari possono richiedere diversi giorni lavorativi per essere elaborati. Per pagare tramite bonifico bancario, trasferisci i fondi utilizzando le seguenti informazioni bancarie.
+    bic: BIC
     bill_from: Da
     bill_to: Fatturare a
+    branch_code: Codice filiale
+    branch_name: Nome filiale
     breakdown: Ripartizione
     breakdown_for_days: Utilizzati %{breakdown_duration} su %{breakdown_total_duration} giorni
     breakdown_of: Ripartizione di %{fee_filter_display_name}
+    clabe: CLABE
+    country: Paese
     coupons: Coupon
     credit_notes: Note di Credito
     date_from: Dal
@@ -29,6 +40,7 @@ it:
       flat_fee_for_the_first: Tariffa fissa per le prime %{to}
       flat_fee_for_the_last: Tariffa fissa per %{from} e oltre
       flat_fee_for_the_next: Tariffa fissa per le seguenti da %{from} a %{to}
+    iban: IBAN
     invoice_number: Numero Fattura
     issue_date: Data Emissione
     item: Articolo
@@ -43,6 +55,7 @@ it:
       free_units_for_the_first: Unità gratuite per il primo %{count}
     paid_invoice: Fattura pagata
     paid_tax_invoice: Fattura fiscale pagata
+    pay_with_bank_transfer: Paga con bonifico bancario
     payment_term: Termine di pagamento
     payment_term_days: "%{net_payment_term} giorni"
     percentage:
@@ -60,15 +73,18 @@ it:
     quarter: trimestre
     quarterly: Trimestrale
     reached_usage_threshold: Questa fatturazione progressiva è generata poiché il tuo utilizzo cumulato ha raggiunto %{usage_amount}, superando la soglia di %{threshold_amount}.
+    routing_number: Numero di routing
     see_breakdown: Vedere la ripartizione per l'unità totale
     self_billed:
       document_name: Fattura di autofatturazione
       footer: Questa fattura di autofatturazione è stata emessa dal cliente per conto del partner, con il suo consenso. Il partner ha accettato di non emettere una propria fattura per questa transazione.
+    sort_code: Codice di ordinamento
     sub_total: Subtotale
     sub_total_with_tax: Subtotale (incl. tasse)
     sub_total_without_tax: Subtotale (escl. tasse)
     subscription: Abbonamento
     subscription_interval: Abbonamento %{plan_interval} - %{plan_name}
+    swift_code: Codice SWIFT
     tax: Tasse
     tax_identification_number: 'Identificativo fiscale: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% su %{amount})"

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -1,17 +1,28 @@
 ---
 nb:
   invoice:
+    account_holder_name: Kontoinnehaver
+    account_number: Kontonummer
+    account_type: Kontotype
     all_subscriptions: Alle Abonnement
     all_usage_based_fees: Alle bruksbaserte kostnader
     already_paid: Allerede betalt
     amount: Beløp
     amount_with_tax: Beløp (inkl. MVA)
     amount_without_tax: Beløp (ekskl. MVA)
+    bank_code: Bankkode
+    bank_name: Banknavn
+    bank_transfer_info: Bankoverføringer kan ta flere virkedager å behandle. For å betale med bankoverføring, overfør midler ved å bruke følgende bankinformasjon.
+    bic: BIC
     bill_from: Fra
     bill_to: Til
+    branch_code: Filialkode
+    branch_name: Filialnavn
     breakdown: Oversikt
     breakdown_for_days: "%{breakdown_duration} av %{breakdown_total_duration} dager"
     breakdown_of: Fordeling av %{fee_filter_display_name}
+    clabe: CLABE
+    country: Land
     coupons: Kuponger
     credit_notes: Kreditnotaer
     date_from: Fra
@@ -29,6 +40,7 @@ nb:
       flat_fee_for_the_first: Fast avgift for de første %{to}
       flat_fee_for_the_last: Fast avgift for %{from} og mer
       flat_fee_for_the_next: Fast avgift for de neste %{from} til %{to}
+    iban: IBAN
     invoice_number: Fakturanummer
     issue_date: Dato
     item: Vare
@@ -43,6 +55,7 @@ nb:
       free_units_for_the_first: Gratis enheter for de første %{count}
     paid_invoice: Betalt faktura
     paid_tax_invoice: Betalt skattefaktura
+    pay_with_bank_transfer: Betal med bankoverføring
     payment_term: Betalingsperiode
     payment_term_days: "%{net_payment_term} dager"
     percentage:
@@ -60,15 +73,18 @@ nb:
     quarter: kvartal
     quarterly: Kvartalsvis
     reached_usage_threshold: Denne progressive faktureringen er generert fordi din akkumulerte bruk har nådd %{usage_amount}, og overskredet terskelen på %{threshold_amount}.
+    routing_number: Routing-nummer
     see_breakdown: Se oversikt for antall enheter
     self_billed:
       document_name: Egenfakturering
       footer: Denne egenfakturaen ble utstedt av kunden på vegne av partneren, med deres samtykke. Partneren har gått med på å ikke utstede sin egen faktura for denne transaksjonen.
+    sort_code: Sorteringskode
     sub_total: Sub total
     sub_total_with_tax: Sub total (inkl. MVA)
     sub_total_without_tax: Sub total (ekskl. MVA)
     subscription: Abonnement
     subscription_interval: "%{plan_interval} abonnement - %{plan_name}"
+    swift_code: SWIFT-kode
     tax: Merverdiavgift
     tax_identification_number: 'Skatte-ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% on %{amount})"

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -1,17 +1,28 @@
 ---
 sv:
   invoice:
+    account_holder_name: Kontoinnehavarens namn
+    account_number: Kontonummer
+    account_type: Kontotyp
     all_subscriptions: Alla prenumerationer
     all_usage_based_fees: Alla avgifter baserade på användning
     already_paid: Redan betalt
     amount: Belopp (exkl. moms)
     amount_with_tax: Belopp (inkl. moms)
     amount_without_tax: Belopp (exkl. moms)
+    bank_code: Bankkod
+    bank_name: Banknamn
+    bank_transfer_info: Banköverföringar kan ta flera arbetsdagar att behandla. För att betala med banköverföring, överför medel med följande bankinformation.
+    bic: BIC
     bill_from: Avsändare
     bill_to: Mottagare
+    branch_code: Filialkod
+    branch_name: Filialnamn
     breakdown: Specifikation
     breakdown_for_days: Använt %{breakdown_duration} av %{breakdown_total_duration} dagar
     breakdown_of: Specifikation för %{fee_filter_display_name}
+    clabe: CLABE
+    country: Land
     credit_notes: Kreditfakturor
     date_from: Avser period
     date_to: till och med
@@ -28,6 +39,7 @@ sv:
       flat_fee_for_the_first: Fast avgift för de första %{to}
       flat_fee_for_the_last: Fast avgift för %{from} och högre
       flat_fee_for_the_next: Fast avgift för de nästa %{from} till %{to}
+    iban: IBAN
     invoice_number: Fakturanummer
     issue_date: Fakturadatum
     item: Artikel
@@ -42,6 +54,7 @@ sv:
       free_units_for_the_first: Gratis enheter för de första %{count}
     paid_invoice: Betald faktura
     paid_tax_invoice: Betald skattefaktura
+    pay_with_bank_transfer: Betala med banköverföring
     payment_term: Betalningsvillkor
     payment_term_days: "%{net_payment_term} dagar"
     percentage:
@@ -59,15 +72,18 @@ sv:
     quarter: kvartal
     quarterly: Kvartalsvis
     reached_usage_threshold: Denna progressiva fakturering skapas eftersom din ackumulerade användning har nått %{usage_amount} och överstiger %{threshold_amount} tröskeln.
+    routing_number: Routingnummer
     see_breakdown: Se uppdelning nedan
     self_billed:
       document_name: Självfakturering
       footer: Denna självfaktura har utfärdats av kunden för partnerns räkning, med deras samtycke. Partnern har gått med på att inte utfärda en egen faktura för denna transaktion.
+    sort_code: Sorteringskod
     sub_total: Delsumma
     sub_total_with_tax: Delsumma (inkl. moms)
     sub_total_without_tax: Delsumma (exkl. moms)
     subscription: Prenumeration
     subscription_interval: "%{plan_interval} prenumeration - %{plan_name}"
+    swift_code: SWIFT-kod
     tax: Skatt
     tax_identification_number: 'Skatte ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% på %{amount})"

--- a/spec/jobs/payment_provider_customers/stripe_sync_funding_instructions_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/stripe_sync_funding_instructions_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviderCustomers::StripeSyncFundingInstructionsJob, type: :job do
+  subject(:stripe_sync_funding_instructions_job) { described_class }
+
+  let(:stripe_customer) { create(:stripe_customer) }
+  let(:stripe_service) { instance_double(PaymentProviderCustomers::Stripe::SyncFundingInstructionsService) }
+
+  it "calls the funding instructions sync service" do
+    allow(PaymentProviderCustomers::Stripe::SyncFundingInstructionsService).to receive(:new)
+      .with(stripe_customer)
+      .and_return(stripe_service)
+    allow(stripe_service).to receive(:call)
+      .and_return(BaseService::Result.new)
+
+    stripe_sync_funding_instructions_job.perform_now(stripe_customer)
+
+    expect(PaymentProviderCustomers::Stripe::SyncFundingInstructionsService).to have_received(:new)
+    expect(stripe_service).to have_received(:call)
+  end
+end

--- a/spec/services/invoice_custom_sections/funding_instructions_formatter_service_spec.rb
+++ b/spec/services/invoice_custom_sections/funding_instructions_formatter_service_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InvoiceCustomSections::FundingInstructionsFormatterService do
+  describe "#call" do
+    subject(:result) { service.call }
+
+    let(:service) { described_class.new(funding_data: funding_data, locale: :en) }
+
+    shared_examples "includes bank transfer info intro" do
+      it "includes the bank transfer info header" do
+        expect(result.details).to start_with("Bank transfers may take several business days to process. To pay via bank transfer, transfer funds using the following bank information.")
+      end
+    end
+
+    context "when funding type is us_bank_transfer" do
+      let(:funding_data) do
+        {
+          type: "us_bank_transfer",
+          financial_addresses: [
+            {
+              type: "aba",
+              aba: {
+                account_holder_name: "Teste",
+                account_number: "11119987600453127",
+                bank_name: "US Test Bank",
+                routing_number: "999999999"
+              }
+            },
+            {
+              type: "swift",
+              swift: {
+                account_holder_name: "Teste",
+                account_number: "11119987600453127",
+                bank_name: "US Test Bank",
+                swift_code: "TESTUS99XXX"
+              }
+            }
+          ]
+        }
+      end
+
+      include_examples "includes bank transfer info intro"
+      it "formats ABA and SWIFT details correctly with headers" do
+        aba_section = <<~TEXT.strip
+          US ACH, Domestic Wire
+          Bank name: US Test Bank
+          Account number: 11119987600453127
+          Routing number: 999999999
+        TEXT
+
+        swift_section = <<~TEXT.strip
+          SWIFT
+          Bank name: US Test Bank
+          Account number: 11119987600453127
+          SWIFT code: TESTUS99XXX
+        TEXT
+
+        expect(result.details).to include(aba_section)
+        expect(result.details).to include(swift_section)
+      end
+    end
+
+    context "when funding type is eu_bank_transfer" do
+      let(:funding_data) do
+        {
+          type: "eu_bank_transfer",
+          financial_addresses: [
+            {
+              type: "iban",
+              iban: {
+                account_holder_name: "Teste",
+                bic: "AGRIFRPPXXX",
+                country: "FR",
+                iban: "FR61284383901570478105144165"
+              }
+            }
+          ]
+        }
+      end
+
+      include_examples "includes bank transfer info intro"
+      it "formats IBAN details correctly" do
+        expect(result.details).to include("BIC: AGRIFRPPXXX")
+        expect(result.details).to include("IBAN: FR61284383901570478105144165")
+        expect(result.details).to include("Country: FR")
+        expect(result.details).to include("Account holder name: Teste")
+      end
+    end
+
+    context "when funding type is mx_bank_transfer" do
+      let(:funding_data) do
+        {
+          type: "mx_bank_transfer",
+          financial_addresses: [
+            {
+              mx_bank_transfer: {
+                clabe: "002010077777777771",
+                bank_name: "Banco MX",
+                bank_code: "002"
+              }
+            }
+          ]
+        }
+      end
+
+      include_examples "includes bank transfer info intro"
+      it "includes CLABE transfer details" do
+        expect(result.details).to include("CLABE: 002010077777777771")
+        expect(result.details).to include("Bank name: Banco MX")
+        expect(result.details).to include("Bank code: 002")
+      end
+    end
+
+    context "when funding type is jp_bank_transfer" do
+      let(:funding_data) do
+        {
+          type: "jp_bank_transfer",
+          financial_addresses: [
+            {
+              jp_bank_transfer: {
+                bank_code: "0005",
+                bank_name: "JP Test Bank",
+                branch_code: "001",
+                branch_name: "Tokyo",
+                account_type: "type_test",
+                account_number: "1234567",
+                account_holder_name: "name_account"
+              }
+            }
+          ]
+        }
+      end
+
+      include_examples "includes bank transfer info intro"
+      it "includes Japanese bank transfer details" do
+        expect(result.details).to include("Bank code: 0005")
+        expect(result.details).to include("Bank name: JP Test Bank")
+        expect(result.details).to include("Branch code: 001")
+        expect(result.details).to include("Branch name: Tokyo")
+        expect(result.details).to include("Account type: type_test")
+        expect(result.details).to include("Account number: 1234567")
+        expect(result.details).to include("Account holder name: name_account")
+      end
+    end
+
+    context "when funding type is gb_bank_transfer" do
+      let(:funding_data) do
+        {
+          type: "gb_bank_transfer",
+          financial_addresses: [
+            {
+              sort_code: {
+                account_number: "12345678",
+                sort_code: "12-34-56",
+                account_holder_name: "Test UK"
+              }
+            }
+          ]
+        }
+      end
+
+      include_examples "includes bank transfer info intro"
+      it "includes GB sort code transfer details" do
+        expect(result.details).to include("Account number: 12345678")
+        expect(result.details).to include("Sort code: 12-34-56")
+        expect(result.details).to include("Account holder name: Test UK")
+      end
+    end
+  end
+end

--- a/spec/services/payment_provider_customers/stripe/sync_funding_instructions_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/sync_funding_instructions_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentProviderCustomers::Stripe::SyncFundingInstructionsService do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:provider_customer_id) { "cus_Rw5Qso78STEap3" }
+  let(:provider_customer) { create(:stripe_customer, customer:, provider_customer_id:, payment_provider: create(:stripe_provider, organization:), payment_method_id: nil) }
+
+  describe "#call" do
+    # TODO working on it
+    # context "when customer has a default payment method in Stripe" do
+    #   it do
+    #     stub_request(:get, %r{/v1/customers/#{provider_customer_id}$}).and_return(
+    #       status: 200, body: File.read(Rails.root.join("spec/fixtures/stripe/customer_with_default_payment_method.json"))
+    #     )
+    #
+    #     result = subject.call
+    #     expect(result.payment_method_id).to eq "pm_1R2DFsQ8iJWBZFaMw3LLbR0r"
+    #   end
+    # end
+  end
+end

--- a/spec/services/payment_provider_customers/stripe/sync_funding_instructions_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/sync_funding_instructions_service_spec.rb
@@ -3,22 +3,53 @@
 require "rails_helper"
 
 RSpec.describe PaymentProviderCustomers::Stripe::SyncFundingInstructionsService do
+  subject(:update_service) { described_class.new(stripe_customer) }
+
   let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let(:customer) { create(:customer, organization:, currency: "USD") }
   let(:provider_customer_id) { "cus_Rw5Qso78STEap3" }
-  let(:provider_customer) { create(:stripe_customer, customer:, provider_customer_id:, payment_provider: create(:stripe_provider, organization:), payment_method_id: nil) }
+  let(:stripe_customer) { create(:stripe_customer, customer:, provider_payment_methods:) }
+  let(:provider_payment_methods) { %w[customer_balance] }
 
   describe "#call" do
-    # TODO working on it
-    # context "when customer has a default payment method in Stripe" do
-    #   it do
-    #     stub_request(:get, %r{/v1/customers/#{provider_customer_id}$}).and_return(
-    #       status: 200, body: File.read(Rails.root.join("spec/fixtures/stripe/customer_with_default_payment_method.json"))
-    #     )
-    #
-    #     result = subject.call
-    #     expect(result.payment_method_id).to eq "pm_1R2DFsQ8iJWBZFaMw3LLbR0r"
-    #   end
-    # end
+    context "when customer is not eligible" do
+      let(:provider_payment_methods) { %w[card] }
+
+      it "returns a successful result without doing anything" do
+        expect(::Stripe::Customer).not_to receive(:create_funding_instructions)
+        result = update_service.call
+        expect(result).to be_success
+      end
+    end
+
+    context "when customer is eligible and everything is valid and section does not yet exist" do
+      let(:funding_instructions) do
+        double("FundingInstructions", bank_transfer: double(to_hash: {some: "details"}))
+      end
+
+      let(:formatter_service_result) { double(details: "formatted bank details") }
+      let(:invoice_custom_section) { create(:invoice_custom_section, organization:) }
+
+      before do
+        allow(stripe_customer.payment_provider).to receive(:secret_key).and_return("sk_test_123")
+        allow(::Stripe::Customer).to receive(:create_funding_instructions)
+          .and_return(funding_instructions)
+        allow(InvoiceCustomSections::FundingInstructionsFormatterService).to receive(:call)
+           .and_return(formatter_service_result)
+        allow(InvoiceCustomSections::CreateService).to receive(:call)
+           .and_return(double(invoice_custom_section: invoice_custom_section))
+        allow(Customers::ManageInvoiceCustomSectionsService).to receive(:call)
+      end
+
+      it "creates the section and returns success" do
+        result = update_service.call
+
+        expect(result).to be_success
+        expect(::Stripe::Customer).to have_received(:create_funding_instructions)
+        expect(InvoiceCustomSections::FundingInstructionsFormatterService).to have_received(:call)
+        expect(InvoiceCustomSections::CreateService).to have_received(:call)
+        expect(Customers::ManageInvoiceCustomSectionsService).to have_received(:call)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

This PR builds on the groundwork introduced in the previous [PR](https://github.com/getlago/lago-api/pull/3456), where we added the section_type enum to distinguish between manual and system-generated invoice custom sections.

Now, we’re introducing the logic that automatically fetches bank transfer instructions from Stripe and injects them into invoices via a system_generated section — enabling customers to see accurate payment details directly on the invoice when bank transfer is selected.

## Description

This PR introduces the following:
- New background service that:
- Retrieves bank transfer instructions from Stripe for a given customer.
- Generates a system_generated InvoiceCustomSection with the Stripe funding details.
- Ensures the section is associated with the correct invoice and doesn’t duplicate if it already exists.
- Introduced logic to determine whether bank transfer is the selected payment method and conditionally trigger the generation.
- Ensures system-generated sections are included via applicable_invoice_custom_sections, alongside any manual sections.

![image](https://github.com/user-attachments/assets/4643dc90-141f-4f27-9cb9-905180c4bf14)

