### PR TITLE
chore(spec): Send `customer.vies_check` webhook if error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ gem "karafka", "~> 2.4.17"
 gem "karafka-web", "~> 0.10.4"
 
 # Taxes
-gem "valvat", require: false
+gem "valvat"
 
 # Data Export
 gem "csv", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1038,4 +1038,4 @@ RUBY VERSION
    ruby 3.3.6p108
 
 BUNDLED WITH
-   2.5.5
+   2.6.6

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -97,7 +97,10 @@ module V1
       vies_value = options.fetch(:vies_check)
 
       {
-        vies_check: vies_value.is_a?(Hash) ? vies_value : {valid: false}
+        vies_check: vies_value.is_a?(Hash) ? vies_value : {
+          valid: false,
+          valid_format: ::Valvat::Syntax.validate(model.tax_identification_number)
+        }
       }
     end
 

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -94,13 +94,8 @@ module V1
     end
 
     def vies_check
-      vies_value = options.fetch(:vies_check)
-
       {
-        vies_check: vies_value.is_a?(Hash) ? vies_value : {
-          valid: false,
-          valid_format: ::Valvat::Syntax.validate(model.tax_identification_number)
-        }
+        vies_check: options.fetch(:vies_check)
       }
     end
 

--- a/app/services/customers/eu_auto_taxes_service.rb
+++ b/app/services/customers/eu_auto_taxes_service.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "valvat"
-
 module Customers
   class EuAutoTaxesService < BaseService
     Result = BaseResult[:tax_code]

