### PR TITLE
refactor(billing): Breakdown RecalculateAndCheckService to inject current_usage

### DIFF
--- a/app/jobs/lifetime_usages/recalculate_and_check_job.rb
+++ b/app/jobs/lifetime_usages/recalculate_and_check_job.rb
@@ -13,7 +13,8 @@ module LifetimeUsages
     unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
 
     def perform(lifetime_usage)
-      LifetimeUsages::RecalculateAndCheckService.call(lifetime_usage:)
+      LifetimeUsages::CalculateService.call!(lifetime_usage:)
+      LifetimeUsages::CheckThresholdsService.call(lifetime_usage:)
     end
   end
 end

--- a/app/services/lifetime_usages/calculate_service.rb
+++ b/app/services/lifetime_usages/calculate_service.rb
@@ -2,8 +2,9 @@
 
 module LifetimeUsages
   class CalculateService < BaseService
-    def initialize(lifetime_usage:)
+    def initialize(lifetime_usage:, current_usage: nil)
       @lifetime_usage = lifetime_usage
+      @current_usage = current_usage
       super
     end
 
@@ -54,12 +55,15 @@ module LifetimeUsages
     end
 
     def calculate_current_usage_amount_cents
-      result = Invoices::CustomerUsageService.call(
+      current_usage.amount_cents
+    end
+
+    def current_usage
+      @current_usage ||= Invoices::CustomerUsageService.call(
         customer: subscription.customer,
         subscription: subscription,
         apply_taxes: false
-      )
-      result.usage.amount_cents
+      ).usage
     end
 
     attr_accessor :lifetime_usage

--- a/app/services/lifetime_usages/check_thresholds_service.rb
+++ b/app/services/lifetime_usages/check_thresholds_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module LifetimeUsages
-  class RecalculateAndCheckService < BaseService
+  class CheckThresholdsService < BaseService
     Result = BaseResult[:invoice]
 
     def initialize(lifetime_usage:)
@@ -11,8 +11,8 @@ module LifetimeUsages
     end
 
     def call
-      LifetimeUsages::CalculateService.call!(lifetime_usage:)
       usage_thresholds = LifetimeUsages::UsageThresholds::CheckService.call!(lifetime_usage:, progressive_billed_amount:).passed_thresholds
+
       if usage_thresholds.any?
         usage_thresholds.each do |usage_threshold|
           SendWebhookJob.perform_later("subscription.usage_threshold_reached", subscription, usage_threshold:)

--- a/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
+++ b/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe LifetimeUsages::RecalculateAndCheckJob, type: :job do
   let(:lifetime_usage) { create(:lifetime_usage) }
 
   it "delegates to the RecalculateAndCheck service" do
-    allow(LifetimeUsages::RecalculateAndCheckService).to receive(:call)
+    allow(LifetimeUsages::CalculateService).to receive(:call!)
+    allow(LifetimeUsages::CheckThresholdsService).to receive(:call)
     described_class.perform_now(lifetime_usage)
-    expect(LifetimeUsages::RecalculateAndCheckService).to have_received(:call).with(lifetime_usage:)
+    expect(LifetimeUsages::CalculateService).to have_received(:call!).with(lifetime_usage:)
+    expect(LifetimeUsages::CheckThresholdsService).to have_received(:call).with(lifetime_usage:)
   end
 end


### PR DESCRIPTION
## Description

[Alerting](https://github.com/getlago/lago-api/pull/3510) is coming and we need to calculate CurrentUsage only once  per subscription for all services.
This PR breaks down `RecalculateAndCheckService` into 2 services:

* `CalculateService`: was already there but current_usage can be injected (not used yet)
* `CheckThresholdsService`: The same as RecalculateAndCheckService except I removed the inner call to `CalculateService`.