### PR TITLE
chore(organization): Add organization_id to credit_notes table

### DIFF
--- a/app/jobs/database_migrations/populate_credit_notes_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_credit_notes_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateCreditNotesWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = CreditNote.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM invoices WHERE invoices.id = credit_notes.invoice_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -11,6 +11,7 @@ class CreditNote < ApplicationRecord
 
   belongs_to :customer, -> { with_discarded }
   belongs_to :invoice
+  # TODO: belongs_to :organization, optional: true
 
   has_one :organization, through: :invoice
   has_one :billing_entity, through: :invoice
@@ -195,15 +196,18 @@ end
 #  updated_at                              :datetime         not null
 #  customer_id                             :uuid             not null
 #  invoice_id                              :uuid             not null
+#  organization_id                         :uuid
 #  sequential_id                           :integer          not null
 #
 # Indexes
 #
-#  index_credit_notes_on_customer_id  (customer_id)
-#  index_credit_notes_on_invoice_id   (invoice_id)
+#  index_credit_notes_on_customer_id      (customer_id)
+#  index_credit_notes_on_invoice_id       (invoice_id)
+#  index_credit_notes_on_organization_id  (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -26,6 +26,7 @@ module CreditNotes
 
       ActiveRecord::Base.transaction do
         result.credit_note = CreditNote.new(
+          organization_id: invoice.organization_id,
           customer: invoice.customer,
           invoice:,
           issuing_date:,
@@ -59,7 +60,7 @@ module CreditNotes
           balance_amount_cents: credit_note.credit_amount_cents
         )
 
-        return result if context == :preview
+        next if context == :preview
 
         credit_note.save!
 
@@ -68,6 +69,7 @@ module CreditNotes
             wallet_credit:, credit_note_id: credit_note.id)
         end
       end
+      return result if context == :preview
 
       if credit_note.finalized?
         after_commit do

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -15,6 +15,7 @@ module CreditNotes
       return result.not_allowed_failure!(code: "invalid_type_or_status") unless valid_type_or_status?
 
       @credit_note = CreditNote.new(
+        organization_id: invoice.organization_id,
         customer: invoice.customer,
         invoice:,
         total_amount_currency: invoice.currency,

--- a/db/migrate/20250505161357_add_organization_id_to_credit_notes.rb
+++ b/db/migrate/20250505161357_add_organization_id_to_credit_notes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToCreditNotes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :credit_notes, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250505161358_add_organization_id_fk_to_credit_notes.rb
+++ b/db/migrate/20250505161358_add_organization_id_fk_to_credit_notes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToCreditNotes < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :credit_notes, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250505161359_validate_credit_notes_organizations_foreign_key.rb
+++ b/db/migrate/20250505161359_validate_credit_notes_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateCreditNotesOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :credit_notes, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -112,6 +112,7 @@ ALTER TABLE IF EXISTS ONLY public.payment_provider_customers DROP CONSTRAINT IF 
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_4934f27a06;
 ALTER TABLE IF EXISTS ONLY public.webhooks DROP CONSTRAINT IF EXISTS fk_rails_49212d501e;
 ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_4117574b51;
+ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_41088c7d45;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_3ff27d7624;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_3f7be5debc;
 ALTER TABLE IF EXISTS ONLY public.invoices_payment_requests DROP CONSTRAINT IF EXISTS fk_rails_3ec3563cf3;
@@ -387,6 +388,7 @@ DROP INDEX IF EXISTS public.index_credit_notes_taxes_on_tax_id;
 DROP INDEX IF EXISTS public.index_credit_notes_taxes_on_tax_code;
 DROP INDEX IF EXISTS public.index_credit_notes_taxes_on_credit_note_id_and_tax_code;
 DROP INDEX IF EXISTS public.index_credit_notes_taxes_on_credit_note_id;
+DROP INDEX IF EXISTS public.index_credit_notes_on_organization_id;
 DROP INDEX IF EXISTS public.index_credit_notes_on_invoice_id;
 DROP INDEX IF EXISTS public.index_credit_notes_on_customer_id;
 DROP INDEX IF EXISTS public.index_credit_note_items_on_fee_id;
@@ -1393,7 +1395,8 @@ CREATE TABLE public.credit_notes (
     coupons_adjustment_amount_cents bigint DEFAULT 0 NOT NULL,
     precise_coupons_adjustment_amount_cents numeric(30,5) DEFAULT 0.0 NOT NULL,
     precise_taxes_amount_cents numeric(30,5) DEFAULT 0.0 NOT NULL,
-    taxes_rate double precision DEFAULT 0.0 NOT NULL
+    taxes_rate double precision DEFAULT 0.0 NOT NULL,
+    organization_id uuid
 );
 
 
@@ -4704,6 +4707,13 @@ CREATE INDEX index_credit_notes_on_invoice_id ON public.credit_notes USING btree
 
 
 --
+-- Name: index_credit_notes_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_credit_notes_on_organization_id ON public.credit_notes USING btree (organization_id);
+
+
+--
 -- Name: index_credit_notes_taxes_on_credit_note_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6622,6 +6632,14 @@ ALTER TABLE ONLY public.charges_taxes
 
 
 --
+-- Name: credit_notes fk_rails_41088c7d45; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.credit_notes
+    ADD CONSTRAINT fk_rails_41088c7d45 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: credit_notes fk_rails_4117574b51; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7454,6 +7472,9 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250507154910'),
 ('20250506170753'),
+('20250505161359'),
+('20250505161358'),
+('20250505161357'),
 ('20250505142221'),
 ('20250505142220'),
 ('20250505142219'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -35,7 +35,6 @@ Rspec.describe "All tables must have an organization_id" do
       commitments_taxes
       coupon_targets
       credit_note_items
-      credit_notes
       credit_notes_taxes
       customer_metadata
       customers_taxes


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `credit_notes` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added