### PR TITLE
fix(deps): Require ostruct when initializing

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -3,6 +3,7 @@
 require_relative "boot"
 
 require "rails/all"
+require "ostruct"
 
 Bundler.require(*Rails.groups)
 


### PR DESCRIPTION
removed here: https://github.com/getlago/lago-api/pull/3470/files#diff-63ba8710e689ec851c82f0151a9e100381f4638f1991dd693d171b8d389ac5e8L3