### PR TITLE
chore(spec): maintain_test_schema! before test

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,12 +48,10 @@ ActiveJob::Uniqueness.test_mode!
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
-# Checks for pending migrations
 begin
   ActiveRecord::Migration.check_all_pending!
-rescue ActiveRecord::PendingMigrationError => e
-  puts e.to_s.strip
-  exit 1
+rescue ActiveRecord::PendingMigrationError
+  FileUtils.cd(Rails.root) { system("bin/rails db:migrate:primary RAILS_ENV=test") }
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
~This was changed when we switched to sql structure dump.
I believe this can be reverted so just load the schema if the test DB isn't up to date (instead of failing).~

If there are pending migrations and we migrate the primary db. We can't rely on `maintain_test_schema!` because it will also try to load the schema in clickhouse but it's not committed, so it fails on CI.

https://github.com/getlago/lago-api/pull/3349/files#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94L54-R53