### PR TITLE
fix(processor): Avoid dead jobs with subscription consumer

### DIFF
--- a/app/services/subscriptions/consume_subscription_refreshed_queue_service.rb
+++ b/app/services/subscriptions/consume_subscription_refreshed_queue_service.rb
@@ -7,7 +7,7 @@ module Subscriptions
     PROCESSING_TIMEOUT = 1.minute
 
     def call
-      return if ENV["LAGO_REDIS_STORE_URL"].blank?
+      return result if ENV["LAGO_REDIS_STORE_URL"].blank?
 
       start_time = Time.current
 


### PR DESCRIPTION
## Context

The `Subscriptions::ConsumeSubscriptionRefreshedQueueService` what recently introduced to handle usage refresh comming from the events-processor.

The service is returning nil instead of an emtpy result when the `LAGO_REDIS_STORE_URL` is not set, leading to dead jobs...

## Description

This PR ensures that the service returns a result instead
