### PR TITLE
Fix/multientities/rebuild indexes

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -565,7 +565,7 @@ end
 #
 # Indexes
 #
-#  idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655  (billing_entity_id,billing_entity_sequential_id DESC) UNIQUE
+#  idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655  (billing_entity_id,billing_entity_sequential_id DESC)
 #  idx_on_organization_id_organization_sequential_id_2387146f54    (organization_id,organization_sequential_id DESC)
 #  index_invoices_on_billing_entity_id                             (billing_entity_id)
 #  index_invoices_on_customer_id                                   (customer_id)

--- a/db/migrate/20250516084025_rebuild_invoice_index_on_billing_entity_sequential_id.rb
+++ b/db/migrate/20250516084025_rebuild_invoice_index_on_billing_entity_sequential_id.rb
@@ -7,12 +7,12 @@ class RebuildInvoiceIndexOnBillingEntitySequentialId < ActiveRecord::Migration[8
     remove_index :invoices,
       [:billing_entity_id, :billing_entity_sequential_id],
       if_exists: true
+
     add_index :invoices,
       [:billing_entity_id, :billing_entity_sequential_id],
       order: {billing_entity_sequential_id: :desc},
       algorithm: :concurrently,
       include: %i[self_billed],
-      unique: true,
       if_not_exists: true
   end
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4123,7 +4123,7 @@ CREATE UNIQUE INDEX idx_on_amount_cents_plan_id_recurring_888044d66b ON public.u
 -- Name: idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655 ON public.invoices USING btree (billing_entity_id, billing_entity_sequential_id DESC) INCLUDE (self_billed);
+CREATE INDEX idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655 ON public.invoices USING btree (billing_entity_id, billing_entity_sequential_id DESC) INCLUDE (self_billed);
 
 
 --


### PR DESCRIPTION
## Context

Because of old invoices that got organization_sequential_id copied into billining_entity_sequential_id, we got not uniq values in billing_entity_sequential_id. For now we're adding this index as not uniq, will add uniqueness after the old invoices are fixed 
Another solution: add two indexes: before 2025 - all values, after 2025 with uniqueness...
