### PR TITLE
feat(avalara-integration): add new tax_customer method

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -248,6 +248,10 @@ class Customer < ApplicationRecord
     wallets.active.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
   end
 
+  def tax_customer
+    anrok_customer || avalara_customer
+  end
+
   private
 
   def ensure_slug

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -855,4 +855,34 @@ RSpec.describe Customer, type: :model do
       }.from(false).to(true)
     end
   end
+
+  describe "#tax_customer" do
+    let(:customer) { create(:customer) }
+
+    context "with anrok attached" do
+      let(:anrok_customer) { create(:anrok_customer, customer:) }
+
+      before { anrok_customer}
+
+      it "returns anrok customer" do
+        expect(customer.tax_customer).to eq(anrok_customer)
+      end
+    end
+
+    context "with avalara attached" do
+      let(:avalara_customer) { create(:avalara_customer, customer:) }
+
+      before { avalara_customer}
+
+      it "returns avalara customer" do
+        expect(customer.tax_customer).to eq(avalara_customer)
+      end
+    end
+
+    context "without any tax integration" do
+      it "returns nil" do
+        expect(customer.tax_customer).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -862,7 +862,7 @@ RSpec.describe Customer, type: :model do
     context "with anrok attached" do
       let(:anrok_customer) { create(:anrok_customer, customer:) }
 
-      before { anrok_customer}
+      before { anrok_customer }
 
       it "returns anrok customer" do
         expect(customer.tax_customer).to eq(anrok_customer)
@@ -872,7 +872,7 @@ RSpec.describe Customer, type: :model do
     context "with avalara attached" do
       let(:avalara_customer) { create(:avalara_customer, customer:) }
 
-      before { avalara_customer}
+      before { avalara_customer }
 
       it "returns avalara customer" do
         expect(customer.tax_customer).to eq(avalara_customer)


### PR DESCRIPTION
## Context

Currently Lago is working on integration with Avalara tax tool

## Description

This PR adds small `tax_customer` method on customer model
