### PR TITLE
misc: Removes some references to OpenStruct

### DIFF
--- a/app/services/billable_metrics/breakdown/item.rb
+++ b/app/services/billable_metrics/breakdown/item.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module BillableMetrics
+  module Breakdown
+    Item = Data.define(:date, :action, :amount, :duration, :total_duration)
+  end
+end

--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -37,7 +37,7 @@ module BillableMetrics
         return [] if persisted_sum.zero?
 
         [
-          OpenStruct.new(
+          Item.new(
             date: from_date_in_customer_timezone,
             action: persisted_sum.negative? ? "remove" : "add",
             amount: persisted_sum,
@@ -49,7 +49,7 @@ module BillableMetrics
 
       def period_breakdown
         event_store.sum_date_breakdown.map do |aggregation|
-          OpenStruct.new(
+          Item.new(
             date: aggregation[:date],
             action: aggregation[:value].negative? ? "remove" : "add",
             amount: aggregation[:value],

--- a/app/services/billable_metrics/breakdown/unique_count_service.rb
+++ b/app/services/billable_metrics/breakdown/unique_count_service.rb
@@ -18,7 +18,7 @@ module BillableMetrics
               datetime = rows.last["timestamp"] unless operation_type == "add_and_removed"
             end
 
-            OpenStruct.new(
+            Item.new(
               date: datetime.in_time_zone(customer.applicable_timezone).to_date,
               action: operation_type,
               amount: row["prorated_value"].ceil,

--- a/lib/lago_utils/lago_utils/version.rb
+++ b/lib/lago_utils/lago_utils/version.rb
@@ -7,12 +7,11 @@ module LagoUtils
     VERSION_FILE = Rails.root.join("LAGO_VERSION")
     GITHUB_BASE_URL = "https://github.com/getlago/lago-api"
 
+    Result = Data.define(:number, :github_url)
+
     class << self
       def call(default:)
-        OpenStruct.new(
-          number: version_number(default:),
-          github_url:
-        )
+        Result.new(version_number(default:), github_url)
       end
 
       private

--- a/lib/lago_utils/lago_utils/version.rb
+++ b/lib/lago_utils/lago_utils/version.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "ostruct"
-
 module LagoUtils
   class Version
     VERSION_FILE = Rails.root.join("LAGO_VERSION")


### PR DESCRIPTION
## Context

This PR is  part of a larger initiative to remove all remaining `OpenStruc` references from the code base and replace them by pre-defined result or specific classes.

## Description

This PR replaces 
- the returns from `LagoUtils::Version#call` by a propert `Result`  defined as `Data.define(:number, :github_url)`
- the result items from `BillableMetrics::Breakdown::SumService` and `BillableMetrics::Breakdown::UniqueCountService` with an array of a new `BillableMetrics::Breakdown::Item` objects defined as `Data.define(:date, :action, :amount, :duration, :total_duration)`