### PR TITLE
chore(organization): Add organization_id to integration_customers table

### DIFF
--- a/app/jobs/database_migrations/populate_integration_customers_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_integration_customers_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateIntegrationCustomersWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = IntegrationCustomers::BaseCustomer.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM customers WHERE customers.id = integration_customers.customer_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/integration_customers/anrok_customer.rb
+++ b/app/models/integration_customers/anrok_customer.rb
@@ -17,6 +17,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
+#  organization_id      :uuid
 #
 # Indexes
 #
@@ -24,9 +25,11 @@ end
 #  index_integration_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
 #  index_integration_customers_on_external_customer_id  (external_customer_id)
 #  index_integration_customers_on_integration_id        (integration_id)
+#  index_integration_customers_on_organization_id       (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/models/integration_customers/avalara_customer.rb
+++ b/app/models/integration_customers/avalara_customer.rb
@@ -17,6 +17,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
+#  organization_id      :uuid
 #
 # Indexes
 #
@@ -24,9 +25,11 @@ end
 #  index_integration_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
 #  index_integration_customers_on_external_customer_id  (external_customer_id)
 #  index_integration_customers_on_integration_id        (integration_id)
+#  index_integration_customers_on_organization_id       (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -9,6 +9,7 @@ module IntegrationCustomers
 
     belongs_to :customer
     belongs_to :integration, class_name: "Integrations::BaseIntegration"
+    belongs_to :organization, optional: true
 
     validates :customer_id, uniqueness: {scope: :type}
 
@@ -61,6 +62,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
+#  organization_id      :uuid
 #
 # Indexes
 #
@@ -68,9 +70,11 @@ end
 #  index_integration_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
 #  index_integration_customers_on_external_customer_id  (external_customer_id)
 #  index_integration_customers_on_integration_id        (integration_id)
+#  index_integration_customers_on_organization_id       (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/models/integration_customers/hubspot_customer.rb
+++ b/app/models/integration_customers/hubspot_customer.rb
@@ -26,6 +26,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
+#  organization_id      :uuid
 #
 # Indexes
 #
@@ -33,9 +34,11 @@ end
 #  index_integration_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
 #  index_integration_customers_on_external_customer_id  (external_customer_id)
 #  index_integration_customers_on_integration_id        (integration_id)
+#  index_integration_customers_on_organization_id       (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/models/integration_customers/netsuite_customer.rb
+++ b/app/models/integration_customers/netsuite_customer.rb
@@ -18,6 +18,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
+#  organization_id      :uuid
 #
 # Indexes
 #
@@ -25,9 +26,11 @@ end
 #  index_integration_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
 #  index_integration_customers_on_external_customer_id  (external_customer_id)
 #  index_integration_customers_on_integration_id        (integration_id)
+#  index_integration_customers_on_organization_id       (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/models/integration_customers/salesforce_customer.rb
+++ b/app/models/integration_customers/salesforce_customer.rb
@@ -17,6 +17,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
+#  organization_id      :uuid
 #
 # Indexes
 #
@@ -24,9 +25,11 @@ end
 #  index_integration_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
 #  index_integration_customers_on_external_customer_id  (external_customer_id)
 #  index_integration_customers_on_integration_id        (integration_id)
+#  index_integration_customers_on_organization_id       (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/models/integration_customers/xero_customer.rb
+++ b/app/models/integration_customers/xero_customer.rb
@@ -17,6 +17,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
+#  organization_id      :uuid
 #
 # Indexes
 #
@@ -24,9 +25,11 @@ end
 #  index_integration_customers_on_customer_id_and_type  (customer_id,type) UNIQUE
 #  index_integration_customers_on_external_customer_id  (external_customer_id)
 #  index_integration_customers_on_integration_id        (integration_id)
+#  index_integration_customers_on_organization_id       (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/integration_customers/anrok_service.rb
+++ b/app/services/integration_customers/anrok_service.rb
@@ -15,6 +15,7 @@ module IntegrationCustomers
       # For Anrok real customer sync happens with the first document sync. In the meantime,
       # integration customer object needs to be stored on Lago side
       new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
+        organization_id: integration.organization_id,
         integration:,
         customer:,
         type: "IntegrationCustomers::AnrokCustomer",

--- a/app/services/integration_customers/avalara_service.rb
+++ b/app/services/integration_customers/avalara_service.rb
@@ -23,6 +23,7 @@ module IntegrationCustomers
       return create_result if create_result.error || create_result.contact_id.nil?
 
       new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
+        organization_id: integration.organization_id,
         integration:,
         customer:,
         external_customer_id: create_result.contact_id,

--- a/app/services/integration_customers/create_service.rb
+++ b/app/services/integration_customers/create_service.rb
@@ -50,6 +50,7 @@ module IntegrationCustomers
       sync_with_provider = integration&.type&.to_s == "Integrations::SalesforceIntegration"
 
       new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
