### PR TITLE
chore(organization): Add organization_id to commitments_taxes table

### DIFF
--- a/app/jobs/database_migrations/populate_commitments_taxes_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_commitments_taxes_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateCommitmentsTaxesWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Commitment::AppliedTax.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM taxes WHERE taxes.id = commitments_taxes.tax_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/commitment/applied_tax.rb
+++ b/app/models/commitment/applied_tax.rb
@@ -6,6 +6,7 @@ class Commitment
 
     belongs_to :commitment
     belongs_to :tax
+    belongs_to :organization, optional: true
   end
 end
 
@@ -13,19 +14,22 @@ end
 #
 # Table name: commitments_taxes
 #
-#  id            :uuid             not null, primary key
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  commitment_id :uuid             not null
-#  tax_id        :uuid             not null
+#  id              :uuid             not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  commitment_id   :uuid             not null
+#  organization_id :uuid
+#  tax_id          :uuid             not null
 #
 # Indexes
 #
-#  index_commitments_taxes_on_commitment_id  (commitment_id)
-#  index_commitments_taxes_on_tax_id         (tax_id)
+#  index_commitments_taxes_on_commitment_id    (commitment_id)
+#  index_commitments_taxes_on_organization_id  (organization_id)
+#  index_commitments_taxes_on_tax_id           (tax_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (commitment_id => commitments.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (tax_id => taxes.id)
 #

--- a/app/services/commitments/apply_taxes_service.rb
+++ b/app/services/commitments/apply_taxes_service.rb
@@ -18,7 +18,9 @@ module Commitments
       ).destroy_all
 
       result.applied_taxes = tax_codes.map do |tax_code|
-        commitment.applied_taxes.find_or_create_by!(tax: taxes.find_by(code: tax_code))
+        commitment.applied_taxes
+          .create_with(organization_id: commitment.plan.organization_id)
+          .find_or_create_by!(tax: taxes.find_by(code: tax_code))
       end
 
       result

--- a/db/migrate/20250513144352_add_organization_id_to_commitments_taxes.rb
+++ b/db/migrate/20250513144352_add_organization_id_to_commitments_taxes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToCommitmentsTaxes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :commitments_taxes, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250513144353_add_organization_id_fk_to_commitments_taxes.rb
+++ b/db/migrate/20250513144353_add_organization_id_fk_to_commitments_taxes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToCommitmentsTaxes < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :commitments_taxes, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250513144354_validate_commitments_taxes_organizations_foreign_key.rb
+++ b/db/migrate/20250513144354_validate_commitments_taxes_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateCommitmentsTaxesOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :commitments_taxes, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -156,6 +156,7 @@ ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS f
 ALTER TABLE IF EXISTS ONLY public.invoices_payment_requests DROP CONSTRAINT IF EXISTS fk_rails_2496c105ed;
 ALTER TABLE IF EXISTS ONLY public.taxes DROP CONSTRAINT IF EXISTS fk_rails_23975f5a47;
 ALTER TABLE IF EXISTS ONLY public.invoices_taxes DROP CONSTRAINT IF EXISTS fk_rails_22af6c6d28;
+ALTER TABLE IF EXISTS ONLY public.commitments_taxes DROP CONSTRAINT IF EXISTS fk_rails_2259c88f26;
 ALTER TABLE IF EXISTS ONLY public.cached_aggregations DROP CONSTRAINT IF EXISTS fk_rails_21eb389927;
 ALTER TABLE IF EXISTS ONLY public.webhook_endpoints DROP CONSTRAINT IF EXISTS fk_rails_21808fa528;
 ALTER TABLE IF EXISTS ONLY public.plans DROP CONSTRAINT IF EXISTS fk_rails_216ac8a975;
@@ -425,6 +426,7 @@ DROP INDEX IF EXISTS public.index_coupon_targets_on_deleted_at;
 DROP INDEX IF EXISTS public.index_coupon_targets_on_coupon_id;
 DROP INDEX IF EXISTS public.index_coupon_targets_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_commitments_taxes_on_tax_id;
+DROP INDEX IF EXISTS public.index_commitments_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_commitments_taxes_on_commitment_id;
 DROP INDEX IF EXISTS public.index_commitments_on_plan_id;
 DROP INDEX IF EXISTS public.index_commitments_on_organization_id;
@@ -1332,7 +1334,8 @@ CREATE TABLE public.commitments_taxes (
     commitment_id uuid NOT NULL,
     tax_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -4703,6 +4706,13 @@ CREATE INDEX index_commitments_taxes_on_commitment_id ON public.commitments_taxe
 
 
 --
+-- Name: index_commitments_taxes_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_commitments_taxes_on_organization_id ON public.commitments_taxes USING btree (organization_id);
+
+
+--
 -- Name: index_commitments_taxes_on_tax_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6550,6 +6560,14 @@ ALTER TABLE ONLY public.cached_aggregations
 
 
 --
+-- Name: commitments_taxes fk_rails_2259c88f26; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.commitments_taxes
+    ADD CONSTRAINT fk_rails_2259c88f26 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: invoices_taxes fk_rails_22af6c6d28; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7736,6 +7754,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250515083935'),
 ('20250515083802'),
 ('20250515083649'),
+('20250513144354'),
+('20250513144353'),
+('20250513144352'),
 ('20250513132425'),
 ('20250513132424'),
 ('20250513132423'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -27,7 +27,6 @@ Rspec.describe "All tables must have an organization_id" do
   let(:tables_to_migrate) do
     %w[
       charge_filter_values
-      commitments_taxes
       credit_note_items
       integration_collection_mappings
       integration_customers


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `commitments_taxes` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
