### PR TITLE
chore(organization): Add organization_id to commitments table

### DIFF
--- a/app/jobs/database_migrations/populate_commitments_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_commitments_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateCommitmentsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Commitment.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM plans WHERE plans.id = commitments.plan_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -2,6 +2,7 @@
 
 class Commitment < ApplicationRecord
   belongs_to :plan
+  belongs_to :organization, optional: true
   has_many :applied_taxes, class_name: "Commitment::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes
 
@@ -31,14 +32,17 @@ end
 #  invoice_display_name :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  organization_id      :uuid
 #  plan_id              :uuid             not null
 #
 # Indexes
 #
 #  index_commitments_on_commitment_type_and_plan_id  (commitment_type,plan_id) UNIQUE
+#  index_commitments_on_organization_id              (organization_id)
 #  index_commitments_on_plan_id                      (plan_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (plan_id => plans.id)
 #

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -85,6 +85,7 @@ module Plans
 
     def create_commitment(plan, args, commitment_type)
       Commitment.create!(
+        organization_id: plan.organization_id,
         plan:,
         commitment_type:,
         invoice_display_name: args[:invoice_display_name],

--- a/app/services/plans/override_service.rb
+++ b/app/services/plans/override_service.rb
@@ -44,7 +44,9 @@ module Plans
         end
 
         if params[:minimum_commitment].present? && License.premium?
-          commitment = Commitment.new(plan: new_plan, commitment_type: "minimum_commitment")
+          commitment = Commitment.new(
+            organization_id: new_plan.organization_id, plan: new_plan, commitment_type: "minimum_commitment"
+          )
           minimum_commitment_params = params[:minimum_commitment].merge(plan_id: new_plan.id)
 
           commitment_override_result = Commitments::OverrideService.call(commitment:, params: minimum_commitment_params)

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -139,7 +139,8 @@ module Plans
 
     def process_minimum_commitment(plan, params)
       if params.present?
-        minimum_commitment = plan.minimum_commitment || Commitment.new(plan:, commitment_type: "minimum_commitment")
+        minimum_commitment = plan.minimum_commitment ||
+          Commitment.new(organization_id: plan.organization_id, plan:, commitment_type: "minimum_commitment")
 
         minimum_commitment.amount_cents = params[:amount_cents] if params.key?(:amount_cents)
         minimum_commitment.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)

--- a/db/migrate/20250513132423_add_organization_id_to_commitments.rb
+++ b/db/migrate/20250513132423_add_organization_id_to_commitments.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToCommitments < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :commitments, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250513132424_add_organization_id_fk_to_commitments.rb
+++ b/db/migrate/20250513132424_add_organization_id_fk_to_commitments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToCommitments < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :commitments, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250513132425_validate_commitments_organizations_foreign_key.rb
+++ b/db/migrate/20250513132425_validate_commitments_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateCommitmentsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :commitments, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -85,6 +85,7 @@ ALTER TABLE IF EXISTS ONLY public.applied_add_ons DROP CONSTRAINT IF EXISTS fk_r
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_78f6642ddf;
 ALTER TABLE IF EXISTS ONLY public.groups DROP CONSTRAINT IF EXISTS fk_rails_7886e1bc34;
 ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS fk_rails_77f2d4440d;
+ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_76ceb88c74;
 ALTER TABLE IF EXISTS ONLY public.integrations DROP CONSTRAINT IF EXISTS fk_rails_755d734f25;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_75577c354e;
 ALTER TABLE IF EXISTS ONLY public.fees_taxes DROP CONSTRAINT IF EXISTS fk_rails_745b4ca7dd;
@@ -426,6 +427,7 @@ DROP INDEX IF EXISTS public.index_coupon_targets_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_commitments_taxes_on_tax_id;
 DROP INDEX IF EXISTS public.index_commitments_taxes_on_commitment_id;
 DROP INDEX IF EXISTS public.index_commitments_on_plan_id;
+DROP INDEX IF EXISTS public.index_commitments_on_organization_id;
 DROP INDEX IF EXISTS public.index_commitments_on_commitment_type_and_plan_id;
 DROP INDEX IF EXISTS public.index_charges_taxes_on_tax_id;
 DROP INDEX IF EXISTS public.index_charges_taxes_on_organization_id;
@@ -1316,7 +1318,8 @@ CREATE TABLE public.commitments (
     amount_cents bigint NOT NULL,
     invoice_display_name character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -4679,6 +4682,13 @@ CREATE UNIQUE INDEX index_commitments_on_commitment_type_and_plan_id ON public.c
 
 
 --
+-- Name: index_commitments_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_commitments_on_organization_id ON public.commitments USING btree (organization_id);
+
+
+--
 -- Name: index_commitments_on_plan_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7100,6 +7110,14 @@ ALTER TABLE ONLY public.integrations
 
 
 --
+-- Name: commitments fk_rails_76ceb88c74; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.commitments
+    ADD CONSTRAINT fk_rails_76ceb88c74 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: credit_notes_taxes fk_rails_77f2d4440d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7718,6 +7736,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250515083935'),
 ('20250515083802'),
 ('20250515083649'),
+('20250513132425'),
+('20250513132424'),
+('20250513132423'),
 ('20250512151248'),
 ('20250512151247'),
 ('20250512151246'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -27,7 +27,6 @@ Rspec.describe "All tables must have an organization_id" do
   let(:tables_to_migrate) do
     %w[
       charge_filter_values
-      commitments
       commitments_taxes
       credit_note_items
       integration_collection_mappings


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `commitments` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
