### PR TITLE
feat(multi entities): Billing entities as source of truth for invoices

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -146,7 +146,7 @@ class Customer < ApplicationRecord
   def applicable_net_payment_term
     return net_payment_term if net_payment_term.present?
 
-    organization.net_payment_term
+    billing_entity.net_payment_term
   end
 
   # `applicable_invoice_custom_sections` includes:

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -180,7 +180,7 @@ class Customer < ApplicationRecord
   def preferred_document_locale
     return document_locale.to_sym if document_locale?
 
-    organization.document_locale.to_sym
+    billing_entity.document_locale.to_sym
   end
 
   def provider_customer

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -140,7 +140,7 @@ class Customer < ApplicationRecord
   def applicable_invoice_grace_period
     return invoice_grace_period if invoice_grace_period.present?
 
-    organization.invoice_grace_period
+    billing_entity.invoice_grace_period || 0
   end
 
   def applicable_net_payment_term

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -134,7 +134,7 @@ class Customer < ApplicationRecord
   def applicable_timezone
     return timezone if timezone.present?
 
-    organization.timezone || "UTC"
+    billing_entity.timezone || "UTC"
   end
 
   def applicable_invoice_grace_period

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -160,6 +160,7 @@ class Customer < ApplicationRecord
     InvoiceCustomSection.where(id: manual_ids + system_ids)
   end
 
+  # TODO: migrate invoice custom sections to Billing Entities
   # `configurable_invoice_custom_sections` are manually selected sections:
   # - either directly configured on the customer
   # - or fallback to selections at the organization level if none on the customer

--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -95,7 +95,7 @@ module Invoices
 
     def should_deliver_email?
       License.premium? &&
-        customer.organization.email_settings.include?("invoice.finalized")
+        customer.billing_entity.email_settings.include?("invoice.finalized")
     end
   end
 end

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -87,7 +87,7 @@ module Invoices
     end
 
     def should_deliver_email?
-      License.premium? && customer.organization.email_settings.include?("invoice.finalized")
+      License.premium? && customer.billing_entity.email_settings.include?("invoice.finalized")
     end
 
     def add_ons

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -108,7 +108,7 @@ module Invoices
     end
 
     def should_deliver_email?
-      License.premium? && customer.billing_entities.email_settings.include?("invoice.finalized")
+      License.premium? && customer.billing_entity.email_settings.include?("invoice.finalized")
     end
 
     def wallet

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -108,7 +108,7 @@ module Invoices
     end
 
     def should_deliver_email?
-      License.premium? && customer.organization.email_settings.include?("invoice.finalized")
+      License.premium? && customer.billing_entities.email_settings.include?("invoice.finalized")
     end
 
     def wallet

--- a/app/services/invoices/finalize_open_credit_service.rb
+++ b/app/services/invoices/finalize_open_credit_service.rb
@@ -39,7 +39,7 @@ module Invoices
 
     def should_deliver_email?
       License.premium? &&
-        invoice.organization.email_settings.include?("invoice.finalized")
+        invoice.billing_entity.email_settings.include?("invoice.finalized")
     end
   end
 end

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -98,7 +98,7 @@ module Invoices
 
     def should_deliver_email?
       License.premium? &&
-        customer.organization.email_settings.include?("invoice.finalized")
+        customer.billing_entity.email_settings.include?("invoice.finalized")
     end
   end
 end

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -120,7 +120,7 @@ module Invoices
     end
 
     def should_deliver_email?
-      License.premium? && subscription.organization.email_settings.include?("invoice.finalized")
+      License.premium? && subscription.billing_entity.email_settings.include?("invoice.finalized")
     end
 
     def create_credit_note_credit

--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -76,7 +76,7 @@ module Invoices
 
       def should_deliver_email?
         License.premium? &&
-          invoice.organization.email_settings.include?("invoice.finalized")
+          invoice.billing_entity.email_settings.include?("invoice.finalized")
       end
 
       def wallet

--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -77,7 +77,7 @@ module Invoices
 
     def should_deliver_email?
       License.premium? &&
