### PR TITLE
fix(customer): Fix email validator

### DIFF
--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -8,6 +8,10 @@ class EmailValidator < ActiveModel::EachValidator
   protected
 
   def valid?(value)
-    value&.match(Regex::EMAIL)
+    return false if value.blank?
+
+    emails = value.split(",").map(&:strip)
+
+    emails.all? { |email| email.match?(Regex::EMAIL) }
   end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -68,6 +68,91 @@ RSpec.describe Customer, type: :model do
       expect(customer).not_to be_valid
     end
 
+    describe "of email" do
+      let(:customer) { build_stubbed(:customer, email:) }
+      let(:error) { customer.errors.where(:email, :invalid_email_format) }
+
+      before { customer.valid? }
+
+      context "when there is only one email" do
+        context "when email is nil" do
+          let(:email) { nil }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+
+        context "when email is empty string" do
+          let(:email) { "" }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+
+        context "when email is valid" do
+          let(:email) { "test@test-test.com" }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+
+        context "when email is invalid" do
+          let(:email) { "test@test- test.com" }
+
+          it "adds an error" do
+            expect(error).to be_present
+          end
+        end
+      end
+
+      context "when there are multiple comma-separated emails" do
+        context "when emails are valid" do
+          let(:email) { "test@test-test.com, test2@test.com" }
+
+          it "does not add an error" do
+            expect(error).not_to be_present
+          end
+        end
+
+        context "when emails are not valid" do
+          context "when one of the emails is blank" do
+            let(:email) { "test@test- test.com, test2@test.com," }
+
+            it "adds an error" do
+              expect(error).to be_present
+            end
+          end
+
+          context "when first one is invalid" do
+            let(:email) { "test@test- test.com, test2@test.com" }
+
+            it "adds an error" do
+              expect(error).to be_present
+            end
+          end
+
+          context "when second one is invalid" do
+            let(:email) { "test@test-test.com, test2@te st.com" }
+
+            it "adds an error" do
+              expect(error).to be_present
+            end
+          end
+
+          context "when both are invalid" do
+            let(:email) { "test@test -test.com, test2@te st.com" }
+
+            it "adds an error" do
+              expect(error).to be_present
+            end
+          end
+        end
+      end
+    end
+
     describe "of country" do
       let(:customer) { build_stubbed(:customer, country:) }
       let(:error) { customer.errors.where(:country, :country_code_invalid) }


### PR DESCRIPTION
## Context

Some mailer jobs fail because the recipient email is invalid.
It is due to the email validator bug in case of multiple comma-separated emails, it was only validating the first one in the list.

This was considered to be valid even if the second email is invalid: `email1@test-email.com, email2@test- email.com`

## Description

This PR fixes the email validator.
