### PR TITLE
feat(multientities): Handle eu tax management at billing entity level

### DIFF
--- a/app/services/billing_entities/change_eu_tax_management_service.rb
+++ b/app/services/billing_entities/change_eu_tax_management_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module BillingEntities
+  class ChangeEuTaxManagementService < BaseService
+    Result = BaseResult[:billing_entity]
+
+    ERROR_CODE = "billing_entity_must_be_in_eu"
+
+    def initialize(billing_entity:, eu_tax_management:)
+      @billing_entity = billing_entity
+      @eu_tax_management = eu_tax_management
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "billing_entity") unless billing_entity
+
+      if !billing_entity.eu_vat_eligible? && eu_tax_management
+        return result.single_validation_failure!(error_code: ERROR_CODE, field: :eu_tax_management)
+      end
+
+      billing_entity.eu_tax_management = eu_tax_management
+
+      # NOTE: autogenerate service generates taxes.
+      #       Taxes belong to organization, but can be applied to the billing_entity,
+      #       So we auto generate taxes for the billing_entity organization
+      ::Taxes::AutoGenerateService.call(organization: billing_entity.organization) if eu_tax_management
+
+      result.billing_entity = billing_entity
+      result
+    end
+
+    private
+
+    attr_reader :billing_entity, :eu_tax_management
+  end
+end

--- a/spec/services/billing_entities/change_eu_tax_management_service_spec.rb
+++ b/spec/services/billing_entities/change_eu_tax_management_service_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BillingEntities::ChangeEuTaxManagementService, type: :service do
+  subject(:service) { described_class.new(billing_entity:, eu_tax_management:) }
+
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { organization.default_billing_entity }
+  let(:eu_tax_management) { true }
+
+  describe "#call" do
+    before do
+      allow(Taxes::AutoGenerateService).to receive(:call)
+    end
+
+    context "when enabling EU tax management" do
+      context "when billing entity is in the EU" do
+        before do
+          billing_entity.update!(country: "FR")
+        end
+
+        it "enables EU tax management" do
+          result = service.call
+
+          expect(result).to be_success
+          expect(result.billing_entity.eu_tax_management).to eq(true)
+        end
+
+        it "calls the taxes auto generate service" do
+          service.call
+
+          expect(Taxes::AutoGenerateService).to have_received(:call).with(organization:)
+        end
+      end
+
+      context "when billing entity is outside the EU" do
+        before do
+          billing_entity.update!(country: "US")
+        end
+
+        it "returns a validation failure" do
+          result = service.call
+
+          expect(result).to be_failure
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages).to eq({eu_tax_management: ["billing_entity_must_be_in_eu"]})
+        end
+
+        it "does not call the taxes auto generate service" do
+          service.call
+
+          expect(Taxes::AutoGenerateService).not_to have_received(:call)
+        end
+      end
+    end
+
+    context "when disabling EU tax management" do
+      let(:eu_tax_management) { false }
+
+      before do
+        billing_entity.update!(eu_tax_management: true)
+      end
+
+      it "disables EU tax management" do
+        result = service.call
+
+        expect(result).to be_success
+        expect(result.billing_entity.eu_tax_management).to eq(false)
+      end
+
+      it "does not call the taxes auto generate service" do
+        service.call
+
+        expect(Taxes::AutoGenerateService).not_to have_received(:call)
+      end
+    end
+
+    context "when billing entity is not provided" do
+      let(:billing_entity) { nil }
+
+      it "returns a not found failure" do
+        result = service.call
+
+        expect(result).to be_failure
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.resource).to eq("billing_entity")
+      end
+    end
+  end
+end

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe BillingEntities::UpdateService do
 
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages).to eq({eu_tax_management: ["org_must_be_in_eu"]})
+          expect(result.error.messages).to eq({eu_tax_management: ["billing_entity_must_be_in_eu"]})
           expect(tax_auto_generate_service).not_to have_received(:call)
         end
       end

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe BillingEntities::UpdateService do
 
           expect(result).to be_success
           expect(BillingEntities::ChangeEuTaxManagementService)
-          .to have_received(:call)
+            .to have_received(:call)
         end
       end
     end

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -179,28 +179,26 @@ RSpec.describe BillingEntities::UpdateService do
     context "with eu tax management" do
       context "with org within the EU" do
         let(:params) { {eu_tax_management: true, country: "fr"} }
-        let(:tax_auto_generate_service) { instance_double(Taxes::AutoGenerateService) }
 
         before do
-          allow(Taxes::AutoGenerateService).to receive(:new).and_return(tax_auto_generate_service)
-          allow(tax_auto_generate_service).to receive(:call)
+          allow(BillingEntities::ChangeEuTaxManagementService).to receive(:call).and_call_original
         end
 
         it "calls the taxes auto generate service" do
           result = update_service.call
 
           expect(result).to be_success
-          expect(tax_auto_generate_service).to have_received(:call)
+          expect(BillingEntities::ChangeEuTaxManagementService)
+            .to have_received(:call)
+            .with(billing_entity:, eu_tax_management: true)
         end
       end
 
       context "with org outside the EU" do
         let(:params) { {eu_tax_management: true, country: "us"} }
-        let(:tax_auto_generate_service) { instance_double(Taxes::AutoGenerateService) }
 
         before do
-          allow(Taxes::AutoGenerateService).to receive(:new).and_return(tax_auto_generate_service)
-          allow(tax_auto_generate_service).to receive(:call)
+          allow(BillingEntities::ChangeEuTaxManagementService).to receive(:call).and_call_original
         end
 
         it "calls the taxes auto generate service" do
@@ -209,26 +207,27 @@ RSpec.describe BillingEntities::UpdateService do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages).to eq({eu_tax_management: ["billing_entity_must_be_in_eu"]})
-          expect(tax_auto_generate_service).not_to have_received(:call)
+          expect(BillingEntities::ChangeEuTaxManagementService)
+            .to have_received(:call)
+            .with(billing_entity:, eu_tax_management: true)
         end
       end
 
       context "with org is outside the EU but feature is already enabled" do
         let(:params) { {eu_tax_management: false} }
-        let(:tax_auto_generate_service) { instance_double(Taxes::AutoGenerateService) }
 
         before do
           billing_entity.country = "us"
           billing_entity.eu_tax_management = true
-          allow(Taxes::AutoGenerateService).to receive(:new).and_return(tax_auto_generate_service)
-          allow(tax_auto_generate_service).to receive(:call)
+          allow(BillingEntities::ChangeEuTaxManagementService).to receive(:call).and_call_original
         end
 
         it "can disable eu_tax_management" do
           result = update_service.call
 
           expect(result).to be_success
-          expect(tax_auto_generate_service).not_to have_received(:call)
+          expect(BillingEntities::ChangeEuTaxManagementService)
+          .to have_received(:call)
         end
       end
     end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

## Description

Introduce a new service to standardize the management of EU taxes from billing entity creates and updates.

Organization update still changes its attribute but not handles the tax creation anymore. This attribute will be removed at some point.