### PR TITLE
misc(job): Add a new ClockJob base job class

### DIFF
--- a/app/jobs/clock/activate_subscriptions_job.rb
+++ b/app/jobs/clock/activate_subscriptions_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class ActivateSubscriptionsJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class ActivateSubscriptionsJob < ClockJob
     unique :until_executed, on_conflict: :log
 
     def perform

--- a/app/jobs/clock/compute_all_daily_usages_job.rb
+++ b/app/jobs/clock/compute_all_daily_usages_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class ComputeAllDailyUsagesJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class ComputeAllDailyUsagesJob < ClockJob
     def perform
       DailyUsages::ComputeAllService.call(timestamp: Time.current)
     end

--- a/app/jobs/clock/consume_subscription_refreshed_queue_job.rb
+++ b/app/jobs/clock/consume_subscription_refreshed_queue_job.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 
-class Clock::ConsumeSubscriptionRefreshedQueueJob < ApplicationJob
-  queue_as do
-    if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-      :clock_worker
-    else
-      :clock
-    end
-  end
-
+class Clock::ConsumeSubscriptionRefreshedQueueJob < ClockJob
   unique :until_executed, on_conflict: :log
 
   def perform

--- a/app/jobs/clock/create_interval_wallet_transactions_job.rb
+++ b/app/jobs/clock/create_interval_wallet_transactions_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class CreateIntervalWalletTransactionsJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class CreateIntervalWalletTransactionsJob < ClockJob
     def perform
       Wallets::CreateIntervalWalletTransactionsService.call
     end

--- a/app/jobs/clock/events_validation_job.rb
+++ b/app/jobs/clock/events_validation_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class EventsValidationJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class EventsValidationJob < ClockJob
     unique :until_executed
 
     def perform

--- a/app/jobs/clock/finalize_invoices_job.rb
+++ b/app/jobs/clock/finalize_invoices_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class FinalizeInvoicesJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class FinalizeInvoicesJob < ClockJob
     unique :until_executed, on_conflict: :log
 
     def perform

--- a/app/jobs/clock/free_trial_subscriptions_biller_job.rb
+++ b/app/jobs/clock/free_trial_subscriptions_biller_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class FreeTrialSubscriptionsBillerJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class FreeTrialSubscriptionsBillerJob < ClockJob
     def perform
       Subscriptions::FreeTrialBillingService.call
     end

--- a/app/jobs/clock/inbound_webhooks_cleanup_job.rb
+++ b/app/jobs/clock/inbound_webhooks_cleanup_job.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class InboundWebhooksCleanupJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as "clock"
-
+  class InboundWebhooksCleanupJob < ClockJob
     def perform
       InboundWebhook.where("updated_at < ?", 90.days.ago).destroy_all
     end

--- a/app/jobs/clock/inbound_webhooks_retry_job.rb
+++ b/app/jobs/clock/inbound_webhooks_retry_job.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class InboundWebhooksRetryJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as "clock"
-
+  class InboundWebhooksRetryJob < ClockJob
     def perform
       InboundWebhook.retriable.find_each do |inbound_webhook|
         InboundWebhooks::ProcessJob.perform_later(inbound_webhook:)

--- a/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
+++ b/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class MarkInvoicesAsPaymentOverdueJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class MarkInvoicesAsPaymentOverdueJob < ClockJob
     def perform
       Invoice
         .finalized

--- a/app/jobs/clock/process_dunning_campaigns_job.rb
+++ b/app/jobs/clock/process_dunning_campaigns_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class ProcessDunningCampaignsJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class ProcessDunningCampaignsJob < ClockJob
     unique :until_executed, on_conflict: :log
 
     def perform

--- a/app/jobs/clock/refresh_draft_invoices_job.rb
+++ b/app/jobs/clock/refresh_draft_invoices_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class RefreshDraftInvoicesJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class RefreshDraftInvoicesJob < ClockJob
     unique :until_executed, on_conflict: :log
 
     def perform

--- a/app/jobs/clock/refresh_lifetime_usages_job.rb
+++ b/app/jobs/clock/refresh_lifetime_usages_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class RefreshLifetimeUsagesJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class RefreshLifetimeUsagesJob < ClockJob
     unique :until_executed, on_conflict: :log
 
     def perform

