### PR TITLE
chore(organization): Add organization_id to payment_provider_customers table

### DIFF
--- a/app/jobs/database_migrations/populate_payment_provider_customers_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_payment_provider_customers_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulatePaymentProviderCustomersWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = PaymentProviderCustomers::BaseCustomer
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM payment_providers WHERE payment_providers.id = payment_provider_customers.payment_provider_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/payment_provider_customers/adyen_customer.rb
+++ b/app/models/payment_provider_customers/adyen_customer.rb
@@ -17,17 +17,20 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  customer_id          :uuid             not null
+#  organization_id      :uuid
 #  payment_provider_id  :uuid
 #  provider_customer_id :string
 #
 # Indexes
 #
 #  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE WHERE (deleted_at IS NULL)
+#  index_payment_provider_customers_on_organization_id       (organization_id)
 #  index_payment_provider_customers_on_payment_provider_id   (payment_provider_id)
 #  index_payment_provider_customers_on_provider_customer_id  (provider_customer_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_provider_id => payment_providers.id)
 #

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -12,6 +12,7 @@ module PaymentProviderCustomers
 
     belongs_to :customer
     belongs_to :payment_provider, optional: true, class_name: "PaymentProviders::BaseProvider"
+    belongs_to :organization, optional: true
 
     has_many :payments
     has_many :refunds, foreign_key: :payment_provider_customer_id
@@ -47,17 +48,20 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  customer_id          :uuid             not null
+#  organization_id      :uuid
 #  payment_provider_id  :uuid
 #  provider_customer_id :string
 #
 # Indexes
 #
 #  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE WHERE (deleted_at IS NULL)
+#  index_payment_provider_customers_on_organization_id       (organization_id)
 #  index_payment_provider_customers_on_payment_provider_id   (payment_provider_id)
 #  index_payment_provider_customers_on_provider_customer_id  (provider_customer_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_provider_id => payment_providers.id)
 #

--- a/app/models/payment_provider_customers/cashfree_customer.rb
+++ b/app/models/payment_provider_customers/cashfree_customer.rb
@@ -19,17 +19,20 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  customer_id          :uuid             not null
+#  organization_id      :uuid
 #  payment_provider_id  :uuid
 #  provider_customer_id :string
 #
 # Indexes
 #
 #  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE WHERE (deleted_at IS NULL)
+#  index_payment_provider_customers_on_organization_id       (organization_id)
 #  index_payment_provider_customers_on_payment_provider_id   (payment_provider_id)
 #  index_payment_provider_customers_on_provider_customer_id  (provider_customer_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_provider_id => payment_providers.id)
 #

--- a/app/models/payment_provider_customers/gocardless_customer.rb
+++ b/app/models/payment_provider_customers/gocardless_customer.rb
@@ -16,17 +16,20 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  customer_id          :uuid             not null
+#  organization_id      :uuid
 #  payment_provider_id  :uuid
 #  provider_customer_id :string
 #
 # Indexes
 #
 #  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE WHERE (deleted_at IS NULL)
+#  index_payment_provider_customers_on_organization_id       (organization_id)
 #  index_payment_provider_customers_on_payment_provider_id   (payment_provider_id)
 #  index_payment_provider_customers_on_provider_customer_id  (provider_customer_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_provider_id => payment_providers.id)
 #

--- a/app/models/payment_provider_customers/moneyhash_customer.rb
+++ b/app/models/payment_provider_customers/moneyhash_customer.rb
@@ -54,17 +54,20 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  customer_id          :uuid             not null
+#  organization_id      :uuid
 #  payment_provider_id  :uuid
 #  provider_customer_id :string
 #
 # Indexes
 #
 #  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE WHERE (deleted_at IS NULL)
+#  index_payment_provider_customers_on_organization_id       (organization_id)
 #  index_payment_provider_customers_on_payment_provider_id   (payment_provider_id)
 #  index_payment_provider_customers_on_provider_customer_id  (provider_customer_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_provider_id => payment_providers.id)
 #

--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -59,17 +59,20 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  customer_id          :uuid             not null
+#  organization_id      :uuid
 #  payment_provider_id  :uuid
 #  provider_customer_id :string
 #
 # Indexes
 #
 #  index_payment_provider_customers_on_customer_id_and_type  (customer_id,type) UNIQUE WHERE (deleted_at IS NULL)
