### PR TITLE
fix: send correct contact error webhook for avalara

### DIFF
--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -137,6 +137,8 @@ module Integrations
         case provider
         when "hubspot"
           "customer.crm_provider_error"
+        when "avalara"
+          "customer.tax_provider_error"
         else
           "customer.accounting_provider_error"
         end


### PR DESCRIPTION
## Context

Currently Lago is working on integration with tax provider Avalara

## Description

This PR fixes code for error webhook dispatched in case of contact sync failure