### PR TITLE
feat(avalara-integration): add support for avalara integration customer

### DIFF
--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -49,6 +49,7 @@ module Types
       field :subscriptions, [Types::Subscriptions::Object], resolver: Resolvers::Customers::SubscriptionsResolver
 
       field :anrok_customer, Types::IntegrationCustomers::Anrok, null: true
+      field :avalara_customer, Types::IntegrationCustomers::Avalara, null: true
       field :hubspot_customer, Types::IntegrationCustomers::Hubspot, null: true
       field :netsuite_customer, Types::IntegrationCustomers::Netsuite, null: true
       field :salesforce_customer, Types::IntegrationCustomers::Salesforce, null: true

--- a/app/graphql/types/integration_customers/avalara.rb
+++ b/app/graphql/types/integration_customers/avalara.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Types
+  module IntegrationCustomers
+    class Avalara < Types::BaseObject
+      graphql_name "AvalaraCustomer"
+
+      field :external_customer_id, String, null: true
+      field :id, ID, null: false
+      field :integration_code, String, null: true
+      field :integration_id, ID, null: true
+      field :integration_type, Types::Integrations::IntegrationTypeEnum, null: true
+      field :sync_with_provider, Boolean, null: true
+
+      def integration_type
+        "avalara"
+      end
+
+      def integration_code
+        object.integration&.code
+      end
+    end
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -79,6 +79,7 @@ class Customer < ApplicationRecord
   has_one :adyen_customer, class_name: "PaymentProviderCustomers::AdyenCustomer"
   has_one :netsuite_customer, class_name: "IntegrationCustomers::NetsuiteCustomer"
   has_one :anrok_customer, class_name: "IntegrationCustomers::AnrokCustomer"
+  has_one :avalara_customer, class_name: "IntegrationCustomers::AvalaraCustomer"
   has_one :xero_customer, class_name: "IntegrationCustomers::XeroCustomer"
   has_one :hubspot_customer, class_name: "IntegrationCustomers::HubspotCustomer"
   has_one :salesforce_customer, class_name: "IntegrationCustomers::SalesforceCustomer"

--- a/app/models/integration_customers/avalara_customer.rb
+++ b/app/models/integration_customers/avalara_customer.rb
@@ -4,3 +4,29 @@ module IntegrationCustomers
   class AvalaraCustomer < BaseCustomer
   end
 end
+
+# == Schema Information
+#
+# Table name: integration_customers
+#
+#  id                   :uuid             not null, primary key
+#  settings             :jsonb            not null
+#  type                 :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  customer_id          :uuid             not null
+#  external_customer_id :string
+#  integration_id       :uuid             not null
+#
+# Indexes
+#
+#  index_integration_customers_on_customer_id           (customer_id)
+#  index_integration_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
+#  index_integration_customers_on_external_customer_id  (external_customer_id)
+#  index_integration_customers_on_integration_id        (integration_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (integration_id => integrations.id)
+#

--- a/app/models/integration_customers/avalara_customer.rb
+++ b/app/models/integration_customers/avalara_customer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class AvalaraCustomer < BaseCustomer
+  end
+end

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -34,6 +34,8 @@ module IntegrationCustomers
         "IntegrationCustomers::OktaCustomer"
       when "anrok"
         "IntegrationCustomers::AnrokCustomer"
+      when "avalara"
+        "IntegrationCustomers::AvalaraCustomer"
       when "xero"
         "IntegrationCustomers::XeroCustomer"
       when "hubspot"

--- a/app/services/integration_customers/avalara_service.rb
+++ b/app/services/integration_customers/avalara_service.rb
@@ -20,12 +20,12 @@ module IntegrationCustomers
         subsidiary_id: nil
       )
 
-      return create_result if create_result.error
+      return create_result if create_result.error || create_result.contact_id.nil?
 
       new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
         integration:,
         customer:,
-        external_customer_id: customer.id,
+        external_customer_id: create_result.contact_id,
         type: "IntegrationCustomers::AvalaraCustomer",
         sync_with_provider: true
       )

