### PR TITLE
feat(fee): reset timestamps when updating fee.payement_status

### DIFF
--- a/app/services/fees/update_service.rb
+++ b/app/services/fees/update_service.rb
@@ -43,6 +43,12 @@ module Fees
     def update_payment_status(payment_status)
       fee.payment_status = payment_status
 
+      # NOTE: A fee can go from pending to failed to pending to succeeded.
+      #       We only want the timestamp associated with the current status to be set.
+      fee.succeeded_at = nil
+      fee.failed_at = nil
+      fee.refunded_at = nil
+
       case payment_status.to_sym
       when :succeeded
         fee.succeeded_at = Time.current


### PR DESCRIPTION
## Context

Until a Fee is attached to an invoice, its payment_status can be updated via the API

## Description

If a fee goes from pending to failed, we'll set the `failed_at`. Then, when going from failed to succeeded, we'll set the `succeeded_at`. If the fee goes back to failed or pending, the `succeeded_at` field is still set.

This PR result all 3 timestamps (`failed_at`, `succeeded_at` and `refunded_at`) so only the timestamp associated with the new payment_status is set.
