### PR TITLE
chore(organization): Add organization_id to invoices_taxes table

### DIFF
--- a/app/jobs/database_migrations/populate_invoices_taxes_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_invoices_taxes_with_organization_job.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
 module DatabaseMigrations
-  class PopulatePaymentProviderCustomersWithOrganizationJob < ApplicationJob
+  class PopulateInvoicesTaxesWithOrganizationJob < ApplicationJob
     queue_as :low_priority
     unique :until_executed
 
     BATCH_SIZE = 1000
 
     def perform(batch_number = 1)
-      batch = PaymentProviderCustomers::BaseCustomer
+      batch = Invoice::AppliedTax.unscoped
         .where(organization_id: nil)
         .limit(BATCH_SIZE)
 
       if batch.exists?
         # rubocop:disable Rails/SkipsModelValidations
-        batch.update_all("organization_id = (SELECT organization_id FROM customers WHERE customers.id = payment_provider_customers.customer_id)")
+        batch.update_all("organization_id = (SELECT organization_id FROM invoices WHERE invoices.id = invoices_taxes.invoice_id)")
         # rubocop:enable Rails/SkipsModelValidations
 
         # Queue the next batch

--- a/app/models/invoice/applied_tax.rb
+++ b/app/models/invoice/applied_tax.rb
@@ -8,6 +8,7 @@ class Invoice
 
     belongs_to :invoice
     belongs_to :tax, optional: true
+    belongs_to :organization, optional: true
 
     monetize :amount_cents,
       :fees_amount_cents,
@@ -49,16 +50,19 @@ end
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  invoice_id                :uuid             not null
+#  organization_id           :uuid
 #  tax_id                    :uuid
 #
 # Indexes
 #
 #  index_invoices_taxes_on_invoice_id             (invoice_id)
 #  index_invoices_taxes_on_invoice_id_and_tax_id  (invoice_id,tax_id) UNIQUE WHERE ((tax_id IS NOT NULL) AND (created_at >= '2023-09-12 00:00:00'::timestamp without time zone))
+#  index_invoices_taxes_on_organization_id        (organization_id)
 #  index_invoices_taxes_on_tax_id                 (tax_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (tax_id => taxes.id)
 #

--- a/app/services/invoices/aggregate_amounts_and_taxes_from_fees.rb
+++ b/app/services/invoices/aggregate_amounts_and_taxes_from_fees.rb
@@ -35,6 +35,7 @@ module Invoices
       invoice.applied_taxes = invoice.fees.includes(:applied_taxes).flat_map(&:applied_taxes).group_by(&:tax_id).map do |tax_id, applied_taxes|
         t = applied_taxes.first
         Invoice::AppliedTax.new(
+          organization: invoice.organization,
           tax_id: tax_id,
           tax_name: t.tax_name,
           tax_code: t.tax_code,

--- a/app/services/invoices/apply_provider_taxes_service.rb
+++ b/app/services/invoices/apply_provider_taxes_service.rb
@@ -18,6 +18,7 @@ module Invoices
         tax_rate = tax.rate.to_f * 100
 
         applied_tax = invoice.applied_taxes.new(
+          organization: invoice.organization,
           tax_description: tax.type,
           tax_code: tax.name.parameterize(separator: "_"),
           tax_name: tax.name,

--- a/app/services/invoices/apply_taxes_service.rb
+++ b/app/services/invoices/apply_taxes_service.rb
@@ -15,6 +15,7 @@ module Invoices
 
       applicable_taxes.each do |tax|
         applied_tax = invoice.applied_taxes.new(
+          organization:,
           tax:,
           tax_description: tax.description,
           tax_code: tax.code,

--- a/db/migrate/20250429150114_add_organization_id_to_invoices_taxes.rb
+++ b/db/migrate/20250429150114_add_organization_id_to_invoices_taxes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToInvoicesTaxes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :invoices_taxes, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250429150128_add_organization_id_fk_to_invoices_taxes.rb
+++ b/db/migrate/20250429150128_add_organization_id_fk_to_invoices_taxes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToInvoicesTaxes < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :invoices_taxes, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250429150146_validate_invoices_taxes_organizations_foreign_key.rb
+++ b/db/migrate/20250429150146_validate_invoices_taxes_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateInvoicesTaxesOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :invoices_taxes, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -145,6 +145,7 @@ ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_1db
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_195153290d;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_150139409e;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_1454058c96;
+ALTER TABLE IF EXISTS ONLY public.invoices_taxes DROP CONSTRAINT IF EXISTS fk_rails_142809fee1;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_12d29bc654;
 ALTER TABLE IF EXISTS ONLY public.applied_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_10428ecad2;
 ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_0e464363cb;
@@ -257,6 +258,7 @@ DROP INDEX IF EXISTS public.index_lifetime_usages_on_recalculate_invoiced_usage;
 DROP INDEX IF EXISTS public.index_lifetime_usages_on_recalculate_current_usage;
 DROP INDEX IF EXISTS public.index_lifetime_usages_on_organization_id;
 DROP INDEX IF EXISTS public.index_invoices_taxes_on_tax_id;
+DROP INDEX IF EXISTS public.index_invoices_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_invoices_taxes_on_invoice_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_invoices_taxes_on_invoice_id;
 DROP INDEX IF EXISTS public.index_invoices_payment_requests_on_payment_request_id;
@@ -2399,7 +2401,8 @@ CREATE TABLE public.invoices_taxes (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     fees_amount_cents bigint DEFAULT 0 NOT NULL,
-    taxable_base_amount_cents bigint DEFAULT 0 NOT NULL
+    taxable_base_amount_cents bigint DEFAULT 0 NOT NULL,
+    organization_id uuid
 );
 
 
@@ -5478,6 +5481,13 @@ CREATE UNIQUE INDEX index_invoices_taxes_on_invoice_id_and_tax_id ON public.invo
 
 
 --
+-- Name: index_invoices_taxes_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_invoices_taxes_on_organization_id ON public.invoices_taxes USING btree (organization_id);
+
+
+--
 -- Name: index_invoices_taxes_on_tax_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6211,6 +6221,14 @@ ALTER TABLE ONLY public.applied_invoice_custom_sections
 
 ALTER TABLE ONLY public.daily_usages
     ADD CONSTRAINT fk_rails_12d29bc654 FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
+
+
+--
+-- Name: invoices_taxes fk_rails_142809fee1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.invoices_taxes
+    ADD CONSTRAINT fk_rails_142809fee1 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -7308,6 +7326,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250429150146'),
+('20250429150128'),
+('20250429150114'),
 ('20250429100154'),
 ('20250429100153'),
 ('20250429100152'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -55,7 +55,6 @@ Rspec.describe "All tables must have an organization_id" do
       integration_resources
       invoice_metadata
       invoices_payment_requests
-      invoices_taxes
       password_resets
       recurring_transaction_rules
       refunds


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `invoices_taxes` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added