### PR TITLE
fix: avoid failure with negative cache expiration

### DIFF
--- a/app/services/subscriptions/charge_cache_middleware.rb
+++ b/app/services/subscriptions/charge_cache_middleware.rb
@@ -24,7 +24,7 @@ module Subscriptions
     attr_reader :subscription, :charge, :to_datetime, :cache
 
     def cache_expiration
-      (to_datetime - Time.current).to_i.seconds
+      [(to_datetime - Time.current).to_i.seconds, 0].max
     end
   end
 end


### PR DESCRIPTION
## Context
Some `UsageMonitoring::ProcessSubscriptionActivityJob` are failing with the following error:

```
ArgumentError: Cache expiration time is invalid, cannot be negative: -42 
```

it happens because a job to refresh subscription activity was enqueued just before the end of a billing period, or because it was retried few times and the comparison between the period to_datetime and the execution time leads to a negative value. 

## Description

This PR makes sure that the cache expiration is floor to 0 seconds meaning nothing will be cached.
