### PR TITLE
Feat(multientities): update old taxes services

### DIFF
--- a/app/services/taxes/create_service.rb
+++ b/app/services/taxes/create_service.rb
@@ -20,6 +20,8 @@ module Taxes
       tax.applied_to_organization = params[:applied_to_organization] if params.key?(:applied_to_organization)
       tax.save!
 
+      apply_taxes_on_billing_entity if params[:applied_to_organization]
+
       result.tax = tax
       result
     rescue ActiveRecord::RecordInvalid => e
@@ -29,5 +31,12 @@ module Taxes
     private
 
     attr_reader :organization, :params
+
+    def apply_taxes_on_billing_entity
+      billing_entity = organization.default_billing_entity
+      if params[:applied_to_organization]
+        BillingEntities::Taxes::ApplyTaxesService.call(billing_entity:, tax_codes: [params[:code]])
+      end
+    end
   end
 end

--- a/app/services/taxes/destroy_service.rb
+++ b/app/services/taxes/destroy_service.rb
@@ -15,6 +15,7 @@ module Taxes
       #       as we need the applied_tax relation
       draft_invoice_ids
 
+      destroy_applied_taxes
       tax.destroy!
 
       Invoice.where(id: draft_invoice_ids).update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
@@ -32,6 +33,11 @@ module Taxes
         .where(customer_id: tax.applicable_customers.select(:id))
         .draft
         .pluck(:id)
+    end
+
+    def destroy_applied_taxes
+      billing_entity = tax.organization.default_billing_entity
+      BillingEntities::Taxes::RemoveTaxesService.call(billing_entity:, tax_codes: [tax.code])
     end
   end
 end

--- a/spec/services/taxes/create_service_spec.rb
+++ b/spec/services/taxes/create_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Taxes::CreateService, type: :service do
   subject(:create_service) { described_class.new(organization:, params:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { organization.default_billing_entity }
   let(:code) { "tax_code" }
   let(:params) do
     {
@@ -25,6 +25,37 @@ RSpec.describe Taxes::CreateService, type: :service do
     it "returns tax in the result" do
       result = create_service.call
       expect(result.tax).to be_a(Tax)
+    end
+
+    it "does not create an applied tax for the default billing entity" do
+      expect { create_service.call }.not_to change { billing_entity.applied_taxes.count }
+    end
+
+    context "when applied_to_organization is true" do
+      let(:params) do
+        {
+          name: "Tax",
+          code:,
+          rate: 15.0,
+          description: "Tax Description",
+          applied_to_organization: true
+        }
+      end
+
+      it "creates an applied tax for the default billing entity" do
+        expect { create_service.call }.to change { billing_entity.applied_taxes.count }.by(1)
+      end
+
+      context "when there are multiple billing entities" do
+        let(:billing_entity2) { create(:billing_entity, organization:) }
+
+        before { billing_entity2 }
+
+        it "creates an applied tax for the default billing entity" do
+          expect { create_service.call }.to change { billing_entity.applied_taxes.count }.by(1)
+          expect { create_service.call }.not_to change { billing_entity2.applied_taxes.count }
+        end
+      end
     end
 
     context "with validation error" do

--- a/spec/services/taxes/destroy_service_spec.rb
+++ b/spec/services/taxes/destroy_service_spec.rb
@@ -5,25 +5,36 @@ require "rails_helper"
 RSpec.describe Taxes::DestroyService, type: :service do
   subject(:destroy_service) { described_class.new(tax:) }
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { organization.default_billing_entity }
   let(:tax) { create(:tax, organization:) }
-
+  let(:tax2) { create(:tax, organization:) }
+  let(:applied_tax2) { create(:billing_entity_applied_tax, billing_entity:, tax: tax2) }
   let(:customer) { create(:customer, organization:) }
 
   describe "#call" do
     before { tax }
 
     it "destroys the tax" do
-      aggregate_failures do
-        expect { destroy_service.call }.to change(Tax, :count).by(-1)
-      end
+      expect { destroy_service.call }.to change(Tax, :count).by(-1)
     end
 
     it "marks invoices as ready to be refreshed" do
       draft_invoice = create(:invoice, :draft, organization:, customer:)
 
       expect { destroy_service.call }.to change { draft_invoice.reload.ready_to_be_refreshed }.to(true)
+    end
+
+    it "does not remove the tax from the default billing entity" do
+      expect { destroy_service.call }.not_to change { billing_entity.applied_taxes.count }
+    end
+
+    context "when tax is applied to the default billing entity" do
+      before { create(:billing_entity_applied_tax, billing_entity:, tax:) }
+
+      it "removes the tax from the default billing entity" do
+        expect { destroy_service.call }.to change { billing_entity.applied_taxes.count }.by(-1)
+      end
     end
 
     context "when tax is not found" do


### PR DESCRIPTION
## Context

The taxes services we had before, should create or delete applied taxes on default_billing_entity

## Description

Updated
- `Taxes::CreateService`
- `Taxes::UpdateService`
- `Taxes::DestroyService`