### PR TITLE
feat(multientities) BillingEntity as source of truth for Invoices

### DIFF
--- a/app/views/templates/invoices/v1.slim
+++ b/app/views/templates/invoices/v1.slim
@@ -367,8 +367,8 @@ html
     .wrapper
       .mb-24
         h1.invoice-title = document_invoice_name
-        - if organization.logo.present?
-          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
+        - if billing_entity.logo.present?
+          img.header-logo src="data:#{billing_entity.logo.content_type};base64,#{billing_entity.base64_logo}"
 
       .mb-24.overflow-auto
         .invoice-information-column
@@ -391,24 +391,24 @@ html
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_from')
           .body-2
-            - if organization.legal_name.present?
-              | #{organization.legal_name}
+            - if billing_entity.legal_name.present?
+              | #{billing_entity.legal_name}
             - else
-              | #{organization.name}
-          .body-2 = organization.address_line1
-          .body-2 = organization.address_line2
+              | #{billing_entity.name}
+          .body-2 = billing_entity.address_line1
+          .body-2 = billing_entity.address_line2
           .body-2
             span
-              = organization.zipcode
-            - if organization.zipcode.present? && organization.city.present?
+              = billing_entity.zipcode
+            - if billing_entity.zipcode.present? && billing_entity.city.present?
               span
                 | , &nbsp;
             span
-              = organization.city
-          - if organization.state.present?
-            .body-2 = organization.state
-          .body-2 = ISO3166::Country.new(organization.country)&.common_name
-          .body-2 = organization.email
+              = billing_entity.city
+          - if billing_entity.state.present?
+            .body-2 = billing_entity.state
+          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          .body-2 = billing_entity.email
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
           .body-2 = customer.display_name
@@ -478,7 +478,7 @@ html
             td.body-1 = I18n.t('invoice.total_due')
             td.body-1 = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
 
-      p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
+      p.body-3.mb-24 = LineBreakHelper.break_lines(billing_entity.invoice_footer)
 
       .powered-by
         span.body-2

--- a/app/views/templates/invoices/v2.slim
+++ b/app/views/templates/invoices/v2.slim
@@ -367,8 +367,8 @@ html
     .wrapper
       .mb-24
         h1.invoice-title = document_invoice_name
-        - if organization.logo.present?
-          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
+        - if billing_entity.logo.present?
+          img.header-logo src="data:#{billing_entity.logo.content_type};base64,#{billing_entity.base64_logo}"
 
       .mb-24.overflow-auto
         .invoice-information-column
@@ -391,24 +391,24 @@ html
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_from')
           .body-2
-            - if organization.legal_name.present?
-              | #{organization.legal_name}
+            - if billing_entity.legal_name.present?
+              | #{billing_entity.legal_name}
             - else
-              | #{organization.name}
-          .body-2 = organization.address_line1
-          .body-2 = organization.address_line2
+              | #{billing_entity.name}
+          .body-2 = billing_entity.address_line1
+          .body-2 = billing_entity.address_line2
           .body-2
             span
-              = organization.zipcode
-            - if organization.zipcode.present? && organization.city.present?
+              = billing_entity.zipcode
+            - if billing_entity.zipcode.present? && billing_entity.city.present?
               span
                 | , &nbsp;
             span
-              = organization.city
-          - if organization.state.present?
-            .body-2 = organization.state
-          .body-2 = ISO3166::Country.new(organization.country)&.common_name
-          .body-2 = organization.email
+              = billing_entity.city
+          - if billing_entity.state.present?
+            .body-2 = billing_entity.state
+          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          .body-2 = billing_entity.email
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
           .body-2 = customer.display_name
@@ -487,7 +487,7 @@ html
             td.body-1 width="30%" = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
 
 
-      p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
+      p.body-3.mb-24 = LineBreakHelper.break_lines(billing_entity.invoice_footer)
 
       .powered-by
         span.body-2

