### PR TITLE
feat(stripe): Mark invoice as disputed for PaymentRequest

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -147,6 +147,10 @@ class Invoice < ApplicationRecord
     %w[customer]
   end
 
+  def payment_invoices
+    Invoice.where(id: id)
+  end
+
   def visible?
     !invisible?
   end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -49,6 +49,16 @@ class Payment < ApplicationRecord
       .where("invoices.id IS NOT NULL OR payment_requests.id IS NOT NULL")
   }
 
+  def invoices
+    if payable.is_a?(Invoice)
+      [payable]
+    elsif payable.is_a?(PaymentRequest)
+      payable.invoices.to_a
+    else
+      []
+    end
+  end
+
   def should_sync_payment?
     return false unless payable.is_a?(Invoice)
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -50,13 +50,7 @@ class Payment < ApplicationRecord
   }
 
   def invoices
-    if payable.is_a?(Invoice)
-      [payable]
-    elsif payable.is_a?(PaymentRequest)
-      payable.invoices.to_a
-    else
-      []
-    end
+    payable.payment_invoices
   end
 
   def should_sync_payment?

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -26,6 +26,10 @@ class PaymentRequest < ApplicationRecord
   monetize :amount_cents
   monetize :total_due_amount_cents, with_model_currency: :currency, allow_nil: true
 
+  def payment_invoices
+    invoices
+  end
+
   def invoice_ids
     applied_invoices.pluck(:invoice_id)
   end

--- a/app/services/payment_providers/adyen/webhooks/chargeback_service.rb
+++ b/app/services/payment_providers/adyen/webhooks/chargeback_service.rb
@@ -13,7 +13,7 @@ module PaymentProviders
           return result.not_found_failure!(resource: "adyen_payment") unless payment
 
           if status == "Lost" && event["success"] == "true"
-            return Invoices::LoseDisputeService.call(invoice: payment.payable, payment_dispute_lost_at:, reason:)
+            return ::Payments::LoseDisputeService.call(payment:, payment_dispute_lost_at:, reason:)
           end
 
           result

--- a/app/services/payment_providers/stripe/webhooks/charge_dispute_closed_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/charge_dispute_closed_service.rb
@@ -10,10 +10,10 @@ module PaymentProviders
           provider_payment_id = event.data.object.payment_intent
 
           payment = Payment.find_by(provider_payment_id:)
-          return result if !payment || !payment.payable.is_a?(Invoice)
+          return result unless payment
 
           if status == "lost"
-            return Invoices::LoseDisputeService.call(invoice: payment.payable, payment_dispute_lost_at:, reason:)
+            return ::Payments::LoseDisputeService.call(payment:, payment_dispute_lost_at:, reason:)
           end
 
           result

--- a/app/services/payments/lose_dispute_service.rb
+++ b/app/services/payments/lose_dispute_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Payments
+  class LoseDisputeService < BaseService
+    def initialize(payment:, payment_dispute_lost_at: nil, reason: nil)
+      @payment = payment
+      @payable = payment&.payable
+      @payment_dispute_lost_at = payment_dispute_lost_at.presence || Time.current
+      @reason = reason
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "payment") if payment.nil?
+      return result.not_found_failure!(resource: "payable") if payable.nil?
+
+      result.payment = payment
+      invoices = payment.invoices
+
+      ActiveRecord::Base.transaction do
+        invoices.each do |invoice|
+          invoice.mark_as_dispute_lost!(payment_dispute_lost_at)
+
+          after_commit do
+            SendWebhookJob.perform_later("invoice.payment_dispute_lost", invoice, provider_error: reason)
+            Invoices::ProviderTaxes::VoidJob.perform_later(invoice:)
+            if invoice.should_update_hubspot_invoice?
+              Integrations::Aggregator::Invoices::Hubspot::UpdateJob.perform_later(invoice:)
+            end
+          end
+        end
+      end
+
+      result.invoices = invoices
+      result
+    rescue ActiveRecord::RecordInvalid => _e
+      result.not_allowed_failure!(code: "not_disputable")
+    end
+
+    private
+
+    attr_reader :payment, :payable, :payment_dispute_lost_at, :reason
+  end
+end

--- a/spec/factories/payment_requests.rb
+++ b/spec/factories/payment_requests.rb
@@ -11,5 +11,15 @@ FactoryBot.define do
     payment_status { "pending" }
     ready_for_payment_processing { true }
     payment_attempts { 0 }
+
+    transient do
+      invoices { [] }
+    end
+
+    after(:create) do |payment_request, evaluator|
+      evaluator.invoices.each do |invoice|
+        PaymentRequest::AppliedInvoice.create!(payment_request:, invoice:)
+      end
+    end
   end
 end

--- a/spec/factories/payment_requests.rb
+++ b/spec/factories/payment_requests.rb
@@ -11,15 +11,5 @@ FactoryBot.define do
     payment_status { "pending" }
     ready_for_payment_processing { true }
     payment_attempts { 0 }
