### PR TITLE
fix(wallets): add lock version to wallet transactions

### DIFF
--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -65,6 +65,7 @@ end
 #  credit_amount                       :decimal(30, 5)   default(0.0), not null
 #  failed_at                           :datetime
 #  invoice_requires_successful_payment :boolean          default(FALSE), not null
+#  lock_version                        :integer          default(0), not null
 #  metadata                            :jsonb
 #  settled_at                          :datetime
 #  source                              :integer          default("manual"), not null

--- a/db/migrate/20250512081332_add_lock_version_to_wallet_transactions.rb
+++ b/db/migrate/20250512081332_add_lock_version_to_wallet_transactions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLockVersionToWalletTransactions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :wallet_transactions, :lock_version, :integer, default: 0, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2613,7 +2613,8 @@ CREATE TABLE public.wallet_transactions (
     metadata jsonb DEFAULT '[]'::jsonb,
     credit_note_id uuid,
     failed_at timestamp(6) without time zone,
-    organization_id uuid
+    organization_id uuid,
+    lock_version integer DEFAULT 0 NOT NULL
 );
 
 
@@ -7596,6 +7597,7 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250512081332'),
 ('20250507154910'),
 ('20250506170753'),
 ('20250506145851'),


### PR DESCRIPTION
 ## Context

We identified race conditions when applying paid credits to wallets, resulting in duplicate wallet increments. Some wallet transactions were settled twice, with status changed from pending to settled twice within milliseconds of each other.

 ## Description

Adding a lock version to wallet transactions prevents these race conditions by ensuring atomic updates and maintaining data integrity during concurrent operations.