### PR TITLE
misc: avoid ActiveRecord::PreparedStatementCacheExpired errors

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,8 @@
 
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  # Avoid raising ActiveRecord::PreparedStatementCacheExpired
+  # from transactions when a migration is adding a new column
+  self.ignored_columns = [:__fake_column__]
 end

--- a/db/migrate/20230403093407_add_balance_cents_to_wallets.rb
+++ b/db/migrate/20230403093407_add_balance_cents_to_wallets.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class AddBalanceCentsToWallets < ActiveRecord::Migration[7.0]
+  class Wallet < ApplicationRecord
+    self.ignored_columns = []
+  end
+
   def change
     safety_assured do
       change_table :wallets, bulk: true do |t|

--- a/db/migrate/20230626124005_migrate_organization_taxes.rb
+++ b/db/migrate/20230626124005_migrate_organization_taxes.rb
@@ -6,7 +6,9 @@ class MigrateOrganizationTaxes < ActiveRecord::Migration[7.0]
 
   class Tax < ApplicationRecord; end
 
-  class Customer < ApplicationRecord; end
+  class Customer < ApplicationRecord
+    self.ignored_columns = []
+  end
 
   class CustomersTax < ApplicationRecord; end
 

--- a/db/migrate/20250325145324_assign_customers_to_billing_entities.rb
+++ b/db/migrate/20250325145324_assign_customers_to_billing_entities.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class AssignCustomersToBillingEntities < ActiveRecord::Migration[7.2]
+  class Customer < ApplicationRecord
+    self.ignored_columns = []
+  end
+
   def change
     # NOTE: ensure first billing entity has the same id as the organization to ease the migration to multi entities.
     BillingEntity.where("id != organization_id").find_in_batches(batch_size: 1000) do |batch|

--- a/db/migrate/20250402135038_assign_discarded_customers_to_billing_entities.rb
+++ b/db/migrate/20250402135038_assign_discarded_customers_to_billing_entities.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class AssignDiscardedCustomersToBillingEntities < ActiveRecord::Migration[7.2]
+  class Customer < ApplicationRecord
+    self.ignored_columns = []
+  end
+
   def up
-    Customer.with_discarded.where("billing_entity_id != organization_id").or(Customer.with_discarded.where(billing_entity_id: nil)).find_in_batches(batch_size: 1000) do |batch|
-      Customer.with_discarded.where(id: batch.pluck(:id))
+    Customer.where("billing_entity_id != organization_id").or(Customer.where(billing_entity_id: nil)).find_in_batches(batch_size: 1000) do |batch|
+      Customer.where(id: batch.pluck(:id))
         .update_all("billing_entity_id = organization_id") # rubocop:disable Rails/SkipsModelValidations
     end
   end


### PR DESCRIPTION
## Context

In some context, when a migration is adding a new column to a table, Postgres might return a `cached plan must not change result type` in a transaction because the cached query plan is not more valid. This error is then raised as a `ActiveRecord::PreparedStatementCacheExpired` by Rails

See https://flexport.engineering/avoiding-activerecord-preparedstatementcacheexpired-errors-4499a4f961cf

## Description

This fix is forcing rails to query explicitly every columns in select instead of using `SELECT *`, so that the cached plan remains valid in the transaction. The only drawback will be with column removal, but it should never happen on a used field and would be prevented by `strong_migrations`
