### PR TITLE
chore(ci): Set permissions to none

### DIFF
--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+permissions: { }
 jobs:
   build-api-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,6 +1,6 @@
 name: Linters
 on: [pull_request]
-
+permissions: { }
 jobs:
   linters:
     name: Linters

--- a/.github/workflows/migrations-test.yml
+++ b/.github/workflows/migrations-test.yml
@@ -5,6 +5,7 @@ on:
       - "main"
   pull_request:
     types: [opened, synchronize, reopened]
+permissions: { }
 jobs:
   run-migrations:
     name: Run migrations

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
         required: true
 env:
   REGISTRY_IMAGE: getlago/api
-
+permissions: { }
 jobs:
   build-images:
     strategy:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -5,6 +5,7 @@ on:
       - "main"
   pull_request:
     types: [opened, synchronize, reopened]
+permissions: { }
 jobs:
   run-spec:
     name: Run Spec


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/{{FEATURE_SLUG}}

## Context

> If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.

See: https://github.com/getlago/lago-api/security/code-scanning/16

## Description

I think we don't need any "GitHub Actions permissions" so I disabled it, let's see.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
