### PR TITLE
misc: Add temporary rails generator to fill the organization_id on every table

### DIFF
--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.autoloaders.main.ignore(
+  "lib/generators"
+)

--- a/lib/generators/organization_id_generator/organization_id_generator_generator.rb
+++ b/lib/generators/organization_id_generator/organization_id_generator_generator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class OrganizationIdGeneratorGenerator < Rails::Generators::NamedBase
+  include Rails::Generators::Migration
+  source_root File.expand_path("templates", __dir__)
+
+  desc "This generator creates the migrations and job to add the organization_id column to a database table"
+
+  def self.next_migration_number(dirname)
+    next_migration_number = current_migration_number(dirname) + 1
+    ActiveRecord::Migration.next_migration_number(next_migration_number)
+  end
+
+  def create_migrations
+    migration_template "add_organization_id_migration.rb.erb", "db/migrate/add_organization_id_to_#{file_name}.rb"
+    migration_template "add_organization_id_fk_migration.rb.erb", "db/migrate/add_organization_id_fk_to_#{file_name}.rb"
+    migration_template "validate_organization_foreign_key_migration.rb.erb", "db/migrate/validate_#{file_name}_organizations_foreign_key.rb"
+  end
+
+  def create_job
+    template "job_template.rb.erb", "app/jobs/database_migrations/populate_#{file_name}_with_organization_job.rb"
+  end
+end

--- a/lib/generators/organization_id_generator/templates/add_organization_id_fk_migration.rb.erb
+++ b/lib/generators/organization_id_generator/templates/add_organization_id_fk_migration.rb.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkTo<%= class_name %> < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :<%= file_name %>, :organizations, validate: false
+  end
+end

--- a/lib/generators/organization_id_generator/templates/add_organization_id_migration.rb.erb
+++ b/lib/generators/organization_id_generator/templates/add_organization_id_migration.rb.erb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdTo<%= class_name %> < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :<%= file_name %>, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/lib/generators/organization_id_generator/templates/job_template.rb.erb
+++ b/lib/generators/organization_id_generator/templates/job_template.rb.erb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class Populate<%= class_name %>WithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = <%= class_name.singularize %>.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM _CHANGE_ME_ WHERE _CHANGE_ME_.id = <%= file_name %>._CHANGE_ME__id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/lib/generators/organization_id_generator/templates/validate_organization_foreign_key_migration.rb.erb
+++ b/lib/generators/organization_id_generator/templates/validate_organization_foreign_key_migration.rb.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Validate<%= class_name %>OrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :<%= file_name %>, :organizations
+  end
+end


### PR DESCRIPTION
# Description

This PR adds a temporary rails generator to creates the migrations and job to add the organization_id column to specific database table.

# Usage:
```bash
  bin/rails generate organization_id_generator table_name
```

This will create:
- A migration to add the organization_id: `db/migrate/TIMESTAMP_add_organization_id_to_table_name.rb`
- A migration to add the foreign key, without validating it: `db/migrate/TIMESTAMP_add_organization_id_fk_to_table_name.rb`
- A migration to validate the foreign key after creation, `db/migrate/TIMESTAMP_validate_table_name_organization.rb`
- A job to fill the organization_id column in the table: `job/database_migrations/populate_table_name_from_organization_job.rb`
