### PR TITLE
chore(organization): Add organization_id to customers_taxes table

### DIFF
--- a/app/jobs/database_migrations/populate_customers_taxes_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_customers_taxes_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateCustomersTaxesWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Customer::AppliedTax.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM taxes WHERE taxes.id = customers_taxes.tax_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/customer/applied_tax.rb
+++ b/app/models/customer/applied_tax.rb
@@ -8,6 +8,7 @@ class Customer
 
     belongs_to :customer
     belongs_to :tax
+    belongs_to :organization, optional: true
   end
 end
 
@@ -15,20 +16,23 @@ end
 #
 # Table name: customers_taxes
 #
-#  id          :uuid             not null, primary key
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  customer_id :uuid             not null
-#  tax_id      :uuid             not null
+#  id              :uuid             not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  customer_id     :uuid             not null
+#  organization_id :uuid
+#  tax_id          :uuid             not null
 #
 # Indexes
 #
 #  index_customers_taxes_on_customer_id             (customer_id)
 #  index_customers_taxes_on_customer_id_and_tax_id  (customer_id,tax_id) UNIQUE
+#  index_customers_taxes_on_organization_id         (organization_id)
 #  index_customers_taxes_on_tax_id                  (tax_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (tax_id => taxes.id)
 #

--- a/app/services/customers/apply_taxes_service.rb
+++ b/app/services/customers/apply_taxes_service.rb
@@ -18,7 +18,9 @@ module Customers
       ).destroy_all
 
       result.applied_taxes = tax_codes.map do |tax_code|
-        customer.applied_taxes.find_or_create_by!(tax: taxes.find_by(code: tax_code))
+        customer.applied_taxes
+          .create_with(organization_id: customer.organization_id)
+          .find_or_create_by!(tax: taxes.find_by(code: tax_code))
       end
 
       customer.invoices.draft.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations

--- a/db/migrate/20250512130614_add_organization_id_to_customers_taxes.rb
+++ b/db/migrate/20250512130614_add_organization_id_to_customers_taxes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToCustomersTaxes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :customers_taxes, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250512130615_add_organization_id_fk_to_customers_taxes.rb
+++ b/db/migrate/20250512130615_add_organization_id_fk_to_customers_taxes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToCustomersTaxes < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :customers_taxes, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250512130616_validate_customers_taxes_organizations_foreign_key.rb
+++ b/db/migrate/20250512130616_validate_customers_taxes_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateCustomersTaxesOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :customers_taxes, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -134,6 +134,7 @@ ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rai
 ALTER TABLE IF EXISTS ONLY public.groups DROP CONSTRAINT IF EXISTS fk_rails_34b5ee1894;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_34ab152115;
 ALTER TABLE IF EXISTS ONLY public.lifetime_usages DROP CONSTRAINT IF EXISTS fk_rails_348acbd245;
+ALTER TABLE IF EXISTS ONLY public.customers_taxes DROP CONSTRAINT IF EXISTS fk_rails_33d169382f;
 ALTER TABLE IF EXISTS ONLY public.payment_requests DROP CONSTRAINT IF EXISTS fk_rails_32600e5a72;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_310fcb3585;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_2fd7ee65e6;
@@ -381,6 +382,7 @@ DROP INDEX IF EXISTS public.index_daily_usages_on_subscription_id;
 DROP INDEX IF EXISTS public.index_daily_usages_on_organization_id;
 DROP INDEX IF EXISTS public.index_daily_usages_on_customer_id;
 DROP INDEX IF EXISTS public.index_customers_taxes_on_tax_id;
+DROP INDEX IF EXISTS public.index_customers_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_customers_taxes_on_customer_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_customers_taxes_on_customer_id;
 DROP INDEX IF EXISTS public.index_customers_on_organization_id;
@@ -1546,7 +1548,8 @@ CREATE TABLE public.customers_taxes (
     customer_id uuid NOT NULL,
     tax_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -4917,6 +4920,13 @@ CREATE UNIQUE INDEX index_customers_taxes_on_customer_id_and_tax_id ON public.cu
 
 
 --
+-- Name: index_customers_taxes_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_customers_taxes_on_organization_id ON public.customers_taxes USING btree (organization_id);
+
+
+--
 -- Name: index_customers_taxes_on_tax_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6627,6 +6637,14 @@ ALTER TABLE ONLY public.payment_requests
 
 
 --
+-- Name: customers_taxes fk_rails_33d169382f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.customers_taxes
+    ADD CONSTRAINT fk_rails_33d169382f FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: lifetime_usages fk_rails_348acbd245; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7633,6 +7651,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250512130616'),
+('20250512130615'),
+('20250512130614'),
 ('20250512123541'),
 ('20250512123540'),
 ('20250512123539'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -31,7 +31,6 @@ Rspec.describe "All tables must have an organization_id" do
       commitments_taxes
       coupon_targets
       credit_note_items
-      customers_taxes
       data_export_parts
       dunning_campaign_thresholds
       integration_collection_mappings


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `credit_notes_taxes` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
