### PR TITLE
hotfix(webhooks): Avoid errors with webhooks delivery

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -5,10 +5,10 @@ class Webhook < ApplicationRecord
 
   STATUS = %i[pending succeeded failed].freeze
 
-  belongs_to :organization, optional: true
   belongs_to :webhook_endpoint
   belongs_to :object, polymorphic: true, optional: true
 
+  # TODO: belongs_to :organization, optional: true
   has_one :organization, through: :webhook_endpoint
 
   enum :status, STATUS


### PR DESCRIPTION
Hotfix for

```
undefined method `updated?' for an instance of ActiveRecord::Associations::HasOneThroughAssociation (NoMethodError) if association.updated? 
```