### PR TITLE
chore(organization): Add organization_id to integration_resources table

### DIFF
--- a/app/jobs/database_migrations/populate_integration_resources_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_integration_resources_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateIntegrationResourcesWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = IntegrationResource.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM integrations WHERE integrations.id = integration_resources.integration_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/integration_resource.rb
+++ b/app/models/integration_resource.rb
@@ -5,6 +5,7 @@ class IntegrationResource < ApplicationRecord
 
   belongs_to :syncable, polymorphic: true
   belongs_to :integration, class_name: "Integrations::BaseIntegration"
+  belongs_to :organization, optional: true
 
   RESOURCE_TYPES = %i[invoice sales_order_deprecated payment credit_note subscription].freeze
 
@@ -15,21 +16,24 @@ end
 #
 # Table name: integration_resources
 #
-#  id             :uuid             not null, primary key
-#  resource_type  :integer          default("invoice"), not null
-#  syncable_type  :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  external_id    :string
-#  integration_id :uuid
-#  syncable_id    :uuid             not null
+#  id              :uuid             not null, primary key
+#  resource_type   :integer          default("invoice"), not null
+#  syncable_type   :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  external_id     :string
+#  integration_id  :uuid
+#  organization_id :uuid
+#  syncable_id     :uuid             not null
 #
 # Indexes
 #
-#  index_integration_resources_on_integration_id  (integration_id)
-#  index_integration_resources_on_syncable        (syncable_type,syncable_id)
+#  index_integration_resources_on_integration_id   (integration_id)
+#  index_integration_resources_on_organization_id  (organization_id)
+#  index_integration_resources_on_syncable         (syncable_type,syncable_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/integrations/aggregator/credit_notes/create_service.rb
+++ b/app/services/integrations/aggregator/credit_notes/create_service.rb
@@ -34,6 +34,7 @@ module Integrations
           return result unless result.external_id
 
           IntegrationResource.create!(
+            organization_id: integration.organization_id,
             integration:,
             external_id: result.external_id,
             syncable_id: credit_note.id,

--- a/app/services/integrations/aggregator/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/invoices/create_service.rb
@@ -35,6 +35,7 @@ module Integrations
           Rails.logger.info "Creating integration resource with external ID: #{result.external_id}"
 
           IntegrationResource.create!(
+            organization_id: integration.organization_id,
             integration:,
             external_id: result.external_id,
             syncable_id: invoice.id,

--- a/app/services/integrations/aggregator/invoices/hubspot/create_service.rb
+++ b/app/services/integrations/aggregator/invoices/hubspot/create_service.rb
@@ -22,6 +22,7 @@ module Integrations
             return result unless result.external_id
 
             IntegrationResource.create!(
+              organization_id: integration.organization_id,
               integration:,
               external_id: result.external_id,
               syncable_id: invoice.id,

--- a/app/services/integrations/aggregator/payments/create_service.rb
+++ b/app/services/integrations/aggregator/payments/create_service.rb
@@ -34,6 +34,7 @@ module Integrations
           return result unless result.external_id
 
           IntegrationResource.create!(
+            organization_id: integration.organization_id,
             integration:,
             external_id: result.external_id,
             syncable_id: payment.id,

--- a/app/services/integrations/aggregator/subscriptions/hubspot/create_service.rb
+++ b/app/services/integrations/aggregator/subscriptions/hubspot/create_service.rb
@@ -20,6 +20,7 @@ module Integrations
             return result unless result.external_id
 
             IntegrationResource.create!(
+              organization_id: integration.organization_id,
               integration:,
               external_id: result.external_id,
               syncable_id: subscription.id,

--- a/app/services/integrations/aggregator/taxes/credit_notes/create_service.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/create_service.rb
@@ -51,6 +51,7 @@ module Integrations
 
           def create_integration_resource
             IntegrationResource.create!(
+              organization_id: integration.organization_id,
               syncable_id: credit_note.id,
               syncable_type: "CreditNote",
               external_id: result.succeeded_id,

--- a/db/migrate/20250513152805_add_organization_id_to_integration_resources.rb
+++ b/db/migrate/20250513152805_add_organization_id_to_integration_resources.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToIntegrationResources < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :integration_resources, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250513152806_add_organization_id_fk_to_integration_resources.rb
+++ b/db/migrate/20250513152806_add_organization_id_fk_to_integration_resources.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToIntegrationResources < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :integration_resources, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250513152807_validate_integration_resources_organizations_foreign_key.rb
+++ b/db/migrate/20250513152807_validate_integration_resources_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateIntegrationResourcesOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :integration_resources, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -30,6 +30,7 @@ ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_ra
 ALTER TABLE IF EXISTS ONLY public.invoice_custom_section_selections DROP CONSTRAINT IF EXISTS fk_rails_dd7e076158;
 ALTER TABLE IF EXISTS ONLY public.invites DROP CONSTRAINT IF EXISTS fk_rails_dd342449a6;
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_d9ffb8b4a1;
+ALTER TABLE IF EXISTS ONLY public.integration_resources DROP CONSTRAINT IF EXISTS fk_rails_d9448a540b;
 ALTER TABLE IF EXISTS ONLY public.idempotency_records DROP CONSTRAINT IF EXISTS fk_rails_d4f02c82b2;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_d07bc24ce3;
 ALTER TABLE IF EXISTS ONLY public.integration_mappings DROP CONSTRAINT IF EXISTS fk_rails_cc318ad1ff;
@@ -321,6 +322,7 @@ DROP INDEX IF EXISTS public.index_invites_on_membership_id;
 DROP INDEX IF EXISTS public.index_integrations_on_organization_id;
 DROP INDEX IF EXISTS public.index_integrations_on_code_and_organization_id;
 DROP INDEX IF EXISTS public.index_integration_resources_on_syncable;
+DROP INDEX IF EXISTS public.index_integration_resources_on_organization_id;
 DROP INDEX IF EXISTS public.index_integration_resources_on_integration_id;
 DROP INDEX IF EXISTS public.index_integration_mappings_on_mappable;
 DROP INDEX IF EXISTS public.index_integration_mappings_on_integration_id;
@@ -2899,7 +2901,8 @@ CREATE TABLE public.integration_resources (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     integration_id uuid,
-    resource_type integer DEFAULT 0 NOT NULL
+    resource_type integer DEFAULT 0 NOT NULL,
+    organization_id uuid
 );
 
 
@@ -5465,6 +5468,13 @@ CREATE INDEX index_integration_resources_on_integration_id ON public.integration
 
 
 --
+-- Name: index_integration_resources_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_integration_resources_on_organization_id ON public.integration_resources USING btree (organization_id);
+
+
+--
 -- Name: index_integration_resources_on_syncable; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7594,6 +7604,14 @@ ALTER TABLE ONLY public.idempotency_records
 
 
 --
+-- Name: integration_resources fk_rails_d9448a540b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.integration_resources
+    ADD CONSTRAINT fk_rails_d9448a540b FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: fees fk_rails_d9ffb8b4a1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7772,6 +7790,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250515083935'),
 ('20250515083802'),
 ('20250515083649'),
+('20250513152807'),
+('20250513152806'),
+('20250513152805'),
 ('20250513151260'),
 ('20250513151259'),
 ('20250513151258'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -31,7 +31,6 @@ Rspec.describe "All tables must have an organization_id" do
       integration_customers
       integration_items
       integration_mappings
-      integration_resources
       recurring_transaction_rules
       refunds
       versions


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `integration_resources` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