--- a/spec/scenarios/customers/customer_eu_taxes_spec.rb
+++ b/spec/scenarios/customers/customer_eu_taxes_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Add customer-specific taxes", :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil, country: "FR", eu_tax_management: false, billing_entities: [create(:billing_entity, country: "FR")]) }
+
+  let(:american_attributes) do
+    {
+      name: "John",
+      country: "US",
+      address_line1: "123 Main St",
+      address_line2: "",
+      state: "Colorado",
+      city: "Denver",
+      zipcode: "80095",
+      currency: "USD"
+    }
+  end
+
+  let(:french_attributes) do
+    {
+      name: "Jean",
+      country: "FR",
+      address_line1: "123 Avenue du General",
+      address_line2: "",
+      state: "",
+      city: "Paris",
+      zipcode: "75018",
+      currency: "EUR"
+    }
+  end
+
+  let(:italian_attributes) do
+    {
+      country: "IT",
+      address_line1: "123 Via Marconi",
+      address_line2: "",
+      state: "",
+      city: "Roma",
+      zipcode: "00146",
+      currency: "EUR"
+    }
+  end
+
+  def enable_eu_tax_management!
+    Organizations::UpdateService.call!(organization:, params: {eu_tax_management: true})
+  end
+
+  context "when customer are created after the feature was enabled" do
+    it "create taxes" do
+      enable_eu_tax_management!
+
+      create_or_update_customer(american_attributes.merge(external_id: "user_usa_123"))
+      expect(Customer.find_by(external_id: "user_usa_123").taxes.sole.code).to eq "lago_eu_tax_exempt"
+
+      create_or_update_customer(french_attributes.merge(external_id: "user_fr_123"))
+      expect(Customer.find_by(external_id: "user_fr_123").taxes.sole.code).to eq "lago_eu_fr_standard"
+
+      create_or_update_customer(italian_attributes.merge(external_id: "user_it_123"))
+      expect(Customer.find_by(external_id: "user_it_123").taxes.sole.code).to eq "lago_eu_it_standard"
+
+      # Update customer to provide an INVALID EU VAT identifier
+      # Nothing changes and no API call is made
+      create_or_update_customer(external_id: "user_it_123", tax_identification_number: "IT123")
+      expect(Customer.find_by(external_id: "user_it_123").taxes.reload.sole.code).to eq "lago_eu_it_standard"
+
+      # Update customer to provide a valid EU VAT identifier
+      # A call is made to VIES api, we mock the service rather than the HTTP call because it's a SOAP API
+      # This customer now have 0% vat
+      mock_vies_check!("IT12345678901")
+      create_or_update_customer(external_id: "user_it_123", tax_identification_number: "IT12345678901")
+      expect(Customer.find_by(external_id: "user_it_123").taxes.reload.sole.code).to eq "lago_eu_reverse_charge"
+
+      mock_vies_check!("FR12345678901")
+      create_or_update_customer(external_id: "user_fr_123", tax_identification_number: "FR12345678901")
+      expect(Customer.find_by(external_id: "user_fr_123").taxes.sole.code).to eq "lago_eu_reverse_charge"
+
+      customer = Customer.find_by(external_id: "user_it_123")
+      # If I had a custom tax for this Customer
+      # It removes the automatic VAT
+      create_tax(name: "Banking rates", code: "banking_rates", rate: 1.3)
+      create_or_update_customer(external_id: customer.external_id, tax_codes: ["banking_rates"])
+      expect(customer.taxes.sole.code).to eq "banking_rates"
+
+      # Make an invoice with this tax
+      addon = create(:add_on, code: :test, organization:)
+      create_one_off_invoice(customer, [addon], taxes: ["banking_rates"])
+      expect(customer.invoices.sole.taxes.sole.code).to eq "banking_rates"
+
+      # Then, remove the tax_identification_number for the customer
+      # The custom tax is overridden by the default VAT of the country, even if an invoice used the previous taxes
+      create_or_update_customer(external_id: customer.external_id, tax_identification_number: nil)
+      expect(customer.taxes.sole.code).to eq "lago_eu_it_standard"
+    end
+  end
+
+  context "when customer are created before the feature was enabled" do
+    it "does not create taxes until the customer is updated" do
+      create_or_update_customer(american_attributes.merge(external_id: "user_usa_123"))
+      expect(Customer.find_by(external_id: "user_usa_123").taxes).to be_empty
+
+      enable_eu_tax_management!
+      expect(Customer.find_by(external_id: "user_usa_123").taxes).to be_empty
+
+      create_or_update_customer(external_id: "user_usa_123", tax_identification_number: "US-111") # Not EU VAT
+      expect(Customer.find_by(external_id: "user_usa_123").taxes.sole.code).to eq "lago_eu_tax_exempt"
+    end
+  end
+
+  context "when customer changes country" do
+    it "updates taxes" do
+      enable_eu_tax_management!
+
+      create_or_update_customer(french_attributes.merge(external_id: "user_moving"))
+      customer = Customer.find_by(external_id: "user_moving")
+      expect(customer.reload.taxes.sole.code).to eq "lago_eu_fr_standard"
+
+      create_or_update_customer(external_id: customer.external_id, country: "DE")
+      expect(customer.reload.taxes.sole.code).to eq "lago_eu_de_standard"
+    end
+  end
+end

--- a/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
+++ b/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
@@ -3,13 +3,11 @@
 require "rails_helper"
 
 describe "Dunning Campaign v1", :scenarios, type: :request do
-  let(:webhook_url) { "https://test.co/lago" }
   let(:organization) do
     create(:organization,
       name: "JC AI",
       premium_integrations: %w[auto_dunning],
-      email_settings: [],
-      webhook_url:)
+      email_settings: [])
   end
 
   let(:dunning_campaign) do
@@ -97,6 +95,8 @@ describe "Dunning Campaign v1", :scenarios, type: :request do
     end
   end
 
+  include_context "with webhook tracking"
+
   # TODO: make it a test metadata `:scenarios, type: :request, premium: true`
   around { |test| lago_premium!(&test) }
 
@@ -104,11 +104,6 @@ describe "Dunning Campaign v1", :scenarios, type: :request do
     stub_pdf_generation
     stripe_customer
     dunning_campaign_threshold
-
-    stub_request(:post, webhook_url).with do |req|
-      webhooks_sent << JSON.parse(req.body)
-      true
-    end.and_return(status: 200)
 
     stub_request(:get, "https://api.stripe.com/v1/customers/#{stripe_customer.provider_customer_id}")
       .and_return(status: 200, body: stripe_customer_response)

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -84,15 +84,12 @@ RSpec.describe ::V1::CustomerSerializer do
   end
 
   context "with a VIES check" do
