### PR TITLE
feat (avalara-integration): Cover void invoice flow

### DIFF
--- a/app/jobs/invoices/provider_taxes/void_job.rb
+++ b/app/jobs/invoices/provider_taxes/void_job.rb
@@ -6,7 +6,7 @@ module Invoices
       queue_as "integrations"
 
       def perform(invoice:)
-        return unless invoice.customer.anrok_customer
+        return unless invoice.customer.tax_customer
 
         # NOTE: We don't want to raise error here.
         #       If sync fails, invoice would be marked and retry option would be available in the UI

--- a/app/services/integrations/aggregator/taxes/credit_notes/payloads/avalara.rb
+++ b/app/services/integrations/aggregator/taxes/credit_notes/payloads/avalara.rb
@@ -63,13 +63,19 @@ module Integrations
                 "item_id" => fee.item_id,
                 "item_code" => mapped_item.external_id,
                 "unit" => fee.units,
-                "amount" => (item.sub_total_excluding_taxes_amount_cents.to_i * -1).fdiv(fee.amount.currency.subunit_to_unit)
+                "amount" => item_amount(item, fee)
               }
             end
 
             private
 
             attr_reader :customer, :integration_customer, :credit_note, :billing_entity
+
+            def item_amount(item, fee)
+              amount = (item.sub_total_excluding_taxes_amount_cents.to_i * -1).fdiv(fee.amount.currency.subunit_to_unit)
+
+              amount.to_s
+            end
           end
         end
       end

--- a/app/services/integrations/aggregator/taxes/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_service.rb
@@ -45,7 +45,9 @@ module Integrations
 
             invoice_data = payload_body.first
             invoice_data["id"] = invoice.id
-            invoice_data["type"] = "salesInvoice" if integration.type.to_s == "Integrations::AvalaraIntegration"
+            if integration.type.to_s == "Integrations::AvalaraIntegration"
+              invoice_data["type"] = invoice.voided? ? "returnInvoice" : "salesInvoice"
+            end
 
             [invoice_data]
           end

--- a/app/services/integrations/aggregator/taxes/invoices/payloads/avalara.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payloads/avalara.rb
@@ -76,7 +76,7 @@ module Integrations
             def item_amount(fee)
               amount = fee.sub_total_excluding_taxes_amount_cents&.to_i&.fdiv(fee.amount.currency.subunit_to_unit)
 
-              amount = amount * -1 if invoice.voided?
+              amount *= -1 if invoice.voided?
 
               amount
             end

--- a/app/services/integrations/aggregator/taxes/invoices/payloads/avalara.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payloads/avalara.rb
@@ -61,7 +61,7 @@ module Integrations
                 "item_id" => fee.id || fee.item_id,
                 "item_code" => mapped_item.external_id,
                 "unit" => fee.units,
-                "amount" => fee.sub_total_excluding_taxes_amount_cents&.to_i&.fdiv(fee.amount.currency.subunit_to_unit)
+                "amount" => item_amount(fee)
               }
             end
 
@@ -71,6 +71,14 @@ module Integrations
 
             def empty_struct
               @empty_struct ||= OpenStruct.new
+            end
+
+            def item_amount(fee)
+              amount = fee.sub_total_excluding_taxes_amount_cents&.to_i&.fdiv(fee.amount.currency.subunit_to_unit)
+
+              amount = amount * -1 if invoice.voided?
+
+              amount
             end
           end
         end

--- a/app/services/integrations/aggregator/taxes/invoices/void_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/void_service.rb
@@ -31,16 +31,17 @@ module Integrations
           private
 
           def payload
-            if integration.type.to_s == "Integrations::AnrokIntegration"
+            case integration.type.to_s
+            when "Integrations::AvalaraIntegration"
               [
                 {
+                  "company_code" => integration.company_code,
                   "id" => invoice.id
                 }
               ]
             else
               [
                 {
-                  "company_code" => integration.company_code,
                   "id" => invoice.id
                 }
               ]

