### PR TITLE
Feat(multientities): use billing_entity when generating a credit note

### DIFF
--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -183,7 +183,7 @@ module CreditNotes
 
     def deliver_email
       # NOTE: We already check the premium state for the credit note creation
-      return unless credit_note.organization.email_settings.include?("credit_note.created")
+      return unless credit_note.billing_entity.email_settings.include?("credit_note.created")
 
       CreditNoteMailer.with(credit_note:)
         .created.deliver_later(wait: 3.seconds)

--- a/app/views/templates/credit_notes/_eu_tax_management.slim
+++ b/app/views/templates/credit_notes/_eu_tax_management.slim
@@ -1,9 +1,9 @@
-- if organization.eu_tax_management.present?
+- if billing_entity.eu_tax_management.present?
   - if applied_taxes.present?
     - applied_tax_codes = applied_taxes.pluck(:tax_code)
     p.body-3.mb-24
       - if applied_tax_codes.include?('lago_eu_tax_exempt')
-        - if organization.country == 'FR'
+        - if billing_entity.country == 'FR'
           = I18n.t('invoice.taxes.fr_tax_exempt')
         - else
           = I18n.t('invoice.taxes.tax_exempt')

--- a/app/views/templates/credit_notes/credit_note.slim
+++ b/app/views/templates/credit_notes/credit_note.slim
@@ -11,8 +11,8 @@ html
     .wrapper
       .mb-24
         h1.credit-note-title = I18n.t('credit_note.document_name')
-        - if organization.logo.present?
-          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
+        - if billing_entity.logo.present?
+          img.header-logo src="data:#{billing_entity.logo.content_type};base64,#{billing_entity.base64_logo}"
 
       .mb-24.overflow-auto
         .credit-note-information-column
@@ -38,28 +38,28 @@ html
         .billing-information-column
           .body-1 = I18n.t('credit_note.credit_from')
           .body-2
-            - if organization.legal_name.present?
-              = organization.legal_name
+            - if billing_entity.legal_name.present?
+              = billing_entity.legal_name
             - else
-              = organization.name
-          - if organization.legal_number.present?
-            .body-2 #{organization.legal_number}
-          .body-2 = organization.address_line1
-          .body-2 = organization.address_line2
+              = billing_entity.name
+          - if billing_entity.legal_number.present?
+            .body-2 #{billing_entity.legal_number}
+          .body-2 = billing_entity.address_line1
+          .body-2 = billing_entity.address_line2
           .body-2
             span
-              = organization.zipcode
-            - if organization.zipcode.present? && organization.city.present?
+              = billing_entity.zipcode
+            - if billing_entity.zipcode.present? && billing_entity.city.present?
               span
                 | , &nbsp;
             span
-              = organization.city
-          - if organization.state.present?
-            .body-2 = organization.state
-          .body-2 = ISO3166::Country.new(organization.country)&.common_name
-          .body-2 = organization.email
-          - if organization.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
+              = billing_entity.city
+          - if billing_entity.state.present?
+            .body-2 = billing_entity.state
+          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          .body-2 = billing_entity.email
+          - if billing_entity.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('credit_note.credit_to')
           .body-2 = customer.display_name
@@ -93,6 +93,6 @@ html
 
       == SlimHelper.render('templates/credit_notes/_details', self)
       == SlimHelper.render('templates/credit_notes/_eu_tax_management', self)
-      p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
+      p.body-3.mb-24 = LineBreakHelper.break_lines(billing_entity.invoice_footer)
 
       == SlimHelper.render('templates/credit_notes/_powered_by_logo', self)

--- a/app/views/templates/credit_notes/self_billed.slim
+++ b/app/views/templates/credit_notes/self_billed.slim
@@ -57,28 +57,28 @@ html
         .billing-information-column
           .body-1 = I18n.t('credit_note.credit_to')
           .body-2
-            - if organization.legal_name.present?
-              = organization.legal_name
+            - if billing_entity.legal_name.present?
+              = billing_entity.legal_name
             - else
-              = organization.name
-          - if organization.legal_number.present?
-            .body-2 #{organization.legal_number}
-          .body-2 = organization.address_line1
-          .body-2 = organization.address_line2
+              = billing_entity.name
+          - if billing_entity.legal_number.present?
+            .body-2 #{billing_entity.legal_number}
+          .body-2 = billing_entity.address_line1
+          .body-2 = billing_entity.address_line2
           .body-2
             span
-              = organization.zipcode
-            - if organization.zipcode.present? && organization.city.present?
+              = billing_entity.zipcode
+            - if billing_entity.zipcode.present? && billing_entity.city.present?
               span
                 | , &nbsp;
             span
-              = organization.city
-          - if organization.state.present?
-            .body-2 = organization.state
-          .body-2 = ISO3166::Country.new(organization.country)&.common_name
-          .body-2 = organization.email
-          - if organization.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
+              = billing_entity.city
+          - if billing_entity.state.present?
+            .body-2 = billing_entity.state
+          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          .body-2 = billing_entity.email
+          - if billing_entity.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
 
       .mb-24
         h2.title-2.mb-8 = MoneyHelper.format(total_amount)

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -150,8 +150,8 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       end
     end
 
-    context "when organization does not have right email settings" do
-      before { invoice.organization.update!(email_settings: []) }
+    context "when billing_entity does not have right email settings" do
+      before { invoice.billing_entity.update!(email_settings: []) }
 
       it "does not enqueue an SendEmailJob" do
         expect do


### PR DESCRIPTION
## Context

When generating a credit note, the data should be taken from the billing entity

## Description

- use billing_entity instead of org when generating PDF
- check email settings on billing_entity when sending an email