-    subject(:serializer) { described_class.new(customer, root_name: "customer", includes: %i[vies_check], vies_check: false) }
+    subject(:serializer) { described_class.new(customer, root_name: "customer", includes: %i[vies_check], vies_check: {custom_hash: "yes"}) }
 
     let(:customer) { create(:customer, :with_salesforce_integration, tax_identification_number: "IT12345678901") }
 
     it "adds vies_check to customer" do
-      expect(result["customer"]["vies_check"]).to eq({
-        "valid" => false,
-        "valid_format" => true
-      })
+      expect(result["customer"]["vies_check"]).to eq({"custom_hash" => "yes"})
     end
   end
 end

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ::V1::CustomerSerializer do
     described_class.new(customer, root_name: "customer", includes: %i[taxes integration_customers applicable_invoice_custom_sections])
   end
 
+  let(:result) { JSON.parse(serializer.to_json) }
   let(:customer) { create(:customer, :with_salesforce_integration) }
   let(:metadata) { create(:customer_metadata, customer:) }
   let(:tax) { create(:tax, organization: customer.organization) }
@@ -21,55 +22,51 @@ RSpec.describe ::V1::CustomerSerializer do
   end
 
   it "serializes the object" do
-    result = JSON.parse(serializer.to_json)
-
-    aggregate_failures do
-      expect(result["customer"]["lago_id"]).to eq(customer.id)
-      expect(result["customer"]["billing_entity_code"]).to eq(customer.billing_entity.code)
-      expect(result["customer"]["external_id"]).to eq(customer.external_id)
-      expect(result["customer"]["account_type"]).to eq(customer.account_type)
-      expect(result["customer"]["name"]).to eq(customer.name)
-      expect(result["customer"]["firstname"]).to eq(customer.firstname)
-      expect(result["customer"]["lastname"]).to eq(customer.lastname)
-      expect(result["customer"]["customer_type"]).to eq(customer.customer_type)
-      expect(result["customer"]["sequential_id"]).to eq(customer.sequential_id)
-      expect(result["customer"]["slug"]).to eq(customer.slug)
-      expect(result["customer"]["created_at"]).to eq(customer.created_at.iso8601)
-      expect(result["customer"]["updated_at"]).to eq(customer.updated_at.iso8601)
-      expect(result["customer"]["country"]).to eq(customer.country)
-      expect(result["customer"]["address_line1"]).to eq(customer.address_line1)
-      expect(result["customer"]["address_line2"]).to eq(customer.address_line2)
-      expect(result["customer"]["state"]).to eq(customer.state)
-      expect(result["customer"]["zipcode"]).to eq(customer.zipcode)
-      expect(result["customer"]["email"]).to eq(customer.email)
-      expect(result["customer"]["city"]).to eq(customer.city)
-      expect(result["customer"]["url"]).to eq(customer.url)
-      expect(result["customer"]["phone"]).to eq(customer.phone)
-      expect(result["customer"]["logo_url"]).to eq(customer.logo_url)
-      expect(result["customer"]["legal_name"]).to eq(customer.legal_name)
-      expect(result["customer"]["legal_number"]).to eq(customer.legal_number)
-      expect(result["customer"]["currency"]).to eq(customer.currency)
-      expect(result["customer"]["timezone"]).to eq(customer.timezone)
-      expect(result["customer"]["applicable_timezone"]).to eq(customer.applicable_timezone)
-      expect(result["customer"]["net_payment_term"]).to eq(customer.net_payment_term)
-      expect(result["customer"]["finalize_zero_amount_invoice"]).to eq(customer.finalize_zero_amount_invoice)
-      expect(result["customer"]["billing_configuration"]["payment_provider"]).to eq(customer.payment_provider)
-      expect(result["customer"]["billing_configuration"]["payment_provider_code"]).to eq(customer.payment_provider_code)
-      expect(result["customer"]["billing_configuration"]["invoice_grace_period"]).to eq(customer.invoice_grace_period)
-      expect(result["customer"]["billing_configuration"]["document_locale"]).to eq(customer.document_locale)
-      expect(result["customer"]["shipping_address"]["address_line1"]).to eq("test1")
-      expect(result["customer"]["shipping_address"]["city"]).to eq("Paris")
-      expect(result["customer"]["shipping_address"]["zipcode"]).to eq("002")
-      expect(result["customer"]["metadata"].first["lago_id"]).to eq(metadata.id)
-      expect(result["customer"]["metadata"].first["key"]).to eq(metadata.key)
-      expect(result["customer"]["metadata"].first["value"]).to eq(metadata.value)
-      expect(result["customer"]["metadata"].first["display_in_invoice"]).to eq(metadata.display_in_invoice)
-      expect(result["customer"]["tax_identification_number"]).to eq(customer.tax_identification_number)
-      expect(result["customer"]["taxes"].count).to eq(1)
-      expect(result["customer"]["integration_customers"].count).to eq(1)
-      expect(result["customer"]["applicable_invoice_custom_sections"].count).to eq(1)
-      expect(result["customer"]["skip_invoice_custom_sections"]).to eq(false)
-    end
+    expect(result["customer"]["lago_id"]).to eq(customer.id)
+    expect(result["customer"]["billing_entity_code"]).to eq(customer.billing_entity.code)
+    expect(result["customer"]["external_id"]).to eq(customer.external_id)
+    expect(result["customer"]["account_type"]).to eq(customer.account_type)
+    expect(result["customer"]["name"]).to eq(customer.name)
+    expect(result["customer"]["firstname"]).to eq(customer.firstname)
+    expect(result["customer"]["lastname"]).to eq(customer.lastname)
+    expect(result["customer"]["customer_type"]).to eq(customer.customer_type)
+    expect(result["customer"]["sequential_id"]).to eq(customer.sequential_id)
+    expect(result["customer"]["slug"]).to eq(customer.slug)
+    expect(result["customer"]["created_at"]).to eq(customer.created_at.iso8601)
+    expect(result["customer"]["updated_at"]).to eq(customer.updated_at.iso8601)
+    expect(result["customer"]["country"]).to eq(customer.country)
+    expect(result["customer"]["address_line1"]).to eq(customer.address_line1)
+    expect(result["customer"]["address_line2"]).to eq(customer.address_line2)
+    expect(result["customer"]["state"]).to eq(customer.state)
+    expect(result["customer"]["zipcode"]).to eq(customer.zipcode)
+    expect(result["customer"]["email"]).to eq(customer.email)
+    expect(result["customer"]["city"]).to eq(customer.city)
+    expect(result["customer"]["url"]).to eq(customer.url)
+    expect(result["customer"]["phone"]).to eq(customer.phone)
+    expect(result["customer"]["logo_url"]).to eq(customer.logo_url)
+    expect(result["customer"]["legal_name"]).to eq(customer.legal_name)
+    expect(result["customer"]["legal_number"]).to eq(customer.legal_number)
+    expect(result["customer"]["currency"]).to eq(customer.currency)
+    expect(result["customer"]["timezone"]).to eq(customer.timezone)
+    expect(result["customer"]["applicable_timezone"]).to eq(customer.applicable_timezone)
+    expect(result["customer"]["net_payment_term"]).to eq(customer.net_payment_term)
+    expect(result["customer"]["finalize_zero_amount_invoice"]).to eq(customer.finalize_zero_amount_invoice)
+    expect(result["customer"]["billing_configuration"]["payment_provider"]).to eq(customer.payment_provider)
+    expect(result["customer"]["billing_configuration"]["payment_provider_code"]).to eq(customer.payment_provider_code)
+    expect(result["customer"]["billing_configuration"]["invoice_grace_period"]).to eq(customer.invoice_grace_period)
+    expect(result["customer"]["billing_configuration"]["document_locale"]).to eq(customer.document_locale)
+    expect(result["customer"]["shipping_address"]["address_line1"]).to eq("test1")
+    expect(result["customer"]["shipping_address"]["city"]).to eq("Paris")
+    expect(result["customer"]["shipping_address"]["zipcode"]).to eq("002")
+    expect(result["customer"]["metadata"].first["lago_id"]).to eq(metadata.id)
+    expect(result["customer"]["metadata"].first["key"]).to eq(metadata.key)
+    expect(result["customer"]["metadata"].first["value"]).to eq(metadata.value)
+    expect(result["customer"]["metadata"].first["display_in_invoice"]).to eq(metadata.display_in_invoice)
+    expect(result["customer"]["tax_identification_number"]).to eq(customer.tax_identification_number)
+    expect(result["customer"]["taxes"].count).to eq(1)
+    expect(result["customer"]["integration_customers"].count).to eq(1)
+    expect(result["customer"]["applicable_invoice_custom_sections"].count).to eq(1)
+    expect(result["customer"]["skip_invoice_custom_sections"]).to eq(false)
   end
 
   context "with a stripe customer" do
