### PR TITLE
feat(pricing_group_keys): Add validation logic for all charge models

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -55,9 +55,9 @@ class Charge < ApplicationRecord
 
   scope :pay_in_advance, -> { where(pay_in_advance: true) }
 
-  # def supports_grouped_by?
-  #   standard? || dynamic? ## Percentage | graduated percentage?? per_event_aggregation
-  # end
+  def supports_grouped_by?
+    standard? || dynamic?
+  end
 
   def equal_properties?(charge)
     charge_model == charge.charge_model && properties == charge.properties

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -60,9 +60,9 @@ class Charge < ApplicationRecord
 
   scope :pay_in_advance, -> { where(pay_in_advance: true) }
 
-  def supports_grouped_by?
-    standard? || dynamic?
-  end
+  # def supports_grouped_by?
+  #   standard? || dynamic? ## Percentage | graduated percentage?? per_event_aggregation
+  # end
 
   def equal_properties?(charge)
     charge_model == charge.charge_model && properties == charge.properties

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -3,6 +3,7 @@
 class ChargeFilter < ApplicationRecord
   include PaperTrailTraceable
   include Discard::Model
+  include ChargePropertiesValidation
   self.discard_column = :deleted_at
 
   belongs_to :charge, -> { with_discarded }, touch: true
@@ -49,29 +50,7 @@ class ChargeFilter < ApplicationRecord
   private
 
   def validate_properties
-    case charge&.charge_model
-    when "standard"
-      validate_charge_model(Charges::Validators::StandardService)
-    when "graduated"
-      validate_charge_model(Charges::Validators::GraduatedService)
-    when "package"
-      validate_charge_model(Charges::Validators::PackageService)
-    when "percentage"
-      validate_charge_model(Charges::Validators::PercentageService)
-    when "volume"
-      validate_charge_model(Charges::Validators::VolumeService)
-    when "graduated_percentage"
-      validate_charge_model(Charges::Validators::GraduatedPercentageService)
-    end
-  end
-
-  def validate_charge_model(validator)
-    instance = validator.new(charge:, properties:)
-    return if instance.valid?
-
-    instance.result.error.messages.map { |_, codes| codes }
-      .flatten
-      .each { |code| errors.add(:properties, code) }
+    validate_charge_model_properties(charge&.charge_model)
   end
 end
 

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -13,6 +13,8 @@ class ChargeFilter < ApplicationRecord
   has_many :billable_metric_filters, through: :values
   has_many :fees
 
+  has_one :billable_metric, through: :charge
+
   validate :validate_properties
 
   # NOTE: Ensure filters are keeping the initial ordering

--- a/app/models/concerns/charge_properties_validation.rb
+++ b/app/models/concerns/charge_properties_validation.rb
@@ -21,6 +21,6 @@ module ChargePropertiesValidation
     instance = validator.new(charge: self)
     return if instance.valid?
 
-    instance.result.error.messages.values.flatten.each { errors.add(:properties, _1) }
+    instance.result.error.messages.values.flatten.each { errors.add(:properties, it) }
   end
 end

--- a/app/models/concerns/charge_properties_validation.rb
+++ b/app/models/concerns/charge_properties_validation.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ChargePropertiesValidation
+  extend ActiveSupport::Concern
+
+  PROPERTIES_VALIDATORS = {
+    standard: Charges::Validators::StandardService,
+    graduated: Charges::Validators::GraduatedService,
+    package: Charges::Validators::PackageService,
+    percentage: Charges::Validators::PercentageService,
+    volume: Charges::Validators::VolumeService,
+    graduated_percentage: Charges::Validators::GraduatedPercentageService
+  }.freeze
+
+  def validate_charge_model_properties(charge_model)
+    return unless charge_model
+
+    validator = PROPERTIES_VALIDATORS[charge_model.to_sym]
+    validator ||= Charges::Validators::BaseService
+
+    instance = validator.new(charge: self)
+    return if instance.valid?
+
+    instance.result.error.messages.values.flatten.each { errors.add(:properties, _1) }
+  end
+end

--- a/app/services/charges/validators/base_service.rb
+++ b/app/services/charges/validators/base_service.rb
@@ -14,6 +14,8 @@ module Charges
       def valid?
         # NOTE: override and add validation rules
 
+        validate_grouped_by
+
         if errors?
           result.validation_failure!(errors:)
           return false
@@ -27,6 +29,17 @@ module Charges
       private
 
       attr_reader :charge
+
+      def grouped_by
+        properties["grouped_by"]
+      end
+
+      def validate_grouped_by
+        return if grouped_by.nil? || grouped_by.is_a?(Array) && grouped_by.blank?
+        return if grouped_by.is_a?(Array) && grouped_by.all? { |f| f.is_a?(String) } && grouped_by.all?(&:present?)
+
+        add_error(field: :grouped_by, error_code: "invalid_type")
+      end
     end
   end
 end

--- a/app/services/charges/validators/base_service.rb
+++ b/app/services/charges/validators/base_service.rb
@@ -14,7 +14,7 @@ module Charges
       def valid?
         # NOTE: override and add validation rules
 
-        validate_grouped_by
+        validate_pricing_group_keys
 
         if errors?
           result.validation_failure!(errors:)
@@ -30,15 +30,25 @@ module Charges
 
       attr_reader :charge
 
-      def grouped_by
-        properties["grouped_by"]
+      def pricing_group_keys
+        @pricing_group_keys ||= properties[grouped_key]
       end
 
-      def validate_grouped_by
-        return if grouped_by.nil? || grouped_by.is_a?(Array) && grouped_by.blank?
-        return if grouped_by.is_a?(Array) && grouped_by.all? { |f| f.is_a?(String) } && grouped_by.all?(&:present?)
+      # NOTE: keep accepting grouped_by until the end of the deprecation period
+      def grouped_key
+        return "pricing_group_keys" unless properties["pricing_group_keys"].nil?
 
