### PR TITLE
chore(organization): Add organization_id to invoice_metadata table

### DIFF
--- a/app/jobs/database_migrations/populate_invoice_metadata_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_invoice_metadata_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateInvoiceMetadataWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Metadata::InvoiceMetadata.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM invoices WHERE invoices.id = invoice_metadata.invoice_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/metadata/invoice_metadata.rb
+++ b/app/models/metadata/invoice_metadata.rb
@@ -5,6 +5,7 @@ module Metadata
     COUNT_PER_INVOICE = 5
 
     belongs_to :invoice
+    belongs_to :organization, optional: true
 
     validates :key, presence: true, uniqueness: {scope: :invoice_id}, length: {maximum: 20}
     validates :value, presence: true
@@ -15,19 +16,22 @@ end
 #
 # Table name: invoice_metadata
 #
-#  id         :uuid             not null, primary key
-#  key        :string           not null
-#  value      :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  invoice_id :uuid             not null
+#  id              :uuid             not null, primary key
+#  key             :string           not null
+#  value           :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  invoice_id      :uuid             not null
+#  organization_id :uuid
 #
 # Indexes
 #
 #  index_invoice_metadata_on_invoice_id          (invoice_id)
 #  index_invoice_metadata_on_invoice_id_and_key  (invoice_id,key) UNIQUE
+#  index_invoice_metadata_on_organization_id     (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (invoice_id => invoices.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/invoices/metadata/update_service.rb
+++ b/app/services/invoices/metadata/update_service.rb
@@ -39,6 +39,7 @@ module Invoices
 
       def create_metadata(payload)
         invoice.metadata.create!(
+          organization_id: invoice.organization_id,
           key: payload[:key],
           value: payload[:value]
         )

--- a/db/migrate/20250506145849_add_organization_id_to_invoice_metadata.rb
+++ b/db/migrate/20250506145849_add_organization_id_to_invoice_metadata.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToInvoiceMetadata < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :invoice_metadata, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250506145850_add_organization_id_fk_to_invoice_metadata.rb
+++ b/db/migrate/20250506145850_add_organization_id_fk_to_invoice_metadata.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToInvoiceMetadata < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :invoice_metadata, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250506145851_validate_invoice_metadata_organizations_foreign_key.rb
+++ b/db/migrate/20250506145851_validate_invoice_metadata_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateInvoiceMetadataOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :invoice_metadata, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -95,6 +95,7 @@ ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rai
 ALTER TABLE IF EXISTS ONLY public.memberships DROP CONSTRAINT IF EXISTS fk_rails_64267aab58;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_63d3df128b;
 ALTER TABLE IF EXISTS ONLY public.applied_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_63ac282e70;
+ALTER TABLE IF EXISTS ONLY public.invoice_metadata DROP CONSTRAINT IF EXISTS fk_rails_63683837a2;
 ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS fk_rails_62d18ea517;
 ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS fk_rails_626209b8d2;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_6023b3f2dd;
@@ -295,6 +296,7 @@ DROP INDEX IF EXISTS public.index_invoice_subscriptions_on_invoice_id_and_subscr
 DROP INDEX IF EXISTS public.index_invoice_subscriptions_on_invoice_id;
 DROP INDEX IF EXISTS public.index_invoice_subscriptions_on_charges_from_and_to_datetime;
 DROP INDEX IF EXISTS public.index_invoice_subscriptions_boundaries;
+DROP INDEX IF EXISTS public.index_invoice_metadata_on_organization_id;
 DROP INDEX IF EXISTS public.index_invoice_metadata_on_invoice_id_and_key;
 DROP INDEX IF EXISTS public.index_invoice_metadata_on_invoice_id;
 DROP INDEX IF EXISTS public.index_invoice_custom_sections_on_section_type;
@@ -2301,7 +2303,8 @@ CREATE TABLE public.invoice_metadata (
     key character varying NOT NULL,
     value character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -5467,6 +5470,13 @@ CREATE UNIQUE INDEX index_invoice_metadata_on_invoice_id_and_key ON public.invoi
 
 
 --
+-- Name: index_invoice_metadata_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_invoice_metadata_on_organization_id ON public.invoice_metadata USING btree (organization_id);
+
+
+--
 -- Name: index_invoice_subscriptions_boundaries; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6884,6 +6894,14 @@ ALTER TABLE ONLY public.payments
 
 
 --
+-- Name: invoice_metadata fk_rails_63683837a2; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.invoice_metadata
+    ADD CONSTRAINT fk_rails_63683837a2 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: applied_invoice_custom_sections fk_rails_63ac282e70; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7580,6 +7598,9 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250507154910'),
 ('20250506170753'),
+('20250506145851'),
+('20250506145850'),
+('20250506145849'),
 ('20250506144002'),
 ('20250506144001'),
 ('20250506144000'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -41,7 +41,6 @@ Rspec.describe "All tables must have an organization_id" do
       integration_items
       integration_mappings
       integration_resources
-      invoice_metadata
       recurring_transaction_rules
       refunds
       versions


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `invoice_metadata` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
