### PR TITLE
Fix(multientities):do not set eu_tax_management if not provided

### DIFF
--- a/app/services/billing_entities/create_service.rb
+++ b/app/services/billing_entities/create_service.rb
@@ -20,7 +20,7 @@ module BillingEntities
         billing_entity.invoice_footer = billing_config[:invoice_footer]
         billing_entity.document_locale = billing_config[:document_locale] if billing_config[:document_locale]
 
-        handle_eu_tax_management
+        handle_eu_tax_management if params[:eu_tax_management]
         handle_base64_logo
 
         if License.premium?

--- a/db/migrate/20250507154910_update_nil_eu_tax_management_on_billing_entities.rb
+++ b/db/migrate/20250507154910_update_nil_eu_tax_management_on_billing_entities.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class UpdateNilEuTaxManagementOnBillingEntities < ActiveRecord::Migration[8.0]
+  def change
+    # rubocop:disable Rails/SkipsModelValidations
+    BillingEntity.where(eu_tax_management: nil).update_all(eu_tax_management: false)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7452,6 +7452,7 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250507154910'),
 ('20250506170753'),
 ('20250505142221'),
 ('20250505142220'),

--- a/spec/services/billing_entities/create_service_spec.rb
+++ b/spec/services/billing_entities/create_service_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe BillingEntities::CreateService, type: :service do
 
       it "sets eu_tax_management when explicitly provided" do
         params[:eu_tax_management] = true
+        params[:country] = "fr"
         expect(result).to be_success
         expect(result.billing_entity.eu_tax_management).to be true
       end

--- a/spec/services/billing_entities/create_service_spec.rb
+++ b/spec/services/billing_entities/create_service_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe BillingEntities::CreateService, type: :service do
         expect(result.billing_entity.code).to eq("billing-entity")
       end
 
+      it "does not set eu_tax_management when not provided" do
+        expect(result).to be_success
+        expect(result.billing_entity.eu_tax_management).to be false
+      end
+
+      it "sets eu_tax_management when explicitly provided" do
+        params[:eu_tax_management] = true
+        expect(result).to be_success
+        expect(result.billing_entity.eu_tax_management).to be true
+      end
+
       it "does not set premium attributes" do
         params.merge!(
           {

--- a/spec/services/organizations/create_service_spec.rb
+++ b/spec/services/organizations/create_service_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Organizations::CreateService, type: :service do
             organization: service_result.organization,
             name: service_result.organization.name,
             code: service_result.organization.name.parameterize(separator: "_"),
+            document_number_prefix: service_result.organization.document_number_prefix,
+            eu_tax_management: false,
             document_numbering: "per_customer"
           )
         end


### PR DESCRIPTION
## Context

when params do not include eu_tax_management, this field should be set to default => false, but because we were always calling the service that sets eu_tax_management to value from params, if value is missing, it becomes nil instead of false

## Description

Only set eu_tax_management if the value is sent in params