### PR TITLE
feat: Add create_org helper to Rails console

### DIFF
--- a/app/services/invites/create_service.rb
+++ b/app/services/invites/create_service.rb
@@ -17,6 +17,7 @@ module Invites
         role: args[:role]
       )
 
+      result.invite_url = build_invite_url(result.invite.token)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
@@ -36,6 +37,11 @@ module Invites
 
     def valid?(args)
       Invites::ValidateService.new(result, **args).valid?
+    end
+
+    def build_invite_url(token)
+      frontend_url = ENV.fetch("LAGO_FRONT_URL", "http://localhost:3000")
+      "#{frontend_url}/invitation/#{token}"
     end
   end
 end

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -71,4 +71,22 @@ module Rails::ConsoleMethods
       puts "Invoice #{id} has been successfully deleted." # rubocop:disable Rails/Output
     end
   end
+
+  def create_organization(org_name:, email:)
+    organization = Organizations::CreateService
+      .call(name: org_name, document_numbering: "per_organization")
+      .raise_if_error!
+      .organization
+
+    result = Invites::CreateService.call(
+      current_organization: organization,
+      email: email,
+      role: :admin
+    )
+
+    url = "https://app.getlago.com/invitation/#{result.invite.token}"
+    puts "Organization `#{org_name}` created with admin invite: #{url}" # rubocop:disable Rails/Output
+
+    {organization:, invite_url: url}
+  end
 end

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -84,9 +84,7 @@ module Rails::ConsoleMethods
       role: :admin
     )
 
-    url = "https://app.getlago.com/invitation/#{result.invite.token}"
-    puts "Organization `#{org_name}` created with admin invite: #{url}" # rubocop:disable Rails/Output
-
-    {organization:, invite_url: url}
+    puts "Organization `#{org_name}` created with admin invite: #{result.invite_url}" # rubocop:disable Rails/Output
+    {organization:, invite_url: result.invite_url}
   end
 end


### PR DESCRIPTION
## Context

This process usually involves calling the Organizations::CreateService and then manually creating an admin invite.
To streamline this, we’re adding a new helper method to Rails::ConsoleMethods.

## Description

This PR adds a create_organization(org_name:, email:) method to the Rails::ConsoleMethods module. It:
Creates an organization using Organizations::CreateService
Creates an admin invite for the specified email via Invites::CreateService
Prints the invitation URL in the console

Also returns the organization and invite_url in a hash for further use.