-        invoice.organization.email_settings.include?("invoice.finalized")
+        invoice.billing_entity.email_settings.include?("invoice.finalized")
     end
 
     def clear_invoice_generation_errors(invoice)

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -139,7 +139,7 @@ module Invoices
 
     def should_deliver_finalized_email?
       License.premium? &&
-        customer.organization.email_settings.include?("invoice.finalized")
+        customer.billing_entity.email_settings.include?("invoice.finalized")
     end
 
     def flag_lifetime_usage_for_refresh

--- a/app/services/invoices/transition_to_final_status_service.rb
+++ b/app/services/invoices/transition_to_final_status_service.rb
@@ -5,7 +5,7 @@ module Invoices
     def initialize(invoice:)
       @invoice = invoice
       @customer = @invoice.customer
-      @organization = @customer.organization
+      @billing_entity = @customer.billing_entity
       super
     end
 
@@ -23,7 +23,7 @@ module Invoices
       return true unless invoice.fees_amount_cents.zero?
       customer_setting = customer.finalize_zero_amount_invoice
       if customer_setting == "inherit"
-        organization.finalize_zero_amount_invoice
+        billing_entity.finalize_zero_amount_invoice
       else
         customer_setting == "finalize"
       end
@@ -31,6 +31,6 @@ module Invoices
 
     private
 
-    attr_reader :invoice, :customer, :organization
+    attr_reader :invoice, :customer, :billing_entity
   end
 end

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -58,8 +58,9 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
+  let(:billing_entity) { create(:billing_entity, organization:, timezone: "America/New_York") }
   let(:customer) do
-    create(:customer, organization:, currency: "EUR", skip_invoice_custom_sections: false)
+    create(:customer, billing_entity:, organization:, currency: "EUR", skip_invoice_custom_sections: false)
   end
   let(:subscription) { create(:subscription, customer:) }
   let(:applied_add_on) { create(:applied_add_on, customer:) }
@@ -69,7 +70,6 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
   let(:invoice_custom_sections) { create_list(:invoice_custom_section, 3, organization:) }
 
   before do
-    organization.update!(timezone: "America/New_York")
     create_list(:invoice, 2, customer:)
     applied_add_on
     applied_tax
@@ -96,23 +96,21 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
 
     customer_response = result["data"]["customer"]
 
-    aggregate_failures do
-      expect(customer_response["id"]).to eq(customer.id)
-      expect(customer_response["subscriptions"].count).to eq(1)
-      expect(customer_response["invoices"].count).to eq(2)
-      expect(customer_response["appliedAddOns"].count).to eq(1)
-      expect(customer_response["taxes"].count).to eq(1)
-      expect(customer_response["currency"]).to be_present
-      expect(customer_response["externalSalesforceId"]).to be_nil
-      expect(customer_response["timezone"]).to be_nil
-      expect(customer_response["applicableTimezone"]).to eq("TZ_AMERICA_NEW_YORK")
-      expect(customer_response["hasCreditNotes"]).to be true
-      expect(customer_response["creditNotesCreditsAvailableCount"]).to eq(1)
-      expect(customer_response["creditNotesBalanceAmountCents"]).to eq("120")
-      expect(customer_response["hasOverwrittenInvoiceCustomSectionsSelection"]).to be true
-      expect(customer_response["skipInvoiceCustomSections"]).to be false
-      expect(customer_response["configurableInvoiceCustomSections"].count).to eq(2)
-    end
+    expect(customer_response["id"]).to eq(customer.id)
+    expect(customer_response["subscriptions"].count).to eq(1)
+    expect(customer_response["invoices"].count).to eq(2)
+    expect(customer_response["appliedAddOns"].count).to eq(1)
+    expect(customer_response["taxes"].count).to eq(1)
+    expect(customer_response["currency"]).to be_present
+    expect(customer_response["externalSalesforceId"]).to be_nil
+    expect(customer_response["timezone"]).to be_nil
+    expect(customer_response["applicableTimezone"]).to eq("TZ_AMERICA_NEW_YORK")
+    expect(customer_response["hasCreditNotes"]).to be true
+    expect(customer_response["creditNotesCreditsAvailableCount"]).to eq(1)
+    expect(customer_response["creditNotesBalanceAmountCents"]).to eq("120")
+    expect(customer_response["hasOverwrittenInvoiceCustomSectionsSelection"]).to be true
+    expect(customer_response["skipInvoiceCustomSections"]).to be false
+    expect(customer_response["configurableInvoiceCustomSections"].count).to eq(2)
   end
 
   context "when customer has invoice_custom_sections selected on organization level" do

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -389,7 +389,7 @@ RSpec.describe Customer, type: :model do
 
       before do
         customer.timezone = nil