--- a/app/views/templates/invoices/v3.slim
+++ b/app/views/templates/invoices/v3.slim
@@ -343,8 +343,8 @@ html
     .wrapper
       .mb-24
         h1.invoice-title = document_invoice_name
-        - if organization.logo.present?
-          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
+        - if billing_entity.logo.present?
+          img.header-logo src="data:#{billing_entity.logo.content_type};base64,#{billing_entity.base64_logo}"
 
       .mb-24.overflow-auto
         .invoice-information-column
@@ -370,28 +370,28 @@ html
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_from')
           .body-2
-            - if organization.legal_name.present?
-              | #{organization.legal_name}
+            - if billing_entity.legal_name.present?
+              | #{billing_entity.legal_name}
             - else
-              | #{organization.name}
-          - if organization.legal_number.present?
-            .body-2 #{organization.legal_number}
-          .body-2 = organization.address_line1
-          .body-2 = organization.address_line2
+              | #{billing_entity.name}
+          - if billing_entity.legal_number.present?
+            .body-2 #{billing_entity.legal_number}
+          .body-2 = billing_entity.address_line1
+          .body-2 = billing_entity.address_line2
           .body-2
             span
-              = organization.zipcode
-            - if organization.zipcode.present? && organization.city.present?
+              = billing_entity.zipcode
+            - if billing_entity.zipcode.present? && billing_entity.city.present?
               span
                 | , &nbsp;
             span
-              = organization.city
-          - if organization.state.present?
-            .body-2 = organization.state
-          .body-2 = ISO3166::Country.new(organization.country)&.common_name
-          .body-2 = organization.email
-          - if organization.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
+              = billing_entity.city
+          - if billing_entity.state.present?
+            .body-2 = billing_entity.state
+          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          .body-2 = billing_entity.email
+          - if billing_entity.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
           .body-2 = customer.display_name
@@ -428,7 +428,7 @@ html
 
       - if applied_invoice_custom_sections.present?
         == SlimHelper.render('templates/invoices/v3/_custom_sections', self)
-      p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
+      p.body-3.mb-24 = LineBreakHelper.break_lines(billing_entity.invoice_footer)
 
       .powered-by
         span.body-2

--- a/app/views/templates/invoices/v3/charge.slim
+++ b/app/views/templates/invoices/v3/charge.slim
@@ -337,8 +337,8 @@ html
     .wrapper
       .mb-24
         h1.invoice-title = document_invoice_name
-        - if organization.logo.present?
-          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
+        - if billing_entity.logo.present?
+          img.header-logo src="data:#{billing_entity.logo.content_type};base64,#{billing_entity.base64_logo}"
 
       .mb-24.overflow-auto
         .invoice-information-column
@@ -364,28 +364,28 @@ html
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_from')
           .body-2
-            - if organization.legal_name.present?
-              | #{organization.legal_name}
+            - if billing_entity.legal_name.present?
+              | #{billing_entity.legal_name}
             - else
-              | #{organization.name}
-          - if organization.legal_number.present?
-            .body-2 #{organization.legal_number}
-          .body-2 = organization.address_line1
-          .body-2 = organization.address_line2
+              | #{billing_entity.name}
+          - if billing_entity.legal_number.present?
+            .body-2 #{billing_entity.legal_number}
+          .body-2 = billing_entity.address_line1
+          .body-2 = billing_entity.address_line2
           .body-2
             span
-              = organization.zipcode
-            - if organization.zipcode.present? && organization.city.present?
+              = billing_entity.zipcode
+            - if billing_entity.zipcode.present? && billing_entity.city.present?
               span
                 | , &nbsp;
             span
-              = organization.city
-          - if organization.state.present?
-            .body-2 = organization.state
-          .body-2 = ISO3166::Country.new(organization.country)&.common_name
-          .body-2 = organization.email
-          - if organization.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
+              = billing_entity.city
+          - if billing_entity.state.present?
+            .body-2 = billing_entity.state
+          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          .body-2 = billing_entity.email
+          - if billing_entity.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
           .body-2 = customer.display_name
