### PR TITLE
feat(multientities): add billing_entity_id to payment_receipts and mailers

### DIFF
--- a/app/mailers/credit_note_mailer.rb
+++ b/app/mailers/credit_note_mailer.rb
@@ -5,11 +5,11 @@ class CreditNoteMailer < ApplicationMailer
 
   def created
     @credit_note = params[:credit_note]
-    @organization = @credit_note.organization
     @customer = @credit_note.customer
-    @show_lago_logo = !@organization.remove_branding_watermark_enabled?
+    @billing_entity = @credit_note.billing_entity
+    @show_lago_logo = !@billing_entity.organization.remove_branding_watermark_enabled?
 
-    return if @organization.email.blank?
+    return if @billing_entity.email.blank?
     return if @customer.email.blank?
 
     if @pdfs_enabled
@@ -21,11 +21,11 @@ class CreditNoteMailer < ApplicationMailer
     I18n.with_locale(@customer.preferred_document_locale) do
       mail(
         to: @customer.email,
-        from: email_address_with_name(@organization.from_email_address, @organization.name),
-        reply_to: email_address_with_name(@organization.email, @organization.name),
+        from: email_address_with_name(@billing_entity.from_email_address, @billing_entity.name),
+        reply_to: email_address_with_name(@billing_entity.email, @billing_entity.name),
         subject: I18n.t(
           "email.credit_note.created.subject",
-          organization_name: @organization.name,
+          billing_entity_name: @billing_entity.name,
           credit_note_number: @credit_note.number
         )
       )

--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -5,10 +5,9 @@ class InvoiceMailer < ApplicationMailer
 
   def finalized
     @invoice = params[:invoice]
-    organization = @invoice.organization
     @billing_entity = @invoice.billing_entity
     @customer = @invoice.customer
-    @show_lago_logo = !organization.remove_branding_watermark_enabled?
+    @show_lago_logo = !@billing_entity.organization.remove_branding_watermark_enabled?
 
     return if @billing_entity.email.blank?
     return if @customer.email.blank?

--- a/app/mailers/payment_receipt_mailer.rb
+++ b/app/mailers/payment_receipt_mailer.rb
@@ -5,14 +5,14 @@ class PaymentReceiptMailer < ApplicationMailer
 
   def created
     @payment_receipt = params[:payment_receipt]
-    @organization = @payment_receipt.organization
+    @billing_entity = @payment_receipt.billing_entity
     @customer = @payment_receipt.payment.payable.customer
-    @show_lago_logo = !@organization.remove_branding_watermark_enabled?
+    @show_lago_logo = !@billing_entity.organization.remove_branding_watermark_enabled?
     @total_due_amount = @payment_receipt.payment.payable.is_a?(Invoice) ?
       @payment_receipt.payment.payable.total_due_amount :
       @payment_receipt.payment.payable.amount - @payment_receipt.payment.amount
 
-    return if @organization.email.blank?
+    return if @billing_entity.email.blank?
     return if @customer.email.blank?
 
     @invoices = if @payment_receipt.payment.payable.is_a?(Invoice)
@@ -34,11 +34,11 @@ class PaymentReceiptMailer < ApplicationMailer
     I18n.with_locale(@customer.preferred_document_locale) do
       mail(
         to: @customer.email,
-        from: email_address_with_name(@organization.from_email_address, @organization.name),
-        reply_to: email_address_with_name(@organization.email, @organization.name),
+        from: email_address_with_name(@billing_entity.from_email_address, @billing_entity.name),
+        reply_to: email_address_with_name(@billing_entity.email, @billing_entity.name),
         subject: I18n.t(
           "email.payment_receipt.created.subject",
-          organization_name: @organization.name,
+          billing_entity_name: @billing_entity.name,
           payment_receipt_number: @payment_receipt.number
         )
       )

--- a/app/mailers/payment_request_mailer.rb
+++ b/app/mailers/payment_request_mailer.rb
@@ -5,11 +5,11 @@ class PaymentRequestMailer < ApplicationMailer
 
   def requested
     @payment_request = params[:payment_request]
-    @organization = @payment_request.organization
-    @show_lago_logo = !@organization.remove_branding_watermark_enabled?
+    @billing_entity = @payment_request.billing_entity
+    @show_lago_logo = !@billing_entity.organization.remove_branding_watermark_enabled?
 
     return if @payment_request.email.blank?
-    return if @organization.email.blank?
+    return if @billing_entity.email.blank?
 
     @customer = @payment_request.customer
     @invoices = @payment_request.invoices