--- a/app/services/integration_customers/avalara_service.rb
+++ b/app/services/integration_customers/avalara_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class AvalaraService < ::BaseService
+    def initialize(integration:, customer:, subsidiary_id:, **params)
+      @customer = customer
+      @subsidiary_id = subsidiary_id
+      @integration = integration
+      @params = params&.with_indifferent_access
+
+      super(nil)
+    end
+
+    def create
+      create_result = Integrations::Aggregator::Contacts::CreateService.call(
+        integration:,
+        customer:,
+        subsidiary_id: nil
+      )
+
+      return create_result if create_result.error
+
+      new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
+        integration:,
+        customer:,
+        external_customer_id: customer.id,
+        type: "IntegrationCustomers::AvalaraCustomer",
+        sync_with_provider: true
+      )
+
+      result.integration_customer = new_integration_customer
+      result
+    end
+
+    private
+
+    attr_reader :integration, :customer, :subsidiary_id, :params
+  end
+end

--- a/app/services/integration_customers/avalara_service.rb
+++ b/app/services/integration_customers/avalara_service.rb
@@ -2,6 +2,8 @@
 
 module IntegrationCustomers
   class AvalaraService < ::BaseService
+    Result = BaseResult[:integration_customer]
+
     def initialize(integration:, customer:, subsidiary_id:, **params)
       @customer = customer
       @subsidiary_id = subsidiary_id

--- a/app/services/integration_customers/factory.rb
+++ b/app/services/integration_customers/factory.rb
@@ -12,6 +12,8 @@ module IntegrationCustomers
         IntegrationCustomers::NetsuiteService
       when "Integrations::AnrokIntegration"
         IntegrationCustomers::AnrokService
+      when "Integrations::AvalaraIntegration"
+        IntegrationCustomers::AvalaraService
       when "Integrations::XeroIntegration"
         IntegrationCustomers::XeroService
       when "Integrations::HubspotIntegration"

