### PR TITLE
chore(organization): Add organization_id to wallets table

### DIFF
--- a/app/jobs/database_migrations/populate_wallets_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_wallets_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateWalletsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Wallet.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM customers WHERE customers.id = wallets.customer_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -72,13 +72,16 @@ end
 #  created_at                          :datetime         not null
 #  updated_at                          :datetime         not null
 #  customer_id                         :uuid             not null
+#  organization_id                     :uuid
 #
 # Indexes
 #
 #  index_wallets_on_customer_id            (customer_id)
+#  index_wallets_on_organization_id        (organization_id)
 #  index_wallets_on_ready_to_be_refreshed  (ready_to_be_refreshed) WHERE ready_to_be_refreshed
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -11,6 +11,7 @@ module Wallets
       return result unless valid?
 
       attributes = {
+        organization_id: result.current_customer.organization_id,
         customer_id: result.current_customer.id,
         name: params[:name],
         rate_amount: params[:rate_amount],

--- a/db/migrate/20250425124804_add_organization_id_to_wallets.rb
+++ b/db/migrate/20250425124804_add_organization_id_to_wallets.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToWallets < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :wallets, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250425124826_add_organization_id_fk_to_wallets.rb
+++ b/db/migrate/20250425124826_add_organization_id_fk_to_wallets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToWallets < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :wallets, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250425124942_validate_wallets_organizations_foreign_key.rb
+++ b/db/migrate/20250425124942_validate_wallets_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateWalletsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :wallets, :organizations
+  end
+end

--- a/db/seeds/01_base.rb
+++ b/db/seeds/01_base.rb
@@ -188,6 +188,7 @@ end
 first_customer = organization.customers.first
 
 wallet = Wallet.create!(
+  organization_id: organization.id,
   customer: first_customer,
   name: "My Active Wallet",
   status: :active,
@@ -202,6 +203,7 @@ wallet = Wallet.create!(
 )
 
 Wallet.create!(
+  organization_id: organization.id,
   customer: first_customer,
   name: "My Terminated Wallet",
   status: :terminated,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -119,6 +119,7 @@ ALTER TABLE IF EXISTS ONLY public.payment_requests DROP CONSTRAINT IF EXISTS fk_
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_2ea4db3a4c;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_2dc6171f57;
 ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_2b35eef34b;
+ALTER TABLE IF EXISTS ONLY public.wallets DROP CONSTRAINT IF EXISTS fk_rails_28077d4aa2;
 ALTER TABLE IF EXISTS ONLY public.charge_filters DROP CONSTRAINT IF EXISTS fk_rails_27b55b8574;
 ALTER TABLE IF EXISTS ONLY public.payment_providers DROP CONSTRAINT IF EXISTS fk_rails_26be2f764d;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_taxes DROP CONSTRAINT IF EXISTS fk_rails_268c288aaa;
@@ -165,6 +166,7 @@ DROP INDEX IF EXISTS public.index_webhooks_on_webhook_endpoint_id;
 DROP INDEX IF EXISTS public.index_webhook_endpoints_on_webhook_url_and_organization_id;
 DROP INDEX IF EXISTS public.index_webhook_endpoints_on_organization_id;
 DROP INDEX IF EXISTS public.index_wallets_on_ready_to_be_refreshed;
+DROP INDEX IF EXISTS public.index_wallets_on_organization_id;
 DROP INDEX IF EXISTS public.index_wallets_on_customer_id;
 DROP INDEX IF EXISTS public.index_wallet_transactions_on_wallet_id;
 DROP INDEX IF EXISTS public.index_wallet_transactions_on_invoice_id;
@@ -2572,7 +2574,8 @@ CREATE TABLE public.wallets (
     depleted_ongoing_balance boolean DEFAULT false NOT NULL,
     invoice_requires_successful_payment boolean DEFAULT false NOT NULL,
     lock_version integer DEFAULT 0 NOT NULL,
-    ready_to_be_refreshed boolean DEFAULT false NOT NULL
+    ready_to_be_refreshed boolean DEFAULT false NOT NULL,
+    organization_id uuid
 );
 
 
@@ -5894,6 +5897,13 @@ CREATE INDEX index_wallets_on_customer_id ON public.wallets USING btree (custome
 
 
 --
+-- Name: index_wallets_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_wallets_on_organization_id ON public.wallets USING btree (organization_id);
+
+
+--
 -- Name: index_wallets_on_ready_to_be_refreshed; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6181,6 +6191,14 @@ ALTER TABLE ONLY public.payment_providers
 
 ALTER TABLE ONLY public.charge_filters
     ADD CONSTRAINT fk_rails_27b55b8574 FOREIGN KEY (charge_id) REFERENCES public.charges(id);
+
+
+--
+-- Name: wallets fk_rails_28077d4aa2; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wallets
+    ADD CONSTRAINT fk_rails_28077d4aa2 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -7070,6 +7088,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250425124942'),
+('20250425124826'),
+('20250425124804'),
 ('20250425122705'),
 ('20250425122641'),
 ('20250425122510'),


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `wallets` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added