### PR TITLE
Feat(multientities): use taxes from selected for the billing entity for invoices

### DIFF
--- a/app/queries/taxes_query.rb
+++ b/app/queries/taxes_query.rb
@@ -44,6 +44,12 @@ class TaxesQuery < BaseQuery
   end
 
   def with_applied_to_organization(scope)
-    scope.where(applied_to_organization: filters.applied_to_organization)
+    if filters.applied_to_organization
+      scope.joins(:billing_entities_taxes)
+        .where(billing_entities_taxes: {billing_entity_id: organization.default_billing_entity.id})
+    else
+      scope.where.not(id: scope.joins(:billing_entities_taxes)
+        .where(billing_entities_taxes: {billing_entity_id: organization.default_billing_entity.id}))
+    end
   end
 end

--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -61,6 +61,7 @@ module Fees
     end
 
     def applicable_taxes
+      # organization.taxes - are all taxes created on the organization
       return customer.organization.taxes.where(code: tax_codes) if tax_codes
       return fee.add_on.taxes if fee.add_on? && fee.add_on.taxes.any?
       return fee.charge.taxes if fee.charge? && fee.charge.taxes.any?
@@ -70,7 +71,8 @@ module Fees
       end
       return customer.taxes if customer.taxes.any?
 
-      customer.organization.taxes.applied_to_organization
+      # billing_entity.taxes - are the default taxes applied on the billing entity
+      customer.billing_entity.taxes
     end
   end
 end

--- a/app/services/invoices/apply_taxes_service.rb
+++ b/app/services/invoices/apply_taxes_service.rb
@@ -53,6 +53,8 @@ module Invoices
 
     delegate :organization, to: :invoice
 
+    # Note: taxes, applied on the fees might be created on organization, but selected for specific add-on, for example
+    # so not applied on the billing_entity
     def applicable_taxes
       organization.taxes.where(id: indexed_fees.keys)
     end

--- a/app/services/taxes/update_service.rb
+++ b/app/services/taxes/update_service.rb
@@ -12,7 +12,7 @@ module Taxes
     def call
       return result.not_found_failure!(resource: "tax") unless tax
 
-      customer_ids = tax.applicable_customers.select(:id)
+      customer_ids = tax.applicable_customers.select(:id).to_a
 
       tax.name = params[:name] if params.key?(:name)
       tax.code = params[:code] if params.key?(:code)

--- a/spec/factories/taxes.rb
+++ b/spec/factories/taxes.rb
@@ -7,7 +7,19 @@ FactoryBot.define do
     description { "French Standard VAT" }
     name { "VAT" }
     rate { 20.0 }
-    applied_to_organization { true }
+    # NOTE: usage of applied_to_organization is deprecated. Please, use :applied_to_billing_entity trait instead
+    applied_to_organization { false }
     auto_generated { false }
+
+    trait :applied_to_billing_entity do
+      transient do
+        billing_entity { nil }
+      end
+
+      before(:create) do |tax, evaluator|
+        billing_entity = evaluator.billing_entity || tax.organization.default_billing_entity
+        billing_entity.taxes << tax
+      end
+    end
   end
 end

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Mutations::Invoices::Create, type: :graphql do
   let(:organization) { membership.organization }
   let(:currency) { "EUR" }
   let(:customer) { create(:customer, organization:) }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
   let(:add_on_first) { create(:add_on, organization:) }
   let(:add_on_second) { create(:add_on, amount_cents: 400, organization:) }
   let(:fees) do

--- a/spec/models/tax_spec.rb
+++ b/spec/models/tax_spec.rb
@@ -23,13 +23,44 @@ RSpec.describe Tax, type: :model do
       expect(tax.customers_count).to eq(1)
     end
 
-    context "when tax is applied by default" do
+    context "when tax is applied to the billing_entity" do
       let(:applied_to_organization) { true }
+      let(:applied_to_billing_entity_tax) { create(:billing_entity_applied_tax, tax:, billing_entity: tax.organization.default_billing_entity) }
 
-      before { create(:customer, organization: tax.organization) }
+      before do
+        create(:customer, organization: tax.organization)
+        applied_to_billing_entity_tax
+      end
 
       it "returns the number of customer without tax" do
         expect(tax.customers_count).to eq(2)
