### PR TITLE
chore(organization): Add organization_id to applied_invoice_custom_sections table

### DIFF
--- a/app/jobs/database_migrations/populate_applied_invoice_custom_sections_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_applied_invoice_custom_sections_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateAppliedInvoiceCustomSectionsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = AppliedInvoiceCustomSection.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM invoices WHERE invoices.id = applied_invoice_custom_sections.invoice_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/applied_invoice_custom_section.rb
+++ b/app/models/applied_invoice_custom_section.rb
@@ -2,26 +2,30 @@
 
 class AppliedInvoiceCustomSection < ApplicationRecord
   belongs_to :invoice
+  belongs_to :organization, optional: true
 end
 
 # == Schema Information
 #
 # Table name: applied_invoice_custom_sections
 #
-#  id           :uuid             not null, primary key
-#  code         :string           not null
-#  details      :string
-#  display_name :string
-#  name         :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  invoice_id   :uuid             not null
+#  id              :uuid             not null, primary key
+#  code            :string           not null
+#  details         :string
+#  display_name    :string
+#  name            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  invoice_id      :uuid             not null
+#  organization_id :uuid
 #
 # Indexes
 #
-#  index_applied_invoice_custom_sections_on_invoice_id  (invoice_id)
+#  index_applied_invoice_custom_sections_on_invoice_id       (invoice_id)
+#  index_applied_invoice_custom_sections_on_organization_id  (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/invoices/apply_invoice_custom_sections_service.rb
+++ b/app/services/invoices/apply_invoice_custom_sections_service.rb
@@ -15,6 +15,7 @@ module Invoices
 
       customer.applicable_invoice_custom_sections.each do |custom_section|
         invoice.applied_invoice_custom_sections.create!(
+          organization_id: invoice.organization_id,
           code: custom_section.code,
           details: custom_section.details,
           display_name: custom_section.display_name,

--- a/db/migrate/20250506084020_add_organization_id_to_applied_invoice_custom_sections.rb
+++ b/db/migrate/20250506084020_add_organization_id_to_applied_invoice_custom_sections.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToAppliedInvoiceCustomSections < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :applied_invoice_custom_sections, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250506084021_add_organization_id_fk_to_applied_invoice_custom_sections.rb
+++ b/db/migrate/20250506084021_add_organization_id_fk_to_applied_invoice_custom_sections.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToAppliedInvoiceCustomSections < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :applied_invoice_custom_sections, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250506084022_validate_applied_invoice_custom_sections_organizations_foreign_key.rb
+++ b/db/migrate/20250506084022_validate_applied_invoice_custom_sections_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateAppliedInvoiceCustomSectionsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :applied_invoice_custom_sections, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -94,6 +94,7 @@ ALTER TABLE IF EXISTS ONLY public.integration_resources DROP CONSTRAINT IF EXIST
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_66eb6b32c1;
 ALTER TABLE IF EXISTS ONLY public.memberships DROP CONSTRAINT IF EXISTS fk_rails_64267aab58;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_63d3df128b;
+ALTER TABLE IF EXISTS ONLY public.applied_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_63ac282e70;
 ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS fk_rails_62d18ea517;
 ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS fk_rails_626209b8d2;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_6023b3f2dd;
@@ -441,6 +442,7 @@ DROP INDEX IF EXISTS public.index_billable_metric_filters_on_deleted_at;
 DROP INDEX IF EXISTS public.index_billable_metric_filters_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_applied_usage_thresholds_on_usage_threshold_id;
 DROP INDEX IF EXISTS public.index_applied_usage_thresholds_on_invoice_id;
+DROP INDEX IF EXISTS public.index_applied_invoice_custom_sections_on_organization_id;
 DROP INDEX IF EXISTS public.index_applied_invoice_custom_sections_on_invoice_id;
 DROP INDEX IF EXISTS public.index_applied_coupons_on_organization_id;
 DROP INDEX IF EXISTS public.index_applied_coupons_on_customer_id;
@@ -1040,7 +1042,8 @@ CREATE TABLE public.applied_invoice_custom_sections (
     details character varying,
     invoice_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -4360,6 +4363,13 @@ CREATE INDEX index_applied_invoice_custom_sections_on_invoice_id ON public.appli
 
 
 --
+-- Name: index_applied_invoice_custom_sections_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_applied_invoice_custom_sections_on_organization_id ON public.applied_invoice_custom_sections USING btree (organization_id);
+
+
+--
 -- Name: index_applied_usage_thresholds_on_invoice_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6802,6 +6812,14 @@ ALTER TABLE ONLY public.payments
 
 
 --
+-- Name: applied_invoice_custom_sections fk_rails_63ac282e70; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.applied_invoice_custom_sections
+    ADD CONSTRAINT fk_rails_63ac282e70 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: subscriptions fk_rails_63d3df128b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7493,6 +7511,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250506085760'),
 ('20250506085759'),
 ('20250506085758'),
+('20250506084022'),
+('20250506084021'),
+('20250506084020'),
 ('20250505161359'),
 ('20250505161358'),
 ('20250505161357'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -26,7 +26,6 @@ Rspec.describe "All tables must have an organization_id" do
 
   let(:tables_to_migrate) do
     %w[
-      applied_invoice_custom_sections
       applied_usage_thresholds
       billable_metric_filters
       billing_entities_taxes


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `applied_invoice_custom_sections` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added