### PR TITLE
misc(webhooks): Add lago_id to payment.requires_action webhook payload

### DIFF
--- a/app/serializers/v1/payments/requires_action_serializer.rb
+++ b/app/serializers/v1/payments/requires_action_serializer.rb
@@ -5,6 +5,7 @@ module V1
     class RequiresActionSerializer < ModelSerializer
       def serialize
         {
+          lago_id: model.id,
           lago_payable_id: model.payable.id,
           lago_customer_id: model.payable.customer.id,
           status: model.status,

--- a/spec/serializers/v1/payments/requires_action_serializer_spec.rb
+++ b/spec/serializers/v1/payments/requires_action_serializer_spec.rb
@@ -16,16 +16,15 @@ RSpec.describe ::V1::Payments::RequiresActionSerializer do
   it "serializes the object" do
     result = JSON.parse(serializer.to_json)
 
-    aggregate_failures do
-      expect(result["payment"]["lago_payable_id"]).to eq(payment.payable.id)
-      expect(result["payment"]["lago_customer_id"]).to eq(payment.payable.customer.id)
-      expect(result["payment"]["status"]).to eq(payment.status)
-      expect(result["payment"]["external_customer_id"]).to eq(payment.payable.customer.external_id)
-      expect(result["payment"]["provider_customer_id"]).to eq(payment.payment_provider_customer.id)
-      expect(result["payment"]["payment_provider_code"]).to eq(payment.payment_provider.code)
-      expect(result["payment"]["payment_provider_type"]).to eq(payment.payment_provider.type)
-      expect(result["payment"]["provider_payment_id"]).to eq(payment.provider_payment_id)
-      expect(result["payment"]["next_action"]).to eq(payment.provider_payment_data)
-    end
+    expect(result["payment"]["lago_id"]).to eq(payment.id)
+    expect(result["payment"]["lago_payable_id"]).to eq(payment.payable.id)
+    expect(result["payment"]["lago_customer_id"]).to eq(payment.payable.customer.id)
+    expect(result["payment"]["status"]).to eq(payment.status)
+    expect(result["payment"]["external_customer_id"]).to eq(payment.payable.customer.external_id)
+    expect(result["payment"]["provider_customer_id"]).to eq(payment.payment_provider_customer.id)
+    expect(result["payment"]["payment_provider_code"]).to eq(payment.payment_provider.code)
+    expect(result["payment"]["payment_provider_type"]).to eq(payment.payment_provider.type)
+    expect(result["payment"]["provider_payment_id"]).to eq(payment.provider_payment_id)
+    expect(result["payment"]["next_action"]).to eq(payment.provider_payment_data)
   end
 end


### PR DESCRIPTION
`lago_id` was missing and it is required to identify the payment for later request to endpoint `GET /api/v1/payments/{lago_id}` to collect more payment information.