+#  index_payment_provider_customers_on_organization_id       (organization_id)
 #  index_payment_provider_customers_on_payment_provider_id   (payment_provider_id)
 #  index_payment_provider_customers_on_provider_customer_id  (provider_customer_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_provider_id => payment_providers.id)
 #

--- a/app/services/payment_providers/adyen/customers/create_service.rb
+++ b/app/services/payment_providers/adyen/customers/create_service.rb
@@ -15,7 +15,11 @@ module PaymentProviders
 
         def call
           provider_customer = PaymentProviderCustomers::AdyenCustomer.find_by(customer_id: customer.id)
-          provider_customer ||= PaymentProviderCustomers::AdyenCustomer.new(customer_id: customer.id, payment_provider_id:)
+          provider_customer ||= PaymentProviderCustomers::AdyenCustomer.new(
+            customer_id: customer.id,
+            payment_provider_id: payment_provider_id,
+            organization_id: organization.id
+          )
 
           if params.key?(:provider_customer_id)
             provider_customer.provider_customer_id = params[:provider_customer_id].presence

--- a/app/services/payment_providers/cashfree/customers/create_service.rb
+++ b/app/services/payment_providers/cashfree/customers/create_service.rb
@@ -15,7 +15,11 @@ module PaymentProviders
 
         def call
           provider_customer = PaymentProviderCustomers::CashfreeCustomer.find_by(customer_id: customer.id)
-          provider_customer ||= PaymentProviderCustomers::CashfreeCustomer.new(customer_id: customer.id, payment_provider_id:)
+          provider_customer ||= PaymentProviderCustomers::CashfreeCustomer.new(
+            customer_id: customer.id,
+            payment_provider_id:,
+            organization_id: organization.id
+          )
 
           if params.key?(:sync_with_provider)
             provider_customer.sync_with_provider = params[:sync_with_provider].presence

--- a/app/services/payment_providers/gocardless/customers/create_service.rb
+++ b/app/services/payment_providers/gocardless/customers/create_service.rb
@@ -15,7 +15,11 @@ module PaymentProviders
 
         def call
           provider_customer = PaymentProviderCustomers::GocardlessCustomer.find_by(customer_id: customer.id)
-          provider_customer ||= PaymentProviderCustomers::GocardlessCustomer.new(customer_id: customer.id, payment_provider_id:)
+          provider_customer ||= PaymentProviderCustomers::GocardlessCustomer.new(
+            customer_id: customer.id,
+            payment_provider_id:,
+            organization_id: organization.id
+          )
 
           if params.key?(:provider_customer_id)
             provider_customer.provider_customer_id = params[:provider_customer_id].presence

--- a/app/services/payment_providers/moneyhash/customers/create_service.rb
+++ b/app/services/payment_providers/moneyhash/customers/create_service.rb
@@ -15,7 +15,11 @@ module PaymentProviders
 
         def call
           provider_customer = PaymentProviderCustomers::MoneyhashCustomer.find_by(customer_id: customer.id)
-          provider_customer ||= PaymentProviderCustomers::MoneyhashCustomer.new(customer_id: customer.id, payment_provider_id:)
+          provider_customer ||= PaymentProviderCustomers::MoneyhashCustomer.new(
+            customer_id: customer.id,
+            payment_provider_id:,
+            organization_id: organization.id
+          )
 
           if params.key?(:provider_customer_id)
             provider_customer.provider_customer_id = params[:provider_customer_id].presence

--- a/app/services/payment_providers/stripe/customers/create_service.rb
+++ b/app/services/payment_providers/stripe/customers/create_service.rb
@@ -15,7 +15,11 @@ module PaymentProviders
 
         def call
           provider_customer = PaymentProviderCustomers::StripeCustomer.find_by(customer_id: customer.id)
-          provider_customer ||= PaymentProviderCustomers::StripeCustomer.new(customer_id: customer.id, payment_provider_id:)
+          provider_customer ||= PaymentProviderCustomers::StripeCustomer.new(
+            customer_id: customer.id,
+            payment_provider_id:,
+            organization_id: organization.id
+          )
 
           if params.key?(:provider_customer_id)
             provider_customer.provider_customer_id = params[:provider_customer_id].presence

