### PR TITLE
feat(avalara-integration): store avalara external transaction id

### DIFF
--- a/app/graphql/types/credit_notes/object.rb
+++ b/app/graphql/types/credit_notes/object.rb
@@ -85,7 +85,7 @@ module Types
       end
 
       def tax_provider_id
-        integration_customer = object.customer&.anrok_customer
+        integration_customer = object.customer&.tax_customer
         return nil unless integration_customer
 
         object.integration_resources.where(integration_id: integration_customer.integration_id).last&.external_id

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -72,6 +72,7 @@ module Types
       field :integration_syncable, GraphQL::Types::Boolean, null: false
       field :payable_type, GraphQL::Types::String, null: false
       field :payments, [Types::Payments::Object], null: true
+      field :tax_provider_id, String, null: true
       field :tax_provider_voidable, GraphQL::Types::Boolean, null: false
 
       def payable_type
@@ -157,6 +158,18 @@ module Types
 
       def associated_active_wallet_present
         object.associated_active_wallet.present?
+      end
+
+      def tax_provider_id
+        integration_customer = object.customer&.tax_customer
+        return nil unless integration_customer
+
+        IntegrationResource.find_by(
+          integration: integration_customer.integration,
+          syncable_id: object.id,
+          syncable_type: "Invoice",
+          resource_type: :invoice
+        )&.external_id
       end
     end
   end

--- a/app/services/integrations/aggregator/taxes/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_service.rb
@@ -20,6 +20,7 @@ module Integrations
 
             process_response(body)
             assign_external_customer_id
+            create_integration_resource if integration.type.to_s == "Integrations::AvalaraIntegration" && result.succeeded_id
 
             result
           rescue LagoHttpClient::HttpError => e
@@ -50,6 +51,16 @@ module Integrations
             end
 
             [invoice_data]
+          end
+
+          def create_integration_resource
+            IntegrationResource.create!(
+              syncable_id: invoice.id,
+              syncable_type: "Invoice",
+              external_id: result.succeeded_id,
+              integration_id: integration.id,
+              resource_type: :invoice
+            )
           end
         end
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -5263,6 +5263,7 @@ type Invoice {
   subTotalExcludingTaxesAmountCents: BigInt!
   subTotalIncludingTaxesAmountCents: BigInt!
   subscriptions: [Subscription!]
+  taxProviderId: String
   taxProviderVoidable: Boolean!
   taxStatus: InvoiceTaxStatusTypeEnum
   taxesAmountCents: BigInt!

--- a/schema.json
+++ b/schema.json
@@ -25777,6 +25777,18 @@
               "args": []
             },
             {
+              "name": "taxProviderId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "taxProviderVoidable",
               "description": null,
               "type": {

--- a/spec/fixtures/integration_aggregator/taxes/invoices/success_response.json
+++ b/spec/fixtures/integration_aggregator/taxes/invoices/success_response.json
@@ -1,6 +1,7 @@
 {
   "succeededInvoices": [
     {
+      "id": "inv_1234567890",
       "issuing_date": "2024-03-07",
       "sub_total_excluding_taxes": 9900,
       "taxes_amount_cents": 99,

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -66,5 +66,7 @@ RSpec.describe Types::Invoices::Object do
     expect(subject).to have_field(:integration_salesforce_syncable).of_type("Boolean!")
     expect(subject).to have_field(:integration_syncable).of_type("Boolean!")
     expect(subject).to have_field(:payments).of_type("[Payment!]")
+
+    expect(subject).to have_field(:tax_provider_id).of_type("String")
   end
 end

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -218,6 +218,12 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
           end
         end
 
+        it "creates integration resource" do
+          service_call
+
+          expect(invoice.reload.integration_resources.count).to eq(1)
+        end
+
         context "when invoice is voided" do
           let(:params) do
             [

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -143,6 +143,10 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
 
           expect(integration_customer.reload.external_customer_id).to eq(customer.external_id)
         end
+
+        it "does not create integration resource" do
+          expect { service_call }.not_to change { invoice.reload.integration_resources.count }
+        end
       end
 
       context "when Avalara taxes are successfully fetched for finalized invoice" do
@@ -219,9 +223,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
         end
 
         it "creates integration resource" do
-          service_call
-
-          expect(invoice.reload.integration_resources.count).to eq(1)
+          expect { service_call }.to change { invoice.reload.integration_resources.count }.by(1)
         end
 
         context "when invoice is voided" do


### PR DESCRIPTION
## Context

Currently Lago is implementing integration with Avalara tax tool

## Description

This PR stores external transaction ID and expose it in GQL. This information is used in the UI for constructing avalara transaction URL