-        billing_entity.timezone = billing_entity_timezone 
+        billing_entity.timezone = billing_entity_timezone
       end
 
       it "returns the billing entity timezone" do

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -408,7 +408,7 @@ RSpec.describe Customer, type: :model do
 
   describe "#applicable_invoice_grace_period" do
     subject(:customer) do
-      described_class.new(organization:, invoice_grace_period: 3)
+      described_class.new(billing_entity:, invoice_grace_period: 3)
     end
 
     it "returns the customer invoice_grace_period" do
@@ -416,19 +416,19 @@ RSpec.describe Customer, type: :model do
     end
 
     context "when customer does not have an invoice grace period" do
-      let(:organization_invoice_grace_period) { 5 }
+      let(:billing_entity_invoice_grace_period) { 5 }
 
       before do
         customer.invoice_grace_period = nil
-        organization.invoice_grace_period = organization_invoice_grace_period
+        billing_entity.invoice_grace_period = billing_entity_invoice_grace_period
       end
 
-      it "returns the organization invoice_grace_period" do
+      it "returns the billing entity invoice_grace_period" do
         expect(customer.applicable_invoice_grace_period).to eq(5)
       end
 
-      context "when organization invoice_grace_period is nil" do
-        let(:organization_invoice_grace_period) { 0 }
+      context "when billing entity invoice_grace_period is nil" do
+        let(:billing_entity_invoice_grace_period) { nil }
 
         it "returns the default invoice_grace_period" do
           expect(customer.applicable_invoice_grace_period).to eq(0)

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -271,24 +271,27 @@ RSpec.describe Customer, type: :model do
   end
 
   describe "preferred_document_locale" do
-    subject(:customer) do
+    subject(:preferred_document_locale) { customer.preferred_document_locale }
+
+    let(:customer) do
       described_class.new(
         organization:,
+        billing_entity:,
         document_locale: "en"
       )
     end
 
     it "returns the customer document_locale" do
-      expect(customer.preferred_document_locale).to eq(:en)
+      expect(preferred_document_locale).to eq(:en)
     end
 
     context "when customer does not have a document_locale" do
       before do
         customer.document_locale = nil
-        customer.organization.document_locale = "fr"
+        billing_entity.document_locale = "fr"
       end
 
-      it "returns the organization document_locale" do
+      it "returns the billing_entity document_locale" do
         expect(customer.preferred_document_locale).to eq(:fr)
       end
     end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Customer, type: :model do
   subject(:customer) { create(:customer) }
 
   let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity, organization:) }
 
   it_behaves_like "paper_trail traceable"
 
@@ -376,7 +377,7 @@ RSpec.describe Customer, type: :model do
 
   describe "#applicable_timezone" do
     subject(:customer) do
-      described_class.new(organization:, timezone: "Europe/Paris")
+      described_class.new(billing_entity:, timezone: "Europe/Paris")
     end
 
     it "returns the customer timezone" do
@@ -384,19 +385,19 @@ RSpec.describe Customer, type: :model do
     end
 
     context "when customer does not have a timezone" do
-      let(:organization_timezone) { "Europe/London" }
+      let(:billing_entity_timezone) { "Europe/London" }
 
       before do
         customer.timezone = nil
-        organization.timezone = organization_timezone
+        billing_entity.timezone = billing_entity_timezone 
       end
 
-      it "returns the organization timezone" do
+      it "returns the billing entity timezone" do
         expect(customer.applicable_timezone).to eq("Europe/London")
       end
 
-      context "when organization timezone is nil" do
-        let(:organization_timezone) { nil }
+      context "when billing entity timezone is nil" do
+        let(:billing_entity_timezone) { nil }
 
         it "returns the default timezone" do
           expect(customer.applicable_timezone).to eq("UTC")

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -437,6 +437,37 @@ RSpec.describe Customer, type: :model do
     end
   end
 