+      end
+    end
+
+    context "when tax is applied to multiple billing entities" do
+      let(:organization) { tax.organization }
+      let(:billing_entity) { organization.default_billing_entity }
+      let(:billing_entity_2) { create(:billing_entity, organization:) }
+      let(:billing_entity_3) { create(:billing_entity, organization:) }
+      let(:applied_to_billing_entity_tax) { create(:billing_entity_applied_tax, tax:, billing_entity:) }
+      let(:applied_to_billing_entity_tax_2) { create(:billing_entity_applied_tax, tax:, billing_entity: billing_entity_2) }
+      let(:customer) { create(:customer, organization:) }
+      let(:customer_2) { create(:customer, organization:, billing_entity: billing_entity_2) }
+      let(:customer_3) { create(:customer, organization:, billing_entity: billing_entity_3) }
+      let(:customer_4) { create(:customer, organization:, billing_entity: billing_entity_3) }
+      let(:customer_4_applied_tax) { create(:customer_applied_tax, customer: customer_4, tax:) }
+
+      before do
+        applied_to_billing_entity_tax
+        applied_to_billing_entity_tax_2
+        customer_4_applied_tax
+        customer
+        customer_2
+        customer_3
+      end
+
+      it "returns correct number of customers" do
+        expect(tax.customers_count).to eq(3)
       end
     end
   end

--- a/spec/models/tax_spec.rb
+++ b/spec/models/tax_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Tax, type: :model do
     end
 
     context "when tax is applied to the billing_entity" do
-      let(:applied_to_organization) { true }
       let(:applied_to_billing_entity_tax) { create(:billing_entity_applied_tax, tax:, billing_entity: tax.organization.default_billing_entity) }
 
       before do

--- a/spec/queries/taxes_query_spec.rb
+++ b/spec/queries/taxes_query_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe TaxesQuery, type: :query do
   let(:order) { nil }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:tax_first) { create(:tax, organization:, name: "defgh", code: "11", rate: 10) }
-  let(:tax_second) { create(:tax, organization:, name: "abcde", code: "22", rate: 5) }
+  let(:tax_first) { create(:tax, organization:, name: "defgh", code: "11", rate: 10, applied_to_organization: true) }
+  let(:tax_second) { create(:tax, organization:, name: "abcde", code: "22", rate: 5, applied_to_organization: true) }
 
   let(:tax_third) do
     create(
@@ -36,7 +36,8 @@ RSpec.describe TaxesQuery, type: :query do
       name: "auto_generated",
       code: "auto_generated",
       rate: 0.0,
-      auto_generated: true
+      auto_generated: true,
+      applied_to_organization: true
     )
   end
 

--- a/spec/queries/taxes_query_spec.rb
+++ b/spec/queries/taxes_query_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe TaxesQuery, type: :query do
   let(:order) { nil }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:tax_first) { create(:tax, organization:, name: "defgh", code: "11", rate: 10, applied_to_organization: true) }
-  let(:tax_second) { create(:tax, organization:, name: "abcde", code: "22", rate: 5, applied_to_organization: true) }
+  let(:tax_first) { create(:tax, :applied_to_billing_entity, organization:, name: "defgh", code: "11", rate: 10) }
+  let(:tax_second) { create(:tax, :applied_to_billing_entity, organization:, name: "abcde", code: "22", rate: 5) }
 
   let(:tax_third) do
     create(
@@ -24,7 +24,6 @@ RSpec.describe TaxesQuery, type: :query do
       organization:,
       name: "presuv",
       code: "33",
-      applied_to_organization: false,
       rate: 20
     )
   end
@@ -32,12 +31,12 @@ RSpec.describe TaxesQuery, type: :query do
   let(:auto_generated_tax) do
     create(
       :tax,
+      :applied_to_billing_entity,
       organization:,
       name: "auto_generated",
       code: "auto_generated",
       rate: 0.0,
-      auto_generated: true,
-      applied_to_organization: true
+      auto_generated: true
     )
   end
 
@@ -95,11 +94,20 @@ RSpec.describe TaxesQuery, type: :query do
     end
   end
 
-  context "with a filter on applied by default" do
+  context "with a filter on not applied to BE" do
     let(:filters) { {applied_to_organization: false} }
 
-    it "returns only one tax" do
+    it "returns only one bot applied tax" do
       expect(result.taxes).to eq([tax_third])