--- a/app/services/integrations/aggregator/taxes/invoices/void_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/void_service.rb
@@ -11,7 +11,7 @@ module Integrations
 
           def call
             return result unless integration
-            return result unless integration.type == "Integrations::AnrokIntegration"
+            return result unless ::Integrations::BaseIntegration::INTEGRATION_TAX_TYPES.include?(integration.type)
 
             response = http_client.post_with_response(payload, headers)
             body = JSON.parse(response.body)
@@ -31,11 +31,20 @@ module Integrations
           private
 
           def payload
-            [
-              {
-                "id" => invoice.id
-              }
-            ]
+            if integration.type.to_s == "Integrations::AnrokIntegration"
+              [
+                {
+                  "id" => invoice.id
+                }
+              ]
+            else
+              [
+                {
+                  "company_code" => integration.company_code,
+                  "id" => invoice.id
+                }
+              ]
+            end
           end
         end
       end

--- a/app/services/invoices/provider_taxes/void_service.rb
+++ b/app/services/invoices/provider_taxes/void_service.rb
@@ -11,7 +11,7 @@ module Invoices
 
       def call
         return result.not_found_failure!(resource: "invoice") if invoice.blank?
-        return result.not_allowed_failure!(code: "not_voided") unless invoice.voided?
+        return result.not_allowed_failure!(code: "status_not_voided") unless invoice.voided?
 
         invoice.error_details.tax_voiding_error.discard_all
 
@@ -23,7 +23,7 @@ module Invoices
           unless negate_result.success?
             return result.validation_failure!(errors: {tax_error: [negate_result.error.code]})
           end
-        elsif locked_transaction?
+        elsif locked_transaction?(tax_result)
           refund_result = perform_invoice_refund
 
           unless refund_result.success?

--- a/app/services/invoices/provider_taxes/void_service.rb
+++ b/app/services/invoices/provider_taxes/void_service.rb
@@ -11,6 +11,7 @@ module Invoices
 
       def call
         return result.not_found_failure!(resource: "invoice") if invoice.blank?
+        return result.not_allowed_failure!(code: "not_voided") unless invoice.voided?
 
         invoice.error_details.tax_voiding_error.discard_all
 
@@ -21,6 +22,12 @@ module Invoices
 
           unless negate_result.success?
             return result.validation_failure!(errors: {tax_error: [negate_result.error.code]})
+          end
+        elsif locked_transaction?
+          refund_result = perform_invoice_refund
+
+          unless refund_result.success?
+            return result.validation_failure!(errors: {tax_error: [refund_result.error.code]})
           end
         elsif !tax_result.success?
           create_error_detail(tax_result.error.code)
@@ -47,6 +54,14 @@ module Invoices
         negate_result
       end
 