+  describe "#applicable_net_payment_term" do
+    subject(:applicable_net_payment_term) { customer.applicable_net_payment_term }
+
+    let(:customer) do
+      described_class.new(organization:, billing_entity:, net_payment_term: 15)
+    end
+
+    it "returns the customer net_payment_term" do
+      expect(applicable_net_payment_term).to eq(15)
+    end
+
+    context "when customer does not have a net payment term" do
+      let(:billing_entity_net_payment_term) { 30 }
+
+      before do
+        customer.net_payment_term = nil
+        billing_entity.net_payment_term = billing_entity_net_payment_term
+      end
+
+      it "returns the billing entity net payment term" do
+        expect(applicable_net_payment_term).to eq(billing_entity_net_payment_term)
+      end
+
+      context "when billing entity net_payment_term is nil" do
+        let(:billing_entity_net_payment_term) { nil }
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+
   describe "scoped selected_invoice_custom_sections" do
     let(:organization) { customer.organization }
     let(:manual_section) { create(:invoice_custom_section, organization:, section_type: :manual) }

--- a/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
+++ b/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
@@ -4,10 +4,11 @@ require "rails_helper"
 
 describe "Dunning Campaign v1", :scenarios, type: :request do
   let(:organization) do
-    create(:organization,
-      name: "JC AI",
-      premium_integrations: %w[auto_dunning],
-      email_settings: [])
+    create(:organization, name: "JC AI", premium_integrations: %w[auto_dunning])
+  end
+
+  let(:billing_entity) do
+    create(:billing_entity, organization:, name: "ACME Corp", email_settings: [])
   end
 
   let(:dunning_campaign) do
@@ -21,7 +22,18 @@ describe "Dunning Campaign v1", :scenarios, type: :request do
   let(:stripe_pm_id) { "pm_123456" }
 
   let(:stripe_provider) { create(:stripe_provider, organization:) }
-  let(:customer) { create(:customer, organization:, payment_provider: :stripe, payment_provider_code: stripe_provider.code, net_payment_term: 2) }
+
+  let(:customer) do
+    create(
+      :customer,
+      organization:,
+      billing_entity:,
+      payment_provider: :stripe,
+      payment_provider_code: stripe_provider.code,
+      net_payment_term: 2
+    )
+  end
+
   let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider: stripe_provider, provider_customer_id: stripe_cus_id) }
 
   let(:external_subscription_id) { "sub_overdue-dunning-campaign-v1" }

--- a/spec/scenarios/fees/recurring_fees_spec.rb
+++ b/spec/scenarios/fees/recurring_fees_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 describe "Recurring Non Invoiceable Fees", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: "http://fees.test/wh") }
-  let(:customer) { create(:customer, organization:) }
+  let(:billing_entity) { create(:billing_entity, organization:) }
+  let(:customer) { create(:customer, organization:, billing_entity:) }
   let(:billable_metric) { create(:unique_count_billable_metric, :recurring, organization:, code: "seats") }
   let(:plan) { create(:plan, organization:, amount_cents: 49.99, pay_in_advance: true) }
   let(:external_subscription_id) { SecureRandom.uuid }
@@ -179,7 +180,8 @@ describe "Recurring Non Invoiceable Fees", :scenarios, type: :request do
       end
 
       context "with grace period" do
-        let(:organization) { create(:organization, webhook_url: "http://fees.test/wh", invoice_grace_period: 3) }
+        let(:organization) { create(:organization, webhook_url: "http://fees.test/wh") }
+        let(:billing_entity) { create(:billing_entity, organization:, invoice_grace_period: 3) }
         let(:grouped_by) { ["item_id"] }
 
         it "creates the recurring fees without the grace period" do

--- a/spec/scenarios/wallets/balance_spec.rb
+++ b/spec/scenarios/wallets/balance_spec.rb
@@ -3,11 +3,12 @@
 require "rails_helper"
 
 describe "Use wallet's credits and recalculate balances", :scenarios, type: :request do
