### PR TITLE
chore(organization): Add organization_id to invoice_subscriptions table

### DIFF
--- a/app/jobs/database_migrations/populate_invoice_subscriptions_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_invoice_subscriptions_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateInvoiceSubscriptionsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = InvoiceSubscription.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM invoices WHERE invoices.id = invoice_subscriptions.invoice_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -5,6 +5,7 @@ class InvoiceSubscription < ApplicationRecord
 
   belongs_to :invoice
   belongs_to :subscription
+  belongs_to :organization, optional: true
 
   has_one :customer, through: :subscription
 
@@ -113,6 +114,7 @@ end
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  invoice_id            :uuid             not null
+#  organization_id       :uuid
 #  subscription_id       :uuid             not null
 #
 # Indexes
@@ -121,6 +123,7 @@ end
 #  index_invoice_subscriptions_on_charges_from_and_to_datetime    (subscription_id,charges_from_datetime,charges_to_datetime) UNIQUE WHERE ((created_at >= '2023-06-09 00:00:00'::timestamp without time zone) AND (recurring IS TRUE))
 #  index_invoice_subscriptions_on_invoice_id                      (invoice_id)
 #  index_invoice_subscriptions_on_invoice_id_and_subscription_id  (invoice_id,subscription_id) UNIQUE WHERE (created_at >= '2023-11-23 00:00:00'::timestamp without time zone)
+#  index_invoice_subscriptions_on_organization_id                 (organization_id)
 #  index_invoice_subscriptions_on_subscription_id                 (subscription_id)
 #  index_unique_starting_subscription_invoice                     (subscription_id,invoicing_reason) UNIQUE WHERE (invoicing_reason = 'subscription_starting'::subscription_invoicing_reason)
 #  index_unique_terminating_subscription_invoice                  (subscription_id,invoicing_reason) UNIQUE WHERE (invoicing_reason = 'subscription_terminating'::subscription_invoicing_reason)
@@ -128,5 +131,6 @@ end
 # Foreign Keys
 #
 #  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (subscription_id => subscriptions.id)
 #

--- a/app/services/invoices/create_advance_charges_invoice_subscription_service.rb
+++ b/app/services/invoices/create_advance_charges_invoice_subscription_service.rb
@@ -22,6 +22,7 @@ module Invoices
 
       subscriptions_with_fees.each do |subscription|
         invoice.invoice_subscriptions << InvoiceSubscription.create!(
+          organization: subscription.organization,
           invoice:,
           subscription:,
           timestamp:,

--- a/app/services/invoices/create_invoice_subscription_service.rb
+++ b/app/services/invoices/create_invoice_subscription_service.rb
@@ -28,6 +28,7 @@ module Invoices
         boundaries = termination_boundaries(subscription, subscription_boundaries)
 
         result.invoice_subscriptions << InvoiceSubscription.create!(
+          organization: subscription.organization,
           invoice:,
           subscription:,
           timestamp: boundaries[:timestamp],

--- a/db/migrate/20250429100149_add_organization_id_to_invoice_subscriptions.rb
+++ b/db/migrate/20250429100149_add_organization_id_to_invoice_subscriptions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToInvoiceSubscriptions < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :invoice_subscriptions, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250429100150_add_organization_id_fk_to_invoice_subscriptions.rb
+++ b/db/migrate/20250429100150_add_organization_id_fk_to_invoice_subscriptions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToInvoiceSubscriptions < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :invoice_subscriptions, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250429100151_validate_invoice_subscriptions_organizations_foreign_key.rb
+++ b/db/migrate/20250429100151_validate_invoice_subscriptions_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateInvoiceSubscriptionsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :invoice_subscriptions, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -141,6 +141,7 @@ ALTER TABLE IF EXISTS ONLY public.plans DROP CONSTRAINT IF EXISTS fk_rails_216ac
 ALTER TABLE IF EXISTS ONLY public.webhooks DROP CONSTRAINT IF EXISTS fk_rails_20cc0de4c7;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_1db0057d9b;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_195153290d;
+ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_150139409e;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_1454058c96;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_12d29bc654;
 ALTER TABLE IF EXISTS ONLY public.applied_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_10428ecad2;
@@ -268,6 +269,7 @@ DROP INDEX IF EXISTS public.index_invoices_on_customer_id_and_sequential_id;
 DROP INDEX IF EXISTS public.index_invoices_on_customer_id;
 DROP INDEX IF EXISTS public.index_invoices_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_invoice_subscriptions_on_subscription_id;
+DROP INDEX IF EXISTS public.index_invoice_subscriptions_on_organization_id;
 DROP INDEX IF EXISTS public.index_invoice_subscriptions_on_invoice_id_and_subscription_id;
 DROP INDEX IF EXISTS public.index_invoice_subscriptions_on_invoice_id;
 DROP INDEX IF EXISTS public.index_invoice_subscriptions_on_charges_from_and_to_datetime;
@@ -2905,7 +2907,8 @@ CREATE TABLE public.invoice_subscriptions (
     to_datetime timestamp(6) without time zone,
     charges_from_datetime timestamp(6) without time zone,
     charges_to_datetime timestamp(6) without time zone,
-    invoicing_reason public.subscription_invoicing_reason
+    invoicing_reason public.subscription_invoicing_reason,
+    organization_id uuid
 );
 
 
@@ -5350,6 +5353,13 @@ CREATE UNIQUE INDEX index_invoice_subscriptions_on_invoice_id_and_subscription_i
 
 
 --
+-- Name: index_invoice_subscriptions_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_invoice_subscriptions_on_organization_id ON public.invoice_subscriptions USING btree (organization_id);
+
+
+--
 -- Name: index_invoice_subscriptions_on_subscription_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6189,6 +6199,14 @@ ALTER TABLE ONLY public.daily_usages
 
 ALTER TABLE ONLY public.coupon_targets
     ADD CONSTRAINT fk_rails_1454058c96 FOREIGN KEY (billable_metric_id) REFERENCES public.billable_metrics(id);
+
+
+--
+-- Name: invoice_subscriptions fk_rails_150139409e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.invoice_subscriptions
+    ADD CONSTRAINT fk_rails_150139409e FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -7254,6 +7272,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250429100151'),
+('20250429100150'),
+('20250429100149'),
 ('20250429100148'),
 ('20250428140148'),
 ('20250428140126'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -54,7 +54,6 @@ Rspec.describe "All tables must have an organization_id" do
       integration_mappings
       integration_resources
       invoice_metadata
-      invoice_subscriptions
       invoices_payment_requests
       invoices_taxes
       password_resets


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `invoice_subscriptions` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added