@@ -20,12 +20,12 @@ class PaymentRequestMailer < ApplicationMailer
     I18n.with_locale(@customer.preferred_document_locale) do
       mail(
         to: @payment_request.email,
-        from: email_address_with_name(@organization.from_email_address, @organization.name),
+        from: email_address_with_name(@billing_entity.from_email_address, @billing_entity.name),
         bcc: bcc_emails,
-        reply_to: email_address_with_name(@organization.email, @organization.name),
+        reply_to: email_address_with_name(@billing_entity.email, @billing_entity.name),
         subject: I18n.t(
           "email.payment_request.requested.subject",
-          organization_name: @organization.name
+          billing_entity_name: @billing_entity.name
         )
       )
     end

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -20,6 +20,7 @@ class BillingEntity < ApplicationRecord
   has_many :customers
   has_many :fees
   has_many :invoices
+  has_many :payment_receipts
   has_many :invoice_custom_section_selections, dependent: :destroy
 
   has_many :credit_notes, through: :invoices

--- a/app/models/payment_receipt.rb
+++ b/app/models/payment_receipt.rb
@@ -3,6 +3,7 @@
 class PaymentReceipt < ApplicationRecord
   belongs_to :payment
   belongs_to :organization
+  belongs_to :billing_entity
 
   has_one_attached :file
 
@@ -17,17 +18,19 @@ end
 #
 # Table name: payment_receipts
 #
-#  id              :uuid             not null, primary key
-#  number          :string           not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  organization_id :uuid             not null
-#  payment_id      :uuid             not null
+#  id                :uuid             not null, primary key
+#  number            :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  billing_entity_id :uuid             not null
+#  organization_id   :uuid             not null
+#  payment_id        :uuid             not null
 #
 # Indexes
 #
-#  index_payment_receipts_on_organization_id  (organization_id)
-#  index_payment_receipts_on_payment_id       (payment_id) UNIQUE
+#  index_payment_receipts_on_billing_entity_id  (billing_entity_id)
+#  index_payment_receipts_on_organization_id    (organization_id)
+#  index_payment_receipts_on_payment_id         (payment_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/services/payment_receipts/create_service.rb
+++ b/app/services/payment_receipts/create_service.rb
@@ -22,7 +22,7 @@ module PaymentReceipts
         return result
       end
 
-      result.payment_receipt = PaymentReceipt.create!(payment:, organization:)
+      result.payment_receipt = PaymentReceipt.create!(payment:, organization:, billing_entity:)
 
       SendWebhookJob.perform_later("payment_receipt.created", result.payment_receipt)
       GeneratePdfAndNotifyJob.perform_later(payment_receipt: result.payment_receipt, email: should_deliver_email?)

--- a/app/views/credit_note_mailer/created.slim
+++ b/app/views/credit_note_mailer/created.slim
@@ -1,7 +1,7 @@
 table cellpadding="0" cellspacing="0" style="margin: auto; padding-bottom: 24px"
   tr
     td style="color: #66758f; font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: center;"
-      = I18n.t('email.credit_note.created.credit_note_from', organization_name: @organization.name)
+      = I18n.t('email.credit_note.created.credit_note_from', billing_entity_name: @billing_entity.name)
   tr
     td style="color: #19212e; font-size: 32px; font-weight: 700; line-height: 40px; letter-spacing: 0em; text-align: center;"
       = @credit_note.total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))

--- a/app/views/payment_receipt_mailer/created.slim
+++ b/app/views/payment_receipt_mailer/created.slim
@@ -1,7 +1,7 @@
 table cellpadding="0" cellspacing="0" style="margin: auto; padding-bottom: 24px"
   tr
     td style="color: #66758f; font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: center;"
-      = I18n.t('email.payment_receipt.created.payment_receipt_from', organization_name: @organization.name)
+      = I18n.t('email.payment_receipt.created.payment_receipt_from', billing_entity_name: @billing_entity.name)
   tr
     td style="margin-bottom: 16px;font-style: normal;font-weight: 700;font-size: 32px;line-height: 40px;color: #19212E; text-align: center;"
       = MoneyHelper.format(@payment_receipt.payment.amount)

--- a/app/views/payment_request_mailer/requested.slim
+++ b/app/views/payment_request_mailer/requested.slim
@@ -1,7 +1,7 @@
 div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"
   = I18n.t("email.payment_request.requested.hello", customer_name: @customer.display_name)
 div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"
