### PR TITLE
chore(organization): Add organization_id to billing_entities_taxes table

### DIFF
--- a/app/jobs/database_migrations/populate_billing_entities_taxes_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_billing_entities_taxes_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateBillingEntitiesTaxesWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = BillingEntity::AppliedTax.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM taxes WHERE taxes.id = billing_entities_taxes.tax_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/billing_entity/applied_tax.rb
+++ b/app/models/billing_entity/applied_tax.rb
@@ -6,6 +6,7 @@ class BillingEntity
 
     belongs_to :billing_entity
     belongs_to :tax
+    belongs_to :organization, optional: true
 
     validates :tax_id, uniqueness: {scope: :billing_entity_id}
   end
@@ -19,16 +20,19 @@ end
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  billing_entity_id :uuid             not null
+#  organization_id   :uuid
 #  tax_id            :uuid             not null
 #
 # Indexes
 #
 #  index_billing_entities_taxes_on_billing_entity_id             (billing_entity_id)
 #  index_billing_entities_taxes_on_billing_entity_id_and_tax_id  (billing_entity_id,tax_id) UNIQUE
+#  index_billing_entities_taxes_on_organization_id               (organization_id)
 #  index_billing_entities_taxes_on_tax_id                        (tax_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (billing_entity_id => billing_entities.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (tax_id => taxes.id)
 #

--- a/app/services/billing_entities/taxes/apply_taxes_service.rb
+++ b/app/services/billing_entities/taxes/apply_taxes_service.rb
@@ -19,7 +19,9 @@ module BillingEntities
         return result if result.failure?
 
         result.applied_taxes = result.taxes_to_apply.map do |tax|
-          billing_entity.applied_taxes.find_or_create_by!(tax:)
+          billing_entity.applied_taxes
+            .create_with(organization_id: tax.organization_id)
+            .find_or_create_by!(tax:)
         end
 
         result

--- a/db/migrate/20250512122606_add_organization_id_to_billing_entities_taxes.rb
+++ b/db/migrate/20250512122606_add_organization_id_to_billing_entities_taxes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToBillingEntitiesTaxes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :billing_entities_taxes, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250512122607_add_organization_id_fk_to_billing_entities_taxes.rb
+++ b/db/migrate/20250512122607_add_organization_id_fk_to_billing_entities_taxes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToBillingEntitiesTaxes < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :billing_entities_taxes, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250512122608_validate_billing_entities_taxes_organizations_foreign_key.rb
+++ b/db/migrate/20250512122608_validate_billing_entities_taxes_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateBillingEntitiesTaxesOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :billing_entities_taxes, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -92,6 +92,7 @@ ALTER TABLE IF EXISTS ONLY public.dunning_campaigns DROP CONSTRAINT IF EXISTS fk
 ALTER TABLE IF EXISTS ONLY public.invoice_custom_section_selections DROP CONSTRAINT IF EXISTS fk_rails_6b1e3d1159;
 ALTER TABLE IF EXISTS ONLY public.integration_resources DROP CONSTRAINT IF EXISTS fk_rails_67d4eb3c92;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_66eb6b32c1;
+ALTER TABLE IF EXISTS ONLY public.billing_entities_taxes DROP CONSTRAINT IF EXISTS fk_rails_651eadaaa4;
 ALTER TABLE IF EXISTS ONLY public.memberships DROP CONSTRAINT IF EXISTS fk_rails_64267aab58;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_63d3df128b;
 ALTER TABLE IF EXISTS ONLY public.applied_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_63ac282e70;
@@ -437,6 +438,7 @@ DROP INDEX IF EXISTS public.index_cached_aggregations_on_event_transaction_id;
 DROP INDEX IF EXISTS public.index_cached_aggregations_on_event_id;
 DROP INDEX IF EXISTS public.index_cached_aggregations_on_charge_id;
 DROP INDEX IF EXISTS public.index_billing_entities_taxes_on_tax_id;
+DROP INDEX IF EXISTS public.index_billing_entities_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_billing_entities_taxes_on_billing_entity_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_billing_entities_taxes_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_billing_entities_on_organization_id;
@@ -1193,7 +1195,8 @@ CREATE TABLE public.billing_entities_taxes (
     billing_entity_id uuid NOT NULL,
     tax_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -4491,6 +4494,13 @@ CREATE UNIQUE INDEX index_billing_entities_taxes_on_billing_entity_id_and_tax_id
 
 
 --
+-- Name: index_billing_entities_taxes_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_billing_entities_taxes_on_organization_id ON public.billing_entities_taxes USING btree (organization_id);
+
+
+--
 -- Name: index_billing_entities_taxes_on_tax_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6927,6 +6937,14 @@ ALTER TABLE ONLY public.memberships
 
 
 --
+-- Name: billing_entities_taxes fk_rails_651eadaaa4; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.billing_entities_taxes
+    ADD CONSTRAINT fk_rails_651eadaaa4 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: subscriptions fk_rails_66eb6b32c1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7597,6 +7615,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250512122608'),
+('20250512122607'),
+('20250512122606'),
 ('20250512081332'),
 ('20250507154910'),
 ('20250506170753'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -26,7 +26,6 @@ Rspec.describe "All tables must have an organization_id" do
 
   let(:tables_to_migrate) do
     %w[
-      billing_entities_taxes
       charge_filter_values
       commitments
       commitments_taxes


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `billing_entities_taxes` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