-  let(:organization) { create(:organization, webhook_url: nil, email_settings: [], premium_integrations: ["progressive_billing"], invoice_grace_period: 10) }
+  let(:organization) { create(:organization, webhook_url: nil, email_settings: [], premium_integrations: ["progressive_billing"]) }
+  let(:billing_entity) { create(:billing_entity, organization:, invoice_grace_period: 10) }
   let(:plan) { create(:plan, organization: organization, interval: "monthly", amount_cents: 1_00, pay_in_advance: false) }
   let(:billable_metric) { create(:billable_metric, organization: organization, field_name: "total", aggregation_type: "sum_agg") }
   let(:charge) { create(:charge, plan: plan, billable_metric: billable_metric, charge_model: "standard", properties: {"amount" => "1"}) }
-  let(:customer) { create(:customer, organization: organization) }
+  let(:customer) { create(:customer, organization:, billing_entity:) }
 
   around { |test| lago_premium!(&test) }
 

--- a/spec/services/customers/update_invoice_payment_due_date_service_spec.rb
+++ b/spec/services/customers/update_invoice_payment_due_date_service_spec.rb
@@ -7,13 +7,22 @@ RSpec.describe Customers::UpdateInvoicePaymentDueDateService, type: :service do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:, net_payment_term: customer_net_payment_term) }
+  let(:billing_entity) { create(:billing_entity, organization:, net_payment_term: 15) }
+  let(:customer) { create(:customer, organization:, billing_entity:, net_payment_term: customer_net_payment_term) }
   let(:net_payment_term) { 30 }
   let(:customer_net_payment_term) { nil }
 
   describe "#call" do
     let(:draft_invoice) do
-      create(:invoice, status: :draft, customer:, issuing_date: DateTime.parse("21 Jun 2022"), net_payment_term: customer.applicable_net_payment_term, organization:)
+      create(
+        :invoice,
+        organization:,
+        billing_entity:,
+        customer:,
+        status: :draft,
+        issuing_date: DateTime.parse("21 Jun 2022"),
+        net_payment_term: customer.applicable_net_payment_term
+      )
     end
 
     before do
@@ -30,20 +39,16 @@ RSpec.describe Customers::UpdateInvoicePaymentDueDateService, type: :service do
       let(:customer_net_payment_term) { 20 }
       let(:net_payment_term) { nil }
 
-      before do
-        organization.update(net_payment_term: 15)
-      end
-
-      it "sets the payment_due_date of the draft_invoice to the org level value" do
+      it "sets the payment_due_date of the draft_invoice to the billing entity level value" do
         expect { update_service.call }.to change { draft_invoice.reload.payment_due_date }
           .from(DateTime.parse("21 Jun 2022"))
-          .to(DateTime.parse("21 Jun 2022") + organization.net_payment_term.days)
+          .to(DateTime.parse("21 Jun 2022") + billing_entity.net_payment_term.days)
       end
 
       it "sets the net_payment_term of the draft_invoice to the org level value" do
         expect { update_service.call }.to change { draft_invoice.reload.net_payment_term }
           .from(customer_net_payment_term)
-          .to(organization.net_payment_term)
+          .to(billing_entity.net_payment_term)
       end
     end
   end

--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
   subject(:compute_service) { described_class.new(subscription:, timestamp:) }
 
   let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let(:billing_entity) { create(:billing_entity, organization:) }
+  let(:customer) { create(:customer, organization:, billing_entity:) }
   let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
   let(:plan) { create(:plan, organization:) }
@@ -90,8 +91,10 @@ RSpec.describe DailyUsages::ComputeService, type: :service do
           expect(result.daily_usage).to eq(existing_daily_usage)
         end
 
-        context "when the organization has a timezone" do
-          let(:organization) { create(:organization, timezone: "America/Sao_Paulo") }
+        context "when the billing_entity has a timezone" do
+          let(:billing_entity) do
+            create(:billing_entity, organization:, timezone: "America/Sao_Paulo")
+          end
 
           let(:existing_daily_usage) do
             create(:daily_usage, subscription:, organization:, customer:, usage_date: usage_date - 4.hours)

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Invoices::AddOnService, type: :service do
       end
 
       context "when organization does not have right email settings" do
