### PR TITLE
Feat(multientities): refresh draft invoices when manage taxes on billing entity

### DIFF
--- a/app/services/billing_entities/taxes/apply_taxes_service.rb
+++ b/app/services/billing_entities/taxes/apply_taxes_service.rb
@@ -23,6 +23,7 @@ module BillingEntities
             .create_with(organization_id: tax.organization_id)
             .find_or_create_by!(tax:)
         end
+        refresh_draft_invoices
 
         result
       end

--- a/app/services/billing_entities/taxes/base_service.rb
+++ b/app/services/billing_entities/taxes/base_service.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module BillingEntities
+  module Taxes
+    class BaseService < BaseService
+      private
+
+      attr_reader :billing_entity
+
+      def refresh_draft_invoices
+        draft_invoice_ids = billing_entity.invoices.draft.pluck(:id)
+
+        Invoice.where(id: draft_invoice_ids).update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+  end
+end

--- a/app/services/billing_entities/taxes/manage_taxes_service.rb
+++ b/app/services/billing_entities/taxes/manage_taxes_service.rb
@@ -15,6 +15,7 @@ module BillingEntities
         return result.not_found_failure!(resource: "billing_entity") unless billing_entity
 
         manage_taxes
+        refresh_draft_invoices
         result
       end
 

--- a/app/services/billing_entities/taxes/remove_taxes_service.rb
+++ b/app/services/billing_entities/taxes/remove_taxes_service.rb
@@ -19,6 +19,7 @@ module BillingEntities
         return result if result.failure?
 
         billing_entity.applied_taxes.where(tax: result.taxes_to_remove).destroy_all
+        refresh_draft_invoices
 
         result
       end

--- a/spec/services/billing_entities/taxes/manage_taxes_service_spec.rb
+++ b/spec/services/billing_entities/taxes/manage_taxes_service_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe BillingEntities::Taxes::ManageTaxesService do
 
           expect(billing_entity.taxes).to eq([tax1, tax2])
         end
+
+        context "when there are draft invoices in this billing_entity" do
+          let(:invoice1) { create(:invoice, :draft, organization:, billing_entity:) }
+          let(:invoice2) { create(:invoice, organization:, billing_entity:) }
+
+          before do
+            invoice1
+            invoice2
+          end
+
+          it "sets to refresh draft invoice of this billing entity" do
+            service.call
+            expect(invoice1.reload.ready_to_be_refreshed).to be_truthy
+            expect(invoice2.reload.ready_to_be_refreshed).to be_falsey
+          end
+        end
       end
 
       context "when tax codes contain duplicates" do

--- a/spec/services/billing_entities/taxes/remove_taxes_service_spec.rb
+++ b/spec/services/billing_entities/taxes/remove_taxes_service_spec.rb
@@ -28,6 +28,22 @@ RSpec.describe BillingEntities::Taxes::RemoveTaxesService do
         expect(result).to be_success
       end
 
+      context "when there are draft invoices in this billing entity" do
+        let(:invoice1) { create(:invoice, :draft, organization:, billing_entity:) }
+        let(:invoice2) { create(:invoice, organization:, billing_entity:) }
+
+        before do
+          invoice1
+          invoice2
+        end
+
+        it "sets to refresh draft invoice of this billing entity" do
+          service.call
+          expect(invoice1.reload.ready_to_be_refreshed).to be_truthy
+          expect(invoice2.reload.ready_to_be_refreshed).to be_falsey
+        end
+      end
+
       context "when some taxes are not applied to the billing entity" do
         before do
           billing_entity.applied_taxes.where(tax: tax2).destroy_all


### PR DESCRIPTION
## Context

Since we're deprecating `applied_to_organization` field on organization, the draft invoices should be refreshed when:
- tax is updated on organization
- tax is applied or removed on applied to billing_entity

## Description

- added refresh_draft_invoices method to all manage taxes on billing_entity services
