### PR TITLE
chore(organization): Add organization_id to customer_metadata table

### DIFF
--- a/app/jobs/database_migrations/populate_customer_metadata_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_customer_metadata_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateCustomerMetadataWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Metadata::CustomerMetadata.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM customers WHERE customers.id = customer_metadata.customer_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/metadata/customer_metadata.rb
+++ b/app/models/metadata/customer_metadata.rb
@@ -5,6 +5,7 @@ module Metadata
     COUNT_PER_CUSTOMER = 5
 
     belongs_to :customer
+    belongs_to :organization, optional: true
 
     validates :key, presence: true, uniqueness: {scope: :customer_id}, length: {maximum: 20}
     validates :value, presence: true, length: {maximum: 100}
@@ -24,13 +25,16 @@ end
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  customer_id        :uuid             not null
+#  organization_id    :uuid
 #
 # Indexes
 #
 #  index_customer_metadata_on_customer_id          (customer_id)
 #  index_customer_metadata_on_customer_id_and_key  (customer_id,key) UNIQUE
+#  index_customer_metadata_on_organization_id      (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -128,6 +128,7 @@ module Customers
 
     def create_metadata(customer:, args:)
       customer.metadata.create!(
+        organization_id: organization.id,
         key: args[:key],
         value: args[:value],
         display_in_invoice: args[:display_in_invoice] || false

--- a/app/services/customers/metadata/update_service.rb
+++ b/app/services/customers/metadata/update_service.rb
@@ -40,6 +40,7 @@ module Customers
 
       def create_metadata(payload)
         customer.metadata.create!(
+          organization_id: customer.organization_id,
           key: payload[:key],
           value: payload[:value],
           display_in_invoice: payload[:display_in_invoice]

--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -175,6 +175,7 @@ module Customers
 
     def create_metadata(customer:, args:)
       customer.metadata.create!(
+        organization_id: organization.id,
         key: args[:key],
         value: args[:value],
         display_in_invoice: args[:display_in_invoice] || false

--- a/db/migrate/20250506085758_add_organization_id_to_customer_metadata.rb
+++ b/db/migrate/20250506085758_add_organization_id_to_customer_metadata.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToCustomerMetadata < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :customer_metadata, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250506085759_add_organization_id_fk_to_customer_metadata.rb
+++ b/db/migrate/20250506085759_add_organization_id_fk_to_customer_metadata.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToCustomerMetadata < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :customer_metadata, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250506085760_validate_customer_metadata_organizations_foreign_key.rb
+++ b/db/migrate/20250506085760_validate_customer_metadata_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateCustomerMetadataOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :customer_metadata, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -23,6 +23,7 @@ ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF
 ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS fk_rails_e88403f4b9;
 ALTER TABLE IF EXISTS ONLY public.customers_taxes DROP CONSTRAINT IF EXISTS fk_rails_e86903e081;
 ALTER TABLE IF EXISTS ONLY public.charge_filters DROP CONSTRAINT IF EXISTS fk_rails_e711e8089e;
+ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_dfac602b2c;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_dea748e529;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_de6b3c3138;
 ALTER TABLE IF EXISTS ONLY public.invoice_custom_section_selections DROP CONSTRAINT IF EXISTS fk_rails_dd7e076158;
@@ -377,6 +378,7 @@ DROP INDEX IF EXISTS public.index_customers_on_deleted_at;
 DROP INDEX IF EXISTS public.index_customers_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_customers_on_applied_dunning_campaign_id;
 DROP INDEX IF EXISTS public.index_customers_on_account_type;
+DROP INDEX IF EXISTS public.index_customer_metadata_on_organization_id;
 DROP INDEX IF EXISTS public.index_customer_metadata_on_customer_id_and_key;
 DROP INDEX IF EXISTS public.index_customer_metadata_on_customer_id;
 DROP INDEX IF EXISTS public.index_credits_on_progressive_billing_invoice_id;
@@ -1450,7 +1452,8 @@ CREATE TABLE public.customer_metadata (
     value character varying NOT NULL,
     display_in_invoice boolean DEFAULT false NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -4791,6 +4794,13 @@ CREATE UNIQUE INDEX index_customer_metadata_on_customer_id_and_key ON public.cus
 
 
 --
+-- Name: index_customer_metadata_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_customer_metadata_on_organization_id ON public.customer_metadata USING btree (organization_id);
+
+
+--
 -- Name: index_customers_on_account_type; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7352,6 +7362,14 @@ ALTER TABLE ONLY public.credit_note_items
 
 
 --
+-- Name: customer_metadata fk_rails_dfac602b2c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.customer_metadata
+    ADD CONSTRAINT fk_rails_dfac602b2c FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: charge_filters fk_rails_e711e8089e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7472,6 +7490,9 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250507154910'),
 ('20250506170753'),
+('20250506085760'),
+('20250506085759'),
+('20250506085758'),
 ('20250505161359'),
 ('20250505161358'),
 ('20250505161357'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -36,7 +36,6 @@ Rspec.describe "All tables must have an organization_id" do
       coupon_targets
       credit_note_items
       credit_notes_taxes
-      customer_metadata
       customers_taxes
       data_export_parts
       dunning_campaign_thresholds


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `customer_metadata` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
