### PR TITLE
misc(filter): Remove OpenStruct for Query::Filters definition

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -44,7 +44,7 @@ module Api
             page: params[:page],
             limit: params[:per_page] || PER_PAGE
           },
-          filters: params.slice(:account_type).merge(billing_entity_ids: billing_entities&.ids)
+          filters: params.slice(:account_type).merge(billing_entity_ids: billing_entities&.ids).permit!
         )
 
         if result.success?

--- a/app/queries/applied_coupons_query.rb
+++ b/app/queries/applied_coupons_query.rb
@@ -2,6 +2,7 @@
 
 class AppliedCouponsQuery < BaseQuery
   Result = BaseResult[:applied_coupons]
+  Filters = BaseFilters[:external_customer_id, :status]
 
   def call
     applied_coupons = paginate(base_scope)

--- a/app/queries/base_filters.rb
+++ b/app/queries/base_filters.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class BaseFilters
+  def self.[](*attributes)
+    Class.new(BaseFilters) { attr_accessor(*attributes) }
+  end
+
+  def initialize(**args)
+    @filters = args
+      .select { |key, _| self.class.method_defined?(key.to_sym) }
+      .to_h
+      .with_indifferent_access
+
+    @filters.each { |key, value| send("#{key}=", value) }
+  end
+
+  attr_reader :filters
+
+  delegate :[], to: :filters
+
+  def to_h
+    filters
+  end
+end

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -6,13 +6,12 @@ class BaseQuery < BaseService
   DEFAULT_ORDER = {created_at: :desc}
 
   Pagination = Struct.new(:page, :limit, keyword_init: true)
-
-  class Filters < OpenStruct; end
+  Filters = BaseFilters
 
   def initialize(organization:, pagination: DEFAULT_PAGINATION_PARAMS, filters: {}, search_term: nil, order: nil)
     @organization = organization
     @pagination_params = pagination
-    @filters = Filters.new(filters)
+    @filters = self.class::Filters.new(**(filters || {}))
     @search_term = search_term
     @order = order
 

--- a/app/queries/billable_metrics_query.rb
+++ b/app/queries/billable_metrics_query.rb
@@ -2,6 +2,7 @@
 
 class BillableMetricsQuery < BaseQuery
   Result = BaseResult[:billable_metrics]
+  Filters = BaseFilters[:organization_id, :recurring, :aggregation_types]
 
   def call
     return result unless validate_filters.success?

--- a/app/queries/coupons_query.rb
+++ b/app/queries/coupons_query.rb
@@ -2,6 +2,7 @@
 
 class CouponsQuery < BaseQuery
   Result = BaseResult[:coupons]
+  Filters = BaseFilters[:organization_id, :status]
 
   def call
     coupons = base_scope.result

--- a/app/queries/credit_notes_query.rb
+++ b/app/queries/credit_notes_query.rb
@@ -2,6 +2,21 @@
 
 class CreditNotesQuery < BaseQuery
   Result = BaseResult[:credit_notes]
+  Filters = BaseFilters[
+    :billing_entity_ids,
+    :currency,
+    :customer_external_id,
+    :customer_id,
+    :invoice_number,
+    :issuing_date_from,
+    :issuing_date_to,
+    :amount_from,
+    :amount_to,
+    :self_billed,
+    :credit_status,
+    :reason,
+    :refund_status
+  ]
 
   def call
     credit_notes = base_scope.result

--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -2,6 +2,7 @@
 
 class CustomersQuery < BaseQuery
   Result = BaseResult[:customers]
+  Filters = BaseFilters[:organization_id, :account_type, :billing_entity_ids, :with_deleted]
 
   def call
     return result unless validate_filters.success?

--- a/app/queries/dunning_campaigns_query.rb
+++ b/app/queries/dunning_campaigns_query.rb
@@ -2,6 +2,7 @@
 
 class DunningCampaignsQuery < BaseQuery
   Result = BaseResult[:dunning_campaigns]
+  Filters = BaseFilters[:currency, :applied_to_organization]
 
   DEFAULT_ORDER = "name"
 

--- a/app/queries/events_query.rb
+++ b/app/queries/events_query.rb
@@ -2,6 +2,12 @@
 
 class EventsQuery < BaseQuery
   Result = BaseResult[:events]
