### PR TITLE
chore(organization): Add organization_id to coupon_targets table

### DIFF
--- a/app/jobs/database_migrations/populate_coupon_targets_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_coupon_targets_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateCouponTargetsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = CouponTarget.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM coupons WHERE coupons.id = coupon_targets.coupon_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/coupon_target.rb
+++ b/app/models/coupon_target.rb
@@ -8,7 +8,7 @@ class CouponTarget < ApplicationRecord
   belongs_to :coupon
   belongs_to :plan, optional: true
   belongs_to :billable_metric, optional: true
-  belongs_to :organization_id, optional: true
+  belongs_to :organization, optional: true
 
   default_scope -> { kept }
 end

--- a/app/models/coupon_target.rb
+++ b/app/models/coupon_target.rb
@@ -8,6 +8,7 @@ class CouponTarget < ApplicationRecord
   belongs_to :coupon
   belongs_to :plan, optional: true
   belongs_to :billable_metric, optional: true
+  belongs_to :organization_id, optional: true
 
   default_scope -> { kept }
 end
@@ -22,6 +23,7 @@ end
 #  updated_at         :datetime         not null
 #  billable_metric_id :uuid
 #  coupon_id          :uuid             not null
+#  organization_id    :uuid
 #  plan_id            :uuid
 #
 # Indexes
@@ -29,11 +31,13 @@ end
 #  index_coupon_targets_on_billable_metric_id  (billable_metric_id)
 #  index_coupon_targets_on_coupon_id           (coupon_id)
 #  index_coupon_targets_on_deleted_at          (deleted_at)
+#  index_coupon_targets_on_organization_id     (organization_id)
 #  index_coupon_targets_on_plan_id             (plan_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (billable_metric_id => billable_metrics.id)
 #  fk_rails_...  (coupon_id => coupons.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_id => plans.id)
 #

--- a/app/services/coupons/create_service.rb
+++ b/app/services/coupons/create_service.rb
@@ -48,10 +48,10 @@ module Coupons
       ActiveRecord::Base.transaction do
         coupon.save!
 
-        plans.each { |plan| CouponTarget.create!(coupon:, plan:) } if plan_identifiers.present?
+        plans.each { |plan| CouponTarget.create!(coupon:, plan:, organization_id:) } if plan_identifiers.present?
 
         if billable_metric_identifiers.present?
-          billable_metrics.each { |billable_metric| CouponTarget.create!(coupon:, billable_metric:) }
+          billable_metrics.each { |bm| CouponTarget.create!(coupon:, billable_metric: bm, organization_id:) }
         end
       end
 

--- a/app/services/coupons/update_service.rb
+++ b/app/services/coupons/update_service.rb
@@ -73,6 +73,8 @@ module Coupons
 
     attr_reader :coupon, :params, :limitations
 
+    delegate :organization, to: :coupon
+
     def plan_identifiers
       key = api_context? ? :plan_codes : :plan_ids
       limitations[key]&.compact&.uniq
@@ -95,7 +97,7 @@ module Coupons
       plans.each do |plan|
         next if existing_coupon_plan_ids.include?(plan.id)
 
-        CouponTarget.create!(coupon:, plan:)
+        CouponTarget.create!(coupon:, plan:, organization_id: organization.id)
       end
 
       sanitize_coupon_plans
@@ -131,7 +133,7 @@ module Coupons
       billable_metrics.each do |billable_metric|
         next if existing_coupon_billable_metric_ids.include?(billable_metric.id)
 
-        CouponTarget.create!(coupon:, billable_metric:)
+        CouponTarget.create!(coupon:, billable_metric:, organization_id: organization.id)
       end
 
       sanitize_coupon_billable_metrics

--- a/db/migrate/20250512151246_add_organization_id_to_coupon_targets.rb
+++ b/db/migrate/20250512151246_add_organization_id_to_coupon_targets.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToCouponTargets < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :coupon_targets, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250512151247_add_organization_id_fk_to_coupon_targets.rb
+++ b/db/migrate/20250512151247_add_organization_id_fk_to_coupon_targets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToCouponTargets < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :coupon_targets, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250512151248_validate_coupon_targets_organizations_foreign_key.rb
+++ b/db/migrate/20250512151248_validate_coupon_targets_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateCouponTargetsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :coupon_targets, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -162,6 +162,7 @@ ALTER TABLE IF EXISTS ONLY public.webhooks DROP CONSTRAINT IF EXISTS fk_rails_20
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_1db0057d9b;
 ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_1d112bf8a0;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_195153290d;
+ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_189f2a3949;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_150139409e;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_1454058c96;
 ALTER TABLE IF EXISTS ONLY public.invoices_taxes DROP CONSTRAINT IF EXISTS fk_rails_142809fee1;
@@ -417,6 +418,7 @@ DROP INDEX IF EXISTS public.index_coupons_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_coupons_on_organization_id;
 DROP INDEX IF EXISTS public.index_coupons_on_deleted_at;
 DROP INDEX IF EXISTS public.index_coupon_targets_on_plan_id;
+DROP INDEX IF EXISTS public.index_coupon_targets_on_organization_id;
 DROP INDEX IF EXISTS public.index_coupon_targets_on_deleted_at;
 DROP INDEX IF EXISTS public.index_coupon_targets_on_coupon_id;
 DROP INDEX IF EXISTS public.index_coupon_targets_on_billable_metric_id;
@@ -1341,7 +1343,8 @@ CREATE TABLE public.coupon_targets (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
-    billable_metric_id uuid
+    billable_metric_id uuid,
+    organization_id uuid
 );
 
 
@@ -4716,6 +4719,13 @@ CREATE INDEX index_coupon_targets_on_deleted_at ON public.coupon_targets USING b
 
 
 --
+-- Name: index_coupon_targets_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_coupon_targets_on_organization_id ON public.coupon_targets USING btree (organization_id);
+
+
+--
 -- Name: index_coupon_targets_on_plan_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6457,6 +6467,14 @@ ALTER TABLE ONLY public.invoice_subscriptions
 
 
 --
+-- Name: coupon_targets fk_rails_189f2a3949; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.coupon_targets
+    ADD CONSTRAINT fk_rails_189f2a3949 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: customer_metadata fk_rails_195153290d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7687,6 +7705,9 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250512151248'),
+('20250512151247'),
+('20250512151246'),
 ('20250512144220'),
 ('20250512144219'),
 ('20250512144218'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -29,7 +29,6 @@ Rspec.describe "All tables must have an organization_id" do
       charge_filter_values
       commitments
       commitments_taxes
-      coupon_targets
       credit_note_items
       integration_collection_mappings
       integration_customers


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `coupon_targets` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
