### PR TITLE
feat(audit_logs): Activity logs for billable metrics

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -3,6 +3,9 @@
 class BaseService
   include AfterCommitEverywhere
 
+  # rubocop:disable ThreadSafety/ClassAndModuleAttributes
+  class_attribute :activity_log_config, instance_writer: false, default: nil
+  # rubocop:enable ThreadSafety/ClassAndModuleAttributes
   class FailedResult < StandardError
     attr_reader :result, :original_error
 
@@ -199,10 +202,14 @@ class BaseService
 
   Result = LegacyResult
 
+  def self.activity_loggable(action:, record:)
+    self.activity_log_config = {action:, record:}
+  end
+
   def self.call(*, **, &)
     LagoTracer.in_span("#{name}#call") do
       instance = new(*, **)
-      return instance.call_with_audit_logs(&) if instance.audit_logs
+      return instance.call_with_activity_log(&) if activity_log_config
 
       instance.call(&)
     end
@@ -223,13 +230,7 @@ class BaseService
     @source = CurrentContext&.source
   end
 
-  def audit_logs; false; end
-
   def call(**args, &block)
-    raise NotImplementedError
-  end
-
-  def call_with_audit_logs(**args, &block)
     raise NotImplementedError
   end
 
@@ -239,6 +240,20 @@ class BaseService
 
   def call_async(**args, &block)
     raise NotImplementedError
+  end
+
+  def call_with_activity_log(&block)
+    action = self.class.activity_log_config[:action]
+
+    if action.include?("updated")
+      record = instance_exec(&self.class.activity_log_config[:record])
+      Utils::ActivityLog.produce(record, action) { call(&block) }
+    else
+      call(&block).tap do |result|
+        record = instance_exec(&self.class.activity_log_config[:record])
+        Utils::ActivityLog.produce(record, action) { result }
+      end
+    end
   end
 
   protected

--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -7,6 +7,11 @@ module BillableMetrics
       super
     end
 
+    activity_loggable(
+      action: "billable_metric.created",
+      record: -> { result.billable_metric }
+    )
+
     def call
       organization = Organization.find_by(id: args[:organization_id])
 
@@ -38,8 +43,6 @@ module BillableMetrics
 
         result.billable_metric = metric
         track_billable_metric_created(metric)
-
-        Utils::ActivityLog.produce(metric, "billable_metric.created")
       end
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -7,6 +7,11 @@ module BillableMetrics
       super
     end
 
+    activity_loggable(
+      action: "billable_metric.deleted",
+      record: -> { metric }
+    )
+
     def call
       return result.not_found_failure!(resource: "billable_metric") unless metric
 
@@ -26,8 +31,6 @@ module BillableMetrics
 
       # NOTE: Discard all related events asynchronously.
       BillableMetrics::DeleteEventsJob.perform_later(metric)
-
-      Utils::ActivityLog.produce(metric, "billable_metric.deleted")
 
       result.billable_metric = metric
       result

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -9,11 +9,10 @@ module BillableMetrics
       super
     end
 
-    def audit_logs; true; end
-
-    def call_with_audit_logs
-      Utils::ActivityLog.produce(billable_metric, "billable_metric.updated") { call }
-    end
+    activity_loggable(
+      action: "billable_metric.updated",
+      record: -> { billable_metric }
+    )
 
     def call
       return result.not_found_failure!(resource: "billable_metric") unless billable_metric

--- a/spec/services/base_service_spec.rb
+++ b/spec/services/base_service_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe ::BaseService, type: :service do
   it { is_expected.to be_kind_of(AfterCommitEverywhere) }
   it { is_expected.to respond_to(:call) }
   it { is_expected.to respond_to(:call_async) }
-  it { is_expected.to respond_to(:audit_logs) }
-  it { is_expected.to respond_to(:call_with_audit_logs) }
+  it { is_expected.to respond_to(:call_with_activity_log) }
 
   context "with current_user" do
     it "assigns the current_user to the result" do

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe BillableMetrics::DestroyService, type: :service do
-  subject(:destroy_service) { described_class.new(metric: billable_metric) }
-
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:billable_metric) { create(:billable_metric, organization:) }
@@ -27,30 +25,30 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
     allow(Utils::ActivityLog).to receive(:produce)
   end
 
