### PR TITLE
chore(organization): Add organization_id to usage_thresholds table

### DIFF
--- a/app/jobs/database_migrations/populate_usage_thresholds_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_usage_thresholds_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateUsageThresholdsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = UsageThreshold.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM plans WHERE plans.id = usage_thresholds.plan_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/usage_threshold.rb
+++ b/app/models/usage_threshold.rb
@@ -6,6 +6,7 @@ class UsageThreshold < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
+  belongs_to :organization, optional: true
   belongs_to :plan
 
   has_many :applied_usage_thresholds
@@ -38,15 +39,18 @@ end
 #  threshold_display_name :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  organization_id        :uuid
 #  plan_id                :uuid             not null
 #
 # Indexes
 #
 #  idx_on_amount_cents_plan_id_recurring_888044d66b  (amount_cents,plan_id,recurring) UNIQUE WHERE (deleted_at IS NULL)
+#  index_usage_thresholds_on_organization_id         (organization_id)
 #  index_usage_thresholds_on_plan_id                 (plan_id)
 #  index_usage_thresholds_on_plan_id_and_recurring   (plan_id,recurring) UNIQUE WHERE ((recurring IS TRUE) AND (deleted_at IS NULL))
 #
 # Foreign Keys
 #
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_id => plans.id)
 #

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -94,6 +94,7 @@ module Plans
 
     def create_usage_threshold(plan, args)
       usage_threshold = plan.usage_thresholds.new(
+        organization_id: plan.organization_id,
         threshold_display_name: args[:threshold_display_name],
         amount_cents: args[:amount_cents],
         recurring: args[:recurring] || false

--- a/app/services/plans/update_usage_thresholds_service.rb
+++ b/app/services/plans/update_usage_thresholds_service.rb
@@ -84,6 +84,7 @@ module Plans
 
       usage_threshold.threshold_display_name = params[:threshold_display_name]
       usage_threshold.amount_cents = params[:amount_cents]
+      usage_threshold.organization_id = plan.organization_id
 
       usage_threshold.save!
       usage_threshold

--- a/app/services/usage_thresholds/override_service.rb
+++ b/app/services/usage_thresholds/override_service.rb
@@ -13,6 +13,7 @@ module UsageThresholds
       ActiveRecord::Base.transaction do
         usage_thresholds_params.each do |params|
           usage_threshold = new_plan.usage_thresholds.new(
+            organization_id: new_plan.organization_id,
             plan_id: new_plan.id,
             threshold_display_name: params[:threshold_display_name],
             amount_cents: params[:amount_cents],

--- a/db/migrate/20250428140111_add_organization_id_to_usage_thresholds.rb
+++ b/db/migrate/20250428140111_add_organization_id_to_usage_thresholds.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToUsageThresholds < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :usage_thresholds, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250428140126_add_organization_id_fk_to_usage_thresholds.rb
+++ b/db/migrate/20250428140126_add_organization_id_fk_to_usage_thresholds.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToUsageThresholds < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :usage_thresholds, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250428140148_validate_usage_thresholds_organizations_foreign_key.rb
+++ b/db/migrate/20250428140148_validate_usage_thresholds_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateUsageThresholdsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :usage_thresholds, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -58,6 +58,7 @@ ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_9
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_9298b8fdad;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_90d93bd016;
 ALTER TABLE IF EXISTS ONLY public.commitments_taxes DROP CONSTRAINT IF EXISTS fk_rails_8fa6f0d920;
+ALTER TABLE IF EXISTS ONLY public.usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_8df9bf2b6c;
 ALTER TABLE IF EXISTS ONLY public.invoice_metadata DROP CONSTRAINT IF EXISTS fk_rails_8bb5b094c4;
 ALTER TABLE IF EXISTS ONLY public.add_ons_taxes DROP CONSTRAINT IF EXISTS fk_rails_89e1020aca;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_88349fc20a;
@@ -181,6 +182,7 @@ DROP INDEX IF EXISTS public.index_wallet_transactions_on_credit_note_id;
 DROP INDEX IF EXISTS public.index_versions_on_item_type_and_item_id;
 DROP INDEX IF EXISTS public.index_usage_thresholds_on_plan_id_and_recurring;
 DROP INDEX IF EXISTS public.index_usage_thresholds_on_plan_id;
+DROP INDEX IF EXISTS public.index_usage_thresholds_on_organization_id;
 DROP INDEX IF EXISTS public.index_unique_transaction_id;
 DROP INDEX IF EXISTS public.index_unique_terminating_subscription_invoice;
 DROP INDEX IF EXISTS public.index_unique_starting_subscription_invoice;
@@ -3218,7 +3220,8 @@ CREATE TABLE public.usage_thresholds (
     recurring boolean DEFAULT false NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    deleted_at timestamp(6) without time zone
+    deleted_at timestamp(6) without time zone,
+    organization_id uuid
 );
 
 
@@ -5942,6 +5945,13 @@ CREATE UNIQUE INDEX index_unique_transaction_id ON public.events USING btree (or
 
 
 --
+-- Name: index_usage_thresholds_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_usage_thresholds_on_organization_id ON public.usage_thresholds USING btree (organization_id);
+
+
+--
 -- Name: index_usage_thresholds_on_plan_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6838,6 +6848,14 @@ ALTER TABLE ONLY public.invoice_metadata
 
 
 --
+-- Name: usage_thresholds fk_rails_8df9bf2b6c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usage_thresholds
+    ADD CONSTRAINT fk_rails_8df9bf2b6c FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: commitments_taxes fk_rails_8fa6f0d920; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7237,6 +7255,9 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250429100148'),
+('20250428140148'),
+('20250428140126'),
+('20250428140111'),
 ('20250428130148'),
 ('20250428130129'),
 ('20250428130107'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -62,7 +62,6 @@ Rspec.describe "All tables must have an organization_id" do
       plans_taxes
       recurring_transaction_rules
       refunds
-      usage_thresholds
       versions
     ]
   end


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `webhooks` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added