@@ -476,7 +476,7 @@ html
 
       - if applied_invoice_custom_sections.present?
         == SlimHelper.render('templates/invoices/v3/_custom_sections', self)
-      p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
+      p.body-3.mb-24 = LineBreakHelper.break_lines(billing_entity.invoice_footer)
 
       .powered-by
         span.body-2

--- a/app/views/templates/invoices/v3/one_off.slim
+++ b/app/views/templates/invoices/v3/one_off.slim
@@ -338,8 +338,8 @@ html
     .wrapper
       .mb-24
         h1.invoice-title = document_invoice_name
-        - if organization.logo.present?
-          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
+        - if billing_entity.logo.present?
+          img.header-logo src="data:#{billing_entity.logo.content_type};base64,#{billing_entity.base64_logo}"
 
       .mb-24.overflow-auto
         .invoice-information-column
@@ -365,28 +365,28 @@ html
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_from')
           .body-2
-            - if organization.legal_name.present?
-              | #{organization.legal_name}
+            - if billing_entity.legal_name.present?
+              | #{billing_entity.legal_name}
             - else
-              | #{organization.name}
-          - if organization.legal_number.present?
-            .body-2 #{organization.legal_number}
-          .body-2 = organization.address_line1
-          .body-2 = organization.address_line2
+              | #{billing_entity.name}
+          - if billing_entity.legal_number.present?
+            .body-2 #{billing_entity.legal_number}
+          .body-2 = billing_entity.address_line1
+          .body-2 = billing_entity.address_line2
           .body-2
             span
-              = organization.zipcode
-            - if organization.zipcode.present? && organization.city.present?
+              = billing_entity.zipcode
+            - if billing_entity.zipcode.present? && billing_entity.city.present?
               span
                 | , &nbsp;
             span
-              = organization.city
-          - if organization.state.present?
-            .body-2 = organization.state
-          .body-2 = ISO3166::Country.new(organization.country)&.common_name
-          .body-2 = organization.email
-          - if organization.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
+              = billing_entity.city
+          - if billing_entity.state.present?
+            .body-2 = billing_entity.state
+          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          .body-2 = billing_entity.email
+          - if billing_entity.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
           .body-2 = customer.display_name
@@ -458,7 +458,7 @@ html
 
       - if applied_invoice_custom_sections.present?
         == SlimHelper.render('templates/invoices/v3/_custom_sections', self)
-      p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
+      p.body-3.mb-24 = LineBreakHelper.break_lines(billing_entity.invoice_footer)
 
       .powered-by
         span.body-2

--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -375,8 +375,8 @@ html
     .wrapper
       .mb-24
         h1.invoice-title = document_invoice_name
-        - if organization.logo.present?
-          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
+        - if billing_entity.logo.present?
+          img.header-logo src="data:#{billing_entity.logo.content_type};base64,#{billing_entity.base64_logo}"
 
       .mb-24.overflow-auto
         .invoice-information-column
@@ -402,28 +402,28 @@ html
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_from')
           .body-2
-            - if organization.legal_name.present?
-              | #{organization.legal_name}
+            - if billing_entity.legal_name.present?
+              | #{billing_entity.legal_name}
             - else
-              | #{organization.name}
-          - if organization.legal_number.present?
-            .body-2 #{organization.legal_number}
-          .body-2 = organization.address_line1
-          .body-2 = organization.address_line2
+              | #{billing_entity.name}
+          - if billing_entity.legal_number.present?
+            .body-2 #{billing_entity.legal_number}
+          .body-2 = billing_entity.address_line1
+          .body-2 = billing_entity.address_line2
           .body-2
             span
