### PR TITLE
feat(dx): improve seeders and truncate db

### DIFF
--- a/db/seeds/01_base.rb
+++ b/db/seeds/01_base.rb
@@ -96,7 +96,7 @@ Charge.create_with(
     billing_time: :calendar
   ).find_or_create_by!(
     customer:,
-    external_id: SecureRandom.uuid,
+    external_id: "cust_#{SecureRandom.hex}",
     plan:
   )
 
@@ -111,7 +111,7 @@ Charge.create_with(
         external_customer_id: customer.external_id,
         external_subscription_id: sub.external_id,
         organization_id: organization.id,
-        transaction_id: SecureRandom.uuid,
+        transaction_id: "tr-#{SecureRandom.hex}",
         timestamp: time - rand(0..12).seconds,
         created_at: time,
         code: sum_metric.code,
@@ -132,7 +132,7 @@ Charge.create_with(
         external_customer_id: customer.external_id,
         external_subscription_id: sub.external_id,
         organization_id: organization.id,
-        transaction_id: SecureRandom.uuid,
+        transaction_id: "tr-#{SecureRandom.hex}",
         timestamp: time - rand(0..12).seconds,
         created_at: time,
         code: count_metric.code,
@@ -152,7 +152,7 @@ Charge.create_with(
       external_customer_id: customer.external_id,
       external_subscription_id: sub.external_id,
       organization_id: organization.id,
-      transaction_id: SecureRandom.uuid,
+      transaction_id: "tr-#{SecureRandom.hex}",
       timestamp: time - 120.seconds,
       created_at: time,
       code: sum_metric.code,
@@ -172,7 +172,7 @@ Charge.create_with(
       external_customer_id: customer.external_id,
       external_subscription_id: sub.external_id,
       organization_id: organization.id,
-      transaction_id: SecureRandom.uuid,
+      transaction_id: "tr-#{SecureRandom.hex}",
       timestamp: time - 120.seconds,
       created_at: time,
       code: "foo",
@@ -238,7 +238,7 @@ organization.customers.find_each do |customer|
       external_customer_id: customer.external_id,
       external_subscription_id: customer.active_subscriptions&.first&.external_id,
       organization_id: organization.id,
-      transaction_id: SecureRandom.uuid,
+      transaction_id: "tr-#{SecureRandom.hex}",
       timestamp: time - rand(0..24).hours,
       created_at: time,
       code: sum_metric.code,

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :db do
+  # NOTE: The main benefit is to avoid PG::ObjectInUse error when dropping
+  #       Migration state is preserved so `db:migrate:redo:primary` can still be used
+  desc "Truncate all tables and keep migrations state"
+  task truncate: :environment do
+    raise "Can only be used in development" unless Rails.env.development?
+
+    ActiveRecord::Base.connection.tables.each do |table|
+      next if table == "schema_migrations" || table == "ar_internal_metadata"
+      ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table} RESTART IDENTITY CASCADE")
+    end
+  end
+end


### PR DESCRIPTION
## Description

As I'm working on alerting I found a few little things that I found annoying

### Seeders

- [x] Prefix `base.rake` so it always run first.
- [x] Don't use uuid when seeding external ids. I find it clearer when looking at a record in the console

### Truncate command

This introduce `bin/rails db:truncate` command to remove all data without dropping the database.
When developing, I had to rerun my migration many times using `db:migrate:redo:primary`. Unfortunately, the seeded data might clash (I'm developing the seeder at the same time).

Dropping the database and re-preparing it is annoying because:
1. you might get `PG::ObjectInUse: ERROR:  database "lago" is being accessed by other users (PG::ObjectInUse)`
2. if you load the schema, the latest change to your migration you're building aren't applied.
3. if you migrate from scratch, it takes ~2 years.

```bash
bin/rails db:truncate db:migrate:redo:primary db:seed
```