### PR TITLE
feat: Enqueue EU tax update job for organizations

### DIFF
--- a/db/migrate/20250415143607_enqueue_update_all_eu_taxes_job.rb
+++ b/db/migrate/20250415143607_enqueue_update_all_eu_taxes_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class EnqueueUpdateAllEuTaxesJob < ActiveRecord::Migration[7.1]
+  def up
+    Taxes::UpdateAllEuTaxesJob.perform_later
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
## Context

We previously had a background job (`Taxes::UpdateAllEuTaxesJob`) that could be manually triggered or called via a rake task. To avoid relying on manual execution, this PR ensures the job is enqueued automatically via a Rails migration during deployment.

## Description

- Added a Rails migration that enqueues the `Taxes::UpdateAllEuTaxesJob` using `perform_later`, allowing the update to happen asynchronously via the background job queue.
- This allows all organizations with `eu_tax_management: true` to have their EU taxes updated without any manual intervention.