-  = I18n.t("email.payment_request.requested.reminder_overdue_balance", organization_name: @organization.name)
+  = I18n.t("email.payment_request.requested.reminder_overdue_balance", billing_entity_name: @billing_entity.name)
 div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"
   = I18n.t("email.payment_request.requested.total_amount_due", amount: MoneyHelper.format(@payment_request.amount))
 div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"

--- a/config/locales/de/email.yml
+++ b/config/locales/de/email.yml
@@ -3,7 +3,7 @@ de:
   email:
     credit_note:
       created:
-        credit_note_from: Gutschriftsbeleg von %{organization_name}
+        credit_note_from: Gutschriftsbeleg von %{billing_entity_name}
         credit_note_number: Gutschriftsbelegnummer
         credited_notice: Gutschrift auf Kundenkonto am %{date}
         credited_refunded_notice: Dem Kundenguthaben gutgeschrieben und am %{date} zurückerstattet
@@ -11,7 +11,7 @@ de:
         invoice_number: Rechnungsnummer
         issue_date: Ausstellungsdatum
         refunded_notice: Zurückerstattet am %{date}
-        subject: 'Dein Gutschriftsbeleg von %{organization_name} #%{credit_note_number}'
+        subject: 'Dein Gutschriftsbeleg von %{billing_entity_name} #%{credit_note_number}'
     invoice:
       finalized:
         download: Rechnung herunterladen, um Details anzuzeigen
@@ -23,8 +23,8 @@ de:
         subject: 'Deine Rechnung von %{billing_entity_name} #%{invoice_number}'
     payment_receipt:
       created:
-        payment_receipt_from: Zahlungsquittung von %{organization_name}
-        subject: 'Ihre Zahlungsquittung von %{organization_name} #%{payment_receipt_number}'
+        payment_receipt_from: Zahlungsquittung von %{billing_entity_name}
+        subject: 'Ihre Zahlungsquittung von %{billing_entity_name} #%{payment_receipt_number}'
     payment_request:
       requested:
         already_paid: Wenn Sie die Zahlung bereits vorgenommen haben, ignorieren Sie bitte diese E-Mail.
@@ -35,8 +35,8 @@ de:
           other: Unsere vertraglich vereinbarten Zahlungsbedingungen sind %{count} Tage.
           zero: Unsere vertraglich vereinbarten Zahlungsbedingungen erfordern die Zahlung bei Rechnungserstellung.
         remaining_amount: Restbetrag zu zahlen
-        reminder_overdue_balance: Dies ist eine Erinnerung des Finanzteams von %{organization_name}, dass einige Rechnungen überfällig sind.
-        subject: Ihr überfälliger Saldo von %{organization_name}
+        reminder_overdue_balance: Dies ist eine Erinnerung des Finanzteams von %{billing_entity_name}, dass einige Rechnungen überfällig sind.
+        subject: Ihr überfälliger Saldo von %{billing_entity_name}
         thank_you: Danke.
         total_amount_due: Der insgesamt fällige Betrag beträgt %{amount}.
     powered_by: Bereitgestellt von

--- a/config/locales/en/email.yml
+++ b/config/locales/en/email.yml
@@ -25,7 +25,7 @@ en:
         subject: Your Lago API key has been rolled
     credit_note:
       created:
-        credit_note_from: Credit Note from %{organization_name}
+        credit_note_from: Credit Note from %{billing_entity_name}
         credit_note_number: Credit note number
         credited_notice: Credited on customer balance on %{date}
         credited_refunded_notice: Credited on customer balance and refunded on %{date}
@@ -33,7 +33,7 @@ en:
         invoice_number: Invoice number
         issue_date: Issue date
         refunded_notice: Refunded on %{date}
-        subject: 'Your credit note from %{organization_name} #%{credit_note_number}'
+        subject: 'Your credit note from %{billing_entity_name} #%{credit_note_number}'
     data_export:
       completed:
         fallback_text: If the link has expired, please generate a new one from your Dashboard.
@@ -56,8 +56,8 @@ en:
       subject: Reset your Lago password
     payment_receipt:
       created:
-        payment_receipt_from: Payment receipt from %{organization_name}
-        subject: 'Your payment receipt from %{organization_name} #%{payment_receipt_number}'
+        payment_receipt_from: Payment receipt from %{billing_entity_name}
+        subject: 'Your payment receipt from %{billing_entity_name} #%{payment_receipt_number}'
     payment_request:
       requested:
         already_paid: If you have already made the payment, please disregard this email.