-        add_error(field: :grouped_by, error_code: "invalid_type")
+        "grouped_by"
+      end
+
+      def validate_pricing_group_keys
+        return if pricing_group_keys.nil? || pricing_group_keys.is_a?(Array) && pricing_group_keys.blank?
+
+        if pricing_group_keys.is_a?(Array)
+          return if pricing_group_keys.all? { it.is_a?(String) } && pricing_group_keys.all?(&:present?)
+        end
+
+        add_error(field: grouped_key, error_code: "invalid_type")
       end
     end
   end

--- a/app/services/charges/validators/standard_service.rb
+++ b/app/services/charges/validators/standard_service.rb
@@ -5,7 +5,6 @@ module Charges
     class StandardService < Charges::Validators::BaseService
       def valid?
         validate_amount
-        validate_grouped_by
 
         super
       end
@@ -16,22 +15,10 @@ module Charges
         properties["amount"]
       end
 
-      def grouped_by
-        properties["grouped_by"]
-      end
-
       def validate_amount
         return if ::Validators::DecimalAmountService.new(amount).valid_amount?
 
         add_error(field: :amount, error_code: "invalid_amount")
-      end
-
-      # TODO: move it to the charge model
-      def validate_grouped_by
-        return if grouped_by.nil? || grouped_by.is_a?(Array) && grouped_by.blank?
-        return if grouped_by.is_a?(Array) && grouped_by.all? { |f| f.is_a?(String) } && grouped_by.all?(&:present?)
-
-        add_error(field: :grouped_by, error_code: "invalid_type")
       end
     end
   end

--- a/app/services/charges/validators/standard_service.rb
+++ b/app/services/charges/validators/standard_service.rb
@@ -26,6 +26,7 @@ module Charges
         add_error(field: :amount, error_code: "invalid_amount")
       end
 
+      # TODO: move it to the charge model
       def validate_grouped_by
         return if grouped_by.nil? || grouped_by.is_a?(Array) && grouped_by.blank?
         return if grouped_by.is_a?(Array) && grouped_by.all? { |f| f.is_a?(String) } && grouped_by.all?(&:present?)

--- a/spec/services/charges/validators/graduated_percentage_service_spec.rb
+++ b/spec/services/charges/validators/graduated_percentage_service_spec.rb
@@ -3,22 +3,40 @@
 require "rails_helper"
 
 RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service do
-  subject(:graduated_percentage_service) { described_class.new(charge:) }
+  subject(:validation_service) { described_class.new(charge:) }
 
-  let(:charge) do
-    build(
-      :graduated_percentage_charge,
-      properties: {graduated_percentage_ranges: ranges}
-    )
+  let(:charge) { build(:graduated_percentage_charge, properties:) }
+  let(:properties) { {graduated_percentage_ranges: ranges} }
+  let(:ranges) do
+    [
+      {
+        from_value: 0,
+        to_value: 10,
+        rate: "3",
+        flat_amount: "0"
+      },
+      {
+        from_value: 11,
+        to_value: 20,
+        rate: "2",
+        flat_amount: "20"
+      },
+      {
+        from_value: 21,
+        to_value: nil,
+        rate: "1",
+        flat_amount: "30"
+      }
+    ]
   end
 
-  let(:ranges) { {} }
-
   describe ".valid?" do
+    it { expect(validation_service).to be_valid }
+
     context "when billable metric is latest_agg" do
       let(:billable_metric) { create(:latest_billable_metric) }
-      let(:charge) { build(:graduated_percentage_charge, properties: graduated_percentage_ranges, billable_metric:) }
-      let(:graduated_percentage_ranges) do
+      let(:charge) { build(:graduated_percentage_charge, properties:, billable_metric:) }
+      let(:properties) do
         {
           graduated_percentage_ranges: ranges
         }
@@ -26,21 +44,23 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
 
       it "is invalid" do
         aggregate_failures do
-          expect(graduated_percentage_service).not_to be_valid
-          expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_percentage_service.result.error.messages.keys).to include(:billable_metric)
-          expect(graduated_percentage_service.result.error.messages[:billable_metric]).to include("invalid_value")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:billable_metric)
+          expect(validation_service.result.error.messages[:billable_metric]).to include("invalid_value")
         end
       end
     end
 
     context "with ranges validation" do
+      let(:ranges) { [] }
+
       it "ensures the presences of ranges" do
         aggregate_failures do
-          expect(graduated_percentage_service).not_to be_valid
-          expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_percentage_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
-          expect(graduated_percentage_service.result.error.messages[:graduated_percentage_ranges])
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
+          expect(validation_service.result.error.messages[:graduated_percentage_ranges])
             .to include("missing_graduated_percentage_ranges")
         end
       end
@@ -50,10 +70,10 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
 
         it "is invalid" do
           aggregate_failures do
