### PR TITLE
Feat forecast calculate price

### DIFF
--- a/app/services/charges/calculate_price_service.rb
+++ b/app/services/charges/calculate_price_service.rb
@@ -3,7 +3,7 @@
 module Charges
   class CalculatePriceService < BaseService
     Result = BaseResult[:charge_amount_cents, :subscription_amount_cents, :total_amount_cents]
-    AggregationResult = Struct.new(:aggregation, :total_aggregated_units, :current_usage_units, :full_units_number)
+    AggregationResult = Struct.new(:aggregation, :total_aggregated_units, :current_usage_units, :full_units_number, :precise_total_amount_cents, :custom_aggregation, :options)
 
     def initialize(subscription:, units:, charge:, charge_filter: nil)
       @subscription = subscription
@@ -48,7 +48,7 @@ module Charges
     end
 
     def aggregation_result
-      AggregationResult.new(units, units, units, units)
+      AggregationResult.new(units, units, units, units, 0, nil, running_total: [])
     end
   end
 end

--- a/app/services/charges/calculate_price_service.rb
+++ b/app/services/charges/calculate_price_service.rb
@@ -45,11 +45,9 @@ module Charges
     end
 
     def build_aggregation_result
-      OpenStruct.new(
-        aggregation: units,
-        total_aggregated_units: units,
-        current_usage_units: units
-      )
+      Struct.new(
+        :aggregation, :total_aggregated_units, :current_usage_units, :full_units_number
+      ).new(units, units, units, units)
     end
   end
 end

--- a/app/services/charges/calculate_price_service.rb
+++ b/app/services/charges/calculate_price_service.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Charges
+  class CalculatePriceService < BaseService
+    Result = BaseResult[:charge_amount_cents, :subscription_amount_cents, :total_amount_cents]
+
+    def initialize(billable_metric:, subscription:, date:, units:)
+      @billable_metric = billable_metric
+      @subscription = subscription
+      @date = date
+      @units = units
+
+      super
+    end
+
+    def call
+      result.charge_amount_cents = calculate_charge_amount
+      result.subscription_amount_cents = plan.amount_cents
+      result.total_amount_cents = result.charge_amount_cents + result.subscription_amount_cents
+      result
+    end
+
+    private
+
+    attr_reader :billable_metric, :subscription, :date, :units
+
+    delegate :plan, to: :subscription
+    delegate :customer, to: :subscription
+
+    def calculate_charge_amount
+      charge = subscription.plan.charges.find_by(billable_metric:)
+      return 0 unless charge
+
+      # For past dates, get the last active charge version
+      # For current/future dates, use the current charge
+      if date.to_time < Time.current
+        version = charge.versions.where("created_at <= ?", date.to_time).order(created_at: :desc).first
+        return 0 unless version
+
+        object = if version.event == "create"
+          version.item
+        else
+          version.reify
+        end
+
+        properties = object.properties.presence || Charges::BuildDefaultPropertiesService.call(object.charge_model)
+      else
+        properties = charge.properties.presence || Charges::BuildDefaultPropertiesService.call(charge.charge_model)
+      end
+
+      properties = Charges::FilterChargeModelPropertiesService.call(charge:, properties:).properties
+
+      charge_model = ChargeModelFactory.new_instance(
+        charge:,
+        aggregation_result: build_aggregation_result,
+        properties:
+      )
+
+      charge_model.apply.amount
+    end
+
+    def build_aggregation_result
+      OpenStruct.new(
+        aggregation: units,
+        total_aggregated_units: units,
+        current_usage_units: units
+      )
+    end
+  end
+end

--- a/app/services/charges/calculate_price_service.rb
+++ b/app/services/charges/calculate_price_service.rb
@@ -3,6 +3,7 @@
 module Charges
   class CalculatePriceService < BaseService
     Result = BaseResult[:charge_amount_cents, :subscription_amount_cents, :total_amount_cents]
+    AggregationResult = Struct.new(:aggregation, :total_aggregated_units, :current_usage_units, :full_units_number)
 
     def initialize(billable_metric:, subscription:, date:, units:)
       @billable_metric = billable_metric
@@ -37,17 +38,15 @@ module Charges
 
       charge_model = ChargeModelFactory.new_instance(
         charge:,
-        aggregation_result: build_aggregation_result,
+        aggregation_result:,
         properties: filtered_properties
       )
 
       charge_model.apply.amount
     end
 
-    def build_aggregation_result
-      Struct.new(
-        :aggregation, :total_aggregated_units, :current_usage_units, :full_units_number
-      ).new(units, units, units, units)
+    def aggregation_result
+      AggregationResult.new(units, units, units, units)
     end
   end
 end