+  Filters = BaseFilters[
+    :code,
+    :external_subscription_id,
+    :timestamp_from,
+    :timestamp_to
+  ]
 
   def call
     events = organization.clickhouse_events_store? ? Clickhouse::EventsRaw : Event

--- a/app/queries/fees_query.rb
+++ b/app/queries/fees_query.rb
@@ -2,6 +2,23 @@
 
 class FeesQuery < BaseQuery
   Result = BaseResult[:fees]
+  Filters = BaseFilters[
+    :external_subscription_id,
+    :external_customer_id,
+    :currency,
+    :billable_metric_code,
+    :fee_type,
+    :payment_status,
+    :event_transaction_id,
+    :created_at_from,
+    :created_at_to,
+    :succeeded_at_from,
+    :succeeded_at_to,
+    :failed_at_from,
+    :failed_at_to,
+    :refunded_at_from,
+    :refunded_at_to
+  ]
 
   def call
     base_scope = if filters.external_customer_id

--- a/app/queries/integration_collection_mappings_query.rb
+++ b/app/queries/integration_collection_mappings_query.rb
@@ -2,6 +2,7 @@
 
 class IntegrationCollectionMappingsQuery < BaseQuery
   Result = BaseResult[:integration_collection_mappings]
+  Filters = BaseFilters[:integration_id, :mapping_type]
 
   def call
     integration_collection_mappings = paginate(base_scope)

--- a/app/queries/integration_items_query.rb
+++ b/app/queries/integration_items_query.rb
@@ -2,6 +2,7 @@
 
 class IntegrationItemsQuery < BaseQuery
   Result = BaseResult[:integration_items]
+  Filters = BaseFilters[:integration_id, :item_type]
 
   def call
     integration_items = base_scope.result

--- a/app/queries/integration_mappings_query.rb
+++ b/app/queries/integration_mappings_query.rb
@@ -2,6 +2,7 @@
 
 class IntegrationMappingsQuery < BaseQuery
   Result = BaseResult[:integration_mappings]
+  Filters = BaseFilters[:integration_id, :mappable_type]
 
   def call
     integration_mappings = paginate(base_scope)

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -2,6 +2,25 @@
 
 class InvoicesQuery < BaseQuery
   Result = BaseResult[:invoices]
+  Filters = BaseFilters[
+    :billing_entity_ids,
+    :currency,
+    :customer_external_id,
+    :customer_id,
+    :invoice_type,
+    :issuing_date_from,
+    :issuing_date_to,
+    :status,
+    :payment_status,
+    :payment_dispute_lost,
+    :payment_overdue,
+    :amount_from,
+    :amount_to,
+    :metadata,
+    :partially_paid,
+    :positive_due_amount,
+    :self_billed
+  ]
 
   def call
     invoices = base_scope.result.includes(:customer).includes(file_attachment: :blob)

--- a/app/queries/past_usage_query.rb
+++ b/app/queries/past_usage_query.rb
@@ -2,6 +2,7 @@
 
 class PastUsageQuery < BaseQuery
   Result = BaseResult[:usage_periods, :current_page, :next_page, :prev_page, :total_pages, :total_count]
+  Filters = BaseFilters[:external_customer_id, :external_subscription_id, :periods_count, :billable_metric_code]
 
   UsagePeriods = Data.define(:invoice_subscription, :fees)
 

--- a/app/queries/payment_receipts_query.rb
+++ b/app/queries/payment_receipts_query.rb
@@ -2,6 +2,7 @@
 
 class PaymentReceiptsQuery < BaseQuery
   Result = BaseResult[:payment_receipts]
+  Filters = BaseFilters[:invoice_id]
 
   def call
     return result unless validate_filters.success?

--- a/app/queries/payment_requests_query.rb
+++ b/app/queries/payment_requests_query.rb
@@ -2,6 +2,7 @@
 
 class PaymentRequestsQuery < BaseQuery
   Result = BaseResult[:payment_requests]
+  Filters = BaseFilters[:external_customer_id]
 
   def call
     payment_requests = PaymentRequest.where(organization:)

--- a/app/queries/payments_query.rb
+++ b/app/queries/payments_query.rb
@@ -2,6 +2,7 @@
 
 class PaymentsQuery < BaseQuery
   Result = BaseResult[:payments]
