### PR TITLE
fix(dispute-lost): Do do call lose dispute service for payment requests

### DIFF
--- a/app/services/payment_providers/stripe/webhooks/charge_dispute_closed_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/charge_dispute_closed_service.rb
@@ -10,7 +10,7 @@ module PaymentProviders
           provider_payment_id = event.data.object.payment_intent
 
           payment = Payment.find_by(provider_payment_id:)
-          return result unless payment
+          return result if !payment || !payment.payable.is_a?(Invoice)
 
           if status == "lost"
             return Invoices::LoseDisputeService.call(invoice: payment.payable, payment_dispute_lost_at:, reason:)

--- a/spec/services/payment_providers/stripe/webhooks/charge_dispute_closed_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/charge_dispute_closed_service_spec.rb
@@ -9,92 +9,125 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::ChargeDisputeClosedService, t
   let(:organization) { create(:organization) }
   let(:membership) { create(:membership, organization:) }
   let(:customer) { create(:customer, organization:) }
-  let(:payment) { create(:payment, payable: invoice, provider_payment_id: "pi_3OzgpDH4tiDZlIUa0Ezzggtg") }
-  let(:lose_dispute_service) { Invoices::LoseDisputeService.new(invoice:) }
-  let(:invoice) { create(:invoice, customer:, organization:, status:, payment_status: "succeeded") }
-
+  let(:payment) { create(:payment, payable:, provider_payment_id: "pi_3OzgpDH4tiDZlIUa0Ezzggtg") }
+  let(:lose_dispute_service) { Invoices::LoseDisputeService.new(payable:) }
   let(:event) { ::Stripe::Event.construct_from(JSON.parse(event_json)) }
 
   describe "#call" do
     before { payment }
 
-    context "when dispute is lost" do
-      let(:event_json) do
-        path = Rails.root.join("spec/fixtures/stripe/charge_dispute_lost_event.json")
-        File.read(path)
-      end
+    context "when payable is not an invoice" do
+      let(:payment) { create(:payment, payable:, provider_payment_id: "pi_3OzgpDH4tiDZlIUa0Ezzggtg") }
+      let(:payable) { create(:payment_request, customer:, organization:) }
 
-      context "when invoice is draft" do
-        let(:status) { "draft" }
+      before { allow(Invoices::LoseDisputeService).to receive(:call) }
 
-        it "does not updates invoice payment dispute lost" do
-          expect do
-            service.call
-            payment.payable.reload
-          end.not_to change(payment.payable.reload, :payment_dispute_lost_at).from(nil)
+      context "when dispute is lost" do
+        let(:event_json) do
+          path = Rails.root.join("spec/fixtures/stripe/charge_dispute_lost_event.json")
+          File.read(path)
         end
 
-        it "does not deliver webhook" do
-          expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+        it "does not call LoseDisputeService" do
+          service.call
+          expect(Invoices::LoseDisputeService).not_to have_received(:call)
         end
       end
 
-      context "when invoice is finalized" do
-        let(:status) { "finalized" }
-
-        it "updates invoice payment dispute lost" do
-          expect do
-            service.call
-            payment.payable.reload
-          end.to change(payment.payable, :payment_dispute_lost_at).from(nil)
+      context "when dispute is won" do
+        let(:event_json) do
+          path = Rails.root.join("spec/fixtures/stripe/charge_dispute_won_event.json")
+          File.read(path)
         end
 
-        it "delivers a webhook" do
-          expect do
-            service.call
-            payment.payable.reload
-          end.to have_enqueued_job(SendWebhookJob).with(
-            "invoice.payment_dispute_lost",
-            payment.payable,
-            provider_error: "fraudulent"
-          )
+        it "does not call LoseDisputeService" do
+          service.call
+          expect(Invoices::LoseDisputeService).not_to have_received(:call)
         end
       end
     end
 
-    context "when dispute is won" do
-      let(:event_json) do
-        path = Rails.root.join("spec/fixtures/stripe/charge_dispute_won_event.json")
-        File.read(path)
+    context "when payable is an invoice" do
+      let(:payable) { create(:invoice, customer:, organization:, status:, payment_status: "succeeded") }
+
+      context "when dispute is lost" do
+        let(:event_json) do
+          path = Rails.root.join("spec/fixtures/stripe/charge_dispute_lost_event.json")
+          File.read(path)
+        end
+
+        context "when invoice is draft" do
+          let(:status) { "draft" }
+
+          it "does not updates invoice payment dispute lost" do
+            expect do
+              service.call
+              payment.payable.reload
+            end.not_to change(payment.payable.reload, :payment_dispute_lost_at).from(nil)
+          end
+
+          it "does not deliver webhook" do
+            expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+          end
+        end
+
+        context "when invoice is finalized" do
+          let(:status) { "finalized" }
+
+          it "updates invoice payment dispute lost" do
+            expect do
+              service.call
+              payment.payable.reload
+            end.to change(payment.payable, :payment_dispute_lost_at).from(nil)
+          end
+
+          it "delivers a webhook" do
+            expect do
+              service.call
+              payment.payable.reload
+            end.to have_enqueued_job(SendWebhookJob).with(
+              "invoice.payment_dispute_lost",
+              payment.payable,
+              provider_error: "fraudulent"
+            )
+          end
+        end
       end
 
-      context "when invoice is draft" do
-        let(:status) { "draft" }
-
-        it "does not updates invoice payment dispute lost" do
-          expect do
-            service.call
-            payment.payable.reload
-          end.not_to change(payment.payable.reload, :payment_dispute_lost_at).from(nil)
+      context "when dispute is won" do
+        let(:event_json) do
+          path = Rails.root.join("spec/fixtures/stripe/charge_dispute_won_event.json")
+          File.read(path)
         end
 
-        it "does not deliver webhook" do
-          expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+        context "when invoice is draft" do
+          let(:status) { "draft" }
+
+          it "does not updates invoice payment dispute lost" do
+            expect do
+              service.call
+              payment.payable.reload
+            end.not_to change(payment.payable.reload, :payment_dispute_lost_at).from(nil)
+          end
+
+          it "does not deliver webhook" do
+            expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+          end
         end
-      end
 
-      context "when invoice is finalized" do
-        let(:status) { "finalized" }
+        context "when invoice is finalized" do
+          let(:status) { "finalized" }
 
-        it "does not updates invoice payment dispute lost" do
-          expect do
-            service.call
-            payment.payable.reload
-          end.not_to change(payment.payable.reload, :payment_dispute_lost_at).from(nil)
-        end
+          it "does not updates invoice payment dispute lost" do
+            expect do
+              service.call
+              payment.payable.reload
+            end.not_to change(payment.payable.reload, :payment_dispute_lost_at).from(nil)
+          end
 
-        it "does not deliver webhook" do
-          expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+          it "does not deliver webhook" do
+            expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+          end
         end
       end
     end


### PR DESCRIPTION
## Context

We're processing payment dispute won or lost events even for payments that belong to payment requests not just invoices.
In that case the service fails because payment requests don't have the method defined:

```
undefined method `mark_as_dispute_lost!' for an instance of PaymentRequest (NoMethodError)
```

## Description

This PR fixes that by calling the method only for invoices.