### PR TITLE
chore(organization): Add organization_id to payments table

### DIFF
--- a/app/jobs/database_migrations/populate_payments_with_organization_from_invoice_job.rb
+++ b/app/jobs/database_migrations/populate_payments_with_organization_from_invoice_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulatePaymentsWithOrganizationFromInvoiceJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Payment.unscoped
+        .where(organization_id: nil).where(payable_type: "Invoice")
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM invoices WHERE invoices.id = payments.payable_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/jobs/database_migrations/populate_payments_with_organization_from_payment_request_job.rb
+++ b/app/jobs/database_migrations/populate_payments_with_organization_from_payment_request_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulatePaymentsWithOrganizationFromPaymentRequestJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Payment.unscoped
+        .where(organization_id: nil).where(payable_type: "PaymentRequest")
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM payment_requests WHERE payment_requests.id = payments.payable_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -5,6 +5,7 @@ class Payment < ApplicationRecord
 
   PAYABLE_PAYMENT_STATUS = %w[pending processing succeeded failed].freeze
 
+  belongs_to :organization, optional: true
   belongs_to :payable, polymorphic: true
   belongs_to :payment_provider, optional: true, class_name: "PaymentProviders::BaseProvider"
   belongs_to :payment_provider_customer, optional: true, class_name: "PaymentProviderCustomers::BaseCustomer"
@@ -114,6 +115,7 @@ end
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  invoice_id                   :uuid
+#  organization_id              :uuid
 #  payable_id                   :uuid
 #  payment_provider_customer_id :uuid
 #  payment_provider_id          :uuid
@@ -123,6 +125,7 @@ end
 # Indexes
 #
 #  index_payments_on_invoice_id                                   (invoice_id)
+#  index_payments_on_organization_id                              (organization_id)
 #  index_payments_on_payable_id_and_payable_type                  (payable_id,payable_type) UNIQUE WHERE ((payable_payment_status = ANY (ARRAY['pending'::payment_payable_payment_status, 'processing'::payment_payable_payment_status])) AND (payment_type = 'provider'::payment_type))
 #  index_payments_on_payable_type_and_payable_id                  (payable_type,payable_id)
 #  index_payments_on_payment_provider_customer_id                 (payment_provider_customer_id)
