### PR TITLE
chore(organization): Add organization_id to credits table

### DIFF
--- a/app/jobs/database_migrations/populate_credits_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_credits_with_organization_job.rb
@@ -1,21 +1,20 @@
 # frozen_string_literal: true
 
 module DatabaseMigrations
-  class PopulateIdempotencyRecordsWithOrganizationJob < ApplicationJob
+  class PopulateCreditsWithOrganizationJob < ApplicationJob
     queue_as :low_priority
     unique :until_executed
 
     BATCH_SIZE = 1000
 
     def perform(batch_number = 1)
-      batch = IdempotencyRecord.unscoped
+      batch = Credit.unscoped
         .where(organization_id: nil)
-        .where(resource_type: "Invoice")
         .limit(BATCH_SIZE)
 
       if batch.exists?
         # rubocop:disable Rails/SkipsModelValidations
-        batch.update_all("organization_id = (SELECT organization_id FROM invoices WHERE invoices.id = idempotency_records.resource_id)")
+        batch.update_all("organization_id = (SELECT organization_id FROM invoices WHERE invoices.id = credits.invoice_id)")
         # rubocop:enable Rails/SkipsModelValidations
 
         # Queue the next batch

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -7,6 +7,7 @@ class Credit < ApplicationRecord
   belongs_to :applied_coupon, optional: true
   belongs_to :credit_note, optional: true
   belongs_to :progressive_billing_invoice, class_name: "Invoice", optional: true
+  belongs_to :organization, optional: true
 
   has_one :coupon, -> { with_discarded }, through: :applied_coupon
 
@@ -84,6 +85,7 @@ end
 #  applied_coupon_id              :uuid
 #  credit_note_id                 :uuid
 #  invoice_id                     :uuid
+#  organization_id                :uuid
 #  progressive_billing_invoice_id :uuid
 #
 # Indexes
@@ -91,6 +93,7 @@ end
 #  index_credits_on_applied_coupon_id               (applied_coupon_id)
 #  index_credits_on_credit_note_id                  (credit_note_id)
 #  index_credits_on_invoice_id                      (invoice_id)
+#  index_credits_on_organization_id                 (organization_id)
 #  index_credits_on_progressive_billing_invoice_id  (progressive_billing_invoice_id)
 #
 # Foreign Keys
@@ -98,5 +101,6 @@ end
 #  fk_rails_...  (applied_coupon_id => applied_coupons.id)
 #  fk_rails_...  (credit_note_id => credit_notes.id)
 #  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (progressive_billing_invoice_id => invoices.id)
 #

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -21,6 +21,7 @@ module Credits
       credit_amount = AppliedCoupons::AmountService.call(applied_coupon:, base_amount_cents:).amount
 
       new_credit = Credit.create!(
+        organization_id: invoice.organization_id,
         invoice:,
         applied_coupon:,
         amount_cents: credit_amount,

--- a/app/services/credits/credit_note_service.rb
+++ b/app/services/credits/credit_note_service.rb
@@ -22,6 +22,7 @@ module Credits
 
           # NOTE: create a new credit line on the invoice
           credit = Credit.new(
+            organization_id: invoice.organization_id,
             invoice:,
             credit_note:,
             amount_cents: credit_amount,

--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -36,6 +36,7 @@ module Credits
 
         if amount_to_credit.positive?
           credit = Credit.create!(
+            organization_id: invoice.organization_id,
             invoice:,
             progressive_billing_invoice:,
             amount_cents: amount_to_credit,

--- a/db/migrate/20250505142219_add_organization_id_to_credits.rb
+++ b/db/migrate/20250505142219_add_organization_id_to_credits.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToCredits < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :credits, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250505142220_add_organization_id_fk_to_credits.rb
+++ b/db/migrate/20250505142220_add_organization_id_fk_to_credits.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToCredits < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :credits, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250505142221_validate_credits_organizations_foreign_key.rb
+++ b/db/migrate/20250505142221_validate_credits_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateCreditsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :credits, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -103,6 +103,7 @@ ALTER TABLE IF EXISTS ONLY public.add_ons_taxes DROP CONSTRAINT IF EXISTS fk_rai
 ALTER TABLE IF EXISTS ONLY public.data_exports DROP CONSTRAINT IF EXISTS fk_rails_5a43da571b;
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_58234c715e;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_56b7167125;
+ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_5628a713de;
 ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_52b72c9b0e;
 ALTER TABLE IF EXISTS ONLY public.password_resets DROP CONSTRAINT IF EXISTS fk_rails_526379cd99;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_521b5240ed;
@@ -378,6 +379,7 @@ DROP INDEX IF EXISTS public.index_customers_on_account_type;
 DROP INDEX IF EXISTS public.index_customer_metadata_on_customer_id_and_key;
 DROP INDEX IF EXISTS public.index_customer_metadata_on_customer_id;
 DROP INDEX IF EXISTS public.index_credits_on_progressive_billing_invoice_id;
+DROP INDEX IF EXISTS public.index_credits_on_organization_id;
 DROP INDEX IF EXISTS public.index_credits_on_invoice_id;
 DROP INDEX IF EXISTS public.index_credits_on_credit_note_id;
 DROP INDEX IF EXISTS public.index_credits_on_applied_coupon_id;
@@ -1429,7 +1431,8 @@ CREATE TABLE public.credits (
     credit_note_id uuid,
     before_taxes boolean DEFAULT false NOT NULL,
     id uuid DEFAULT gen_random_uuid() NOT NULL,
-    progressive_billing_invoice_id uuid
+    progressive_billing_invoice_id uuid,
+    organization_id uuid
 );
 
 
@@ -4750,6 +4753,13 @@ CREATE INDEX index_credits_on_invoice_id ON public.credits USING btree (invoice_
 
 
 --
+-- Name: index_credits_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_credits_on_organization_id ON public.credits USING btree (organization_id);
+
+
+--
 -- Name: index_credits_on_progressive_billing_invoice_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6676,6 +6686,14 @@ ALTER TABLE ONLY public.applied_usage_thresholds
 
 
 --
+-- Name: credits fk_rails_5628a713de; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.credits
+    ADD CONSTRAINT fk_rails_5628a713de FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: charges_taxes fk_rails_56b7167125; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7434,6 +7452,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250505142221'),
+('20250505142220'),
+('20250505142219'),
 ('20250505140928'),
 ('20250505140927'),
 ('20250505140926'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -37,7 +37,6 @@ Rspec.describe "All tables must have an organization_id" do
       credit_note_items
       credit_notes
       credit_notes_taxes
-      credits
       customer_metadata
       customers_taxes
       data_export_parts


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `charges_taxes` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added