### PR TITLE
fix(service-error):fail the webhook if we cant have the payment metho…

### DIFF
--- a/app/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service.rb
@@ -20,7 +20,7 @@ module PaymentProviders
 
           result.stripe_customer = stripe_customer
           result
-        rescue ::Stripe::PermissionError => e
+        rescue ::Stripe::PermissionError, ::Stripe::InvalidRequestError => e
           result.service_failure!(code: "stripe_error", message: e.message)
         end
 

--- a/spec/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service_spec.rb
@@ -38,6 +38,20 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::SetupIntentSucceededService, 
       )
     end
 
+    context "when stripe fails to set default_payment_method", aggregate_failures: true do
+      before do
+        allow(Stripe::Customer).to receive(:update).and_raise(::Stripe::InvalidRequestError.new("test error", {}))
+      end
+
+      it "raises a service failure error" do
+        result = webhook_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.message).to eq("stripe_error: test error")
+      end
+    end
+
     context "when stripe customer is not found", aggregate_failures: true do
       let(:provider_customer_id) { "cus_InvaLid" }
 


### PR DESCRIPTION
Stripe sends us an event `setup_intent.succeeded` which we execute [this service](https://github.com/getlago/lago-api/blob/987e47c32f7bef83fd9d1056afc6eda508338753/app/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service.rb) to set the `invoice_settings.default_payment_method` but it may fail due to payment_method_id is not in the customer payment methods. 

For some unknown reason, some jobs failed with `Stripe::InvalidRequestError` and with the message `The customer does not have a payment method with the ID <payment_method_id>. The payment method must be attached to the customer.`

### Alternatives to fix
1. We can ignore the error for a moment and let it try again in the future.
2. We can check if the customer has that payment method is his payment methods list
When the user do not have the payment method, what would we do?
   1. Try to attach the payment method to the customer and let it continue.
   2. Do not attach the paymenet method, fail the job and let it retry later.

@vincent-pochet what do you think we should do?