@@ -81,9 +78,21 @@ RSpec.describe ::V1::CustomerSerializer do
     end
 
     it "serializes the object" do
-      result = JSON.parse(serializer.to_json)
       expect(result["customer"]["billing_configuration"]["provider_customer_id"]).to eq(stripe_customer.provider_customer_id)
       expect(result["customer"]["billing_configuration"]["provider_payment_methods"]).to eq(stripe_customer.provider_payment_methods)
+    end
+  end
+
+  context "with a VIES check" do
+    subject(:serializer) { described_class.new(customer, root_name: "customer", includes: %i[vies_check], vies_check: false) }
+
+    let(:customer) { create(:customer, :with_salesforce_integration, tax_identification_number: "IT12345678901") }
+
+    it "adds vies_check to customer" do
+      expect(result["customer"]["vies_check"]).to eq({
+        "valid" => false,
+        "valid_format" => true
+      })
     end
   end
 end

--- a/spec/services/customers/eu_auto_taxes_service_spec.rb
+++ b/spec/services/customers/eu_auto_taxes_service_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "valvat"
 
 RSpec.describe Customers::EuAutoTaxesService, type: :service do
   subject(:eu_tax_service) { described_class.new(customer:, new_record:, tax_attributes_changed:) }

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -115,6 +115,17 @@ module ScenariosHelper
     post_with_token(organization, "/api/v1/taxes", {tax: params})
   end
 
