### PR TITLE
feat(multi entities): Invoice mailer uses billing entity as data source

### DIFF
--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -5,11 +5,12 @@ class InvoiceMailer < ApplicationMailer
 
   def finalized
     @invoice = params[:invoice]
-    @organization = @invoice.organization
+    organization = @invoice.organization
+    @billing_entity = @invoice.billing_entity
     @customer = @invoice.customer
-    @show_lago_logo = !@organization.remove_branding_watermark_enabled?
+    @show_lago_logo = !organization.remove_branding_watermark_enabled?
 
-    return if @organization.email.blank?
+    return if @billing_entity.email.blank?
     return if @customer.email.blank?
     return if @invoice.fees_amount_cents.zero?
 
@@ -24,11 +25,11 @@ class InvoiceMailer < ApplicationMailer
     I18n.with_locale(@customer.preferred_document_locale) do
       mail(
         to: @customer.email,
-        from: email_address_with_name(@organization.from_email_address, @organization.name),
-        reply_to: email_address_with_name(@organization.email, @organization.name),
+        from: email_address_with_name(@billing_entity.from_email_address, @billing_entity.name),
+        reply_to: email_address_with_name(@billing_entity.email, @billing_entity.name),
         subject: I18n.t(
           "email.invoice.finalized.subject",
-          organization_name: @organization.name,
+          billing_entity_name: @billing_entity.name,
           invoice_number: @invoice.number
         )
       )

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -95,6 +95,12 @@ class BillingEntity < ApplicationRecord
     country && LagoEuVat::Rate.country_codes.include?(country)
   end
 
+  def from_email_address
+    return email if organization.from_email_enabled?
+
+    ENV["LAGO_FROM_EMAIL"]
+  end
+
   private
 
   def generate_document_number_prefix

--- a/app/views/invoice_mailer/finalized.slim
+++ b/app/views/invoice_mailer/finalized.slim
@@ -1,7 +1,7 @@
 table cellpadding="0" cellspacing="0" style="margin: auto; padding-bottom: 24px"
   tr
     td style="color: #66758f; font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: center;"
-      = I18n.t('email.invoice.finalized.invoice_from', organization_name: @organization.name)
+      = I18n.t('email.invoice.finalized.invoice_from', billing_entity_name: @billing_entity.name)
   tr
     td style="color: #19212e; font-size: 32px; font-weight: 700; line-height: 40px; letter-spacing: 0em; text-align: center;"
       = @invoice.total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))

--- a/config/locales/de/email.yml
+++ b/config/locales/de/email.yml
@@ -16,11 +16,11 @@ de:
       finalized:
         download: Rechnung herunterladen, um Details anzuzeigen
         due_date: Gesamtbetrag fällig am %{date}
-        invoice_from: Rechnung von %{organization_name}
+        invoice_from: Rechnung von %{billing_entity_name}
         invoice_number: Rechnungsnummer
         issue_date: Ausstellungsdatum
         issued_on: ausgestellt am %{date}
-        subject: 'Deine Rechnung von %{organization_name} #%{invoice_number}'
+        subject: 'Deine Rechnung von %{billing_entity_name} #%{invoice_number}'
     payment_receipt:
       created:
         payment_receipt_from: Zahlungsquittung von %{organization_name}

--- a/config/locales/en/email.yml
+++ b/config/locales/en/email.yml
@@ -47,11 +47,11 @@ en:
       finalized:
         download: Download invoice for details
         due_date: total due %{date}
-        invoice_from: Invoice from %{organization_name}
+        invoice_from: Invoice from %{billing_entity_name}
         invoice_number: Invoice Number
         issue_date: Issue Date
         issued_on: issued on %{date}
-        subject: 'Your Invoice from %{organization_name} #%{invoice_number}'
+        subject: 'Your Invoice from %{billing_entity_name} #%{invoice_number}'
     password_reset:
       subject: Reset your Lago password
     payment_receipt:

--- a/config/locales/es/email.yml
+++ b/config/locales/es/email.yml
@@ -16,11 +16,11 @@ es:
       finalized:
         download: Descargar factura para más detalles
         due_date: Vence el %{date}
-        invoice_from: Factura de %{organization_name}
+        invoice_from: Factura de %{billing_entity_name}
         invoice_number: Número de factura
         issue_date: Fecha de emisión
         issued_on: emitida el %{date}
-        subject: 'Tu factura de %{organization_name} #%{invoice_number}'
+        subject: 'Tu factura de %{billing_entity_name} #%{invoice_number}'
     payment_receipt:
       created:
         payment_receipt_from: Recibo de pago de %{organization_name}

--- a/config/locales/fr/email.yml
+++ b/config/locales/fr/email.yml
@@ -16,11 +16,11 @@ fr:
       finalized:
         download: Télécharger la facture pour plus de détails
         due_date: Date d'émission le %{date}
-        invoice_from: Facture de %{organization_name}
+        invoice_from: Facture de %{billing_entity_name}
         invoice_number: Nº de facture
         issue_date: Date d'émission
         issued_on: émise le %{date}
-        subject: Votre facture nº %{invoice_number} de %{organization_name}
+        subject: Votre facture nº %{invoice_number} de %{billing_entity_name}
     payment_receipt:
       created:
         payment_receipt_from: Reçu de paiement de %{organization_name}