@@ -68,8 +68,8 @@ en:
           other: Our contractually agreed payment terms are %{count} days.
           zero: Our contractually agreed payment terms require payment upon invoice generation.
         remaining_amount: Remaining amount to pay
-        reminder_overdue_balance: This is a reminder from the %{organization_name} finance team that some invoices are overdue.
-        subject: Your overdue balance from %{organization_name}
+        reminder_overdue_balance: This is a reminder from the %{billing_entity_name} finance team that some invoices are overdue.
+        subject: Your overdue balance from %{billing_entity_name}
         thank_you: Thank you.
         total_amount_due: The total amount due is %{amount}.
     powered_by: Powered by

--- a/config/locales/es/email.yml
+++ b/config/locales/es/email.yml
@@ -3,7 +3,7 @@ es:
   email:
     credit_note:
       created:
-        credit_note_from: Nota de crédito de %{organization_name}
+        credit_note_from: Nota de crédito de %{billing_entity_name}
         credit_note_number: Número de nota de crédito
         credited_notice: Acreditado en el saldo del cliente el %{date}
         credited_refunded_notice: Acreditado en el saldo del cliente y reembolsado el %{date}
@@ -11,7 +11,7 @@ es:
         invoice_number: Número de factura
         issue_date: Fecha de emisión
         refunded_notice: Reembolso hecho el %{date}
-        subject: 'Tu nota de crédito de %{organization_name} #%{credit_note_number}'
+        subject: 'Tu nota de crédito de %{billing_entity_name} #%{credit_note_number}'
     invoice:
       finalized:
         download: Descargar factura para más detalles
@@ -23,8 +23,8 @@ es:
         subject: 'Tu factura de %{billing_entity_name} #%{invoice_number}'
     payment_receipt:
       created:
-        payment_receipt_from: Recibo de pago de %{organization_name}
-        subject: 'Tu recibo de pago de %{organization_name} #%{payment_receipt_number}'
+        payment_receipt_from: Recibo de pago de %{billing_entity_name}
+        subject: 'Tu recibo de pago de %{billing_entity_name} #%{payment_receipt_number}'
     payment_request:
       requested:
         already_paid: Si ya ha realizado el pago, por favor ignore este correo electrónico.
@@ -35,8 +35,8 @@ es:
           other: Nuestros términos de pago acordados contractualmente son %{count} días.
           zero: Nuestros términos de pago acordados contractualmente requieren el pago al generar la factura.
         remaining_amount: Monto restante a pagar
-        reminder_overdue_balance: Este es un recordatorio del equipo financiero de %{organization_name} de que algunas facturas están vencidas.
-        subject: Su saldo vencido de %{organization_name}
+        reminder_overdue_balance: Este es un recordatorio del equipo financiero de %{billing_entity_name} de que algunas facturas están vencidas.
+        subject: Su saldo vencido de %{billing_entity_name}
         thank_you: Gracias.
         total_amount_due: El monto total adeudado es de %{amount}.
     powered_by_lago: Powered by

--- a/config/locales/fr/email.yml
+++ b/config/locales/fr/email.yml
@@ -3,7 +3,7 @@ fr:
   email:
     credit_note:
       created:
-        credit_note_from: Votre avoir de %{organization_name}
+        credit_note_from: Votre avoir de %{billing_entity_name}
         credit_note_number: Avoir nº
         credited_notice: Crédité sur le solde du client le %{date}
         credited_refunded_notice: Crédité sur le solde du client et remboursé le %{date}
@@ -11,7 +11,7 @@ fr:
         invoice_number: Facture nº
         issue_date: Date d'émission
         refunded_notice: Remboursé le %{date}
-        subject: Votre avoir nº  %{credit_note_number} de %{organization_name}
+        subject: Votre avoir nº  %{credit_note_number} de %{billing_entity_name}
     invoice:
       finalized:
         download: Télécharger la facture pour plus de détails
@@ -23,8 +23,8 @@ fr:
         subject: Votre facture nº %{invoice_number} de %{billing_entity_name}
     payment_receipt:
       created:
-        payment_receipt_from: Reçu de paiement de %{organization_name}
-        subject: 'Votre reçu de paiement de %{organization_name} #%{payment_receipt_number}'
+        payment_receipt_from: Reçu de paiement de %{billing_entity_name}
+        subject: 'Votre reçu de paiement de %{billing_entity_name} #%{payment_receipt_number}'
     payment_request:
       requested:
         already_paid: Si vous avez déjà réglé ces factures, veuillez ignorer cet e-mail.
