### PR TITLE
fix(stripe): Deliver error webhook when wrong key for registering webhooks

### DIFF
--- a/app/services/payment_providers/stripe/register_webhook_service.rb
+++ b/app/services/payment_providers/stripe/register_webhook_service.rb
@@ -21,7 +21,7 @@ module PaymentProviders
         result
       rescue ActiveRecord::RecordInvalid => e
         result.record_validation_failure!(record: e.record)
-      rescue ::Stripe::AuthenticationError => e
+      rescue ::Stripe::AuthenticationError, ::Stripe::PermissionError => e
         deliver_error_webhook(action: "payment_provider.register_webhook", error: e)
         result
       rescue ::Stripe::InvalidRequestError => e


### PR DESCRIPTION
When setting up Stripe in Lago, you must use the private key, not the publishable one.
When registering webhook an error is raised by stripe but it wasn't forwarded to the users and created a dead job.

```
Stripe::PermissionError: This API call cannot be made with a publishable API key. Please use a secret API key. You can find a list of your API keys at https://dashboard.stripe.com/account/apikeys.
```