### PR TITLE
feat(console): Add `deadjobs_summary` helper

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -27,6 +27,10 @@ Rails.application.console do
     end
   end
 
+  def deadjobs_summary
+    Sidekiq::DeadSet.new.map { it.args[0]["job_class"] }.tally
+  end
+
   def enable_premium_integration!(org_id, integration_name)
     org = Organization.find(org_id)
     org.premium_integrations << integration_name


### PR DESCRIPTION
Going through your dead queue can be painful if one jobs failed a lot. You might miss more important jobs.

```
lago-api(dev)> deadjobs_summary
=>
{"Clock::ConsumeSubscriptionRefreshedQueueJob" => 7044,
 "Clock::ProcessAllSubscriptionActivitiesJob" => 14,
 "Clock::FreeTrialSubscriptionsBillerJob" => 1,
 "Clock::RefreshDraftInvoicesJob" => 1,
 "Clock::ActivateSubscriptionsJob" => 17,
 "SendHttpWebhookJob" => 9,
 "SendWebhookJob" => 29,
 "PaymentProviderCustomers::StripeCheckoutUrlJob" => 1,
 "Clock::SubscriptionsToBeTerminatedJob" => 2,
 "Clock::ComputeAllDailyUsagesJob" => 1,
 "Clock::TerminateEndedSubscriptionsJob" => 1,
 "Subscriptions::OrganizationBillingJob" => 1}
```