-              = organization.zipcode
-            - if organization.zipcode.present? && organization.city.present?
+              = billing_entity.zipcode
+            - if billing_entity.zipcode.present? && billing_entity.city.present?
               span
                 | , &nbsp;
             span
-              = organization.city
-          - if organization.state.present?
-            .body-2 = organization.state
-          .body-2 = ISO3166::Country.new(organization.country)&.common_name
-          .body-2 = organization.email
-          - if organization.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
+              = billing_entity.city
+          - if billing_entity.state.present?
+            .body-2 = billing_entity.state
+          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          .body-2 = billing_entity.email
+          - if billing_entity.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
           .body-2 = customer.display_name
@@ -469,7 +469,7 @@ html
       - if applied_invoice_custom_sections.present?
         == SlimHelper.render('templates/invoices/v4/_custom_sections', self)
 
-      p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
+      p.body-3.mb-24 = LineBreakHelper.break_lines(billing_entity.invoice_footer)
 
       == SlimHelper.render('templates/invoices/v4/_powered_by_logo', self)
 

--- a/app/views/templates/invoices/v4/_eu_tax_management.slim
+++ b/app/views/templates/invoices/v4/_eu_tax_management.slim
@@ -1,9 +1,9 @@
-- if organization.eu_tax_management.present?
+- if billing_entity.eu_tax_management.present?
   - if applied_taxes.present?
     - applied_tax_codes = applied_taxes.pluck(:tax_code)
     p.body-3.mb-24
       - if applied_tax_codes.include?('lago_eu_tax_exempt')
-        - if organization.country == 'FR'
+        - if billing_entity.country == 'FR'
           = I18n.t('invoice.taxes.fr_tax_exempt')
         - else
           = I18n.t('invoice.taxes.tax_exempt')

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -371,8 +371,8 @@ html
     .wrapper
       .mb-24
         h1.invoice-title = document_invoice_name
-        - if organization.logo.present?
-          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
+        - if billing_entity.logo.present?
+          img.header-logo src="data:#{billing_entity.logo.content_type};base64,#{billing_entity.base64_logo}"
 
       .mb-24.overflow-auto
         .invoice-information-column
@@ -398,28 +398,28 @@ html
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_from')
           .body-2
-            - if organization.legal_name.present?
-              | #{organization.legal_name}
+            - if billing_entity.legal_name.present?
+              | #{billing_entity.legal_name}
             - else
-              | #{organization.name}
-          - if organization.legal_number.present?
-            .body-2 #{organization.legal_number}
-          .body-2 = organization.address_line1
-          .body-2 = organization.address_line2
+              | #{billing_entity.name}
+          - if billing_entity.legal_number.present?
+            .body-2 #{billing_entity.legal_number}
+          .body-2 = billing_entity.address_line1
+          .body-2 = billing_entity.address_line2
           .body-2
             span
-              = organization.zipcode
-            - if organization.zipcode.present? && organization.city.present?
+              = billing_entity.zipcode
+            - if billing_entity.zipcode.present? && billing_entity.city.present?
               span
                 | , &nbsp;
             span
-              = organization.city
-          - if organization.state.present?
-            .body-2 = organization.state
-          .body-2 = ISO3166::Country.new(organization.country)&.common_name
-          .body-2 = organization.email
-          - if organization.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
+              = billing_entity.city
+          - if billing_entity.state.present?
+            .body-2 = billing_entity.state
+          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          .body-2 = billing_entity.email
+          - if billing_entity.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
           .body-2 = customer.display_name
@@ -453,6 +453,6 @@ html
       - if applied_invoice_custom_sections.present?
         == SlimHelper.render('templates/invoices/v4/_custom_sections', self)
 
-      p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
+      p.body-3.mb-24 = LineBreakHelper.break_lines(billing_entity.invoice_footer)
 
       == SlimHelper.render('templates/invoices/v4/_powered_by_logo', self)

