### PR TITLE
chore(organization): Add organization_id to webhooks table

### DIFF
--- a/app/jobs/database_migrations/populate_webhooks_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_webhooks_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateWebhooksWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Webhook.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM webhook_endpoints WHERE webhook_endpoints.id = webhooks.webhook_endpoint_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -5,6 +5,7 @@ class Webhook < ApplicationRecord
 
   STATUS = %i[pending succeeded failed].freeze
 
+  belongs_to :organization, optional: true
   belongs_to :webhook_endpoint
   belongs_to :object, polymorphic: true, optional: true
 
@@ -82,13 +83,16 @@ end
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  object_id           :uuid
+#  organization_id     :uuid
 #  webhook_endpoint_id :uuid
 #
 # Indexes
 #
+#  index_webhooks_on_organization_id      (organization_id)
 #  index_webhooks_on_webhook_endpoint_id  (webhook_endpoint_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (webhook_endpoint_id => webhook_endpoints.id)
 #

--- a/app/services/webhooks/base_service.rb
+++ b/app/services/webhooks/base_service.rb
@@ -49,6 +49,7 @@ module Webhooks
 
     def create_webhook(webhook_endpoint, payload)
       webhook = Webhook.new(webhook_endpoint:)
+      webhook.organization_id = current_organization&.id
       webhook.webhook_type = webhook_type
       webhook.endpoint = webhook_endpoint.webhook_url
       # Question: When can this be a hash?

--- a/db/migrate/20250428130107_add_organization_id_to_webhooks.rb
+++ b/db/migrate/20250428130107_add_organization_id_to_webhooks.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToWebhooks < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :webhooks, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250428130129_add_organization_id_fk_to_webhooks.rb
+++ b/db/migrate/20250428130129_add_organization_id_fk_to_webhooks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToWebhooks < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :webhooks, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250428130148_validate_webhooks_organizations_foreign_key.rb
+++ b/db/migrate/20250428130148_validate_webhooks_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateWebhooksOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :webhooks, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -98,6 +98,7 @@ ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_521
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_51ac39a0c6;
 ALTER TABLE IF EXISTS ONLY public.payment_provider_customers DROP CONSTRAINT IF EXISTS fk_rails_50d46d3679;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_4934f27a06;
+ALTER TABLE IF EXISTS ONLY public.webhooks DROP CONSTRAINT IF EXISTS fk_rails_49212d501e;
 ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_4117574b51;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_3ff27d7624;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_3f7be5debc;
@@ -165,6 +166,7 @@ SELECT
     NULL::json AS filters,
     NULL::jsonb AS filters_grouped_by;
 DROP INDEX IF EXISTS public.index_webhooks_on_webhook_endpoint_id;
+DROP INDEX IF EXISTS public.index_webhooks_on_organization_id;
 DROP INDEX IF EXISTS public.index_webhook_endpoints_on_webhook_url_and_organization_id;
 DROP INDEX IF EXISTS public.index_webhook_endpoints_on_organization_id;
 DROP INDEX IF EXISTS public.index_wallets_on_ready_to_be_refreshed;
@@ -3259,7 +3261,8 @@ CREATE TABLE public.webhooks (
     last_retried_at timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    webhook_endpoint_id uuid
+    webhook_endpoint_id uuid,
+    organization_id uuid
 );
 
 
@@ -5945,6 +5948,13 @@ CREATE UNIQUE INDEX index_webhook_endpoints_on_webhook_url_and_organization_id O
 
 
 --
+-- Name: index_webhooks_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_webhooks_on_organization_id ON public.webhooks USING btree (organization_id);
+
+
+--
 -- Name: index_webhooks_on_webhook_endpoint_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6403,6 +6413,14 @@ ALTER TABLE ONLY public.charges_taxes
 
 ALTER TABLE ONLY public.credit_notes
     ADD CONSTRAINT fk_rails_4117574b51 FOREIGN KEY (invoice_id) REFERENCES public.invoices(id);
+
+
+--
+-- Name: webhooks fk_rails_49212d501e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.webhooks
+    ADD CONSTRAINT fk_rails_49212d501e FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -7124,6 +7142,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250428130148'),
+('20250428130129'),
+('20250428130107'),
 ('20250428111042'),
 ('20250425132821'),
 ('20250425132757'),


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `webhooks` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added