-            expect(graduated_percentage_service).not_to be_valid
-            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(graduated_percentage_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
-            expect(graduated_percentage_service.result.error.messages[:graduated_percentage_ranges])
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
+            expect(validation_service.result.error.messages[:graduated_percentage_ranges])
               .to include("invalid_graduated_percentage_ranges")
           end
         end
@@ -64,10 +84,10 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
 
         it "is invalid" do
           aggregate_failures do
-            expect(graduated_percentage_service).not_to be_valid
-            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(graduated_percentage_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
-            expect(graduated_percentage_service.result.error.messages[:graduated_percentage_ranges])
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
+            expect(validation_service.result.error.messages[:graduated_percentage_ranges])
               .to include("invalid_graduated_percentage_ranges")
           end
         end
@@ -83,10 +103,10 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
 
         it "is invalid" do
           aggregate_failures do
-            expect(graduated_percentage_service).not_to be_valid
-            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(graduated_percentage_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
-            expect(graduated_percentage_service.result.error.messages[:graduated_percentage_ranges])
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
+            expect(validation_service.result.error.messages[:graduated_percentage_ranges])
               .to include("invalid_graduated_percentage_ranges")
           end
         end
@@ -102,10 +122,10 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
 
         it "is invalid" do
           aggregate_failures do
-            expect(graduated_percentage_service).not_to be_valid
-            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(graduated_percentage_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
-            expect(graduated_percentage_service.result.error.messages[:graduated_percentage_ranges])
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
+            expect(validation_service.result.error.messages[:graduated_percentage_ranges])
               .to include("invalid_graduated_percentage_ranges")
           end
         end
@@ -120,10 +140,10 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
 
         it "is invalid" do
           aggregate_failures do
-            expect(graduated_percentage_service).not_to be_valid
-            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(graduated_percentage_service.result.error.messages.keys).to include(:rate)
-            expect(graduated_percentage_service.result.error.messages[:rate]).to include("invalid_rate")
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:rate)
+            expect(validation_service.result.error.messages[:rate]).to include("invalid_rate")
           end
         end
       end
@@ -133,10 +153,10 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
 
         it "is invalid" do
           aggregate_failures do
-            expect(graduated_percentage_service).not_to be_valid
-            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(graduated_percentage_service.result.error.messages.keys).to include(:rate)
-            expect(graduated_percentage_service.result.error.messages[:rate]).to include("invalid_rate")
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:rate)
+            expect(validation_service.result.error.messages[:rate]).to include("invalid_rate")
           end
         end
       end
@@ -146,10 +166,10 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
 
         it "is invalid" do
           aggregate_failures do
-            expect(graduated_percentage_service).not_to be_valid
-            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(graduated_percentage_service.result.error.messages.keys).to include(:rate)
-            expect(graduated_percentage_service.result.error.messages[:rate]).to include("invalid_rate")
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:rate)
+            expect(validation_service.result.error.messages[:rate]).to include("invalid_rate")
           end
         end
       end
@@ -163,10 +183,10 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
 
         it "is invalid" do
           aggregate_failures do
-            expect(graduated_percentage_service).not_to be_valid
-            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(graduated_percentage_service.result.error.messages.keys).to include(:flat_amount)
-            expect(graduated_percentage_service.result.error.messages[:flat_amount]).to include("invalid_amount")
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:flat_amount)
+            expect(validation_service.result.error.messages[:flat_amount]).to include("invalid_amount")
           end
         end
       end
@@ -176,10 +196,10 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
 
         it "is invalid" do
           aggregate_failures do
-            expect(graduated_percentage_service).not_to be_valid
-            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(graduated_percentage_service.result.error.messages.keys).to include(:flat_amount)
-            expect(graduated_percentage_service.result.error.messages[:flat_amount]).to include("invalid_amount")
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:flat_amount)
+            expect(validation_service.result.error.messages[:flat_amount]).to include("invalid_amount")
           end
         end
       end
@@ -189,40 +209,19 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
 
         it "is invalid" do
           aggregate_failures do
-            expect(graduated_percentage_service).not_to be_valid
-            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(graduated_percentage_service.result.error.messages.keys).to include(:flat_amount)
-            expect(graduated_percentage_service.result.error.messages[:flat_amount]).to include("invalid_amount")
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:flat_amount)
+            expect(validation_service.result.error.messages[:flat_amount]).to include("invalid_amount")
           end
         end
       end
     end
 
-    context "with applicable ranges" do
-      let(:ranges) do
-        [
-          {
-            from_value: 0,
-            to_value: 10,
-            rate: "3",
-            flat_amount: "0"
-          },
-          {
-            from_value: 11,
-            to_value: 20,
-            rate: "2",
-            flat_amount: "20"
-          },
-          {
-            from_value: 21,
-            to_value: nil,
-            rate: "1",
-            flat_amount: "30"
-          }
-        ]
+    it_behaves_like "pricing_group_keys property validation" do
+      let(:properties) do
+        {"graduated_percentage_ranges" => ranges}.merge(grouping_properties)
       end
-
-      it { expect(graduated_percentage_service).to be_valid }
     end
   end
 end

--- a/spec/services/charges/validators/graduated_service_spec.rb
+++ b/spec/services/charges/validators/graduated_service_spec.rb
@@ -3,21 +3,47 @@
 require "rails_helper"
 
 RSpec.describe Charges::Validators::GraduatedService, type: :service do
-  subject(:graduated_service) { described_class.new(charge:) }
+  subject(:validation_service) { described_class.new(charge:) }
 
-  let(:charge) { build(:graduated_charge, properties: {graduated_ranges: ranges}) }
+  let(:charge) { build(:graduated_charge, properties:) }
 
+  let(:properties) { {"graduated_ranges" => ranges} }
   let(:ranges) do
-    []
+    [
+      {
+        from_value: 0,
+        to_value: 10,
+        per_unit_amount: "0",
+        flat_amount: "0"
+      },
+      {
+        from_value: 11,
+        to_value: 20,
+        per_unit_amount: "10",
+        flat_amount: "20"
+      },
+      {
+        from_value: 21,
+        to_value: nil,
+        per_unit_amount: "15",
+        flat_amount: "30"
+      }
+    ]
   end
 
   describe ".valid?" do
-    it "ensures the presence of ranges" do
-      aggregate_failures do
-        expect(graduated_service).not_to be_valid
-        expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-        expect(graduated_service.result.error.messages.keys).to include(:graduated_ranges)
-        expect(graduated_service.result.error.messages[:graduated_ranges]).to include("missing_graduated_ranges")
+    it { expect(validation_service).to be_valid }
+
+    context "with empty ranges" do
+      let(:ranges) { [] }
+
+      it "ensures the presence of ranges" do
+        aggregate_failures do
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:graduated_ranges)
+          expect(validation_service.result.error.messages[:graduated_ranges]).to include("missing_graduated_ranges")
+        end
       end
     end
 
@@ -28,10 +54,10 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(graduated_service).not_to be_valid
-          expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:graduated_ranges)
-          expect(graduated_service.result.error.messages[:graduated_ranges]).to include("invalid_graduated_ranges")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:graduated_ranges)
+          expect(validation_service.result.error.messages[:graduated_ranges]).to include("invalid_graduated_ranges")
         end
       end
     end