@@ -35,8 +35,8 @@ fr:
           other: Nos conditions de paiement convenues contractuellement sont de %{count} jours.
           zero: Nos conditions de paiement définies contractuellement exigent le paiement à la création de la facture.
         remaining_amount: Montant restant à payer
-        reminder_overdue_balance: Ceci est un rappel de l'équipe financière de %{organization_name} que certaines de vos factures sont arrivées à échéance et non réglées.
-        subject: Votre solde impayé pour %{organization_name}
+        reminder_overdue_balance: Ceci est un rappel de l'équipe financière de %{billing_entity_name} que certaines de vos factures sont arrivées à échéance et non réglées.
+        subject: Votre solde impayé pour %{billing_entity_name}
         thank_you: Merci.
         total_amount_due: Le montant total dû est de %{amount}.
     powered_by: Généré par

--- a/config/locales/it/email.yml
+++ b/config/locales/it/email.yml
@@ -3,7 +3,7 @@ it:
   email:
     credit_note:
       created:
-        credit_note_from: Nota di credito da %{organization_name}
+        credit_note_from: Nota di credito da %{billing_entity_name}
         credit_note_number: Numero Nota di Credito
         credited_notice: Accreditato sul saldo cliente il %{date}
         credited_refunded_notice: Accreditato sul saldo cliente e rimborsato il %{date}
@@ -11,7 +11,7 @@ it:
         invoice_number: Numero Fattura
         issue_date: Data Emissione
         refunded_notice: Rimborsato il %{date}
-        subject: 'La tua nota di credito da %{organization_name} #%{credit_note_number}'
+        subject: 'La tua nota di credito da %{billing_entity_name} #%{credit_note_number}'
     invoice:
       finalized:
         download: Scarica la fattura per ulteriori dettagli
@@ -23,8 +23,8 @@ it:
         subject: 'La tua fattura da %{billing_entity_name} #%{invoice_number}'
     payment_receipt:
       created:
-        payment_receipt_from: Ricevuta di pagamento da %{organization_name}
-        subject: 'La tua ricevuta di pagamento da %{organization_name} #%{payment_receipt_number}'
+        payment_receipt_from: Ricevuta di pagamento da %{billing_entity_name}
+        subject: 'La tua ricevuta di pagamento da %{billing_entity_name} #%{payment_receipt_number}'
     payment_request:
       requested:
         already_paid: Se hai già effettuato il pagamento, ti preghiamo di ignorare questa email.
@@ -35,8 +35,8 @@ it:
           other: I nostri termini di pagamento contrattualmente concordati sono %{count} giorni.
           zero: I nostri termini di pagamento contrattualmente concordati richiedono il pagamento al momento della generazione della fattura.
         remaining_amount: Importo residuo da pagare
-        reminder_overdue_balance: Questo è un promemoria del team finanziario di %{organization_name} che alcune fatture sono in ritardo.
-        subject: Il tuo saldo in ritardo da %{organization_name}
+        reminder_overdue_balance: Questo è un promemoria del team finanziario di %{billing_entity_name} che alcune fatture sono in ritardo.
+        subject: Il tuo saldo in ritardo da %{billing_entity_name}
         thank_you: Grazie.
         total_amount_due: L'importo totale dovuto è di %{amount}.
     powered_by: Elaborato da

--- a/config/locales/nb/email.yml
+++ b/config/locales/nb/email.yml
@@ -3,7 +3,7 @@ nb:
   email:
     credit_note:
       created:
-        credit_note_from: Kreditnota fra %{organization_name}
+        credit_note_from: Kreditnota fra %{billing_entity_name}
         credit_note_number: Kreditnota nummer
         credited_notice: Kreditert til kontobalanse %{date}
         credited_refunded_notice: Kreditert til kontobalanse og refundert %{date}
@@ -11,7 +11,7 @@ nb:
         invoice_number: Faktura nummer
         issue_date: Dato
         refunded_notice: Refundert %{date}
-        subject: 'Kreditnota din fra %{organization_name} #%{credit_note_number}'
+        subject: 'Kreditnota din fra %{billing_entity_name} #%{credit_note_number}'
     invoice:
       finalized:
         download: Last ned faktura for detaljer
@@ -23,8 +23,8 @@ nb:
         subject: 'Faktura fra %{billing_entity_name} #%{invoice_number}'
     payment_receipt:
       created:
