### PR TITLE
feat(audit_logs): Ability to fetch activity logs thru the API

### DIFF
--- a/app/controllers/api/v1/activity_logs_controller.rb
+++ b/app/controllers/api/v1/activity_logs_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ActivityLogsController < Api::BaseController
+      def index
+        result = ActivityLogsQuery.call(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          },
+          filters: index_filters
+        )
+
+        if result.success?
+          render(
+            json: ::CollectionSerializer.new(
+              result.activity_logs,
+              ::V1::ActivityLogSerializer,
+              collection_name: "activity_logs",
+              meta: pagination_metadata(result.activity_logs)
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
+      private
+
+      def resource_name
+        "activity_log"
+      end
+
+      def index_filters
+        {
+          from_date: params[:from_date],
+          to_date: params[:to_date],
+          activity_types: params[:activity_types],
+          activity_sources: params[:activity_sources],
+          user_emails: params[:user_emails],
+          external_customer_id: params[:external_customer_id],
+          external_subscription_id: params[:external_subscription_id],
+          resource_ids: params[:resource_ids],
+          resource_types: params[:resource_types]
+        }
+      end
+    end
+  end
+end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -4,7 +4,7 @@ class ApiKey < ApplicationRecord
   include PaperTrailTraceable
 
   RESOURCES = %w[
-    add_on analytic billable_metric coupon applied_coupon credit_note customer_usage
+    activity_log add_on analytic billable_metric coupon applied_coupon credit_note customer_usage
     customer event fee invoice organization payment payment_receipt payment_request plan subscription lifetime_usage
     tax wallet wallet_transaction webhook_endpoint webhook_jwt_public_key invoice_custom_section
   ].freeze

--- a/app/queries/activity_logs_query.rb
+++ b/app/queries/activity_logs_query.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class ActivityLogsQuery < BaseQuery
+  Result = BaseResult[:activity_logs]
+  Filters = BaseFilters[
+    :from_date,
+    :to_date,
+    :activity_types,
+    :activity_sources,
+    :user_emails,
+    :external_customer_id,
+    :external_subscription_id,
+    :resource_id,
+    :resource_type
+  ]
+
+  MAX_AGE = 30.days
+
+  def call
+    activity_logs = Clickhouse::ActivityLog.where(organization_id: organization.id, logged_at: MAX_AGE.ago..)
+    activity_logs = paginate(activity_logs)
+    activity_logs = activity_logs.order(logged_at: :desc)
+
+    activity_logs = with_logged_at_range(activity_logs) if filters.from_date || filters.to_date
+    activity_logs = with_activity_types(activity_logs) if filters.activity_types.present?
+    activity_logs = with_activity_sources(activity_logs) if filters.activity_sources.present?
+    activity_logs = with_user_emails(activity_logs) if filters.user_emails.present?
+    activity_logs = with_external_customer_id(activity_logs) if filters.external_customer_id.present?
+    activity_logs = with_external_subscription_id(activity_logs) if filters.external_subscription_id.present?
+    activity_logs = with_resource_id(activity_logs) if filters.resource_id.present?
+    activity_logs = with_resource_type(activity_logs) if filters.resource_type.present?
+
+    result.activity_logs = activity_logs
+    result
+  end
+
+  private
+
+  def with_logged_at_range(scope)
+    scope = scope.where(logged_at: from_date..) if filters.from_date
+    scope = scope.where(logged_at: ..to_date) if filters.to_date
+    scope
+  end
+
+  def with_activity_types(scope)
+    scope.where(activity_type: filters.activity_types)
+  end
+
+  def with_activity_sources(scope)
+    scope.where(activity_source: filters.activity_sources)
+  end
+
+  def with_user_emails(scope)
+    user_ids = organization.users.where(email: filters.user_emails).pluck(:id)
+    scope.where(user_id: user_ids)
+  end
+
+  def with_external_customer_id(scope)
+    scope.where(external_customer_id: filters.external_customer_id)
+  end
+
+  def with_external_subscription_id(scope)
+    scope.where(external_subscription_id: filters.external_subscription_id)
+  end
+
+  def with_resource_id(scope)
+    scope.where(resource_id: filters.resource_id)
+  end
+
+  def with_resource_type(scope)
+    scope.where(resource_type: filters.resource_type)
+  end
+
+  def from_date
+    @from_date ||= parse_datetime_filter(:from_date)
+  end
+
+  def to_date
+    @to_date ||= parse_datetime_filter(:to_date)
+  end
+end

--- a/app/queries/activity_logs_query.rb
+++ b/app/queries/activity_logs_query.rb
@@ -10,8 +10,8 @@ class ActivityLogsQuery < BaseQuery
     :user_emails,
     :external_customer_id,
     :external_subscription_id,
-    :resource_id,
-    :resource_type
+    :resource_ids,
+    :resource_types
   ]
 
   MAX_AGE = 30.days
@@ -27,8 +27,8 @@ class ActivityLogsQuery < BaseQuery
     activity_logs = with_user_emails(activity_logs) if filters.user_emails.present?
     activity_logs = with_external_customer_id(activity_logs) if filters.external_customer_id.present?
     activity_logs = with_external_subscription_id(activity_logs) if filters.external_subscription_id.present?
-    activity_logs = with_resource_id(activity_logs) if filters.resource_id.present?
-    activity_logs = with_resource_type(activity_logs) if filters.resource_type.present?
+    activity_logs = with_resource_ids(activity_logs) if filters.resource_ids.present?
+    activity_logs = with_resource_types(activity_logs) if filters.resource_types.present?
 
     result.activity_logs = activity_logs
     result
@@ -63,12 +63,12 @@ class ActivityLogsQuery < BaseQuery
     scope.where(external_subscription_id: filters.external_subscription_id)
   end
 
-  def with_resource_id(scope)
-    scope.where(resource_id: filters.resource_id)
+  def with_resource_ids(scope)
+    scope.where(resource_id: filters.resource_ids)
   end
 
-  def with_resource_type(scope)
-    scope.where(resource_type: filters.resource_type)
+  def with_resource_types(scope)
+    scope.where(resource_type: filters.resource_types)
   end
 
   def from_date

--- a/app/serializers/v1/activity_log_serializer.rb
+++ b/app/serializers/v1/activity_log_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V1
+  class ActivityLogSerializer < ModelSerializer
+    def serialize
+      {
+        lago_user_id: model.user_id,
+        resource_id: model.resource_id,
+        resource_type: model.resource_type,
+        activity_id: model.activity_id,
+        activity_type: model.activity_type,
+        activity_source: model.activity_source,
+        external_customer_id: model.external_customer_id,
+        external_subscription_id: model.external_subscription_id,
+        logged_at: model.logged_at.iso8601,
+        created_at: model.created_at.iso8601,
+        activity_object: model.activity_object,
+        activity_object_changes: model.activity_object_changes
+      }
+    end
+  end
+end

--- a/app/serializers/v1/activity_log_serializer.rb
+++ b/app/serializers/v1/activity_log_serializer.rb
@@ -4,18 +4,18 @@ module V1
   class ActivityLogSerializer < ModelSerializer
     def serialize
       {
-        lago_user_id: model.user_id,
-        resource_id: model.resource_id,
-        resource_type: model.resource_type,
         activity_id: model.activity_id,
         activity_type: model.activity_type,
         activity_source: model.activity_source,
+        activity_object: model.activity_object,
+        activity_object_changes: model.activity_object_changes,
+        user_email: model.user&.email,
+        resource_id: model.resource_id,
+        resource_type: model.resource_type,
         external_customer_id: model.external_customer_id,
         external_subscription_id: model.external_subscription_id,
         logged_at: model.logged_at.iso8601,
-        created_at: model.created_at.iso8601,
-        activity_object: model.activity_object,
-        activity_object_changes: model.activity_object_changes
+        created_at: model.created_at.iso8601
       }
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      resources :activity_logs, only: %i[index]
+
       namespace :analytics do
         get :gross_revenue, to: "gross_revenues#index", as: :gross_revenue
         get :invoiced_usage, to: "invoiced_usages#index", as: :invoiced_usage

--- a/spec/factories/clickhouse/activity_logs.rb
+++ b/spec/factories/clickhouse/activity_logs.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     api_key_id { create(:api_key, organization: membership.organization).id }
     external_customer_id { customer.external_id }
     external_subscription_id { subscription.external_id }
-    activity_type { "create" }
+    activity_type { "billable_metric.created" }
     activity_source { "api" }
     logged_at { Time.current }
     activity_object { {"foo" => "bar", "baz" => "qux"} }

--- a/spec/queries/activity_logs_query_spec.rb
+++ b/spec/queries/activity_logs_query_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ActivityLogsQuery, type: :query, clickhouse: true do
+  subject(:result) do
+    described_class.call(organization:, pagination:, filters:)
+  end
+
+  let(:returned_ids) { result.activity_logs.pluck(:activity_id) }
+  let(:organization) { activity_log.organization }
+  let(:activity_log) { create(:clickhouse_activity_log) }
+  let(:pagination) { {page: 1, limit: 10} }
+  let(:filters) { nil }
+
+  before do
+    activity_log
+  end
+
+  it "returns all activity logs" do
+    expect(result.activity_logs.count).to eq(1)
+    expect(returned_ids).to include(activity_log.activity_id)
+  end
+
+  context "with old activity logs" do
+    let(:old_activity_log) do
+      create(:clickhouse_activity_log, organization_id: organization.id, logged_at: (ActivityLogsQuery::MAX_AGE + 3.days).ago)
+    end
+
+    before do
+      old_activity_log
+    end
+
+    it "returns only recent ones" do
+      expect(result.activity_logs.count).to eq(1)
+      expect(returned_ids).to eq([activity_log.activity_id])
+    end
+  end
+
+  context "with pagination" do
+    let(:pagination) { {page: 1, limit: 1} }
+
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.activity_logs.count).to eq(1)
+      expect(result.activity_logs.current_page).to eq(1)
+      expect(result.activity_logs.prev_page).to be_nil
+      expect(result.activity_logs.next_page).to be_nil
+      expect(result.activity_logs.total_pages).to eq(1)
+      expect(result.activity_logs.total_count).to eq(1)
+    end
+  end
+
+  context "with from_date and to_date filters" do
+    it "returns expected activity logs" do
+      filters = {from_date: activity_log.logged_at + 1.day}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+
+      filters = {from_date: activity_log.logged_at - 1.day, to_date: activity_log.logged_at + 1.day}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {to_date: activity_log.logged_at - 1.day}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with activity_types filter" do
+    it "returns expected activity logs" do
+      filters = {activity_types: [activity_log.activity_type]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {activity_types: ["other"]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with activity_sources filter" do
+    it "returns expected activity logs" do
+      filters = {activity_sources: [activity_log.activity_source]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {activity_sources: ["other"]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with user_emails filter" do
+    it "returns expected activity logs" do
+      filters = {user_emails: [activity_log.user.email]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {user_emails: ["other"]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with external_customer_id filter" do
+    it "returns expected activity logs" do
+      filters = {external_customer_id: activity_log.external_customer_id}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {external_customer_id: "other"}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with external_subscription_id filter" do
+    it "returns expected activity logs" do
+      filters = {external_subscription_id: activity_log.external_subscription_id}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {external_subscription_id: "other"}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with resource_id filter" do
+    it "returns expected activity logs" do
+      filters = {resource_id: activity_log.resource_id}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {resource_id: "other"}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with resource_type filter" do
+    it "returns expected activity logs" do
+      filters = {resource_type: activity_log.resource_type}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {resource_type: "other"}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+end

--- a/spec/queries/activity_logs_query_spec.rb
+++ b/spec/queries/activity_logs_query_spec.rb
@@ -114,22 +114,22 @@ RSpec.describe ActivityLogsQuery, type: :query, clickhouse: true do
     end
   end
 
-  context "with resource_id filter" do
+  context "with resource_ids filter" do
     it "returns expected activity logs" do
-      filters = {resource_id: activity_log.resource_id}
+      filters = {resource_ids: [activity_log.resource_id]}
       expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
 
-      filters = {resource_id: "other"}
+      filters = {resource_ids: ["other"]}
       expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
     end
   end
 
-  context "with resource_type filter" do
+  context "with resource_types filter" do
     it "returns expected activity logs" do
-      filters = {resource_type: activity_log.resource_type}
+      filters = {resource_types: [activity_log.resource_type]}
       expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
 
-      filters = {resource_type: "other"}
+      filters = {resource_types: ["other"]}
       expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
     end
   end

--- a/spec/requests/api/v1/activity_logs_controller_spec.rb
+++ b/spec/requests/api/v1/activity_logs_controller_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::ActivityLogsController, type: :request, clickhouse: true do
+  describe "GET /api/v1/activity_logs" do
+    subject { get_with_token(organization, "/api/v1/activity_logs", params) }
+
+    let(:activity_log) { create(:clickhouse_activity_log) }
+    let(:invoice_activity_log) do
+      create(
+        :clickhouse_activity_log,
+        organization_id: organization.id,
+        external_customer_id: "ext_123",
+        external_subscription_id: "ext_456",
+        resource: invoice,
+        activity_type: "invoice.created",
+        activity_source: "front",
+        logged_at: 1.day.ago
+      )
+    end
+    let(:invoice) { create(:invoice, organization:) }
+    let(:organization) { activity_log.organization }
+    let(:params) { {} }
+
+    before do
+      activity_log
+      invoice_activity_log
+    end
+
+    include_examples "requires API permission", "activity_log", "read"
+
+    it "returns activity logs" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:activity_logs].count).to eq(2)
+      expect(json[:activity_logs].map { |l| l[:activity_id] }).to include(activity_log.activity_id, invoice_activity_log.activity_id)
+    end
+
+    context "when filtering by external_customer_id" do
+      let(:params) { {external_customer_id: activity_log.external_customer_id} }
+
+      it "returns activity logs for the specified external customer" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:external_customer_id]).to eq(activity_log.external_customer_id)
+      end
+    end
+
+    context "when filtering by external_subscription_id" do
+      let(:params) { {external_subscription_id: activity_log.external_subscription_id} }
+
+      it "returns activity logs for the specified external subscription" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:external_subscription_id]).to eq(activity_log.external_subscription_id)
+      end
+    end
+
+    context "when filtering by resource_id" do
+      let(:params) { {resource_ids: [activity_log.resource_id]} }
+
+      it "returns activity logs for the specified resource" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:resource_id]).to eq(activity_log.resource_id)
+      end
+    end
+
+    context "when filtering by resource_type" do
+      let(:params) { {resource_types: [activity_log.resource_type]} }
+
+      it "returns activity logs for the specified resource type" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:resource_type]).to eq(activity_log.resource_type)
+      end
+    end
+
+    context "when filtering by user_email" do
+      let(:params) { {user_emails: [activity_log.user.email]} }
+
+      it "returns activity logs for the specified user email" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:user_email]).to eq(activity_log.user.email)
+      end
+    end
+
+    context "when filtering by activity_type" do
+      let(:params) { {activity_types: [activity_log.activity_type]} }
+
+      it "returns activity logs for the specified activity type" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:activity_type]).to eq(activity_log.activity_type)
+      end
+    end
+
+    context "when filtering by activity_source" do
+      let(:params) { {activity_sources: [activity_log.activity_source]} }
+
+      it "returns activity logs for the specified activity source" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:activity_source]).to eq(activity_log.activity_source)
+      end
+    end
+
+    context "when filtering by from_date" do
+      let(:params) { {from_date: activity_log.logged_at.iso8601} }
+
+      it "returns activity logs for the specified date range" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:logged_at]).to eq(activity_log.logged_at.iso8601)
+      end
+    end
+
+    context "when filtering by to_date" do
+      let(:params) { {to_date: activity_log.logged_at.iso8601} }
+
+      it "returns activity logs for the specified date range" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(invoice_activity_log.activity_id)
+        expect(json[:activity_logs].first[:logged_at]).to eq(invoice_activity_log.logged_at.iso8601)
+      end
+    end
+
+    context "with pagination" do
+      let(:params) { {page: 1, per_page: 1} }
+
+      it "returns activity logs with correct meta data" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:meta][:current_page]).to eq(1)
+        expect(json[:meta][:next_page]).to eq(2)
+        expect(json[:meta][:prev_page]).to eq(nil)
+        expect(json[:meta][:total_pages]).to eq(2)
+        expect(json[:meta][:total_count]).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/serializers/v1/activity_log_serializer_spec.rb
+++ b/spec/serializers/v1/activity_log_serializer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::V1::ActivityLogSerializer, clickhouse: true do
+  subject(:serializer) { described_class.new(activity_log, root_name: "activity_log") }
+
+  let(:activity_log) { create(:clickhouse_activity_log) }
+
+  it "serializes the object" do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result["activity_log"]["lago_user_id"]).to eq(activity_log.user_id)
+      expect(result["activity_log"]["resource_id"]).to eq(activity_log.resource_id)
+      expect(result["activity_log"]["resource_type"]).to eq(activity_log.resource_type)
+      expect(result["activity_log"]["activity_type"]).to eq(activity_log.activity_type)
+      expect(result["activity_log"]["activity_source"]).to eq(activity_log.activity_source)
+      expect(result["activity_log"]["logged_at"]).to eq(activity_log.logged_at.iso8601)
+      expect(result["activity_log"]["activity_object"]).to eq(activity_log.activity_object)
+      expect(result["activity_log"]["activity_object_changes"]).to eq(activity_log.activity_object_changes)
+    end
+  end
+end