--- a/db/migrate/20250429100152_add_organization_id_to_payment_provider_customers.rb
+++ b/db/migrate/20250429100152_add_organization_id_to_payment_provider_customers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToPaymentProviderCustomers < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :payment_provider_customers, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250429100153_add_organization_id_fk_to_payment_provider_customers.rb
+++ b/db/migrate/20250429100153_add_organization_id_fk_to_payment_provider_customers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToPaymentProviderCustomers < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :payment_provider_customers, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250429100154_validate_payment_provider_customers_organizations_foreign_key.rb
+++ b/db/migrate/20250429100154_validate_payment_provider_customers_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidatePaymentProviderCustomersOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :payment_provider_customers, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -16,6 +16,7 @@ ALTER TABLE IF EXISTS ONLY public.payment_receipts DROP CONSTRAINT IF EXISTS fk_
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS fk_rails_f510acb495;
 ALTER TABLE IF EXISTS ONLY public.payment_requests DROP CONSTRAINT IF EXISTS fk_rails_f228550fda;
 ALTER TABLE IF EXISTS ONLY public.invoices_payment_requests DROP CONSTRAINT IF EXISTS fk_rails_ed387e0992;
+ALTER TABLE IF EXISTS ONLY public.payment_provider_customers DROP CONSTRAINT IF EXISTS fk_rails_ecb466254b;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_eaca9421be;
 ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_ea80151038;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS fk_rails_e8bac9c5bb;
@@ -239,6 +240,7 @@ DROP INDEX IF EXISTS public.index_payment_providers_on_organization_id;
 DROP INDEX IF EXISTS public.index_payment_providers_on_code_and_organization_id;
 DROP INDEX IF EXISTS public.index_payment_provider_customers_on_provider_customer_id;
 DROP INDEX IF EXISTS public.index_payment_provider_customers_on_payment_provider_id;
+DROP INDEX IF EXISTS public.index_payment_provider_customers_on_organization_id;
 DROP INDEX IF EXISTS public.index_payment_provider_customers_on_customer_id_and_type;
 DROP INDEX IF EXISTS public.index_payment_intents_on_organization_id;
 DROP INDEX IF EXISTS public.index_payment_intents_on_invoice_id_and_status;
@@ -1960,7 +1962,8 @@ CREATE TABLE public.payment_provider_customers (
     settings jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    deleted_at timestamp(6) without time zone
+    deleted_at timestamp(6) without time zone,
+    organization_id uuid
 );
 
 
@@ -5587,6 +5590,13 @@ CREATE UNIQUE INDEX index_payment_provider_customers_on_customer_id_and_type ON 
 
 
 --
+-- Name: index_payment_provider_customers_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_payment_provider_customers_on_organization_id ON public.payment_provider_customers USING btree (organization_id);
+
+
+--
 -- Name: index_payment_provider_customers_on_payment_provider_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7228,6 +7238,14 @@ ALTER TABLE ONLY public.fees
 
 
 --
+-- Name: payment_provider_customers fk_rails_ecb466254b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.payment_provider_customers
+    ADD CONSTRAINT fk_rails_ecb466254b FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: invoices_payment_requests fk_rails_ed387e0992; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7290,6 +7308,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250429100154'),
+('20250429100153'),
+('20250429100152'),
 ('20250429100151'),
 ('20250429100150'),
 ('20250429100149'),

--- a/spec/factories/payment_provider_customers.rb
+++ b/spec/factories/payment_provider_customers.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :stripe_customer, class: "PaymentProviderCustomers::StripeCustomer" do
     customer
+    organization { customer.organization }
 
     provider_customer_id { SecureRandom.uuid }
     provider_payment_methods { %w[card sepa_debit] }
@@ -10,24 +11,28 @@ FactoryBot.define do
 
   factory :gocardless_customer, class: "PaymentProviderCustomers::GocardlessCustomer" do
     customer
+    organization { customer.organization }
 
     provider_customer_id { SecureRandom.uuid }
   end
 
   factory :cashfree_customer, class: "PaymentProviderCustomers::CashfreeCustomer" do
     customer
+    organization { customer.organization }
 
     provider_customer_id { SecureRandom.uuid }
   end
 
   factory :adyen_customer, class: "PaymentProviderCustomers::AdyenCustomer" do
     customer
+    organization { customer.organization }
 
     provider_customer_id { SecureRandom.uuid }
   end
 
   factory :moneyhash_customer, class: "PaymentProviderCustomers::MoneyhashCustomer" do
     customer
+    organization { customer.organization }
 
     provider_customer_id { SecureRandom.uuid }
   end

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -57,7 +57,6 @@ Rspec.describe "All tables must have an organization_id" do
       invoices_payment_requests
       invoices_taxes
       password_resets
-      payment_provider_customers
       recurring_transaction_rules
       refunds
       versions


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `payment_provider_customers` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added