### PR TITLE
chore(organization): Add organization_id to plans_taxes table

### DIFF
--- a/app/jobs/database_migrations/populate_plans_taxes_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_plans_taxes_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulatePlansTaxesWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Plan::AppliedTax
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM plans WHERE plans.id = plans_taxes.plan_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/plan/applied_tax.rb
+++ b/app/models/plan/applied_tax.rb
@@ -8,6 +8,7 @@ class Plan
 
     belongs_to :plan
     belongs_to :tax
+    belongs_to :organization, optional: true
   end
 end
 
@@ -15,20 +16,23 @@ end
 #
 # Table name: plans_taxes
 #
-#  id         :uuid             not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  plan_id    :uuid             not null
-#  tax_id     :uuid             not null
+#  id              :uuid             not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :uuid
+#  plan_id         :uuid             not null
+#  tax_id          :uuid             not null
 #
 # Indexes
 #
+#  index_plans_taxes_on_organization_id     (organization_id)
 #  index_plans_taxes_on_plan_id             (plan_id)
 #  index_plans_taxes_on_plan_id_and_tax_id  (plan_id,tax_id) UNIQUE
 #  index_plans_taxes_on_tax_id              (tax_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_id => plans.id)
 #  fk_rails_...  (tax_id => taxes.id)
 #

--- a/app/services/plans/apply_taxes_service.rb
+++ b/app/services/plans/apply_taxes_service.rb
@@ -18,7 +18,9 @@ module Plans
       ).destroy_all
 
       result.applied_taxes = tax_codes.map do |tax_code|
-        plan.applied_taxes.find_or_create_by!(tax: taxes.find_by(code: tax_code))
+        plan.applied_taxes
+          .create_with(organization: plan.organization)
+          .find_or_create_by!(tax: taxes.find_by(code: tax_code))
       end
 
       result

--- a/db/migrate/20250428154444_add_organization_id_to_plans_taxes.rb
+++ b/db/migrate/20250428154444_add_organization_id_to_plans_taxes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToPlansTaxes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :plans_taxes, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250428154500_add_organization_id_fk_to_plans_taxes.rb
+++ b/db/migrate/20250428154500_add_organization_id_fk_to_plans_taxes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToPlansTaxes < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :plans_taxes, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250428154519_validate_plans_taxes_organizations_foreign_key.rb
+++ b/db/migrate/20250428154519_validate_plans_taxes_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidatePlansTaxesOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :plans_taxes, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -19,6 +19,7 @@ ALTER TABLE IF EXISTS ONLY public.invoices_payment_requests DROP CONSTRAINT IF E
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_eaca9421be;
 ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_ea80151038;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS fk_rails_e8bac9c5bb;
+ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS fk_rails_e88403f4b9;
 ALTER TABLE IF EXISTS ONLY public.customers_taxes DROP CONSTRAINT IF EXISTS fk_rails_e86903e081;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_dea748e529;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_de6b3c3138;
@@ -215,6 +216,7 @@ DROP INDEX IF EXISTS public.index_quantified_events_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_tax_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_plan_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_plan_id;
+DROP INDEX IF EXISTS public.index_plans_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_plans_on_parent_id;
 DROP INDEX IF EXISTS public.index_plans_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_plans_on_organization_id;
@@ -2447,7 +2449,8 @@ CREATE TABLE public.plans_taxes (
     plan_id uuid NOT NULL,
     tax_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -5738,6 +5741,13 @@ CREATE INDEX index_plans_on_parent_id ON public.plans USING btree (parent_id);
 
 
 --
+-- Name: index_plans_taxes_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_plans_taxes_on_organization_id ON public.plans_taxes USING btree (organization_id);
+
+
+--
 -- Name: index_plans_taxes_on_plan_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7186,6 +7196,14 @@ ALTER TABLE ONLY public.customers_taxes
 
 
 --
+-- Name: plans_taxes fk_rails_e88403f4b9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.plans_taxes
+    ADD CONSTRAINT fk_rails_e88403f4b9 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: recurring_transaction_rules fk_rails_e8bac9c5bb; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7276,6 +7294,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250429100150'),
 ('20250429100149'),
 ('20250429100148'),
+('20250428154519'),
+('20250428154500'),
+('20250428154444'),
 ('20250428140148'),
 ('20250428140126'),
 ('20250428140111'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -58,7 +58,6 @@ Rspec.describe "All tables must have an organization_id" do
       invoices_taxes
       password_resets
       payment_provider_customers
-      plans_taxes
       recurring_transaction_rules
       refunds
       versions


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `plans_taxes` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added