--- a/spec/serializers/v1/activity_log_serializer_spec.rb
+++ b/spec/serializers/v1/activity_log_serializer_spec.rb
@@ -11,14 +11,18 @@ RSpec.describe ::V1::ActivityLogSerializer, clickhouse: true do
     result = JSON.parse(serializer.to_json)
 
     aggregate_failures do
-      expect(result["activity_log"]["lago_user_id"]).to eq(activity_log.user_id)
-      expect(result["activity_log"]["resource_id"]).to eq(activity_log.resource_id)
-      expect(result["activity_log"]["resource_type"]).to eq(activity_log.resource_type)
+      expect(result["activity_log"]["activity_id"]).to eq(activity_log.activity_id)
       expect(result["activity_log"]["activity_type"]).to eq(activity_log.activity_type)
       expect(result["activity_log"]["activity_source"]).to eq(activity_log.activity_source)
-      expect(result["activity_log"]["logged_at"]).to eq(activity_log.logged_at.iso8601)
       expect(result["activity_log"]["activity_object"]).to eq(activity_log.activity_object)
       expect(result["activity_log"]["activity_object_changes"]).to eq(activity_log.activity_object_changes)
+      expect(result["activity_log"]["user_email"]).to eq(activity_log.user.email)
+      expect(result["activity_log"]["resource_id"]).to eq(activity_log.resource_id)
+      expect(result["activity_log"]["resource_type"]).to eq(activity_log.resource_type)
+      expect(result["activity_log"]["external_customer_id"]).to eq(activity_log.external_customer_id)
+      expect(result["activity_log"]["external_subscription_id"]).to eq(activity_log.external_subscription_id)
+      expect(result["activity_log"]["logged_at"]).to eq(activity_log.logged_at.iso8601)
+      expect(result["activity_log"]["created_at"]).to eq(activity_log.created_at.iso8601)
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context

Our users want to have visibility on what’s happening in Lago.

Examples:
- *A plan and prices have been updated: When? By whom? What?*
- *A subscription has been deleted: When? By whom? What?*

## Description

The goal of this PR is to be able to fetch activity logs thru the API.