-        payment_receipt_from: Betalingskvittering fra %{organization_name}
-        subject: 'Din betalingskvittering fra %{organization_name} #%{payment_receipt_number}'
+        payment_receipt_from: Betalingskvittering fra %{billing_entity_name}
+        subject: 'Din betalingskvittering fra %{billing_entity_name} #%{payment_receipt_number}'
     payment_request:
       requested:
         already_paid: Hvis du allerede har foretatt betalingen, vennligst se bort fra denne e-posten.
@@ -35,8 +35,8 @@ nb:
           other: Våre avtalte betalingsbetingelser er %{count} dager.
           zero: Våre avtalte betalingsbetingelser krever betaling ved fakturautstedelse.
         remaining_amount: Gjenstående beløp å betale
-        reminder_overdue_balance: Dette er en påminnelse fra økonomiavdelingen i %{organization_name} om at noen fakturaer er forfalt.
-        subject: Din forfalte saldo fra %{organization_name}
+        reminder_overdue_balance: Dette er en påminnelse fra økonomiavdelingen i %{billing_entity_name} om at noen fakturaer er forfalt.
+        subject: Din forfalte saldo fra %{billing_entity_name}
         thank_you: Takk.
         total_amount_due: Totalbeløpet som forfaller er %{amount}.
     powered_by: Fakturering drevet av

--- a/config/locales/sv/email.yml
+++ b/config/locales/sv/email.yml
@@ -3,7 +3,7 @@ sv:
   email:
     credit_note:
       created:
-        credit_note_from: Kreditfaktura från %{organization_name}
+        credit_note_from: Kreditfaktura från %{billing_entity_name}
         credit_note_number: Kreditfakturanummer
         credited_notice: Krediterad till kundens förbetalda kontobalans den %{date}
         credited_refunded_notice: Krediterad till kundens förbetalda kontobalans och återbetald den %{date}
@@ -11,7 +11,7 @@ sv:
         invoice_number: Fakturanummer
         issue_date: Fakturadatum
         refunded_notice: Återbetald den %{date}
-        subject: 'Din kreditfaktura från %{organization_name} #%{credit_note_number}'
+        subject: 'Din kreditfaktura från %{billing_entity_name} #%{credit_note_number}'
     invoice:
       finalized:
         download: Ladda ner fakturan för ytterligare information
@@ -23,8 +23,8 @@ sv:
         subject: 'Din faktura från %{billing_entity_name} #%{invoice_number}'
     payment_receipt:
       created:
-        payment_receipt_from: Betalningskvitto från %{organization_name}
-        subject: 'Ditt betalningskvitto från %{organization_name} #%{payment_receipt_number}'
+        payment_receipt_from: Betalningskvitto från %{billing_entity_name}
+        subject: 'Ditt betalningskvitto från %{billing_entity_name} #%{payment_receipt_number}'
     payment_request:
       requested:
         already_paid: Om du redan har gjort betalningen, vänligen bortse från detta mejl.
@@ -35,8 +35,8 @@ sv:
           other: Våra avtalsenliga betalningsvillkor är %{count} dagar.
           zero: Våra avtalsenliga betalningsvillkor kräver betalning vid fakturautställning.
         remaining_amount: Återstående belopp att betala
-        reminder_overdue_balance: Detta är en påminnelse från ekonomiavdelningen på %{organization_name} om att vissa fakturor är förfallna.
-        subject: Din förfallna saldo från %{organization_name}
+        reminder_overdue_balance: Detta är en påminnelse från ekonomiavdelningen på %{billing_entity_name} om att vissa fakturor är förfallna.
+        subject: Din förfallna saldo från %{billing_entity_name}
         thank_you: Tack.
         total_amount_due: Det totala förfallna beloppet är %{amount}.
     powered_by_lago: Powered by

--- a/db/migrate/20250515083649_add_billing_entity_id_to_payment_receipts.rb
+++ b/db/migrate/20250515083649_add_billing_entity_id_to_payment_receipts.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddBillingEntityIdToPaymentReceipts < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :payment_receipts, :billing_entity, type: :uuid, null: true, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250515083802_populate_payment_receipts_billing_entity_id.rb
+++ b/db/migrate/20250515083802_populate_payment_receipts_billing_entity_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PopulatePaymentReceiptsBillingEntityId < ActiveRecord::Migration[8.0]
+  def change
+    PaymentReceipt.where(billing_entity_id: nil).update_all("billing_entity_id = organization_id") # rubocop:disable Rails/SkipsModelValidations
+  end
+end