@@ -43,10 +69,10 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(graduated_service).not_to be_valid
-          expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:graduated_ranges)
-          expect(graduated_service.result.error.messages[:graduated_ranges]).to include("invalid_graduated_ranges")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:graduated_ranges)
+          expect(validation_service.result.error.messages[:graduated_ranges]).to include("invalid_graduated_ranges")
         end
       end
     end
@@ -61,10 +87,10 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(graduated_service).not_to be_valid
-          expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:graduated_ranges)
-          expect(graduated_service.result.error.messages[:graduated_ranges]).to include("invalid_graduated_ranges")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:graduated_ranges)
+          expect(validation_service.result.error.messages[:graduated_ranges]).to include("invalid_graduated_ranges")
         end
       end
     end
@@ -79,10 +105,10 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(graduated_service).not_to be_valid
-          expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:graduated_ranges)
-          expect(graduated_service.result.error.messages[:graduated_ranges]).to include("invalid_graduated_ranges")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:graduated_ranges)
+          expect(validation_service.result.error.messages[:graduated_ranges]).to include("invalid_graduated_ranges")
         end
       end
     end
@@ -94,10 +120,10 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(graduated_service).not_to be_valid
-          expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:per_unit_amount)
-          expect(graduated_service.result.error.messages[:per_unit_amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:per_unit_amount)
+          expect(validation_service.result.error.messages[:per_unit_amount]).to include("invalid_amount")
         end
       end
     end
@@ -109,10 +135,10 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(graduated_service).not_to be_valid
-          expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:per_unit_amount)
-          expect(graduated_service.result.error.messages[:per_unit_amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:per_unit_amount)
+          expect(validation_service.result.error.messages[:per_unit_amount]).to include("invalid_amount")
         end
       end
     end
@@ -124,10 +150,10 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(graduated_service).not_to be_valid
-          expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:per_unit_amount)
-          expect(graduated_service.result.error.messages[:per_unit_amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:per_unit_amount)
+          expect(validation_service.result.error.messages[:per_unit_amount]).to include("invalid_amount")
         end
       end
     end
@@ -139,10 +165,10 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(graduated_service).not_to be_valid
-          expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:flat_amount)
-          expect(graduated_service.result.error.messages[:flat_amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:flat_amount)
+          expect(validation_service.result.error.messages[:flat_amount]).to include("invalid_amount")
         end
       end
     end
@@ -154,10 +180,10 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(graduated_service).not_to be_valid
-          expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:flat_amount)
-          expect(graduated_service.result.error.messages[:flat_amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:flat_amount)
+          expect(validation_service.result.error.messages[:flat_amount]).to include("invalid_amount")
         end
       end
     end
@@ -169,39 +195,16 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(graduated_service).not_to be_valid
-          expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:flat_amount)
-          expect(graduated_service.result.error.messages[:flat_amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:flat_amount)
+          expect(validation_service.result.error.messages[:flat_amount]).to include("invalid_amount")
         end
       end
     end
 
-    context "with applicable ranges" do
-      let(:ranges) do
-        [
-          {
-            from_value: 0,
-            to_value: 10,
-            per_unit_amount: "0",
-            flat_amount: "0"
-          },
-          {
-            from_value: 11,
-            to_value: 20,
-            per_unit_amount: "10",
-            flat_amount: "20"
-          },
-          {
-            from_value: 21,
-            to_value: nil,
-            per_unit_amount: "15",
-            flat_amount: "30"
-          }
-        ]
-      end
-
-      it { expect(graduated_service).to be_valid }
+    it_behaves_like "pricing_group_keys property validation" do
+      let(:properties) { {"graduated_ranges" => ranges}.merge(grouping_properties) }
     end
   end
 end

--- a/spec/services/charges/validators/package_service_spec.rb
+++ b/spec/services/charges/validators/package_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Charges::Validators::PackageService, type: :service do
-  subject(:package_service) { described_class.new(charge:) }
+  subject(:validation_service) { described_class.new(charge:) }
 
   let(:charge) { build(:package_charge, properties: package_properties) }
 
@@ -16,7 +16,7 @@ RSpec.describe Charges::Validators::PackageService, type: :service do
   end
 
   describe ".valid?" do
-    it { expect(package_service).to be_valid }
+    it { expect(validation_service).to be_valid }
 
     context "without amount" do
       let(:package_properties) do
@@ -28,10 +28,10 @@ RSpec.describe Charges::Validators::PackageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(package_service).not_to be_valid
-          expect(package_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(package_service.result.error.messages.keys).to include(:amount)
-          expect(package_service.result.error.messages[:amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:amount)
+          expect(validation_service.result.error.messages[:amount]).to include("invalid_amount")
         end
       end
     end
@@ -47,10 +47,10 @@ RSpec.describe Charges::Validators::PackageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(package_service).not_to be_valid
-          expect(package_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(package_service.result.error.messages.keys).to include(:amount)
-          expect(package_service.result.error.messages[:amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:amount)
+          expect(validation_service.result.error.messages[:amount]).to include("invalid_amount")
         end
       end
     end
@@ -66,10 +66,10 @@ RSpec.describe Charges::Validators::PackageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(package_service).not_to be_valid
-          expect(package_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(package_service.result.error.messages.keys).to include(:amount)
-          expect(package_service.result.error.messages[:amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:amount)
+          expect(validation_service.result.error.messages[:amount]).to include("invalid_amount")
         end
       end
     end
@@ -84,10 +84,10 @@ RSpec.describe Charges::Validators::PackageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(package_service).not_to be_valid
-          expect(package_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(package_service.result.error.messages.keys).to include(:package_size)
-          expect(package_service.result.error.messages[:package_size]).to include("invalid_package_size")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:package_size)
+          expect(validation_service.result.error.messages[:package_size]).to include("invalid_package_size")
         end
       end
     end
@@ -103,10 +103,10 @@ RSpec.describe Charges::Validators::PackageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(package_service).not_to be_valid
-          expect(package_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(package_service.result.error.messages.keys).to include(:package_size)
-          expect(package_service.result.error.messages[:package_size]).to include("invalid_package_size")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:package_size)
+          expect(validation_service.result.error.messages[:package_size]).to include("invalid_package_size")
         end
       end
     end
@@ -122,10 +122,10 @@ RSpec.describe Charges::Validators::PackageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(package_service).not_to be_valid
-          expect(package_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(package_service.result.error.messages.keys).to include(:package_size)
-          expect(package_service.result.error.messages[:package_size]).to include("invalid_package_size")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:package_size)
+          expect(validation_service.result.error.messages[:package_size]).to include("invalid_package_size")
         end
       end
     end
@@ -141,10 +141,10 @@ RSpec.describe Charges::Validators::PackageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(package_service).not_to be_valid
-          expect(package_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(package_service.result.error.messages.keys).to include(:package_size)
-          expect(package_service.result.error.messages[:package_size]).to include("invalid_package_size")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:package_size)
+          expect(validation_service.result.error.messages[:package_size]).to include("invalid_package_size")
         end
       end
     end
@@ -159,10 +159,10 @@ RSpec.describe Charges::Validators::PackageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(package_service).not_to be_valid
-          expect(package_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(package_service.result.error.messages.keys).to include(:free_units)
-          expect(package_service.result.error.messages[:free_units]).to include("invalid_free_units")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:free_units)
+          expect(validation_service.result.error.messages[:free_units]).to include("invalid_free_units")
         end
       end
     end
@@ -178,10 +178,10 @@ RSpec.describe Charges::Validators::PackageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(package_service).not_to be_valid
-          expect(package_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(package_service.result.error.messages.keys).to include(:free_units)
-          expect(package_service.result.error.messages[:free_units]).to include("invalid_free_units")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:free_units)
+          expect(validation_service.result.error.messages[:free_units]).to include("invalid_free_units")
         end
       end
     end
@@ -197,11 +197,21 @@ RSpec.describe Charges::Validators::PackageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(package_service).not_to be_valid
-          expect(package_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(package_service.result.error.messages.keys).to include(:free_units)
-          expect(package_service.result.error.messages[:free_units]).to include("invalid_free_units")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:free_units)
+          expect(validation_service.result.error.messages[:free_units]).to include("invalid_free_units")
         end
+      end
+    end
+
+    it_behaves_like "pricing_group_keys property validation" do
+      let(:package_properties) do
+        {
+          package_size: 10,
+          free_units: 10,
+          amount: "100"
+        }.merge(grouping_properties)
       end
     end
   end

--- a/spec/services/charges/validators/percentage_service_spec.rb
+++ b/spec/services/charges/validators/percentage_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Charges::Validators::PercentageService, type: :service do
-  subject(:percentage_service) { described_class.new(charge:) }
+  subject(:validation_service) { described_class.new(charge:) }
 
   let(:charge) { build(:percentage_charge, properties: percentage_properties) }
 
@@ -15,7 +15,7 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
   end
 
   describe ".valid?" do
-    it { expect(percentage_service).to be_valid }
+    it { expect(validation_service).to be_valid }
 
     context "when billable metric is latest_agg" do
       let(:billable_metric) { create(:latest_billable_metric) }
@@ -29,10 +29,10 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(percentage_service).not_to be_valid
-          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(percentage_service.result.error.messages.keys).to include(:billable_metric)
-          expect(percentage_service.result.error.messages[:billable_metric]).to include("invalid_value")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:billable_metric)
+          expect(validation_service.result.error.messages[:billable_metric]).to include("invalid_value")
         end
       end
     end
@@ -46,10 +46,10 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(percentage_service).not_to be_valid
-          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(percentage_service.result.error.messages.keys).to include(:rate)
-          expect(percentage_service.result.error.messages[:rate]).to include("invalid_rate")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:rate)
+          expect(validation_service.result.error.messages[:rate]).to include("invalid_rate")
         end
       end
     end
@@ -64,10 +64,10 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(percentage_service).not_to be_valid
-          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(percentage_service.result.error.messages.keys).to include(:rate)
-          expect(percentage_service.result.error.messages[:rate]).to include("invalid_rate")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:rate)
+          expect(validation_service.result.error.messages[:rate]).to include("invalid_rate")
         end
       end
     end
@@ -82,10 +82,10 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(percentage_service).not_to be_valid
-          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(percentage_service.result.error.messages.keys).to include(:rate)
-          expect(percentage_service.result.error.messages[:rate]).to include("invalid_rate")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:rate)
+          expect(validation_service.result.error.messages[:rate]).to include("invalid_rate")
         end
       end
     end
@@ -100,10 +100,10 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(percentage_service).not_to be_valid
-          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(percentage_service.result.error.messages.keys).to include(:rate)
-          expect(percentage_service.result.error.messages[:rate]).to include("invalid_rate")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:rate)
+          expect(validation_service.result.error.messages[:rate]).to include("invalid_rate")
         end
       end
     end
@@ -113,7 +113,7 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
         {rate: "0.00", fixed_amount: "2"}
       end
 
-      it { expect(percentage_service).to be_valid }
+      it { expect(validation_service).to be_valid }
     end
 
     context "when free_units_per_events is not an integer" do
@@ -126,10 +126,10 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(percentage_service).not_to be_valid
-          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(percentage_service.result.error.messages.keys).to include(:free_units_per_events)
-          expect(percentage_service.result.error.messages[:free_units_per_events])
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:free_units_per_events)
+          expect(validation_service.result.error.messages[:free_units_per_events])
             .to include("invalid_free_units_per_events")
         end
       end
@@ -145,10 +145,10 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(percentage_service).not_to be_valid
-          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(percentage_service.result.error.messages.keys).to include(:free_units_per_events)
-          expect(percentage_service.result.error.messages[:free_units_per_events])
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:free_units_per_events)
+          expect(validation_service.result.error.messages[:free_units_per_events])
             .to include("invalid_free_units_per_events")
         end
       end
