### PR TITLE
feat(multientities): Add taxes (applied) to billing entity serializer

### DIFF
--- a/app/controllers/api/v1/billing_entities_controller.rb
+++ b/app/controllers/api/v1/billing_entities_controller.rb
@@ -19,7 +19,7 @@ module Api
         return not_found_error(resource: "billing_entity") if entity.blank?
 
         render(
-          json: ::V1::BillingEntitySerializer.new(entity, root_name: "billing_entity")
+          json: ::V1::BillingEntitySerializer.new(entity, root_name: "billing_entity", includes: [:taxes])
         )
       end
     end

--- a/app/serializers/v1/billing_entity_serializer.rb
+++ b/app/serializers/v1/billing_entity_serializer.rb
@@ -3,7 +3,7 @@
 module V1
   class BillingEntitySerializer < ModelSerializer
     def serialize
-      {
+      payload = {
         lago_id: model.id,
         code: model.code,
         name: model.name,
@@ -33,6 +33,20 @@ module V1
         eu_tax_management: model.eu_tax_management,
         logo_url: model.logo_url
       }
+
+      payload = payload.merge(taxes) if include?(:taxes)
+
+      payload
+    end
+
+    private
+
+    def taxes
+      ::CollectionSerializer.new(
+        model.taxes,
+        ::V1::TaxSerializer,
+        collection_name: "taxes"
+      ).serialize
     end
   end
 end

--- a/spec/requests/api/v1/billing_entities_controller_spec.rb
+++ b/spec/requests/api/v1/billing_entities_controller_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe Api::V1::BillingEntitiesController, type: :request do
       expect(json[:billing_entity][:lago_id]).to eq(billing_entity1.id)
     end
 
+    context "when the billing entity has applied taxes" do
+      let(:tax) { create(:tax) }
+      let(:applied_tax) { create(:billing_entity_applied_tax, billing_entity: billing_entity1, tax:) }
+
+      before { applied_tax }
+
+      it "returns the billing entity with the applied taxes" do
+        subject
+        expect(json[:billing_entity][:taxes].count).to eq(1)
+      end
+    end
+
     context "when the billing entity from another organization is requested" do
       subject do
         get_with_token(organization, "/api/v1/billing_entities/#{billing_entity3.code}")


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

 ## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

 ## Description

Billing Entity serializer accepts `includes: [:taxes]` to include billing entity's applied taxes serialized.

Also, GET /api/v1/billing_entity/:code (#show) returns the serialized taxes within the billing entity object

