### PR TITLE
chore(organization): Add organization_id to credit_notes_taxes table

### DIFF
--- a/app/jobs/database_migrations/populate_credit_notes_taxes_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_credit_notes_taxes_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateCreditNotesTaxesWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = CreditNote::AppliedTax.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM taxes WHERE taxes.id = credit_notes_taxes.tax_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/credit_note/applied_tax.rb
+++ b/app/models/credit_note/applied_tax.rb
@@ -8,6 +8,7 @@ class CreditNote
 
     belongs_to :credit_note
     belongs_to :tax, optional: true
+    belongs_to :organization, optional: true
 
     monetize :amount_cents
     monetize :base_amount_cents, with_model_currency: :amount_currency
@@ -29,17 +30,20 @@ end
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  credit_note_id    :uuid             not null
+#  organization_id   :uuid
 #  tax_id            :uuid
 #
 # Indexes
 #
 #  index_credit_notes_taxes_on_credit_note_id               (credit_note_id)
 #  index_credit_notes_taxes_on_credit_note_id_and_tax_code  (credit_note_id,tax_code) UNIQUE
+#  index_credit_notes_taxes_on_organization_id              (organization_id)
 #  index_credit_notes_taxes_on_tax_code                     (tax_code)
 #  index_credit_notes_taxes_on_tax_id                       (tax_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (credit_note_id => credit_notes.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (tax_id => taxes.id)
 #

--- a/app/services/credit_notes/apply_taxes_service.rb
+++ b/app/services/credit_notes/apply_taxes_service.rb
@@ -20,6 +20,7 @@ module CreditNotes
         invoice_applied_tax = find_invoice_applied_tax(tax_code)
 
         applied_tax = CreditNote::AppliedTax.new(
+          organization_id: invoice.organization_id,
           tax: invoice_applied_tax.tax,
           tax_description: invoice_applied_tax.tax_description,
           tax_code: invoice_applied_tax.tax_code,

--- a/db/migrate/20250512123539_add_organization_id_to_credit_notes_taxes.rb
+++ b/db/migrate/20250512123539_add_organization_id_to_credit_notes_taxes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToCreditNotesTaxes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :credit_notes_taxes, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250512123540_add_organization_id_fk_to_credit_notes_taxes.rb
+++ b/db/migrate/20250512123540_add_organization_id_fk_to_credit_notes_taxes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToCreditNotesTaxes < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :credit_notes_taxes, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250512123541_validate_credit_notes_taxes_organizations_foreign_key.rb
+++ b/db/migrate/20250512123541_validate_credit_notes_taxes_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateCreditNotesTaxesOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :credit_notes_taxes, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -82,6 +82,7 @@ ALTER TABLE IF EXISTS ONLY public.billable_metric_filters DROP CONSTRAINT IF EXI
 ALTER TABLE IF EXISTS ONLY public.applied_add_ons DROP CONSTRAINT IF EXISTS fk_rails_7995206484;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_78f6642ddf;
 ALTER TABLE IF EXISTS ONLY public.groups DROP CONSTRAINT IF EXISTS fk_rails_7886e1bc34;
+ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS fk_rails_77f2d4440d;
 ALTER TABLE IF EXISTS ONLY public.integrations DROP CONSTRAINT IF EXISTS fk_rails_755d734f25;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_75577c354e;
 ALTER TABLE IF EXISTS ONLY public.fees_taxes DROP CONSTRAINT IF EXISTS fk_rails_745b4ca7dd;
@@ -398,6 +399,7 @@ DROP INDEX IF EXISTS public.index_credits_on_credit_note_id;
 DROP INDEX IF EXISTS public.index_credits_on_applied_coupon_id;
 DROP INDEX IF EXISTS public.index_credit_notes_taxes_on_tax_id;
 DROP INDEX IF EXISTS public.index_credit_notes_taxes_on_tax_code;
+DROP INDEX IF EXISTS public.index_credit_notes_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_credit_notes_taxes_on_credit_note_id_and_tax_code;
 DROP INDEX IF EXISTS public.index_credit_notes_taxes_on_credit_note_id;
 DROP INDEX IF EXISTS public.index_credit_notes_on_organization_id;
@@ -1436,7 +1438,8 @@ CREATE TABLE public.credit_notes_taxes (
     amount_currency character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    base_amount_cents bigint DEFAULT 0 NOT NULL
+    base_amount_cents bigint DEFAULT 0 NOT NULL,
+    organization_id uuid
 );
 
 
@@ -4781,6 +4784,13 @@ CREATE UNIQUE INDEX index_credit_notes_taxes_on_credit_note_id_and_tax_code ON p
 
 
 --
+-- Name: index_credit_notes_taxes_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_credit_notes_taxes_on_organization_id ON public.credit_notes_taxes USING btree (organization_id);
+
+
+--
 -- Name: index_credit_notes_taxes_on_tax_code; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7025,6 +7035,14 @@ ALTER TABLE ONLY public.integrations
 
 
 --
+-- Name: credit_notes_taxes fk_rails_77f2d4440d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.credit_notes_taxes
+    ADD CONSTRAINT fk_rails_77f2d4440d FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: groups fk_rails_7886e1bc34; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7615,6 +7633,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250512123541'),
+('20250512123540'),
+('20250512123539'),
 ('20250512122608'),
 ('20250512122607'),
 ('20250512122606'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -31,7 +31,6 @@ Rspec.describe "All tables must have an organization_id" do
       commitments_taxes
       coupon_targets
       credit_note_items
-      credit_notes_taxes
       customers_taxes
       data_export_parts
       dunning_campaign_thresholds


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `credit_notes_taxes` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
