### PR TITLE
fix(console): Fix console helpers

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Rails::ConsoleMethods
+Rails.application.console do
   if Rails.env.development?
     def gavin
       @gavin ||= hooli.users.find_by email: "gavin@hooli.com"


### PR DESCRIPTION
Rails 8.0 [removed deprecated Rails::ConsoleMethods](https://guides.rubyonrails.org/8_0_release_notes.html#railties), which broke our console helpers. 
This PR uses the new way of defining console helper, which I should have used from the beginning 😬

As I'm on support, I really miss the `find` helper!

https://github.com/getlago/lago-api/blob/009a8bbc03603bcda524061e2f493292ad943cb3/config/initializers/console.rb#L20-L28