@@ -165,17 +165,17 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(percentage_service).not_to be_valid
-          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(percentage_service.result.error.messages.keys).to eq(
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to eq(
             [
               :fixed_amount,
               :free_units_per_total_aggregation
             ]
           )
-          expect(percentage_service.result.error.messages[:fixed_amount])
+          expect(validation_service.result.error.messages[:fixed_amount])
             .to include("invalid_fixed_amount")
-          expect(percentage_service.result.error.messages[:free_units_per_total_aggregation])
+          expect(validation_service.result.error.messages[:free_units_per_total_aggregation])
             .to include("invalid_free_units_per_total_aggregation")
         end
       end
@@ -192,17 +192,17 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(percentage_service).not_to be_valid
-          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(percentage_service.result.error.messages.keys).to eq(
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to eq(
             [
               :fixed_amount,
               :free_units_per_total_aggregation
             ]
           )
-          expect(percentage_service.result.error.messages[:fixed_amount])
+          expect(validation_service.result.error.messages[:fixed_amount])
             .to include("invalid_fixed_amount")
-          expect(percentage_service.result.error.messages[:free_units_per_total_aggregation])
+          expect(validation_service.result.error.messages[:free_units_per_total_aggregation])
             .to include("invalid_free_units_per_total_aggregation")
         end
       end
@@ -218,10 +218,10 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(percentage_service).not_to be_valid
-          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(percentage_service.result.error.messages.keys).to include(:fixed_amount)
-          expect(percentage_service.result.error.messages[:fixed_amount]).to include("invalid_fixed_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:fixed_amount)
+          expect(validation_service.result.error.messages[:fixed_amount]).to include("invalid_fixed_amount")
         end
       end
     end
@@ -238,20 +238,20 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(percentage_service).not_to be_valid
-          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(percentage_service.result.error.messages.keys).to eq(
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to eq(
             [
               :fixed_amount,
               :free_units_per_events,
               :free_units_per_total_aggregation
             ]
           )
-          expect(percentage_service.result.error.messages[:fixed_amount])
+          expect(validation_service.result.error.messages[:fixed_amount])
             .to include("invalid_fixed_amount")
-          expect(percentage_service.result.error.messages[:free_units_per_events])
+          expect(validation_service.result.error.messages[:free_units_per_events])
             .to include("invalid_free_units_per_events")
-          expect(percentage_service.result.error.messages[:free_units_per_total_aggregation])
+          expect(validation_service.result.error.messages[:free_units_per_total_aggregation])
             .to include("invalid_free_units_per_total_aggregation")
         end
       end
@@ -264,7 +264,7 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
         }
       end
 
-      it { expect(percentage_service).to be_valid }
+      it { expect(validation_service).to be_valid }
     end
 
     context "with per_transaction_min_amount" do
@@ -283,10 +283,10 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
         it "is invalid" do
           aggregate_failures do
-            expect(percentage_service).not_to be_valid
-            expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(percentage_service.result.error.messages.keys).to include(:per_transaction_min_amount)
-            expect(percentage_service.result.error.messages[:per_transaction_min_amount])
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:per_transaction_min_amount)
+            expect(validation_service.result.error.messages[:per_transaction_min_amount])
               .to include("invalid_amount")
           end
         end
@@ -297,10 +297,10 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
         it "is invalid" do
           aggregate_failures do
-            expect(percentage_service).not_to be_valid
-            expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(percentage_service.result.error.messages.keys).to include(:per_transaction_min_amount)
-            expect(percentage_service.result.error.messages[:per_transaction_min_amount])
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:per_transaction_min_amount)
+            expect(validation_service.result.error.messages[:per_transaction_min_amount])
               .to include("invalid_amount")
           end
         end
@@ -323,10 +323,10 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
         it "is invalid" do
           aggregate_failures do
-            expect(percentage_service).not_to be_valid
-            expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(percentage_service.result.error.messages.keys).to include(:per_transaction_max_amount)
-            expect(percentage_service.result.error.messages[:per_transaction_max_amount])
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:per_transaction_max_amount)
+            expect(validation_service.result.error.messages[:per_transaction_max_amount])
               .to include("invalid_amount")
           end
         end
