### PR TITLE
misc(plans): Extract plan GraphQL arguments in types

### DIFF
--- a/app/graphql/mutations/plans/create.rb
+++ b/app/graphql/mutations/plans/create.rb
@@ -11,22 +11,7 @@ module Mutations
       graphql_name "CreatePlan"
       description "Creates a new Plan"
 
-      argument :amount_cents, GraphQL::Types::BigInt, required: true
-      argument :amount_currency, Types::CurrencyEnum
-      argument :bill_charges_monthly, Boolean, required: false
-      argument :code, String, required: true
-      argument :description, String, required: false
-      argument :interval, Types::Plans::IntervalEnum, required: true
-      argument :invoice_display_name, String, required: false
-      argument :name, String, required: true
-      argument :pay_in_advance, Boolean, required: true
-      argument :tax_codes, [String], required: false
-      argument :trial_period, Float, required: false
-
-      argument :charges, [Types::Charges::Input]
-      argument :minimum_commitment, Types::Commitments::Input, required: false
-      argument :usage_thresholds, [Types::UsageThresholds::Input], required: false
-
+      input_object_class Types::Plans::CreateInput
       type Types::Plans::Object
 
       def resolve(**args)

--- a/app/graphql/mutations/plans/update.rb
+++ b/app/graphql/mutations/plans/update.rb
@@ -10,24 +10,7 @@ module Mutations
       graphql_name "UpdatePlan"
       description "Updates an existing Plan"
 
-      argument :amount_cents, GraphQL::Types::BigInt, required: true
-      argument :amount_currency, Types::CurrencyEnum, required: true
-      argument :bill_charges_monthly, Boolean, required: false
-      argument :cascade_updates, Boolean, required: false
-      argument :code, String, required: true
-      argument :description, String, required: false
-      argument :id, String, required: true
-      argument :interval, Types::Plans::IntervalEnum, required: true
-      argument :invoice_display_name, String, required: false
-      argument :name, String, required: true
-      argument :pay_in_advance, Boolean, required: true
-      argument :tax_codes, [String], required: false
-      argument :trial_period, Float, required: false
-
-      argument :charges, [Types::Charges::Input]
-      argument :minimum_commitment, Types::Commitments::Input, required: false
-      argument :usage_thresholds, [Types::UsageThresholds::Input], required: false
-
+      input_object_class Types::Plans::UpdateInput
       type Types::Plans::Object
 
       def resolve(**args)

--- a/app/graphql/types/plans/create_input.rb
+++ b/app/graphql/types/plans/create_input.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Types
+  module Plans
+    class CreateInput < Types::BaseInputObject
+      graphql_name "CreatePlanInput"
+
+      argument :amount_cents, GraphQL::Types::BigInt, required: true
+      argument :amount_currency, Types::CurrencyEnum
+      argument :bill_charges_monthly, Boolean, required: false
+      argument :code, String, required: true
+      argument :description, String, required: false
+      argument :interval, Types::Plans::IntervalEnum, required: true
+      argument :invoice_display_name, String, required: false
+      argument :name, String, required: true
+      argument :pay_in_advance, Boolean, required: true
+      argument :tax_codes, [String], required: false
+      argument :trial_period, Float, required: false
+
+      argument :charges, [Types::Charges::Input]
+      argument :minimum_commitment, Types::Commitments::Input, required: false
+      argument :usage_thresholds, [Types::UsageThresholds::Input], required: false
+    end
+  end
+end

