### PR TITLE
chore(organization): Add organization_id to invoices_payment_requests table

### DIFF
--- a/app/jobs/database_migrations/populate_invoices_payment_requests_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_invoices_payment_requests_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateInvoicesPaymentRequestsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = PaymentRequest::AppliedInvoice.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM invoices WHERE invoices.id = invoices_payment_requests.invoice_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/payment_request/applied_invoice.rb
+++ b/app/models/payment_request/applied_invoice.rb
@@ -6,6 +6,7 @@ class PaymentRequest
 
     belongs_to :invoice
     belongs_to :payment_request
+    belongs_to :organization, optional: true
   end
 end
 
@@ -17,16 +18,19 @@ end
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  invoice_id         :uuid             not null
+#  organization_id    :uuid
 #  payment_request_id :uuid             not null
 #
 # Indexes
 #
 #  idx_on_invoice_id_payment_request_id_aa550779a4        (invoice_id,payment_request_id) UNIQUE
 #  index_invoices_payment_requests_on_invoice_id          (invoice_id)
+#  index_invoices_payment_requests_on_organization_id     (organization_id)
 #  index_invoices_payment_requests_on_payment_request_id  (payment_request_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_request_id => payment_requests.id)
 #

--- a/db/migrate/20250506144000_add_organization_id_to_invoices_payment_requests.rb
+++ b/db/migrate/20250506144000_add_organization_id_to_invoices_payment_requests.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToInvoicesPaymentRequests < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :invoices_payment_requests, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250506144001_add_organization_id_fk_to_invoices_payment_requests.rb
+++ b/db/migrate/20250506144001_add_organization_id_fk_to_invoices_payment_requests.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToInvoicesPaymentRequests < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :invoices_payment_requests, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250506144002_validate_invoices_payment_requests_organizations_foreign_key.rb
+++ b/db/migrate/20250506144002_validate_invoices_payment_requests_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateInvoicesPaymentRequestsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :invoices_payment_requests, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -146,6 +146,7 @@ ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_257af2
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_2561c00887;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_25267b0e17;
 ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS fk_rails_25232a0ec3;
+ALTER TABLE IF EXISTS ONLY public.invoices_payment_requests DROP CONSTRAINT IF EXISTS fk_rails_2496c105ed;
 ALTER TABLE IF EXISTS ONLY public.taxes DROP CONSTRAINT IF EXISTS fk_rails_23975f5a47;
 ALTER TABLE IF EXISTS ONLY public.invoices_taxes DROP CONSTRAINT IF EXISTS fk_rails_22af6c6d28;
 ALTER TABLE IF EXISTS ONLY public.cached_aggregations DROP CONSTRAINT IF EXISTS fk_rails_21eb389927;
@@ -275,6 +276,7 @@ DROP INDEX IF EXISTS public.index_invoices_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_invoices_taxes_on_invoice_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_invoices_taxes_on_invoice_id;
 DROP INDEX IF EXISTS public.index_invoices_payment_requests_on_payment_request_id;
+DROP INDEX IF EXISTS public.index_invoices_payment_requests_on_organization_id;
 DROP INDEX IF EXISTS public.index_invoices_payment_requests_on_invoice_id;
 DROP INDEX IF EXISTS public.index_invoices_on_status;
 DROP INDEX IF EXISTS public.index_invoices_on_sequential_id;
@@ -2969,7 +2971,8 @@ CREATE TABLE public.invoices_payment_requests (
     invoice_id uuid NOT NULL,
     payment_request_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -5590,6 +5593,13 @@ CREATE INDEX index_invoices_payment_requests_on_invoice_id ON public.invoices_pa
 
 
 --
+-- Name: index_invoices_payment_requests_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_invoices_payment_requests_on_organization_id ON public.invoices_payment_requests USING btree (organization_id);
+
+
+--
 -- Name: index_invoices_payment_requests_on_payment_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6455,6 +6465,14 @@ ALTER TABLE ONLY public.invoices_taxes
 
 ALTER TABLE ONLY public.taxes
     ADD CONSTRAINT fk_rails_23975f5a47 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: invoices_payment_requests fk_rails_2496c105ed; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.invoices_payment_requests
+    ADD CONSTRAINT fk_rails_2496c105ed FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -7562,6 +7580,9 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250507154910'),
 ('20250506170753'),
+('20250506144002'),
+('20250506144001'),
+('20250506144000'),
 ('20250506121532'),
 ('20250506121531'),
 ('20250506121530'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -42,7 +42,6 @@ Rspec.describe "All tables must have an organization_id" do
       integration_mappings
       integration_resources
       invoice_metadata
-      invoices_payment_requests
       recurring_transaction_rules
       refunds
       versions


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `fees_taxes` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added

