### PR TITLE
fix(usages): Add billable_metric_code to usages resolver

### DIFF
--- a/app/graphql/resolvers/data_api/usages_resolver.rb
+++ b/app/graphql/resolvers/data_api/usages_resolver.rb
@@ -25,6 +25,7 @@ module Resolvers
       argument :external_customer_id, String, required: false
       argument :external_subscription_id, String, required: false
 
+      argument :billable_metric_code, String, required: false
       argument :plan_code, String, required: false
 
       type Types::DataApi::Usages::Object.collection_type, null: false

--- a/app/services/data_api/usages_service.rb
+++ b/app/services/data_api/usages_service.rb
@@ -20,7 +20,9 @@ module DataApi
         {
           time_granularity: "daily",
           start_of_period_dt: Date.current - 30.days
-        }
+        }.tap do |filtered|
+          filtered[:billable_metric_code] = params[:billable_metric_code] if params[:billable_metric_code].present?
+        end
       end
     end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -7698,7 +7698,7 @@ type Query {
   """
   Query usages of an organization
   """
-  dataApiUsages(currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, isBillableMetricRecurring: Boolean, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiUsageCollection!
+  dataApiUsages(billableMetricCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, isBillableMetricRecurring: Boolean, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiUsageCollection!
 
   """
   Query usages of an organization

--- a/schema.json
+++ b/schema.json
@@ -39159,6 +39159,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "billableMetricCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "planCode",
                   "description": null,
                   "type": {

--- a/spec/services/data_api/usages_service_spec.rb
+++ b/spec/services/data_api/usages_service_spec.rb
@@ -65,12 +65,20 @@ RSpec.describe DataApi::UsagesService, type: :service do
 
     context "when licence is not premium" do
       context "when additional params are provided" do
-        let(:params) { {time_granularity: "daily", from_date: Date.current - 60.days, additional_param: "value"} }
+        let(:params) do
+          {
+            billable_metric_code: "code",
+            time_granularity: "weekly",
+            from_date: Date.current - 60.days,
+            additional_param: "value"
+          }
+        end
 
         it "returns default params with daily granularity and 30 days back start date" do
           expect(filtered_params).to eq(
             time_granularity: "daily",
-            start_of_period_dt: Date.current - 30.days
+            start_of_period_dt: Date.current - 30.days,
+            billable_metric_code: "code"
           )
         end
       end


### PR DESCRIPTION
## Context

billable_metric_code was missing in the usages filters

## Description

This PR adds `billable_metric_code` to:
- usages controller
- usages service
- and GQL resolver