### PR TITLE
chore(organization): Add organization_id to fees_taxes table

### DIFF
--- a/app/jobs/database_migrations/populate_fees_taxes_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_fees_taxes_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateFeesTaxesWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = FeesTax.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM fees WHERE fees.id = fees_taxes.fee_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/fee/applied_tax.rb
+++ b/app/models/fee/applied_tax.rb
@@ -8,6 +8,7 @@ class Fee
 
     belongs_to :fee
     belongs_to :tax, optional: true
+    belongs_to :organization, optional: true
   end
 end
 
@@ -26,16 +27,19 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  fee_id               :uuid             not null
+#  organization_id      :uuid
 #  tax_id               :uuid
 #
 # Indexes
 #
 #  index_fees_taxes_on_fee_id             (fee_id)
 #  index_fees_taxes_on_fee_id_and_tax_id  (fee_id,tax_id) UNIQUE WHERE ((tax_id IS NOT NULL) AND (created_at >= '2023-09-12 00:00:00'::timestamp without time zone))
+#  index_fees_taxes_on_organization_id    (organization_id)
 #  index_fees_taxes_on_tax_id             (tax_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (fee_id => fees.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (tax_id => taxes.id)
 #

--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -19,6 +19,7 @@ module Fees
 
       applicable_taxes.each do |tax|
         applied_tax = Fee::AppliedTax.new(
+          organization: fee.organization,
           fee:,
           tax:,
           tax_description: tax.description,

--- a/db/migrate/20250506121530_add_organization_id_to_fees_taxes.rb
+++ b/db/migrate/20250506121530_add_organization_id_to_fees_taxes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToFeesTaxes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :fees_taxes, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250506121531_add_organization_id_fk_to_fees_taxes.rb
+++ b/db/migrate/20250506121531_add_organization_id_fk_to_fees_taxes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToFeesTaxes < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :fees_taxes, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250506121532_validate_fees_taxes_organizations_foreign_key.rb
+++ b/db/migrate/20250506121532_validate_fees_taxes_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateFeesTaxesOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :fees_taxes, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -160,6 +160,7 @@ ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_ra
 ALTER TABLE IF EXISTS ONLY public.invoices_taxes DROP CONSTRAINT IF EXISTS fk_rails_142809fee1;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_12d29bc654;
 ALTER TABLE IF EXISTS ONLY public.applied_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_10428ecad2;
+ALTER TABLE IF EXISTS ONLY public.fees_taxes DROP CONSTRAINT IF EXISTS fk_rails_103e187859;
 ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_0e464363cb;
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_0d349e632f;
 ALTER TABLE IF EXISTS ONLY public.customers_taxes DROP CONSTRAINT IF EXISTS fk_rails_0d2be3d72c;
@@ -332,6 +333,7 @@ DROP INDEX IF EXISTS public.index_group_properties_on_deleted_at;
 DROP INDEX IF EXISTS public.index_group_properties_on_charge_id_and_group_id;
 DROP INDEX IF EXISTS public.index_group_properties_on_charge_id;
 DROP INDEX IF EXISTS public.index_fees_taxes_on_tax_id;
+DROP INDEX IF EXISTS public.index_fees_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_fees_taxes_on_fee_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_fees_taxes_on_fee_id;
 DROP INDEX IF EXISTS public.index_fees_on_true_up_parent_fee_id;
@@ -2261,7 +2263,8 @@ CREATE TABLE public.fees_taxes (
     amount_currency character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    precise_amount_cents numeric(40,15) DEFAULT 0.0 NOT NULL
+    precise_amount_cents numeric(40,15) DEFAULT 0.0 NOT NULL,
+    organization_id uuid
 );
 
 
@@ -5174,6 +5177,13 @@ CREATE UNIQUE INDEX index_fees_taxes_on_fee_id_and_tax_id ON public.fees_taxes U
 
 
 --
+-- Name: index_fees_taxes_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_fees_taxes_on_organization_id ON public.fees_taxes USING btree (organization_id);
+
+
+--
 -- Name: index_fees_taxes_on_tax_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6325,6 +6335,14 @@ ALTER TABLE ONLY public.invoices
 
 ALTER TABLE ONLY public.integration_customers
     ADD CONSTRAINT fk_rails_0e464363cb FOREIGN KEY (customer_id) REFERENCES public.customers(id);
+
+
+--
+-- Name: fees_taxes fk_rails_103e187859; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.fees_taxes
+    ADD CONSTRAINT fk_rails_103e187859 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -7544,6 +7562,9 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250507154910'),
 ('20250506170753'),
+('20250506121532'),
+('20250506121531'),
+('20250506121530'),
 ('20250506115439'),
 ('20250506115438'),
 ('20250506115437'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -36,7 +36,6 @@ Rspec.describe "All tables must have an organization_id" do
       customers_taxes
       data_export_parts
       dunning_campaign_thresholds
-      fees_taxes
       integration_collection_mappings
       integration_customers
       integration_items


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `fees_taxes` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
