### PR TITLE
fix(multientities):  wrong document numbering

### DIFF
--- a/db/migrate/20250507110137_fix_billing_entity_document_numbering_prefix.rb
+++ b/db/migrate/20250507110137_fix_billing_entity_document_numbering_prefix.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class FixBillingEntityDocumentNumberingPrefix < ActiveRecord::Migration[8.0]
+  class Organization < ApplicationRecord
+    has_many :billing_entities, foreign_key: :organization_id
+  end
+
+  class BillingEntity < ApplicationRecord
+    belongs_to :organization, foreign_key: :organization_id
+  end
+
+  def up
+    # Find all billing entities that need to be updated
+    billing_entities = Organization
+      .joins(:billing_entities)
+      .where(billing_entities: { archived_at: nil })
+      .where('organizations.document_number_prefix != billing_entities.document_number_prefix')
+      .where('billing_entities.id = organizations.id')
+      .select('billing_entities.id, organizations.document_number_prefix')
+
+    # Update each billing entity with its organization's document number prefix
+    billing_entities.each do |be|
+      BillingEntity.where(id: be.id).update_all(document_number_prefix: be.document_number_prefix)
+    end
+  end
+
+  def down
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7452,6 +7452,7 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250507110137'),
 ('20250506170753'),
 ('20250505142221'),
 ('20250505142220'),


### PR DESCRIPTION
## Context

When creating billing entity per organization, we generate it's document number the same way as we generate it for org: first 3 letters of name + last 3 letters of id. That's why when we create a first billing_entity per organization, it inherits org's ID.
But at some point we were not populating the id of billing entity, as result generated document_number_prefix was different from the organization (the id part).
Later billing_entities ids were fixed to always match organizations, but we didn't fix the document_number_prefix (on US cluster there are 4 orgs with this issue, 0 on EU).
This PR finds these BEs and fixes them

## Description

Find default billing_entities per organizations, where billing_entity.documnet_number_prefix != organization.document_number_prefix and fix them to have org's document_number_prefix
