### PR TITLE
chore(organization): Add organization_id to dunning_campaign_thresholds table

### DIFF
--- a/app/jobs/database_migrations/populate_dunning_campaign_thresholds_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_dunning_campaign_thresholds_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateDunningCampaignThresholdsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = DunningCampaignThreshold.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM dunning_campaigns WHERE dunning_campaigns.id = dunning_campaign_thresholds.dunning_campaign_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/dunning_campaign_threshold.rb
+++ b/app/models/dunning_campaign_threshold.rb
@@ -7,6 +7,7 @@ class DunningCampaignThreshold < ApplicationRecord
   self.discard_column = :deleted_at
 
   belongs_to :dunning_campaign
+  belongs_to :organization, optional: true
 
   validates :amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :currency, inclusion: {in: currency_list}
@@ -28,14 +29,17 @@ end
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  dunning_campaign_id :uuid             not null
+#  organization_id     :uuid
 #
 # Indexes
 #
 #  idx_on_dunning_campaign_id_currency_fbf233b2ae            (dunning_campaign_id,currency) UNIQUE WHERE (deleted_at IS NULL)
 #  index_dunning_campaign_thresholds_on_deleted_at           (deleted_at)
 #  index_dunning_campaign_thresholds_on_dunning_campaign_id  (dunning_campaign_id)
+#  index_dunning_campaign_thresholds_on_organization_id      (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (dunning_campaign_id => dunning_campaigns.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/dunning_campaigns/create_service.rb
+++ b/app/services/dunning_campaigns/create_service.rb
@@ -29,7 +29,7 @@ module DunningCampaigns
           max_attempts: params[:max_attempts],
           name: params[:name],
           description: params[:description],
-          thresholds_attributes: params[:thresholds].map(&:to_h)
+          thresholds_attributes: params[:thresholds].map { _1.to_h.merge(organization_id: organization.id) }
         )
 
         result.dunning_campaign = dunning_campaign

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -49,9 +49,8 @@ module DunningCampaigns
 
       # Update or create new thresholds from the input
       params[:thresholds].each do |threshold_input|
-        threshold = dunning_campaign.thresholds.find_or_initialize_by(
-          id: threshold_input[:id]
-        )
+        threshold = dunning_campaign.thresholds
+          .find_or_initialize_by(id: threshold_input[:id]) { |t| t.organization_id = organization.id }
 
         threshold.assign_attributes(threshold_input.to_h.slice(:amount_cents, :currency))
 

--- a/db/migrate/20250512144218_add_organization_id_to_dunning_campaign_thresholds.rb
+++ b/db/migrate/20250512144218_add_organization_id_to_dunning_campaign_thresholds.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToDunningCampaignThresholds < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :dunning_campaign_thresholds, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250512144219_add_organization_id_fk_to_dunning_campaign_thresholds.rb
+++ b/db/migrate/20250512144219_add_organization_id_fk_to_dunning_campaign_thresholds.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToDunningCampaignThresholds < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :dunning_campaign_thresholds, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250512144220_validate_dunning_campaign_thresholds_organizations_foreign_key.rb
+++ b/db/migrate/20250512144220_validate_dunning_campaign_thresholds_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateDunningCampaignThresholdsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :dunning_campaign_thresholds, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -9,6 +9,7 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+ALTER TABLE IF EXISTS ONLY public.dunning_campaign_thresholds DROP CONSTRAINT IF EXISTS fk_rails_fd84cdb7c6;
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_fd399a23d3;
 ALTER TABLE IF EXISTS ONLY public.fees_taxes DROP CONSTRAINT IF EXISTS fk_rails_f98413d404;
 ALTER TABLE IF EXISTS ONLY public.billing_entities DROP CONSTRAINT IF EXISTS fk_rails_f66617edcb;
@@ -373,6 +374,7 @@ DROP INDEX IF EXISTS public.index_error_details_on_deleted_at;
 DROP INDEX IF EXISTS public.index_dunning_campaigns_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_dunning_campaigns_on_organization_id;
 DROP INDEX IF EXISTS public.index_dunning_campaigns_on_deleted_at;
+DROP INDEX IF EXISTS public.index_dunning_campaign_thresholds_on_organization_id;
 DROP INDEX IF EXISTS public.index_dunning_campaign_thresholds_on_dunning_campaign_id;
 DROP INDEX IF EXISTS public.index_dunning_campaign_thresholds_on_deleted_at;
 DROP INDEX IF EXISTS public.index_data_exports_on_organization_id;
@@ -1624,7 +1626,8 @@ CREATE TABLE public.dunning_campaign_thresholds (
     amount_cents bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    deleted_at timestamp without time zone
+    deleted_at timestamp without time zone,
+    organization_id uuid
 );
 
 
@@ -5007,6 +5010,13 @@ CREATE INDEX index_dunning_campaign_thresholds_on_dunning_campaign_id ON public.
 
 
 --
+-- Name: index_dunning_campaign_thresholds_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_dunning_campaign_thresholds_on_organization_id ON public.dunning_campaign_thresholds USING btree (organization_id);
+
+
+--
 -- Name: index_dunning_campaigns_on_deleted_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7663,12 +7673,23 @@ ALTER TABLE ONLY public.adjusted_fees
 
 
 --
+-- Name: dunning_campaign_thresholds fk_rails_fd84cdb7c6; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dunning_campaign_thresholds
+    ADD CONSTRAINT fk_rails_fd84cdb7c6 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250512144220'),
+('20250512144219'),
+('20250512144218'),
 ('20250512142914'),
 ('20250512142913'),
 ('20250512142912'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -31,7 +31,6 @@ Rspec.describe "All tables must have an organization_id" do
       commitments_taxes
       coupon_targets
       credit_note_items
-      dunning_campaign_thresholds
       integration_collection_mappings
       integration_customers
       integration_items


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `dunning_campaign_thresholds` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
