### PR TITLE
feat(avalara-integration): add support for company code

### DIFF
--- a/app/graphql/types/integrations/avalara.rb
+++ b/app/graphql/types/integrations/avalara.rb
@@ -7,6 +7,7 @@ module Types
 
       field :account_id, String, null: false
       field :code, String, null: false
+      field :company_code, String, null: false
       field :failed_invoices_count, Integer, null: true
       field :has_mappings_configured, Boolean
       field :id, ID, null: false

--- a/app/graphql/types/integrations/avalara/create_input.rb
+++ b/app/graphql/types/integrations/avalara/create_input.rb
@@ -10,6 +10,7 @@ module Types
         argument :name, String, required: true
 
         argument :account_id, String, required: true
+        argument :company_code, String, required: true
         argument :connection_id, String, required: true
         argument :license_key, String, required: true
       end

--- a/app/graphql/types/integrations/avalara/update_input.rb
+++ b/app/graphql/types/integrations/avalara/update_input.rb
@@ -9,6 +9,7 @@ module Types
         argument :id, ID, required: false
 
         argument :code, String, required: false
+        argument :company_code, String, required: false
         argument :name, String, required: false
 
         argument :account_id, String, required: false

--- a/app/models/integrations/avalara_integration.rb
+++ b/app/models/integrations/avalara_integration.rb
@@ -6,9 +6,9 @@ module Integrations
       primary_key: :organization_id,
       foreign_key: :organization_id
 
-    validates :connection_id, :account_id, :license_key, presence: true
+    validates :company_code, :connection_id, :account_id, :license_key, presence: true
 
-    settings_accessors :account_id
+    settings_accessors :account_id, :company_code
     secrets_accessors :connection_id, :license_key
   end
 end

--- a/app/services/integrations/avalara/create_service.rb
+++ b/app/services/integrations/avalara/create_service.rb
@@ -22,6 +22,7 @@ module Integrations
           organization:,
           name: params[:name],
           code: params[:code],
+          company_code: params[:company_code],
           connection_id: params[:connection_id],
           account_id: params[:account_id],
           license_key: params[:license_key]

--- a/app/services/integrations/avalara/update_service.rb
+++ b/app/services/integrations/avalara/update_service.rb
@@ -21,8 +21,6 @@ module Integrations
 
         integration.name = params[:name] if params.key?(:name)
         integration.code = params[:code] if params.key?(:code)
-        integration.account_id = params[:account_id] if params.key?(:account_id)
-        integration.license_key = params[:license_key] if params.key?(:license_key)
 
         integration.save!
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -264,6 +264,7 @@ type Authorize {
 type AvalaraIntegration {
   accountId: String!
   code: String!
+  companyCode: String!
   failedInvoicesCount: Int
   hasMappingsConfigured: Boolean
   id: ID!
@@ -2017,6 +2018,7 @@ input CreateAvalaraIntegrationInput {
   """
   clientMutationId: String
   code: String!
+  companyCode: String!
   connectionId: String!
   licenseKey: String!
   name: String!
@@ -9000,6 +9002,7 @@ input UpdateAvalaraIntegrationInput {
   """
   clientMutationId: String
   code: String
+  companyCode: String
   id: ID
   licenseKey: String
   name: String

--- a/schema.json
+++ b/schema.json
@@ -2110,6 +2110,22 @@
               "args": []
             },
             {
+              "name": "companyCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "failedInvoicesCount",
               "description": null,
               "type": {
@@ -7496,6 +7512,22 @@
             },
             {
               "name": "accountId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "companyCode",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -44212,6 +44244,18 @@
             },
             {
               "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "companyCode",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/spec/factories/integrations.rb
+++ b/spec/factories/integrations.rb
@@ -49,7 +49,7 @@ FactoryBot.define do
     name { "Avalara Integration" }
 
     settings do
-      {account_id: SecureRandom.uuid}
+      {account_id: SecureRandom.uuid, company_code: "DEFAULT"}
     end
 
     secrets do

--- a/spec/graphql/mutations/integrations/avalara/create_spec.rb
+++ b/spec/graphql/mutations/integrations/avalara/create_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Mutations::Integrations::Avalara::Create, type: :graphql do
           code,
           name,
           accountId,
-          licenseKey
+          licenseKey,
+          companyCode
         }
       }
     GQL
@@ -42,7 +43,8 @@ RSpec.describe Mutations::Integrations::Avalara::Create, type: :graphql do
           name:,
           accountId: "account-id1",
           licenseKey: "license-key12",
-          connectionId: "this-is-random-uuid"
+          connectionId: "this-is-random-uuid",
+          companyCode: "company-code1"
         }
       }
     )
@@ -55,6 +57,7 @@ RSpec.describe Mutations::Integrations::Avalara::Create, type: :graphql do
       expect(result_data["name"]).to eq(name)
       expect(result_data["licenseKey"]).to eq("••••••••…y12")
       expect(result_data["accountId"]).to eq("account-id1")
+      expect(result_data["companyCode"]).to eq("company-code1")
       expect(Integrations::AvalaraIntegration.order(:created_at).last.connection_id).to eq("this-is-random-uuid")
     end
   end