-        before { applied_add_on.customer.organization.update!(email_settings: []) }
+        before { applied_add_on.customer.billing_entity.update!(email_settings: []) }
 
         it "enqueue an GeneratePdfAndNotifyJob with email false" do
           expect do

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
       end
 
       context "when organization does not have right email settings" do
-        before { customer.organization.update!(email_settings: []) }
+        before { customer.billing_entity.update!(email_settings: []) }
 
         it "enqueues GeneratePdfAndNotifyJob with email false" do
           expect do

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
   end
 
   let(:timestamp) { Time.zone.now.beginning_of_month }
-  let(:organization) { create(:organization, email_settings:) }
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { customer.billing_entity }
   let(:billable_metric) { create(:billable_metric, organization:) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }
@@ -31,7 +32,10 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
     )
   end
 
-  before { create(:tax, organization:, applied_to_organization: true) }
+  before do
+    create(:tax, organization:, applied_to_organization: true)
+    billing_entity.update!(email_settings:)
+  end
 
   describe "call" do
     let(:aggregation_result) do

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
       end
 
       context "when organization does not have right email settings" do
-        before { customer.organization.update!(email_settings: []) }
+        before { customer.billing_entity.update!(email_settings: []) }
 
         it "does not enqueue an SendEmailJob" do
           expect do

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
 
   describe "#call" do
     let(:organization) { create(:organization) }
+    let(:billing_entity) { create(:billing_entity, organization:) }
     let(:tax) { create(:tax, rate: 50.0, organization:) }
-    let(:customer) { build(:customer, organization:) }
+    let(:customer) { build(:customer, organization:, billing_entity:) }
     let(:timestamp) { Time.zone.parse("30 Mar 2024") }
     let(:plan) { create(:plan, organization:, interval: "monthly") }
     let(:billing_time) { "calendar" }
@@ -64,7 +65,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
       end
 
       context "when currencies do not match" do
-        let(:customer) { build(:customer, organization:, currency: "USD") }
+        let(:customer) { build(:customer, organization:, billing_entity:, currency: "USD") }
 
         it "returns an error" do
           result = preview_service.call
@@ -75,7 +76,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
       end
 
       context "when billing periods do not match" do
-        let(:customer) { create(:customer, organization:) }
+        let(:customer) { create(:customer, organization:, billing_entity:) }
         let(:plan1) { create(:plan, organization:, interval: "monthly") }
         let(:plan2) { create(:plan, organization:, interval: "monthly") }
         let(:subscriptions) { [subscription1, subscription2] }
@@ -119,7 +120,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
 
         context "with one persisted subscription" do
