### PR TITLE
chore(rubocop): Disable Rails/SkipsModelValidations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,9 @@ RSpec/NestedGroups:
 RSpec/NamedSubject:
   Enabled: false
 
+Rails/SkipsModelValidations:
+  Enabled: false
+
 # GraphQL
 
 GraphQL/ArgumentDescription:

--- a/app/jobs/billable_metrics/delete_events_job.rb
+++ b/app/jobs/billable_metrics/delete_events_job.rb
@@ -15,7 +15,7 @@ module BillableMetrics
         subscription_id: Charge.with_discarded
           .where(billable_metric_id: metric.id)
           .joins(plan: :subscriptions).pluck("subscriptions.id")
-      ).update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
+      ).update_all(deleted_at:)
 
       # Delete events using the new `external_subscription_id`
       Event.where(
@@ -24,7 +24,7 @@ module BillableMetrics
         external_subscription_id: Charge.with_discarded
           .where(billable_metric_id: metric.id)
           .joins(plan: :subscriptions).pluck("subscriptions.external_id")
-      ).update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
+      ).update_all(deleted_at:)
 
       # Delete events_raw & events_enriched on clickhouse using `external_subscription_id`
       if ENV["LAGO_CLICKHOUSE_ENABLED"].present?

--- a/app/jobs/database_migrations/fix_invoices_organization_sequential_id_job.rb
+++ b/app/jobs/database_migrations/fix_invoices_organization_sequential_id_job.rb
@@ -12,7 +12,7 @@ module DatabaseMigrations
         next if last_organization_sequential_id == invoices_count
 
         last_invoice = organization.invoices.non_self_billed.with_generated_number.order(created_at: :desc).limit(1)
-        last_invoice.update_all(organization_sequential_id: invoices_count) # rubocop:disable Rails/SkipsModelValidations
+        last_invoice.update_all(organization_sequential_id: invoices_count)
       end
     end
   end

--- a/app/jobs/database_migrations/populate_charges_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_charges_with_organization_job.rb
@@ -13,9 +13,8 @@ module DatabaseMigrations
         .limit(BATCH_SIZE)
 
       if batch.exists?
-        # rubocop:disable Rails/SkipsModelValidations
+
         batch.update_all("organization_id = (SELECT organization_id FROM plans WHERE plans.id = charges.plan_id)")
-        # rubocop:enable Rails/SkipsModelValidations
 
         # Queue the next batch
         self.class.perform_later(batch_number + 1)

--- a/app/jobs/database_migrations/populate_fees_with_billing_entity_id_job.rb
+++ b/app/jobs/database_migrations/populate_fees_with_billing_entity_id_job.rb
@@ -11,9 +11,8 @@ module DatabaseMigrations
       batch = Fee.unscoped.where(billing_entity_id: nil).limit(BATCH_SIZE)
 
       if batch.exists?
-        # rubocop:disable Rails/SkipsModelValidations
+
         batch.update_all("billing_entity_id = organization_id")
-        # rubocop:enable Rails/SkipsModelValidations
 
         # Queue the next batch
         self.class.perform_later(batch_number + 1)

--- a/app/jobs/database_migrations/populate_fees_with_organization_from_invoice_job.rb
+++ b/app/jobs/database_migrations/populate_fees_with_organization_from_invoice_job.rb
@@ -12,12 +12,11 @@ module DatabaseMigrations
         .joins(:invoice).limit(BATCH_SIZE)
 
       if batch.exists?
-        # rubocop:disable Rails/SkipsModelValidations
+
         batch.update_all(
           "organization_id = (SELECT organization_id FROM invoices WHERE invoices.id = fees.invoice_id),
            billing_entity_id = (SELECT organization_id FROM invoices WHERE invoices.id = fees.invoice_id)"
         )
-        # rubocop:enable Rails/SkipsModelValidations
 
         # Queue the next batch
         self.class.perform_later(batch_number + 1)

--- a/app/jobs/database_migrations/populate_fees_with_organization_from_subscription_job.rb
+++ b/app/jobs/database_migrations/populate_fees_with_organization_from_subscription_job.rb
@@ -12,7 +12,7 @@ module DatabaseMigrations
         .joins(subscription: :customer).limit(BATCH_SIZE)
 
       if batch.exists?
-        # rubocop:disable Rails/SkipsModelValidations
+
         batch.update_all(
           "organization_id = (SELECT customers.organization_id FROM subscriptions
                             JOIN customers ON customers.id = subscriptions.customer_id
@@ -21,7 +21,6 @@ module DatabaseMigrations
                               JOIN customers ON customers.id = subscriptions.customer_id
                               WHERE subscriptions.id = fees.subscription_id)"
         )