+  Filters = BaseFilters[:invoice_id, :external_customer_id]
 
   def call
     return result unless validate_filters.success?

--- a/app/queries/plans_query.rb
+++ b/app/queries/plans_query.rb
@@ -2,6 +2,7 @@
 
 class PlansQuery < BaseQuery
   Result = BaseResult[:plans]
+  Filters = BaseFilters[:with_deleted, :include_pending_deletion]
 
   def call
     plans = base_scope.result

--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -2,6 +2,7 @@
 
 class SubscriptionsQuery < BaseQuery
   Result = BaseResult[:subscriptions]
+  Filters = BaseFilters[:external_customer_id, :plan_code, :status]
 
   def call
     subscriptions = paginate(organization.subscriptions)

--- a/app/queries/taxes_query.rb
+++ b/app/queries/taxes_query.rb
@@ -2,6 +2,7 @@
 
 class TaxesQuery < BaseQuery
   Result = BaseResult[:taxes]
+  Filters = BaseFilters[:auto_generated, :applied_to_organization]
 
   DEFAULT_ORDER = "name"
 

--- a/app/queries/wallet_transactions_query.rb
+++ b/app/queries/wallet_transactions_query.rb
@@ -2,6 +2,7 @@
 
 class WalletTransactionsQuery < BaseQuery
   Result = BaseResult[:wallet_transactions]
+  Filters = BaseFilters[:transaction_type, :status]
 
   def initialize(organization:, wallet_id:, pagination: DEFAULT_PAGINATION_PARAMS, filters: {}, search_term: nil, order: nil)
     @wallet = organization.wallets.find_by(id: wallet_id)

--- a/app/queries/wallets_query.rb
+++ b/app/queries/wallets_query.rb
@@ -2,6 +2,7 @@
 
 class WalletsQuery < BaseQuery
   Result = BaseResult[:wallets]
+  Filters = BaseFilters[:external_customer_id]
 
   def call
     validate_filters

--- a/app/queries/webhooks_query.rb
+++ b/app/queries/webhooks_query.rb
@@ -2,6 +2,7 @@
 
 class WebhooksQuery < BaseQuery
   Result = BaseResult[:webhooks]
+  Filters = BaseFilters[:status]
 
   def initialize(webhook_endpoint:, pagination: DEFAULT_PAGINATION_PARAMS, filters: {}, search_term: nil, order: nil)
     @webhook_endpoint = webhook_endpoint

--- a/spec/factories/data_exports.rb
+++ b/spec/factories/data_exports.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
 
     format { "csv" }
     resource_type { "invoices" }
-    resource_query { {filters: {currency: "EUR"}} }
+    resource_query { {currency: "EUR"} }
     status { "pending" }
     file { nil }
 

--- a/spec/queries/base_filters_spec.rb
+++ b/spec/queries/base_filters_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BaseFilters do
+  dummy_filters = described_class[:value, :name]
+
+  subject(:filters) { dummy_filters.new(**attributes) }
+
+  let(:attributes) { {value: "test", name: "test"} }
+
+  describe "filters" do
+    it "returns the list of filters" do
+      expect(filters.filters).to eq({"value" => "test", "name" => "test"})
+
+      expect(filters.value).to eql("test")
+      expect(filters.name).to eql("test")
+    end
+
+    context "with unexpected attributes" do
+      let(:attributes) { {value: "test", name: "test", unexpected: "unexpected"} }
+
+      it "ignores unexpected attributes" do
+        expect(filters.filters).to eq({"value" => "test", "name" => "test"})
+      end
+    end
+  end
+
+  describe "[]" do
+    it "returns the value of the filter" do
+      expect(filters[:value]).to eq("test")
+    end
+
+    context "with querying unexpected keys" do
+      it "returns nil" do
+        expect(filters[:unexpected]).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR is part of the global initiative to remove `OpenStruct` from the codebase

## Description

This PR replaces the definition of  `BaseQuery::Filters` defined as an `OpenStruct` with a new `BaseFilter` class.
In a similar way of the `BaseResult` this new class enforces the whitelisting of accepted filters, by defining the full list of accepted arguments.

NOTE: A future pull request will rework this to integrate with `Queries::*QueryFiltersContract` definitions