### PR TITLE
chore(organization): Add organization_id to integration_items table

### DIFF
--- a/app/jobs/database_migrations/populate_integration_items_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_integration_items_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateIntegrationItemsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = IntegrationItem.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM integrations WHERE integrations.id = integration_items.integration_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/integration_item.rb
+++ b/app/models/integration_item.rb
@@ -4,6 +4,7 @@ class IntegrationItem < ApplicationRecord
   include PaperTrailTraceable
 
   belongs_to :integration, class_name: "Integrations::BaseIntegration"
+  belongs_to :organization, optional: true
 
   ITEM_TYPES = [
     :standard,
@@ -32,13 +33,16 @@ end
 #  updated_at            :datetime         not null
 #  external_id           :string           not null
 #  integration_id        :uuid             not null
+#  organization_id       :uuid
 #
 # Indexes
 #
 #  index_int_items_on_external_id_and_int_id_and_type  (external_id,integration_id,item_type) UNIQUE
 #  index_integration_items_on_integration_id           (integration_id)
+#  index_integration_items_on_organization_id          (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/integrations/aggregator/accounts_service.rb
+++ b/app/services/integrations/aggregator/accounts_service.rb
@@ -46,6 +46,7 @@ module Integrations
       def handle_accounts(new_items)
         new_items.each do |item|
           integration_item = IntegrationItem.new(
+            organization_id: integration.organization_id,
             integration:,
             external_id: item["id"],
             external_account_code: item["code"],

--- a/app/services/integrations/aggregator/items_service.rb
+++ b/app/services/integrations/aggregator/items_service.rb
@@ -46,6 +46,7 @@ module Integrations
       def handle_items(new_items)
         new_items.each do |item|
           integration_item = IntegrationItem.new(
+            organization_id: integration.organization_id,
             integration:,
             external_id: item["id"],
             external_account_code: item["account_code"],

--- a/db/migrate/20250516095313_add_organization_id_to_integration_items.rb
+++ b/db/migrate/20250516095313_add_organization_id_to_integration_items.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToIntegrationItems < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :integration_items, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250516095314_add_organization_id_fk_to_integration_items.rb
+++ b/db/migrate/20250516095314_add_organization_id_fk_to_integration_items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToIntegrationItems < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :integration_items, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250516095315_validate_integration_items_organizations_foreign_key.rb
+++ b/db/migrate/20250516095315_validate_integration_items_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateIntegrationItemsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :integration_items, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -123,6 +123,7 @@ ALTER TABLE IF EXISTS ONLY public.billable_metric_filters DROP CONSTRAINT IF EXI
 ALTER TABLE IF EXISTS ONLY public.payment_provider_customers DROP CONSTRAINT IF EXISTS fk_rails_50d46d3679;
 ALTER TABLE IF EXISTS ONLY public.charges DROP CONSTRAINT IF EXISTS fk_rails_4934f27a06;
 ALTER TABLE IF EXISTS ONLY public.webhooks DROP CONSTRAINT IF EXISTS fk_rails_49212d501e;
+ALTER TABLE IF EXISTS ONLY public.integration_items DROP CONSTRAINT IF EXISTS fk_rails_47d8081062;
 ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_4117574b51;
 ALTER TABLE IF EXISTS ONLY public.credit_notes DROP CONSTRAINT IF EXISTS fk_rails_41088c7d45;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_3ff27d7624;
@@ -329,6 +330,7 @@ DROP INDEX IF EXISTS public.index_integration_resources_on_integration_id;
 DROP INDEX IF EXISTS public.index_integration_mappings_on_organization_id;
 DROP INDEX IF EXISTS public.index_integration_mappings_on_mappable;
 DROP INDEX IF EXISTS public.index_integration_mappings_on_integration_id;
+DROP INDEX IF EXISTS public.index_integration_items_on_organization_id;
 DROP INDEX IF EXISTS public.index_integration_items_on_integration_id;
 DROP INDEX IF EXISTS public.index_integration_customers_on_organization_id;
 DROP INDEX IF EXISTS public.index_integration_customers_on_integration_id;
@@ -2874,7 +2876,8 @@ CREATE TABLE public.integration_items (
     external_account_code character varying,
     external_name character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -5460,6 +5463,13 @@ CREATE INDEX index_integration_items_on_integration_id ON public.integration_ite
 
 
 --
+-- Name: index_integration_items_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_integration_items_on_organization_id ON public.integration_items USING btree (organization_id);
+
+
+--
 -- Name: index_integration_mappings_on_integration_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6904,6 +6914,14 @@ ALTER TABLE ONLY public.credit_notes
 
 
 --
+-- Name: integration_items fk_rails_47d8081062; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.integration_items
+    ADD CONSTRAINT fk_rails_47d8081062 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: webhooks fk_rails_49212d501e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7825,6 +7843,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250516100026'),
 ('20250516100025'),
 ('20250516100024'),
+('20250516095315'),
+('20250516095314'),
+('20250516095313'),
 ('20250516084025'),
 ('20250515085230'),
 ('20250515083935'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -28,7 +28,6 @@ Rspec.describe "All tables must have an organization_id" do
     %w[
       charge_filter_values
       integration_collection_mappings
-      integration_items
       recurring_transaction_rules
       refunds
       versions


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `integration_items` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