-  describe "#call" do
+  describe ".call" do
     it "soft deletes the billable metric" do
       freeze_time do
-        expect { destroy_service.call }.to change(BillableMetric, :count).by(-1)
+        expect { described_class.call(metric: billable_metric) }.to change(BillableMetric, :count).by(-1)
           .and change { billable_metric.reload.deleted_at }.from(nil).to(Time.current)
       end
     end
 
     it "soft deletes all the related charges" do
       freeze_time do
-        expect { destroy_service.call }.to change { charge.reload.deleted_at }.from(nil).to(Time.current)
+        expect { described_class.call(metric: billable_metric) }.to change { charge.reload.deleted_at }.from(nil).to(Time.current)
       end
     end
 
     it "soft deletes all related filters" do
       freeze_time do
-        expect { destroy_service.call }.to change { billable_metric.filters.reload.kept.count }.from(2).to(0)
+        expect { described_class.call(metric: billable_metric) }.to change { billable_metric.filters.reload.kept.count }.from(2).to(0)
           .and change { filter_value.reload.reload.deleted_at }.from(nil).to(Time.current)
       end
     end
 
     it "enqueues a BillableMetrics::DeleteEventsJob" do
       expect do
-        destroy_service.call
+        described_class.call(metric: billable_metric)
       end.to have_enqueued_job(BillableMetrics::DeleteEventsJob).with(billable_metric)
     end
 
@@ -58,18 +56,18 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
       invoice = create(:invoice, :draft)
       create(:invoice_subscription, subscription:, invoice:)
 
-      expect { destroy_service.call }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
+      expect { described_class.call(metric: billable_metric) }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
     end
 
     it "produces an activity log" do
-      destroy_service.call
+      described_class.call(metric: billable_metric)
 
       expect(Utils::ActivityLog).to have_received(:produce).with(billable_metric, "billable_metric.deleted")
     end
 
     context "when billable metric is not found" do
       it "returns an error" do
-        result = described_class.new(metric: nil).call
+        result = described_class.call(metric: nil)
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq("billable_metric_not_found")

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe BillableMetrics::UpdateService, type: :service do
-  subject(:update_service) { described_class.new(billable_metric:, params:) }
-
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
@@ -25,13 +23,13 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
   end
   let(:filters) { nil }
 
-  describe "#call" do
+  describe ".call" do
     before do
-      allow(Utils::ActivityLog).to receive(:produce)
+      allow(Utils::ActivityLog).to receive(:produce).and_call_original
     end
 
     it "updates the billable metric" do
-      result = update_service.call
+      result = described_class.call(billable_metric:, params:)
       expect(result).to be_success
 
       metric = result.billable_metric
@@ -47,7 +45,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
     end
 
     it "produces an activity log" do
-      update_service.call
+      described_class.call(billable_metric:, params:)
 
       expect(Utils::ActivityLog).to have_received(:produce).with(billable_metric, "billable_metric.updated")
     end
@@ -63,7 +61,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       end
 
       it "updates billable metric's filters" do
-        expect { update_service.call }.to change { billable_metric.filters.reload.count }.from(0).to(1)
+        expect { described_class.call(billable_metric:, params:) }.to change { billable_metric.filters.reload.count }.from(0).to(1)
       end
     end
 
@@ -78,7 +76,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       end
 
       it "returns an error" do
-        result = update_service.call
+        result = described_class.call(billable_metric:, params:)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)
@@ -90,7 +88,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       let(:billable_metric) { nil }
 
       it "returns an error" do
-        result = update_service.call
+        result = described_class.call(billable_metric:, params:)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::NotFoundFailure)
@@ -102,7 +100,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       let(:params) { {aggregation_type: "custom_agg"} }
 
       it "returns a forbidden failure" do
-        result = update_service.call
+        result = described_class.call(billable_metric:, params:)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ForbiddenFailure)
@@ -116,7 +114,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       before { charge }
 
       it "updates only name and description" do
-        result = update_service.call
+        result = described_class.call(billable_metric:, params:)
 
         expect(result).to be_success
 


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context

Our users want to have visibility on what’s happening in Lago.

Examples:
- *A plan and prices have been updated: When? By whom? What?*
- *A subscription has been deleted: When? By whom? What?*

## Description

The goal of this PR is to create activity logs when creating/updating or deleting a billable metric.