--- a/spec/services/charges/calculate_price_service_spec.rb
+++ b/spec/services/charges/calculate_price_service_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Charges::CalculatePriceService do
+  subject(:calculate_price_service) do
+    described_class.new(
+      billable_metric:,
+      subscription:,
+      date:,
+      units:
+    )
+  end
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, amount_cents: 1000) }
+  let(:subscription) { create(:subscription, customer:, plan:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:date) { Time.current }
+  let(:units) { 5 }
+
+  describe "#call" do
+    context "when there is no charge for the billable metric" do
+      it "returns only the subscription amount" do
+        result = calculate_price_service.call
+
+        expect(result.charge_amount_cents).to eq(0)
+        expect(result.subscription_amount_cents).to eq(1000)
+        expect(result.total_amount_cents).to eq(1000)
+      end
+    end
+
+    context "when there is a standard charge" do
+      let(:charge) do
+        create(:standard_charge,
+          plan:,
+          billable_metric:,
+          properties: {amount: "10"})
+      end
+
+      before { charge }
+
+      it "calculates the total amount correctly" do
+        result = calculate_price_service.call
+
+        expect(result.charge_amount_cents).to eq(50) # 5 units * 10
+        expect(result.subscription_amount_cents).to eq(1000)
+        expect(result.total_amount_cents).to eq(1050)
+      end
+    end
+
+    context "when there is a graduated charge" do
+      let(:charge) do
+        create(:graduated_charge,
+          plan:,
+          billable_metric:,
+          properties: {
+            graduated_ranges: [
+              {from_value: 0, to_value: 2, per_unit_amount: "2", flat_amount: "0"},
+              {from_value: 3, to_value: nil, per_unit_amount: "3", flat_amount: "0"}
+            ]
+          })
+      end
+
+      before { charge }
+
+      it "calculates the total amount correctly" do
+        result = calculate_price_service.call
+
+        # First range: 2 units * 2 = 4
+        # Second range: 3 units * 3 = 9
+        # Total charge: 13
+        expect(result.charge_amount_cents).to eq(13)
+        expect(result.subscription_amount_cents).to eq(1000)
+        expect(result.total_amount_cents).to eq(1013)
+      end
+    end
+
+    context "when there is a package charge" do
+      let(:charge) do
+        create(:package_charge,
+          plan:,
+          billable_metric:,
+          properties: {
+            package_size: 2,
+            amount: "10",
+            free_units: 1
+          })
+      end
+
+      before { charge }
+
+      it "calculates the total amount correctly" do
+        result = calculate_price_service.call
+
+        # 5 units - 1 free unit = 4 paid units
+        # 4 paid units / 2 package size = 2 packages
+        # 2 packages * 10 = 20
+        expect(result.charge_amount_cents).to eq(20)
+        expect(result.subscription_amount_cents).to eq(1000)
+        expect(result.total_amount_cents).to eq(1020)
+      end
+    end
+
+    context "when there is a volume charge" do
+      let(:charge) do
+        create(:volume_charge,
+          plan:,
+          billable_metric:,
+          properties: {
+            volume_ranges: [
+              {from_value: 0, to_value: 2, per_unit_amount: "2", flat_amount: "0"},
+              {from_value: 3, to_value: nil, per_unit_amount: "3", flat_amount: "0"}
+            ]
+          })
+      end
+
+      before { charge }
+
+      it "calculates the total amount correctly" do
+        result = calculate_price_service.call
+
+        # All 5 units fall into the second range
+        # 5 units * 3 = 15
+        expect(result.charge_amount_cents).to eq(15)
+        expect(result.subscription_amount_cents).to eq(1000)
+        expect(result.total_amount_cents).to eq(1015)
+      end
+    end
+  end
+end

--- a/spec/services/charges/calculate_price_service_spec.rb
+++ b/spec/services/charges/calculate_price_service_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Charges::CalculatePriceService do
     context "when there is no charge for the billable metric" do
       let(:charge) { nil }
 
+      before { charge }
+
       it "returns only the subscription amount" do
         result = calculate_price_service.call
 
@@ -33,13 +35,13 @@ RSpec.describe Charges::CalculatePriceService do
 
     context "when there is a standard charge" do
       let(:charge) do
-        create(:standard_charge,
+        create(
+          :standard_charge,
           plan:,
           billable_metric:,
-          properties: {amount: "10"})
+          properties: {amount: "10"}
+        )
       end
-
-      before { charge }
 
       it "calculates the total amount correctly" do
         result = calculate_price_service.call
@@ -52,7 +54,8 @@ RSpec.describe Charges::CalculatePriceService do
 
     context "when there is a graduated charge" do
       let(:charge) do
-        create(:graduated_charge,
+        create(
+          :graduated_charge,
           plan:,
           billable_metric:,
           properties: {
@@ -60,10 +63,9 @@ RSpec.describe Charges::CalculatePriceService do
               {from_value: 0, to_value: 2, per_unit_amount: "2", flat_amount: "0"},
               {from_value: 3, to_value: nil, per_unit_amount: "3", flat_amount: "0"}
             ]
-          })
+          }
+        )
       end
