### PR TITLE
fix(invoice-preview): Handle downgraded subscriptions in invoice previews

### DIFF
--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -217,7 +217,7 @@ module Invoices
     end
 
     def create_credit_note_credits
-      terminated_subscription = subscriptions.find(&:terminated?)
+      terminated_subscription = subscriptions.none?(&:downgraded?) ? subscriptions.find(&:terminated?) : nil
       credits = Preview::CreditsService.call!(invoice:, terminated_subscription:).credits
 
       invoice.credits << credits

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -465,7 +465,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
               Rails.cache.clear
             end
 
-            it "creates preview invoice for 1 day" do
+            it "creates preview invoice" do
               # only charges from March (3 days), full April billed by new plan
 
               travel_to(Time.zone.parse("30 Mar 2024 05:00")) do

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -241,8 +241,6 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 customer:,
                 plan:,
                 billing_time:,
-                status: "terminated",
-                terminated_at: timestamp + 15.hours,
                 subscription_at: timestamp,
                 started_at: timestamp,
                 created_at: timestamp
@@ -271,7 +269,12 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
             end
 
             before do
-              events if subscription
+              subscription.assign_attributes(
+                status: "terminated",
+                terminated_at: timestamp + 15.hours
+              )
+
+              events
               charge
               Rails.cache.clear
             end
@@ -306,8 +309,6 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 customer:,
                 plan:,
                 billing_time:,
-                status: "terminated",
-                terminated_at: timestamp + 15.hours,
                 subscription_at: timestamp,
                 started_at: timestamp,
                 created_at: timestamp
@@ -362,7 +363,7 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 terminated_at: timestamp + 15.hours
               )
 
-              events if terminated_subscription
+              events
               charge
               Rails.cache.clear
             end
@@ -383,6 +384,104 @@ RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
                 expect(result.invoice.taxes_amount_cents).to eq(18)
                 expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(53)
                 expect(result.invoice.total_amount_cents).to eq(53)
+              end
+            end
+          end
+
+          context "when subscription is downgraded" do
+            let(:timestamp) { Time.zone.parse("29 Mar 2024") }
+            let(:rotate_timestamp) { Time.zone.parse("1 Apr 2024 01:00") }
+            let(:plan) { create(:plan, organization:, interval: "monthly", pay_in_advance: true) }
+            let(:plan_new) { create(:plan, organization:, interval: "monthly", amount_cents: 50, pay_in_advance: true) }
+            let(:subscriptions) { [terminated_subscription, downgraded_subscription] }
+
+            let(:terminated_subscription) do
+              create(
+                :subscription,
+                customer:,
+                plan:,
+                billing_time:,
+                subscription_at: timestamp,
+                started_at: timestamp,
+                created_at: timestamp
+              )
+            end
+
+            let(:downgraded_subscription) do
+              build(
+                :subscription,
+                customer:,
+                plan: plan_new,
+                billing_time:,
+                status: "active",
+                subscription_at: rotate_timestamp,
+                started_at: rotate_timestamp,
+                created_at: rotate_timestamp
+              )
+            end
+
+            let(:billable_metric) do
+              create(:billable_metric, aggregation_type: "sum_agg", recurring: true, field_name: "amount")
+            end
+
+            let(:charge) do
+              create(
+                :standard_charge,
+                plan:,
+                billable_metric:,
+                pay_in_advance: false,
+                prorated: true,
+                properties: {amount: "1"}
+              )
+            end
+
+            let(:events) do
+              create_pair(
+                :event,
+                organization:,
+                subscription: terminated_subscription,
+                customer:,
+                code: billable_metric.code,
+                timestamp: timestamp + 5.hours,
+                properties: {amount: "5"}
+              )
+            end
+
+            before do
+              BillSubscriptionJob.perform_now(
+                [terminated_subscription],
+                timestamp.to_i,
+                invoicing_reason: :subscription_starting
+              )
+
+              terminated_subscription.assign_attributes(
+                status: "terminated",
+                terminated_at: rotate_timestamp,
+                next_subscriptions: [downgraded_subscription]
+              )
+
+              events
+              charge
+              Rails.cache.clear
+            end
+
+            it "creates preview invoice for 1 day" do
+              # only charges from March (3 days), full April billed by new plan
+
+              travel_to(Time.zone.parse("30 Mar 2024 05:00")) do
+                result = preview_service.call
+
+                expect(result).to be_success
+                expect(result.invoice.subscriptions.size).to eq(2)
+                expect(result.invoice.fees.length).to eq(2)
+                expect(result.invoice.invoice_type).to eq("subscription")
+                expect(result.invoice.issuing_date.to_s).to eq("2024-04-01")
+                expect(result.invoice.fees_amount_cents).to eq(147) # 97 (charges) + 50 (new plan) = 147
+                expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(147)
+                expect(result.invoice.taxes_amount_cents).to eq(74) # 49 (charges) + 25 (new plan) = 90
+                expect(result.invoice.credit_notes_amount_cents).to eq(0)
+                expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(221)
+                expect(result.invoice.total_amount_cents).to eq(221)
               end
             end
           end


### PR DESCRIPTION
## Context

Currently we're generating credit note for case when we simulate subscription downgrade. That was creating issues since for downgrade case existing subscription always billed for full billing period and there's nothing to refund.

## Description

Adjust logic in `Invoices::PreviewService` to skip credit note generation for terminated subscription if it's downgrade case.
