### PR TITLE
feat(audit_logs): Utils to push activity logs to kafka

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -29,6 +29,7 @@ module Admin
 
     def set_context_source
       CurrentContext.source = "admin"
+      CurrentContext.api_key_id = nil
     end
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -34,6 +34,7 @@ module Api
 
     def set_context_source
       CurrentContext.source = "api"
+      CurrentContext.api_key_id = current_api_key.id
     end
 
     def track_api_key_usage

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -90,5 +90,6 @@ class GraphqlController < ApplicationController
 
   def set_context_source
     CurrentContext.source = "graphql"
+    CurrentContext.api_key_id = nil
   end
 end

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Utils
+  class ActivityLog
+    class << self
+      IGNORED_FIELDS = %w[updated_at].freeze
+
+      def produce(object, activity_type, activity_id: SecureRandom.uuid)
+        return if ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"].blank?
+        return if ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"].blank?
+
+        current_time = Time.current.iso8601[...-1]
+        Karafka.producer.produce_async(
+          topic: ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"],
+          key: "#{organization_id(object)}--#{activity_id}",
+          payload: {
+            activity_source:,
+            api_key_id: CurrentContext.api_key_id,
+            user_id:,
+            activity_type:,
+            activity_id:,
+            logged_at: current_time,
+            created_at: current_time,
+            resource_id: resource(object).id,
+            resource_type: resource(object).class.name,
+            organization_id: organization_id(object),
+            activity_object: activity_object(object),
+            activity_object_changes: activity_object_changes(object)
+          }.to_json
+        )
+      end
+
+      private
+
+      def activity_source
+        return "front" if CurrentContext.source == "graphql"
+
+        CurrentContext.source
+      end
+
+      def user_id
+        return nil if CurrentContext.api_key_id.present?
+
+        Membership.find_by(id: CurrentContext.membership.split("/").last)&.user_id
+      end
+
+      def activity_object(object)
+        "V1::#{object.class.name}Serializer".constantize.new(object).serialize
+      end
+
+      def activity_object_changes(object)
+        changes = object.previous_changes.except(*IGNORED_FIELDS).transform_values(&:to_s)
+
+        return nil if changes.key?("id")
+
+        changes
+      end
+
+      def organization_id(activity_object)
+        case activity_object.class.name
+        when "AppliedCoupon"
+          activity_object.coupon.organization_id
+        else
+          activity_object.organization_id
+        end
+      end
+
+      def resource(activity_object)
+        case activity_object.class.name
+        when "Payment"
+          activity_object.invoice
+        when "AppliedCoupon"
+          activity_object.coupon
+        when "WalletTransaction"
+          activity_object.wallet
+        else
+          activity_object
+        end
+      end
+    end
+  end
+end

--- a/lib/current_context.rb
+++ b/lib/current_context.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CurrentContext
-  thread_mattr_accessor :membership, :source, :email
+  thread_mattr_accessor :membership, :source, :email, :api_key_id
 end

--- a/spec/requests/api/base_controller_spec.rb
+++ b/spec/requests/api/base_controller_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Api::BaseController, type: :controller do
     get :index
 
     expect(CurrentContext.source).to eq "api"
+    expect(CurrentContext.api_key_id).to eq api_key.id
   end
 
   describe "#authenticate" do

--- a/spec/requests/graphql_controller_spec.rb
+++ b/spec/requests/graphql_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe GraphqlController, type: :request do
 
       expect(response.status).to be(200)
       expect(CurrentContext.source).to eq "graphql"
-
+      expect(CurrentContext.api_key_id).to be_nil
       json = JSON.parse(response.body)
       expect(json["data"]["loginUser"]["token"]).to be_present
       expect(json["data"]["loginUser"]["user"]["id"]).to eq(user.id)

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe Utils::ActivityLog, type: :service do
+  subject(:activity_log) { described_class }
+
+  let(:membership) { create(:membership) }
+  let(:api_key) { create(:api_key) }
+
+  before do
+    allow(CurrentContext).to receive(:membership).and_return(membership.id)
+    allow(CurrentContext).to receive(:api_key_id).and_return(api_key.id)
+    allow(CurrentContext).to receive(:source).and_return("api")
+    travel_to(Time.zone.parse("2023-03-22 12:00:00"))
+  end
+
+  describe ".produce" do
+    let(:organization) { create(:organization) }
+    let(:invoice) { create(:invoice, organization:) }
+    let(:karafka_producer) { instance_double(WaterDrop::Producer) }
+
+    before do
+      allow(Karafka).to receive(:producer).and_return(karafka_producer)
+      allow(karafka_producer).to receive(:produce_async)
+    end
+
+    context "when kafka is configured" do
+      before do
+        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = "kafka"
+        ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"] = "activity_logs"
+      end
+
+      after do
+        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = nil
+        ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"] = nil
+      end
+
+      it "produces the event on kafka" do
+        activity_log.produce(invoice, "invoice.created", activity_id: "activity-id")
+
+        expect(karafka_producer).to have_received(:produce_async).with(
+          topic: "activity_logs",
+          key: "#{organization.id}--activity-id",
+          payload: {
+            activity_source: "api",
+            api_key_id: api_key.id,
+            user_id: nil,
+            activity_type: "invoice.created",
+            activity_id: "activity-id",
+            logged_at: Time.current.iso8601[...-1],
+            created_at: Time.current.iso8601[...-1],
+            resource_id: invoice.id,
+            resource_type: "Invoice",
+            organization_id: organization.id,
+            activity_object: V1::InvoiceSerializer.new(invoice).serialize,
+            activity_object_changes: nil
+          }.to_json
+        )
+      end
+    end
+
+    context "when kafka is not configured" do
+      before do
+        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = nil
+        ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"] = nil
+      end
+
+      it "does not produce message" do
+        activity_log.produce(invoice, "invoice.created")
+        expect(karafka_producer).not_to have_received(:produce_async)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context

Our users want to have visibility on what’s happening in Lago.

Examples:
- *A plan and prices have been updated: When? By whom? What?*
- *A subscription has been deleted: When? By whom? What?*

## Description

The goal of this PR is to introduce the utils class to push activity logs into kafka.