### PR TITLE
fix(exports): Force type for exports

### DIFF
--- a/db/views/exports_applied_coupons_v01.sql
+++ b/db/views/exports_applied_coupons_v01.sql
@@ -12,11 +12,11 @@ SELECT
         WHEN 0 THEN null
         WHEN 1 THEN null
         ELSE
-            CASE 
+            CASE
                 WHEN cp.coupon_type = 1 THEN NULL -- coupon is percentage
                 ELSE
                     ac.amount_cents - (
-                        SELECT SUM(cr.amount_cents)
+                        SELECT SUM(cr.amount_cents)::bigint
                         FROM credits AS cr
                         WHERE cr.applied_coupon_id = ac.id
                     )

--- a/db/views/exports_billable_metrics_v01.sql
+++ b/db/views/exports_billable_metrics_v01.sql
@@ -14,9 +14,9 @@ SELECT
     WHEN 7 THEN 'custom_agg'
     ELSE 'unknown'
   END AS aggregation_type,
-  bm.weighted_interval,
+  bm.weighted_interval::text,
   bm.recurring,
-  bm.rounding_function,
+  bm.rounding_function::text,
   bm.rounding_precision,
   bm.created_at,
   bm.updated_at,

--- a/db/views/exports_charges_v01.sql
+++ b/db/views/exports_charges_v01.sql
@@ -1,45 +1,54 @@
 SELECT
