### PR TITLE
Feat(multientiites): add billing entities to data exports

### DIFF
--- a/app/graphql/types/data_exports/credit_notes/filters_input.rb
+++ b/app/graphql/types/data_exports/credit_notes/filters_input.rb
@@ -9,6 +9,7 @@ module Types
 
         argument :amount_from, Integer, required: false
         argument :amount_to, Integer, required: false
+        argument :billing_entity_ids, [ID], required: false
         argument :credit_status, [Types::CreditNotes::CreditStatusTypeEnum], required: false
         argument :currency, Types::CurrencyEnum, required: false
         argument :customer_external_id, String, required: false

--- a/app/graphql/types/data_exports/invoices/filters_input.rb
+++ b/app/graphql/types/data_exports/invoices/filters_input.rb
@@ -9,6 +9,7 @@ module Types
 
         argument :amount_from, Integer, required: false
         argument :amount_to, Integer, required: false
+        argument :billing_entity_ids, [ID], required: false
         argument :currency, Types::CurrencyEnum, required: false
         argument :customer_external_id, String, required: false
         argument :invoice_type, [Types::Invoices::InvoiceTypeEnum], required: false

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -42,7 +42,6 @@ module DataExports
           payment_due_date
           payment_dispute_lost_at
           payment_overdue
-          billing_entity_code
         ]
       end
 

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -11,7 +11,7 @@ module DataExports
       def initialize(data_export_part:, serializer_klass: V1::InvoiceSerializer)
         @data_export_part = data_export_part
         @serializer_klass = serializer_klass
-        @progressive_billing_enabled = data_export_part.data_export.organization&.progressive_billing_enabled?
+        @progressive_billing_enabled = organization&.progressive_billing_enabled?
         super
       end
 
@@ -42,12 +42,14 @@ module DataExports
           payment_due_date
           payment_dispute_lost_at
           payment_overdue
+          billing_entity_code
         ]
       end
 
       def headers
         base = self.class.base_headers.dup
         base << "progressive_billing_credit_amount_cents" if progressive_billing_enabled
+        base << "billing_entity_code" if org_has_multiple_billing_entities?
         base
       end
 
@@ -89,11 +91,22 @@ module DataExports
         ]
 
         row << serialized_invoice[:progressive_billing_credit_amount_cents] if progressive_billing_enabled
+        row << serialized_invoice[:billing_entity_code] if org_has_multiple_billing_entities?
         csv << row
       end
 
       def collection
         Invoice.find(data_export_part.object_ids)
