### PR TITLE
fix(migration): handle invoices billing_entity_sequential_id index

### DIFF
--- a/db/migrate/20250327130156_change_invoices_index_on_billing_entity_sequential_id.rb
+++ b/db/migrate/20250327130156_change_invoices_index_on_billing_entity_sequential_id.rb
@@ -7,14 +7,14 @@ class ChangeInvoicesIndexOnBillingEntitySequentialId < ActiveRecord::Migration[7
     remove_index :invoices, [:organization_id, :billing_entity_sequential_id],
       order: {billing_entity_sequential_id: :desc},
       algorithm: :concurrently,
-      if_not_exists: true,
-      include: %i[self_billed]
+      include: %i[self_billed],
+      if_exists: true
 
     add_index :invoices, [:billing_entity_id, :billing_entity_sequential_id],
       order: {billing_entity_sequential_id: :desc},
       algorithm: :concurrently,
-      if_not_exists: true,
       include: %i[self_billed],
-      unique: true
+      unique: true,
+      if_not_exists: true
   end
 end


### PR DESCRIPTION
Fix migration that updates the invoices billing_entity_sequential_id index.

## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/{{FEATURE_SLUG}}

## Context

Include relevant motivation and context.

## Description

Describe your changes in detail.

List any dependencies that are required.