+    end
+  end
+
+  context "with a filter on applied to BE" do
+    let(:filters) { {applied_to_organization: true} }
+
+    it "returns all applied taxes" do
+      expect(result.taxes.count).to eq(3)
+      expect(result.taxes).to match_array([tax_first, tax_second, auto_generated_tax])
     end
   end
 

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
     end
 
     let(:params) { {external_subscription_id: subscription.external_id} }
-    let(:tax) { create(:tax, organization:, rate: 20) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
     let(:metric) { create(:billable_metric, aggregation_type: "count_agg") }
 
     let(:charge) do

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Api::V1::InvoicesController, type: :request do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
 
   before { tax }
 
@@ -1089,6 +1089,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
 
     context "when sending billing_entity_code" do
       let(:billing_entity) { create(:billing_entity, organization:) }
+      let(:applied_tax) { create(:billing_entity_applied_tax, billing_entity:, tax:) }
       let(:preview_params) do
         {
           customer: {
@@ -1101,6 +1102,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
           billing_entity_code: billing_entity.code
         }
       end
+
+      before { applied_tax }
 
       it "creates a preview invoice" do
         subject

--- a/spec/scenarios/charge_models/percentage_spec.rb
+++ b/spec/scenarios/charge_models/percentage_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe "Charge Models - Percentage Scenarios", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
 
   let(:plan) { create(:plan, organization:, amount_cents: 1000) }
   let(:billable_metric) { create(:billable_metric, organization:, aggregation_type:, field_name:) }

--- a/spec/scenarios/credit_note_spec.rb
+++ b/spec/scenarios/credit_note_spec.rb
@@ -6,7 +6,7 @@ describe "Create credit note Scenarios", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
   let(:customer) { create(:customer, organization:) }
 
-  let(:tax) { create(:tax, organization:, rate: 10) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 10) }
 
   let(:plan1) do
     create(
@@ -343,7 +343,7 @@ describe "Create credit note Scenarios", :scenarios, type: :request do
 
   context "when creating credit note with possible rounding issues" do
     context "when creating credit notes for small items with taxes, so sum of items with their taxes is bigger than invoice total amount" do
-      let(:tax) { create(:tax, organization:, rate: 20) }
+      let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
 
       context "when two similar items are refunded separately" do
         let(:add_ons) { create_list(:add_on, 2, organization:, amount_cents: 68_33) }
@@ -680,7 +680,7 @@ describe "Create credit note Scenarios", :scenarios, type: :request do
     end
 
     context "when creating credit note with small items and applied coupons" do
-      let(:tax) { create(:tax, organization:, rate: 20) }
+      let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
       let(:plan_tax) { create(:tax, organization:, name: "Plan Tax", rate: 20, applied_to_organization: false) }
       let(:plan) do
         create(

--- a/spec/scenarios/invoices/advance_charges_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_spec.rb
@@ -22,7 +22,7 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
   end
 
   before do
-    create(:tax, organization:, rate: tax_rate)
+    create(:tax, :applied_to_billing_entity, organization:, rate: tax_rate)
     create(:standard_charge, regroup_paid_fees: "invoice", pay_in_advance: true, invoiceable: false, prorated: true, billable_metric:, plan:, properties: {amount: bm_amount.to_s, grouped_by: nil})
   end
 

--- a/spec/scenarios/invoices/advance_charges_taxes_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_taxes_spec.rb
@@ -31,8 +31,8 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
   end
 
   before do
-    create(:tax, organization:, rate: tax_rate_1, code: "tax-1", description: "VAT 1", name: "VAT")
-    create(:tax, organization:, rate: tax_rate_2, code: "tax-2", description: "VAT 2", name: "bug VAT")
+    create(:tax, :applied_to_billing_entity, organization:, rate: tax_rate_1, code: "tax-1", description: "VAT 1", name: "VAT")
+    create(:tax, :applied_to_billing_entity, organization:, rate: tax_rate_2, code: "tax-2", description: "VAT 2", name: "bug VAT")
     create(:standard_charge, billable_metric: billable_metric_cards, regroup_paid_fees: "invoice", pay_in_advance: true, invoiceable: false, prorated: true, plan:, properties: {amount: "30", grouped_by: nil})
     create(:standard_charge, billable_metric: billable_metric_transfer, regroup_paid_fees: "invoice", pay_in_advance: true, invoiceable: false, prorated: false, plan:, properties: {amount: "1", grouped_by: nil})
   end

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -4,13 +4,13 @@ require "rails_helper"
 
 describe "Invoices Scenarios", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
 
   before { tax }
 
   context "when pay in advance subscription with free trial used on several subscriptions" do
     let(:organization) { create(:organization, webhook_url: nil) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 3500, pay_in_advance: true, trial_period: 7) }
 
@@ -63,7 +63,7 @@ describe "Invoices Scenarios", :scenarios, type: :request do
 
   context "when timezone is negative and not the same day as UTC" do
     let(:organization) { create(:organization, webhook_url: nil) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:customer) { create(:customer, organization:, timezone: "America/Denver") } # UTC-6
     let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: "weekly") }
 
