### PR TITLE
feat(gql): add next_subscription attributes

### DIFF
--- a/app/graphql/types/subscriptions/next_subscription_type_enum.rb
+++ b/app/graphql/types/subscriptions/next_subscription_type_enum.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Types
+  module Subscriptions
+    class NextSubscriptionTypeEnum < Types::BaseEnum
+      value "upgrade"
+      value "downgrade"
+    end
+  end
+end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -11,8 +11,6 @@ module Types
       field :plan, Types::Plans::Object, null: false
 
       field :name, String, null: true
-      field :next_name, String, null: true
-      field :next_pending_start_date, GraphQL::Types::ISO8601Date, method: :downgrade_plan_date
       field :period_end_date, GraphQL::Types::ISO8601Date
       field :status, Types::Subscriptions::StatusTypeEnum
 
@@ -29,8 +27,14 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      field :next_name, String, null: true
       field :next_plan, Types::Plans::Object
       field :next_subscription, Types::Subscriptions::Object
+      field :next_subscription_at, GraphQL::Types::ISO8601DateTime
+      field :next_subscription_type, Types::Subscriptions::NextSubscriptionTypeEnum
+
+      # TODO: Remove once frontend is updated
+      field :next_pending_start_date, GraphQL::Types::ISO8601Date, method: :downgrade_plan_date # Deprecated
 
       field :fees, [Types::Fees::Object], null: true
 
@@ -42,6 +46,18 @@ module Types
 
       def next_name
         object.next_subscription&.name
+      end
+
+      def next_subscription_type
+        if object.upgraded?
+          "upgrade"
+        elsif object.downgraded?
+          "downgrade"
+        end
+      end
+
+      def next_subscription_at
+        object.next_subscription&.started_at || object.next_subscription&.subscription_at
       end
 
       def period_end_date

--- a/schema.graphql
+++ b/schema.graphql
@@ -6957,6 +6957,11 @@ type NetsuiteIntegration {
   tokenSecret: ObfuscatedString
 }
 
+enum NextSubscriptionTypeEnum {
+  downgrade
+  upgrade
+}
+
 scalar ObfuscatedString
 
 """
@@ -8378,6 +8383,8 @@ type Subscription {
   nextPendingStartDate: ISO8601Date
   nextPlan: Plan
   nextSubscription: Subscription
+  nextSubscriptionAt: ISO8601DateTime
+  nextSubscriptionType: NextSubscriptionTypeEnum
   periodEndDate: ISO8601Date
   plan: Plan!
   startedAt: ISO8601DateTime

--- a/schema.json
+++ b/schema.json
@@ -32347,6 +32347,29 @@
           "enumValues": null
         },
         {
+          "kind": "ENUM",
+          "name": "NextSubscriptionTypeEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "upgrade",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "downgrade",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
           "kind": "SCALAR",
           "name": "ObfuscatedString",
           "description": null,
@@ -43635,6 +43658,30 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Subscription",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "nextSubscriptionAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "nextSubscriptionType",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "NextSubscriptionTypeEnum",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe Types::Subscriptions::Object do
 
     expect(subject).to have_field(:next_plan).of_type("Plan")
     expect(subject).to have_field(:next_subscription).of_type("Subscription")
+    expect(subject).to have_field(:next_subscription_type).of_type("NextSubscriptionTypeEnum")
+    expect(subject).to have_field(:next_subscription_at).of_type("ISO8601DateTime")
 
     expect(subject).to have_field(:fees).of_type("[Fee!]")
 


### PR DESCRIPTION
## Description

We recently started showing terminated subscription in the frontend. This caused some dislay bug where terminated subscription would be considered "soon to be downgraded" subscription.

These attributes give some more context to the frontend.
