### PR TITLE
chore(organization): Add organization_id to data_export_parts table

### DIFF
--- a/app/jobs/database_migrations/populate_data_export_parts_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_data_export_parts_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateDataExportPartsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = DataExportPart.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM data_exports WHERE data_exports.id = data_export_parts.data_export_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/data_export_part.rb
+++ b/app/models/data_export_part.rb
@@ -2,6 +2,7 @@
 
 class DataExportPart < ApplicationRecord
   belongs_to :data_export
+  belongs_to :organization, optional: true
 
   scope :completed, -> { where(completed: true) }
 end
@@ -10,20 +11,23 @@ end
 #
 # Table name: data_export_parts
 #
-#  id             :uuid             not null, primary key
-#  completed      :boolean          default(FALSE), not null
-#  csv_lines      :text
-#  index          :integer
-#  object_ids     :uuid             not null, is an Array
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  data_export_id :uuid             not null
+#  id              :uuid             not null, primary key
+#  completed       :boolean          default(FALSE), not null
+#  csv_lines       :text
+#  index           :integer
+#  object_ids      :uuid             not null, is an Array
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  data_export_id  :uuid             not null
+#  organization_id :uuid
 #
 # Indexes
 #
-#  index_data_export_parts_on_data_export_id  (data_export_id)
+#  index_data_export_parts_on_data_export_id   (data_export_id)
+#  index_data_export_parts_on_organization_id  (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (data_export_id => data_exports.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/data_exports/create_part_service.rb
+++ b/app/services/data_exports/create_part_service.rb
@@ -11,7 +11,11 @@ module DataExports
     end
 
     def call
-      result.data_export_part = data_export.data_export_parts.create!(object_ids:, index:)
+      result.data_export_part = data_export.data_export_parts.create!(
+        organization_id: data_export.organization_id,
+        object_ids:,
+        index:
+      )
       after_commit { DataExports::ProcessPartJob.perform_later(result.data_export_part) }
       result
     rescue => e

--- a/db/migrate/20250512142912_add_organization_id_to_data_export_parts.rb
+++ b/db/migrate/20250512142912_add_organization_id_to_data_export_parts.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToDataExportParts < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :data_export_parts, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250512142913_add_organization_id_fk_to_data_export_parts.rb
+++ b/db/migrate/20250512142913_add_organization_id_fk_to_data_export_parts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToDataExportParts < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :data_export_parts, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250512142914_validate_data_export_parts_organizations_foreign_key.rb
+++ b/db/migrate/20250512142914_validate_data_export_parts_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateDataExportPartsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :data_export_parts, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -63,6 +63,7 @@ ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rai
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_94cc21031f;
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_9298b8fdad;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_90d93bd016;
+ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_909197908c;
 ALTER TABLE IF EXISTS ONLY public.commitments_taxes DROP CONSTRAINT IF EXISTS fk_rails_8fa6f0d920;
 ALTER TABLE IF EXISTS ONLY public.usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_8df9bf2b6c;
 ALTER TABLE IF EXISTS ONLY public.invoice_metadata DROP CONSTRAINT IF EXISTS fk_rails_8bb5b094c4;
@@ -376,6 +377,7 @@ DROP INDEX IF EXISTS public.index_dunning_campaign_thresholds_on_dunning_campaig
 DROP INDEX IF EXISTS public.index_dunning_campaign_thresholds_on_deleted_at;
 DROP INDEX IF EXISTS public.index_data_exports_on_organization_id;
 DROP INDEX IF EXISTS public.index_data_exports_on_membership_id;
+DROP INDEX IF EXISTS public.index_data_export_parts_on_organization_id;
 DROP INDEX IF EXISTS public.index_data_export_parts_on_data_export_id;
 DROP INDEX IF EXISTS public.index_daily_usages_on_usage_date;
 DROP INDEX IF EXISTS public.index_daily_usages_on_subscription_id;
@@ -1586,7 +1588,8 @@ CREATE TABLE public.data_export_parts (
     completed boolean DEFAULT false NOT NULL,
     csv_lines text,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -4969,6 +4972,13 @@ CREATE INDEX index_data_export_parts_on_data_export_id ON public.data_export_par
 
 
 --
+-- Name: index_data_export_parts_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_data_export_parts_on_organization_id ON public.data_export_parts USING btree (organization_id);
+
+
+--
 -- Name: index_data_exports_on_membership_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7213,6 +7223,14 @@ ALTER TABLE ONLY public.commitments_taxes
 
 
 --
+-- Name: data_export_parts fk_rails_909197908c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.data_export_parts
+    ADD CONSTRAINT fk_rails_909197908c FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: invoice_subscriptions fk_rails_90d93bd016; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7651,6 +7669,9 @@ ALTER TABLE ONLY public.adjusted_fees
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250512142914'),
+('20250512142913'),
+('20250512142912'),
 ('20250512130616'),
 ('20250512130615'),
 ('20250512130614'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -31,7 +31,6 @@ Rspec.describe "All tables must have an organization_id" do
       commitments_taxes
       coupon_targets
       credit_note_items
-      data_export_parts
       dunning_campaign_thresholds
       integration_collection_mappings
       integration_customers


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `data_export_parts` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