+        organization_id: integration.organization_id,
         integration:,
         customer:,
         external_customer_id: params[:external_customer_id],

--- a/app/services/integration_customers/hubspot_service.rb
+++ b/app/services/integration_customers/hubspot_service.rb
@@ -21,6 +21,7 @@ module IntegrationCustomers
       return create_result if create_result.error
 
       new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
+        organization_id: integration.organization_id,
         integration:,
         customer:,
         external_customer_id: create_result.contact_id,

--- a/app/services/integration_customers/netsuite_service.rb
+++ b/app/services/integration_customers/netsuite_service.rb
@@ -16,6 +16,7 @@ module IntegrationCustomers
       return create_result if create_result.error
 
       new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
+        organization_id: integration.organization_id,
         integration:,
         customer:,
         external_customer_id: create_result.contact_id,

--- a/app/services/integration_customers/salesforce_service.rb
+++ b/app/services/integration_customers/salesforce_service.rb
@@ -13,6 +13,7 @@ module IntegrationCustomers
 
     def create
       new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
+        organization_id: integration.organization_id,
         integration:,
         customer:,
         type: "IntegrationCustomers::SalesforceCustomer",

--- a/app/services/integration_customers/xero_service.rb
+++ b/app/services/integration_customers/xero_service.rb
@@ -21,6 +21,7 @@ module IntegrationCustomers
       return create_result if create_result.error
 
       new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
+        organization_id: integration.organization_id,
         integration:,
         customer:,
         external_customer_id: create_result.contact_id,

--- a/db/migrate/20250513153628_add_organization_id_to_integration_customers.rb
+++ b/db/migrate/20250513153628_add_organization_id_to_integration_customers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToIntegrationCustomers < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :integration_customers, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250513153629_add_organization_id_fk_to_integration_customers.rb
+++ b/db/migrate/20250513153629_add_organization_id_fk_to_integration_customers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToIntegrationCustomers < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :integration_customers, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250513153630_validate_integration_customers_organizations_foreign_key.rb
+++ b/db/migrate/20250513153630_validate_integration_customers_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateIntegrationCustomersOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :integration_customers, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -33,6 +33,7 @@ ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_d9ffb8
 ALTER TABLE IF EXISTS ONLY public.integration_resources DROP CONSTRAINT IF EXISTS fk_rails_d9448a540b;
 ALTER TABLE IF EXISTS ONLY public.idempotency_records DROP CONSTRAINT IF EXISTS fk_rails_d4f02c82b2;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_d07bc24ce3;
+ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_ce2c63d69f;
 ALTER TABLE IF EXISTS ONLY public.integration_mappings DROP CONSTRAINT IF EXISTS fk_rails_cc318ad1ff;
 ALTER TABLE IF EXISTS ONLY public.plans DROP CONSTRAINT IF EXISTS fk_rails_cbf700aeb8;
 ALTER TABLE IF EXISTS ONLY public.usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_caeb5a3949;
@@ -327,6 +328,7 @@ DROP INDEX IF EXISTS public.index_integration_resources_on_integration_id;
 DROP INDEX IF EXISTS public.index_integration_mappings_on_mappable;
 DROP INDEX IF EXISTS public.index_integration_mappings_on_integration_id;
 DROP INDEX IF EXISTS public.index_integration_items_on_integration_id;
+DROP INDEX IF EXISTS public.index_integration_customers_on_organization_id;
 DROP INDEX IF EXISTS public.index_integration_customers_on_integration_id;
 DROP INDEX IF EXISTS public.index_integration_customers_on_external_customer_id;
 DROP INDEX IF EXISTS public.index_integration_customers_on_customer_id_and_type;
@@ -2853,7 +2855,8 @@ CREATE TABLE public.integration_customers (
     type character varying NOT NULL,
     settings jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -5440,6 +5443,13 @@ CREATE INDEX index_integration_customers_on_integration_id ON public.integration
 
 
 --
+-- Name: index_integration_customers_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_integration_customers_on_organization_id ON public.integration_customers USING btree (organization_id);
+
+
+--
 -- Name: index_integration_items_on_integration_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7588,6 +7598,14 @@ ALTER TABLE ONLY public.integration_mappings
 
 
 --
+-- Name: integration_customers fk_rails_ce2c63d69f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.integration_customers
+    ADD CONSTRAINT fk_rails_ce2c63d69f FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: wallet_transactions fk_rails_d07bc24ce3; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7790,6 +7808,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250515083935'),
 ('20250515083802'),
 ('20250515083649'),
+('20250513153630'),
+('20250513153629'),
+('20250513153628'),
 ('20250513152807'),
 ('20250513152806'),
 ('20250513152805'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -28,7 +28,6 @@ Rspec.describe "All tables must have an organization_id" do
     %w[
       charge_filter_values
       integration_collection_mappings
-      integration_customers
       integration_items
       integration_mappings
       recurring_transaction_rules


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `integration_customers` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