-
-      before { charge }
 
       it "calculates the total amount correctly" do
         result = calculate_price_service.call
@@ -91,8 +93,6 @@ RSpec.describe Charges::CalculatePriceService do
         )
       end
 
-      before { charge }
-
       it "calculates the total amount correctly" do
         result = calculate_price_service.call
 
@@ -118,8 +118,6 @@ RSpec.describe Charges::CalculatePriceService do
           })
       end
 
-      before { charge }
-
       it "calculates the total amount correctly" do
         result = calculate_price_service.call
 
@@ -128,6 +126,96 @@ RSpec.describe Charges::CalculatePriceService do
         expect(result.charge_amount_cents).to eq(15)
         expect(result.subscription_amount_cents).to eq(1000)
         expect(result.total_amount_cents).to eq(1015)
+      end
+    end
+
+    context "when there is a percentage charge" do
+      let(:charge) do
+        create(
+          :percentage_charge,
+          plan:,
+          billable_metric:,
+          properties: {
+            rate: "10"
+          }
+        )
+      end
+
+      it "calculates the total amount correctly" do
+        result = calculate_price_service.call
+
+        expect(result.charge_amount_cents).to eq(0.5)
+        expect(result.subscription_amount_cents).to eq(1000)
+        expect(result.total_amount_cents).to eq(1000.5)
+      end
+    end
+
+    context "when there is a graduated percentage charge" do
+      let(:charge) do
+        create(
+          :graduated_percentage_charge,
+          plan:,
+          billable_metric:,
+          properties: {
+            graduated_percentage_ranges: [
+              {from_value: 0, to_value: 2, rate: "10", flat_amount: "10"},
+              {from_value: 3, to_value: nil, rate: "20", flat_amount: "20"}
+            ]
+          }
+        )
+      end
+
+      around { |test| lago_premium!(&test) }
+
+      it "calculates the total amount correctly" do
+        result = calculate_price_service.call
+
+        # First range: 2 units * 0.1 = 0.2
+        # Second range: 3 units * 0.2 = 0.6
+        # Total charge: 0.8
+        expect(result.charge_amount_cents).to eq(30.8)
+        expect(result.subscription_amount_cents).to eq(1000)
+        expect(result.total_amount_cents).to eq(1030.8)
+      end
+    end
+
+    context "when there is a dynamic charge" do
+      let(:billable_metric) { create(:sum_billable_metric, organization:) }
+
+      let(:charge) do
+        create(
+          :dynamic_charge,
+          plan:,
+          billable_metric:
+        )
+      end
+
+      around { |test| lago_premium!(&test) }
+
+      it "calculates the total amount correctly" do
+        result = calculate_price_service.call
+
+        expect(result.charge_amount_cents).to eq(0)
+        expect(result.subscription_amount_cents).to eq(1000)
+        expect(result.total_amount_cents).to eq(1000)
+      end
+    end
+
+    context "when there is a custom charge" do
+      let(:billable_metric) { create(:custom_billable_metric, organization:) }
+
+      let(:charge) do
+        create(:custom_charge, plan:, billable_metric:)
+      end
+
+      around { |test| lago_premium!(&test) }
+
+      it "calculates the total amount correctly" do
+        result = calculate_price_service.call
+
+        expect(result.charge_amount_cents).to eq(0)
+        expect(result.subscription_amount_cents).to eq(1000)
+        expect(result.total_amount_cents).to eq(1000)
       end
     end
   end

--- a/spec/services/charges/calculate_price_service_spec.rb
+++ b/spec/services/charges/calculate_price_service_spec.rb
@@ -5,10 +5,9 @@ require "rails_helper"
 RSpec.describe Charges::CalculatePriceService do
   subject(:calculate_price_service) do
     described_class.new(
-      billable_metric:,
       subscription:,
-      date:,
-      units:
+      units:,
+      charge:
     )
   end
 
@@ -17,11 +16,12 @@ RSpec.describe Charges::CalculatePriceService do
   let(:plan) { create(:plan, organization:, amount_cents: 1000) }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:billable_metric) { create(:billable_metric, organization:) }
-  let(:date) { Time.current }
   let(:units) { 5 }
 
   describe "#call" do
     context "when there is no charge for the billable metric" do
+      let(:charge) { nil }
+
       it "returns only the subscription amount" do
         result = calculate_price_service.call
 
@@ -79,14 +79,16 @@ RSpec.describe Charges::CalculatePriceService do
 
     context "when there is a package charge" do
       let(:charge) do
-        create(:package_charge,
+        create(
+          :package_charge,
           plan:,
           billable_metric:,
           properties: {
             package_size: 2,
             amount: "10",
             free_units: 1
-          })
+          }
+        )
       end
 
       before { charge }


### PR DESCRIPTION
## Context

This is part of the feature that calculates and saves prices for number of units predicted by ML model.

## Description

This PR only contains a service that uses charge model services to calculate price based on multiple input params.