@@ -133,5 +136,6 @@ end
 # Foreign Keys
 #
 #  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_provider_id => payment_providers.id)
 #

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -71,6 +71,7 @@ module Invoices
         increment_payment_attempts
 
         Payment.new(
+          organization_id: invoice.organization_id,
           payable: invoice,
           payment_provider_id: adyen_payment_provider.id,
           payment_provider_customer_id: customer.adyen_customer.id,

--- a/app/services/invoices/payments/cashfree_service.rb
+++ b/app/services/invoices/payments/cashfree_service.rb
@@ -61,6 +61,7 @@ module Invoices
         increment_payment_attempts
 
         Payment.new(
+          organization_id: @invoice.organization_id,
           payable: @invoice,
           payment_provider_id: cashfree_payment_provider.id,
           payment_provider_customer_id: customer.cashfree_customer.id,

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -31,6 +31,7 @@ module Invoices
         invoice.update!(payment_attempts: invoice.payment_attempts + 1)
 
         payment ||= Payment.create_with(
+          organization_id: invoice.organization_id,
           payment_provider_id: current_payment_provider.id,
           payment_provider_customer_id: current_payment_provider_customer.id,
           amount_cents: invoice.total_due_amount_cents,

--- a/app/services/invoices/payments/moneyhash_service.rb
+++ b/app/services/invoices/payments/moneyhash_service.rb
@@ -96,6 +96,7 @@ module Invoices
         end
         increment_payment_attempts
         Payment.new(
+          organization_id: @invoice.organization_id,
           payable: invoice,
           payment_provider_id: moneyhash_payment_provider.id,
           payment_provider_customer_id: customer.moneyhash_customer.id,

--- a/app/services/payment_requests/payments/adyen_service.rb
+++ b/app/services/payment_requests/payments/adyen_service.rb
@@ -142,6 +142,7 @@ module PaymentRequests
         payable.increment_payment_attempts!
 
         Payment.new(
+          organization_id: payable.organization_id,
           payable:,
           payment_provider_id: adyen_payment_provider.id,
           payment_provider_customer_id: customer.adyen_customer.id,

--- a/app/services/payment_requests/payments/cashfree_service.rb
+++ b/app/services/payment_requests/payments/cashfree_service.rb
@@ -153,6 +153,7 @@ module PaymentRequests
         payable.increment_payment_attempts!
 
         Payment.new(
+          organization_id: payable.organization_id,
           payable:,
           payment_provider_id: cashfree_payment_provider.id,
           payment_provider_customer_id: customer.cashfree_customer.id,

--- a/app/services/payment_requests/payments/create_service.rb
+++ b/app/services/payment_requests/payments/create_service.rb
@@ -34,6 +34,7 @@ module PaymentRequests
         payable.increment_payment_attempts!
 
         payment ||= Payment.create_with(
+          organization_id: payable.organization_id,
           payment_provider_id: current_payment_provider.id,
           payment_provider_customer_id: current_payment_provider_customer.id,
           amount_cents: payable.total_amount_cents,

--- a/app/services/payment_requests/payments/moneyhash_service.rb
+++ b/app/services/payment_requests/payments/moneyhash_service.rb
@@ -29,6 +29,7 @@ module PaymentRequests
         mh_status = moneyhash_result.dig("data", "status")
 
         payment = Payment.new(
+          organization_id: payable.organization_id,
           payable: payable,
           payment_provider_id: moneyhash_payment_provider.id,
           payment_provider_customer_id: customer.moneyhash_customer.id,
@@ -108,6 +109,7 @@ module PaymentRequests
         payable.increment_payment_attempts!
 
         Payment.new(
+          organization_id: payable.organization_id,
           payable:,
           payment_provider_id: moneyhash_payment_provider.id,
           payment_provider_customer_id: customer.moneyhash_customer.id,

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -175,6 +175,7 @@ module PaymentRequests
         @payable.increment_payment_attempts!
 
         Payment.new(
+          organization_id: @payable.organization_id,
           payable: @payable,
           payment_provider_id: stripe_payment_provider.id,
           payment_provider_customer_id: customer.stripe_customer.id,

--- a/app/services/payments/manual_create_service.rb
+++ b/app/services/payments/manual_create_service.rb
@@ -16,6 +16,7 @@ module Payments
 
       ActiveRecord::Base.transaction do
         payment = invoice.payments.create!(
+          organization_id: invoice.organization_id,
           amount_cents:,
           reference: params[:reference],
           amount_currency: invoice.currency,

--- a/db/migrate/20250425132724_add_organization_id_to_payments.rb
+++ b/db/migrate/20250425132724_add_organization_id_to_payments.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToPayments < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :payments, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250425132757_add_organization_id_fk_to_paymants.rb
+++ b/db/migrate/20250425132757_add_organization_id_fk_to_paymants.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToPaymants < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :payments, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250425132821_validate_payments_organizations_foreign_key.rb
+++ b/db/migrate/20250425132821_validate_payments_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidatePaymentsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :payments, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -106,6 +106,7 @@ ALTER TABLE IF EXISTS ONLY public.integration_collection_mappings DROP CONSTRAIN
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_3cfe1d68d7;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_3c7c3920c0;
 ALTER TABLE IF EXISTS ONLY public.group_properties DROP CONSTRAINT IF EXISTS fk_rails_3acf9e789c;
+ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS fk_rails_3ab959bfc4;
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_3a303bf667;
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS fk_rails_3926855f12;
 ALTER TABLE IF EXISTS ONLY public.inbound_webhooks DROP CONSTRAINT IF EXISTS fk_rails_36cda06530;
@@ -218,6 +219,7 @@ DROP INDEX IF EXISTS public.index_payments_on_payment_provider_id;
 DROP INDEX IF EXISTS public.index_payments_on_payment_provider_customer_id;
 DROP INDEX IF EXISTS public.index_payments_on_payable_type_and_payable_id;
 DROP INDEX IF EXISTS public.index_payments_on_payable_id_and_payable_type;
+DROP INDEX IF EXISTS public.index_payments_on_organization_id;
 DROP INDEX IF EXISTS public.index_payments_on_invoice_id;
 DROP INDEX IF EXISTS public.index_payment_requests_on_organization_id;
 DROP INDEX IF EXISTS public.index_payment_requests_on_dunning_campaign_id;
@@ -3080,7 +3082,8 @@ CREATE TABLE public.payments (
     payment_type public.payment_type DEFAULT 'provider'::public.payment_type NOT NULL,
     reference character varying,
     provider_payment_method_data jsonb DEFAULT '{}'::jsonb NOT NULL,
-    provider_payment_method_id character varying
+    provider_payment_method_id character varying,
+    organization_id uuid
 );
 
 
@@ -5557,6 +5560,13 @@ CREATE INDEX index_payments_on_invoice_id ON public.payments USING btree (invoic
 
 
 --
+-- Name: index_payments_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_payments_on_organization_id ON public.payments USING btree (organization_id);
+
+
+--
 -- Name: index_payments_on_payable_id_and_payable_type; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6321,6 +6331,14 @@ ALTER TABLE ONLY public.quantified_events
 
 ALTER TABLE ONLY public.invoices
     ADD CONSTRAINT fk_rails_3a303bf667 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: payments fk_rails_3ab959bfc4; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.payments
+    ADD CONSTRAINT fk_rails_3ab959bfc4 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -7107,6 +7125,9 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250428111042'),
+('20250425132821'),
+('20250425132757'),
+('20250425132724'),
 ('20250425130412'),
 ('20250425130345'),
 ('20250425130332'),


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `payments` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added