### PR TITLE
feat(multi entities): Add REST endpoint and GraphQL mutation to update a billing entity

### DIFF
--- a/app/controllers/api/v1/billing_entities_controller.rb
+++ b/app/controllers/api/v1/billing_entities_controller.rb
@@ -23,6 +23,25 @@ module Api
         )
       end
 
+      def update
+        entity = BillingEntity.find_by(code: params[:code], organization: current_organization)
+        return not_found_error(resource: "billing_entity") if entity.blank?
+
+        result = BillingEntities::UpdateService.call(billing_entity: entity, params: update_params)
+
+        if result.success?
+          render(
+            json: ::V1::BillingEntitySerializer.new(
+              result.billing_entity,
+              root_name: "billing_entity",
+              includes: [:taxes]
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
       def manage_taxes
         entity = BillingEntity.find_by(code: params[:code], organization: current_organization)
         return not_found_error(resource: "billing_entity") if entity.blank?
@@ -34,6 +53,38 @@ module Api
         else
           render_error_response(result)
         end
+      end
+
+      private
+
+      def update_params
+        params.require(:billing_entity).permit(
+          :name,
+          :email,
+          :legal_name,
+          :legal_number,
+          :tax_identification_number,
+          :address_line1,
+          :address_line2,
+          :city,
+          :state,
+          :zipcode,
+          :country,
+          :default_currency,
+          :timezone,
+          :document_numbering,
+          :document_number_prefix,
+          :finalize_zero_amount_invoice,
+          :net_payment_term,
+          :eu_tax_management,
+          :logo,
+          email_settings: [],
+          billing_configuration: [
+            :invoice_footer,
+            :invoice_grace_period,
+            :document_locale
+          ]
+        )
       end
     end
   end

--- a/app/graphql/mutations/billing_entities/update.rb
+++ b/app/graphql/mutations/billing_entities/update.rb
@@ -9,15 +9,17 @@ module Mutations
       REQUIRED_PERMISSION = "billing_entities:update"
 
       graphql_name "UpdateBillingEntity"
-      description "Updates a new Billing Entity"
+      description "Updates a Billing Entity"
 
       input_object_class Types::BillingEntities::UpdateInput
 
       type Types::BillingEntities::Object
 
-      # We're not allowing now to update billing entities
-      def resolve(_args)
-        current_organization.default_billing_entity
+      def resolve(**args)
+        billing_entity = current_organization.billing_entities.find_by(id: args[:id])
+        result = ::BillingEntities::UpdateService.call(billing_entity:, params: args)
+
+        result.success? ? result.billing_entity : result_error(result)
       end
     end
   end

--- a/app/graphql/types/billing_entities/object.rb
+++ b/app/graphql/types/billing_entities/object.rb
@@ -36,8 +36,8 @@ module Types
 
       field :eu_tax_management, Boolean, null: false
 
-      field :billing_configuration, Types::BillingEntities::BillingConfiguration, permission: "billing_entity:invoices:view"
-      field :email_settings, [Types::BillingEntities::EmailSettingsEnum], permission: "billing_entity:emails:view"
+      field :billing_configuration, Types::BillingEntities::BillingConfiguration, permission: "billing_entities:invoices:view"
+      field :email_settings, [Types::BillingEntities::EmailSettingsEnum], permission: "billing_entities:emails:view"
       field :finalize_zero_amount_invoice, Boolean, null: false
       field :is_default, Boolean, null: false
 

--- a/app/graphql/types/billing_entities/object.rb
+++ b/app/graphql/types/billing_entities/object.rb
@@ -46,6 +46,15 @@ module Types
       def is_default
         object.organization.default_billing_entity&.id == object.id
       end
+
+      def billing_configuration
+        {
+          id: "#{object&.id}-c1nf", # Each nested object needs ID so that appollo cache system can work properly
+          document_locale: object&.document_locale,
+          invoice_footer: object&.invoice_footer,
+          invoice_grace_period: object&.invoice_grace_period
+        }
+      end
     end
   end
 end

--- a/app/graphql/types/billing_entities/update_input.rb
+++ b/app/graphql/types/billing_entities/update_input.rb
@@ -5,7 +5,9 @@ module Types
     class UpdateInput < BaseInputObject
       description "Update Billing Entity input arguments"
 
-      argument :code, String, required: true
+      argument :id, ID, required: true
+
+      argument :code, String, required: false
       argument :name, String, required: false
 
       argument :default_currency, Types::CurrencyEnum, required: false

--- a/app/graphql/types/billing_entities/update_input.rb
+++ b/app/graphql/types/billing_entities/update_input.rb
@@ -32,8 +32,8 @@ module Types
       argument :document_number_prefix, String, required: false
       argument :document_numbering, Types::BillingEntities::DocumentNumberingEnum, required: false
 
-      argument :billing_configuration, Types::BillingEntities::BillingConfigurationInput, required: false, permission: "organization:invoices:view"
-      argument :email_settings, [Types::BillingEntities::EmailSettingsEnum], required: false, permission: "organization:emails:view"
+      argument :billing_configuration, Types::BillingEntities::BillingConfigurationInput, required: false, permission: "billing_entities:invoices:view"
+      argument :email_settings, [Types::BillingEntities::EmailSettingsEnum], required: false, permission: "billing_entities:emails:view"
       argument :finalize_zero_amount_invoice, Boolean, required: false
     end
   end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -7,6 +7,7 @@ class ApiKey < ApplicationRecord
     activity_log add_on analytic billable_metric coupon applied_coupon credit_note customer_usage
     customer event fee invoice organization payment payment_receipt payment_request plan subscription lifetime_usage
     tax wallet wallet_transaction webhook_endpoint webhook_jwt_public_key invoice_custom_section
+    billing_entity
   ].freeze
 
   MODES = %w[read write].freeze

--- a/app/services/billing_entities/update_service.rb
+++ b/app/services/billing_entities/update_service.rb
@@ -14,6 +14,7 @@ module BillingEntities
     def call
       return result.not_found_failure!(resource: "billing_entity") unless billing_entity
 
+      billing_entity.name = params[:name] if params.key?(:name)
       billing_entity.email = params[:email] if params.key?(:email)
       billing_entity.legal_name = params[:legal_name] if params.key?(:legal_name)
       billing_entity.legal_number = params[:legal_number] if params.key?(:legal_number)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,4 +48,7 @@ Rails.application.configure do
     config.cache_store = :redis_cache_store, redis_store_config
   end
   config.cache_store = :null_store
+
+  # Set default API URL for test environment
+  ENV["LAGO_API_URL"] ||= "http://localhost:3000"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
 
       get "analytics/usage", to: "data_api/usages#index", as: :usage
 
-      resources :billing_entities, param: :code, only: %i[index show] do
+      resources :billing_entities, param: :code, only: %i[index show update] do
         post :manage_taxes, on: :member
       end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -6632,7 +6632,7 @@ type Mutation {
   ): BillableMetric
 
   """
-  Updates a new Billing Entity
+  Updates a Billing Entity
   """
   updateBillingEntity(
     """
@@ -9489,7 +9489,7 @@ input UpdateBillingEntityInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  code: String!
+  code: String
   country: CountryCode
   defaultCurrency: CurrencyEnum
   documentNumberPrefix: String
@@ -9498,6 +9498,7 @@ input UpdateBillingEntityInput {
   emailSettings: [BillingEntityEmailSettingsEnum!]
   euTaxManagement: Boolean
   finalizeZeroAmountInvoice: Boolean
+  id: ID!
   legalName: String
   legalNumber: String
   logo: String

--- a/schema.json
+++ b/schema.json
@@ -31216,7 +31216,7 @@
             },
             {
               "name": "updateBillingEntity",
-              "description": "Updates a new Billing Entity",
+              "description": "Updates a Billing Entity",
               "type": {
                 "kind": "OBJECT",
                 "name": "BillingEntity",
@@ -46739,16 +46739,28 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "code",
+              "name": "id",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/mutations/billing_entities/update_spec.rb
+++ b/spec/graphql/mutations/billing_entities/update_spec.rb
@@ -6,31 +6,34 @@ RSpec.describe Mutations::BillingEntities::Update, type: :graphql do
   let(:required_permission) { "billing_entities:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
+  let(:billing_entity) { create(:billing_entity, organization:) }
+
   let(:mutation) do
     <<~GQL
       mutation($input: UpdateBillingEntityInput!) {
         updateBillingEntity(input: $input) {
           id
-          name,
-          code,
-          defaultCurrency,
-          email,
-          legalName,
-          legalNumber,
-          taxIdentificationNumber,
-          addressLine1,
-          addressLine2,
-          city,
-          country,
-          netPaymentTerm,
-          state,
-          zipcode,
-          timezone,
-          euTaxManagement,
-          documentNumberPrefix,
-          documentNumbering,
-          emailSettings,
-          finalizeZeroAmountInvoice,
+          name
+          code
+          defaultCurrency
+          email
+          legalName
+          legalNumber
+          taxIdentificationNumber
+          addressLine1
+          addressLine2
+          city
+          country
+          netPaymentTerm
+          state
+          zipcode
+          timezone
+          logoUrl
+          euTaxManagement
+          documentNumberPrefix
+          documentNumbering
+          emailSettings
+          finalizeZeroAmountInvoice
           billingConfiguration {
             invoiceFooter,
             invoiceGracePeriod,
@@ -41,33 +44,129 @@ RSpec.describe Mutations::BillingEntities::Update, type: :graphql do
     GQL
   end
 
-  before do
-    allow(BillingEntities::UpdateService).to receive(:call).and_call_original
+  let(:logo) do
+    logo_file = File.read(Rails.root.join("spec/factories/images/logo.png"))
+    base64_logo = Base64.encode64(logo_file)
+
+    "data:image/png;base64,#{base64_logo}"
+  end
+
+  let(:input) do
+    {
+      id: billing_entity.id,
+      code: billing_entity.code,
+      name: "Updated entity",
+      email: "updated@email.com",
+      legalName: "Updated legal name",
+      legalNumber: "1234567890",
+      taxIdentificationNumber: "Tax-1234",
+      addressLine1: "Calle de la Princesa 1",
+      addressLine2: "Apt 1",
+      city: "Barcelona",
+      state: "Barcelona",
+      zipcode: "08001",
+      country: "ES",
+      defaultCurrency: "EUR",
+      timezone: "TZ_EUROPE_MADRID",
+      documentNumbering: "per_billing_entity",
+      documentNumberPrefix: "NEW-0001",
+      euTaxManagement: true,
+      finalizeZeroAmountInvoice: true,
+      netPaymentTerm: 15,
+      logo: logo,
+      emailSettings: ["invoice_finalized", "credit_note_created"],
+      billingConfiguration: {
+        invoiceFooter: "invoice footer",
+        documentLocale: "es",
+        invoiceGracePeriod: 10
+      }
+    }
   end
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "billing_entities:update"
 
-  # We're not allowing now to update a billing entity, but this endpoint is needed for FE
-  it "returns default billing entity for the current organization" do
+  around { |test| lago_premium!(&test) }
+
+  it "updates the billing entity" do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,
       permissions: required_permission,
       query: mutation,
-      variables: {
-        input: {
-          name: "Upddated entity",
-          code: "updated_entity"
-        }
-      }
+      variables: {input:}
     )
 
     result_data = result["data"]["updateBillingEntity"]
+
     expect(result_data["id"]).to be_present
-    expect(result_data["name"]).to eq(organization.default_billing_entity.name)
-    expect(result_data["code"]).to eq(organization.default_billing_entity.code)
-    expect(BillingEntities::UpdateService).not_to have_received(:call)
+    expect(result_data["code"]).to eq(billing_entity.code)
+    expect(result_data["name"]).to eq("Updated entity")
+    expect(result_data["email"]).to eq("updated@email.com")
+    expect(result_data["legalName"]).to eq("Updated legal name")
+    expect(result_data["legalNumber"]).to eq("1234567890")
+    expect(result_data["taxIdentificationNumber"]).to eq("Tax-1234")
+    expect(result_data["addressLine1"]).to eq("Calle de la Princesa 1")
+    expect(result_data["addressLine2"]).to eq("Apt 1")
+    expect(result_data["state"]).to eq("Barcelona")
+    expect(result_data["city"]).to eq("Barcelona")
+    expect(result_data["zipcode"]).to eq("08001")
+    expect(result_data["country"]).to eq("ES")
+    expect(result_data["defaultCurrency"]).to eq("EUR")
+    expect(result_data["timezone"]).to eq("TZ_EUROPE_MADRID")
+    expect(result_data["documentNumbering"]).to eq("per_billing_entity")
+    expect(result_data["documentNumberPrefix"]).to eq("NEW-0001")
+    expect(result_data["euTaxManagement"]).to eq true
+    expect(result_data["finalizeZeroAmountInvoice"]).to eq true
+    expect(result_data["netPaymentTerm"]).to eq(15)
+    expect(result_data["logoUrl"]).to match(%r{http://localhost:3000/rails/active_storage/blobs/redirect/.*/logo})
+    expect(result_data["emailSettings"]).to be_nil
+    expect(result_data["billingConfiguration"]).to be_nil
+  end
+
+  context "with extra view permissions" do
+    let(:permissions) do
+      [required_permission].concat(%w[billing_entities:emails:view billing_entities:invoices:view])
+    end
+
+    it "includes the email settings and billing configuration in the response" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions:,
+        query: mutation,
+        variables: {input:}
+      )
+
+      result_data = result["data"]["updateBillingEntity"]
+
+      expect(result_data["emailSettings"]).to eq(["invoice_finalized", "credit_note_created"])
+      expect(result_data["billingConfiguration"]["invoiceFooter"]).to eq("invoice footer")
+      expect(result_data["billingConfiguration"]["documentLocale"]).to eq("es")
+      expect(result_data["billingConfiguration"]["invoiceGracePeriod"]).to eq(10)
+    end
+  end
+
+  context "when the billing entity is not found" do
+    it "returns a not found error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            id: "non_existent_id",
+            name: "Updated entity"
+          }
+        }
+      )
+
+      expect_graphql_error(
+        result:,
+        message: "Resource not found"
+      )
+    end
   end
 end

--- a/spec/graphql/mutations/billing_entities/update_spec.rb
+++ b/spec/graphql/mutations/billing_entities/update_spec.rb
@@ -83,11 +83,11 @@ RSpec.describe Mutations::BillingEntities::Update, type: :graphql do
     }
   end
 
+  around { |test| lago_premium!(&test) }
+
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "billing_entities:update"
-
-  around { |test| lago_premium!(&test) }
 
   it "updates the billing entity" do
     result = execute_graphql(

--- a/spec/graphql/mutations/billing_entities/update_spec.rb
+++ b/spec/graphql/mutations/billing_entities/update_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Mutations::BillingEntities::Update, type: :graphql do
     expect(result_data["euTaxManagement"]).to eq true
     expect(result_data["finalizeZeroAmountInvoice"]).to eq true
     expect(result_data["netPaymentTerm"]).to eq(15)
-    expect(result_data["logoUrl"]).to match(%r{http://localhost:3000/rails/active_storage/blobs/redirect/.*/logo})
+    expect(result_data["logoUrl"]).to match(%r{.*/rails/active_storage/blobs/redirect/.*/logo})
     expect(result_data["emailSettings"]).to be_nil
     expect(result_data["billingConfiguration"]).to be_nil
   end

--- a/spec/requests/api/v1/billing_entities_controller_spec.rb
+++ b/spec/requests/api/v1/billing_entities_controller_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Api::V1::BillingEntitiesController, type: :request do
       expect(json[:billing_entity][:invoice_footer]).to eq("New Invoice Footer")
       expect(json[:billing_entity][:document_locale]).to eq("es")
       expect(json[:billing_entity][:invoice_grace_period]).to eq(10)
-      expect(json[:billing_entity][:logo_url]).to match(%r{http://localhost:3000/rails/active_storage/blobs/redirect/.*/logo})
+      expect(json[:billing_entity][:logo_url]).to match(%r{.*/rails/active_storage/blobs/redirect/.*/logo})
     end
 
     context "when the billing entity is not found" do

--- a/spec/requests/api/v1/billing_entities_controller_spec.rb
+++ b/spec/requests/api/v1/billing_entities_controller_spec.rb
@@ -89,6 +89,95 @@ RSpec.describe Api::V1::BillingEntitiesController, type: :request do
     end
   end
 
+  describe "PUT /api/v1/billing_entities/:code" do
+    subject do
+      put_with_token(organization, "/api/v1/billing_entities/#{billing_entity_code}", update_params)
+    end
+
+    let(:billing_entity_code) { billing_entity1.code }
+
+    let(:update_params) do
+      {
+        billing_entity: {
+          name: "New Name",
+          email: "new@email.com",
+          legal_name: "New Legal Name",
+          legal_number: "1234567890",
+          tax_identification_number: "Tax-1234",
+          address_line1: "Calle de la Princesa 1",
+          address_line2: "Apt 1",
+          city: "Barcelona",
+          state: "Barcelona",
+          zipcode: "08001",
+          country: "ES",
+          default_currency: "EUR",
+          timezone: "Europe/Madrid",
+          document_numbering: "per_billing_entity",
+          document_number_prefix: "NEW-0001",
+          finalize_zero_amount_invoice: true,
+          net_payment_term: 10,
+          eu_tax_management: true,
+          logo: logo,
+          email_settings: ["invoice.finalized", "credit_note.created"],
+          billing_configuration: {
+            invoice_footer: "New Invoice Footer",
+            document_locale: "es",
+            invoice_grace_period: 10
+          }
+        }
+      }
+    end
+
+    let(:logo) do
+      logo_file = File.read(Rails.root.join("spec/factories/images/logo.png"))
+      base64_logo = Base64.encode64(logo_file)
+
+      "data:image/png;base64,#{base64_logo}"
+    end
+
+    around { |test| lago_premium!(&test) }
+
+    it "updates the billing entity" do
+      subject
+
+      expect(response).to be_successful
+      expect(billing_entity1.reload.name).to eq("New Name")
+
+      expect(json[:billing_entity][:name]).to eq("New Name")
+      expect(json[:billing_entity][:email]).to eq("new@email.com")
+      expect(json[:billing_entity][:legal_name]).to eq("New Legal Name")
+      expect(json[:billing_entity][:legal_number]).to eq("1234567890")
+      expect(json[:billing_entity][:tax_identification_number]).to eq("Tax-1234")
+      expect(json[:billing_entity][:address_line1]).to eq("Calle de la Princesa 1")
+      expect(json[:billing_entity][:address_line2]).to eq("Apt 1")
+      expect(json[:billing_entity][:city]).to eq("Barcelona")
+      expect(json[:billing_entity][:state]).to eq("Barcelona")
+      expect(json[:billing_entity][:zipcode]).to eq("08001")
+      expect(json[:billing_entity][:country]).to eq("ES")
+      expect(json[:billing_entity][:default_currency]).to eq("EUR")
+      expect(json[:billing_entity][:timezone]).to eq("Europe/Madrid")
+      expect(json[:billing_entity][:document_numbering]).to eq("per_billing_entity")
+      expect(json[:billing_entity][:document_number_prefix]).to eq("NEW-0001")
+      expect(json[:billing_entity][:finalize_zero_amount_invoice]).to eq(true)
+      expect(json[:billing_entity][:net_payment_term]).to eq(10)
+      expect(json[:billing_entity][:eu_tax_management]).to eq(true)
+      expect(json[:billing_entity][:email_settings]).to eq(["invoice.finalized", "credit_note.created"])
+      expect(json[:billing_entity][:invoice_footer]).to eq("New Invoice Footer")
+      expect(json[:billing_entity][:document_locale]).to eq("es")
+      expect(json[:billing_entity][:invoice_grace_period]).to eq(10)
+      expect(json[:billing_entity][:logo_url]).to match(%r{http://localhost:3000/rails/active_storage/blobs/redirect/.*/logo})
+    end
+
+    context "when the billing entity is not found" do
+      let(:billing_entity_code) { "NON_EXISTING_CODE" }
+
+      it "returns a 404" do
+        subject
+        expect(response).to be_not_found
+      end
+    end
+  end
+
   describe "POST /api/v1/billing_entities/:code/manage_taxes" do
     subject do
       post_with_token(organization, "/api/v1/billing_entities/#{billing_entity_code}/manage_taxes", tax_codes: tax_codes)

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe BillingEntities::UpdateService do
 
   let(:params) do
     {
+      name: "New Name",
       legal_name: "Foobar",
       legal_number: "1234",
       tax_identification_number: "2246",
@@ -41,6 +42,7 @@ RSpec.describe BillingEntities::UpdateService do
     it "updates the billing_entity" do
       result = update_service.call
 
+      expect(result.billing_entity.name).to eq("New Name")
       expect(result.billing_entity.legal_name).to eq("Foobar")
       expect(result.billing_entity.legal_number).to eq("1234")
       expect(result.billing_entity.tax_identification_number).to eq("2246")


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

 ## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

 ## Description

Add PUT /api/v1/billing_entity/:billing_entity_code REST endpoint and Billing Entity Update GraphQL mutation to update a billing entity.

Also fixes the billing entities update service to also allow updating the billing entity name as it was missing.
