### PR TITLE
misc: Add organization_id field on charges

### DIFF
--- a/app/jobs/database_migrations/populate_charges_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_charges_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateChargesWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Charge.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM plans WHERE plans.id = charges.plan_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -6,6 +6,7 @@ class Charge < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
+  belongs_to :organization, optional: true
   belongs_to :plan, -> { with_discarded }, touch: true
   belongs_to :billable_metric, -> { with_discarded }
   belongs_to :parent, class_name: "Charge", optional: true
@@ -184,6 +185,7 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  billable_metric_id   :uuid
+#  organization_id      :uuid
 #  parent_id            :uuid
 #  plan_id              :uuid
 #
@@ -191,6 +193,7 @@ end
 #
 #  index_charges_on_billable_metric_id  (billable_metric_id) WHERE (deleted_at IS NULL)
 #  index_charges_on_deleted_at          (deleted_at)
+#  index_charges_on_organization_id     (organization_id)
 #  index_charges_on_parent_id           (parent_id)
 #  index_charges_on_plan_id             (plan_id)
 #  index_charges_pay_in_advance         (billable_metric_id) WHERE ((deleted_at IS NULL) AND (pay_in_advance = true))
@@ -198,6 +201,7 @@ end
 # Foreign Keys
 #
 #  fk_rails_...  (billable_metric_id => billable_metrics.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (parent_id => charges.id)
 #  fk_rails_...  (plan_id => plans.id)
 #

--- a/app/services/charges/create_service.rb
+++ b/app/services/charges/create_service.rb
@@ -14,6 +14,7 @@ module Charges
 
       ActiveRecord::Base.transaction do
         charge = plan.charges.new(
+          organization_id: plan.organization_id,
           billable_metric_id: params[:billable_metric_id],
           invoice_display_name: params[:invoice_display_name],
           amount_currency: params[:amount_currency],

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -104,6 +104,7 @@ module Plans
 
     def create_charge(plan, args)
       charge = plan.charges.new(
+        organization_id: plan.organization_id,
         billable_metric_id: args[:billable_metric_id],
         invoice_display_name: args[:invoice_display_name],
         charge_model: charge_model(args),

--- a/db/migrate/20250424135624_add_organization_id_to_charges.rb
+++ b/db/migrate/20250424135624_add_organization_id_to_charges.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToCharges < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :charges, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250424140359_add_organization_id_fk_to_charges.rb
+++ b/db/migrate/20250424140359_add_organization_id_fk_to_charges.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToCharges < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :charges, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250424140537_validate_charges_organizations_foreign_key.rb
+++ b/db/migrate/20250424140537_validate_charges_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateChargesOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :charges, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -96,6 +96,7 @@ ALTER TABLE IF EXISTS ONLY public.password_resets DROP CONSTRAINT IF EXISTS fk_r
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_521b5240ed;
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_51ac39a0c6;
 ALTER TABLE IF EXISTS ONLY public.payment_provider_customers DROP CONSTRAINT IF EXISTS fk_rails_50d46d3679;
+ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_4934f27a06;
 ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_4117574b51;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_3ff27d7624;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_3f7be5debc;
@@ -373,6 +374,7 @@ DROP INDEX IF EXISTS public.index_charges_taxes_on_charge_id;
 DROP INDEX IF EXISTS public.index_charges_pay_in_advance;
 DROP INDEX IF EXISTS public.index_charges_on_plan_id;
 DROP INDEX IF EXISTS public.index_charges_on_parent_id;
+DROP INDEX IF EXISTS public.index_charges_on_organization_id;
 DROP INDEX IF EXISTS public.index_charges_on_deleted_at;
 DROP INDEX IF EXISTS public.index_charges_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_charge_filters_on_deleted_at;
@@ -1199,7 +1201,8 @@ CREATE TABLE public.charges (
     prorated boolean DEFAULT false NOT NULL,
     invoice_display_name character varying,
     regroup_paid_fees integer,
-    parent_id uuid
+    parent_id uuid,
+    organization_id uuid
 );
 
 
@@ -4354,6 +4357,13 @@ CREATE INDEX index_charges_on_deleted_at ON public.charges USING btree (deleted_
 
 
 --
+-- Name: index_charges_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_charges_on_organization_id ON public.charges USING btree (organization_id);
+
+
+--
 -- Name: index_charges_on_parent_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6282,6 +6292,14 @@ ALTER TABLE ONLY public.credit_notes
 
 
 --
+-- Name: charges fk_rails_4934f27a06; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.charges
+    ADD CONSTRAINT fk_rails_4934f27a06 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: payment_provider_customers fk_rails_50d46d3679; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -6984,6 +7002,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250424140537'),
+('20250424140359'),
+('20250424135624'),
 ('20250415143607'),
 ('20250414122904'),
 ('20250414122643'),

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Charge, type: :model do
 
   it_behaves_like "paper_trail traceable"
 
+  it { is_expected.to belong_to(:organization).optional }
   it { is_expected.to have_many(:filters).dependent(:destroy) }
 
   describe "#validate_graduated" do

--- a/spec/services/charges/create_service_spec.rb
+++ b/spec/services/charges/create_service_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Charges::CreateService, type: :service do
 
           expect(plan.reload.charges.graduated_percentage.first).to have_attributes(
             {
+              organization_id: organization.id,
               pay_in_advance: false,
               invoiceable: true,
               charge_model: "graduated_percentage"
@@ -120,6 +121,7 @@ RSpec.describe Charges::CreateService, type: :service do
           stored_charge = plan.reload.charges.first
 
           expect(stored_charge.reload).to have_attributes(
+            organization_id: organization.id,
             prorated: true,
             pay_in_advance: false,
             parent_id: parent_charge.id,
@@ -152,7 +154,11 @@ RSpec.describe Charges::CreateService, type: :service do
 
             stored_charge = plan.reload.charges.first
 
-            expect(stored_charge).to have_attributes(invoiceable: false, min_amount_cents: 10)
+            expect(stored_charge).to have_attributes(
+              organization_id: organization.id,
+              invoiceable: false,
+              min_amount_cents: 10
+            )
           end
         end
       end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -179,6 +179,7 @@ RSpec.describe Plans::CreateService, type: :service do
       graduated_charge = plan.charges.graduated.first
 
       expect(standard_charge).to have_attributes(
+        organization_id: organization.id,
         pay_in_advance: false,
         prorated: false,
         min_amount_cents: 0,
@@ -195,7 +196,12 @@ RSpec.describe Plans::CreateService, type: :service do
         values: ["card"]
       )
 
-      expect(graduated_charge).to have_attributes(pay_in_advance: true, invoiceable: true, prorated: false)
+      expect(graduated_charge).to have_attributes(
+        organization_id: organization.id,
+        pay_in_advance: true,
+        invoiceable: true,
+        prorated: false
+      )
     end
 
     it "calls SegmentTrackJob" do
@@ -273,6 +279,7 @@ RSpec.describe Plans::CreateService, type: :service do
 
         expect(plan.charges.standard.first).to have_attributes(
           {
+            organization_id: organization.id,
             pay_in_advance: false,
             min_amount_cents: 100,
             invoiceable: true
@@ -281,6 +288,7 @@ RSpec.describe Plans::CreateService, type: :service do
 
         expect(plan.charges.graduated_percentage.first).to have_attributes(
           {
+            organization_id: organization.id,
             pay_in_advance: true,
             invoiceable: false,
             regroup_paid_fees: "invoice",


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `charges` table. For now the field allows null values. It will be back-filled in a later pull request and then updated to ensure the presence of a value (not null)