### PR TITLE
chore(organization): Add organization_id to charge_taxes table

### DIFF
--- a/app/jobs/database_migrations/populate_charges_taxes_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_charges_taxes_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateChargesTaxesWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Charge::AppliedTax.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM charges WHERE charges.id = charges_taxes.charge_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/charge/applied_tax.rb
+++ b/app/models/charge/applied_tax.rb
@@ -6,6 +6,7 @@ class Charge
 
     belongs_to :charge
     belongs_to :tax
+    belongs_to :organization, optional: true
   end
 end
 
@@ -13,20 +14,23 @@ end
 #
 # Table name: charges_taxes
 #
-#  id         :uuid             not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  charge_id  :uuid             not null
-#  tax_id     :uuid             not null
+#  id              :uuid             not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  charge_id       :uuid             not null
+#  organization_id :uuid
+#  tax_id          :uuid             not null
 #
 # Indexes
 #
 #  index_charges_taxes_on_charge_id             (charge_id)
 #  index_charges_taxes_on_charge_id_and_tax_id  (charge_id,tax_id) UNIQUE
+#  index_charges_taxes_on_organization_id       (organization_id)
 #  index_charges_taxes_on_tax_id                (tax_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (charge_id => charges.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (tax_id => taxes.id)
 #

--- a/app/services/charges/apply_taxes_service.rb
+++ b/app/services/charges/apply_taxes_service.rb
@@ -18,7 +18,9 @@ module Charges
       ).destroy_all
 
       result.applied_taxes = tax_codes.map do |tax_code|
-        charge.applied_taxes.find_or_create_by!(tax: taxes.find_by(code: tax_code))
+        charge.applied_taxes
+          .create_with(organization_id: charge.organization_id)
+          .find_or_create_by!(tax: taxes.find_by(code: tax_code))
       end
 
       result

--- a/db/migrate/20250505140926_add_organization_id_to_charges_taxes.rb
+++ b/db/migrate/20250505140926_add_organization_id_to_charges_taxes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToChargesTaxes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :charges_taxes, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250505140927_add_organization_id_fk_to_charges_taxes.rb
+++ b/db/migrate/20250505140927_add_organization_id_fk_to_charges_taxes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToChargesTaxes < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :charges_taxes, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250505140928_validate_charges_taxes_organizations_foreign_key.rb
+++ b/db/migrate/20250505140928_validate_charges_taxes_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateChargesTaxesOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :charges_taxes, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -102,6 +102,7 @@ ALTER TABLE IF EXISTS ONLY public.error_details DROP CONSTRAINT IF EXISTS fk_rai
 ALTER TABLE IF EXISTS ONLY public.add_ons_taxes DROP CONSTRAINT IF EXISTS fk_rails_5ade8984b1;
 ALTER TABLE IF EXISTS ONLY public.data_exports DROP CONSTRAINT IF EXISTS fk_rails_5a43da571b;
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_58234c715e;
+ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_56b7167125;
 ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_52b72c9b0e;
 ALTER TABLE IF EXISTS ONLY public.password_resets DROP CONSTRAINT IF EXISTS fk_rails_526379cd99;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_521b5240ed;
@@ -400,6 +401,7 @@ DROP INDEX IF EXISTS public.index_commitments_taxes_on_commitment_id;
 DROP INDEX IF EXISTS public.index_commitments_on_plan_id;
 DROP INDEX IF EXISTS public.index_commitments_on_commitment_type_and_plan_id;
 DROP INDEX IF EXISTS public.index_charges_taxes_on_tax_id;
+DROP INDEX IF EXISTS public.index_charges_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_charges_taxes_on_charge_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_charges_taxes_on_charge_id;
 DROP INDEX IF EXISTS public.index_charges_pay_in_advance;
@@ -1263,7 +1265,8 @@ CREATE TABLE public.charges_taxes (
     charge_id uuid NOT NULL,
     tax_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -4579,6 +4582,13 @@ CREATE UNIQUE INDEX index_charges_taxes_on_charge_id_and_tax_id ON public.charge
 
 
 --
+-- Name: index_charges_taxes_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_charges_taxes_on_organization_id ON public.charges_taxes USING btree (organization_id);
+
+
+--
 -- Name: index_charges_taxes_on_tax_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6666,6 +6676,14 @@ ALTER TABLE ONLY public.applied_usage_thresholds
 
 
 --
+-- Name: charges_taxes fk_rails_56b7167125; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.charges_taxes
+    ADD CONSTRAINT fk_rails_56b7167125 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: customers fk_rails_58234c715e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7416,6 +7434,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250505140928'),
+('20250505140927'),
+('20250505140926'),
 ('20250505135821'),
 ('20250505135820'),
 ('20250505135819'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -31,7 +31,6 @@ Rspec.describe "All tables must have an organization_id" do
       billable_metric_filters
       billing_entities_taxes
       charge_filter_values
-      charges_taxes
       commitments
       commitments_taxes
       coupon_targets


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `charges_taxes` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added