-    p.organization_id,
-    c.id AS lago_id,
-    c.billable_metric_id AS lago_billable_metric_id,
-    c.invoice_display_name,
-    c.created_at,
-    c.updated_at,
-    CASE c.charge_model
-        WHEN 0 THEN 'standard'
-        WHEN 1 THEN 'graduated'
-        WHEN 2 THEN 'package'
-        WHEN 3 THEN 'percentage'
-        WHEN 4 THEN 'volume'
-        WHEN 5 THEN 'graduated_percentage'
-        WHEN 6 THEN 'custom'
-        WHEN 7 THEN 'dynamic'
-    END AS charge_model,
-    c.invoiceable,
-    c.regroup_paid_fees,
-    c.pay_in_advance,
-    c.prorated,
-    c.min_amount_cents,
-    c.properties,
-    (
-        SELECT json_agg(
-            json_build_object(
-                'invoice_display_name', cf.invoice_display_name,
-                'properties',cf.properties,
-                'values', (
-                    SELECT json_agg(
-                        json_build_object(
-                            cfcv.billable_metric_filter_id,
-                            cfcv.values
-                        )
-                    )
-                    FROM charge_filter_values AS cfcv
-                    WHERE cfcv.charge_filter_id = cf.id
-                )
-            )
+  p.organization_id,
+  c.id AS lago_id,
+  c.billable_metric_id AS lago_billable_metric_id,
+  c.invoice_display_name,
+  c.created_at,
+  c.updated_at,
+  CASE c.charge_model
+    WHEN 0 THEN 'standard'
+    WHEN 1 THEN 'graduated'
+    WHEN 2 THEN 'package'
+    WHEN 3 THEN 'percentage'
+    WHEN 4 THEN 'volume'
+    WHEN 5 THEN 'graduated_percentage'
+    WHEN 6 THEN 'custom'
+    WHEN 7 THEN 'dynamic'
+  END AS charge_model,
+  c.invoiceable,
+  CASE c.regroup_paid_fees
+    WHEN 0 THEN 'invoice'
+  END AS regroup_paid_fees,
+  c.pay_in_advance,
+  c.prorated,
+  c.min_amount_cents,
+  c.properties,
+  (
+    SELECT
+      json_agg (
+        json_build_object (
+          'invoice_display_name',
+          cf.invoice_display_name,
+          'properties',
+          cf.properties,
+          'values',
+          (
+            SELECT
+              json_agg (
+                json_build_object (cfcv.billable_metric_filter_id, cfcv.values)
+              )
+            FROM
+              charge_filter_values AS cfcv
+            WHERE
+              cfcv.charge_filter_id = cf.id
+          )
         )
-        FROM charge_filters AS cf
-        WHERE cf.charge_id = c.id
-    ) AS charge_filters
-FROM charges AS c
-LEFT JOIN plans AS p ON p.id = c.plan_id;
+      )
+    FROM
+      charge_filters AS cf
+    WHERE
+      cf.charge_id = c.id
+  ) AS charge_filters
+FROM
+  charges AS c
+  LEFT JOIN plans AS p ON p.id = c.plan_id;

--- a/db/views/exports_coupons_v01.sql
+++ b/db/views/exports_coupons_v01.sql
@@ -1,36 +1,54 @@
 SELECT
-    cp.organization_id,
-    cp.id AS lago_id,
-    cp.name,
-    cp.code,
-    cp.description,
-    CASE cp.coupon_type
-        WHEN 0 THEN 'fixed_amount'
-        WHEN 1 THEN 'percentage'
-    END AS coupon_type,
-    cp.amount_cents,
-    cp.amount_currency,
-    cp.percentage_rate,
-    cp.frequency,
-    cp.frequency_duration,
-    cp.reusable,
-    cp.limited_plans,
-    cp.limited_billable_metrics,
+  cp.organization_id,
+  cp.id AS lago_id,
+  cp.name,
+  cp.code,
+  cp.description,
+  CASE cp.coupon_type
+    WHEN 0 THEN 'fixed_amount'
+    WHEN 1 THEN 'percentage'
+  END AS coupon_type,
+  cp.amount_cents,
+  cp.amount_currency,
+  cp.percentage_rate,
+  CASE cp.frequency
+    WHEN 0 THEN 'once'
+    WHEN 1 THEN 'recurring'
+    WHEN 2 THEN 'forever'
+  END as frequency,
+  cp.frequency_duration,
+  cp.reusable,
+  cp.limited_plans,
+  cp.limited_billable_metrics,
+  to_json (
     ARRAY(
-        SELECT cpt.plan_id
-        FROM coupon_targets AS cpt
-        WHERE cpt.coupon_id = cp.id
+      SELECT
+        cpt.plan_id
+      FROM
+        coupon_targets AS cpt
+      WHERE
+        cpt.coupon_id = cp.id
         AND cpt.plan_id IS NOT NULL
-    ) AS lago_plan_ids,
+    )
+  ) AS lago_plan_ids,
+  to_json (
     ARRAY(
-        SELECT cpt.billable_metric_id
-        FROM coupon_targets AS cpt
-        WHERE cpt.coupon_id = cp.id
+      SELECT
+        cpt.billable_metric_id
+      FROM
+        coupon_targets AS cpt
+      WHERE
+        cpt.coupon_id = cp.id
         AND cpt.billable_metric_id IS NOT NULL
-    ) AS lago_billable_metrics_ids,
-    cp.created_at,
-    cp.expiration,
-    cp.expiration_at,
-    cp.terminated_at,
-    cp.updated_at
-FROM coupons AS cp;
+    )
+  ) AS lago_billable_metrics_ids,
+  cp.created_at,
+  CASE cp.expiration
+    WHEN 0 then 'no_expiration'
+    WHEN 1 then 'time_limit'
+  END AS expiration,
+  cp.expiration_at,
+  cp.terminated_at,
+  cp.updated_at
+FROM
+  coupons AS cp;

--- a/db/views/exports_credit_notes_v01.sql
+++ b/db/views/exports_credit_notes_v01.sql
@@ -1,61 +1,85 @@
 SELECT
