### PR TITLE
feat(AR): Force Rails to specify column list

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,9 @@
 
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  # NOTE: This fake column will force Rails to explicitly list columns in SELECT queries
+  #       instead of using `SELECT *`, which prevent theActiveRecord::PreparedStatementCacheExpired error on deploy
+  #       See: https://github.com/getlago/lago-api/pull/3640
+  self.ignored_columns += %i[__force_column_list__]
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Invoice < ApplicationRecord
-  self.ignored_columns += [:negative_amount_cents] # TODO: remove when negative_amount_cents is removed from the database
+  self.ignored_columns += [:negative_amount_cents]
 
   include AASM
   include PaperTrailTraceable

--- a/db/migrate/20230403093407_add_balance_cents_to_wallets.rb
+++ b/db/migrate/20230403093407_add_balance_cents_to_wallets.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+class ApplicationRecord
+  self.ignored_columns = []
+end
+
 class AddBalanceCentsToWallets < ActiveRecord::Migration[7.0]
   def change
     safety_assured do


### PR DESCRIPTION
## Context

Some `ActiveRecord::PreparedStatementCacheExpired` started popping up recently, always during deploy.

> ERROR: cached plan must not change result type (ActiveRecord::PreparedStatementCacheExpired)

## TL;DR

The DB uses some cache and when a table is modified (adding/removing column) it's invalidate the cache. If this happens in the middle of a transaction, it breaks!

The best solution is to force Rails to list all columns in select queries instead of using `SELECT *`. The cache will continue to be valid because the "result type" wasn't changed.

## Description

```
ActiveRecord::PreparedStatementCacheExpired
ERROR:  cached plan must not change result type (ActiveRecord::PreparedStatementCacheExpired)

PG::FeatureNotSupported
ERROR:  cached plan must not change result type (PG::FeatureNotSupported)
```

This is only an issue when the migration happened *during an open transaction*. Our pods are running during the migration so this happens *sometimes*. Then, all pods are "restarted" (rolling roll out).

### Solution

The only known way to force Rails to list all columns in a select query is to ignore columns. The feature is used to stop using a column before it's removed from the table.

To ensure all models have something in `self.ignored_columns` we add a fake name to the parent `ApplicationRecord`. The column doesn't have to exist.

https://flexport.engineering/avoiding-activerecord-preparedstatementcacheexpired-errors-4499a4f961cf
https://github.com/rails/rails/pull/22170

### Before / After

It's a little annoying because the query is getting very big and only a little bit is meaningful but it's a small price to pay.

![CleanShot 2025-05-14 at 09 28 55@2x](https://github.com/user-attachments/assets/bbac57ba-73ce-4c02-b3de-1139f1c6efbe)

![CleanShot 2025-05-14 at 09 29 05@2x](https://github.com/user-attachments/assets/01ac9b9d-39fe-4b69-a18a-bae045d4340f)

