### PR TITLE
chore(organization): Add organization_id to billable_metric_filters table

### DIFF
--- a/app/jobs/database_migrations/populate_billable_metric_filters_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_billable_metric_filters_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateBillableMetricFiltersWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = BillableMetricFilter.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM billable_metrics WHERE billable_metrics.id = billable_metric_filters.billable_metric_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/billable_metric_filter.rb
+++ b/app/models/billable_metric_filter.rb
@@ -6,6 +6,7 @@ class BillableMetricFilter < ApplicationRecord
   self.discard_column = :deleted_at
 
   belongs_to :billable_metric, -> { with_discarded }
+  belongs_to :organization, optional: true
 
   has_many :filter_values, class_name: "ChargeFilterValue", dependent: :destroy
   has_many :charge_filters, through: :filter_values
@@ -27,14 +28,17 @@ end
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  billable_metric_id :uuid             not null
+#  organization_id    :uuid
 #
 # Indexes
 #
 #  index_active_metric_filters                          (billable_metric_id) WHERE (deleted_at IS NULL)
 #  index_billable_metric_filters_on_billable_metric_id  (billable_metric_id)
 #  index_billable_metric_filters_on_deleted_at          (deleted_at)
+#  index_billable_metric_filters_on_organization_id     (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (billable_metric_id => billable_metrics.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -20,7 +20,9 @@ module BillableMetricFilters
 
       ActiveRecord::Base.transaction do
         filters_params.each do |filter_param|
-          filter = billable_metric.filters.find_or_initialize_by(key: filter_param[:key])
+          filter = billable_metric.filters
+            .create_with(organization_id: billable_metric.organization_id)
+            .find_or_initialize_by(key: filter_param[:key])
           new_values = (filter_param[:values] || []).uniq
 
           if filter.persisted?

--- a/db/migrate/20250506115437_add_organization_id_to_billable_metric_filters.rb
+++ b/db/migrate/20250506115437_add_organization_id_to_billable_metric_filters.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToBillableMetricFilters < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :billable_metric_filters, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250506115438_add_organization_id_fk_to_billable_metric_filters.rb
+++ b/db/migrate/20250506115438_add_organization_id_fk_to_billable_metric_filters.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToBillableMetricFilters < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :billable_metric_filters, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250506115439_validate_billable_metric_filters_organizations_foreign_key.rb
+++ b/db/migrate/20250506115439_validate_billable_metric_filters_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateBillableMetricFiltersOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :billable_metric_filters, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -110,6 +110,7 @@ ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EX
 ALTER TABLE IF EXISTS ONLY public.password_resets DROP CONSTRAINT IF EXISTS fk_rails_526379cd99;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_521b5240ed;
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_51ac39a0c6;
+ALTER TABLE IF EXISTS ONLY public.billable_metric_filters DROP CONSTRAINT IF EXISTS fk_rails_51077e7c0e;
 ALTER TABLE IF EXISTS ONLY public.payment_provider_customers DROP CONSTRAINT IF EXISTS fk_rails_50d46d3679;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_4934f27a06;
 ALTER TABLE IF EXISTS ONLY public.webhooks DROP CONSTRAINT IF EXISTS fk_rails_49212d501e;
@@ -439,6 +440,7 @@ DROP INDEX IF EXISTS public.index_billable_metrics_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_billable_metrics_on_organization_id;
 DROP INDEX IF EXISTS public.index_billable_metrics_on_org_id_and_code_and_expr;
 DROP INDEX IF EXISTS public.index_billable_metrics_on_deleted_at;
+DROP INDEX IF EXISTS public.index_billable_metric_filters_on_organization_id;
 DROP INDEX IF EXISTS public.index_billable_metric_filters_on_deleted_at;
 DROP INDEX IF EXISTS public.index_billable_metric_filters_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_applied_usage_thresholds_on_usage_threshold_id;
@@ -1087,7 +1089,8 @@ CREATE TABLE public.billable_metric_filters (
     "values" character varying[] DEFAULT '{}'::character varying[] NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    deleted_at timestamp(6) without time zone
+    deleted_at timestamp(6) without time zone,
+    organization_id uuid
 );
 
 
@@ -4408,6 +4411,13 @@ CREATE INDEX index_billable_metric_filters_on_deleted_at ON public.billable_metr
 
 
 --
+-- Name: index_billable_metric_filters_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_billable_metric_filters_on_organization_id ON public.billable_metric_filters USING btree (organization_id);
+
+
+--
 -- Name: index_billable_metrics_on_deleted_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6710,6 +6720,14 @@ ALTER TABLE ONLY public.payment_provider_customers
 
 
 --
+-- Name: billable_metric_filters fk_rails_51077e7c0e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.billable_metric_filters
+    ADD CONSTRAINT fk_rails_51077e7c0e FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: commitments fk_rails_51ac39a0c6; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7526,6 +7544,9 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250507154910'),
 ('20250506170753'),
+('20250506115439'),
+('20250506115438'),
+('20250506115437'),
 ('20250506085760'),
 ('20250506085759'),
 ('20250506085758'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -26,7 +26,6 @@ Rspec.describe "All tables must have an organization_id" do
 
   let(:tables_to_migrate) do
     %w[
-      billable_metric_filters
       billing_entities_taxes
       charge_filter_values
       commitments


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `billable_metric_filters` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
