### PR TITLE
fix(avalara-integration): add small avalara payload fix

### DIFF
--- a/app/services/integrations/aggregator/taxes/invoices/payloads/avalara.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payloads/avalara.rb
@@ -74,11 +74,20 @@ module Integrations
             end
 
             def item_amount(fee)
-              amount = fee.sub_total_excluding_taxes_amount_cents&.to_i&.fdiv(fee.amount.currency.subunit_to_unit)
+              amount = fee.sub_total_excluding_taxes_amount_cents&.to_i&.fdiv(subunit_to_unit(fee))
 
               amount *= -1 if invoice.voided?
 
-              amount
+              amount.to_s
+            end
+
+            def subunit_to_unit(fee)
+              if fee.is_a?(Fee)
+                fee.amount.currency.subunit_to_unit
+              else
+                amount_cents = fee.amount_cents || fee.sub_total_excluding_taxes_amount_cents
+                Fee.new(amount_currency: invoice.currency, amount_cents:).amount.currency.subunit_to_unit
+              end
             end
           end
         end

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -184,14 +184,14 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
                   "item_id" => fee_add_on.id,
                   "item_code" => "m1",
                   "unit" => 0.00,
-                  "amount" => 2.00
+                  "amount" => "2.0"
                 },
                 {
                   "item_key" => fee_add_on_two.item_key,
                   "item_id" => fee_add_on_two.id,
                   "item_code" => "1",
                   "unit" => 0.00,
-                  "amount" => 2.00
+                  "amount" => "2.0"
                 }
               ]
             }
@@ -258,14 +258,14 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
                     "item_id" => fee_add_on.id,
                     "item_code" => "m1",
                     "unit" => 0.00,
-                    "amount" => -2.00
+                    "amount" => "-2.0"
                   },
                   {
                     "item_key" => fee_add_on_two.item_key,
                     "item_id" => fee_add_on_two.id,
                     "item_code" => "1",
                     "unit" => 0.00,
-                    "amount" => -2.00
+                    "amount" => "-2.0"
                   }
                 ]
               }

--- a/spec/services/integrations/aggregator/taxes/invoices/payloads/avalara_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/payloads/avalara_spec.rb
@@ -97,14 +97,14 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::Payloads::Avalara do
               "item_id" => fee_add_on.id,
               "item_code" => "m1",
               "unit" => 1,
-              "amount" => 20.35
+              "amount" => "20.35"
             },
             {
               "item_key" => fee_add_on_two.item_key,
               "item_id" => fee_add_on_two.id,
               "item_code" => "1",
               "unit" => 1,
-              "amount" => 20.35
+              "amount" => "20.35"
             }
           ]
         }
@@ -145,14 +145,14 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::Payloads::Avalara do
                 "item_id" => fee_add_on.id,
                 "item_code" => "m1",
                 "unit" => 1,
-                "amount" => -20.35
+                "amount" => "-20.35"
               },
               {
                 "item_key" => fee_add_on_two.item_key,
                 "item_id" => fee_add_on_two.id,
                 "item_code" => "1",
                 "unit" => 1,
-                "amount" => -20.35
+                "amount" => "-20.35"
               }
             ]
           }


### PR DESCRIPTION
## Context

Lago is currently adding integration with tax provider Avalara.

## Description

This PR fixes payload for reporting invoices in avalara. Amount needs to be string and subunit to unit conversion need to take  into account one-off form where taxes are fetched for non-existing fees