-
-    transient do
-      invoices { [] }
-    end
-
-    after(:create) do |payment_request, evaluator|
-      evaluator.invoices.each do |invoice|
-        PaymentRequest::AppliedInvoice.create!(payment_request:, invoice:)
-      end
-    end
   end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -308,6 +308,26 @@ RSpec.describe Payment, type: :model do
     end
   end
 
+  describe "#invoices" do
+    context "when payable is an invoice" do
+      let(:payable) { create(:invoice) }
+
+      it "returns the payable in an array" do
+        expect(subject.invoices).to eq([payable])
+      end
+    end
+
+    context "when payable is a payment request" do
+      let(:invoices) { create_list(:invoice, 2) }
+      let(:payable) { create(:payment_request, invoices:) }
+
+      it "returns the payable in an array" do
+        expect(subject.invoices).to be_a Array
+        expect(subject.invoices).to eq(invoices)
+      end
+    end
+  end
+
   describe "#payment_provider_type" do
     subject(:payment_provider_type) { payment.payment_provider_type }
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -312,8 +312,9 @@ RSpec.describe Payment, type: :model do
     context "when payable is an invoice" do
       let(:payable) { create(:invoice) }
 
-      it "returns the payable in an array" do
-        expect(subject.invoices).to eq([payable])
+      it "returns the invoice as a relationship" do
+        expect(subject.invoices).to be_a(ActiveRecord::Relation)
+        expect(subject.invoices.sole).to eq payable
       end
     end
 
@@ -322,7 +323,7 @@ RSpec.describe Payment, type: :model do
       let(:payable) { create(:payment_request, invoices:) }
 
       it "returns the payable in an array" do
-        expect(subject.invoices).to be_a Array
+        expect(subject.invoices).to be_a ActiveRecord::Relation
         expect(subject.invoices).to eq(invoices)
       end
     end

--- a/spec/services/payment_providers/adyen/webhooks/chargeback_service_spec.rb
+++ b/spec/services/payment_providers/adyen/webhooks/chargeback_service_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe PaymentProviders::Adyen::Webhooks::ChargebackService, type: :serv
   let(:membership) { create(:membership, organization:) }
   let(:customer) { create(:customer, organization:) }
   let(:payment) { create(:payment, payable: invoice, provider_payment_id: "9915555555555555") }
-  let(:lose_dispute_service) { Invoices::LoseDisputeService.new(invoice:) }
   let(:invoice) { create(:invoice, customer:, organization:, status:, payment_status: "succeeded") }
 
   describe "#call" do

--- a/spec/services/payment_providers/stripe/webhooks/charge_dispute_closed_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/charge_dispute_closed_service_spec.rb
@@ -10,42 +10,12 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::ChargeDisputeClosedService, t
   let(:membership) { create(:membership, organization:) }
   let(:customer) { create(:customer, organization:) }
   let(:payment) { create(:payment, payable:, provider_payment_id: "pi_3OzgpDH4tiDZlIUa0Ezzggtg") }
-  let(:lose_dispute_service) { Invoices::LoseDisputeService.new(payable:) }
   let(:event) { ::Stripe::Event.construct_from(JSON.parse(event_json)) }
+
+  before { allow(::Payments::LoseDisputeService).to receive(:call).and_call_original }
 
   describe "#call" do
     before { payment }
-
-    context "when payable is not an invoice" do
-      let(:payment) { create(:payment, payable:, provider_payment_id: "pi_3OzgpDH4tiDZlIUa0Ezzggtg") }
-      let(:payable) { create(:payment_request, customer:, organization:) }
-
-      before { allow(Invoices::LoseDisputeService).to receive(:call) }
-
-      context "when dispute is lost" do
-        let(:event_json) do
-          path = Rails.root.join("spec/fixtures/stripe/charge_dispute_lost_event.json")
-          File.read(path)
-        end
-
-        it "does not call LoseDisputeService" do
-          service.call
-          expect(Invoices::LoseDisputeService).not_to have_received(:call)
-        end
-      end
-
-      context "when dispute is won" do
-        let(:event_json) do
-          path = Rails.root.join("spec/fixtures/stripe/charge_dispute_won_event.json")
-          File.read(path)
-        end
-
-        it "does not call LoseDisputeService" do
-          service.call
-          expect(Invoices::LoseDisputeService).not_to have_received(:call)
-        end
-      end
-    end
 
     context "when payable is an invoice" do
       let(:payable) { create(:invoice, customer:, organization:, status:, payment_status: "succeeded") }
@@ -128,6 +98,46 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::ChargeDisputeClosedService, t
           it "does not deliver webhook" do
             expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
           end