@@ -337,10 +337,10 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
         it "is invalid" do
           aggregate_failures do
-            expect(percentage_service).not_to be_valid
-            expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(percentage_service.result.error.messages.keys).to include(:per_transaction_max_amount)
-            expect(percentage_service.result.error.messages[:per_transaction_max_amount])
+            expect(validation_service).not_to be_valid
+            expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(validation_service.result.error.messages.keys).to include(:per_transaction_max_amount)
+            expect(validation_service.result.error.messages[:per_transaction_max_amount])
               .to include("invalid_amount")
           end
         end
@@ -361,12 +361,21 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it "ensures that max is higher than min" do
         aggregate_failures do
-          expect(percentage_service).not_to be_valid
-          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(percentage_service.result.error.messages.keys).to include(:per_transaction_max_amount)
-          expect(percentage_service.result.error.messages[:per_transaction_max_amount])
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:per_transaction_max_amount)
+          expect(validation_service.result.error.messages[:per_transaction_max_amount])
             .to include("per_transaction_max_lower_than_per_transaction_min")
         end
+      end
+    end
+
+    it_behaves_like "pricing_group_keys property validation" do
+      let(:percentage_properties) do
+        {
+          rate: "0.25",
+          fixed_amount: "2"
+        }.merge(grouping_properties)
       end
     end
   end

--- a/spec/services/charges/validators/standard_service_spec.rb
+++ b/spec/services/charges/validators/standard_service_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Charges::Validators::StandardService, type: :service do
-  subject(:standard_service) { described_class.new(charge:) }
+  subject(:validation_service) { described_class.new(charge:) }
 
   let(:charge) { build(:standard_charge, properties:) }
   let(:properties) { {} }
@@ -11,10 +11,10 @@ RSpec.describe Charges::Validators::StandardService, type: :service do
   describe ".valid?" do
     it "is invalid" do
       aggregate_failures do