-        # rubocop:enable Rails/SkipsModelValidations
         # Queue the next batch
         self.class.perform_later(batch_number + 1)
       else

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -243,7 +243,7 @@ class Customer < ApplicationRecord
   end
 
   def flag_wallets_for_refresh
-    wallets.active.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+    wallets.active.update_all(ready_to_be_refreshed: true)
   end
 
   private

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -37,7 +37,7 @@ class DunningCampaign < ApplicationRecord
 
   def reset_customers_last_attempt
     # NOTE: Reset last attempt on customers with the campaign applied explicitly
-    customers.update_all( # rubocop:disable Rails/SkipsModelValidations
+    customers.update_all(
       last_dunning_campaign_attempt: 0,
       last_dunning_campaign_attempt_at: nil
     )

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -177,7 +177,7 @@ class Organization < ApplicationRecord
   def reset_customers_last_dunning_campaign_attempt
     customers
       .falling_back_to_default_dunning_campaign
-      .update_all( # rubocop:disable Rails/SkipsModelValidations
+      .update_all(
         last_dunning_campaign_attempt: 0,
         last_dunning_campaign_attempt_at: nil
       )

--- a/app/services/api_keys/destroy_service.rb
+++ b/app/services/api_keys/destroy_service.rb
@@ -16,7 +16,7 @@ module ApiKeys
         return result.single_validation_failure!(error_code: "last_non_expiring_api_key")
       end
 
-      api_key.touch(:expires_at) # rubocop:disable Rails/SkipsModelValidations
+      api_key.touch(:expires_at)
 
       ApiKeyMailer.with(api_key:).destroyed.deliver_later
       ApiKeys::CacheService.expire_cache(api_key.value)

--- a/app/services/api_keys/track_usage_service.rb
+++ b/app/services/api_keys/track_usage_service.rb
@@ -9,7 +9,7 @@ module ApiKeys
 
         next unless last_used_at
 
-        api_key.update_columns(last_used_at:) # rubocop:disable Rails/SkipsModelValidations
+        api_key.update_columns(last_used_at:)
         Rails.cache.delete(cache_key)
       end
     end

--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -92,7 +92,7 @@ module BillableMetricFilters
         .where(billable_metrics: {id: billable_metric.id})
         .distinct
 
-      draft_invoices.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+      draft_invoices.update_all(ready_to_be_refreshed: true)
     end
   end
 end

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -21,7 +21,7 @@ module BillableMetrics
 
         discard_filters
 
-        Invoice.where(id: draft_invoice_ids).update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+        Invoice.where(id: draft_invoice_ids).update_all(ready_to_be_refreshed: true)
       end
 
       # NOTE: Discard all related events asynchronously.

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -43,7 +43,7 @@ module ChargeFilters
             end
 
             if parent_filter.blank? || parent_filter_properties(parent_filter) != filter.properties
-              filter.touch # rubocop:disable Rails/SkipsModelValidations
+              filter.touch
               result.filters << filter
 
               next
@@ -59,7 +59,7 @@ module ChargeFilters
           ).properties
           if filter.save! && touch && !filter.changed?
             # NOTE: Make sure update_at is touched even if not changed to keep the right order
-            filter.touch # rubocop:disable Rails/SkipsModelValidations
+            filter.touch
           end
 
           # NOTE: Create or update the filter values
@@ -73,7 +73,7 @@ module ChargeFilters
             filter_value.values = values
             if filter_value.save! && touch && !filter_value.changed?
               # NOTE: Make sure update_at is touched even if not changed to keep the right order
-              filter_value.touch # rubocop:disable Rails/SkipsModelValidations
+              filter_value.touch
             end
           end
 

--- a/app/services/customers/apply_taxes_service.rb
+++ b/app/services/customers/apply_taxes_service.rb
@@ -21,7 +21,7 @@ module Customers
         customer.applied_taxes.find_or_create_by!(tax: taxes.find_by(code: tax_code))
       end
 
-      customer.invoices.draft.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+      customer.invoices.draft.update_all(ready_to_be_refreshed: true)
 
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/dunning_campaigns/create_service.rb
+++ b/app/services/dunning_campaigns/create_service.rb
@@ -16,7 +16,7 @@ module DunningCampaigns
       ActiveRecord::Base.transaction do
         if params[:applied_to_organization]
           organization.dunning_campaigns.applied_to_organization
-            .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
+            .update_all(applied_to_organization: false)
 
           organization.reset_customers_last_dunning_campaign_attempt
         end

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -100,11 +100,11 @@ module DunningCampaigns
       organization
         .dunning_campaigns
         .applied_to_organization
-        .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
+        .update_all(applied_to_organization: false)
 
       organization.reset_customers_last_dunning_campaign_attempt
 
-      customers_fallback_campaign.update_all( # rubocop:disable Rails/SkipsModelValidations
+      customers_fallback_campaign.update_all(
         last_dunning_campaign_attempt_at: nil,
         last_dunning_campaign_attempt: 0
       )

--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -82,7 +82,7 @@ module Invoices
           is.subscription.fees
             .where(invoice: nil, payment_status: :succeeded)
             .where("succeeded_at <= ?", is.timestamp)
-            .update_all(invoice_id: invoice.id) # rubocop:disable Rails/SkipsModelValidations
+            .update_all(invoice_id: invoice.id)
         end
 
         if invoice.fees.empty?

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -72,7 +72,7 @@ module Invoices
         end
 
         # NOTE: In case of a refresh the same day of the termination.
-        invoice.fees.update_all(created_at: invoice.created_at) # rubocop:disable Rails/SkipsModelValidations
+        invoice.fees.update_all(created_at: invoice.created_at)
 
         return result if tax_error?(calculate_result.error)
 
@@ -117,7 +117,7 @@ module Invoices
     end
 
     def reset_invoice_values
-      invoice.credit_notes.each { |cn| cn.items.update_all(fee_id: nil) } # rubocop:disable Rails/SkipsModelValidations
+      invoice.credit_notes.each { |cn| cn.items.update_all(fee_id: nil) }
       invoice.fees.destroy_all
       invoice_subscriptions.destroy_all
       invoice.applied_taxes.destroy_all

--- a/app/services/lifetime_usages/flag_refresh_from_plan_update_service.rb
+++ b/app/services/lifetime_usages/flag_refresh_from_plan_update_service.rb
@@ -12,7 +12,7 @@ module LifetimeUsages
     def call
       result.updated_lifetime_usages = LifetimeUsage
         .where(subscription_id: plan.subscriptions.active.select(:id))
-        .update_all(recalculate_invoiced_usage: true) # rubocop:disable Rails/SkipsModelValidations
+        .update_all(recalculate_invoiced_usage: true)
       result
     end
 

--- a/app/services/payment_providers/adyen_service.rb
+++ b/app/services/payment_providers/adyen_service.rb
@@ -32,7 +32,7 @@ module PaymentProviders
       adyen_provider.save!
 
       if payment_provider_code_changed?(adyen_provider, old_code, args)
-        adyen_provider.customers.update_all(payment_provider_code: args[:code]) # rubocop:disable Rails/SkipsModelValidations
+        adyen_provider.customers.update_all(payment_provider_code: args[:code])
       end
 
       result.adyen_provider = adyen_provider

--- a/app/services/payment_providers/cashfree_service.rb
+++ b/app/services/payment_providers/cashfree_service.rb
@@ -33,7 +33,7 @@ module PaymentProviders
       cashfree_provider.save!
 
       if payment_provider_code_changed?(cashfree_provider, old_code, args)
-        cashfree_provider.customers.update_all(payment_provider_code: args[:code]) # rubocop:disable Rails/SkipsModelValidations
+        cashfree_provider.customers.update_all(payment_provider_code: args[:code])
       end
 
       result.cashfree_provider = cashfree_provider

--- a/app/services/payment_providers/destroy_service.rb
+++ b/app/services/payment_providers/destroy_service.rb
@@ -14,10 +14,10 @@ module PaymentProviders
       customer_ids = payment_provider.customer_ids
 
       ActiveRecord::Base.transaction do
-        payment_provider.payment_provider_customers.update_all(payment_provider_id: nil) # rubocop:disable Rails/SkipsModelValidations
+        payment_provider.payment_provider_customers.update_all(payment_provider_id: nil)
         payment_provider.discard!
 
-        Customer.where(id: customer_ids).update_all(payment_provider: nil, payment_provider_code: nil) # rubocop:disable Rails/SkipsModelValidations
+        Customer.where(id: customer_ids).update_all(payment_provider: nil, payment_provider_code: nil)
       end
 
       result.payment_provider = payment_provider

--- a/app/services/payment_providers/gocardless_service.rb
+++ b/app/services/payment_providers/gocardless_service.rb
@@ -35,7 +35,7 @@ module PaymentProviders
       gocardless_provider.save!
 
       if payment_provider_code_changed?(gocardless_provider, old_code, args)
-        gocardless_provider.customers.update_all(payment_provider_code: args[:code]) # rubocop:disable Rails/SkipsModelValidations
+        gocardless_provider.customers.update_all(payment_provider_code: args[:code])
       end
 
       result.gocardless_provider = gocardless_provider

--- a/app/services/payment_providers/moneyhash_service.rb
+++ b/app/services/payment_providers/moneyhash_service.rb
@@ -44,7 +44,7 @@ module PaymentProviders
       moneyhash_provider.save(validate: false)
 
       if payment_provider_code_changed?(moneyhash_provider, old_code, args)
-        moneyhash_provider.customers.update_all(payment_provider_code: args[:code]) # rubocop:disable Rails/SkipsModelValidations
+        moneyhash_provider.customers.update_all(payment_provider_code: args[:code])
       end
 
       result.moneyhash_provider = moneyhash_provider

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -35,7 +35,7 @@ module PaymentProviders
       end
 
       if payment_provider_code_changed?(stripe_provider, old_code, args)
-        stripe_provider.customers.update_all(payment_provider_code: args[:code]) # rubocop:disable Rails/SkipsModelValidations
+        stripe_provider.customers.update_all(payment_provider_code: args[:code])
       end
 
       result.stripe_provider = stripe_provider

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -60,7 +60,7 @@ module Plans
 
       cascade_subscription_fee_update(old_amount_cents)
 
-      plan.invoices.draft.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+      plan.invoices.draft.update_all(ready_to_be_refreshed: true)
 
       result.plan = plan.reload
       result

--- a/app/services/subscriptions/flag_refreshed_service.rb
+++ b/app/services/subscriptions/flag_refreshed_service.rb
@@ -26,7 +26,7 @@ module Subscriptions
         .active
         .joins(:customer)
         .where(customers: {id: Subscription.where(id: subscription_id).select(:customer_id)})
-        .update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+        .update_all(ready_to_be_refreshed: true)
     end
 
     def flag_lifetime_usage_for_refresh

--- a/app/services/taxes/destroy_service.rb
+++ b/app/services/taxes/destroy_service.rb
@@ -18,7 +18,7 @@ module Taxes
       destroy_applied_taxes
       tax.destroy!
 
-      Invoice.where(id: draft_invoice_ids).update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+      Invoice.where(id: draft_invoice_ids).update_all(ready_to_be_refreshed: true)
 
       result.tax = tax
       result

--- a/app/services/taxes/update_service.rb
+++ b/app/services/taxes/update_service.rb
@@ -25,7 +25,7 @@ module Taxes
 
       customer_ids = (customer_ids + tax.reload.applicable_customers.select(:id)).uniq
       draft_invoices = tax.organization.invoices.where(customer_id: customer_ids).draft
-      draft_invoices.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+      draft_invoices.update_all(ready_to_be_refreshed: true)
 
       result.tax = tax
       result

--- a/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
+++ b/db/migrate/20241022144437_add_parent_to_charges_from_plan_parent.rb
@@ -74,7 +74,7 @@ class AddParentToChargesFromPlanParent < ActiveRecord::Migration[7.1]
     end
 
     # write only once for all children charges
-    Charge.where(id: full_match_ids.concat(partial_match_ids)).update_all(parent_id: parent_charge.id) # rubocop:disable Rails/SkipsModelValidations
+    Charge.where(id: full_match_ids.concat(partial_match_ids)).update_all(parent_id: parent_charge.id)
   end
 
   def charge_has_copy?(parent_charge, parent_plan, mode)

--- a/db/migrate/20241118103032_fulfill_adjusted_fee_unit_precise_amount_cents.rb
+++ b/db/migrate/20241118103032_fulfill_adjusted_fee_unit_precise_amount_cents.rb
@@ -11,7 +11,7 @@ class FulfillAdjustedFeeUnitPreciseAmountCents < ActiveRecord::Migration[7.1]
 
   def up
     AdjustedFee.joins(:invoice).where(invoice: {status: "draft"}).where(unit_precise_amount_cents: 0).find_each do |af|
-      af.update_attribute(:unit_precise_amount_cents, af.unit_amount_cents.to_f) # rubocop:disable Rails/SkipsModelValidations
+      af.update_attribute(:unit_precise_amount_cents, af.unit_amount_cents.to_f)
     end
   end
 

--- a/db/migrate/20241120094557_add_permissions_to_api_keys.rb
+++ b/db/migrate/20241120094557_add_permissions_to_api_keys.rb
@@ -4,7 +4,7 @@ class AddPermissionsToApiKeys < ActiveRecord::Migration[7.1]
   def up
     add_column :api_keys, :permissions, :jsonb, null: false, default: {}
 
-    ApiKey.update_all(permissions: ApiKey.default_permissions) # rubocop:disable Rails/SkipsModelValidations
+    ApiKey.update_all(permissions: ApiKey.default_permissions)
 
     change_column_default :api_keys, :permissions, nil
   end

--- a/db/migrate/20241128132010_add_new_permissions_to_api_keys.rb
+++ b/db/migrate/20241128132010_add_new_permissions_to_api_keys.rb
@@ -2,11 +2,11 @@
 
 class AddNewPermissionsToApiKeys < ActiveRecord::Migration[7.1]
   def up
-    ApiKey.update_all(permissions: ApiKey.default_permissions) # rubocop:disable Rails/SkipsModelValidations
+    ApiKey.update_all(permissions: ApiKey.default_permissions)
   end
 
   def down
-    ApiKey.update_all( # rubocop:disable Rails/SkipsModelValidations
+    ApiKey.update_all(
       permissions: ApiKey.default_permissions.without("event", "webhook_jwt_public_key")
     )
   end

--- a/db/migrate/20241220095049_backfill_payable_payment_status.rb
+++ b/db/migrate/20241220095049_backfill_payable_payment_status.rb
@@ -35,7 +35,7 @@ class BackfillPayablePaymentStatus < ActiveRecord::Migration[7.1]
       # Update all other duplicate_statuses payments for this `payable_id` to "failed"
       Payment.where(status: duplicate_statuses, payable_id: payable_id)
         .where.not(id: latest_pending_payment.id)
-        .update_all(status: "failed") # rubocop:disable Rails/SkipsModelValidations
+        .update_all(status: "failed")
     end
 
     provider_types = PaymentProviders::BaseProvider.distinct.pluck(:type)
@@ -44,15 +44,15 @@ class BackfillPayablePaymentStatus < ActiveRecord::Migration[7.1]
 
       payments = Payment.joins(:payment_provider)
         .where(payment_providers: {type: provider_type}, status: provider_class::PROCESSING_STATUSES)
-      payments.update_all(payable_payment_status: :pending) # rubocop:disable Rails/SkipsModelValidations
+      payments.update_all(payable_payment_status: :pending)
 
       payments = Payment.joins(:payment_provider)
         .where(payment_providers: {type: provider_type}, status: provider_class::SUCCESS_STATUSES)
-      payments.update_all(payable_payment_status: :succeeded) # rubocop:disable Rails/SkipsModelValidations
+      payments.update_all(payable_payment_status: :succeeded)
 
       payments = Payment.joins(:payment_provider)
         .where(payment_providers: {type: provider_type}, status: provider_class::FAILED_STATUSES)
-      payments.update_all(payable_payment_status: :failed) # rubocop:disable Rails/SkipsModelValidations
+      payments.update_all(payable_payment_status: :failed)
     end
   end
 end

--- a/db/migrate/20241223144027_backfill_failed_payable_payment_status.rb
+++ b/db/migrate/20241223144027_backfill_failed_payable_payment_status.rb
@@ -3,6 +3,6 @@
 class BackfillFailedPayablePaymentStatus < ActiveRecord::Migration[7.1]
   def change
     Payment.where(status: "failed", payable_payment_status: nil)
-      .update_all(payable_payment_status: "failed") # rubocop:disable Rails/SkipsModelValidations
+      .update_all(payable_payment_status: "failed")
   end
 end

--- a/db/migrate/20241224141116_add_payment_type_and_reference_to_payments.rb
+++ b/db/migrate/20241224141116_add_payment_type_and_reference_to_payments.rb
@@ -14,7 +14,7 @@ class AddPaymentTypeAndReferenceToPayments < ActiveRecord::Migration[7.1]
     end
 
     # Backfill existing records
-    Payment.in_batches(of: 10_000).update_all(payment_type: "provider") # rubocop:disable Rails/SkipsModelValidations
+    Payment.in_batches(of: 10_000).update_all(payment_type: "provider")
 
     safety_assured do
       execute <<~SQL

--- a/db/migrate/20241224142141_add_total_paid_amount_cents_to_invoices.rb
+++ b/db/migrate/20241224142141_add_total_paid_amount_cents_to_invoices.rb
@@ -7,7 +7,7 @@ class AddTotalPaidAmountCentsToInvoices < ActiveRecord::Migration[7.1]
     add_column :invoices, :total_paid_amount_cents, :bigint, null: true
     # Backfill
     Invoice.in_batches(of: 10_000).each do |batch|
-      batch.update_all(total_paid_amount_cents: 0) # rubocop:disable Rails/SkipsModelValidations
+      batch.update_all(total_paid_amount_cents: 0)
     end
 
     safety_assured do

--- a/db/migrate/20250212123207_backfill_invoices_and_payments.rb
+++ b/db/migrate/20250212123207_backfill_invoices_and_payments.rb
@@ -37,7 +37,7 @@ class BackfillInvoicesAndPayments < ActiveRecord::Migration[7.1]
 
   def update_invoices
     Invoice.where(payment_status: Invoice::PAYMENT_STATUS[:succeeded])
-      .update_all("total_paid_amount_cents = total_amount_cents") # rubocop:disable Rails/SkipsModelValidations
+      .update_all("total_paid_amount_cents = total_amount_cents")
   end
 
   def update_payments
@@ -76,6 +76,6 @@ class BackfillInvoicesAndPayments < ActiveRecord::Migration[7.1]
     Payment.left_joins(:payment_provider)
       .where("payment_providers.type = ? OR payment_providers.id IS NULL", provider_type)
       .where(payable_payment_status: nil, status: statuses)
-      .update_all(payable_payment_status: new_status) # rubocop:disable Rails/SkipsModelValidations
+      .update_all(payable_payment_status: new_status)
   end
 end

--- a/db/migrate/20250310213734_add_expiration_and_termination_to_recurring_transaction_rules.rb
+++ b/db/migrate/20250310213734_add_expiration_and_termination_to_recurring_transaction_rules.rb
@@ -13,7 +13,7 @@ class AddExpirationAndTerminationToRecurringTransactionRules < ActiveRecord::Mig
     end
 
     safety_assured do
-      RecurringTransactionRule.in_batches.update_all(status: 0) # rubocop:disable Rails/SkipsModelValidations
+      RecurringTransactionRule.in_batches.update_all(status: 0)
     end
 
     change_column_default :recurring_transaction_rules, :status, 0

--- a/db/migrate/20250325145324_assign_customers_to_billing_entities.rb
+++ b/db/migrate/20250325145324_assign_customers_to_billing_entities.rb
@@ -5,13 +5,13 @@ class AssignCustomersToBillingEntities < ActiveRecord::Migration[7.2]
     # NOTE: ensure first billing entity has the same id as the organization to ease the migration to multi entities.
     BillingEntity.where("id != organization_id").find_in_batches(batch_size: 1000) do |batch|
       BillingEntity.where(id: batch.pluck(:id))
-        .update_all("id = organization_id") # rubocop:disable Rails/SkipsModelValidations
+        .update_all("id = organization_id")
     end
 
     # NOTE: Update all customers to have the same billing_entity_id as organization_id
     Customer.where("billing_entity_id != organization_id").or(Customer.where(billing_entity_id: nil)).find_in_batches(batch_size: 1000) do |batch|
       Customer.where(id: batch.pluck(:id))
-        .update_all("billing_entity_id = organization_id") # rubocop:disable Rails/SkipsModelValidations
+        .update_all("billing_entity_id = organization_id")
     end
   end
 end

--- a/db/migrate/20250325162648_assign_invoices_to_billing_entities.rb
+++ b/db/migrate/20250325162648_assign_invoices_to_billing_entities.rb
@@ -4,7 +4,7 @@ class AssignInvoicesToBillingEntities < ActiveRecord::Migration[7.2]
   def change
     Invoice.find_in_batches(batch_size: 1000) do |batch|
       Invoice.where(id: batch.pluck(:id))
-        .update_all("billing_entity_id = organization_id") # rubocop:disable Rails/SkipsModelValidations
+        .update_all("billing_entity_id = organization_id")
     end
   end
 end

--- a/db/migrate/20250327130155_remove_default_billing_entity_sequential_id_on_invoices.rb
+++ b/db/migrate/20250327130155_remove_default_billing_entity_sequential_id_on_invoices.rb
@@ -7,7 +7,7 @@ class RemoveDefaultBillingEntitySequentialIdOnInvoices < ActiveRecord::Migration
     change_column_default :invoices, :billing_entity_sequential_id, from: 0, to: nil
 
     Invoice.in_batches(of: 1000) do |batch|
-      batch.update_all( # rubocop:disable Rails/SkipsModelValidations
+      batch.update_all(
         "billing_entity_sequential_id = CASE WHEN organization_sequential_id = 0 THEN NULL ELSE organization_sequential_id END"
       )
     end

--- a/db/migrate/20250402135038_assign_discarded_customers_to_billing_entities.rb
+++ b/db/migrate/20250402135038_assign_discarded_customers_to_billing_entities.rb
@@ -4,7 +4,7 @@ class AssignDiscardedCustomersToBillingEntities < ActiveRecord::Migration[7.2]
   def up
     Customer.with_discarded.where("billing_entity_id != organization_id").or(Customer.with_discarded.where(billing_entity_id: nil)).find_in_batches(batch_size: 1000) do |batch|
       Customer.with_discarded.where(id: batch.pluck(:id))
-        .update_all("billing_entity_id = organization_id") # rubocop:disable Rails/SkipsModelValidations
+        .update_all("billing_entity_id = organization_id")
     end
   end
 

--- a/db/migrate/20250403110833_add_section_type_to_invoice_custom_sections.rb
+++ b/db/migrate/20250403110833_add_section_type_to_invoice_custom_sections.rb
@@ -13,7 +13,7 @@ class AddSectionTypeToInvoiceCustomSections < ActiveRecord::Migration[7.2]
     end
 
     # Backfill all existing rows as manual
-    InvoiceCustomSection.unscoped.in_batches(of: 10_000).update_all(section_type: "manual") # rubocop:disable Rails/SkipsModelValidations
+    InvoiceCustomSection.unscoped.in_batches(of: 10_000).update_all(section_type: "manual")
 
     safety_assured do
       execute <<~SQL

--- a/db/migrate/20250408121522_ensure_all_billing_entities_have_invoice_sequential_id.rb
+++ b/db/migrate/20250408121522_ensure_all_billing_entities_have_invoice_sequential_id.rb
@@ -9,7 +9,7 @@ class EnsureAllBillingEntitiesHaveInvoiceSequentialId < ActiveRecord::Migration[
       next if last_billing_entity_sequential_id == invoices_count
 
       last_invoice = billing_entity.invoices.non_self_billed.with_generated_number.where(billing_entity_sequential_id: nil).order(created_at: :desc).limit(1)
-      last_invoice.update_all(billing_entity_sequential_id: invoices_count) # rubocop:disable Rails/SkipsModelValidations
+      last_invoice.update_all(billing_entity_sequential_id: invoices_count)
     end
   end
 end

--- a/db/migrate/20250411152022_migrate_applied_taxes_to_billing_entities.rb
+++ b/db/migrate/20250411152022_migrate_applied_taxes_to_billing_entities.rb
@@ -14,11 +14,9 @@ class MigrateAppliedTaxesToBillingEntities < ActiveRecord::Migration[7.2]
       }
     end
 
-    # rubocop:disable Rails/SkipsModelValidations
     BillingEntity::AppliedTax.insert_all(
       rows,
       unique_by: :index_billing_entities_taxes_on_billing_entity_id_and_tax_id
     )
-    # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/lib/tasks/subscriptions.rake
+++ b/lib/tasks/subscriptions.rake
@@ -29,7 +29,7 @@ namespace :subscriptions do
     invoice = result.invoice
 
     invoice.update!(created_at: Time.zone.at(args[:timestamp].to_i))
-    invoice.fees.update_all(created_at: invoice.created_at + 1.second) # rubocop:disable Rails/SkipsModelValidations
+    invoice.fees.update_all(created_at: invoice.created_at + 1.second)
 
     # NOTE: Do not generate the PDF file if invoice is draft.
     Invoices::GeneratePdfService.call(invoice:) if invoice.finalized?

--- a/lib/tasks/tests/seed_plans.rake
+++ b/lib/tasks/tests/seed_plans.rake
@@ -92,12 +92,12 @@ def generate_children_plans(plan, all_metrics, delete_charge_parents)
     # change plan, do not change charges
     res = Plans::OverrideService.call(plan: plan, params: {name: "Plan '#{plan.code}' child"})
     pl = res.plan
-    pl.charges.update_all(parent_id: nil) if delete_charge_parents # rubocop:disable Rails/SkipsModelValidations
+    pl.charges.update_all(parent_id: nil) if delete_charge_parents
 
     # change charges models and properties (randomly)
     res = Plans::OverrideService.call(plan: plan, params: {charges: override_charges_rand(plan, all_metrics)})
     pl = res.plan
-    pl.charges.update_all(parent_id: nil) if delete_charge_parents # rubocop:disable Rails/SkipsModelValidations
+    pl.charges.update_all(parent_id: nil) if delete_charge_parents
   end
 end
 

--- a/spec/graphql/resolvers/webhooks_resolver_spec.rb
+++ b/spec/graphql/resolvers/webhooks_resolver_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Resolvers::WebhooksResolver, type: :graphql do
   context "when the webhook payload is json-serialized in the database" do
     it "returns a list of webhooks" do
       Webhook.all.find_each do |w|
-        w.update_column(:payload, {"foo" => "bar"}.to_json) # rubocop:disable Rails/SkipsModelValidations
+        w.update_column(:payload, {"foo" => "bar"}.to_json)
       end
 
       result = execute_graphql(

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -18,7 +18,7 @@ describe "Charge Models - Prorated Graduated Scenarios", :scenarios, type: :requ
 
     describe "three ranges and one overflow case" do
       it "returns the expected invoice and usage amounts" do
-        Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+        Organization.update_all(webhook_url: nil)
         WebhookEndpoint.destroy_all
 
         travel_to(DateTime.new(2023, 9, 1)) do
@@ -199,7 +199,7 @@ describe "Charge Models - Prorated Graduated Scenarios", :scenarios, type: :requ
 
       context "when there are old events before first invoice" do
         it "returns expected invoice and usage amounts" do
-          Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+          Organization.update_all(webhook_url: nil)
           WebhookEndpoint.destroy_all
 
           travel_to(DateTime.new(2023, 12, 1)) do
@@ -303,7 +303,7 @@ describe "Charge Models - Prorated Graduated Scenarios", :scenarios, type: :requ
 
       context "when there are old events before first invoice and subscription is terminated" do
         it "returns expected invoice and usage amounts" do
-          Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+          Organization.update_all(webhook_url: nil)
           WebhookEndpoint.destroy_all
 
           travel_to(DateTime.new(2023, 10, 1)) do
@@ -410,7 +410,7 @@ describe "Charge Models - Prorated Graduated Scenarios", :scenarios, type: :requ
         let(:plan_new) { create(:plan, organization:, amount_cents: 100) }
 
         it "returns expected invoice and usage amounts" do
-          Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+          Organization.update_all(webhook_url: nil)
           WebhookEndpoint.destroy_all
 
           travel_to(DateTime.new(2023, 9, 1)) do
@@ -638,7 +638,7 @@ describe "Charge Models - Prorated Graduated Scenarios", :scenarios, type: :requ
 
     describe "two ranges" do
       it "returns the expected invoice and usage amounts" do
-        Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+        Organization.update_all(webhook_url: nil)
         WebhookEndpoint.destroy_all
 
         travel_to(DateTime.new(2023, 9, 1)) do
@@ -809,7 +809,7 @@ describe "Charge Models - Prorated Graduated Scenarios", :scenarios, type: :requ
 
     context "with multiple events on the same day" do
       it "returns the expected invoice and usage amounts" do
-        Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+        Organization.update_all(webhook_url: nil)
         WebhookEndpoint.destroy_all
 
         travel_to(DateTime.new(2023, 9, 1)) do
@@ -963,7 +963,7 @@ describe "Charge Models - Prorated Graduated Scenarios", :scenarios, type: :requ
 
       context "when there are old events before first invoice and subscription is terminated" do
         it "returns expected invoice and usage amounts" do
-          Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+          Organization.update_all(webhook_url: nil)
           WebhookEndpoint.destroy_all
 
           travel_to(DateTime.new(2023, 10, 1)) do

--- a/spec/scenarios/subscriptions/terminate_ended_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_spec.rb
@@ -246,7 +246,7 @@ describe "Subscriptions Termination Scenario", :scenarios, type: :request do
           expect(subscription).to be_active
         end
 
-        Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+        Organization.update_all(webhook_url: nil)
         WebhookEndpoint.destroy_all
 
         travel_to(creation_time + 5.hours) do
@@ -456,7 +456,7 @@ describe "Subscriptions Termination Scenario", :scenarios, type: :request do
             expect(subscription).to be_active
           end
 
-          Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+          Organization.update_all(webhook_url: nil)
           WebhookEndpoint.destroy_all
 
           travel_to(ending_at + 5.minutes) do
@@ -505,7 +505,7 @@ describe "Subscriptions Termination Scenario", :scenarios, type: :request do
             expect(subscription).to be_active
           end
 
-          Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+          Organization.update_all(webhook_url: nil)
           WebhookEndpoint.destroy_all
 
           travel_to(ending_at + 5.minutes) do

--- a/spec/services/billing_entities/resolve_service_spec.rb
+++ b/spec/services/billing_entities/resolve_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BillingEntities::ResolveService do
     let(:billing_entity_code) { organization.all_billing_entities.first.code }
 
     before do
-      organization.billing_entities.update_all(archived_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+      organization.billing_entities.update_all(archived_at: Time.current)
     end
 
     it "returns not found failure" do

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Customers::CreateService, type: :service do
 
   context "when organization has no active billing entity" do
     before do
-      organization.billing_entities.update_all(archived_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+      organization.billing_entities.update_all(archived_at: Time.current)
     end
 
     it "return a failed result" do

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Customers::UpsertFromApiService, type: :service do
 
   context "when organization has no active billing entity" do
     before do
-      organization.billing_entities.update_all(archived_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+      organization.billing_entities.update_all(archived_at: Time.current)
     end
 
     it "return a failed result" do

--- a/spec/services/taxes/auto_generate_service_spec.rb
+++ b/spec/services/taxes/auto_generate_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Taxes::AutoGenerateService, type: :service do
 
     it "updates eu taxes for organization" do
       auto_generate_service.call
-      organization.taxes.update_all(rate: 99) # rubocop:disable Rails/SkipsModelValidations
+      organization.taxes.update_all(rate: 99)
       expect(organization.taxes.pluck(:rate)).to all eq 99
 
       auto_generate_service.call


### PR DESCRIPTION
## Description

1. We rely on `insert_all` and such in many places and for good reasons
2. Every body in this team know this skips the model validation and callbacks (_that's the point!_)
3. A good rubocop rule shouldn't be disabled 56 times 😬 

If anybody wants to keep it, I'm happy to close this PR and keep adding the magic comment wherever we use these methods.