### PR TITLE
Gql/plan bm relation

### DIFF
--- a/app/graphql/resolvers/billable_metrics_resolver.rb
+++ b/app/graphql/resolvers/billable_metrics_resolver.rb
@@ -15,6 +15,7 @@ module Resolvers
     argument :search_term, String, required: false
 
     argument :aggregation_types, [Types::BillableMetrics::AggregationTypeEnum], required: false
+    argument :plan_id, ID, required: false
 
     type Types::BillableMetrics::Object.collection_type, null: false
 
@@ -23,7 +24,7 @@ module Resolvers
         organization: current_organization,
         search_term: args[:search_term],
         pagination: {page: args[:page], limit: args[:limit]},
-        filters: args.slice(:recurring, :aggregation_types)
+        filters: args.slice(:recurring, :aggregation_types, :plan_id)
       )
 
       result.billable_metrics

--- a/app/queries/billable_metrics_query.rb
+++ b/app/queries/billable_metrics_query.rb
@@ -2,7 +2,7 @@
 
 class BillableMetricsQuery < BaseQuery
   Result = BaseResult[:billable_metrics]
-  Filters = BaseFilters[:organization_id, :recurring, :aggregation_types]
+  Filters = BaseFilters[:organization_id, :recurring, :aggregation_types, :plan_id]
 
   def call
     return result unless validate_filters.success?
@@ -13,6 +13,7 @@ class BillableMetricsQuery < BaseQuery
 
     metrics = with_recurring(metrics) unless filters.recurring.nil?
     metrics = with_aggregation_type(metrics) if filters.aggregation_types.present?
+    metrics = with_plan(metrics) if filters.plan_id.present?
 
     result.billable_metrics = metrics
     result
@@ -44,5 +45,9 @@ class BillableMetricsQuery < BaseQuery
 
   def with_aggregation_type(scope)
     scope.where(aggregation_type: filters.aggregation_types)
+  end
+
+  def with_plan(scope)
+    scope.joins(:charges).where(charges: {plan_id: filters.plan_id})
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -7504,7 +7504,7 @@ type Query {
   """
   Query billable metrics of an organization
   """
-  billableMetrics(aggregationTypes: [AggregationTypeEnum!], limit: Int, page: Int, recurring: Boolean, searchTerm: String): BillableMetricCollection!
+  billableMetrics(aggregationTypes: [AggregationTypeEnum!], limit: Int, page: Int, planId: ID, recurring: Boolean, searchTerm: String): BillableMetricCollection!
 
   """
   Query active billing_entities of an organization

--- a/schema.json
+++ b/schema.json
@@ -37383,6 +37383,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "planId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },

--- a/spec/queries/billable_metrics_query_spec.rb
+++ b/spec/queries/billable_metrics_query_spec.rb
@@ -145,4 +145,20 @@ RSpec.describe BillableMetricsQuery, type: :query do
       expect(returned_ids).not_to include(billable_metric_third.id)
     end
   end
+
+  context "when filtering by plan_id" do
+    let(:plan) { create(:plan, organization:) }
+    let(:charge) { create(:standard_charge, plan:, billable_metric: billable_metric_first) }
+    let(:filters) { {plan_id: plan.id} }
+
+    before { charge }
+
+    it "returns only billable metrics associated with the plan" do
+      expect(returned_ids.count).to eq(1)
+      expect(returned_ids).to include(billable_metric_first.id)
+      expect(returned_ids).not_to include(billable_metric_second.id)
+      expect(returned_ids).not_to include(billable_metric_third.id)
+      expect(returned_ids).not_to include(billable_metric_fourth.id)
+    end
+  end
 end


### PR DESCRIPTION
Add a way to filter billable metrics per `plan_id` to retrieve all BM used in a plan.

This is part of the Alerting feature.