+  # The mock always return a valid response,
+  # To get an invalid response, simply use a invalid format (like YY123)
+  def mock_vies_check!(vat_number)
+    valvat = instance_double(Valvat)
+    allow(Valvat).to receive(:new).with(vat_number).and_return(valvat)
+    allow(valvat).to receive(:exists?).with(detail: true).and_return({
+      countryCode: vat_number[0..1].upcase,
+      vatNumber: vat_number.upcase
+    })
+  end
+
   ### Wallets
 
   def create_wallet(params)

--- a/spec/support/shared_context/webhook_tracking.rb
+++ b/spec/support/shared_context/webhook_tracking.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with webhook tracking" do
+  let(:webhooks_sent) { [] }
+
+  before do
+    webhook_url = organization.webhook_endpoints.sole.webhook_url
+
+    stub_request(:post, webhook_url).with do |req|
+      webhooks_sent << JSON.parse(req.body)
+      true
+    end.and_return(status: 200)
+  rescue ActiveRecord::SoleRecordExceeded
+    raise "`with webhook tracking` shared context only works with a single webhook endpoint"
+  end
+end


### PR DESCRIPTION
## Description

Adds scenario tests about customer taxes and EU tax management. Ensure a webhook is sent in case of success or failure.

This ensure the webhook is sent in case of error

When using Valvat, the gem will perform format check via Regex before calling the API. If the format is invalid, the API isn't called.

In the webhook pay load the `customer.vies_check` hash has multple form.

**Notice that valvat is now autloaded with Bundler. I don't know why it was done manually (since the gem was added).**

### When valid

The response from the VIES API is returned, like before

### When format is invalid

```json
{
  "valid": false,
  "valid_format": false,
}
```

### When format is valid but number doesn't exist

```json
{
  "valid": false,
  "valid_format": true
}
```


### When the API returned an error (timeout, rate limit and so on)

```json
{
  "valid": false,
  "valid_format": true,
  "error": "The  web service returned the error: <ERROR FROM VIES>"
}
```

The error message prefix is from valvat.