@@ -86,7 +86,7 @@ describe "Invoices Scenarios", :scenarios, type: :request do
 
   context "when timezone is negative but same day as UTC" do
     let(:organization) { create(:organization, webhook_url: nil) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:customer) { create(:customer, organization:, timezone: "America/Halifax") } # UTC-3
     let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: "weekly") }
 
@@ -109,7 +109,7 @@ describe "Invoices Scenarios", :scenarios, type: :request do
 
   context "when timezone is positive but same day as UTC" do
     let(:organization) { create(:organization, webhook_url: nil) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:customer) { create(:customer, organization:, timezone: "Europe/Paris") } # UTC+2
     let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: "weekly") }
 
@@ -132,7 +132,7 @@ describe "Invoices Scenarios", :scenarios, type: :request do
 
   context "when timezone is positive and not the same day as UTC" do
     let(:organization) { create(:organization, webhook_url: nil) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:customer) { create(:customer, organization:, timezone: "Asia/Karachi") } # UTC+5
     let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: "weekly") }
 
@@ -155,7 +155,7 @@ describe "Invoices Scenarios", :scenarios, type: :request do
 
   context "when invoice boundaries should cover leap month february" do
     let(:organization) { create(:organization, webhook_url: nil) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: true, interval: "monthly") }
 
@@ -653,7 +653,7 @@ describe "Invoices Scenarios", :scenarios, type: :request do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: true) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 29_000, pay_in_advance: true) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:metric) do
       create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
@@ -740,7 +740,7 @@ describe "Invoices Scenarios", :scenarios, type: :request do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: false) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 29_000, pay_in_advance: false) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:metric) do
       create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
@@ -825,7 +825,7 @@ describe "Invoices Scenarios", :scenarios, type: :request do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 0, pay_in_advance: false) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 0, pay_in_advance: false) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:metric) do
       create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: false, field_name: "amount")
     end
@@ -952,7 +952,7 @@ describe "Invoices Scenarios", :scenarios, type: :request do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: true) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 29_000, pay_in_advance: true) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:metric) do
       create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
@@ -1025,7 +1025,7 @@ describe "Invoices Scenarios", :scenarios, type: :request do
   context "when pay in advance subscription is terminated on the same day" do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: true) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:metric) { create(:billable_metric, organization:) }
 
     it "bills fees correctly" do
@@ -1108,7 +1108,7 @@ describe "Invoices Scenarios", :scenarios, type: :request do
   context "when pay in advance subscription with grace period is terminated" do
     let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
     let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: true) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:metric) do
       create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end
@@ -1374,7 +1374,7 @@ describe "Invoices Scenarios", :scenarios, type: :request do
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: false) }
     let(:plan_new) { create(:plan, organization:, amount_cents: 29_000, pay_in_advance: false) }
-    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 0) }
     let(:metric) do
       create(:billable_metric, organization:, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
     end

--- a/spec/scenarios/spending_minimum_spec.rb
+++ b/spec/scenarios/spending_minimum_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe "Spending Minimum Scenarios", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
   let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 5000) }
   let(:metric) { create(:billable_metric, organization:) }
 

--- a/spec/scenarios/subscriptions/multiple_upgrade_spec.rb
+++ b/spec/scenarios/subscriptions/multiple_upgrade_spec.rb
@@ -6,7 +6,7 @@ describe "Multiple Subscription Upgrade Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
 
   let(:customer) { create(:customer, organization:) }