+      def perform_invoice_refund
+        refund_result = Integrations::Aggregator::Taxes::Invoices::CreateService.new(invoice:).call
+
+        create_error_detail(refund_result.error.code) unless refund_result.success?
+
+        refund_result
+      end
+
       def create_error_detail(code)
         error_result = ErrorDetails::CreateService.call(
           owner: invoice,
@@ -64,7 +79,15 @@ module Invoices
       # transactionFrozenForFiling error means that tax is already reported to the tax authority
       # We should call negate action instead
       def frozen_transaction?(tax_result)
+        return false unless invoice.customer.anrok_customer
+
         !tax_result.success? && tax_result.error.code == "transactionFrozenForFiling"
+      end
+
+      def locked_transaction?(tax_result)
+        return false unless invoice.customer.avalara_customer
+
+        !tax_result.success? && tax_result.error.code == "CannotModifyLockedTransaction"
       end
     end
   end

--- a/spec/fixtures/integration_aggregator/taxes/invoices/failure_response_locked_void.json
+++ b/spec/fixtures/integration_aggregator/taxes/invoices/failure_response_locked_void.json
@@ -1,0 +1,11 @@
+{
+  "succeededInvoices": [],
+  "failedInvoices": [
+    {
+      "id": "invoice_id",
+      "validation_errors": {
+        "type": "CannotModifyLockedTransaction"
+      }
+    }
+  ]
+}

--- a/spec/jobs/invoices/provider_taxes/void_job_spec.rb
+++ b/spec/jobs/invoices/provider_taxes/void_job_spec.rb
@@ -28,7 +28,20 @@ RSpec.describe Invoices::ProviderTaxes::VoidJob, type: :job do
     end
   end
 
-  context "when there is NOT anrok customer" do
+  context "when there is avalara customer" do
+    let(:integration) { create(:avalara_integration, organization:) }
+    let(:integration_customer) { create(:avalara_customer, integration:, customer:) }
+
+    before { integration_customer }
+
+    it "calls successfully void service" do
+      described_class.perform_now(invoice:)
+
+      expect(Invoices::ProviderTaxes::VoidService).to have_received(:call)
+    end
+  end
+
+  context "when there is NOT tax customer" do
     it "does not call void service" do
       described_class.perform_now(invoice:)
 

--- a/spec/services/integrations/aggregator/taxes/credit_notes/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/payloads/avalara_spec.rb
@@ -107,13 +107,13 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::Payloads::Avalara d
             "item_id" => fee_add_on.item_id,
             "item_code" => "m1",
             "unit" => 0.0,
-            "amount" => -1.90
+            "amount" => "-1.9"
           },
           {
             "item_id" => fee_add_on_two.item_id,
             "item_code" => "1",
             "unit" => 0.0,
-            "amount" => -1.62
+            "amount" => "-1.62"
           }
         ]
       }

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -217,6 +217,61 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
             expect(result.fees.first["tax_breakdown"].last["rate"]).to eq("0.00")
           end
         end
+
+        context "when invoice is voided" do
+          let(:params) do
+            [
+              {
+                "id" => invoice.id,
+                "type" => "returnInvoice",
+                "issuing_date" => invoice.issuing_date,
+                "currency" => invoice.currency,
+                "contact" => {
+                  "external_id" => "123",
+                  "name" => customer.name,
+                  "address_line_1" => customer.address_line1,
+                  "city" => customer.city,
+                  "zip" => customer.zipcode,
+                  "region" => customer.state,
+                  "country" => customer.country,
+                  "taxable" => false,
+                  "tax_number" => nil
+                },
+                "billing_entity" => {
+                  "address_line_1" => customer.billing_entity&.address_line1,
+                  "city" => customer.billing_entity&.city,
+                  "zip" => customer.billing_entity&.zipcode,
+                  "region" => customer.billing_entity&.state,
+                  "country" => customer.billing_entity&.country
+                },
+                "fees" => [
+                  {
+                    "item_key" => fee_add_on.item_key,
+                    "item_id" => fee_add_on.id,
+                    "item_code" => "m1",
+                    "unit" => 0.00,
+                    "amount" => -2.00
+                  },
+                  {
+                    "item_key" => fee_add_on_two.item_key,
+                    "item_id" => fee_add_on_two.id,
+                    "item_code" => "1",
+                    "unit" => 0.00,
+                    "amount" => -2.00
+                  }
+                ]
+              }
+            ]
+          end
+
+          before { invoice.voided! }
+
+          it "returns fees for valid request payload" do
+            result = service_call
+
+            expect(result).to be_success
+          end
+        end
       end
 
       context "when taxes are not successfully fetched for finalized invoice" do

--- a/spec/services/integrations/aggregator/taxes/invoices/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/payloads/avalara_spec.rb
@@ -114,5 +114,56 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::Payloads::Avalara do
     it "returns the payload body" do
       expect(call).to eq payload_body
     end