--- a/app/graphql/types/plans/update_input.rb
+++ b/app/graphql/types/plans/update_input.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Types
+  module Plans
+    class UpdateInput < Types::BaseInputObject
+      graphql_name "UpdatePlanInput"
+
+      argument :id, ID, required: true
+
+      argument :amount_cents, GraphQL::Types::BigInt, required: true
+      argument :amount_currency, Types::CurrencyEnum, required: true
+      argument :bill_charges_monthly, Boolean, required: false
+      argument :cascade_updates, Boolean, required: false
+      argument :code, String, required: true
+      argument :description, String, required: false
+      argument :interval, Types::Plans::IntervalEnum, required: true
+      argument :invoice_display_name, String, required: false
+      argument :name, String, required: true
+      argument :pay_in_advance, Boolean, required: true
+      argument :tax_codes, [String], required: false
+      argument :trial_period, Float, required: false
+
+      argument :charges, [Types::Charges::Input]
+      argument :minimum_commitment, Types::Commitments::Input, required: false
+      argument :usage_thresholds, [Types::UsageThresholds::Input], required: false
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -9461,7 +9461,7 @@ input UpdatePlanInput {
   clientMutationId: String
   code: String!
   description: String
-  id: String!
+  id: ID!
   interval: PlanInterval!
   invoiceDisplayName: String
   minimumCommitment: CommitmentInput

--- a/schema.json
+++ b/schema.json
@@ -10476,18 +10476,6 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "clientMutationId",
-              "description": "A unique identifier for the client performing the mutation.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "amountCents",
               "description": null,
               "type": {
@@ -10702,6 +10690,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -47524,12 +47524,16 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "clientMutationId",
-              "description": "A unique identifier for the client performing the mutation.",
+              "name": "id",
+              "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -47614,22 +47618,6 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -47778,6 +47766,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/types/plans/create_input_spec.rb
+++ b/spec/graphql/types/plans/create_input_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Plans::CreateInput do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:amount_cents).of_type("BigInt!")
+    expect(subject).to accept_argument(:amount_currency).of_type("CurrencyEnum!")
+    expect(subject).to accept_argument(:bill_charges_monthly).of_type("Boolean")
+    expect(subject).to accept_argument(:code).of_type("String!")
+    expect(subject).to accept_argument(:description).of_type("String")
+    expect(subject).to accept_argument(:interval).of_type("PlanInterval!")
+    expect(subject).to accept_argument(:invoice_display_name).of_type("String")
+    expect(subject).to accept_argument(:name).of_type("String!")
+    expect(subject).to accept_argument(:pay_in_advance).of_type("Boolean!")
+    expect(subject).to accept_argument(:tax_codes).of_type("[String!]")
+    expect(subject).to accept_argument(:trial_period).of_type("Float")
+
+    expect(subject).to accept_argument(:charges).of_type("[ChargeInput!]!")
+    expect(subject).to accept_argument(:minimum_commitment).of_type("CommitmentInput")
+    expect(subject).to accept_argument(:usage_thresholds).of_type("[UsageThresholdInput!]")
+  end
+end

--- a/spec/graphql/types/plans/update_input_spec.rb
+++ b/spec/graphql/types/plans/update_input_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Plans::UpdateInput do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:id).of_type("ID!")
+    expect(subject).to accept_argument(:amount_cents).of_type("BigInt!")
+    expect(subject).to accept_argument(:amount_currency).of_type("CurrencyEnum!")
+    expect(subject).to accept_argument(:bill_charges_monthly).of_type("Boolean")
+    expect(subject).to accept_argument(:cascade_updates).of_type("Boolean")
+    expect(subject).to accept_argument(:code).of_type("String!")
+    expect(subject).to accept_argument(:description).of_type("String")
+    expect(subject).to accept_argument(:interval).of_type("PlanInterval!")
+    expect(subject).to accept_argument(:invoice_display_name).of_type("String")
+    expect(subject).to accept_argument(:name).of_type("String!")
+    expect(subject).to accept_argument(:pay_in_advance).of_type("Boolean!")
+    expect(subject).to accept_argument(:tax_codes).of_type("[String!]")
+    expect(subject).to accept_argument(:trial_period).of_type("Float")
+
+    expect(subject).to accept_argument(:charges).of_type("[ChargeInput!]!")
+    expect(subject).to accept_argument(:minimum_commitment).of_type("CommitmentInput")
+    expect(subject).to accept_argument(:usage_thresholds).of_type("[UsageThresholdInput!]")
+  end
+end


### PR DESCRIPTION
## Description

This PR extracts the arguments from the `CreatePlan` and `UpdatePlan` mutation into proper types, respectively `CreatePlanInput` and `UpdatePlanInput`

These types will be later extended with the coming alerting feature