+        end
+      end
+    end
+
+    context "when payable is a payment request" do
+      let(:payment) { create(:payment, payable:, provider_payment_id: "pi_3OzgpDH4tiDZlIUa0Ezzggtg") }
+      let(:payable) { create(:payment_request, customer:, organization:, invoices: [invoice_1, invoice_2]) }
+      let(:invoice_1) { create(:invoice, customer:, organization:, status: "finalized", payment_status: "succeeded") }
+      let(:invoice_2) { create(:invoice, customer:, organization:, status: "finalized", payment_status: "succeeded") }
+
+      context "when dispute is lost" do
+        let(:event_json) do
+          path = Rails.root.join("spec/fixtures/stripe/charge_dispute_lost_event.json")
+          File.read(path)
+        end
+
+        it "flags all the invoices of the PaymentRequests" do
+          service.call
+          expect(::Payments::LoseDisputeService).to have_received(:call)
+          expect(invoice_1.reload.payment_dispute_lost_at).to eq "2024-03-29 14:58:14 UTC"
+          expect(invoice_2.reload.payment_dispute_lost_at).to eq "2024-03-29 14:58:14 UTC"
+
+          expect(SendWebhookJob).to have_been_enqueued.once
+            .with("invoice.payment_dispute_lost", invoice_1, provider_error: "fraudulent")
+          expect(SendWebhookJob).to have_been_enqueued.once
+            .with("invoice.payment_dispute_lost", invoice_2, provider_error: "fraudulent")
+
+          expect(Invoices::ProviderTaxes::VoidJob).to have_been_enqueued.twice
+        end
+      end
+
+      context "when dispute is won" do
+        let(:event_json) do
+          path = Rails.root.join("spec/fixtures/stripe/charge_dispute_won_event.json")
+          File.read(path)
+        end
+
+        it "does not call LoseDisputeService" do
+          service.call
+          expect(::Payments::LoseDisputeService).not_to have_received(:call)
         end
       end
     end

--- a/spec/services/payments/lose_dispute_service_spec.rb
+++ b/spec/services/payments/lose_dispute_service_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Payments::LoseDisputeService, type: :service do
+  subject(:lose_dispute_service) { described_class.new(payment:) }
+
+  describe "#call" do
+    context "when payment does not exist" do
+      let(:payment) { nil }
+
+      it "returns a failure" do
+        result = lose_dispute_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq("payment")
+        end
+      end
+
+      it "does not enqueue a send webhook job for the invoice" do
+        expect { lose_dispute_service.call }.not_to have_enqueued_job(SendWebhookJob)
+      end
+    end
+
+    context "when payable is an invoice" do
+      let(:payment) { create(:payment, payable: create(:invoice, status:)) }
+
+      context "when the invoice is voided" do
+        let(:status) { :voided }
+
+        it "returns a failure" do
+          result = lose_dispute_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(result.error.code).to eq("not_disputable")
+        end
+
+        it "does not enqueue a send webhook job for the invoice" do
+          expect { lose_dispute_service.call }.not_to have_enqueued_job(SendWebhookJob)
+        end
+      end
+
+      context "when the invoice is draft" do
+        let(:status) { :draft }
+
+        it "returns a failure" do
+          result = lose_dispute_service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(result.error.code).to eq("not_disputable")
+        end
+
+        it "does not enqueue a send webhook job for the invoice" do
+          expect { lose_dispute_service.call }.not_to have_enqueued_job(SendWebhookJob)
+        end
+      end
+
+      context "when the invoice is finalized" do
+        let(:status) { :finalized }
+
+        it "marks the dispute as lost" do
+          result = lose_dispute_service.call
+
+          expect(result).to be_success
+          expect(result.invoices.sole.payment_dispute_lost_at).to be_present
+        end
+
+        it "enqueues a send webhook job for the invoice" do
+          expect do
+            lose_dispute_service.call
+          end.to have_enqueued_job(SendWebhookJob).with("invoice.payment_dispute_lost", payment.payable, provider_error: nil)
+        end
+
+        it "enqueues a sync void invoice job" do
+          expect do
+            lose_dispute_service.call
+          end.to have_enqueued_job(Invoices::ProviderTaxes::VoidJob).with(invoice: payment.payable)
+        end
+      end
+    end
+
+    context "when payable is a payment request" do
+      let(:payment_request) { create(:payment_request, invoices: create_list(:invoice, 3)) }
+      let(:payment) { create(:payment, payable: payment_request) }
+
+      it "marks all invoices as dispute lost" do
+        result = lose_dispute_service.call
+
+        expect(result).to be_success
+        expect(result.invoices.count).to eq 3
+        expect(result.invoices.pluck(:payment_dispute_lost_at)).to all be_within(5.seconds).of(Time.current)
+        expect(SendWebhookJob).to have_been_enqueued.exactly(3).times.with("invoice.payment_dispute_lost", Invoice, provider_error: nil)
+        expect(Invoices::ProviderTaxes::VoidJob).to have_been_enqueued.exactly(3).times
+      end
+    end
+  end
+end


### PR DESCRIPTION
A payment has `payable` which can be an Invoice or a `PaymentRequest`.

When a dispute is lost, Stripe sends a `charge.dispute.closed` webhook with the payment details included. When attached to an invoice, the invoice is flagged as disputed but it it was a PaymentRequest, it wasn't handled.

This PR loops over each invoices of the PaymentRequest and mark them as disputed.

The Adyen service was also updated and since the test don't mock the service call, but check the result, they don't need to be updated.


Note that the original `Invoices::LoseDisputeService` is still [used by GraphQL](https://github.com/getlago/lago-api/blob/b99e8a592fa2d736ce772ff0abff5257fc879543/app/graphql/mutations/invoices/lose_dispute.rb#L19) when marking an invoice as last.