-  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 25, applied_to_organization: true) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 25) }
 
   let(:plan1) do
     create(

--- a/spec/scenarios/subscriptions/multiple_upgrade_spec.rb
+++ b/spec/scenarios/subscriptions/multiple_upgrade_spec.rb
@@ -6,7 +6,7 @@ describe "Multiple Subscription Upgrade Scenario", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
 
   let(:customer) { create(:customer, organization:) }
-  let(:tax) { create(:tax, organization:, rate: 25, applied_to_organization: true) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 25, applied_to_organization: true) }
 
   let(:plan1) do
     create(

--- a/spec/scenarios/terminate_pay_in_advance_spec.rb
+++ b/spec/scenarios/terminate_pay_in_advance_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe "Terminate Pay in Advance Scenarios", :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
   let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 5000) }
   let(:metric) { create(:billable_metric, organization:) }
 

--- a/spec/scenarios/wallets/balance_spec.rb
+++ b/spec/scenarios/wallets/balance_spec.rb
@@ -125,7 +125,7 @@ describe "Use wallet's credits and recalculate balances", :scenarios, type: :req
 
   context "with pay in advance charges and taxes" do
     let(:charge) { create(:charge, :pay_in_advance, plan: plan, billable_metric: billable_metric, charge_model: "standard", properties: {"amount" => "1"}) }
-    let(:tax) { create(:tax, organization: organization, rate: 10) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization: organization, rate: 10, billing_entity:) }
 
     before do
       charge
@@ -204,7 +204,7 @@ describe "Use wallet's credits and recalculate balances", :scenarios, type: :req
     let(:charge3) { create(:charge, plan: plan3, billable_metric: billable_metric, charge_model: "standard", properties: {"amount" => "10"}) }
     let(:usage_threshold) { create(:usage_threshold, plan: plan3, amount_cents: 200_00, recurring: true) }
 
-    let(:tax) { create(:tax, organization: organization, rate: 10) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization: organization, rate: 10, billing_entity:) }
 
     before { [charge1, charge2, charge3, usage_threshold, tax] }
 
@@ -337,7 +337,7 @@ describe "Use wallet's credits and recalculate balances", :scenarios, type: :req
     let(:usage_threshold2) { create(:usage_threshold, plan: plan, amount_cents: 500_00, recurring: false) }
     let(:usage_threshold3) { create(:usage_threshold, plan: plan, amount_cents: 200_00, recurring: true) }
 
-    let(:tax) { create(:tax, organization: organization, rate: 10) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization: organization, rate: 10, billing_entity:) }
 
     before { [charge, usage_threshold, usage_threshold2, usage_threshold3, tax] }
 

--- a/spec/services/fees/add_on_service_spec.rb
+++ b/spec/services/fees/add_on_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Fees::AddOnService do
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:applied_add_on) { create(:applied_add_on, customer:) }
 
-  let(:tax) { create(:tax, rate: 20, organization:) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, rate: 20, organization:) }
 
   before { tax }
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -2118,7 +2118,7 @@ RSpec.describe Fees::ChargeService do
       let(:apply_taxes) { true }
 
       before do
-        create(:tax, organization:, rate: 20)
+        create(:tax, :applied_to_billing_entity, organization:, rate: 20)
 
         create(
           :event,

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
 
   let(:charge_filter) { nil }
 

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fees::OneOffService do
   let(:billing_entity) { create(:billing_entity) }
   let(:organization) { billing_entity.organization }
   let(:customer) { create(:customer, organization:) }
-  let(:tax) { create(:tax, organization:) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, billing_entity:) }
   let(:tax2) { create(:tax, organization:, applied_to_organization: false) }
   let(:add_on_first) { create(:add_on, organization:) }
   let(:add_on_second) { create(:add_on, amount_cents: 400, organization:) }

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Invoices::AddOnService, type: :service do
   let(:organization) { customer.organization }
   let(:applied_add_on) { create(:applied_add_on, customer:) }
 
-  let(:tax) { create(:tax, rate: 20, organization:) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, rate: 20, organization:) }
 
   before { tax }
 

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
   let(:recurring) { false }
   let(:context) { nil }
 

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Invoices::ComputeAmountsFromFees, type: :service do
   let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, organization:, customer:) }
 
-  let(:tax1) { create(:tax, organization:, rate: 10) }
-  let(:tax2) { create(:tax, organization:, rate: 20) }
+  let(:tax1) { create(:tax, :applied_to_billing_entity, organization:, rate: 10) }
+  let(:tax2) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
 
   let(:fee1) { create(:fee, invoice:, amount_cents: 151) }
   let(:fee2) { create(:fee, invoice:, amount_cents: 379, precise_coupons_amount_cents: 100) }

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
   let(:timestamp) { Time.zone.now.beginning_of_month }
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
   let(:currency) { "EUR" }
   let(:add_on_first) { create(:add_on, organization:) }
   let(:add_on_second) { create(:add_on, amount_cents: 400, organization:) }

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
   end
 
   before do