--- a/db/migrate/20250515083935_set_payment_receipts_not_null_constraint_on_billing_entity_id.rb
+++ b/db/migrate/20250515083935_set_payment_receipts_not_null_constraint_on_billing_entity_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SetPaymentReceiptsNotNullConstraintOnBillingEntityId < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :payment_receipts, "billing_entity_id IS NOT NULL", name: "payment_receipts_billing_entity_id_null", validate: false
+  end
+end

--- a/db/migrate/20250515085230_validate_set_payment_receipts_not_null_constraint_on_billing_entity_id.rb
+++ b/db/migrate/20250515085230_validate_set_payment_receipts_not_null_constraint_on_billing_entity_id.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ValidateSetPaymentReceiptsNotNullConstraintOnBillingEntityId < ActiveRecord::Migration[8.0]
+    def up
+      validate_check_constraint :payment_receipts, name: "payment_receipts_billing_entity_id_null"
+      change_column_null :payment_receipts, :billing_entity_id, false
+      remove_check_constraint :payment_receipts, name: "payment_receipts_billing_entity_id_null"
+    end
+
+    def down
+      add_check_constraint :payment_receipts, "billing_entity_id IS NOT NULL", name: "payment_receipts_billing_entity_id_null", validate: false
+      change_column_null :payment_receipts, :billing_entity_id, true
+    end
+end

--- a/db/migrate/20250515085230_validate_set_payment_receipts_not_null_constraint_on_billing_entity_id.rb
+++ b/db/migrate/20250515085230_validate_set_payment_receipts_not_null_constraint_on_billing_entity_id.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class ValidateSetPaymentReceiptsNotNullConstraintOnBillingEntityId < ActiveRecord::Migration[8.0]
-    def up
-      validate_check_constraint :payment_receipts, name: "payment_receipts_billing_entity_id_null"
-      change_column_null :payment_receipts, :billing_entity_id, false
-      remove_check_constraint :payment_receipts, name: "payment_receipts_billing_entity_id_null"
-    end
+  def up
+    validate_check_constraint :payment_receipts, name: "payment_receipts_billing_entity_id_null"
+    change_column_null :payment_receipts, :billing_entity_id, false
+    remove_check_constraint :payment_receipts, name: "payment_receipts_billing_entity_id_null"
+  end
 
-    def down
-      add_check_constraint :payment_receipts, "billing_entity_id IS NOT NULL", name: "payment_receipts_billing_entity_id_null", validate: false
-      change_column_null :payment_receipts, :billing_entity_id, true
-    end
+  def down
+    add_check_constraint :payment_receipts, "billing_entity_id IS NOT NULL", name: "payment_receipts_billing_entity_id_null", validate: false
+    change_column_null :payment_receipts, :billing_entity_id, true
+  end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -258,6 +258,7 @@ DROP INDEX IF EXISTS public.index_payment_requests_on_dunning_campaign_id;
 DROP INDEX IF EXISTS public.index_payment_requests_on_customer_id;
 DROP INDEX IF EXISTS public.index_payment_receipts_on_payment_id;
 DROP INDEX IF EXISTS public.index_payment_receipts_on_organization_id;
+DROP INDEX IF EXISTS public.index_payment_receipts_on_billing_entity_id;
 DROP INDEX IF EXISTS public.index_payment_providers_on_organization_id;
 DROP INDEX IF EXISTS public.index_payment_providers_on_code_and_organization_id;
 DROP INDEX IF EXISTS public.index_payment_provider_customers_on_provider_customer_id;
@@ -3125,7 +3126,8 @@ CREATE TABLE public.payment_receipts (
     payment_id uuid NOT NULL,
     organization_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    billing_entity_id uuid NOT NULL
 );
 
 
@@ -5846,6 +5848,13 @@ CREATE INDEX index_payment_providers_on_organization_id ON public.payment_provid
 
 
 --
+-- Name: index_payment_receipts_on_billing_entity_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_payment_receipts_on_billing_entity_id ON public.payment_receipts USING btree (billing_entity_id);
+
+
+--
 -- Name: index_payment_receipts_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7705,6 +7714,10 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250515085230'),
+('20250515083935'),
+('20250515083802'),
+('20250515083649'),
 ('20250512151248'),
 ('20250512151247'),
 ('20250512151246'),

--- a/spec/factories/payment_receipts.rb
+++ b/spec/factories/payment_receipts.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     number { Faker::Alphanumeric.alphanumeric(number: 12) }
     payment
     organization
+    billing_entity { organization&.default_billing_entity || association(:billing_entity) }
   end
 end