-        expect(standard_service).not_to be_valid
-        expect(standard_service.result.error).to be_a(BaseService::ValidationFailure)
-        expect(standard_service.result.error.messages.keys).to include(:amount)
-        expect(standard_service.result.error.messages[:amount]).to include("invalid_amount")
+        expect(validation_service).not_to be_valid
+        expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+        expect(validation_service.result.error.messages.keys).to include(:amount)
+        expect(validation_service.result.error.messages[:amount]).to include("invalid_amount")
       end
     end
 
@@ -23,10 +23,10 @@ RSpec.describe Charges::Validators::StandardService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(standard_service).not_to be_valid
-          expect(standard_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(standard_service.result.error.messages.keys).to include(:amount)
-          expect(standard_service.result.error.messages[:amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:amount)
+          expect(validation_service.result.error.messages[:amount]).to include("invalid_amount")
         end
       end
     end
@@ -36,10 +36,10 @@ RSpec.describe Charges::Validators::StandardService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(standard_service).not_to be_valid
-          expect(standard_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(standard_service.result.error.messages.keys).to include(:amount)
-          expect(standard_service.result.error.messages[:amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:amount)
+          expect(validation_service.result.error.messages[:amount]).to include("invalid_amount")
         end
       end
     end
@@ -47,53 +47,11 @@ RSpec.describe Charges::Validators::StandardService, type: :service do
     context "with an applicable amount" do
       let(:properties) { {amount: "12"} }
 
-      it { expect(standard_service).to be_valid }
+      it { expect(validation_service).to be_valid }
     end
 
-    describe "grouped_by" do
-      let(:properties) { {"amount" => "12", "grouped_by" => grouped_by} }
-      let(:grouped_by) { [] }
-
-      it { expect(standard_service).to be_valid }
-
-      context "when attribute is not an array" do
-        let(:grouped_by) { "group" }
-
-        it "is invalid" do
-          aggregate_failures do
-            expect(standard_service).not_to be_valid
-            expect(standard_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(standard_service.result.error.messages.keys).to include(:grouped_by)
-            expect(standard_service.result.error.messages[:grouped_by]).to include("invalid_type")
-          end
-        end
-      end
-
-      context "when attribute is not a list of string" do
-        let(:grouped_by) { [12, 45] }
-
-        it "is invalid" do
-          aggregate_failures do
-            expect(standard_service).not_to be_valid
-            expect(standard_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(standard_service.result.error.messages.keys).to include(:grouped_by)
-            expect(standard_service.result.error.messages[:grouped_by]).to include("invalid_type")
-          end
-        end
-      end
-
-      context "when attribute is an empty string" do
-        let(:grouped_by) { "" }
-
-        it "is invalid" do
-          aggregate_failures do
-            expect(standard_service).not_to be_valid
-            expect(standard_service.result.error).to be_a(BaseService::ValidationFailure)
-            expect(standard_service.result.error.messages.keys).to include(:grouped_by)
-            expect(standard_service.result.error.messages[:grouped_by]).to include("invalid_type")
-          end
-        end
-      end
+    it_behaves_like "pricing_group_keys property validation" do
+      let(:properties) { {"amount" => "12"}.merge(grouping_properties) }
     end
   end
 end

--- a/spec/services/charges/validators/volume_service_spec.rb
+++ b/spec/services/charges/validators/volume_service_spec.rb
@@ -3,21 +3,47 @@
 require "rails_helper"
 
 RSpec.describe Charges::Validators::VolumeService, type: :service do
-  subject(:volume_service) { described_class.new(charge:) }
+  subject(:validation_service) { described_class.new(charge:) }
 
-  let(:charge) { build(:volume_charge, properties: {volume_ranges: ranges}) }
+  let(:charge) { build(:volume_charge, properties:) }
 
+  let(:properties) { {volume_ranges: ranges} }
   let(:ranges) do
-    []
+    [
+      {
+        from_value: 0,
+        to_value: 10,
+        per_unit_amount: "0",
+        flat_amount: "0"
+      },
+      {
+        from_value: 11,
+        to_value: 20,
+        per_unit_amount: "10",
+        flat_amount: "20"
+      },
+      {
+        from_value: 21,
+        to_value: nil,
+        per_unit_amount: "15",
+        flat_amount: "30"
+      }
+    ]
   end
 
   describe ".validate" do
-    it "is invalid" do
-      aggregate_failures do
-        expect(volume_service).not_to be_valid
-        expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-        expect(volume_service.result.error.messages.keys).to include(:volume_ranges)
-        expect(volume_service.result.error.messages[:volume_ranges]).to include("missing_volume_ranges")
+    it { expect(validation_service).to be_valid }
+
+    context "with empty ranges" do
+      let(:ranges) { [] }
+
+      it "is invalid" do
+        aggregate_failures do
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:volume_ranges)
+          expect(validation_service.result.error.messages[:volume_ranges]).to include("missing_volume_ranges")
+        end
       end
     end
 
@@ -28,10 +54,10 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(volume_service).not_to be_valid
-          expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:volume_ranges)
-          expect(volume_service.result.error.messages[:volume_ranges]).to include("invalid_volume_ranges")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:volume_ranges)
+          expect(validation_service.result.error.messages[:volume_ranges]).to include("invalid_volume_ranges")
         end
       end
     end
@@ -43,10 +69,10 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(volume_service).not_to be_valid
-          expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:volume_ranges)
-          expect(volume_service.result.error.messages[:volume_ranges]).to include("invalid_volume_ranges")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:volume_ranges)
+          expect(validation_service.result.error.messages[:volume_ranges]).to include("invalid_volume_ranges")
         end
       end
     end
@@ -61,10 +87,10 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(volume_service).not_to be_valid
-          expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:volume_ranges)
-          expect(volume_service.result.error.messages[:volume_ranges]).to include("invalid_volume_ranges")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:volume_ranges)
+          expect(validation_service.result.error.messages[:volume_ranges]).to include("invalid_volume_ranges")
         end
       end
     end