--- a/config/locales/it/email.yml
+++ b/config/locales/it/email.yml
@@ -16,11 +16,11 @@ it:
       finalized:
         download: Scarica la fattura per ulteriori dettagli
         due_date: Totale dovuto il %{date}
-        invoice_from: Fattura da %{organization_name}
+        invoice_from: Fattura da %{billing_entity_name}
         invoice_number: Numero Fattura
         issue_date: Data Emissione
         issued_on: emessa il %{date}
-        subject: 'La tua fattura da %{organization_name} #%{invoice_number}'
+        subject: 'La tua fattura da %{billing_entity_name} #%{invoice_number}'
     payment_receipt:
       created:
         payment_receipt_from: Ricevuta di pagamento da %{organization_name}

--- a/config/locales/nb/email.yml
+++ b/config/locales/nb/email.yml
@@ -16,11 +16,11 @@ nb:
       finalized:
         download: Last ned faktura for detaljer
         due_date: Forfallsdato %{date}
-        invoice_from: Faktura fra %{organization_name}
+        invoice_from: Faktura fra %{billing_entity_name}
         invoice_number: Fakturanummer
         issue_date: Dato
         issued_on: utstedt den %{date}
-        subject: 'Faktura fra %{organization_name} #%{invoice_number}'
+        subject: 'Faktura fra %{billing_entity_name} #%{invoice_number}'
     payment_receipt:
       created:
         payment_receipt_from: Betalingskvittering fra %{organization_name}

--- a/config/locales/sv/email.yml
+++ b/config/locales/sv/email.yml
@@ -16,11 +16,11 @@ sv:
       finalized:
         download: Ladda ner fakturan för ytterligare information
         due_date: Förfaller %{date}
-        invoice_from: Faktura från %{organization_name}
+        invoice_from: Faktura från %{billing_entity_name}
         invoice_number: Fakturanummer
         issue_date: Fakturadatum
         issued_on: utfärdad den %{date}
-        subject: 'Din faktura från %{organization_name} #%{invoice_number}'
+        subject: 'Din faktura från %{billing_entity_name} #%{invoice_number}'
     payment_receipt:
       created:
         payment_receipt_from: Betalningskvitto från %{organization_name}

--- a/spec/mailers/invoice_mailer_spec.rb
+++ b/spec/mailers/invoice_mailer_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe InvoiceMailer, type: :mailer do
       end
     end
 
-    context "when organization email is nil" do
+    context "when billing_entity email is nil" do
       let(:billing_entity_email) { nil }
 
       it "returns a mailer with nil values" do

--- a/spec/mailers/invoice_mailer_spec.rb
+++ b/spec/mailers/invoice_mailer_spec.rb
@@ -5,7 +5,17 @@ require "rails_helper"
 RSpec.describe InvoiceMailer, type: :mailer do
   subject(:invoice_mailer) { described_class }
 
-  let(:invoice) { create(:invoice, fees_amount_cents: 100) }
+  let(:invoice) { create(:invoice, organization:, billing_entity:, fees_amount_cents: 100) }
+  let(:organization) { create(:organization) }
+  let(:billing_entity) do
+    create(
+      :billing_entity,
+      organization:,
+      name: "ACME Corp",
+      email: billing_entity_email
+    )
+  end
+  let(:billing_entity_email) { "billing_entity@email.com" }
 
   before do
     invoice.file.attach(io: File.open(Rails.root.join("spec/fixtures/blank.pdf")), filename: "blank.pdf")
@@ -15,8 +25,10 @@ RSpec.describe InvoiceMailer, type: :mailer do
     specify do
       mailer = invoice_mailer.with(invoice:).finalized
 
+      expect(mailer.subject).to eq("Your Invoice from ACME Corp ##{invoice.number}")
       expect(mailer.to).to eq([invoice.customer.email])
-      expect(mailer.reply_to).to eq([invoice.organization.email])
+      expect(mailer.from).to eq(["noreply@getlago.com"])
+      expect(mailer.reply_to).to eq([billing_entity_email])
       expect(mailer.attachments).not_to be_empty
       expect(mailer.attachments.first.filename).to eq("invoice-#{invoice.number}.pdf")
     end
@@ -51,9 +63,7 @@ RSpec.describe InvoiceMailer, type: :mailer do
     end
 
     context "when organization email is nil" do
-      before do
-        invoice.organization.update(email: nil)
-      end
+      let(:billing_entity_email) { nil }
 
       it "returns a mailer with nil values" do
         mailer = invoice_mailer.with(invoice:).finalized

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -265,4 +265,23 @@ RSpec.describe BillingEntity, type: :model do
       end
     end
   end
+
+  describe "#from_email_address" do
+    subject(:from_email_address) { billing_entity.from_email_address }
+
+    it "returns the env var email" do
+      expect(from_email_address).to eq("noreply@getlago.com")
+    end
+
+    context "when organization from_email integration is enabled" do
+      let(:organization) { create(:organization, premium_integrations: ["from_email"]) }
+      let(:billing_entity) { build(:billing_entity, organization:) }
+
+      around { |test| lago_premium!(&test) }
+
+      it "returns the billing_entity email" do
+        expect(from_email_address).to eq(billing_entity.email)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

## Description

Invoice mailer uses billing entity (instead of organization) as data source for name, email from, etc. Also, update the email template and locale accordingly.