### PR TITLE
chore(organization): Add organization_id to subscriptions table

### DIFF
--- a/app/jobs/database_migrations/populate_subscriptions_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_subscriptions_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateSubscriptionsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Subscription
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM customers WHERE customers.id = subscriptions.customer_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -235,6 +235,7 @@ end
 #  updated_at               :datetime         not null
 #  customer_id              :uuid             not null
 #  external_id              :string           not null
+#  organization_id          :uuid
 #  plan_id                  :uuid             not null
 #  previous_subscription_id :uuid
 #
@@ -242,6 +243,7 @@ end
 #
 #  index_subscriptions_on_customer_id                          (customer_id)
 #  index_subscriptions_on_external_id                          (external_id)
+#  index_subscriptions_on_organization_id                      (organization_id)
 #  index_subscriptions_on_plan_id                              (plan_id)
 #  index_subscriptions_on_previous_subscription_id_and_status  (previous_subscription_id,status)
 #  index_subscriptions_on_started_at                           (started_at)
@@ -251,5 +253,6 @@ end
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_id => plans.id)
 #

--- a/app/services/invoices/preview/build_subscription_service.rb
+++ b/app/services/invoices/preview/build_subscription_service.rb
@@ -27,6 +27,7 @@ module Invoices
 
       def build_subscription
         Subscription.new(
+          organization_id: organization.id,
           customer:,
           plan:,
           subscription_at: params[:subscription_at].presence || Time.current,

--- a/app/services/invoices/preview/subscription_plan_change_service.rb
+++ b/app/services/invoices/preview/subscription_plan_change_service.rb
@@ -48,6 +48,7 @@ module Invoices
 
       def new_subscription
         @new_subscription ||= Subscription.new(
+          organization_id: organization.id,
           customer:,
           plan: target_plan,
           name: target_plan.name,

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -92,6 +92,7 @@ module Subscriptions
 
     def create_subscription
       new_subscription = Subscription.new(
+        organization_id: customer.organization_id,
         customer:,
         plan: params.key?(:plan_overrides) ? override_plan(plan) : plan,
         subscription_at:,
@@ -152,6 +153,7 @@ module Subscriptions
       # NOTE: When downgrading a subscription, we keep the current one active
       #       until the next billing day. The new subscription will become active at this date
       current_subscription.next_subscriptions.create!(
+        organization_id: customer.organization_id,
         customer:,
         plan: params.key?(:plan_overrides) ? override_plan(plan) : plan,
         name:,

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -55,6 +55,7 @@ module Subscriptions
 
     def new_subscription_with_overrides
       Subscription.new(
+        organization_id: current_subscription.customer.organization_id,
         customer: current_subscription.customer,
         plan: params.key?(:plan_overrides) ? override_plan : plan,
         name:,

--- a/db/migrate/20250425122510_add_organization_id_to_subscriptions.rb
+++ b/db/migrate/20250425122510_add_organization_id_to_subscriptions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToSubscriptions < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :subscriptions, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250425122641_add_organization_id_fk_to_subscription.rb
+++ b/db/migrate/20250425122641_add_organization_id_fk_to_subscription.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToSubscription < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :subscriptions, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250425122705_validate_subscriptions_organizations_foreign_key.rb
+++ b/db/migrate/20250425122705_validate_subscriptions_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateSubscriptionsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :subscriptions, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -108,6 +108,7 @@ ALTER TABLE IF EXISTS ONLY public.group_properties DROP CONSTRAINT IF EXISTS fk_
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_3a303bf667;
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS fk_rails_3926855f12;
 ALTER TABLE IF EXISTS ONLY public.inbound_webhooks DROP CONSTRAINT IF EXISTS fk_rails_36cda06530;
+ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_364213cc3e;
 ALTER TABLE IF EXISTS ONLY public.groups DROP CONSTRAINT IF EXISTS fk_rails_34b5ee1894;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_34ab152115;
 ALTER TABLE IF EXISTS ONLY public.lifetime_usages DROP CONSTRAINT IF EXISTS fk_rails_348acbd245;
@@ -182,6 +183,7 @@ DROP INDEX IF EXISTS public.index_subscriptions_on_started_at_and_ending_at;
 DROP INDEX IF EXISTS public.index_subscriptions_on_started_at;
 DROP INDEX IF EXISTS public.index_subscriptions_on_previous_subscription_id_and_status;
 DROP INDEX IF EXISTS public.index_subscriptions_on_plan_id;
+DROP INDEX IF EXISTS public.index_subscriptions_on_organization_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_external_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_customer_id;
 DROP INDEX IF EXISTS public.index_search_quantified_events;
@@ -2071,7 +2073,8 @@ CREATE TABLE public.subscriptions (
     billing_time integer DEFAULT 0 NOT NULL,
     subscription_at timestamp(6) without time zone,
     ending_at timestamp(6) without time zone,
-    trial_ended_at timestamp(6) without time zone
+    trial_ended_at timestamp(6) without time zone,
+    organization_id uuid
 );
 
 
@@ -5758,6 +5761,13 @@ CREATE INDEX index_subscriptions_on_external_id ON public.subscriptions USING bt
 
 
 --
+-- Name: index_subscriptions_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscriptions_on_organization_id ON public.subscriptions USING btree (organization_id);
+
+
+--
 -- Name: index_subscriptions_on_plan_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6251,6 +6261,14 @@ ALTER TABLE ONLY public.fees
 
 ALTER TABLE ONLY public.groups
     ADD CONSTRAINT fk_rails_34b5ee1894 FOREIGN KEY (billable_metric_id) REFERENCES public.billable_metrics(id) ON DELETE CASCADE;
+
+
+--
+-- Name: subscriptions fk_rails_364213cc3e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscriptions
+    ADD CONSTRAINT fk_rails_364213cc3e FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -7052,6 +7070,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250425122705'),
+('20250425122641'),
+('20250425122510'),
 ('20250424140537'),
 ('20250424140359'),
 ('20250424135624'),


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `subscriptions` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added