### PR TITLE
feat(multi entities): Add REST endpoint and GraphQL mutation to create a billing entity

### DIFF
--- a/app/controllers/api/v1/billing_entities_controller.rb
+++ b/app/controllers/api/v1/billing_entities_controller.rb
@@ -23,6 +23,24 @@ module Api
         )
       end
 
+      def create
+        result = BillingEntities::CreateService.new(
+          organization: current_organization,
+          params: create_params
+        ).call
+
+        if result.success?
+          render(
+            json: ::V1::BillingEntitySerializer.new(
+              result.billing_entity,
+              root_name: "billing_entity"
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
       def update
         entity = BillingEntity.find_by(code: params[:code], organization: current_organization)
         return not_found_error(resource: "billing_entity") if entity.blank?
@@ -56,6 +74,37 @@ module Api
       end
 
       private
+
+      def create_params
+        params.require(:billing_entity).permit(
+          :code,
+          :name,
+          :email,
+          :legal_name,
+          :legal_number,
+          :tax_identification_number,
+          :address_line1,
+          :address_line2,
+          :city,
+          :state,
+          :zipcode,
+          :country,
+          :default_currency,
+          :timezone,
+          :document_numbering,
+          :document_number_prefix,
+          :finalize_zero_amount_invoice,
+          :net_payment_term,
+          :eu_tax_management,
+          :logo,
+          email_settings: [],
+          billing_configuration: [
+            :invoice_footer,
+            :invoice_grace_period,
+            :document_locale
+          ]
+        )
+      end
 
       def update_params
         params.require(:billing_entity).permit(

--- a/app/graphql/mutations/billing_entities/create.rb
+++ b/app/graphql/mutations/billing_entities/create.rb
@@ -15,9 +15,13 @@ module Mutations
 
       type Types::BillingEntities::Object
 
-      # We're not allowing now to create a new billing entity, but this endpoint is needed for FE
-      def resolve(_args)
-        current_organization.default_billing_entity
+      def resolve(**args)
+        result = ::BillingEntities::CreateService.call(
+          organization: current_organization,
+          params: args
+        )
+
+        result.success? ? result.billing_entity : result_error(result)
       end
     end
   end

--- a/app/graphql/types/billing_entities/create_input.rb
+++ b/app/graphql/types/billing_entities/create_input.rb
@@ -30,8 +30,8 @@ module Types
       argument :document_number_prefix, String, required: false
       argument :document_numbering, Types::BillingEntities::DocumentNumberingEnum, required: false
 
-      argument :billing_configuration, Types::BillingEntities::BillingConfigurationInput, required: false, permission: "organization:invoices:view"
-      argument :email_settings, [Types::BillingEntities::EmailSettingsEnum], required: false, permission: "organization:emails:view"
+      argument :billing_configuration, Types::BillingEntities::BillingConfigurationInput, required: false, permission: "billing_entities:invoices:view"
+      argument :email_settings, [Types::BillingEntities::EmailSettingsEnum], required: false, permission: "billing_entities:emails:view"
       argument :finalize_zero_amount_invoice, Boolean, required: false
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
 
       get "analytics/usage", to: "data_api/usages#index", as: :usage
 
-      resources :billing_entities, param: :code, only: %i[index show update] do
+      resources :billing_entities, param: :code, only: %i[index show update create] do
         post :manage_taxes, on: :member
       end
 

--- a/spec/graphql/mutations/billing_entities/create_spec.rb
+++ b/spec/graphql/mutations/billing_entities/create_spec.rb
@@ -4,8 +4,8 @@ require "rails_helper"
 
 RSpec.describe Mutations::BillingEntities::Create, type: :graphql do
   let(:required_permission) { "billing_entities:create" }
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let(:membership) { create(:membership, organization:) }
+  let(:organization) { create(:organization) }
   let(:mutation) do
     <<~GQL
       mutation($input: CreateBillingEntityInput!) {
@@ -17,6 +17,7 @@ RSpec.describe Mutations::BillingEntities::Create, type: :graphql do
           email,
           legalName,
           legalNumber,
+          logoUrl,
           taxIdentificationNumber,
           addressLine1,
           addressLine2,
@@ -41,33 +42,123 @@ RSpec.describe Mutations::BillingEntities::Create, type: :graphql do
     GQL
   end
 
-  before do
-    allow(BillingEntities::CreateService).to receive(:call).and_call_original
+  let(:input) do
+    {
+      code: "NEW-0001",
+      name: "New entity",
+      email: "new@email.com",
+      legalName: "New legal name",
+      legalNumber: "1234567890",
+      taxIdentificationNumber: "Tax-1234",
+      addressLine1: "Calle de la Princesa 1",
+      addressLine2: "Apt 1",
+      city: "Barcelona",
+      state: "Barcelona",
+      zipcode: "08001",
+      country: "ES",
+      defaultCurrency: "EUR",
+      timezone: "TZ_EUROPE_MADRID",
+      documentNumbering: "per_billing_entity",
+      documentNumberPrefix: "NEW-0001",
+      euTaxManagement: true,
+      finalizeZeroAmountInvoice: true,
+      netPaymentTerm: 15,
+      logo: logo,
+      emailSettings: ["invoice_finalized", "credit_note_created"],
+      billingConfiguration: {
+        invoiceFooter: "invoice footer",
+        documentLocale: "es",
+        invoiceGracePeriod: 10
+      }
+    }
   end
+
+  let(:logo) do
+    logo_file = File.read(Rails.root.join("spec/factories/images/logo.png"))
+    base64_logo = Base64.encode64(logo_file)
+
+    "data:image/png;base64,#{base64_logo}"
+  end
+
+  around { |test| lago_premium!(&test) }
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "billing_entities:create"
 
-  # We're not allowing now to create a new billing entity, but this endpoint is needed for FE
-  it "returns default billing entity for the current organization" do
+  it "returns a feaature not available error" do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,
       permissions: required_permission,
       query: mutation,
-      variables: {
-        input: {
-          name: "New entity",
-          code: "new_entity"
-        }
-      }
+      variables: {input:}
     )
 
-    result_data = result["data"]["createBillingEntity"]
-    expect(result_data["id"]).to be_present
-    expect(result_data["name"]).to eq(organization.default_billing_entity.name)
-    expect(result_data["code"]).to eq(organization.default_billing_entity.code)
-    expect(BillingEntities::CreateService).not_to have_received(:call)
+    expect_graphql_error(
+      result:,
+      message: "forbidden"
+    )
+  end
+
+  context "when the organization can create billing entities" do
+    let(:organization) { create(:organization, premium_integrations: %w[multi_entities_enterprise]) }
+
+    it "creates a billing entity for the current organization" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {input:}
+      )
+
+      result_data = result["data"]["createBillingEntity"]
+      expect(result_data["id"]).to be_present
+      expect(result_data["code"]).to eq("NEW-0001")
+      expect(result_data["name"]).to eq("New entity")
+      expect(result_data["email"]).to eq("new@email.com")
+      expect(result_data["legalName"]).to eq("New legal name")
+      expect(result_data["legalNumber"]).to eq("1234567890")
+      expect(result_data["taxIdentificationNumber"]).to eq("Tax-1234")
+      expect(result_data["addressLine1"]).to eq("Calle de la Princesa 1")
+      expect(result_data["addressLine2"]).to eq("Apt 1")
+      expect(result_data["state"]).to eq("Barcelona")
+      expect(result_data["city"]).to eq("Barcelona")
+      expect(result_data["zipcode"]).to eq("08001")
+      expect(result_data["country"]).to eq("ES")
+      expect(result_data["defaultCurrency"]).to eq("EUR")
+      expect(result_data["timezone"]).to eq("TZ_EUROPE_MADRID")
+      expect(result_data["documentNumbering"]).to eq("per_billing_entity")
+      expect(result_data["documentNumberPrefix"]).to eq("NEW-0001")
+      expect(result_data["euTaxManagement"]).to eq true
+      expect(result_data["finalizeZeroAmountInvoice"]).to eq true
+      expect(result_data["netPaymentTerm"]).to eq(15)
+      expect(result_data["logoUrl"]).to match(%r{.*/rails/active_storage/blobs/redirect/.*/logo})
+      expect(result_data["emailSettings"]).to be_nil
+      expect(result_data["billingConfiguration"]).to be_nil
+    end
+
+    context "with extra view permissions" do
+      let(:permissions) do
+        [required_permission].concat(%w[billing_entities:emails:view billing_entities:invoices:view])
+      end
+
+      it "includes the email settings and billing configuration in the response" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: membership.organization,
+          permissions:,
+          query: mutation,
+          variables: {input:}
+        )
+
+        result_data = result["data"]["createBillingEntity"]
+        expect(result_data["emailSettings"]).to eq(["invoice_finalized", "credit_note_created"])
+        expect(result_data["billingConfiguration"]["invoiceFooter"]).to eq("invoice footer")
+        expect(result_data["billingConfiguration"]["documentLocale"]).to eq("es")
+        expect(result_data["billingConfiguration"]["invoiceGracePeriod"]).to eq(10)
+      end
+    end
   end
 end


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

 ## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

 ## Description

Add POST /api/v1/billing_entity REST endpoint
and Billing Entity create GraphQL mutation to create a billing entity.