+      end
+
+      def organization
+        @organization ||= data_export_part.data_export.organization
+      end
+
+      def org_has_multiple_billing_entities?
+        return false unless organization
+
+        organization.billing_entities.count > 1
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4188,6 +4188,7 @@ Export credit notes search query and filters input argument
 input DataExportCreditNoteFiltersInput {
   amountFrom: Int
   amountTo: Int
+  billingEntityIds: [ID!]
   creditStatus: [CreditNoteCreditStatusEnum!]
   currency: CurrencyEnum
   customerExternalId: String
@@ -4215,6 +4216,7 @@ Export Invoices search query and filters input argument
 input DataExportInvoiceFiltersInput {
   amountFrom: Int
   amountTo: Int
+  billingEntityIds: [ID!]
   currency: CurrencyEnum
   customerExternalId: String
   invoiceType: [InvoiceTypeEnum!]

--- a/schema.json
+++ b/schema.json
@@ -19043,6 +19043,26 @@
               "deprecationReason": null
             },
             {
+              "name": "billingEntityIds",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "creditStatus",
               "description": null,
               "type": {
@@ -19245,6 +19265,26 @@
                 "kind": "SCALAR",
                 "name": "Int",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billingEntityIds",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/types/data_exports/credit_notes/filters_input_spec.rb
+++ b/spec/graphql/types/data_exports/credit_notes/filters_input_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::DataExports::CreditNotes::FiltersInput do
   it do
     expect(subject).to accept_argument(:amount_from).of_type("Int")
     expect(subject).to accept_argument(:amount_to).of_type("Int")
+    expect(subject).to accept_argument(:billing_entity_ids).of_type("[ID]")
     expect(subject).to accept_argument(:credit_status).of_type("[CreditNoteCreditStatusEnum!]")
     expect(subject).to accept_argument(:currency).of_type("CurrencyEnum")
     expect(subject).to accept_argument(:customer_external_id).of_type("String")

--- a/spec/graphql/types/data_exports/credit_notes/filters_input_spec.rb
+++ b/spec/graphql/types/data_exports/credit_notes/filters_input_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Types::DataExports::CreditNotes::FiltersInput do
   it do
     expect(subject).to accept_argument(:amount_from).of_type("Int")
     expect(subject).to accept_argument(:amount_to).of_type("Int")
-    expect(subject).to accept_argument(:billing_entity_ids).of_type("[ID]")
+    expect(subject).to accept_argument(:billing_entity_ids).of_type("[ID!]")
     expect(subject).to accept_argument(:credit_status).of_type("[CreditNoteCreditStatusEnum!]")
     expect(subject).to accept_argument(:currency).of_type("CurrencyEnum")
     expect(subject).to accept_argument(:customer_external_id).of_type("String")

--- a/spec/graphql/types/data_exports/invoices/filters_input_spec.rb
+++ b/spec/graphql/types/data_exports/invoices/filters_input_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::DataExports::Invoices::FiltersInput do
   it do
     expect(subject).to accept_argument(:amount_from).of_type("Int")
     expect(subject).to accept_argument(:amount_to).of_type("Int")
+    expect(subject).to accept_argument(:billing_entity_ids).of_type("[ID]")
     expect(subject).to accept_argument(:currency).of_type("CurrencyEnum")
     expect(subject).to accept_argument(:customer_external_id).of_type("String")
     expect(subject).to accept_argument(:invoice_type).of_type("[InvoiceTypeEnum!]")

--- a/spec/graphql/types/data_exports/invoices/filters_input_spec.rb
+++ b/spec/graphql/types/data_exports/invoices/filters_input_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Types::DataExports::Invoices::FiltersInput do
   it do
     expect(subject).to accept_argument(:amount_from).of_type("Int")
     expect(subject).to accept_argument(:amount_to).of_type("Int")
-    expect(subject).to accept_argument(:billing_entity_ids).of_type("[ID]")
+    expect(subject).to accept_argument(:billing_entity_ids).of_type("[ID!]")
     expect(subject).to accept_argument(:currency).of_type("CurrencyEnum")
     expect(subject).to accept_argument(:customer_external_id).of_type("String")
     expect(subject).to accept_argument(:invoice_type).of_type("[InvoiceTypeEnum!]")

--- a/spec/services/data_exports/csv/credit_notes_spec.rb
+++ b/spec/services/data_exports/csv/credit_notes_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe DataExports::Csv::CreditNotes do
   describe "#call" do
     subject(:result) { described_class.new(data_export_part:).call }
 
-    let(:data_export) { create(:data_export, resource_type: "credit_notes") }
-    let(:credit_notes) { create_pair(:credit_note) }
+    let(:data_export) { create(:data_export, resource_type: "credit_notes", organization:) }
+    let(:billing_entity) { create(:billing_entity) }
+    let(:organization) { billing_entity.organization }
+    let(:credit_notes) { create_pair(:credit_note, billing_entity:) }
 
     let(:data_export_part) do
       create(:data_export_part, data_export:, object_ids: credit_notes.pluck(:id))
@@ -57,6 +59,54 @@ RSpec.describe DataExports::Csv::CreditNotes do
       expect(result).to be_success
       parsed_rows = CSV.parse(result.csv_file, nil_value: "")
       expect(parsed_rows).to eq(expected_rows)
+    end
+
+    context "when organization has multiple billing_entities" do
+      let(:billing_entity2) { create(:billing_entity, organization:) }
+      let(:credit_note) { create(:credit_note, billing_entity:) }
+      let(:data_export_part) do
+        create(:data_export_part, data_export:, object_ids: [credit_note.id])
+      end
+      let(:expected_rows) do
+        [[
+          credit_note.id,
+          credit_note.sequential_id,
+          credit_note.invoice.self_billed,
+          credit_note.issuing_date.iso8601,
+          credit_note.customer.id,
+          credit_note.customer.external_id,
+          credit_note.customer.name,
+          credit_note.customer.email,
+          credit_note.customer.country,
+          credit_note.customer.tax_identification_number,
+          credit_note.number,
+          credit_note.invoice.number,
+          credit_note.credit_status,
+          credit_note.refund_status,
+          credit_note.reason,
+          credit_note.description,
+          credit_note.currency,
+          credit_note.total_amount_cents,
+          credit_note.taxes_amount_cents,
+          credit_note.sub_total_excluding_taxes_amount_cents,
+          credit_note.coupons_adjustment_amount_cents,
+          credit_note.credit_amount_cents,
+          credit_note.balance_amount_cents,
+          credit_note.refund_amount_cents,
+          credit_note.file_url,
+          credit_note.billing_entity.code
+        ].map(&:to_s)]
+      end
+
+      before do
+        billing_entity2
+      end
+
+      it "adds serialized credit notes to csv" do
+        expect(result).to be_success
+        parsed_rows = CSV.parse(result.csv_file, nil_value: "")
+        expect(parsed_rows).to eq(expected_rows)
+      end
     end
   end
 end

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -72,7 +72,8 @@ RSpec.describe DataExports::Csv::Invoices do
       payment_due_date: "2023-02-01",
       payment_dispute_lost_at: "2023-12-22",
       payment_overdue: false,
-      progressive_billing_credit_amount_cents: 999
+      progressive_billing_credit_amount_cents: 999,
+      billing_entity_code: "the-test-bil-ent"
     }
   end
 
@@ -103,6 +104,26 @@ RSpec.describe DataExports::Csv::Invoices do
       file.close
       File.unlink(file.path)
       expect(generated_csv).to eq(expected_csv)
+    end
+
+    context "when organization has multiple billing_entities" do
+      let(:billing_entity) { create(:billing_entity, organization:) }
+
+      before { billing_entity }
+
+      it "adds billing_entity_code to the csv" do
+        expected_csv = <<~CSV
+          invoice-lago-id-123,SEQ123,false,2023-01-01,customer-lago-id-456,CUST123,customer name,customer@eamil.com,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false,999,the-test-bil-ent
+        CSV
+
+        expect(result).to be_success
+        file = result.csv_file
+        generated_csv = file.read
+
+        file.close
+        File.unlink(file.path)
+        expect(generated_csv).to eq(expected_csv)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

When creating a data export, if an organization has multiple entities, we want to show the billing_entity_code in the csv export

## Description

- Added billing_entity_code into filters input for invoices and credit notes
- Added an optional column to the data export csv, if an organization has multiple billing_entities