--- a/spec/mailers/credit_note_mailer_spec.rb
+++ b/spec/mailers/credit_note_mailer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CreditNoteMailer, type: :mailer do
       mailer = credit_note_mailer.with(credit_note:).created
 
       expect(mailer.to).to eq([credit_note.customer.email])
-      expect(mailer.reply_to).to eq([credit_note.organization.email])
+      expect(mailer.reply_to).to eq([credit_note.billing_entity.email])
       expect(mailer.attachments).not_to be_empty
       expect(mailer.attachments.first.filename).to eq("credit_note-#{credit_note.number}.pdf")
     end
@@ -50,9 +50,9 @@ RSpec.describe CreditNoteMailer, type: :mailer do
       end
     end
 
-    context "when organization email is nil" do
+    context "when billing entity email is nil" do
       before do
-        credit_note.organization.update(email: nil)
+        credit_note.billing_entity.update(email: nil)
       end
 
       it "returns a mailer with nil values" do

--- a/spec/mailers/payment_receipt_mailer_spec.rb
+++ b/spec/mailers/payment_receipt_mailer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PaymentReceiptMailer, type: :mailer do
       mailer = payment_receipt_mailer.with(payment_receipt:).created
 
       expect(mailer.to).to eq([payment_receipt.payment.payable.customer.email])
-      expect(mailer.reply_to).to eq([payment_receipt.organization.email])
+      expect(mailer.reply_to).to eq([payment_receipt.billing_entity.email])
       expect(mailer.attachments).not_to be_empty
       expect(mailer.attachments.first.filename).to eq("receipt-#{payment_receipt.number}.pdf")
     end
@@ -51,9 +51,9 @@ RSpec.describe PaymentReceiptMailer, type: :mailer do
       end
     end
 
-    context "when organization email is nil" do
+    context "when billing entity email is nil" do
       before do
-        payment_receipt.organization.update(email: nil)
+        payment_receipt.billing_entity.update(email: nil)
       end
 
       it "returns a mailer with nil values" do

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe BillingEntity, type: :model do
   it { is_expected.to have_many(:invoice_custom_section_selections) }
   it { is_expected.to have_many(:selected_invoice_custom_sections).through(:invoice_custom_section_selections) }
   it { is_expected.to have_many(:fees) }
+  it { is_expected.to have_many(:payment_receipts) }
   it { is_expected.to have_many(:subscriptions).through(:customers) }
   it { is_expected.to have_many(:wallets).through(:customers) }
   it { is_expected.to have_many(:wallet_transactions).through(:wallets) }

--- a/spec/models/payment_receipt_spec.rb
+++ b/spec/models/payment_receipt_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe PaymentReceipt, type: :model do
   it do
     expect(subject).to belong_to(:payment)
     expect(subject).to belong_to(:organization)
+    expect(subject).to belong_to(:billing_entity)
     expect(subject).to have_one_attached(:file)
   end
 

--- a/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
+++ b/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
@@ -156,10 +156,10 @@ describe "Dunning Campaign v1", :scenarios, type: :request do
       perform_dunning
       # NOTE: Email is sent twice: first synchronously after Stripe response, and then when the webhook is received
       expect(ActionMailer::Base.deliveries.count).to eq(2)
-      expect(ActionMailer::Base.deliveries.map(&:subject)).to all eq "Your overdue balance from JC AI"
+      expect(ActionMailer::Base.deliveries.map(&:subject)).to all eq "Your overdue balance from ACME Corp"
 
       mail = ActionMailer::Base.deliveries.last
-      expect(mail.subject).to eq "Your overdue balance from JC AI"
+      expect(mail.subject).to eq "Your overdue balance from ACME Corp"
 
       pr = customer.payment_requests.sole
       expect(pr.amount_cents).to eq(155_00)

--- a/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
+++ b/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
@@ -113,7 +113,7 @@ describe "Dunning Campaign v1", :scenarios, type: :request do
       )
       perform_billing
 
-      expect(webhooks_sent.map { _1["webhook_type"] }).to eq(%w[
+      expect(webhooks_sent.map { it["webhook_type"] }).to eq(%w[
         subscription.started
         invoice.created
         invoice.generated


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

## Description

- Add `billing_entity_id` to `payment_receipts` to identify the billing entity from which the payment receipt was issued.
- Migrate all existing payment receipts to have a `billing_entity_id`.
- Migrate payment receipts, payment requests, and credit notes mailers and templates to use the `billing_entity` as source of information.