### PR TITLE
feat(audit_logs): Create GraphQL classes for activity log

### DIFF
--- a/app/config/permissions/definition.yml
+++ b/app/config/permissions/definition.yml
@@ -1,4 +1,6 @@
 ---
+audit_logs:
+  view: true
 analytics:
   overdue_balances:
     view:

--- a/app/config/permissions/role-finance.yml
+++ b/app/config/permissions/role-finance.yml
@@ -1,4 +1,6 @@
 ---
+audit_logs:
+  view: false
 analytics:
   overdue_balances:
     view: true

--- a/app/config/permissions/role-manager.yml
+++ b/app/config/permissions/role-manager.yml
@@ -1,4 +1,6 @@
 ---
+audit_logs:
+  view: false
 analytics:
   overdue_balances:
     view: true

--- a/app/controllers/api/v1/activity_logs_controller.rb
+++ b/app/controllers/api/v1/activity_logs_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ActivityLogsController < Api::BaseController
+      def index
+        result = ActivityLogsQuery.call(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          },
+          filters: index_filters
+        )
+
+        if result.success?
+          render(
+            json: ::CollectionSerializer.new(
+              result.activity_logs,
+              ::V1::ActivityLogSerializer,
+              collection_name: "activity_logs",
+              meta: pagination_metadata(result.activity_logs)
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
+      private
+
+      def resource_name
+        "activity_log"
+      end
+
+      def index_filters
+        {
+          from_date: params[:from_date],
+          to_date: params[:to_date],
+          activity_types: params[:activity_types],
+          activity_sources: params[:activity_sources],
+          user_emails: params[:user_emails],
+          external_customer_id: params[:external_customer_id],
+          external_subscription_id: params[:external_subscription_id],
+          resource_id: params[:resource_id],
+          resource_type: params[:resource_type]
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/activity_logs_controller.rb
+++ b/app/controllers/api/v1/activity_logs_controller.rb
@@ -27,6 +27,22 @@ module Api
         end
       end
 
+      def show
+        activity_log = Clickhouse::ActivityLog.find_by(
+          organization_id: current_organization.id,
+          activity_id: params[:activity_id]
+        )
+
+        return not_found_error(resource: "activity_log") unless activity_log
+
+        render(
+          json: ::V1::ActivityLogSerializer.new(
+            activity_log,
+            root_name: "activity_log"
+          )
+        )
+      end
+
       private
 
       def resource_name

--- a/app/graphql/resolvers/activity_log_resolver.rb
+++ b/app/graphql/resolvers/activity_log_resolver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class ActivityLogResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "audit_logs:view"
+
+    description "Query a single activity log of an organization"
+
+    argument :activity_id, ID, required: true, description: "Uniq ID of the activity log"
+
+    type Types::ActivityLogs::Object, null: true
+
+    def resolve(activity_id: nil)
+      current_organization.activity_logs.find_by!(activity_id: activity_id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: "activity_log")
+    end
+  end
+end

--- a/app/graphql/resolvers/activity_logs_resolver.rb
+++ b/app/graphql/resolvers/activity_logs_resolver.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class ActivityLogsResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "audit_logs:view"
+
+    description "Query activity logs of an organization"
+
+    argument :limit, Integer, required: false
+    argument :page, Integer, required: false
+
+    argument :activity_sources, [Types::ActivityLogs::ActivitySourceTypeEnum], required: false
+    argument :activity_types, [String], required: false
+    argument :api_key_ids, [String], required: false
+    argument :external_customer_id, String, required: false
+    argument :external_subscription_id, String, required: false
+    argument :from_date, GraphQL::Types::ISO8601Date, required: false
+    argument :resource_id, String, required: false
+    argument :resource_type, String, required: false
+    argument :to_date, GraphQL::Types::ISO8601Date, required: false
+    argument :user_emails, [String], required: false
+
+    type Types::ActivityLogs::Object.collection_type, null: true
+
+    def resolve(**args)
+      result = ActivityLogsQuery.call(
+        organization: current_organization,
+        filters: {
+          from_date: args[:from_date],
+          to_date: args[:to_date],
+          activity_types: args[:activity_types],
+          activity_sources: args[:activity_sources],
+          user_emails: args[:user_emails],
+          external_customer_id: args[:external_customer_id],
+          external_subscription_id: args[:external_subscription_id],
+          resource_id: args[:resource_id],
+          resource_type: args[:resource_type]
+        },
+        pagination: {
+          page: args[:page],
+          limit: args[:limit]
+        }
+      )
+
+      result.activity_logs
+    end
+  end
+end

--- a/app/graphql/resolvers/activity_logs_resolver.rb
+++ b/app/graphql/resolvers/activity_logs_resolver.rb
@@ -18,8 +18,8 @@ module Resolvers
     argument :external_customer_id, String, required: false
     argument :external_subscription_id, String, required: false
     argument :from_date, GraphQL::Types::ISO8601Date, required: false
-    argument :resource_id, String, required: false
-    argument :resource_type, String, required: false
+    argument :resource_ids, [String], required: false
+    argument :resource_types, [String], required: false
     argument :to_date, GraphQL::Types::ISO8601Date, required: false
     argument :user_emails, [String], required: false
 
@@ -36,8 +36,8 @@ module Resolvers
           user_emails: args[:user_emails],
           external_customer_id: args[:external_customer_id],
           external_subscription_id: args[:external_subscription_id],
-          resource_id: args[:resource_id],
-          resource_type: args[:resource_type]
+          resource_ids: args[:resource_ids],
+          resource_types: args[:resource_types]
         },
         pagination: {
           page: args[:page],

--- a/app/graphql/resolvers/activity_logs_resolver.rb
+++ b/app/graphql/resolvers/activity_logs_resolver.rb
@@ -13,7 +13,7 @@ module Resolvers
     argument :page, Integer, required: false
 
     argument :activity_sources, [Types::ActivityLogs::ActivitySourceTypeEnum], required: false
-    argument :activity_types, [String], required: false
+    argument :activity_types, [Types::ActivityLogs::ActivityTypeTypeEnum], required: false
     argument :api_key_ids, [String], required: false
     argument :external_customer_id, String, required: false
     argument :external_subscription_id, String, required: false

--- a/app/graphql/types/activity_logs/activity_source_type_enum.rb
+++ b/app/graphql/types/activity_logs/activity_source_type_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module ActivityLogs
+    class ActivitySourceTypeEnum < Types::BaseEnum
+      description "Activity Logs source type enums"
+
+      [:api, :front, :system].each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/activity_logs/activity_type_type_enum.rb
+++ b/app/graphql/types/activity_logs/activity_type_type_enum.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Types
+  module ActivityLogs
+    class ActivityTypeTypeEnum < Types::BaseEnum
+      description "Activity Logs Types type enums"
+
+      class << self
+        DELIMITER = "_"
+
+        def basic_types(record_type, except: [])
+          %w[created updated deleted].excluding(except).map do |type|
+            "#{record_type}#{DELIMITER}#{type}"
+          end
+        end
+
+        def invoice_types
+          %w[drafted failed created paid_credit_added generated payment_status_updated payment_overdue voided payment_failure].map do |type|
+            "invoice#{DELIMITER}#{type}"
+          end
+        end
+
+        def payment_receipts_types
+          %w[created generated].map do |type|
+            "payment_receipt#{DELIMITER}#{type}"
+          end
+        end
+
+        def credit_note_types
+          %w[created generated refund_failure].map do |type|
+            "credit_note#{DELIMITER}#{type}"
+          end
+        end
+
+        def subscription_types
+          %w[started terminated updated].map do |type|
+            "subscription#{DELIMITER}#{type}"
+          end
+        end
+
+        def wallet_transaction_types
+          %w[payment_failure].map do |type|
+            "wallet_transaction#{DELIMITER}#{type}"
+          end + basic_types("wallet_transaction", except: ["deleted"])
+        end
+
+        def payment_types
+          ["payment#{DELIMITER}recorded"]
+        end
+      end
+
+      [
+        *basic_types("billable_metric"),
+        *basic_types("plan"),
+        *basic_types("customer"),
+        *invoice_types,
+        *payment_receipts_types,
+        *credit_note_types,
+        *basic_types("billing_entities"),
+        *subscription_types,
+        *basic_types("wallet", except: ["deleted"]),
+        *wallet_transaction_types,
+        *payment_types,
+        *basic_types("coupon"),
+        *basic_types("applied_coupon", except: ["updated"])
+      ].each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/activity_logs/activity_type_type_enum.rb
+++ b/app/graphql/types/activity_logs/activity_type_type_enum.rb
@@ -5,66 +5,8 @@ module Types
     class ActivityTypeTypeEnum < Types::BaseEnum
       description "Activity Logs Types type enums"
 
-      class << self
-        DELIMITER = "_"
-
-        def basic_types(record_type, except: [])
-          %w[created updated deleted].excluding(except).map do |type|
-            "#{record_type}#{DELIMITER}#{type}"
-          end
-        end
-
-        def invoice_types
-          %w[drafted failed created paid_credit_added generated payment_status_updated payment_overdue voided payment_failure].map do |type|
-            "invoice#{DELIMITER}#{type}"
-          end
-        end
-
-        def payment_receipts_types
-          %w[created generated].map do |type|
-            "payment_receipt#{DELIMITER}#{type}"
-          end
-        end
-
-        def credit_note_types
-          %w[created generated refund_failure].map do |type|
-            "credit_note#{DELIMITER}#{type}"
-          end
-        end
-
-        def subscription_types
-          %w[started terminated updated].map do |type|
-            "subscription#{DELIMITER}#{type}"
-          end
-        end
-
-        def wallet_transaction_types
-          %w[payment_failure].map do |type|
-            "wallet_transaction#{DELIMITER}#{type}"
-          end + basic_types("wallet_transaction", except: ["deleted"])
-        end
-
-        def payment_types
-          ["payment#{DELIMITER}recorded"]
-        end
-      end
-
-      [
-        *basic_types("billable_metric"),
-        *basic_types("plan"),
-        *basic_types("customer"),
-        *invoice_types,
-        *payment_receipts_types,
-        *credit_note_types,
-        *basic_types("billing_entities"),
-        *subscription_types,
-        *basic_types("wallet", except: ["deleted"]),
-        *wallet_transaction_types,
-        *payment_types,
-        *basic_types("coupon"),
-        *basic_types("applied_coupon", except: ["updated"])
-      ].each do |type|
-        value type
+      Clickhouse::ActivityLog::ACTIVITY_TYPES.each do |key, value|
+        value key, value:, description: value
       end
     end
   end

--- a/app/graphql/types/activity_logs/object.rb
+++ b/app/graphql/types/activity_logs/object.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Types
+  module ActivityLogs
+    class Object < Types::BaseObject
+      graphql_name "ActivityLog"
+      description "Base activity log"
+
+      field :activity_id, ID, null: false
+      field :activity_source, Types::ActivityLogs::ActivitySourceTypeEnum, null: false
+      field :activity_type, String, null: false
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :external_customer_id, String
+      field :external_subscription_id, String
+      field :logged_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :organization, Types::Organizations::OrganizationType
+      field :resource_changes, String
+      field :resource_id, String, null: false
+      field :resource_type, String, null: false
+      field :user, Types::UserType
+    end
+  end
+end

--- a/app/graphql/types/activity_logs/object.rb
+++ b/app/graphql/types/activity_logs/object.rb
@@ -8,7 +8,7 @@ module Types
 
       field :activity_id, ID, null: false
       field :activity_source, Types::ActivityLogs::ActivitySourceTypeEnum, null: false
-      field :activity_type, String, null: false
+      field :activity_type, Types::ActivityLogs::ActivityTypeTypeEnum, null: false
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :external_customer_id, String
       field :external_subscription_id, String

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -9,6 +9,7 @@ module Types
 
     field :current_user, resolver: Resolvers::CurrentUserResolver
 
+    field :activity_log, resolver: Resolvers::ActivityLogResolver
     field :add_on, resolver: Resolvers::AddOnResolver
     field :add_ons, resolver: Resolvers::AddOnsResolver
     field :api_key, resolver: Resolvers::ApiKeyResolver

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -10,6 +10,7 @@ module Types
     field :current_user, resolver: Resolvers::CurrentUserResolver
 
     field :activity_log, resolver: Resolvers::ActivityLogResolver
+    field :activity_logs, resolver: Resolvers::ActivityLogsResolver
     field :add_on, resolver: Resolvers::AddOnResolver
     field :add_ons, resolver: Resolvers::AddOnsResolver
     field :api_key, resolver: Resolvers::ApiKeyResolver

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -4,7 +4,7 @@ class ApiKey < ApplicationRecord
   include PaperTrailTraceable
 
   RESOURCES = %w[
-    add_on analytic billable_metric coupon applied_coupon credit_note customer_usage
+    activity_log add_on analytic billable_metric coupon applied_coupon credit_note customer_usage
     customer event fee invoice organization payment payment_receipt payment_request plan subscription lifetime_usage
     tax wallet wallet_transaction webhook_endpoint webhook_jwt_public_key invoice_custom_section
   ].freeze

--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Clickhouse
+  class ActivityLog < BaseRecord
+    self.table_name = "activity_logs"
+    self.primary_key = nil
+
+    before_save :ensure_activity_id
+
+    def organization
+      Organization.find_by(id: organization_id)
+    end
+
+    def user
+      organization.users.find_by(id: user_id)
+    end
+
+    def api_key
+      organization.api_keys.find_by(id: api_key_id)
+    end
+
+    def customer
+      organization.customers.find_by(external_id: external_customer_id)
+    end
+
+    def subscription
+      organization.subscriptions.find_by(external_id: external_subscription_id)
+    end
+
+    def resource
+      resource_type.constantize.find_by(id: resource_id)
+    end
+
+    private
+
+    def ensure_activity_id
+      self.activity_id = SecureRandom.uuid if activity_id.blank?
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: activity_logs
+#
+#  activity_object          :string
+#  activity_object_changes  :string
+#  activity_source          :Enum8('api' = 1, not null
+#  activity_type            :string           not null
+#  logged_at                :datetime         not null
+#  resource_type            :string           not null
+#  created_at               :datetime         not null
+#  activity_id              :string           not null
+#  api_key_id               :string
+#  external_customer_id     :string
+#  external_subscription_id :string
+#  organization_id          :string           not null
+#  resource_id              :string           not null
+#  user_id                  :string
+#

--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -5,6 +5,49 @@ module Clickhouse
     self.table_name = "activity_logs"
     self.primary_key = nil
 
+    ACTIVITY_TYPES = {
+      billable_metric_created: "billable_metric.created",
+      billable_metric_updated: "billable_metric.updated",
+      billable_metric_deleted: "billable_metric.deleted",
+      plan_created: "plan.created",
+      plan_updated: "plan.updated",
+      plan_deleted: "plan.deleted",
+      customer_created: "customer.created",
+      customer_updated: "customer.updated",
+      customer_deleted: "customer.deleted",
+      invoice_drafted: "invoice.drafted",
+      invoice_failed: "invoice.failed",
+      invoice_created: "invoice.created",
+      invoice_paid_credit_added: "invoice.paid_credit_added",
+      invoice_generated: "invoice.generated",
+      invoice_payment_status_updated: "invoice.payment_status_updated",
+      invoice_payment_overdue: "invoice.payment_overdue",
+      invoice_voided: "invoice.voided",
+      invoice_payment_failure: "invoice.payment_failure",
+      payment_receipt_created: "payment_receipt.created",
+      payment_receipt_generated: "payment_receipt.generated",
+      credit_note_created: "credit_note.created",
+      credit_note_generated: "credit_note.generated",
+      credit_note_refund_failure: "credit_note.refund_failure",
+      billing_entities_created: "billing_entities.created",
+      billing_entities_updated: "billing_entities.updated",
+      billing_entities_deleted: "billing_entities.deleted",
+      subscription_started: "subscription.started",
+      subscription_terminated: "subscription.terminated",
+      subscription_updated: "subscription.updated",
+      wallet_created: "wallet.created",
+      wallet_updated: "wallet.updated",
+      wallet_transaction_payment_failure: "wallet_transaction.payment_failure",
+      wallet_transaction_created: "wallet_transaction.created",
+      wallet_transaction_updated: "wallet_transaction.updated",
+      payment_recorded: "payment.recorded",
+      coupon_created: "coupon.created",
+      coupon_updated: "coupon.updated",
+      coupon_deleted: "coupon.deleted",
+      applied_coupon_created: "applied_coupon.created",
+      applied_coupon_deleted: "applied_coupon.deleted"
+    }
+
     before_save :ensure_activity_id
 
     def organization

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -47,6 +47,7 @@ class Organization < ApplicationRecord
   has_many :data_exports
   has_many :error_details
   has_many :dunning_campaigns
+  has_many :activity_logs, class_name: "Clickhouse::ActivityLog"
 
   has_many :stripe_payment_providers, class_name: "PaymentProviders::StripeProvider"
   has_many :gocardless_payment_providers, class_name: "PaymentProviders::GocardlessProvider"

--- a/app/queries/activity_logs_query.rb
+++ b/app/queries/activity_logs_query.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+class ActivityLogsQuery < BaseQuery
+  Result = BaseResult[:activity_logs]
+  Filters = BaseFilters[
+    :from_date,
+    :to_date,
+    :activity_types,
+    :activity_sources,
+    :user_emails,
+    :external_customer_id,
+    :external_subscription_id,
+    :resource_id,
+    :resource_type
+  ]
+
+  def call
+    activity_logs = Clickhouse::ActivityLog.where(organization_id: organization.id)
+    activity_logs = paginate(activity_logs)
+    activity_logs = activity_logs.order(logged_at: :desc)
+
+    activity_logs = with_logged_at_range(activity_logs) if filters.from_date || filters.to_date
+    activity_logs = with_activity_types(activity_logs) if filters.activity_types.present?
+    activity_logs = with_activity_sources(activity_logs) if filters.activity_sources.present?
+    activity_logs = with_user_emails(activity_logs) if filters.user_emails.present?
+    activity_logs = with_external_customer_id(activity_logs) if filters.external_customer_id.present?
+    activity_logs = with_external_subscription_id(activity_logs) if filters.external_subscription_id.present?
+    activity_logs = with_resource_id(activity_logs) if filters.resource_id.present?
+    activity_logs = with_resource_type(activity_logs) if filters.resource_type.present?
+
+    result.activity_logs = activity_logs
+    result
+  end
+
+  private
+
+  def with_logged_at_range(scope)
+    scope = scope.where(logged_at: from_date..) if filters.from_date
+    scope = scope.where(logged_at: ..to_date) if filters.to_date
+    scope
+  end
+
+  def with_activity_types(scope)
+    scope.where(activity_type: filters.activity_types)
+  end
+
+  def with_activity_sources(scope)
+    scope.where(activity_source: filters.activity_sources)
+  end
+
+  def with_user_emails(scope)
+    user_ids = organization.users.where(email: filters.user_emails).pluck(:id)
+    scope.where(user_id: user_ids)
+  end
+
+  def with_external_customer_id(scope)
+    scope.where(external_customer_id: filters.external_customer_id)
+  end
+
+  def with_external_subscription_id(scope)
+    scope.where(external_subscription_id: filters.external_subscription_id)
+  end
+
+  def with_resource_id(scope)
+    scope.where(resource_id: filters.resource_id)
+  end
+
+  def with_resource_type(scope)
+    scope.where(resource_type: filters.resource_type)
+  end
+
+  def from_date
+    @from_date ||= parse_datetime_filter(:from_date)
+  end
+
+  def to_date
+    @to_date ||= parse_datetime_filter(:to_date)
+  end
+end

--- a/app/serializers/v1/activity_log_serializer.rb
+++ b/app/serializers/v1/activity_log_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module V1
+  class ActivityLogSerializer < ModelSerializer
+    def serialize
+      {
+        lago_user_id: model.user_id,
+        resource_id: model.resource_id,
+        resource_type: model.resource_type,
+        activity_id: model.activity_id,
+        activity_type: model.activity_type,
+        activity_source: model.activity_source,
+        external_customer_id: model.external_customer_id,
+        external_subscription_id: model.external_subscription_id,
+        logged_at: model.logged_at.iso8601,
+        created_at: model.created_at.iso8601
+        # TODO: add resource and resource_changes (via serializers)
+        # resource: model.resource,
+        # resource_changes: model.resource_changes
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :activity_logs, only: %i[index]
+      resources :activity_logs, param: :activity_id, only: %i[index show]
 
       namespace :analytics do
         get :gross_revenue, to: "gross_revenues#index", as: :gross_revenue

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      resources :activity_logs, only: %i[index]
+
       namespace :analytics do
         get :gross_revenue, to: "gross_revenues#index", as: :gross_revenue
         get :invoiced_usage, to: "invoiced_usages#index", as: :invoiced_usage

--- a/db/clickhouse_migrate/20250416103745_create_activity_logs.rb
+++ b/db/clickhouse_migrate/20250416103745_create_activity_logs.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CreateActivityLogs < ActiveRecord::Migration[7.1]
+  def change
+    options = <<-SQL
+      ReplacingMergeTree(logged_at)
+      PRIMARY KEY (organization_id, activity_id, logged_at)
+      ORDER BY (organization_id, activity_id, logged_at)
+    SQL
+
+    create_table :activity_logs, id: false, options: do |t|
+      t.string :organization_id, null: false
+      t.string :user_id
+      t.string :api_key_id
+
+      t.string :external_customer_id
+      t.string :external_subscription_id
+
+      t.string :activity_id, null: false
+      t.string :activity_type, null: false
+      t.enum :activity_source, value: {api: 1, front: 2, system: 3}, null: false
+      t.string :activity_object, map: true
+      t.string :activity_object_changes, map: true
+
+      t.string :resource_id, null: false
+      t.string :resource_type, null: false
+
+      t.datetime :logged_at, null: false, precision: 3
+      t.datetime :created_at, null: false, precision: 3
+    end
+  end
+end

--- a/db/clickhouse_migrate/20250416104012_create_activity_logs_queue.rb
+++ b/db/clickhouse_migrate/20250416104012_create_activity_logs_queue.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreateActivityLogsQueue < ActiveRecord::Migration[7.0]
+  def change
+    options = <<-SQL
+      Kafka()
+      SETTINGS
+        kafka_broker_list = '#{ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"]}',
+        kafka_topic_list = '#{ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"]}',
+        kafka_group_name = '#{ENV["LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP"]}',
+        kafka_format = 'JSONEachRow'
+    SQL
+
+    create_table :activity_logs_queue, id: false, options: do |t|
+      t.string :organization_id, null: false
+      t.string :user_id
+      t.string :api_key_id
+
+      t.string :external_customer_id
+      t.string :external_subscription_id
+
+      t.string :activity_id, null: false
+      t.string :activity_type, null: false
+      t.enum :activity_source, value: {api: 1, front: 2, system: 3}, null: false
+      t.string :activity_object, map: true
+      t.string :activity_object_changes, map: true
+
+      t.string :resource_id, null: false
+      t.string :resource_type, null: false
+
+      t.datetime :logged_at, null: false, precision: 3
+      t.datetime :created_at, null: false, precision: 3
+    end
+  end
+end

--- a/db/clickhouse_migrate/20250416104534_create_activity_logs_mv.rb
+++ b/db/clickhouse_migrate/20250416104534_create_activity_logs_mv.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: false
+
+class CreateActivityLogsMv < ActiveRecord::Migration[7.0]
+  def change
+    sql = <<-SQL
+      SELECT
+        organization_id,
+        user_id,
+        api_key_id,
+        external_customer_id,
+        external_subscription_id,
+        activity_id,
+        resource_id,
+        resource_type,
+        activity_object,
+        activity_object_changes,
+        activity_type,
+        activity_source,
+        logged_at,
+        created_at
+      FROM activity_logs_queue
+    SQL
+
+    create_view :activity_logs_mv, materialized: true, as: sql, to: "activity_logs"
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -58,6 +58,211 @@ enum ActivitySourceTypeEnum {
 }
 
 """
+Activity Logs Types type enums
+"""
+enum ActivityTypeTypeEnum {
+  """
+  applied_coupon.created
+  """
+  applied_coupon_created
+
+  """
+  applied_coupon.deleted
+  """
+  applied_coupon_deleted
+
+  """
+  billable_metric.created
+  """
+  billable_metric_created
+
+  """
+  billable_metric.deleted
+  """
+  billable_metric_deleted
+
+  """
+  billable_metric.updated
+  """
+  billable_metric_updated
+
+  """
+  billing_entities.created
+  """
+  billing_entities_created
+
+  """
+  billing_entities.deleted
+  """
+  billing_entities_deleted
+
+  """
+  billing_entities.updated
+  """
+  billing_entities_updated
+
+  """
+  coupon.created
+  """
+  coupon_created
+
+  """
+  coupon.deleted
+  """
+  coupon_deleted
+
+  """
+  coupon.updated
+  """
+  coupon_updated
+
+  """
+  credit_note.created
+  """
+  credit_note_created
+
+  """
+  credit_note.generated
+  """
+  credit_note_generated
+
+  """
+  credit_note.refund_failure
+  """
+  credit_note_refund_failure
+
+  """
+  customer.created
+  """
+  customer_created
+
+  """
+  customer.deleted
+  """
+  customer_deleted
+
+  """
+  customer.updated
+  """
+  customer_updated
+
+  """
+  invoice.created
+  """
+  invoice_created
+
+  """
+  invoice.drafted
+  """
+  invoice_drafted
+
+  """
+  invoice.failed
+  """
+  invoice_failed
+
+  """
+  invoice.generated
+  """
+  invoice_generated
+
+  """
+  invoice.paid_credit_added
+  """
+  invoice_paid_credit_added
+
+  """
+  invoice.payment_failure
+  """
+  invoice_payment_failure
+
+  """
+  invoice.payment_overdue
+  """
+  invoice_payment_overdue
+
+  """
+  invoice.payment_status_updated
+  """
+  invoice_payment_status_updated
+
+  """
+  invoice.voided
+  """
+  invoice_voided
+
+  """
+  payment_receipt.created
+  """
+  payment_receipt_created
+
+  """
+  payment_receipt.generated
+  """
+  payment_receipt_generated
+
+  """
+  payment.recorded
+  """
+  payment_recorded
+
+  """
+  plan.created
+  """
+  plan_created
+
+  """
+  plan.deleted
+  """
+  plan_deleted
+
+  """
+  plan.updated
+  """
+  plan_updated
+
+  """
+  subscription.started
+  """
+  subscription_started
+
+  """
+  subscription.terminated
+  """
+  subscription_terminated
+
+  """
+  subscription.updated
+  """
+  subscription_updated
+
+  """
+  wallet.created
+  """
+  wallet_created
+
+  """
+  wallet_transaction.created
+  """
+  wallet_transaction_created
+
+  """
+  wallet_transaction.payment_failure
+  """
+  wallet_transaction_payment_failure
+
+  """
+  wallet_transaction.updated
+  """
+  wallet_transaction_updated
+
+  """
+  wallet.updated
+  """
+  wallet_updated
+}
+
+"""
 Adyen input arguments
 """
 input AddAdyenPaymentProviderInput {
@@ -7231,7 +7436,7 @@ type Query {
   """
   Query activity logs of an organization
   """
-  activityLogs(activitySources: [ActivitySourceTypeEnum!], activityTypes: [String!], apiKeyIds: [String!], externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, limit: Int, page: Int, resourceId: String, resourceType: String, toDate: ISO8601Date, userEmails: [String!]): ActivityLogCollection
+  activityLogs(activitySources: [ActivitySourceTypeEnum!], activityTypes: [ActivityTypeTypeEnum!], apiKeyIds: [String!], externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, limit: Int, page: Int, resourceIds: [String!], resourceTypes: [String!], toDate: ISO8601Date, userEmails: [String!]): ActivityLogCollection
 
   """
   Query a single add-on of an organization

--- a/schema.graphql
+++ b/schema.graphql
@@ -6921,6 +6921,7 @@ type Permissions {
   addonsView: Boolean!
   analyticsOverdueBalancesView: Boolean!
   analyticsView: Boolean!
+  auditLogsView: Boolean!
   billableMetricsCreate: Boolean!
   billableMetricsDelete: Boolean!
   billableMetricsUpdate: Boolean!

--- a/schema.graphql
+++ b/schema.graphql
@@ -16,6 +16,33 @@ input AcceptInviteInput {
 }
 
 """
+Base activity log
+"""
+type ActivityLog {
+  activityId: ID!
+  activitySource: ActivitySourceTypeEnum!
+  activityType: String!
+  createdAt: ISO8601DateTime!
+  externalCustomerId: String
+  externalSubscriptionId: String
+  loggedAt: ISO8601DateTime!
+  organization: Organization
+  resourceChanges: String
+  resourceId: String!
+  resourceType: String!
+  user: User
+}
+
+"""
+Activity Logs source type enums
+"""
+enum ActivitySourceTypeEnum {
+  api
+  front
+  system
+}
+
+"""
 Adyen input arguments
 """
 input AddAdyenPaymentProviderInput {
@@ -7176,6 +7203,16 @@ enum ProviderTypeEnum {
 }
 
 type Query {
+  """
+  Query a single activity log of an organization
+  """
+  activityLog(
+    """
+    Uniq ID of the activity log
+    """
+    activityId: ID!
+  ): ActivityLog
+
   """
   Query a single add-on of an organization
   """

--- a/schema.graphql
+++ b/schema.graphql
@@ -34,6 +34,21 @@ type ActivityLog {
 }
 
 """
+ActivityLogCollection type
+"""
+type ActivityLogCollection {
+  """
+  A collection of paginated ActivityLogCollection
+  """
+  collection: [ActivityLog!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
+"""
 Activity Logs source type enums
 """
 enum ActivitySourceTypeEnum {
@@ -7212,6 +7227,11 @@ type Query {
     """
     activityId: ID!
   ): ActivityLog
+
+  """
+  Query activity logs of an organization
+  """
+  activityLogs(activitySources: [ActivitySourceTypeEnum!], activityTypes: [String!], apiKeyIds: [String!], externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, limit: Int, page: Int, resourceId: String, resourceType: String, toDate: ISO8601Date, userEmails: [String!]): ActivityLogCollection
 
   """
   Query a single add-on of an organization

--- a/schema.json
+++ b/schema.json
@@ -344,6 +344,257 @@
           ]
         },
         {
+          "kind": "ENUM",
+          "name": "ActivityTypeTypeEnum",
+          "description": "Activity Logs Types type enums",
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "billable_metric_created",
+              "description": "billable_metric.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billable_metric_updated",
+              "description": "billable_metric.updated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billable_metric_deleted",
+              "description": "billable_metric.deleted",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "plan_created",
+              "description": "plan.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "plan_updated",
+              "description": "plan.updated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "plan_deleted",
+              "description": "plan.deleted",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customer_created",
+              "description": "customer.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customer_updated",
+              "description": "customer.updated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customer_deleted",
+              "description": "customer.deleted",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoice_drafted",
+              "description": "invoice.drafted",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoice_failed",
+              "description": "invoice.failed",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoice_created",
+              "description": "invoice.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoice_paid_credit_added",
+              "description": "invoice.paid_credit_added",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoice_generated",
+              "description": "invoice.generated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoice_payment_status_updated",
+              "description": "invoice.payment_status_updated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoice_payment_overdue",
+              "description": "invoice.payment_overdue",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoice_voided",
+              "description": "invoice.voided",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoice_payment_failure",
+              "description": "invoice.payment_failure",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "payment_receipt_created",
+              "description": "payment_receipt.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "payment_receipt_generated",
+              "description": "payment_receipt.generated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "credit_note_created",
+              "description": "credit_note.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "credit_note_generated",
+              "description": "credit_note.generated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "credit_note_refund_failure",
+              "description": "credit_note.refund_failure",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billing_entities_created",
+              "description": "billing_entities.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billing_entities_updated",
+              "description": "billing_entities.updated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billing_entities_deleted",
+              "description": "billing_entities.deleted",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscription_started",
+              "description": "subscription.started",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscription_terminated",
+              "description": "subscription.terminated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscription_updated",
+              "description": "subscription.updated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wallet_created",
+              "description": "wallet.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wallet_updated",
+              "description": "wallet.updated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wallet_transaction_payment_failure",
+              "description": "wallet_transaction.payment_failure",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wallet_transaction_created",
+              "description": "wallet_transaction.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wallet_transaction_updated",
+              "description": "wallet_transaction.updated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "payment_recorded",
+              "description": "payment.recorded",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "coupon_created",
+              "description": "coupon.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "coupon_updated",
+              "description": "coupon.updated",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "coupon_deleted",
+              "description": "coupon.deleted",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "applied_coupon_created",
+              "description": "applied_coupon.created",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "applied_coupon_deleted",
+              "description": "applied_coupon.deleted",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "AddAdyenPaymentProviderInput",
           "description": "Adyen input arguments",
@@ -36571,8 +36822,8 @@
                       "kind": "NON_NULL",
                       "name": null,
                       "ofType": {
-                        "kind": "SCALAR",
-                        "name": "String",
+                        "kind": "ENUM",
+                        "name": "ActivityTypeTypeEnum",
                         "ofType": null
                       }
                     }
@@ -36638,24 +36889,40 @@
                   "deprecationReason": null
                 },
                 {
-                  "name": "resourceId",
+                  "name": "resourceIds",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
                 },
                 {
-                  "name": "resourceType",
+                  "name": "resourceTypes",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -81,6 +81,218 @@
           "enumValues": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ActivityLog",
+          "description": "Base activity log",
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "activityId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "activitySource",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ActivitySourceTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "activityType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "externalCustomerId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "externalSubscriptionId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "loggedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "organization",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Organization",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "resourceChanges",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "resourceId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "resourceType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "user",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ActivitySourceTypeEnum",
+          "description": "Activity Logs source type enums",
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "api",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "front",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "system",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "AddAdyenPaymentProviderInput",
           "description": "Adyen input arguments",
@@ -36214,6 +36426,35 @@
           "interfaces": [],
           "possibleTypes": null,
           "fields": [
+            {
+              "name": "activityLog",
+              "description": "Query a single activity log of an organization",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ActivityLog",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "activityId",
+                  "description": "Uniq ID of the activity log",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
             {
               "name": "addOn",
               "description": "Query a single add-on of an organization",

--- a/schema.json
+++ b/schema.json
@@ -33345,6 +33345,22 @@
               "args": []
             },
             {
+              "name": "auditLogsView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "billableMetricsCreate",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -264,6 +264,57 @@
           "enumValues": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ActivityLogCollection",
+          "description": "ActivityLogCollection type",
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated ActivityLogCollection",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ActivityLog",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
           "kind": "ENUM",
           "name": "ActivitySourceTypeEnum",
           "description": "Activity Logs source type enums",
@@ -36447,6 +36498,195 @@
                       "kind": "SCALAR",
                       "name": "ID",
                       "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "activityLogs",
+              "description": "Query activity logs of an organization",
+              "type": {
+                "kind": "OBJECT",
+                "name": "ActivityLogCollection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "activitySources",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "ActivitySourceTypeEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "activityTypes",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "apiKeyIds",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "externalCustomerId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "externalSubscriptionId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "fromDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601Date",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "resourceId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "resourceType",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "toDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601Date",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "userEmails",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
                     }
                   },
                   "defaultValue": null,

--- a/spec/factories/clickhouse/activity_logs.rb
+++ b/spec/factories/clickhouse/activity_logs.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     external_subscription_id { subscription.external_id }
     resource_id { metric.id }
     resource_type { metric.class.name }
-    activity_type { "create" }
+    activity_type { "billable_metric.created" }
     activity_source { "api" }
     logged_at { Time.current }
     activity_object { {"foo" => "bar", "baz" => "qux"} }

--- a/spec/factories/clickhouse/activity_logs.rb
+++ b/spec/factories/clickhouse/activity_logs.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :clickhouse_activity_log, class: "Clickhouse::ActivityLog" do
+    transient do
+      membership { create(:membership) }
+      customer { create(:customer, organization: membership.organization) }
+      subscription { create(:subscription, customer:) }
+      metric { create(:billable_metric, organization: membership.organization) }
+    end
+
+    organization_id { membership.organization_id }
+    user_id { membership.user_id }
+    api_key_id { create(:api_key, organization: membership.organization).id }
+    external_customer_id { customer.external_id }
+    external_subscription_id { subscription.external_id }
+    resource_id { metric.id }
+    resource_type { metric.class.name }
+    activity_type { "create" }
+    activity_source { "api" }
+    logged_at { Time.current }
+    activity_object { {"foo" => "bar", "baz" => "qux"} }
+    activity_object_changes { {"foo" => "bar"} }
+  end
+end

--- a/spec/graphql/resolvers/activity_log_resolver_spec.rb
+++ b/spec/graphql/resolvers/activity_log_resolver_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::ActivityLogResolver, type: :graphql, clickhouse: true do
+  let(:required_permission) { "audit_logs:view" }
+  let(:query) do
+    <<~GQL
+      query($activityLogId: ID!) {
+        activityLog(activityId: $activityLogId) {
+          activityId
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:clickhouse_activity_log) { create(:clickhouse_activity_log, membership:) }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "audit_logs:view"
+
+  it "returns a single activity log" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:,
+      variables: {activityLogId: clickhouse_activity_log.activity_id}
+    )
+
+    activity_log_response = result["data"]["activityLog"]
+
+    expect(activity_log_response["activityId"]).to eq(clickhouse_activity_log.activity_id)
+  end
+
+  context "when activity log is not found" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {activityLogId: "invalid"}
+      )
+
+      expect_graphql_error(result:, message: "Resource not found")
+    end
+  end
+end

--- a/spec/graphql/resolvers/activity_logs_resolver_spec.rb
+++ b/spec/graphql/resolvers/activity_logs_resolver_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::ActivityLogsResolver, type: :graphql, clickhouse: true do
+  let(:required_permission) { "audit_logs:view" }
+  let(:query) do
+    <<~GQL
+      query {
+        activityLogs(limit: 5) {
+          collection {
+            activityId
+          }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:clickhouse_activity_log) { create(:clickhouse_activity_log, membership:) }
+
+  before { clickhouse_activity_log }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "audit_logs:view"
+
+  it "returns the list of activity logs" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:
+    )
+
+    activity_logs_response = result["data"]["activityLogs"]
+
+    expect(activity_logs_response["collection"].count).to eq(organization.activity_logs.count)
+    expect(activity_logs_response["collection"].first["activityId"]).to eq(clickhouse_activity_log.activity_id)
+
+    expect(activity_logs_response["metadata"]["currentPage"]).to eq(1)
+    expect(activity_logs_response["metadata"]["totalCount"]).to eq(1)
+  end
+
+  context "with filters" do
+    let(:filters) do
+      {
+        from_date: nil,
+        to_date: nil,
+        activity_types: nil,
+        activity_sources: nil,
+        user_emails: nil,
+        external_customer_id: nil,
+        external_subscription_id: nil,
+        resource_id: nil,
+        resource_type: nil
+      }
+    end
+
+    it "sends all possible filters to query" do
+      allow(ActivityLogsQuery).to receive(:call).and_call_original
+
+      execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      expect(ActivityLogsQuery).to have_received(:call).with(
+        organization: organization,
+        pagination: {limit: 5, page: nil},
+        filters:
+      )
+    end
+  end
+end

--- a/spec/graphql/resolvers/activity_logs_resolver_spec.rb
+++ b/spec/graphql/resolvers/activity_logs_resolver_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Resolvers::ActivityLogsResolver, type: :graphql, clickhouse: true
         user_emails: nil,
         external_customer_id: nil,
         external_subscription_id: nil,
-        resource_id: nil,
-        resource_type: nil
+        resource_ids: nil,
+        resource_types: nil
       }
     end
 

--- a/spec/graphql/types/activity_logs/activity_source_type_enum_spec.rb
+++ b/spec/graphql/types/activity_logs/activity_source_type_enum_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::ActivityLogs::ActivitySourceTypeEnum do
+  it "enumerates the correct values" do
+    expect(described_class.values.keys).to match_array(%w[api front system])
+  end
+end

--- a/spec/graphql/types/activity_logs/activity_type_type_enum_spec.rb
+++ b/spec/graphql/types/activity_logs/activity_type_type_enum_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::ActivityLogs::ActivityTypeTypeEnum do
+  it "enumerates the correct values" do
+    expect(described_class.values.keys).to match_array(
+      %w[
+        billable_metric_created
+        billable_metric_updated
+        billable_metric_deleted
+        plan_created
+        plan_updated
+        plan_deleted
+        customer_created
+        customer_updated
+        customer_deleted
+        invoice_drafted
+        invoice_failed
+        invoice_created
+        invoice_paid_credit_added
+        invoice_generated
+        invoice_payment_status_updated
+        invoice_payment_overdue
+        invoice_voided
+        invoice_payment_failure
+        payment_receipt_created
+        payment_receipt_generated
+        credit_note_created
+        credit_note_generated
+        credit_note_refund_failure
+        billing_entities_created
+        billing_entities_updated
+        billing_entities_deleted
+        subscription_started
+        subscription_terminated
+        subscription_updated
+        wallet_created
+        wallet_updated
+        wallet_transaction_payment_failure
+        wallet_transaction_created
+        wallet_transaction_updated
+        payment_recorded
+        coupon_created
+        coupon_updated
+        coupon_deleted
+        applied_coupon_created
+        applied_coupon_deleted
+      ]
+    )
+  end
+end

--- a/spec/models/clickhouse/activity_log_spec.rb
+++ b/spec/models/clickhouse/activity_log_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Clickhouse::ActivityLog, type: :model, clickhouse: true do
+  subject(:activity_log) { create(:clickhouse_activity_log) }
+
+  describe "#ensure_activity_id" do
+    it "sets the activity_id if it is not set" do
+      expect(activity_log.activity_id).to be_present
+    end
+  end
+
+  describe "#organization" do
+    it "returns the organization" do
+      expect(activity_log.organization).to be_a(Organization)
+    end
+  end
+
+  describe "#user" do
+    it "returns the user" do
+      expect(activity_log.user).to be_a(User)
+    end
+  end
+
+  describe "#api_key" do
+    it "returns the api key" do
+      expect(activity_log.api_key).to be_a(ApiKey)
+    end
+  end
+
+  describe "#customer" do
+    it "returns the customer" do
+      expect(activity_log.customer).to be_a(Customer)
+    end
+  end
+
+  describe "#subscription" do
+    it "returns the subscription" do
+      expect(activity_log.subscription).to be_a(Subscription)
+    end
+  end
+
+  describe "#resource" do
+    it "returns the resource" do
+      expect(activity_log.resource).to be_a(BillableMetric)
+    end
+  end
+end

--- a/spec/queries/activity_logs_query_spec.rb
+++ b/spec/queries/activity_logs_query_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ActivityLogsQuery, type: :query, clickhouse: true do
+  subject(:result) do
+    described_class.call(organization:, pagination:, filters:)
+  end
+
+  let(:returned_ids) { result.activity_logs.pluck(:activity_id) }
+  let(:organization) { activity_log.organization }
+  let(:activity_log) { create(:clickhouse_activity_log) }
+  let(:pagination) { {page: 1, limit: 10} }
+  let(:filters) { nil }
+
+  before do
+    activity_log
+  end
+
+  it "returns all activity logs" do
+    expect(result.activity_logs.count).to eq(1)
+    expect(returned_ids).to include(activity_log.activity_id)
+  end
+
+  context "with pagination" do
+    let(:pagination) { {page: 1, limit: 1} }
+
+    it "applies the pagination" do
+      expect(result).to be_success
+      expect(result.activity_logs.count).to eq(1)
+      expect(result.activity_logs.current_page).to eq(1)
+      expect(result.activity_logs.prev_page).to be_nil
+      expect(result.activity_logs.next_page).to be_nil
+      expect(result.activity_logs.total_pages).to eq(1)
+      expect(result.activity_logs.total_count).to eq(1)
+    end
+  end
+
+  context "with from_date and to_date filters" do
+    it "returns expected activity logs" do
+      filters = {from_date: activity_log.logged_at + 1.day}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+
+      filters = {from_date: activity_log.logged_at - 1.day, to_date: activity_log.logged_at + 1.day}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {to_date: activity_log.logged_at - 1.day}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with activity_types filter" do
+    it "returns expected activity logs" do
+      filters = {activity_types: [activity_log.activity_type]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {activity_types: ["other"]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with activity_sources filter" do
+    it "returns expected activity logs" do
+      filters = {activity_sources: [activity_log.activity_source]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {activity_sources: ["other"]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with user_emails filter" do
+    it "returns expected activity logs" do
+      filters = {user_emails: [activity_log.user.email]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {user_emails: ["other"]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with external_customer_id filter" do
+    it "returns expected activity logs" do
+      filters = {external_customer_id: activity_log.external_customer_id}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {external_customer_id: "other"}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with external_subscription_id filter" do
+    it "returns expected activity logs" do
+      filters = {external_subscription_id: activity_log.external_subscription_id}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {external_subscription_id: "other"}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with resource_id filter" do
+    it "returns expected activity logs" do
+      filters = {resource_id: activity_log.resource_id}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {resource_id: "other"}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with resource_type filter" do
+    it "returns expected activity logs" do
+      filters = {resource_type: activity_log.resource_type}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {resource_type: "other"}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+end

--- a/spec/requests/api/v1/activity_logs_controller_spec.rb
+++ b/spec/requests/api/v1/activity_logs_controller_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::ActivityLogsController, type: :request, clickhouse: true do
+  describe "GET /api/v1/activity_logs" do
+    subject { get_with_token(organization, "/api/v1/activity_logs", params) }
+
+    let(:activity_log) { create(:clickhouse_activity_log) }
+    let(:invoice_activity_log) do
+      create(
+        :clickhouse_activity_log,
+        organization_id: organization.id,
+        external_customer_id: "ext_123",
+        external_subscription_id: "ext_456",
+        resource_id: "invoice-id",
+        resource_type: "invoice",
+        activity_type: "invoice.created",
+        activity_source: "front",
+        logged_at: 1.day.ago
+      )
+    end
+    let(:organization) { activity_log.organization }
+    let(:params) { {} }
+
+    before do
+      activity_log
+      invoice_activity_log
+    end
+
+    include_examples "requires API permission", "activity_log", "read"
+
+    it "returns activity logs" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:activity_logs].count).to eq(2)
+      expect(json[:activity_logs].map { |l| l[:activity_id] }).to include(activity_log.activity_id, invoice_activity_log.activity_id)
+    end
+
+    context "when filtering by external_customer_id" do
+      let(:params) { {external_customer_id: activity_log.external_customer_id} }
+
+      it "returns activity logs for the specified external customer" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:external_customer_id]).to eq(activity_log.external_customer_id)
+      end
+    end
+
+    context "when filtering by external_subscription_id" do
+      let(:params) { {external_subscription_id: activity_log.external_subscription_id} }
+
+      it "returns activity logs for the specified external subscription" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:external_subscription_id]).to eq(activity_log.external_subscription_id)
+      end
+    end
+
+    context "when filtering by resource_id" do
+      let(:params) { {resource_id: activity_log.resource_id} }
+
+      it "returns activity logs for the specified resource" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:resource_id]).to eq(activity_log.resource_id)
+      end
+    end
+
+    context "when filtering by resource_type" do
+      let(:params) { {resource_type: activity_log.resource_type} }
+
+      it "returns activity logs for the specified resource type" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:resource_type]).to eq(activity_log.resource_type)
+      end
+    end
+
+    context "when filtering by user_email" do
+      let(:params) { {user_emails: [activity_log.user.email]} }
+
+      it "returns activity logs for the specified user email" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:lago_user_id]).to eq(activity_log.user_id)
+      end
+    end
+
+    context "when filtering by activity_type" do
+      let(:params) { {activity_types: [activity_log.activity_type]} }
+
+      it "returns activity logs for the specified activity type" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:activity_type]).to eq(activity_log.activity_type)
+      end
+    end
+
+    context "when filtering by activity_source" do
+      let(:params) { {activity_sources: [activity_log.activity_source]} }
+
+      it "returns activity logs for the specified activity source" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:activity_source]).to eq(activity_log.activity_source)
+      end
+    end
+
+    context "when filtering by from_date" do
+      let(:params) { {from_date: activity_log.logged_at.iso8601} }
+
+      it "returns activity logs for the specified date range" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
+        expect(json[:activity_logs].first[:logged_at]).to eq(activity_log.logged_at.iso8601)
+      end
+    end
+
+    context "when filtering by to_date" do
+      let(:params) { {to_date: activity_log.logged_at.iso8601} }
+
+      it "returns activity logs for the specified date range" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:activity_logs].first[:activity_id]).to eq(invoice_activity_log.activity_id)
+        expect(json[:activity_logs].first[:logged_at]).to eq(invoice_activity_log.logged_at.iso8601)
+      end
+    end
+
+    context "with pagination" do
+      let(:params) { {page: 1, per_page: 1} }
+
+      it "returns activity logs with correct meta data" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:activity_logs].count).to eq(1)
+        expect(json[:meta][:current_page]).to eq(1)
+        expect(json[:meta][:next_page]).to eq(2)
+        expect(json[:meta][:prev_page]).to eq(nil)
+        expect(json[:meta][:total_pages]).to eq(2)
+        expect(json[:meta][:total_count]).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/activity_logs_controller_spec.rb
+++ b/spec/requests/api/v1/activity_logs_controller_spec.rb
@@ -3,6 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::ActivityLogsController, type: :request, clickhouse: true do
+  let(:organization) { activity_log.organization }
+  let(:params) { {} }
+
   describe "GET /api/v1/activity_logs" do
     subject { get_with_token(organization, "/api/v1/activity_logs", params) }
 
@@ -20,8 +23,6 @@ RSpec.describe Api::V1::ActivityLogsController, type: :request, clickhouse: true
         logged_at: 1.day.ago
       )
     end
-    let(:organization) { activity_log.organization }
-    let(:params) { {} }
 
     before do
       activity_log
@@ -169,6 +170,24 @@ RSpec.describe Api::V1::ActivityLogsController, type: :request, clickhouse: true
         expect(json[:meta][:total_pages]).to eq(2)
         expect(json[:meta][:total_count]).to eq(2)
       end
+    end
+  end
+
+  describe "GET /api/v1/activity_logs/:activity_id" do
+    subject { get_with_token(organization, "/api/v1/activity_logs/#{activity_log.activity_id}", params) }
+
+    let(:activity_log) { create(:clickhouse_activity_log) }
+
+    include_examples "requires API permission", "activity_log", "read"
+
+    it "returns activity logs" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:activity_log][:activity_id]).to eq(activity_log.activity_id)
+      expect(json[:activity_log][:activity_source]).to eq(activity_log.activity_source)
+      expect(json[:activity_log][:resource_type]).to eq(activity_log.resource_type)
+      expect(json[:activity_log][:external_customer_id]).to eq(activity_log.external_customer_id)
     end
   end
 end

--- a/spec/serializers/v1/activity_log_serializer_spec.rb
+++ b/spec/serializers/v1/activity_log_serializer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::V1::ActivityLogSerializer, clickhouse: true do
+  subject(:serializer) { described_class.new(activity_log, root_name: "activity_log") }
+
+  let(:activity_log) { create(:clickhouse_activity_log) }
+
+  it "serializes the object" do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result["activity_log"]["lago_user_id"]).to eq(activity_log.user_id)
+      expect(result["activity_log"]["resource_id"]).to eq(activity_log.resource_id)
+      expect(result["activity_log"]["resource_type"]).to eq(activity_log.resource_type)
+      expect(result["activity_log"]["activity_type"]).to eq(activity_log.activity_type)
+      expect(result["activity_log"]["activity_source"]).to eq(activity_log.activity_source)
+      expect(result["activity_log"]["logged_at"]).to eq(activity_log.logged_at.iso8601)
+      # expect(result["activity_log"]["resource"]).to eq(activity_log.resource)
+      # expect(result["activity_log"]["resource_changes"]).to eq(activity_log.resource_changes)
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context
Our users want to have visibility on what’s happening in Lago.

Examples:

A plan and prices have been updated: When? By whom? What?
A subscription has been deleted: When? By whom? What?

## Description

The goal of this PR is to create the a new Graphql classes for activity_logs, so they can presented on Front.