### PR TITLE
feat(audit_logs): Create Clickhouse::ActivityLog model

### DIFF
--- a/app/config/permissions/definition.yml
+++ b/app/config/permissions/definition.yml
@@ -1,4 +1,6 @@
 ---
+audit_logs:
+  view: true
 analytics:
   overdue_balances:
     view:

--- a/app/config/permissions/role-finance.yml
+++ b/app/config/permissions/role-finance.yml
@@ -1,4 +1,6 @@
 ---
+audit_logs:
+  view: false
 analytics:
   overdue_balances:
     view: true

--- a/app/config/permissions/role-manager.yml
+++ b/app/config/permissions/role-manager.yml
@@ -1,4 +1,6 @@
 ---
+audit_logs:
+  view: false
 analytics:
   overdue_balances:
     view: true

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -18,6 +18,8 @@ class BillableMetric < ApplicationRecord
   has_many :groups, dependent: :delete_all
   has_many :filters, -> { order(:key) }, dependent: :delete_all, class_name: "BillableMetricFilter"
 
+  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+
   AGGREGATION_TYPES = {
     count_agg: 0,
     sum_agg: 1,

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -29,6 +29,8 @@ class BillingEntity < ApplicationRecord
   has_many :wallets, through: :customers
   has_many :wallet_transactions, through: :wallets
 
+  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+
   belongs_to :applied_dunning_campaign, class_name: "DunningCampaign", optional: true
 
   has_one_attached :logo

--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -6,6 +6,9 @@ module Clickhouse
     self.primary_key = nil
 
     belongs_to :organization
+    belongs_to :resource, polymorphic: true
+
+    before_save :ensure_activity_id
 
     def user
       organization.users.find_by(id: user_id)
@@ -23,8 +26,10 @@ module Clickhouse
       organization.subscriptions.find_by(external_id: external_subscription_id)
     end
 
-    def resource
-      resource_type.constantize.find_by(id: resource_id)
+    private
+
+    def ensure_activity_id
+      self.activity_id = SecureRandom.uuid if activity_id.blank?
     end
   end
 end

--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Clickhouse
+  class ActivityLog < BaseRecord
+    self.table_name = "activity_logs"
+    self.primary_key = nil
+
+    belongs_to :organization
+
+    def user
+      organization.users.find_by(id: user_id)
+    end
+
+    def api_key
+      organization.api_keys.find_by(id: api_key_id)
+    end
+
+    def customer
+      organization.customers.find_by(external_id: external_customer_id)
+    end
+
+    def subscription
+      organization.subscriptions.find_by(external_id: external_subscription_id)
+    end
+
+    def resource
+      resource_type.constantize.find_by(id: resource_id)
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: activity_logs
+#
+#  activity_object          :string
+#  activity_object_changes  :string
+#  activity_source          :Enum8('api' = 1, not null
+#  activity_type            :string           not null
+#  logged_at                :datetime         not null
+#  resource_type            :string           not null
+#  created_at               :datetime         not null
+#  activity_id              :string           not null
+#  api_key_id               :string
+#  external_customer_id     :string
+#  external_subscription_id :string
+#  organization_id          :string           not null
+#  resource_id              :string           not null
+#  user_id                  :string
+#

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -14,6 +14,8 @@ class Coupon < ApplicationRecord
   has_many :plans, through: :coupon_targets
   has_many :billable_metrics, through: :coupon_targets
 
+  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+
   STATUSES = [
     :active,
     :terminated

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -24,6 +24,8 @@ class CreditNote < ApplicationRecord
   has_many :integration_resources, as: :syncable
   has_many :error_details, as: :owner, dependent: :destroy
 
+  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+
   has_one_attached :file
 
   monetize :credit_amount_cents

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -73,6 +73,8 @@ class Customer < ApplicationRecord
     through: :invoice_custom_section_selections,
     source: :invoice_custom_section
 
+  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+
   has_one :stripe_customer, class_name: "PaymentProviderCustomers::StripeCustomer"
   has_one :gocardless_customer, class_name: "PaymentProviderCustomers::GocardlessCustomer"
   has_one :cashfree_customer, class_name: "PaymentProviderCustomers::CashfreeCustomer"

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -45,6 +45,8 @@ class Invoice < ApplicationRecord
   has_many :usage_thresholds, through: :applied_usage_thresholds
   has_many :applied_invoice_custom_sections
 
+  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+
   has_one_attached :file
 
   monetize :coupons_amount_cents,

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -17,6 +17,7 @@ class Organization < ApplicationRecord
     enterprise: Float::INFINITY
   }.freeze
 
+  has_many :activity_logs, class_name: "Clickhouse::ActivityLog"
   has_many :api_keys
   has_many :billing_entities, -> { active }
   has_many :all_billing_entities, class_name: "BillingEntity"

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -25,6 +25,8 @@ class Plan < ApplicationRecord
   has_many :applied_taxes, class_name: "Plan::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes
 
+  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+
   INTERVALS = %i[
     weekly
     monthly

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -16,8 +16,11 @@ class Subscription < ApplicationRecord
   has_many :integration_resources, as: :syncable
   has_many :fees
   has_many :daily_usages
-  has_one :lifetime_usage, autosave: true
   has_many :usage_thresholds, through: :plan
+
+  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+
+  has_one :lifetime_usage, autosave: true
   has_one :subscription_activity, class_name: "UsageMonitoring::SubscriptionActivity"
 
   validates :external_id, :billing_time, presence: true

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -11,6 +11,8 @@ class Wallet < ApplicationRecord
   has_many :wallet_transactions
   has_many :recurring_transaction_rules
 
+  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+
   monetize :balance_cents
   monetize :consumed_amount_cents
   monetize :ongoing_balance_cents, :ongoing_usage_balance_cents, with_model_currency: :balance_currency

--- a/db/clickhouse_migrate/20250416103745_create_activity_logs.rb
+++ b/db/clickhouse_migrate/20250416103745_create_activity_logs.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CreateActivityLogs < ActiveRecord::Migration[7.1]
+  def change
+    options = <<-SQL
+      ReplacingMergeTree(logged_at)
+      PRIMARY KEY (organization_id, activity_id, logged_at)
+      ORDER BY (organization_id, activity_id, logged_at)
+    SQL
+
+    create_table :activity_logs, id: false, options: do |t|
+      t.string :organization_id, null: false
+      t.string :user_id
+      t.string :api_key_id
+
+      t.string :external_customer_id
+      t.string :external_subscription_id
+
+      t.string :activity_id, null: false
+      t.string :activity_type, null: false
+      t.enum :activity_source, value: {api: 1, front: 2, system: 3}, null: false
+      t.string :activity_object, map: true
+      t.string :activity_object_changes, map: true
+
+      t.string :resource_id, null: false
+      t.string :resource_type, null: false
+
+      t.datetime :logged_at, null: false, precision: 3
+      t.datetime :created_at, null: false, precision: 3
+    end
+  end
+end

--- a/db/clickhouse_migrate/20250416104012_create_activity_logs_queue.rb
+++ b/db/clickhouse_migrate/20250416104012_create_activity_logs_queue.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreateActivityLogsQueue < ActiveRecord::Migration[7.0]
+  def change
+    options = <<-SQL
+      Kafka()
+      SETTINGS
+        kafka_broker_list = '#{ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"]}',
+        kafka_topic_list = '#{ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"]}',
+        kafka_group_name = '#{ENV["LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP"]}',
+        kafka_format = 'JSONEachRow'
+    SQL
+
+    create_table :activity_logs_queue, id: false, options: do |t|
+      t.string :organization_id, null: false
+      t.string :user_id
+      t.string :api_key_id
+
+      t.string :external_customer_id
+      t.string :external_subscription_id
+
+      t.string :activity_id, null: false
+      t.string :activity_type, null: false
+      t.enum :activity_source, value: {api: 1, front: 2, system: 3}, null: false
+      t.string :activity_object, map: true
+      t.string :activity_object_changes, map: true
+
+      t.string :resource_id, null: false
+      t.string :resource_type, null: false
+
+      t.datetime :logged_at, null: false, precision: 3
+      t.datetime :created_at, null: false, precision: 3
+    end
+  end
+end

--- a/db/clickhouse_migrate/20250416104534_create_activity_logs_mv.rb
+++ b/db/clickhouse_migrate/20250416104534_create_activity_logs_mv.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: false
+
+class CreateActivityLogsMv < ActiveRecord::Migration[7.0]
+  def change
+    sql = <<-SQL
+      SELECT
+        organization_id,
+        user_id,
+        api_key_id,
+        external_customer_id,
+        external_subscription_id,
+        activity_id,
+        resource_id,
+        resource_type,
+        activity_object,
+        activity_object_changes,
+        activity_type,
+        activity_source,
+        logged_at,
+        created_at
+      FROM activity_logs_queue
+    SQL
+
+    create_view :activity_logs_mv, materialized: true, as: sql, to: "activity_logs"
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -6890,6 +6890,7 @@ type Permissions {
   addonsView: Boolean!
   analyticsOverdueBalancesView: Boolean!
   analyticsView: Boolean!
+  auditLogsView: Boolean!
   billableMetricsCreate: Boolean!
   billableMetricsDelete: Boolean!
   billableMetricsUpdate: Boolean!

--- a/schema.json
+++ b/schema.json
@@ -33140,6 +33140,22 @@
               "args": []
             },
             {
+              "name": "auditLogsView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "billableMetricsCreate",
               "description": null,
               "type": {

--- a/spec/factories/clickhouse/activity_logs.rb
+++ b/spec/factories/clickhouse/activity_logs.rb
@@ -9,13 +9,12 @@ FactoryBot.define do
       metric { create(:billable_metric, organization: membership.organization) }
     end
 
-    organization_id { membership.organization_id }
+    organization { membership.organization }
+    resource { metric }
     user_id { membership.user_id }
     api_key_id { create(:api_key, organization: membership.organization).id }
     external_customer_id { customer.external_id }
     external_subscription_id { subscription.external_id }
-    resource_id { metric.id }
-    resource_type { metric.class.name }
     activity_type { "create" }
     activity_source { "api" }
     logged_at { Time.current }

--- a/spec/factories/clickhouse/activity_logs.rb
+++ b/spec/factories/clickhouse/activity_logs.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :clickhouse_activity_log, class: "Clickhouse::ActivityLog" do
+    transient do
+      membership { create(:membership) }
+      customer { create(:customer, organization: membership.organization) }
+      subscription { create(:subscription, customer:) }
+      metric { create(:billable_metric, organization: membership.organization) }
+    end
+
+    organization_id { membership.organization_id }
+    user_id { membership.user_id }
+    api_key_id { create(:api_key, organization: membership.organization).id }
+    external_customer_id { customer.external_id }
+    external_subscription_id { subscription.external_id }
+    resource_id { metric.id }
+    resource_type { metric.class.name }
+    activity_type { "create" }
+    activity_source { "api" }
+    logged_at { Time.current }
+    activity_object { {"foo" => "bar", "baz" => "qux"} }
+    activity_object_changes { {"foo" => "bar"} }
+  end
+end

--- a/spec/models/billable_metric_spec.rb
+++ b/spec/models/billable_metric_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe BillableMetric, type: :model do
 
   it { is_expected.to belong_to(:organization) }
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   it { is_expected.to have_many(:charges).dependent(:destroy) }
   it { is_expected.to have_many(:plans).through(:charges) }
   it { is_expected.to have_many(:fees).through(:charges) }

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe BillingEntity, type: :model do
   it { is_expected.to have_many(:applied_taxes).dependent(:destroy) }
   it { is_expected.to have_many(:taxes).through(:applied_taxes) }
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   describe "code validation" do
     let(:organization) { create :organization }
 

--- a/spec/models/clickhouse/activity_log_spec.rb
+++ b/spec/models/clickhouse/activity_log_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe Clickhouse::ActivityLog, type: :model, clickhouse: true do
   subject(:activity_log) { create(:clickhouse_activity_log) }
 
   it { is_expected.to belong_to(:organization) }
+  it { is_expected.to belong_to(:resource) }
+
+  describe "#ensure_activity_id" do
+    it "sets the activity_id if it is not set" do
+      expect(activity_log.activity_id).to be_present
+    end
+  end
 
   describe "#user" do
     it "returns the user" do
@@ -28,12 +35,6 @@ RSpec.describe Clickhouse::ActivityLog, type: :model, clickhouse: true do
   describe "#subscription" do
     it "returns the subscription" do
       expect(activity_log.subscription).to be_a(Subscription)
-    end
-  end
-
-  describe "#resource" do
-    it "returns the resource" do
-      expect(activity_log.resource).to be_a(BillableMetric)
     end
   end
 end

--- a/spec/models/clickhouse/activity_log_spec.rb
+++ b/spec/models/clickhouse/activity_log_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Clickhouse::ActivityLog, type: :model, clickhouse: true do
+  subject(:activity_log) { create(:clickhouse_activity_log) }
+
+  it { is_expected.to belong_to(:organization) }
+
+  describe "#user" do
+    it "returns the user" do
+      expect(activity_log.user).to be_a(User)
+    end
+  end
+
+  describe "#api_key" do
+    it "returns the api key" do
+      expect(activity_log.api_key).to be_a(ApiKey)
+    end
+  end
+
+  describe "#customer" do
+    it "returns the customer" do
+      expect(activity_log.customer).to be_a(Customer)
+    end
+  end
+
+  describe "#subscription" do
+    it "returns the subscription" do
+      expect(activity_log.subscription).to be_a(Subscription)
+    end
+  end
+
+  describe "#resource" do
+    it "returns the resource" do
+      expect(activity_log.resource).to be_a(BillableMetric)
+    end
+  end
+end

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Coupon, type: :model do
 
   it_behaves_like "paper_trail traceable"
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than(0).allow_nil }
 

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe CreditNote, type: :model do
   it { is_expected.to have_many(:integration_resources) }
   it { is_expected.to have_many(:error_details) }
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   describe "sequential_id" do
     let(:invoice) { create(:invoice) }
     let(:customer) { invoice.customer }

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe Customer, type: :model do
   it { is_expected.to have_many(:invoice_custom_section_selections) }
   it { is_expected.to have_many(:selected_invoice_custom_sections) }
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   it "sets the default value to inherit" do
     expect(customer.finalize_zero_amount_invoice).to eq "inherit"
   end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Invoice, type: :model do
   it { is_expected.to have_many(:applied_usage_thresholds) }
   it { is_expected.to have_many(:usage_thresholds).through(:applied_usage_thresholds) }
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   it { is_expected.to belong_to(:billing_entity).optional }
 
   it "has fixed status mapping" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:gocardless_payment_providers) }
   it { is_expected.to have_many(:adyen_payment_providers) }
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   it { is_expected.to have_many(:api_keys) }
   it { is_expected.to have_many(:billing_entities).conditions(archived_at: nil) }
   it { is_expected.to have_many(:all_billing_entities).class_name("BillingEntity") }

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Plan, type: :model do
   it { is_expected.to have_one(:minimum_commitment) }
   it { is_expected.to have_many(:usage_thresholds) }
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   it { is_expected.to validate_presence_of(:interval) }
   it { is_expected.to define_enum_for(:interval).with_values(Plan::INTERVALS) }
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Subscription, type: :model do
   it { is_expected.to have_one(:lifetime_usage) }
   it { is_expected.to have_many(:usage_thresholds).through(:plan) }
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   describe "#upgraded?" do
     let(:previous_subscription) { nil }
     let(:subscription) do

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Wallet, type: :model do
 
   it_behaves_like "paper_trail traceable"
 
+  describe "Clickhouse associations", clickhouse: true do
+    it { is_expected.to have_many(:activity_logs).class_name("Clickhouse::ActivityLog") }
+  end
+
   describe "validations" do
     it { is_expected.to validate_numericality_of(:rate_amount).is_greater_than(0) }
   end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context

Our users want to have visibility on what’s happening in Lago.

Examples:
- *A plan and prices have been updated: When? By whom? What?*
- *A subscription has been deleted: When? By whom? What?*

## Description

The goal of this PR is to introduce a new Clickhouse table `activity_logs` for storing all activity events from our customers.

We decided to put logs on Clickhouse instead of PG.
This is the first type of logs, but we want to add api and security logs in the future.
