### PR TITLE
Feat(multientities): payment generation switch to entity

### DIFF
--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -46,7 +46,7 @@ module Invoices
         payment_result = ::PaymentProviders::CreatePaymentFactory.new_instance(
           provider:,
           payment:,
-          reference: "#{invoice.organization.name} - Invoice #{invoice.number}",
+          reference: "#{invoice.billing_entity.name} - Invoice #{invoice.number}",
           metadata: {
             lago_invoice_id: invoice.id,
             lago_customer_id: invoice.customer_id,

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -123,7 +123,7 @@ module PaymentProviders
               lago_payable_type: payment.payable_type,
               lago_customer_id: payment.payable.customer_id,
               lago_organization_id: payment.payable.organization_id,
-              lago_billing_entity_id: payment.payable.billing_entity.id,
+              lago_billing_entity_id: payment.payable.billing_entity.id
             }
           )
         end

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -122,7 +122,8 @@ module PaymentProviders
               lago_payable_id: payment.payable_id,
               lago_payable_type: payment.payable_type,
               lago_customer_id: payment.payable.customer_id,
-              lago_organization_id: payment.payable.organization_id
+              lago_organization_id: payment.payable.organization_id,
+              lago_billing_entity_id: payment.payable.billing_entity.id,
             }
           )
         end

--- a/app/services/payment_receipts/create_service.rb
+++ b/app/services/payment_receipts/create_service.rb
@@ -7,6 +7,7 @@ module PaymentReceipts
     def initialize(payment:)
       @payment = payment
       @organization = payment&.payable&.organization
+      @billing_entity = payment&.payable&.billing_entity
       super
     end
 
@@ -33,10 +34,10 @@ module PaymentReceipts
 
     private
 
-    attr_reader :payment, :organization
+    attr_reader :payment, :organization, :billing_entity
 
     def should_deliver_email?
-      License.premium? && organization.email_settings.include?("payment_receipt.created")
+      License.premium? && billing_entity.email_settings.include?("payment_receipt.created")
     end
   end
 end

--- a/app/services/payment_requests/payments/create_service.rb
+++ b/app/services/payment_requests/payments/create_service.rb
@@ -49,7 +49,7 @@ module PaymentRequests
         payment_result = ::PaymentProviders::CreatePaymentFactory.new_instance(
           provider:,
           payment:,
-          reference: "#{organization.name} - Overdue invoices",
+          reference: "#{payable.billing_entity.name} - Overdue invoices",
           metadata: {
             lago_customer_id: payable.customer_id,
             lago_payable_id: payable.id,

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -87,7 +87,7 @@ module PaymentRequests
       end
 
       def description
-        "#{organization.name} - Overdue invoices"
+        "#{customer.billing_entity.name} - Overdue invoices"
       end
 
       def update_payable_payment_status(payment_status:, deliver_webhook: true, processing: false)

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Invoices::Payments::CreateService, type: :service do
         .to receive(:new)
         .with(
           payment: an_instance_of(Payment),
-          reference: "#{invoice.organization.name} - Invoice #{invoice.number}",
+          reference: "#{invoice.billing_entity.name} - Invoice #{invoice.number}",
           metadata: {
             lago_invoice_id: invoice.id,
             lago_customer_id: customer.id,

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service
       invoice_type: invoice.invoice_type,
       lago_payable_id: payment.payable_id,
       lago_payable_type: payment.payable_type,
-      lago_organization_id: payment.payable.organization_id
+      lago_organization_id: payment.payable.organization_id,
+      lago_billing_entity_id: payment.payable.billing_entity.id
     }
   end
 

--- a/spec/services/payment_receipts/create_service_spec.rb
+++ b/spec/services/payment_receipts/create_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe PaymentReceipts::CreateService, type: :service do
 
   let(:invoice) { create(:invoice, customer:, organization:, total_amount_cents: 10000, status: :finalized) }
   let(:organization) { create(:organization) }
+  let(:billing_entity) { organization.default_billing_entity }
   let(:customer) { create(:customer, organization:) }
   let(:payment) { create(:payment, payable: invoice) }
 
@@ -93,8 +94,8 @@ RSpec.describe PaymentReceipts::CreateService, type: :service do
 
               it "enqueues the generate pdf job" do
                 expect do
-                  organization.email_settings << "payment_receipt.created"
-                  organization.save!
+                  billing_entity.email_settings << "payment_receipt.created"
+                  billing_entity.save!
                   service.call
                 end.to have_enqueued_job(PaymentReceipts::GeneratePdfAndNotifyJob).with(payment_receipt:, email: true)
               end

--- a/spec/services/payment_requests/payments/create_service_spec.rb
+++ b/spec/services/payment_requests/payments/create_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
   subject(:create_service) { described_class.new(payable: payment_request, payment_provider: provider) }
 
   let(:organization) { create(:organization) }
+  let(:billing_entity) { organization.default_billing_entity }
   let(:customer) { create(:customer, organization:, payment_provider: provider, payment_provider_code:) }
   let(:provider) { "stripe" }
   let(:payment_provider_code) { "stripe_1" }
@@ -62,7 +63,7 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
         .to receive(:new)
         .with(
           payment: an_instance_of(Payment),
-          reference: "#{organization.name} - Overdue invoices",
+          reference: "#{billing_entity.name} - Overdue invoices",
           metadata: {
             lago_customer_id: customer.id,
             lago_payable_id: payment_request.id,

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
 
   let(:customer) { create(:customer, payment_provider_code: code) }
   let(:organization) { customer.organization }
+  let(:billing_entity) { organization.default_billing_entity }
   let(:stripe_payment_provider) { create(:stripe_provider, organization:, code:) }
   let(:stripe_customer) {
     create(:stripe_customer, customer:, payment_method_id: stripe_payment_method_id)
@@ -80,7 +81,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
             customer: customer.stripe_customer.provider_customer_id,
             payment_method_types: customer.stripe_customer.provider_payment_methods,
             payment_intent_data: {
-              description: "#{organization.name} - Overdue invoices",
+              description: "#{billing_entity.name} - Overdue invoices",
               metadata: {
                 lago_customer_id: customer.id,
                 lago_payable_id: payment_request.id,


### PR DESCRIPTION
## Context

When creating payments, the info should be taken from the billing_entity

## Description

- added billing_entity into payment description and metadata
