### PR TITLE
Fix(invoices): Ensure invoices got organization sequential id

### DIFF
--- a/db/migrate/20250428111042_ensure_organization_last_invoice_got_organization_sequential_id_retry.rb
+++ b/db/migrate/20250428111042_ensure_organization_last_invoice_got_organization_sequential_id_retry.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class EnsureOrganizationLastInvoiceGotOrganizationSequentialIdRetry < ActiveRecord::Migration[7.2]
+  def change
+    DatabaseMigrations::FixInvoicesOrganizationSequentialIdJob.perform_later
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7106,6 +7106,7 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250428111042'),
 ('20250425130412'),
 ('20250425130345'),
 ('20250425130332'),


### PR DESCRIPTION
Queue again the database migration job as it failed in the previous attempt due to code loading once the job was queued.

This change queues again the job to ensure no organization is missing the organization sequential id on its last invoice if it changed from numbering per customer to per organization... very unlikely at this point.