--- a/spec/graphql/mutations/integrations/avalara/update_spec.rb
+++ b/spec/graphql/mutations/integrations/avalara/update_spec.rb
@@ -59,8 +59,6 @@ RSpec.describe Mutations::Integrations::Avalara::Update, type: :graphql do
     aggregate_failures do
       expect(result_data["name"]).to eq(name)
       expect(result_data["code"]).to eq(code)
-      expect(result_data["accountId"]).to eq(account_id)
-      expect(result_data["licenseKey"]).to eq("••••••••…789")
     end
   end
 end

--- a/spec/graphql/types/integrations/avalara/create_input_spec.rb
+++ b/spec/graphql/types/integrations/avalara/create_input_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::Integrations::Avalara::CreateInput do
   it do
     expect(subject).to accept_argument(:code).of_type("String!")
     expect(subject).to accept_argument(:name).of_type("String!")
+    expect(subject).to accept_argument(:company_code).of_type("String!")
     expect(subject).to accept_argument(:connection_id).of_type("String!")
     expect(subject).to accept_argument(:account_id).of_type("String!")
     expect(subject).to accept_argument(:license_key).of_type("String!")

--- a/spec/graphql/types/integrations/avalara/update_input_spec.rb
+++ b/spec/graphql/types/integrations/avalara/update_input_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::Integrations::Avalara::UpdateInput do
   it do
     expect(subject).to accept_argument(:id).of_type("ID")
     expect(subject).to accept_argument(:code).of_type("String")
+    expect(subject).to accept_argument(:company_code).of_type("String")
     expect(subject).to accept_argument(:name).of_type("String")
     expect(subject).to accept_argument(:account_id).of_type("String")
     expect(subject).to accept_argument(:license_key).of_type("String")

--- a/spec/graphql/types/integrations/avalara_spec.rb
+++ b/spec/graphql/types/integrations/avalara_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Types::Integrations::Avalara do
     expect(subject).to have_field(:license_key).of_type("ObfuscatedString!")
     expect(subject).to have_field(:account_id).of_type("String!")
     expect(subject).to have_field(:code).of_type("String!")
+    expect(subject).to have_field(:company_code).of_type("String!")
     expect(subject).to have_field(:failed_invoices_count).of_type("Int")
     expect(subject).to have_field(:has_mappings_configured).of_type("Boolean")
     expect(subject).to have_field(:name).of_type("String!")

--- a/spec/models/integrations/avalara_integration_spec.rb
+++ b/spec/models/integrations/avalara_integration_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Integrations::AvalaraIntegration, type: :model do
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:connection_id) }
   it { is_expected.to validate_presence_of(:account_id) }
+  it { is_expected.to validate_presence_of(:company_code) }
   it { is_expected.to validate_presence_of(:license_key) }
   it { is_expected.to have_many(:error_details) }
 
@@ -18,7 +19,7 @@ RSpec.describe Integrations::AvalaraIntegration, type: :model do
   end
 
   describe ".license_key" do
-    it "assigns and retrieve an license_key" do
+    it "assigns and retrieve an secret pair" do
       avalara_integration.license_key = "123abc456"
       expect(avalara_integration.license_key).to eq("123abc456")
     end
@@ -32,9 +33,16 @@ RSpec.describe Integrations::AvalaraIntegration, type: :model do
   end
 
   describe ".account_id" do
-    it "assigns and retrieve a secret pair" do
+    it "assigns and retrieve a settings pair" do
       avalara_integration.account_id = "account_id"
       expect(avalara_integration.account_id).to eq("account_id")
+    end
+  end
+
+  describe ".company_code" do
+    it "assigns and retrieve a settings pair" do
+      avalara_integration.company_code = "company_code"
+      expect(avalara_integration.company_code).to eq("company_code")
     end
   end
 end

--- a/spec/services/integrations/avalara/create_service_spec.rb
+++ b/spec/services/integrations/avalara/create_service_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Integrations::Avalara::CreateService, type: :service do
         organization_id: organization.id,
         connection_id: "conn1",
         account_id: "account-id1",
+        company_code: "company-code1",
         license_key: "123456789"
       }
     end
@@ -69,6 +70,7 @@ RSpec.describe Integrations::Avalara::CreateService, type: :service do
             expect(result.integration.code).to eq("anrok1")
             expect(result.integration.organization).to eq(organization)
             expect(result.integration.connection_id).to eq("conn1")
+            expect(result.integration.company_code).to eq("company-code1")
             expect(result.integration.account_id).to eq("account-id1")
             expect(result.integration.license_key).to eq("123456789")
           end

--- a/spec/services/integrations/avalara/update_service_spec.rb
+++ b/spec/services/integrations/avalara/update_service_spec.rb
@@ -60,8 +60,6 @@ RSpec.describe Integrations::Avalara::UpdateService, type: :service do
             integration = Integrations::AvalaraIntegration.order(:updated_at).last
             expect(integration.name).to eq(name)
             expect(integration.code).to eq("anrok1")
-            expect(integration.account_id).to eq("acc-id-1")
-            expect(integration.license_key).to eq("123456789")
           end
 
           it "returns an integration in result object" do


### PR DESCRIPTION
## Context

Currently Lago is working on integration with tax provider Avalara

## Description

This PR adds `company_code` support that was initially skipped during connection part.

Company code would be needed for fetching company ID, that is expected parameter in several Avalara requests.