### PR TITLE
fix: Output condition for populate organization_id jobs

### DIFF
--- a/app/jobs/database_migrations/populate_adjusted_fees_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_adjusted_fees_with_organization_job.rb
@@ -16,10 +16,12 @@ module DatabaseMigrations
         # rubocop:disable Rails/SkipsModelValidations
         batch.update_all("organization_id = (SELECT organization_id FROM invoices WHERE invoices.id = adjusted_fees.invoice_id)")
         # rubocop:enable Rails/SkipsModelValidations
-      end
 
-      # Queue the next batch
-      self.class.perform_later(batch_number + 1)
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
     end
 
     def lock_key_arguments

--- a/app/jobs/database_migrations/populate_applied_coupons_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_applied_coupons_with_organization_job.rb
@@ -16,10 +16,12 @@ module DatabaseMigrations
         # rubocop:disable Rails/SkipsModelValidations
         batch.update_all("organization_id = (SELECT organization_id FROM customers WHERE customers.id = applied_coupons.customer_id)")
         # rubocop:enable Rails/SkipsModelValidations
-      end
 
-      # Queue the next batch
-      self.class.perform_later(batch_number + 1)
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
     end
 
     private


### PR DESCRIPTION
## Description

Fix related to https://github.com/getlago/lago-api/pull/3540 and https://github.com/getlago/lago-api/pull/3543

Some jobs to fill `organization_id` on some tables are looping for ever because no output condition were set in the job