-    create(:tax, :applied_to_billing_entity, organization:, applied_to_organization: true)
+    create(:tax, :applied_to_billing_entity, organization:)
     billing_entity.update!(email_settings:)
   end
 

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
   end
 
   before do
-    create(:tax, organization:, applied_to_organization: true)
+    create(:tax, :applied_to_billing_entity, organization:, applied_to_organization: true)
     billing_entity.update!(email_settings:)
   end
 

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
   let(:customer) { create(:customer, organization:) }
   let(:customer_id) { customer&.id }
   let(:subscription_id) { subscription&.id }

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
   describe "#call" do
     let(:organization) { create(:organization) }
     let(:billing_entity) { create(:billing_entity, organization:) }
-    let(:tax) { create(:tax, rate: 50.0, organization:) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, rate: 50.0, organization:, billing_entity:) }
     let(:customer) { build(:customer, organization:, billing_entity:) }
     let(:timestamp) { Time.zone.parse("30 Mar 2024") }
     let(:plan) { create(:plan, organization:, interval: "monthly") }
@@ -897,7 +897,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
         end
 
         context "with multiple persisted subscriptions" do
-          let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
+          let(:customer) { create(:customer, organization:, invoice_grace_period: 3, billing_entity:) }
           let(:plan1) { create(:plan, organization:, interval: "monthly") }
           let(:plan2) { create(:plan, organization:, interval: "monthly") }
           let(:subscriptions) { [subscription1, subscription2] }

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service do
 
   let(:timestamp) { Time.zone.parse(Date.current.strftime("%Y-%m-%d 10:00:00")) }
 
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
   let(:billable_metric) { create(:sum_billable_metric, organization:, field_name: "value") }
   let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: {amount: "1"}) }
 

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Invoices::RefreshDraftService, type: :service do
     end
 
     let(:invoice_subscription) { create(:invoice_subscription, invoice:, subscription:, recurring: true) }
-    let(:tax) { create(:tax, organization:, rate: 15) }
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 15) }
 
     before do
       invoice_subscription

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
   let(:organization) { create(:organization) }
   let(:billing_entity) { create(:billing_entity, organization:) }
   let(:customer) { create(:customer, organization:, billing_entity:) }
-  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20, billing_entity:) }
 
   let(:invoicing_reason) { :subscription_periodic }
 

--- a/spec/services/taxes/destroy_service_spec.rb
+++ b/spec/services/taxes/destroy_service_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe Taxes::DestroyService, type: :service do
 
   let(:organization) { create(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
-  let(:tax) { create(:tax, organization:) }
-  let(:tax2) { create(:tax, organization:) }
-  let(:applied_tax2) { create(:billing_entity_applied_tax, billing_entity:, tax: tax2) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:) }
+  let(:tax2) { create(:tax, :applied_to_billing_entity, organization:) }
   let(:customer) { create(:customer, organization:) }
 
   describe "#call" do
@@ -25,16 +24,8 @@ RSpec.describe Taxes::DestroyService, type: :service do
       expect { destroy_service.call }.to change { draft_invoice.reload.ready_to_be_refreshed }.to(true)
     end
 
-    it "does not remove the tax from the default billing entity" do
-      expect { destroy_service.call }.not_to change { billing_entity.applied_taxes.count }
-    end
-
-    context "when tax is applied to the default billing entity" do
-      before { create(:billing_entity_applied_tax, billing_entity:, tax:) }
-
-      it "removes the tax from the default billing entity" do
-        expect { destroy_service.call }.to change { billing_entity.applied_taxes.count }.by(-1)
-      end
+    it "does not remove the other tax from the default billing entity" do
+      expect { destroy_service.call }.to change { billing_entity.applied_taxes.count }.by(-1)
     end
 
     context "when tax is not found" do


### PR DESCRIPTION
## Context

As now taxes are applied on billing entitites, this PR switches invoices generation with applied taxes taken from billing_entities to the taxes form the organization

## Description

- Switch the applied taxes definition
- updated tax.applicable_customers method
- updated tests to ignore `applied_to_organization` field on tax