@@ -79,10 +105,10 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(volume_service).not_to be_valid
-          expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:volume_ranges)
-          expect(volume_service.result.error.messages[:volume_ranges]).to include("invalid_volume_ranges")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:volume_ranges)
+          expect(validation_service.result.error.messages[:volume_ranges]).to include("invalid_volume_ranges")
         end
       end
     end
@@ -94,10 +120,10 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(volume_service).not_to be_valid
-          expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:per_unit_amount)
-          expect(volume_service.result.error.messages[:per_unit_amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:per_unit_amount)
+          expect(validation_service.result.error.messages[:per_unit_amount]).to include("invalid_amount")
         end
       end
     end
@@ -109,10 +135,10 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(volume_service).not_to be_valid
-          expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:per_unit_amount)
-          expect(volume_service.result.error.messages[:per_unit_amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:per_unit_amount)
+          expect(validation_service.result.error.messages[:per_unit_amount]).to include("invalid_amount")
         end
       end
     end
@@ -124,10 +150,10 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(volume_service).not_to be_valid
-          expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:per_unit_amount)
-          expect(volume_service.result.error.messages[:per_unit_amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:per_unit_amount)
+          expect(validation_service.result.error.messages[:per_unit_amount]).to include("invalid_amount")
         end
       end
     end
@@ -139,10 +165,10 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(volume_service).not_to be_valid
-          expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:flat_amount)
-          expect(volume_service.result.error.messages[:flat_amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:flat_amount)
+          expect(validation_service.result.error.messages[:flat_amount]).to include("invalid_amount")
         end
       end
     end
@@ -154,10 +180,10 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(volume_service).not_to be_valid
-          expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:flat_amount)
-          expect(volume_service.result.error.messages[:flat_amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:flat_amount)
+          expect(validation_service.result.error.messages[:flat_amount]).to include("invalid_amount")
         end
       end
     end
@@ -169,39 +195,16 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
 
       it "is invalid" do
         aggregate_failures do
-          expect(volume_service).not_to be_valid
-          expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:flat_amount)
-          expect(volume_service.result.error.messages[:flat_amount]).to include("invalid_amount")
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:flat_amount)
+          expect(validation_service.result.error.messages[:flat_amount]).to include("invalid_amount")
         end
       end
     end
 
-    context "with applicable ranges" do
-      let(:ranges) do
-        [
-          {
-            from_value: 0,
-            to_value: 10,
-            per_unit_amount: "0",
-            flat_amount: "0"
-          },
-          {
-            from_value: 11,
-            to_value: 20,
-            per_unit_amount: "10",
-            flat_amount: "20"
-          },
-          {
-            from_value: 21,
-            to_value: nil,
-            per_unit_amount: "15",
-            flat_amount: "30"
-          }
-        ]
-      end
-
-      it { expect(volume_service).to be_valid }
+    it_behaves_like "pricing_group_keys property validation" do
+      let(:properties) { {"volume_ranges" => ranges}.merge(grouping_properties) }
     end
   end
 end

--- a/spec/support/shared_examples/charges/pricing_group_keys_validation.rb
+++ b/spec/support/shared_examples/charges/pricing_group_keys_validation.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "pricing_group_keys property validation" do
+  let(:grouping_properties) { {"pricing_group_keys" => pricing_group_keys} }
+  let(:pricing_group_keys) { [] }
+
+  it { expect(validation_service).to be_valid }
+
+  context "when attribute is not an array" do
+    let(:pricing_group_keys) { "group" }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:pricing_group_keys)
+      expect(validation_service.result.error.messages[:pricing_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when attribute is not a list of string" do
+    let(:pricing_group_keys) { [12, 45] }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:pricing_group_keys)
+      expect(validation_service.result.error.messages[:pricing_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when attribute is an empty string" do
+    let(:pricing_group_keys) { "" }
+
+    it "is invalid" do
+      expect(validation_service).not_to be_valid
+      expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+      expect(validation_service.result.error.messages.keys).to include(:pricing_group_keys)
+      expect(validation_service.result.error.messages[:pricing_group_keys]).to include("invalid_type")
+    end
+  end
+
+  context "when using legacy grouped_by property" do
+    let(:grouping_properties) { {"grouped_by" => grouped_by} }
+    let(:grouped_by) { [] }
+
+    it { expect(validation_service).to be_valid }
+
+    context "when attribute is not an array" do
+      let(:grouped_by) { "group" }
+
+      it "is invalid" do
+        expect(validation_service).not_to be_valid
+        expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+        expect(validation_service.result.error.messages.keys).to include(:grouped_by)
+        expect(validation_service.result.error.messages[:grouped_by]).to include("invalid_type")
+      end
+    end
+
+    context "when attribute is not a list of string" do
+      let(:grouped_by) { [12, 45] }
+
+      it "is invalid" do
+        expect(validation_service).not_to be_valid
+        expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+        expect(validation_service.result.error.messages.keys).to include(:grouped_by)
+        expect(validation_service.result.error.messages[:grouped_by]).to include("invalid_type")
+      end
+    end
+
+    context "when attribute is an empty string" do
+      let(:grouped_by) { "" }
+
+      it "is invalid" do
+        expect(validation_service).not_to be_valid
+        expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+        expect(validation_service.result.error.messages.keys).to include(:grouped_by)
+        expect(validation_service.result.error.messages[:grouped_by]).to include("invalid_type")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR is part of an epic to add grouped_by feature on all charge models and not only on the standard one like today. 

## Description

This PR is the first step:
- It refactors the validation logic for `Charge` and `ChargeFilter` to share the logic
- It moves the grouped_by validation logic from the `Charges::Validators::StandardService` to the `Charges::Validators::BaseService` so that it can be applied to all charge models
- It adds the ability to send grouping keys via `pricing_group_keys` or `grouped_by` to ensure a smooth transition between the two keys.

For now `grouped_by` properties remains whitelisted only on the standard charge model. This will remain like this until the grouped_by logic is applied to all charge model
