### PR TITLE
Fix: rebuild invoices index

### DIFF
--- a/db/migrate/20250516084025_rebuild_invoice_index_on_billing_entity_sequential_id.rb
+++ b/db/migrate/20250516084025_rebuild_invoice_index_on_billing_entity_sequential_id.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RebuildInvoiceIndexOnBillingEntitySequentialId < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :invoices,
+                 [:billing_entity_id, :billing_entity_sequential_id],
+                 if_exists: true
+    add_index :invoices,
+              [:billing_entity_id, :billing_entity_sequential_id],
+              order: { billing_entity_sequential_id: :desc },
+              algorithm: :concurrently,
+              include: %i[self_billed],
+              unique: true,
+              if_not_exists: true
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20250516084025_rebuild_invoice_index_on_billing_entity_sequential_id.rb
+++ b/db/migrate/20250516084025_rebuild_invoice_index_on_billing_entity_sequential_id.rb
@@ -5,15 +5,15 @@ class RebuildInvoiceIndexOnBillingEntitySequentialId < ActiveRecord::Migration[8
 
   def up
     remove_index :invoices,
-                 [:billing_entity_id, :billing_entity_sequential_id],
-                 if_exists: true
+      [:billing_entity_id, :billing_entity_sequential_id],
+      if_exists: true
     add_index :invoices,
-              [:billing_entity_id, :billing_entity_sequential_id],
-              order: { billing_entity_sequential_id: :desc },
-              algorithm: :concurrently,
-              include: %i[self_billed],
-              unique: true,
-              if_not_exists: true
+      [:billing_entity_id, :billing_entity_sequential_id],
+      order: {billing_entity_sequential_id: :desc},
+      algorithm: :concurrently,
+      include: %i[self_billed],
+      unique: true,
+      if_not_exists: true
   end
 
   def down

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7714,6 +7714,7 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250516084025'),
 ('20250515085230'),
 ('20250515083935'),
 ('20250515083802'),


### PR DESCRIPTION
## Context

PGHero indicates that invoices indes on billing_entity_id and billing_entity_sequential_id is broken and suggests us to recreate it

## Description

- drop existing index
- create it again