--- a/app/services/integrations/aggregator/contacts/payloads/avalara.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/avalara.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    module Contacts
+      module Payloads
+        class Avalara < BasePayload
+          def create_body
+            [
+              {
+                "external_id" => customer.id,
+                "name" => name,
+                "address_line_1" => customer.shipping_address_line1 || customer.address_line1,
+                "city" => customer.shipping_city || customer.city,
+                "zip" => customer.shipping_zipcode || customer.zipcode,
+                "country" => customer.shipping_country || customer.country,
+                "state" => customer.shipping_state || customer.state,
+                "tax_number" => customer.tax_identification_number
+              }
+            ]
+          end
+
+          def update_body
+            [
+              {
+                "external_id" => integration_customer.external_customer_id,
+                "name" => name,
+                "address_line_1" => customer.shipping_address_line1 || customer.address_line1,
+                "city" => customer.shipping_city || customer.city,
+                "zip" => customer.shipping_zipcode || customer.zipcode,
+                "country" => customer.shipping_country || customer.country,
+                "state" => customer.shipping_state || customer.state,
+                "tax_number" => customer.tax_identification_number
+              }
+            ]
+          end
+
+          private
+
+          def name
+            return customer.name if customer.name.present?
+
+            "#{customer.firstname} #{customer.lastname}".strip
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/integrations/aggregator/contacts/payloads/avalara.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/avalara.rb
@@ -23,7 +23,7 @@ module Integrations
           def update_body
             [
               {
-                "external_id" => integration_customer.external_customer_id,
+                "external_id" => customer.id,
                 "name" => name,
                 "address_line_1" => customer.shipping_address_line1 || customer.address_line1,
                 "city" => customer.shipping_city || customer.city,

--- a/app/services/integrations/aggregator/contacts/payloads/factory.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/factory.rb
@@ -28,6 +28,13 @@ module Integrations
                 integration_customer:,
                 subsidiary_id:
               )
+            when "Integrations::AvalaraIntegration"
+              Integrations::Aggregator::Contacts::Payloads::Avalara.new(
+                integration:,
+                customer:,
+                integration_customer:,
+                subsidiary_id:
+              )
             when "Integrations::HubspotIntegration"
               Integrations::Aggregator::Contacts::Payloads::Hubspot.new(
                 integration:,

--- a/schema.graphql
+++ b/schema.graphql
@@ -261,6 +261,15 @@ type Authorize {
   url: String!
 }
 
+type AvalaraCustomer {
+  externalCustomerId: String
+  id: ID!
+  integrationCode: String
+  integrationId: ID
+  integrationType: IntegrationTypeEnum
+  syncWithProvider: Boolean
+}
+
 type AvalaraIntegration {
   accountId: String!
   code: String!
@@ -3417,6 +3426,7 @@ type Customer {
   appliedAddOns: [AppliedAddOn!]
   appliedCoupons: [AppliedCoupon!]
   appliedDunningCampaign: DunningCampaign
+  avalaraCustomer: AvalaraCustomer
   billingConfiguration: CustomerBillingConfiguration
   billingEntity: BillingEntity!
 

--- a/schema.json
+++ b/schema.json
@@ -2072,6 +2072,93 @@
         },
         {
           "kind": "OBJECT",
+          "name": "AvalaraCustomer",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "externalCustomerId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "integrationCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "integrationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "integrationType",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "IntegrationTypeEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "syncWithProvider",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "AvalaraIntegration",
           "description": null,
           "interfaces": [],
@@ -14137,6 +14224,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "DunningCampaign",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "avalaraCustomer",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "AvalaraCustomer",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/factories/integration_customers.rb
+++ b/spec/factories/integration_customers.rb
@@ -23,6 +23,17 @@ FactoryBot.define do
     end
   end
 
+  factory :avalara_customer, class: "IntegrationCustomers::AvalaraCustomer" do
+    association :integration, factory: :avalara_integration
+    customer
+    type { "IntegrationCustomers::AvalaraCustomer" }
+    external_customer_id { SecureRandom.uuid }
+
+    settings do
+      {sync_with_provider: true}
+    end
+  end
+
   factory :xero_customer, class: "IntegrationCustomers::XeroCustomer" do
     association :integration, factory: :xero_integration
     customer

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Types::Customers::Object do
     expect(subject).to have_field(:shipping_address).of_type("CustomerAddress")
 
     expect(subject).to have_field(:anrok_customer).of_type("AnrokCustomer")
+    expect(subject).to have_field(:avalara_customer).of_type("AvalaraCustomer")
     expect(subject).to have_field(:hubspot_customer).of_type("HubspotCustomer")
     expect(subject).to have_field(:netsuite_customer).of_type("NetsuiteCustomer")
     expect(subject).to have_field(:salesforce_customer).of_type("SalesforceCustomer")

--- a/spec/graphql/types/integration_customers/avalara_spec.rb
+++ b/spec/graphql/types/integration_customers/avalara_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::IntegrationCustomers::Avalara do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:external_customer_id).of_type("String")
+    expect(subject).to have_field(:id).of_type("ID!")
+    expect(subject).to have_field(:integration_type).of_type("IntegrationTypeEnum")
+    expect(subject).to have_field(:integration_id).of_type("ID")
+    expect(subject).to have_field(:integration_code).of_type("String")
+    expect(subject).to have_field(:sync_with_provider).of_type("Boolean")
+  end
+end

--- a/spec/services/integration_customers/avalara_service_spec.rb
+++ b/spec/services/integration_customers/avalara_service_spec.rb
@@ -11,8 +11,11 @@ RSpec.describe IntegrationCustomers::AvalaraService, type: :service do
   describe "#create" do
     subject(:service_call) { described_class.new(integration:, customer:, subsidiary_id: nil).create }
 
+    let(:contact_id) { SecureRandom.uuid }
     let(:create_result) do
-      BaseService::Result.new
+      result = BaseService::Result.new
+      result.contact_id = contact_id
+      result
     end
     let(:aggregator_contacts_create_service) do
       instance_double(Integrations::Aggregator::Contacts::CreateService)
@@ -31,7 +34,7 @@ RSpec.describe IntegrationCustomers::AvalaraService, type: :service do
       aggregate_failures do
         expect(aggregator_contacts_create_service).to have_received(:call)
         expect(result).to be_success
-        expect(result.integration_customer.external_customer_id).to eq(customer.id)
+        expect(result.integration_customer.external_customer_id).to eq(contact_id)
         expect(result.integration_customer.integration_id).to eq(integration.id)
         expect(result.integration_customer.customer_id).to eq(customer.id)
         expect(result.integration_customer.type).to eq("IntegrationCustomers::AvalaraCustomer")

--- a/spec/services/integration_customers/avalara_service_spec.rb
+++ b/spec/services/integration_customers/avalara_service_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IntegrationCustomers::AvalaraService, type: :service do
+  let(:integration) { create(:avalara_integration, organization:) }
+  let(:organization) { membership.organization }
+  let(:membership) { create(:membership) }
+  let(:customer) { create(:customer, organization:) }
+
+  describe "#create" do
+    subject(:service_call) { described_class.new(integration:, customer:, subsidiary_id: nil).create }
+
+    let(:create_result) do
+      BaseService::Result.new
+    end
+    let(:aggregator_contacts_create_service) do
+      instance_double(Integrations::Aggregator::Contacts::CreateService)
+    end
+
+    before do
+      allow(Integrations::Aggregator::Contacts::CreateService)
+        .to receive(:new).and_return(aggregator_contacts_create_service)
+
+      allow(aggregator_contacts_create_service).to receive(:call).and_return(create_result)
+    end
+
+    it "returns integration customer" do
+      result = service_call
+
+      aggregate_failures do
+        expect(aggregator_contacts_create_service).to have_received(:call)
+        expect(result).to be_success
+        expect(result.integration_customer.external_customer_id).to eq(customer.id)
+        expect(result.integration_customer.integration_id).to eq(integration.id)
+        expect(result.integration_customer.customer_id).to eq(customer.id)
+        expect(result.integration_customer.type).to eq("IntegrationCustomers::AvalaraCustomer")
+      end
+    end
+
+    it "creates integration customer" do
+      expect { service_call }.to change(IntegrationCustomers::AvalaraCustomer, :count).by(1)
+    end
+  end
+end

--- a/spec/services/integrations/aggregator/contacts/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/avalara_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Avalara do
 
     context "when name, firstname and lastname are present" do
       let(:firstname) { "John" }
-      let(:lastname) { "Doe"}
+      let(:lastname) { "Doe" }
       let(:customer_name) { "Mark Doe" }
       let(:name) { customer.name }
 

--- a/spec/services/integrations/aggregator/contacts/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/avalara_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Integrations::Aggregator::Contacts::Payloads::Avalara do
+  let(:integration) { integration_customer.integration }
+  let(:integration_customer) { create(:avalara_customer, customer:, external_customer_id: customer.id) }
+  let(:payload) { described_class.new(integration:, customer:, integration_customer:) }
+  let(:name) { "#{firstname} #{lastname}" }
+  let(:customer_name) { nil }
+  let(:customer) do
+    create(
+      :customer,
+      firstname:,
+      lastname:,
+      name: customer_name,
+      shipping_address_line1: "123 Main St",
+      address_line1: "456 Elm St",
+      city: "Springfield",
+      zipcode: "12345",
+      country: "US",
+      state: "IL",
+      tax_identification_number: "123456789"
+    )
+  end
+
+  describe "#create_body" do
+    subject(:create_body_call) { payload.create_body }
+
+    let(:payload_body) do
+      [
+        {
+          "external_id" => customer.id,
+          "name" => name,
+          "address_line_1" => customer.shipping_address_line1,
+          "city" => customer.city,
+          "zip" => customer.zipcode,
+          "country" => customer.country,
+          "state" => customer.state,
+          "tax_number" => customer.tax_identification_number
+        }
+      ]
+    end
+
+    context "when name, firstname and lastname are present" do
+      let(:firstname) { "John" }
+      let(:lastname) { "Doe"}
+      let(:customer_name) { "Mark Doe" }
+      let(:name) { customer.name }
+
+      it "returns the payload body" do
+        expect(subject).to eq payload_body
+      end
+    end
+
+    context "when firstname and lastname are present" do
+      let(:firstname) { "John" }
+      let(:lastname) { "Doe" }
+
+      it "returns the payload body" do
+        expect(subject).to eq payload_body
+      end
+    end
+
+    context "when both firstname and lastname are empty" do
+      let(:firstname) { "" }
+      let(:lastname) { "" }
+      let(:name) { "" }
+
+      it "returns the payload body" do
+        expect(subject).to eq payload_body
+      end
+    end
+
+    context "when lastname is blank" do
+      let(:firstname) { "John" }
+      let(:lastname) { "" }
+      let(:name) { "John" }
+
+      it "returns the payload body" do
+        expect(subject).to eq payload_body
+      end
+    end
+  end
+
+  describe "#update_body" do
+    subject(:update_body_call) { payload.update_body }
+
+    let(:payload_body) do
+      [
+        {
+          "external_id" => integration_customer.external_customer_id,
+          "name" => name,
+          "address_line_1" => customer.shipping_address_line1,
+          "city" => customer.city,
+          "zip" => customer.zipcode,
+          "country" => customer.country,
+          "state" => customer.state,
+          "tax_number" => customer.tax_identification_number
+        }
+      ]
+    end
+
+    context "when firstname and lastname are present" do
+      let(:firstname) { "John" }
+      let(:lastname) { "Doe" }
+
+      it "returns the payload body" do
+        expect(subject).to eq payload_body
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently Lago is implementing integration with Avalara tax provider

## Description

This PR adds basic support for creating and updating avalara customers in Lago. It provides graphql support and updates all related places in the code. 
