### PR TITLE
fix(serializer): Dont serialize nil original_error

### DIFF
--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -142,7 +142,7 @@ module Invoices
             message: payment_result.error_message,
             error_code: payment_result.error_code
           },
-          error_details: V1::Errors::ErrorSerializerFactory.new_instance(e.original_error).serialize
+          error_details: e.original_error ? V1::Errors::ErrorSerializerFactory.new_instance(e.original_error).serialize : {}
         })
       end
 


### PR DESCRIPTION
## Description

`original_error` is not always set. In the first implementation this used to raise `NotImplementedError` but in the end it made more sense to use the default serializer. This handle the case where original_error is nil.