### PR TITLE
fix: Fix organization_id migration job for fees_taxes table

### DIFF
--- a/app/jobs/database_migrations/populate_fees_taxes_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_fees_taxes_with_organization_job.rb
@@ -8,7 +8,7 @@ module DatabaseMigrations
     BATCH_SIZE = 1000
 
     def perform(batch_number = 1)
-      batch = FeesTax.unscoped
+      batch = Fee::AppliedTax.unscoped
         .where(organization_id: nil)
         .limit(BATCH_SIZE)
 


### PR DESCRIPTION
## Description`

`DatabaseMigrations::PopulateFeesTaxesWithOrganizationJob` for fees_taxes table is not using the right model. `FeesTax` should instead be `Fee::AppliedTax`