--- a/app/jobs/clock/refresh_wallets_ongoing_balance_job.rb
+++ b/app/jobs/clock/refresh_wallets_ongoing_balance_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class RefreshWalletsOngoingBalanceJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class RefreshWalletsOngoingBalanceJob < ClockJob
     unique :until_executed, on_conflict: :log
 
     def perform

--- a/app/jobs/clock/retry_failed_invoices_job.rb
+++ b/app/jobs/clock/retry_failed_invoices_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class RetryFailedInvoicesJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class RetryFailedInvoicesJob < ClockJob
     def perform
       Invoice
         .failed

--- a/app/jobs/clock/retry_generating_subscription_invoices_job.rb
+++ b/app/jobs/clock/retry_generating_subscription_invoices_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class RetryGeneratingSubscriptionInvoicesJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class RetryGeneratingSubscriptionInvoicesJob < ClockJob
     THRESHOLD = -> { 1.day.ago }
 
     def perform

--- a/app/jobs/clock/subscriptions_biller_job.rb
+++ b/app/jobs/clock/subscriptions_biller_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class SubscriptionsBillerJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class SubscriptionsBillerJob < ClockJob
     def perform
       Organization.find_each do |organization|
         Subscriptions::OrganizationBillingJob.perform_later(organization:)

--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class SubscriptionsToBeTerminatedJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class SubscriptionsToBeTerminatedJob < ClockJob
     def perform
       Subscription
         .joins(customer: :organization)

--- a/app/jobs/clock/terminate_coupons_job.rb
+++ b/app/jobs/clock/terminate_coupons_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class TerminateCouponsJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class TerminateCouponsJob < ClockJob
     def perform
       Coupons::TerminateService.terminate_all_expired
     end

--- a/app/jobs/clock/terminate_ended_subscriptions_job.rb
+++ b/app/jobs/clock/terminate_ended_subscriptions_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class TerminateEndedSubscriptionsJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class TerminateEndedSubscriptionsJob < ClockJob
     def perform
       Subscription
         .joins(customer: :organization)

--- a/app/jobs/clock/terminate_recurring_transaction_rules_job.rb
+++ b/app/jobs/clock/terminate_recurring_transaction_rules_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class TerminateRecurringTransactionRulesJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class TerminateRecurringTransactionRulesJob < ClockJob
     def perform
       RecurringTransactionRule.eligible_for_termination.find_each do |recurring_transaction_rule|
         Wallets::RecurringTransactionRules::TerminateService.call(recurring_transaction_rule:)

--- a/app/jobs/clock/terminate_wallets_job.rb
+++ b/app/jobs/clock/terminate_wallets_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class TerminateWalletsJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class TerminateWalletsJob < ClockJob
     def perform
       Wallet.active.expired.find_each do |wallet|
         Wallets::TerminateService.call(wallet:)

--- a/app/jobs/clock/webhooks_cleanup_job.rb
+++ b/app/jobs/clock/webhooks_cleanup_job.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 module Clock
-  class WebhooksCleanupJob < ApplicationJob
-    if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
-      include SentryCronConcern
-    end
-
-    queue_as do
-      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
-        :clock_worker
-      else
-        :clock
-      end
-    end
-
+  class WebhooksCleanupJob < ClockJob
     def perform
       Webhook.where("updated_at < ?", 90.days.ago).destroy_all
     end

--- a/app/jobs/clock_job.rb
+++ b/app/jobs/clock_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ClockJob < ApplicationJob
+  if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
+    include SentryCronConcern
+  end
+
+  queue_as do
+    if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
+      :clock_worker
+    else
+      :clock
+    end
+  end
+end


### PR DESCRIPTION
## Context

The following code is repeated over and over in all jobs defined in `/app/jobs/clock`:

```ruby
 if ENV["SENTRY_DSN"].present? && ENV["SENTRY_ENABLE_CRONS"].present?
    include SentryCronConcern
  end

  queue_as do
    if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
      :clock_worker
    else
      :clock
    end
  end
```

## Description

This PR just moves this logic in a new `ClockJob` base job class, updates the parent class of all related job and removes the duplicated logic