-    c.organization_id,
-    cn.id AS lago_id,
-    cn.sequential_id,
-    cn.number,
-    cn.invoice_id AS lago_invoice_id,
-    cn.issuing_date,
-    CASE cn.credit_status
-        WHEN 0 THEN 'available'
-        WHEN 1 THEN 'consumed'
-        WHEN 2 THEN 'voided'
-    END AS credit_status,
-    CASE cn.refund_status
-        WHEN 0 THEN 'pending'
-        WHEN 1 THEN 'succeeded'
-        WHEN 2 THEN 'failed'
-    END AS refund_status,
-    cn.reason,
-    cn.description,
-    cn.total_amount_currency AS currency,
-    cn.total_amount_cents,
-    cn.taxes_amount_cents,
-    ROUND(
-        (
-            SELECT SUM(ci.precise_amount_cents)
-            FROM credit_note_items AS ci
-            WHERE ci.credit_note_id = cn.id
-        ) - cn.precise_coupons_adjustment_amount_cents
-    ) AS sub_total_excluding_taxes_amount_cents,
-    cn.balance_amount_cents,
-    cn.credit_amount_cents,
-    cn.refund_amount_cents,
-    cn.coupons_adjustment_amount_cents,
-    cn.taxes_rate,
-    cn.created_at,
-    cn.updated_at,
+  c.organization_id,
+  cn.id AS lago_id,
+  cn.sequential_id,
+  cn.number,
+  cn.invoice_id AS lago_invoice_id,
+  cn.issuing_date,
+  CASE cn.credit_status
+    WHEN 0 THEN 'available'
+    WHEN 1 THEN 'consumed'
+    WHEN 2 THEN 'voided'
+  END AS credit_status,
+  CASE cn.refund_status
+    WHEN 0 THEN 'pending'
+    WHEN 1 THEN 'succeeded'
+    WHEN 2 THEN 'failed'
+  END AS refund_status,
+  CASE cn.reason
+    WHEN 0 then 'duplicated_charge'
+    WHEN 1 then 'product_unsatisfactory'
+    WHEN 2 then 'order_change'
+    when 3 then 'order_cancellation'
+    when 4 then 'fraudulent_charge'
+    when 5 then 'other'
+  END as reason,
+  cn.description,
+  cn.total_amount_currency AS currency,
+  cn.total_amount_cents,
+  cn.taxes_amount_cents,
+  ROUND(
     (
-        SELECT json_agg(
-            json_build_object(
-                'lago_id', ci.id,
-                'amount_cents', ci.amount_cents,
-                'amount_currency', ci.amount_currency,
-                'lago_fee_id', ci.fee_id
-            )
+      SELECT
+        SUM(ci.precise_amount_cents)::bigint
+      FROM
+        credit_note_items AS ci
+      WHERE
+        ci.credit_note_id = cn.id
+    ) - cn.precise_coupons_adjustment_amount_cents
+  )::bigint AS sub_total_excluding_taxes_amount_cents,
+  cn.balance_amount_cents,
+  cn.credit_amount_cents,
+  cn.refund_amount_cents,
+  cn.coupons_adjustment_amount_cents,
+  cn.taxes_rate,
+  cn.created_at,
+  cn.updated_at,
+  (
+    SELECT
+      json_agg (
+        json_build_object (
+          'lago_id',
+          ci.id,
+          'amount_cents',
+          ci.amount_cents,
+          'amount_currency',
+          ci.amount_currency,
+          'lago_fee_id',
+          ci.fee_id
         )
-        FROM credit_note_items AS ci
-        WHERE ci.credit_note_id = cn.id
-    ) AS items,
-    (
-        SELECT json_agg(
-            json_build_object(
-                'lago_id', ed.id,
-                'error_code', ed.error_code,
-                'details', ed.details
-            )
+      )
+    FROM
+      credit_note_items AS ci
+    WHERE
+      ci.credit_note_id = cn.id
+  ) AS items,
+  (
+    SELECT
+      json_agg (
+        json_build_object (
+          'lago_id',
+          ed.id,
+          'error_code',
+          ed.error_code,
+          'details',
+          ed.details
         )
-        FROM error_details AS ed
-        WHERE ed.owner_id = cn.id
-    ) AS error_details
-FROM credit_notes AS cn
-LEFT JOIN customers AS c ON c.id = cn.customer_id;
+      )
+    FROM
+      error_details AS ed
+    WHERE
+      ed.owner_id = cn.id
+  ) AS error_details
+FROM
+  credit_notes AS cn
+  LEFT JOIN customers AS c ON c.id = cn.customer_id;

--- a/db/views/exports_plans_v01.sql
+++ b/db/views/exports_plans_v01.sql
@@ -11,7 +11,7 @@ SELECT
     WHEN 1 then 'monthly'
     WHEN 2 then 'yearly'
     WHEN 3 then 'quarterly'
-  END AS interval,
+  END AS plan_interval,
   p.description,
   p.amount_cents,
   p.amount_currency,
@@ -19,10 +19,17 @@ SELECT
   p.pay_in_advance,
   p.bill_charges_monthly,
   p.parent_id,
-  ARRAY(
-    SELECT pt.tax_id AS lago_tax_id
-    FROM plans_taxes AS pt
-    WHERE pt.plan_id = p.id
+  to_json (
+    ARRAY(
+      SELECT
+        pt.tax_id AS lago_tax_id
+      FROM
+        plans_taxes AS pt
+      WHERE
+        pt.plan_id = p.id
+    )
   ) AS lago_taxes_ids
-FROM plans AS p
-WHERE p.deleted_at IS NULL;
+FROM
+  plans AS p
+WHERE
+  p.deleted_at IS NULL;

--- a/db/views/exports_subscriptions_v01.sql
+++ b/db/views/exports_subscriptions_v01.sql
@@ -1,33 +1,39 @@
 SELECT
-    c.organization_id,
-    s.id AS lago_id,
-    s.external_id,
-    s.customer_id AS lago_customer_id,
-    s.name,
-    s.plan_id AS lago_plan_id,
-    CASE s.status
-        WHEN 0 THEN 'pending'
-        WHEN 1 THEN 'active'
-        WHEN 2 THEN 'terminated'
-        WHEN 3 THEN 'canceled'
-    END AS status,
-    CASE s.billing_time
-        WHEN 0 THEN 'calendar'
-        WHEN 1 THEN 'anniversary'
-    END AS billing_time,
-    s.subscription_at,
-    s.started_at,
-    s.trial_ended_at,
-    s.ending_at,
-    s.terminated_at,
-    s.canceled_at,
-    s.created_at,
-    s.updated_at,
+  c.organization_id,
+  s.id AS lago_id,
+  s.external_id,
+  s.customer_id AS lago_customer_id,
+  s.name,
+  s.plan_id AS lago_plan_id,
+  CASE s.status
+    WHEN 0 THEN 'pending'
+    WHEN 1 THEN 'active'
+    WHEN 2 THEN 'terminated'
+    WHEN 3 THEN 'canceled'
+  END AS status,
+  CASE s.billing_time
+    WHEN 0 THEN 'calendar'
+    WHEN 1 THEN 'anniversary'
+  END AS billing_time,
+  s.subscription_at,
+  s.started_at,
+  s.trial_ended_at,
+  s.ending_at,
+  s.terminated_at,
+  s.canceled_at,
+  s.created_at,
+  s.updated_at,
+  to_json (
     ARRAY(
-        SELECT ns.id
-        FROM subscriptions AS ns
-        WHERE ns.previous_subscription_id = s.id
-    ) AS lago_next_subscriptions_id,
-    s.previous_subscription_id AS lago_previous_subscription_id    
-FROM subscriptions AS s
-LEFT JOIN customers AS c ON s.customer_id = c.id;
+      SELECT
+        ns.id
+      FROM
+        subscriptions AS ns
+      WHERE
+        ns.previous_subscription_id = s.id
+    )
+  ) AS lago_next_subscriptions_id,
+  s.previous_subscription_id AS lago_previous_subscription_id
+FROM
+  subscriptions AS s
+  LEFT JOIN customers AS c ON s.customer_id = c.id;


### PR DESCRIPTION
This PR fixes the exposed data type and format for the export introduced by https://github.com/getlago/lago-api/pull/3491


NOTE: views have been manually updated in production.
The following commands will have to be executed locally to fix the `db/structure.sql` file:
```
lago exec api rails db:migrate:down:primary VERSION=20250407000001
```