+
+    context "when invoice is voided" do
+      let(:payload_body) do
+        [
+          {
+            "issuing_date" => invoice.issuing_date,
+            "currency" => invoice.currency,
+            "contact" => {
+              "external_id" => integration_customer&.external_customer_id || customer.external_id,
+              "name" => customer.name,
+              "address_line_1" => customer.shipping_address_line1 || customer.address_line1,
+              "city" => customer.shipping_city || customer.city,
+              "zip" => customer.shipping_zipcode || customer.zipcode,
+              "region" => customer.shipping_state || customer.state,
+              "country" => customer.shipping_country || customer.country,
+              "taxable" => customer.tax_identification_number.present?,
+              "tax_number" => customer.tax_identification_number
+            },
+            "billing_entity" => {
+              "address_line_1" => customer.billing_entity.address_line1,
+              "city" => customer.billing_entity.city,
+              "zip" => customer.billing_entity.zipcode,
+              "region" => customer.billing_entity.state,
+              "country" => customer.billing_entity.country
+            },
+            "fees" => [
+              {
+                "item_key" => fee_add_on.item_key,
+                "item_id" => fee_add_on.id,
+                "item_code" => "m1",
+                "unit" => 1,
+                "amount" => -20.35
+              },
+              {
+                "item_key" => fee_add_on_two.item_key,
+                "item_id" => fee_add_on_two.id,
+                "item_code" => "1",
+                "unit" => 1,
+                "amount" => -20.35
+              }
+            ]
+          }
+        ]
+      end
+
+      before { invoice.voided! }
+
+      it "returns the payload body" do
+        expect(call).to eq payload_body
+      end
+    end
   end
 end

--- a/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
@@ -71,10 +71,8 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
         it "returns invoice_id" do
           result = service_call
 
-          aggregate_failures do
-            expect(result).to be_success
-            expect(result.invoice_id).to be_present
-          end
+          expect(result).to be_success
+          expect(result.invoice_id).to be_present
         end
       end
 
@@ -110,10 +108,8 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
         it "returns invoice_id" do
           result = service_call
 
-          aggregate_failures do
-            expect(result).to be_success
-            expect(result.invoice_id).to be_present
-          end
+          expect(result).to be_success
+          expect(result.invoice_id).to be_present
         end
       end
 
@@ -126,11 +122,9 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
         it "returns errors" do
           result = service_call
 
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::ServiceFailure)
-            expect(result.error.code).to eq("taxDateTooFarInFuture")
-          end
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq("taxDateTooFarInFuture")
         end
 
         it "delivers an error webhook" do
@@ -167,12 +161,10 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
         it "returns an error" do
           result = service_call
 
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.fees).to be(nil)
-            expect(result.error).to be_a(BaseService::ServiceFailure)
-            expect(result.error.code).to eq("action_script_runtime_error")
-          end
+          expect(result).not_to be_success
+          expect(result.fees).to be(nil)
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq("action_script_runtime_error")
         end
       end
     end

--- a/spec/services/invoices/provider_taxes/void_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/void_service_spec.rb
@@ -102,10 +102,8 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
       it "returns an error" do
         result = described_class.new(invoice: nil).call
 
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error.error_code).to eq("invoice_not_found")
-        end
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq("invoice_not_found")
       end
     end
 
@@ -115,10 +113,8 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
       it "returns an error" do
         result = void_service.call
 
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error.code).to eq("status_not_voided")
-        end
+        expect(result).not_to be_success
+        expect(result.error.code).to eq("status_not_voided")
       end
     end
 
@@ -126,10 +122,8 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
       it "returns successful result" do
         result = void_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.invoice.id).to eq(invoice.id)
-        end
+        expect(result).to be_success
+        expect(result.invoice.id).to eq(invoice.id)
       end
 
       it "discards previous tax errors" do
@@ -147,13 +141,11 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
       it "keeps invoice in voided status" do
         result = void_service.call
 
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(LagoHttpClient::Client).to have_received(:new).with(void_endpoint)
-          expect(LagoHttpClient::Client).not_to have_received(:new).with(negate_endpoint)
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(invoice.reload.status).to eq("voided")
-        end
+        expect(result).not_to be_success
+        expect(LagoHttpClient::Client).to have_received(:new).with(void_endpoint)
+        expect(LagoHttpClient::Client).not_to have_received(:new).with(negate_endpoint)
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(invoice.reload.status).to eq("voided")
       end
 
       it "resolves old tax error and creates new one" do
