### PR TITLE
chore(organization): Add organization_id to wallet_transactions table

### DIFF
--- a/app/jobs/database_migrations/populate_wallet_transactions_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_wallet_transactions_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateWalletTransactionsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = WalletTransaction.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM wallets WHERE wallets.id = wallet_transactions.wallet_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -4,6 +4,7 @@ class WalletTransaction < ApplicationRecord
   include PaperTrailTraceable
 
   belongs_to :wallet
+  belongs_to :organization, optional: true
 
   # these two relationships are populated only for outbound transactions
   belongs_to :invoice, optional: true
@@ -74,17 +75,20 @@ end
 #  updated_at                          :datetime         not null
 #  credit_note_id                      :uuid
 #  invoice_id                          :uuid
+#  organization_id                     :uuid
 #  wallet_id                           :uuid             not null
 #
 # Indexes
 #
-#  index_wallet_transactions_on_credit_note_id  (credit_note_id)
-#  index_wallet_transactions_on_invoice_id      (invoice_id)
-#  index_wallet_transactions_on_wallet_id       (wallet_id)
+#  index_wallet_transactions_on_credit_note_id   (credit_note_id)
+#  index_wallet_transactions_on_invoice_id       (invoice_id)
+#  index_wallet_transactions_on_organization_id  (organization_id)
+#  index_wallet_transactions_on_wallet_id        (wallet_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (credit_note_id => credit_notes.id)
 #  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (wallet_id => wallets.id)
 #

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -21,6 +21,7 @@ module WalletTransactions
 
     def call
       result.wallet_transaction = wallet.wallet_transactions.create!(
+        organization_id: wallet.organization_id,
         amount:,
         status:,
         credit_amount:,

--- a/db/migrate/20250425130332_add_organization_id_to_wallet_transactions.rb
+++ b/db/migrate/20250425130332_add_organization_id_to_wallet_transactions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToWalletTransactions < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :wallet_transactions, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250425130345_add_organization_id_fk_to_wallet_transactions.rb
+++ b/db/migrate/20250425130345_add_organization_id_fk_to_wallet_transactions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToWalletTransactions < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :wallet_transactions, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250425130412_validate_wallets_transactions_organization_foreign_key.rb
+++ b/db/migrate/20250425130412_validate_wallets_transactions_organization_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateWalletsTransactionsOrganizationForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :wallet_transactions, :organizations
+  end
+end

--- a/db/seeds/01_base.rb
+++ b/db/seeds/01_base.rb
@@ -221,6 +221,7 @@ Wallet.create!(
 
 3.times do
   WalletTransaction.create!(
+    organization_id: organization.id,
     wallet:,
     transaction_type: :outbound,
     status: :settled,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -70,6 +70,7 @@ ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rai
 ALTER TABLE IF EXISTS ONLY public.api_keys DROP CONSTRAINT IF EXISTS fk_rails_7aab96f30e;
 ALTER TABLE IF EXISTS ONLY public.billable_metric_filters DROP CONSTRAINT IF EXISTS fk_rails_7a0704ce72;
 ALTER TABLE IF EXISTS ONLY public.applied_add_ons DROP CONSTRAINT IF EXISTS fk_rails_7995206484;
+ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_78f6642ddf;
 ALTER TABLE IF EXISTS ONLY public.groups DROP CONSTRAINT IF EXISTS fk_rails_7886e1bc34;
 ALTER TABLE IF EXISTS ONLY public.integrations DROP CONSTRAINT IF EXISTS fk_rails_755d734f25;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_75577c354e;
@@ -169,6 +170,7 @@ DROP INDEX IF EXISTS public.index_wallets_on_ready_to_be_refreshed;
 DROP INDEX IF EXISTS public.index_wallets_on_organization_id;
 DROP INDEX IF EXISTS public.index_wallets_on_customer_id;
 DROP INDEX IF EXISTS public.index_wallet_transactions_on_wallet_id;
+DROP INDEX IF EXISTS public.index_wallet_transactions_on_organization_id;
 DROP INDEX IF EXISTS public.index_wallet_transactions_on_invoice_id;
 DROP INDEX IF EXISTS public.index_wallet_transactions_on_credit_note_id;
 DROP INDEX IF EXISTS public.index_versions_on_item_type_and_item_id;
@@ -2541,7 +2543,8 @@ CREATE TABLE public.wallet_transactions (
     invoice_requires_successful_payment boolean DEFAULT false NOT NULL,
     metadata jsonb DEFAULT '[]'::jsonb,
     credit_note_id uuid,
-    failed_at timestamp(6) without time zone
+    failed_at timestamp(6) without time zone,
+    organization_id uuid
 );
 
 
@@ -5883,6 +5886,13 @@ CREATE INDEX index_wallet_transactions_on_invoice_id ON public.wallet_transactio
 
 
 --
+-- Name: index_wallet_transactions_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_wallet_transactions_on_organization_id ON public.wallet_transactions USING btree (organization_id);
+
+
+--
 -- Name: index_wallet_transactions_on_wallet_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6594,6 +6604,14 @@ ALTER TABLE ONLY public.groups
 
 
 --
+-- Name: wallet_transactions fk_rails_78f6642ddf; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wallet_transactions
+    ADD CONSTRAINT fk_rails_78f6642ddf FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: applied_add_ons fk_rails_7995206484; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7088,6 +7106,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250425130412'),
+('20250425130345'),
+('20250425130332'),
 ('20250425124942'),
 ('20250425124826'),
 ('20250425124804'),


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `wallet_transactions` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added