### PR TITLE
fix(stripe): Ignore error if payment method is not attached

### DIFF
--- a/app/jobs/payment_providers/stripe/handle_event_job.rb
+++ b/app/jobs/payment_providers/stripe/handle_event_job.rb
@@ -20,6 +20,9 @@ module PaymentProviders
           event_json: event
         )
         result.raise_if_error!
+      rescue BaseService::ServiceFailure => e
+        # If the payment method wasn't attached to the customer, there is no need to retry to make it the default method
+        raise e unless e.message.include?("The customer does not have a payment method with the ID")
       end
     end
   end

--- a/app/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service.rb
@@ -20,8 +20,8 @@ module PaymentProviders
 
           result.stripe_customer = stripe_customer
           result
-        rescue ::Stripe::PermissionError => e
-          result.service_failure!(code: "stripe_error", message: e.message)
+        rescue ::Stripe::PermissionError, ::Stripe::InvalidRequestError => e
+          result.service_failure!(code: "stripe_error", message: e.message, error: e)
         end
 
         private


### PR DESCRIPTION
These dead jobs cannot be retried (they'll fail again).
Unfortunately, I'm not sure when this happens yet.