@@ -161,11 +153,9 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
 
         void_service.call
 
-        aggregate_failures do
-          expect(invoice.error_details.tax_voiding_error.last.id).not_to eql(old_error_id)
-          expect(invoice.error_details.tax_voiding_error.count).to be(1)
-          expect(invoice.error_details.tax_voiding_error.order(created_at: :asc).last.discarded?).to be(false)
-        end
+        expect(invoice.error_details.tax_voiding_error.last.id).not_to eql(old_error_id)
+        expect(invoice.error_details.tax_voiding_error.count).to be(1)
+        expect(invoice.error_details.tax_voiding_error.order(created_at: :asc).last).not_to be_discarded
       end
     end
 
@@ -182,13 +172,11 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
       it "keeps invoice in voided status" do
         result = void_service.call
 
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(LagoHttpClient::Client).to have_received(:new).with(void_endpoint)
-          expect(LagoHttpClient::Client).to have_received(:new).with(negate_endpoint)
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(invoice.reload.status).to eq("voided")
-        end
+        expect(result).not_to be_success
+        expect(LagoHttpClient::Client).to have_received(:new).with(void_endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(negate_endpoint)
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(invoice.reload.status).to eq("voided")
       end
 
       it "resolves old tax error and creates new one" do
@@ -196,11 +184,9 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
 
         void_service.call
 
-        aggregate_failures do
-          expect(invoice.error_details.tax_voiding_error.last.id).not_to eql(old_error_id)
-          expect(invoice.error_details.tax_voiding_error.count).to be(1)
-          expect(invoice.error_details.tax_voiding_error.order(created_at: :asc).last.discarded?).to be(false)
-        end
+        expect(invoice.error_details.tax_voiding_error.last.id).not_to eql(old_error_id)
+        expect(invoice.error_details.tax_voiding_error.count).to be(1)
+        expect(invoice.error_details.tax_voiding_error.order(created_at: :asc).last).not_to be_discarded
       end
     end
 
@@ -221,13 +207,11 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
       it "keeps invoice in voided status" do
         result = void_service.call
 
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(LagoHttpClient::Client).to have_received(:new).with(void_endpoint)
-          expect(LagoHttpClient::Client).to have_received(:new).with(negate_endpoint)
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(invoice.reload.status).to eq("voided")
-        end
+        expect(result).not_to be_success
+        expect(LagoHttpClient::Client).to have_received(:new).with(void_endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(negate_endpoint)
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(invoice.reload.status).to eq("voided")
       end
 
       it "resolves old tax error and creates new one" do
@@ -235,11 +219,9 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
 
         void_service.call
 
-        aggregate_failures do
-          expect(invoice.error_details.tax_voiding_error.last.id).not_to eql(old_error_id)
-          expect(invoice.error_details.tax_voiding_error.count).to be(1)
-          expect(invoice.error_details.tax_voiding_error.order(created_at: :asc).last.discarded?).to be(false)
-        end
+        expect(invoice.error_details.tax_voiding_error.last.id).not_to eql(old_error_id)
+        expect(invoice.error_details.tax_voiding_error.count).to be(1)
+        expect(invoice.error_details.tax_voiding_error.order(created_at: :asc).last).not_to be_discarded
       end
     end
   end


### PR DESCRIPTION
## Context

Lago is currently adding integration with tax provider Avalara.

## Description

This PR handles void invoice flow.

When invoice is voided in Lago it needs to be reported in the tax provider.

The only exception is when Avalara transaction is in the locked state. In that case, it is not possible to change transaction in any way, so we need to create negative transaction which will act as the refund.



This one is opened instead of https://github.com/getlago/lago-api/pull/3604