### PR TITLE
chore(organization): Add organization_id to applied_usage_thresholds table

### DIFF
--- a/app/jobs/database_migrations/populate_applied_usage_thresholds_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_applied_usage_thresholds_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateAppliedUsageThresholdsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = AppliedUsageThreshold.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM invoices WHERE invoices.id = applied_usage_thresholds.invoice_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/applied_usage_threshold.rb
+++ b/app/models/applied_usage_threshold.rb
@@ -3,6 +3,7 @@
 class AppliedUsageThreshold < ApplicationRecord
   belongs_to :usage_threshold, -> { with_discarded }
   belongs_to :invoice
+  belongs_to :organization, optional: true
 
   validates :usage_threshold_id, uniqueness: {scope: :invoice_id}
 
@@ -31,16 +32,19 @@ end
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  invoice_id                  :uuid             not null
+#  organization_id             :uuid
 #  usage_threshold_id          :uuid             not null
 #
 # Indexes
 #
 #  idx_on_usage_threshold_id_invoice_id_cb82cdf163       (usage_threshold_id,invoice_id) UNIQUE
 #  index_applied_usage_thresholds_on_invoice_id          (invoice_id)
+#  index_applied_usage_thresholds_on_organization_id     (organization_id)
 #  index_applied_usage_thresholds_on_usage_threshold_id  (usage_threshold_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (usage_threshold_id => usage_thresholds.id)
 #

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -126,6 +126,7 @@ module Invoices
     def create_applied_usage_thresholds
       sorted_usage_thresholds.each do
         AppliedUsageThreshold.create!(
+          organization_id: lifetime_usage.organization_id,
           invoice:,
           usage_threshold: _1,
           lifetime_usage_amount_cents: lifetime_usage.total_amount_cents

--- a/db/migrate/20250506084827_add_organization_id_to_applied_usage_thresholds.rb
+++ b/db/migrate/20250506084827_add_organization_id_to_applied_usage_thresholds.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToAppliedUsageThresholds < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :applied_usage_thresholds, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250506084828_add_organization_id_fk_to_applied_usage_thresholds.rb
+++ b/db/migrate/20250506084828_add_organization_id_fk_to_applied_usage_thresholds.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToAppliedUsageThresholds < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :applied_usage_thresholds, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250506084829_validate_applied_usage_thresholds_organizations_foreign_key.rb
+++ b/db/migrate/20250506084829_validate_applied_usage_thresholds_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateAppliedUsageThresholdsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :applied_usage_thresholds, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -152,6 +152,7 @@ ALTER TABLE IF EXISTS ONLY public.webhook_endpoints DROP CONSTRAINT IF EXISTS fk
 ALTER TABLE IF EXISTS ONLY public.plans DROP CONSTRAINT IF EXISTS fk_rails_216ac8a975;
 ALTER TABLE IF EXISTS ONLY public.webhooks DROP CONSTRAINT IF EXISTS fk_rails_20cc0de4c7;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_1db0057d9b;
+ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_1d112bf8a0;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_195153290d;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_150139409e;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_1454058c96;
@@ -441,6 +442,7 @@ DROP INDEX IF EXISTS public.index_billable_metrics_on_deleted_at;
 DROP INDEX IF EXISTS public.index_billable_metric_filters_on_deleted_at;
 DROP INDEX IF EXISTS public.index_billable_metric_filters_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_applied_usage_thresholds_on_usage_threshold_id;
+DROP INDEX IF EXISTS public.index_applied_usage_thresholds_on_organization_id;
 DROP INDEX IF EXISTS public.index_applied_usage_thresholds_on_invoice_id;
 DROP INDEX IF EXISTS public.index_applied_invoice_custom_sections_on_organization_id;
 DROP INDEX IF EXISTS public.index_applied_invoice_custom_sections_on_invoice_id;
@@ -1057,7 +1059,8 @@ CREATE TABLE public.applied_usage_thresholds (
     invoice_id uuid NOT NULL,
     lifetime_usage_amount_cents bigint DEFAULT 0 NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -4377,6 +4380,13 @@ CREATE INDEX index_applied_usage_thresholds_on_invoice_id ON public.applied_usag
 
 
 --
+-- Name: index_applied_usage_thresholds_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_applied_usage_thresholds_on_organization_id ON public.applied_usage_thresholds USING btree (organization_id);
+
+
+--
 -- Name: index_applied_usage_thresholds_on_usage_threshold_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6356,6 +6366,14 @@ ALTER TABLE ONLY public.customer_metadata
 
 
 --
+-- Name: applied_usage_thresholds fk_rails_1d112bf8a0; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.applied_usage_thresholds
+    ADD CONSTRAINT fk_rails_1d112bf8a0 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: credits fk_rails_1db0057d9b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7511,6 +7529,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250506085760'),
 ('20250506085759'),
 ('20250506085758'),
+('20250506084829'),
+('20250506084828'),
+('20250506084827'),
 ('20250506084022'),
 ('20250506084021'),
 ('20250506084020'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -26,7 +26,6 @@ Rspec.describe "All tables must have an organization_id" do
 
   let(:tables_to_migrate) do
     %w[
-      applied_usage_thresholds
       billable_metric_filters
       billing_entities_taxes
       charge_filter_values


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `applied_usage_thresholds` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
