### PR TITLE
Feat(multientities): add missing fields to serializer

### DIFF
--- a/app/serializers/v1/billing_entity_serializer.rb
+++ b/app/serializers/v1/billing_entity_serializer.rb
@@ -29,7 +29,9 @@ module V1
         invoice_footer: model.invoice_footer,
         invoice_grace_period: model.invoice_grace_period,
         document_locale: model.document_locale,
-        is_default: model.organization.default_billing_entity&.id == model.id
+        is_default: model.organization.default_billing_entity&.id == model.id,
+        eu_tax_management: model.eu_tax_management,
+        logo_url: model.logo_url,
       }
     end
   end

--- a/app/serializers/v1/billing_entity_serializer.rb
+++ b/app/serializers/v1/billing_entity_serializer.rb
@@ -31,7 +31,7 @@ module V1
         document_locale: model.document_locale,
         is_default: model.organization.default_billing_entity&.id == model.id,
         eu_tax_management: model.eu_tax_management,
-        logo_url: model.logo_url,
+        logo_url: model.logo_url
       }
     end
   end

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     fee_type { "subscription" }
     subscription
     organization { invoice&.organization || subscription&.organization || association(:organization) }
-    billing_entity { invoice&.billing_entity || association(:billing_entity) }
+    billing_entity_id { invoice&.billing_entity_id || subscription&.customer&.billing_entity_id || association(:billing_entity).id }
 
     amount_cents { 200 }
     precise_amount_cents { 200.0000000001 }

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     fee_type { "subscription" }
     subscription
     organization { invoice&.organization || subscription&.organization || association(:organization) }
-    billing_entity_id { invoice&.billing_entity_id || subscription&.customer&.billing_entity_id || association(:billing_entity).id }
+    billing_entity { invoice&.billing_entity || subscription&.customer&.billing_entity || association(:billing_entity) }
 
     amount_cents { 200 }
     precise_amount_cents { 200.0000000001 }

--- a/spec/serializers/v1/billing_entity_serializer_spec.rb
+++ b/spec/serializers/v1/billing_entity_serializer_spec.rb
@@ -36,5 +36,7 @@ RSpec.describe V1::BillingEntitySerializer, type: :serializer do
     expect(billing_entity_serialized.fetch("invoice_grace_period")).to eq(billing_entity.invoice_grace_period)
     expect(billing_entity_serialized.fetch("document_locale")).to eq(billing_entity.document_locale)
     expect(billing_entity_serialized.fetch("is_default")).to eq(billing_entity.organization.default_billing_entity.id == billing_entity.id)
+    expect(billing_entity_serialized.fetch("eu_tax_management")).to eq(billing_entity.eu_tax_management)
+    expect(billing_entity_serialized.fetch("logo_url")).to eq(billing_entity.logo_url)
   end
 end


### PR DESCRIPTION
## Context

While writing clients I realized we missed some fields in billing_entity_serializer - added all of them