--- a/app/views/templates/invoices/v4/one_off.slim
+++ b/app/views/templates/invoices/v4/one_off.slim
@@ -340,8 +340,8 @@ html
     .wrapper
       .mb-24
         h1.invoice-title = document_invoice_name
-        - if organization.logo.present?
-          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
+        - if billing_entity.logo.present?
+          img.header-logo src="data:#{billing_entity.logo.content_type};base64,#{billing_entity.base64_logo}"
 
       .mb-24.overflow-auto
         .invoice-information-column
@@ -367,28 +367,28 @@ html
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_from')
           .body-2
-            - if organization.legal_name.present?
-              | #{organization.legal_name}
+            - if billing_entity.legal_name.present?
+              | #{billing_entity.legal_name}
             - else
-              | #{organization.name}
-          - if organization.legal_number.present?
-            .body-2 #{organization.legal_number}
-          .body-2 = organization.address_line1
-          .body-2 = organization.address_line2
+              | #{billing_entity.name}
+          - if billing_entity.legal_number.present?
+            .body-2 #{billing_entity.legal_number}
+          .body-2 = billing_entity.address_line1
+          .body-2 = billing_entity.address_line2
           .body-2
             span
-              = organization.zipcode
-            - if organization.zipcode.present? && organization.city.present?
+              = billing_entity.zipcode
+            - if billing_entity.zipcode.present? && billing_entity.city.present?
               span
                 | , &nbsp;
             span
-              = organization.city
-          - if organization.state.present?
-            .body-2 = organization.state
-          .body-2 = ISO3166::Country.new(organization.country)&.common_name
-          .body-2 = organization.email
-          - if organization.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
+              = billing_entity.city
+          - if billing_entity.state.present?
+            .body-2 = billing_entity.state
+          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          .body-2 = billing_entity.email
+          - if billing_entity.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
           .body-2 = customer.display_name
@@ -422,6 +422,6 @@ html
       - if applied_invoice_custom_sections.present?
         == SlimHelper.render('templates/invoices/v4/_custom_sections', self)
 
-      p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
+      p.body-3.mb-24 = LineBreakHelper.break_lines(billing_entity.invoice_footer)
 
       == SlimHelper.render('templates/invoices/v4/_powered_by_logo', self)

--- a/app/views/templates/invoices/v4/self_billed.slim
+++ b/app/views/templates/invoices/v4/self_billed.slim
@@ -419,32 +419,32 @@ html
           - if customer.tax_identification_number.present?
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)
 
-        // Recipient (organization) information
+        // Recipient (billing_entity) information
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
           .body-2
-            - if organization.legal_name.present?
-              | #{organization.legal_name}
+            - if billing_entity.legal_name.present?
+              | #{billing_entity.legal_name}
             - else
-              | #{organization.name}
-          - if organization.legal_number.present?
-            .body-2 #{organization.legal_number}
-          .body-2 = organization.address_line1
-          .body-2 = organization.address_line2
+              | #{billing_entity.name}
+          - if billing_entity.legal_number.present?
+            .body-2 #{billing_entity.legal_number}
+          .body-2 = billing_entity.address_line1
+          .body-2 = billing_entity.address_line2
           .body-2
             span
-              = organization.zipcode
-            - if organization.zipcode.present? && organization.city.present?
+              = billing_entity.zipcode
+            - if billing_entity.zipcode.present? && billing_entity.city.present?
               span
                 | , &nbsp;
             span
-              = organization.city
-          - if organization.state.present?
-            .body-2 = organization.state
-          .body-2 = ISO3166::Country.new(organization.country)&.common_name
-          .body-2 = organization.email
-          - if organization.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
+              = billing_entity.city
+          - if billing_entity.state.present?
+            .body-2 = billing_entity.state
+          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          .body-2 = billing_entity.email
+          - if billing_entity.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
 
       .mb-24
         h2.title-2.mb-4 = MoneyHelper.format(total_amount)


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

 ## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

 ## Description

Invoice templates uses billing entity as data source of truth