-          let(:customer) { create(:customer, organization:) }
+          let(:customer) { create(:customer, organization:, billing_entity:) }
           let(:subscription) do
             create(
               :subscription,
@@ -389,7 +390,8 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
 
         context "with in advance billing in the future" do
-          let(:organization) { create(:organization, invoice_grace_period: 2) }
+          let(:organization) { create(:organization) }
+          let(:billing_entity) { create(:billing_entity, organization:, invoice_grace_period: 2) }
           let(:plan) { create(:plan, organization:, interval: "monthly", pay_in_advance: true) }
           let(:subscription) do
             build(
@@ -424,7 +426,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
 
         context "with in advance billing with persisted subscription" do
-          let(:customer) { create(:customer, organization:) }
+          let(:customer) { create(:customer, organization:, billing_entity:) }
           let(:plan) { create(:plan, organization:, interval: "monthly", pay_in_advance: true) }
           let(:subscription) do
             create(
@@ -656,7 +658,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
           end
 
           context "with customer that is persisted" do
-            let(:customer) { create(:customer, organization:) }
+            let(:customer) { create(:customer, organization:, billing_entity:) }
             let(:wallet) { create(:wallet, customer:, balance: "0.03", credits_balance: "0.03") }
 
             it "applies credits" do
@@ -809,7 +811,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
 
         context "with one persisted subscriptions" do
-          let(:customer) { create(:customer, organization:) }
+          let(:customer) { create(:customer, organization:, billing_entity:) }
           let(:subscription) do
             create(
               :subscription,

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service do
       end
 
       context "when organization does not have right email settings" do
-        before { subscription.organization.update!(email_settings: []) }
+        before { subscription.billing_entity.update!(email_settings: []) }
 
         it "enqueue an GeneratePdfAndNotifyJob with email false" do
           expect { create_service.call }

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
         end
 
         context "when organization does not have right email settings" do
-          before { invoice.organization.update!(email_settings: []) }
+          before { invoice.billing_entity.update!(email_settings: []) }
 
           it "enqueues GeneratePdfAndNotifyJob with email false" do
             expect do

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
       end
 
       context "when organization does not have right email settings" do
-        before { invoice.organization.update!(email_settings: []) }
+        before { invoice.billing_entity.update!(email_settings: []) }
 
         it "enqueues GeneratePdfAndNotifyJob with email false" do
           expect do

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
       end
 
       context "when organization does not have right email settings" do
-        before { subscription.customer.organization.update!(email_settings: []) }
+        before { customer.billing_entity.update!(email_settings: []) }
 
         it "enqueues GeneratePdfAndNotifyJob with email false" do
           expect do

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
   end
 
   let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
+  let(:billing_entity) { create(:billing_entity, organization:) }
+  let(:customer) { create(:customer, organization:, billing_entity:) }
   let(:tax) { create(:tax, organization:, rate: 20) }
 
   let(:invoicing_reason) { :subscription_periodic }
@@ -305,10 +306,8 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
           expect(result.invoice.number).to include("DRAFT")
         end
 
-        context "when organization gas grace period" do
-          before do
-            organization.update!(invoice_grace_period: 30)
-          end
+        context "when billing entity has grace period" do
+          let(:billing_entity) { create(:billing_entity, organization:, invoice_grace_period: 30) }
 
           it "creates an invoice in :draft status" do
             result = invoice_service.call

--- a/spec/services/invoices/transition_to_final_status_service_spec.rb
+++ b/spec/services/invoices/transition_to_final_status_service_spec.rb
@@ -5,9 +5,10 @@ require "rails_helper"
 RSpec.describe Invoices::TransitionToFinalStatusService, type: :service do
   subject { described_class.new(invoice: invoice) }
 
-  let(:organization) { create(:organization, finalize_zero_amount_invoice: organization_setting) }
-  let(:customer) { create(:customer, organization:, finalize_zero_amount_invoice: customer_setting) }
-  let(:organization_setting) { "true" } # default value
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity, organization:, finalize_zero_amount_invoice: billing_entity_setting) }
+  let(:customer) { create(:customer, organization:, billing_entity:, finalize_zero_amount_invoice: customer_setting) }
+  let(:billing_entity_setting) { "true" } # default value
   let(:customer_setting) { "inherit" }  # default value
   let(:fees_amount_cents) { 100 }
   let(:invoice) do
@@ -29,7 +30,7 @@ RSpec.describe Invoices::TransitionToFinalStatusService, type: :service do
         expect(invoice.status).to eq("finalized")
       end
 
-      context "with organization and customer settings defined to not finalize" do
+      context "with billing entity and customer settings defined to not finalize" do
         let(:organization_setting) { "false" }
         let(:customer_setting) { "skip" }
 
@@ -63,16 +64,16 @@ RSpec.describe Invoices::TransitionToFinalStatusService, type: :service do
       context "with customer setting defined to inherit" do
         let(:customer_setting) { "inherit" }
 
-        context "with organization setting to finalize" do
-          let(:organization_setting) { "true" }
+        context "with billing_entity setting to finalize" do
+          let(:billing_entity_setting) { "true" }
 
           it "finalizes the invoice" do
             expect(invoice.status).to eq("finalized")
           end
         end
 
-        context "with organization setting to skip" do
-          let(:organization_setting) { "false" }
+        context "with billing_entity setting to skip" do
+          let(:billing_entity_setting) { "false" }
 
           it "closes the invoice" do
             expect(invoice.status).to eq("closed")


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

 ## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

 ## Description

use billing entity data instead of organization data as source of truth for invoices data.

customer fallbacks to billing entities instead of organization for default values.