### PR TITLE
chore(organization): Add organization_id to charge_filters table

### DIFF
--- a/app/jobs/database_migrations/populate_charge_filters_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_charge_filters_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateChargeFiltersWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = ChargeFilter.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM charges WHERE charges.id = charge_filters.charge_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -6,6 +6,7 @@ class ChargeFilter < ApplicationRecord
   self.discard_column = :deleted_at
 
   belongs_to :charge, -> { with_discarded }, touch: true
+  belongs_to :organization, optional: true
 
   has_many :values, class_name: "ChargeFilterValue", dependent: :destroy
   has_many :billable_metric_filters, through: :values
@@ -85,14 +86,17 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  charge_id            :uuid             not null
+#  organization_id      :uuid
 #
 # Indexes
 #
-#  index_active_charge_filters         (charge_id) WHERE (deleted_at IS NULL)
-#  index_charge_filters_on_charge_id   (charge_id)
-#  index_charge_filters_on_deleted_at  (deleted_at)
+#  index_active_charge_filters              (charge_id) WHERE (deleted_at IS NULL)
+#  index_charge_filters_on_charge_id        (charge_id)
+#  index_charge_filters_on_deleted_at       (deleted_at)
+#  index_charge_filters_on_organization_id  (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (charge_id => charges.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -50,7 +50,7 @@ module ChargeFilters
             end
           end
 
-          filter ||= charge.filters.new
+          filter ||= charge.filters.new(organization_id: charge.organization_id)
 
           filter.invoice_display_name = filter_param[:invoice_display_name]
           filter.properties = Charges::FilterChargeModelPropertiesService.call(

--- a/db/migrate/20250505135819_add_organization_id_to_charge_filters.rb
+++ b/db/migrate/20250505135819_add_organization_id_to_charge_filters.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToChargeFilters < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :charge_filters, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250505135820_add_organization_id_fk_to_charge_filters.rb
+++ b/db/migrate/20250505135820_add_organization_id_fk_to_charge_filters.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToChargeFilters < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :charge_filters, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250505135821_validate_charge_filters_organizations_foreign_key.rb
+++ b/db/migrate/20250505135821_validate_charge_filters_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateChargeFiltersOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :charge_filters, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -22,6 +22,7 @@ ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXIST
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS fk_rails_e8bac9c5bb;
 ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS fk_rails_e88403f4b9;
 ALTER TABLE IF EXISTS ONLY public.customers_taxes DROP CONSTRAINT IF EXISTS fk_rails_e86903e081;
+ALTER TABLE IF EXISTS ONLY public.charge_filters DROP CONSTRAINT IF EXISTS fk_rails_e711e8089e;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_dea748e529;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_de6b3c3138;
 ALTER TABLE IF EXISTS ONLY public.invoice_custom_section_selections DROP CONSTRAINT IF EXISTS fk_rails_dd7e076158;
@@ -407,6 +408,7 @@ DROP INDEX IF EXISTS public.index_charges_on_parent_id;
 DROP INDEX IF EXISTS public.index_charges_on_organization_id;
 DROP INDEX IF EXISTS public.index_charges_on_deleted_at;
 DROP INDEX IF EXISTS public.index_charges_on_billable_metric_id;
+DROP INDEX IF EXISTS public.index_charge_filters_on_organization_id;
 DROP INDEX IF EXISTS public.index_charge_filters_on_deleted_at;
 DROP INDEX IF EXISTS public.index_charge_filters_on_charge_id;
 DROP INDEX IF EXISTS public.index_charge_filter_values_on_deleted_at;
@@ -1222,7 +1224,8 @@ CREATE TABLE public.charge_filters (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
-    invoice_display_name character varying
+    invoice_display_name character varying,
+    organization_id uuid
 );
 
 
@@ -4513,6 +4516,13 @@ CREATE INDEX index_charge_filters_on_deleted_at ON public.charge_filters USING b
 
 
 --
+-- Name: index_charge_filters_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_charge_filters_on_organization_id ON public.charge_filters USING btree (organization_id);
+
+
+--
 -- Name: index_charges_on_billable_metric_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7288,6 +7298,14 @@ ALTER TABLE ONLY public.credit_note_items
 
 
 --
+-- Name: charge_filters fk_rails_e711e8089e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.charge_filters
+    ADD CONSTRAINT fk_rails_e711e8089e FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: customers_taxes fk_rails_e86903e081; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7398,6 +7416,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250505135821'),
+('20250505135820'),
+('20250505135819'),
 ('20250505125354'),
 ('20250505125335'),
 ('20250505125308'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -20,6 +20,7 @@ Rspec.describe "All tables must have an organization_id" do
       applied_add_ons
       group_properties
       groups
+      password_resets
     ]
   end
 
@@ -30,7 +31,6 @@ Rspec.describe "All tables must have an organization_id" do
       billable_metric_filters
       billing_entities_taxes
       charge_filter_values
-      charge_filters
       charges_taxes
       commitments
       commitments_taxes
@@ -51,7 +51,6 @@ Rspec.describe "All tables must have an organization_id" do
       integration_resources
       invoice_metadata
       invoices_payment_requests
-      password_resets
       recurring_transaction_rules
       refunds
       versions


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `charge_filters` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added