### PR TITLE
Feat(multientities): payment receipt pdf use billing_entity_info

### DIFF
--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -11,6 +11,8 @@ class PaymentRequest < ApplicationRecord
   belongs_to :customer, -> { with_discarded }
   belongs_to :dunning_campaign, -> { with_discarded }, optional: true
 
+  delegate :billing_entity, to: :customer
+
   validates :amount_cents, presence: true
   validates :amount_currency, presence: true
 

--- a/app/views/templates/payment_receipts/v1.slim
+++ b/app/views/templates/payment_receipts/v1.slim
@@ -8,14 +8,14 @@ html
   body
     == SlimHelper.render('templates/payment_receipts/v1/_styles', self)
 
-    - @organization = payment.payable.organization
+    - @billing_entity = payment.payable.billing_entity
     - @customer = payment.payable.customer
 
     .wrapper
       .mb-24
         h1.invoice-title = I18n.t('payment_receipt.document_name')
-        - if @organization.logo.present?
-          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
+        - if @billing_entity.logo.present?
+          img.header-logo src="data:#{@biling_entity.logo.content_type};base64,#{@biling_entity.base64_logo}"
 
       .mb-24.overflow-auto
         .invoice-information-column
@@ -48,28 +48,28 @@ html
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_from')
           .body-2
-            - if @organization.legal_name.present?
-              | #{@organization.legal_name}
+            - if @billing_entity.legal_name.present?
+              | #{@billing_entity.legal_name}
             - else
-              | #{@organization.name}
-          - if @organization.legal_number.present?
-            .body-2 #{@organization.legal_number}
-          .body-2 = @organization.address_line1
-          .body-2 = @organization.address_line2
+              | #{@billing_entity.name}
+          - if @billing_entity.legal_number.present?
+            .body-2 #{@billing_entity.legal_number}
+          .body-2 = @billing_entity.address_line1
+          .body-2 = @billing_entity.address_line2
           .body-2
             span
-              = @organization.zipcode
-            - if @organization.zipcode.present? && @organization.city.present?
+              = @billing_entity.zipcode
+            - if @billing_entity.zipcode.present? && @billing_entity.city.present?
               span
                 | , &nbsp;
             span
-              = @organization.city
-          - if @organization.state.present?
-            .body-2 = @organization.state
-          .body-2 = ISO3166::Country.new(@organization.country)&.common_name
-          .body-2 = @organization.email
-          - if @organization.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: @organization.tax_identification_number)
+              = @billing_entity.city
+          - if @billing_entity.state.present?
+            .body-2 = @billing_entity.state
+          .body-2 = ISO3166::Country.new(@billing_entity.country)&.common_name
+          .body-2 = @billing_entity.email
+          - if @billing_entity.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: @billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
           .body-2 = @customer.display_name
@@ -125,7 +125,7 @@ html
         - if payment.payable.applied_invoice_custom_sections.present?
           == SlimHelper.render('templates/invoices/v4/_custom_sections', payment.payable)
 
-        p.body-3.mb-24 = LineBreakHelper.break_lines(@organization.invoice_footer)
+        p.body-3.mb-24 = LineBreakHelper.break_lines(@billing_entity.invoice_footer)
 
         == SlimHelper.render('templates/invoices/v4/_powered_by_logo', payment.payable)
 
@@ -135,6 +135,6 @@ html
       - else
         == SlimHelper.render('templates/payment_receipts/v1/_payment_request', self)
 
-        p.body-3.mb-24 = LineBreakHelper.break_lines(@organization.invoice_footer)
+        p.body-3.mb-24 = LineBreakHelper.break_lines(@billing_entity.invoice_footer)
 
         == SlimHelper.render('templates/payment_receipts/v1/_powered_by_logo', self)


### PR DESCRIPTION
## Context

when generating payment receipt PDFs we should use the billing_entity, associated to the payable of this receipt. Payable can be invoice or payment_request. Invoice belongs to a billing_entity, but payment_request did not, so we added a relation on payment_request to the billing_entity through customer

## Description

- updated payment receipt pdfs
- added relation to billing_entity from payment_request through customer
