### PR TITLE
chore(logs): Log when idempotency record is not unique

### DIFF
--- a/spec/services/idempotency_spec.rb
+++ b/spec/services/idempotency_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Idempotency, transaction: false do
           described_class.transaction do
             # No operations
           end
-        end.to raise_error(ArgumentError, "An idempotent_transaction cannot be created when already in a transaction")
+        end.to raise_error(ArgumentError, "An idempotent_transaction cannot be created in a transaction. (1 open transactions)")
       end
     end
 
@@ -145,7 +145,7 @@ RSpec.describe Idempotency, transaction: false do
           described_class.transaction do
             described_class.unique!(invoice, id: invoice.id)
           end
-        end.to raise_error(Idempotency::IdempotencyError)
+        end.to raise_error(Idempotency::IdempotencyError, "Idempotency key already exists for resource [#{invoice.to_gid}] based on {id: \"#{invoice.id}\"}.")
       end
     end
 


### PR DESCRIPTION
## Context

IdempotencyRecords were recently added to ensure uniqueness across the app.

## Description

The goal is to add an entry to the logs so we can start ignoring this exception when needed. For example, an inbound webhook coming from payment provider can be ignored if they are processed twice. Yet, I think we want to add something to the logs.