### PR TITLE
chore(organization): Add organization_id to credit_note_items table

### DIFF
--- a/app/jobs/database_migrations/populate_credit_note_items_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_credit_note_items_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateCreditNoteItemsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = CreditNoteItem.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM fees WHERE fees.id = credit_note_items.fee_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -3,6 +3,7 @@
 class CreditNoteItem < ApplicationRecord
   belongs_to :credit_note
   belongs_to :fee
+  belongs_to :organization, optional: true
 
   monetize :amount_cents
 
@@ -35,14 +36,17 @@ end
 #  updated_at           :datetime         not null
 #  credit_note_id       :uuid             not null
 #  fee_id               :uuid
+#  organization_id      :uuid
 #
 # Indexes
 #
-#  index_credit_note_items_on_credit_note_id  (credit_note_id)
-#  index_credit_note_items_on_fee_id          (fee_id)
+#  index_credit_note_items_on_credit_note_id   (credit_note_id)
+#  index_credit_note_items_on_fee_id           (fee_id)
+#  index_credit_note_items_on_organization_id  (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (credit_note_id => credit_notes.id)
 #  fk_rails_...  (fee_id => fees.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -136,6 +136,7 @@ module CreditNotes
         amount_cents = item_attr[:amount_cents] || 0
 
         item = credit_note.items.new(
+          organization_id: invoice.organization_id,
           fee: invoice.fees.find_by(id: item_attr[:fee_id]),
           amount_cents: amount_cents.round,
           precise_amount_cents: amount_cents,

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -50,6 +50,7 @@ module CreditNotes
         amount_cents = item_attr[:amount_cents]&.to_i || 0
 
         item = CreditNoteItem.new(
+          organization_id: invoice.organization_id,
           fee: invoice.fees.find_by(id: item_attr[:fee_id]),
           amount_cents: amount_cents.round,
           precise_amount_cents: amount_cents,

--- a/db/migrate/20250513151258_add_organization_id_to_credit_note_items.rb
+++ b/db/migrate/20250513151258_add_organization_id_to_credit_note_items.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToCreditNoteItems < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :credit_note_items, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250513151259_add_organization_id_fk_to_credit_note_items.rb
+++ b/db/migrate/20250513151259_add_organization_id_fk_to_credit_note_items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToCreditNoteItems < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :credit_note_items, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250513151260_validate_credit_note_items_organizations_foreign_key.rb
+++ b/db/migrate/20250513151260_validate_credit_note_items_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateCreditNoteItemsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :credit_note_items, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -105,6 +105,7 @@ ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS fk_rails_62
 ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS fk_rails_626209b8d2;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_6023b3f2dd;
 ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_5cb67dee79;
+ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_5cb2f24c3d;
 ALTER TABLE IF EXISTS ONLY public.payment_receipts DROP CONSTRAINT IF EXISTS fk_rails_5c2e0b6d34;
 ALTER TABLE IF EXISTS ONLY public.error_details DROP CONSTRAINT IF EXISTS fk_rails_5c21eece29;
 ALTER TABLE IF EXISTS ONLY public.add_ons_taxes DROP CONSTRAINT IF EXISTS fk_rails_5ade8984b1;
@@ -415,6 +416,7 @@ DROP INDEX IF EXISTS public.index_credit_notes_taxes_on_credit_note_id;
 DROP INDEX IF EXISTS public.index_credit_notes_on_organization_id;
 DROP INDEX IF EXISTS public.index_credit_notes_on_invoice_id;
 DROP INDEX IF EXISTS public.index_credit_notes_on_customer_id;
+DROP INDEX IF EXISTS public.index_credit_note_items_on_organization_id;
 DROP INDEX IF EXISTS public.index_credit_note_items_on_fee_id;
 DROP INDEX IF EXISTS public.index_credit_note_items_on_credit_note_id;
 DROP INDEX IF EXISTS public.index_coupons_on_organization_id_and_code;
@@ -1396,7 +1398,8 @@ CREATE TABLE public.credit_note_items (
     amount_currency character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    precise_amount_cents numeric(30,5) NOT NULL
+    precise_amount_cents numeric(30,5) NOT NULL,
+    organization_id uuid
 );
 
 
@@ -4790,6 +4793,13 @@ CREATE INDEX index_credit_note_items_on_fee_id ON public.credit_note_items USING
 
 
 --
+-- Name: index_credit_note_items_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_credit_note_items_on_organization_id ON public.credit_note_items USING btree (organization_id);
+
+
+--
 -- Name: index_credit_notes_on_customer_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6976,6 +6986,14 @@ ALTER TABLE ONLY public.payment_receipts
 
 
 --
+-- Name: credit_note_items fk_rails_5cb2f24c3d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.credit_note_items
+    ADD CONSTRAINT fk_rails_5cb2f24c3d FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: credit_notes fk_rails_5cb67dee79; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7754,6 +7772,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250515083935'),
 ('20250515083802'),
 ('20250515083649'),
+('20250513151260'),
+('20250513151259'),
+('20250513151258'),
 ('20250513144354'),
 ('20250513144353'),
 ('20250513144352'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -27,7 +27,6 @@ Rspec.describe "All tables must have an organization_id" do
   let(:tables_to_migrate) do
     %w[
       charge_filter_values
-      credit_note_items
       integration_collection_mappings
       integration_customers
       integration_items


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `credit_note_items` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
