### PR TITLE
Feat(multientities): use billing entity timezone

### DIFF
--- a/app/jobs/clock/terminate_ended_subscriptions_job.rb
+++ b/app/jobs/clock/terminate_ended_subscriptions_job.rb
@@ -4,7 +4,7 @@ module Clock
   class TerminateEndedSubscriptionsJob < ClockJob
     def perform
       Subscription
-        .joins(customer: :organization)
+        .joins(customer: [:organization, :billing_entity])
         .active
         .where(
           "DATE(subscriptions.ending_at#{Utils::Timezone.at_time_zone_sql}) = " \

--- a/app/jobs/clock/terminate_ended_subscriptions_job.rb
+++ b/app/jobs/clock/terminate_ended_subscriptions_job.rb
@@ -4,7 +4,7 @@ module Clock
   class TerminateEndedSubscriptionsJob < ClockJob
     def perform
       Subscription
-        .joins(customer: [:organization, :billing_entity])
+        .joins(customer: :billing_entity)
         .active
         .where(
           "DATE(subscriptions.ending_at#{Utils::Timezone.at_time_zone_sql}) = " \

--- a/app/models/daily_usage.rb
+++ b/app/models/daily_usage.rb
@@ -6,9 +6,10 @@ class DailyUsage < ApplicationRecord
   belongs_to :subscription
 
   scope :usage_date_in_timezone, ->(timestamp) do
-    at_time_zone = Utils::Timezone.at_time_zone_sql(customer: "cus", organization: "org")
+    at_time_zone = Utils::Timezone.at_time_zone_sql(customer: "cus", billing_entity: "billing_entities", organization: "org")
 
     joins("INNER JOIN customers AS cus ON daily_usages.customer_id = cus.id")
+      .joins("INNER JOIN billing_entities ON cus.billing_entity_id = billing_entities.id")
       .joins("INNER JOIN organizations AS org ON daily_usages.organization_id = org.id")
       .where("DATE((daily_usages.usage_date)#{at_time_zone}) = DATE(:timestamp#{at_time_zone})", timestamp:)
   end

--- a/app/models/daily_usage.rb
+++ b/app/models/daily_usage.rb
@@ -10,7 +10,6 @@ class DailyUsage < ApplicationRecord
 
     joins("INNER JOIN customers AS cus ON daily_usages.customer_id = cus.id")
       .joins("INNER JOIN billing_entities ON cus.billing_entity_id = billing_entities.id")
-      .joins("INNER JOIN organizations AS org ON daily_usages.organization_id = org.id")
       .where("DATE((daily_usages.usage_date)#{at_time_zone}) = DATE(:timestamp#{at_time_zone})", timestamp:)
   end
 end

--- a/app/models/daily_usage.rb
+++ b/app/models/daily_usage.rb
@@ -6,7 +6,7 @@ class DailyUsage < ApplicationRecord
   belongs_to :subscription
 
   scope :usage_date_in_timezone, ->(timestamp) do
-    at_time_zone = Utils::Timezone.at_time_zone_sql(customer: "cus", billing_entity: "billing_entities", organization: "org")
+    at_time_zone = Utils::Timezone.at_time_zone_sql(customer: "cus", billing_entity: "billing_entities")
 
     joins("INNER JOIN customers AS cus ON daily_usages.customer_id = cus.id")
       .joins("INNER JOIN billing_entities ON cus.billing_entity_id = billing_entities.id")

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -248,7 +248,7 @@ class BaseService
     source&.to_sym == :graphql
   end
 
-  def at_time_zone(customer: "customers", billing_entity: "billing_entities", organization: "organizations")
-    Utils::Timezone.at_time_zone_sql(customer:, billing_entity:, organization:)
+  def at_time_zone(customer: "customers", billing_entity: "billing_entities")
+    Utils::Timezone.at_time_zone_sql(customer:, billing_entity:)
   end
 end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -248,7 +248,7 @@ class BaseService
     source&.to_sym == :graphql
   end
 
-  def at_time_zone(customer: "customers", organization: "organizations")
-    Utils::Timezone.at_time_zone_sql(customer:, organization:)
+  def at_time_zone(customer: "customers", billing_entity: "billing_entities", organization: "organizations")
+    Utils::Timezone.at_time_zone_sql(customer:, billing_entity:, organization:)
   end
 end

--- a/app/services/daily_usages/compute_all_service.rb
+++ b/app/services/daily_usages/compute_all_service.rb
@@ -25,7 +25,7 @@ module DailyUsages
       #                   This might change in the future
       Subscription
         .with(existing_daily_usage:)
-        .joins(customer: :organization)
+        .joins(customer: [:organization, :billing_entity])
         .merge(Organization.with_revenue_analytics_support)
         .joins("LEFT JOIN existing_daily_usage ON subscriptions.id = existing_daily_usage.subscription_id")
         .active

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -10,7 +10,7 @@ module Subscriptions
 
     def activate_all_pending
       Subscription
-        .joins(customer: :organization)
+        .joins(customer: [:organization, :billing_entity])
         .pending
         .where(previous_subscription: nil)
         .where(

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -10,7 +10,7 @@ module Subscriptions
 
     def activate_all_pending
       Subscription
-        .joins(customer: [:organization, :billing_entity])
+        .joins(customer: :billing_entity)
         .pending
         .where(previous_subscription: nil)
         .where(

--- a/app/services/subscriptions/free_trial_billing_service.rb
+++ b/app/services/subscriptions/free_trial_billing_service.rb
@@ -64,6 +64,7 @@ module Subscriptions
           INNER JOIN plans ON subscriptions.plan_id = plans.id
           INNER JOIN initial_started_at ON initial_started_at.external_id = subscriptions.external_id
           INNER JOIN customers ON subscriptions.customer_id = customers.id
+          INNER JOIN billing_entities ON customers.billing_entity_id = billing_entities.id
           INNER JOIN organizations ON customers.organization_id = organizations.id
           LEFT JOIN already_billed_today ON already_billed_today.subscription_id = subscriptions.id
         WHERE
@@ -100,12 +101,13 @@ module Subscriptions
         FROM invoice_subscriptions
           INNER JOIN subscriptions AS sub ON invoice_subscriptions.subscription_id = sub.id
           INNER JOIN customers AS cus ON sub.customer_id = cus.id
+          INNER JOIN billing_entities ON cus.billing_entity_id = billing_entities.id
           INNER JOIN organizations AS org ON cus.organization_id = org.id
         WHERE invoice_subscriptions.recurring = 't'
           AND invoice_subscriptions.timestamp IS NOT NULL
           AND DATE(
-            (invoice_subscriptions.timestamp)#{at_time_zone(customer: "cus", organization: "org")}
-          ) = DATE('#{timestamp}'#{at_time_zone(customer: "cus", organization: "org")})
+            (invoice_subscriptions.timestamp)#{at_time_zone(customer: "cus", billing_entity: "billing_entities", organization: "org")}
+          ) = DATE('#{timestamp}'#{at_time_zone(customer: "cus", billing_entity: "billing_entities", organization: "org")})
         GROUP BY invoice_subscriptions.subscription_id
       SQL
     end

--- a/app/services/subscriptions/free_trial_billing_service.rb
+++ b/app/services/subscriptions/free_trial_billing_service.rb
@@ -106,8 +106,8 @@ module Subscriptions
         WHERE invoice_subscriptions.recurring = 't'
           AND invoice_subscriptions.timestamp IS NOT NULL
           AND DATE(
-            (invoice_subscriptions.timestamp)#{at_time_zone(customer: "cus", billing_entity: "billing_entities", organization: "org")}
-          ) = DATE('#{timestamp}'#{at_time_zone(customer: "cus", billing_entity: "billing_entities", organization: "org")})
+            (invoice_subscriptions.timestamp)#{at_time_zone(customer: "cus", billing_entity: "billing_entities")}
+          ) = DATE('#{timestamp}'#{at_time_zone(customer: "cus", billing_entity: "billing_entities")})
         GROUP BY invoice_subscriptions.subscription_id
       SQL
     end

--- a/app/services/subscriptions/free_trial_billing_service.rb
+++ b/app/services/subscriptions/free_trial_billing_service.rb
@@ -65,7 +65,6 @@ module Subscriptions
           INNER JOIN initial_started_at ON initial_started_at.external_id = subscriptions.external_id
           INNER JOIN customers ON subscriptions.customer_id = customers.id
           INNER JOIN billing_entities ON customers.billing_entity_id = billing_entities.id
-          INNER JOIN organizations ON customers.organization_id = organizations.id
           LEFT JOIN already_billed_today ON already_billed_today.subscription_id = subscriptions.id
         WHERE
           subscriptions.status = 1
@@ -102,7 +101,6 @@ module Subscriptions
           INNER JOIN subscriptions AS sub ON invoice_subscriptions.subscription_id = sub.id
           INNER JOIN customers AS cus ON sub.customer_id = cus.id
           INNER JOIN billing_entities ON cus.billing_entity_id = billing_entities.id
-          INNER JOIN organizations AS org ON cus.organization_id = org.id
         WHERE invoice_subscriptions.recurring = 't'
           AND invoice_subscriptions.timestamp IS NOT NULL
           AND DATE(

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# ASK VINCENT ABOUT THE TIMEZONES!!!
 
 module Subscriptions
   class OrganizationBillingService < BaseService
@@ -74,6 +75,7 @@ module Subscriptions
           INNER JOIN billable_subscriptions ON billable_subscriptions.subscription_id = subscriptions.id
           INNER JOIN customers ON customers.id = subscriptions.customer_id
           INNER JOIN organizations ON organizations.id = customers.organization_id
+          INNER JOIN billing_entities ON billing_entities.id = customers.billing_entity_id
           LEFT JOIN already_billed_today ON already_billed_today.subscription_id = subscriptions.id
         WHERE
           organizations.id = '#{organization.id}'
@@ -101,6 +103,7 @@ module Subscriptions
         FROM subscriptions
           INNER JOIN plans ON plans.id = subscriptions.plan_id
           INNER JOIN customers ON customers.id = subscriptions.customer_id
+          INNER JOIN billing_entities ON billing_entities.id = customers.billing_entity_id
           INNER JOIN organizations ON organizations.id = customers.organization_id
         WHERE subscriptions.status = #{Subscription.statuses[:active]}
           AND organizations.id = '#{organization.id}'

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# ASK VINCENT ABOUT THE TIMEZONES!!!
 
 module Subscriptions
   class OrganizationBillingService < BaseService
@@ -313,6 +312,7 @@ module Subscriptions
         FROM invoice_subscriptions
           INNER JOIN subscriptions AS sub ON invoice_subscriptions.subscription_id = sub.id
           INNER JOIN customers AS cus ON sub.customer_id = cus.id
+          INNER JOIN billing_entities ON cus.billing_entity_id = billing_entities.id
           INNER JOIN organizations AS org ON cus.organization_id = org.id
         WHERE invoice_subscriptions.recurring = 't'
           AND org.id = '#{organization.id}'

--- a/app/services/subscriptions/organization_billing_service.rb
+++ b/app/services/subscriptions/organization_billing_service.rb
@@ -318,8 +318,8 @@ module Subscriptions
           AND org.id = '#{organization.id}'
           AND invoice_subscriptions.timestamp IS NOT NULL
           AND DATE(
-            (invoice_subscriptions.timestamp)#{at_time_zone(customer: "cus", organization: "org")}
-          ) = DATE(:today#{at_time_zone(customer: "cus", organization: "org")})
+            (invoice_subscriptions.timestamp)#{at_time_zone(customer: "cus", billing_entity: "billing_entities")}
+          ) = DATE(:today#{at_time_zone(customer: "cus", billing_entity: "billing_entities")})
         GROUP BY invoice_subscriptions.subscription_id
       SQL
     end

--- a/app/services/utils/timezone.rb
+++ b/app/services/utils/timezone.rb
@@ -13,9 +13,9 @@ module Utils
       "(#{sanitized_field_name})::timestamptz AT TIME ZONE '#{sanitized_timezone}'"
     end
 
-    def self.at_time_zone_sql(customer: "customers", organization: "organizations")
+    def self.at_time_zone_sql(customer: "customers", billing_entity: "billing_entities", organization: "organizations")
       <<-SQL
-        ::timestamptz AT TIME ZONE COALESCE(#{customer}.timezone, #{organization}.timezone, 'UTC')
+        ::timestamptz AT TIME ZONE COALESCE(#{customer}.timezone, #{billing_entity}.timezone, #{organization}.timezone, 'UTC')
       SQL
     end
   end

--- a/app/services/utils/timezone.rb
+++ b/app/services/utils/timezone.rb
@@ -13,9 +13,9 @@ module Utils
       "(#{sanitized_field_name})::timestamptz AT TIME ZONE '#{sanitized_timezone}'"
     end
 
-    def self.at_time_zone_sql(customer: "customers", billing_entity: "billing_entities", organization: "organizations")
+    def self.at_time_zone_sql(customer: "customers", billing_entity: "billing_entities")
       <<-SQL
-        ::timestamptz AT TIME ZONE COALESCE(#{customer}.timezone, #{billing_entity}.timezone, #{organization}.timezone, 'UTC')
+        ::timestamptz AT TIME ZONE COALESCE(#{customer}.timezone, #{billing_entity}.timezone, 'UTC')
       SQL
     end
   end

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -65,7 +65,6 @@ module Wallets
           INNER JOIN wallets ON wallets.id = recurring_transaction_rules.wallet_id
           INNER JOIN customers ON customers.id = wallets.customer_id
           INNER JOIN billing_entities ON billing_entities.id = customers.billing_entity_id
-          INNER JOIN organizations ON organizations.id = customers.organization_id
           LEFT JOIN already_applied_today ON already_applied_today.wallet_id = wallets.id
         WHERE
           -- Exclude top-ups already applied today
@@ -85,8 +84,7 @@ module Wallets
           INNER JOIN wallets ON wallets.id = recurring_transaction_rules.wallet_id
           INNER JOIN customers ON customers.id = wallets.customer_id
           INNER JOIN billing_entities ON billing_entities.id = customers.billing_entity_id
-          INNER JOIN organizations ON organizations.id = customers.organization_id
-        WHERE wallets.status = #{Wallet.statuses[:active]}
+        WHERE wallets.status = #{Wallet.statuses[:active]} 
           AND recurring_transaction_rules.status = #{RecurringTransactionRule.statuses[:active]}
           AND recurring_transaction_rules.trigger = #{RecurringTransactionRule.triggers[:interval]}
           AND recurring_transaction_rules.interval = #{RecurringTransactionRule.intervals[interval]}
@@ -218,7 +216,6 @@ module Wallets
           INNER JOIN wallets AS wal ON wallet_transactions.wallet_id = wal.id
           INNER JOIN customers AS cus ON wal.customer_id = cus.id
           INNER JOIN billing_entities ON cus.billing_entity_id = billing_entities.id
-          INNER JOIN organizations AS org ON cus.organization_id = org.id
         WHERE wallet_transactions.source = #{WalletTransaction.sources[:interval]}
           AND wallet_transactions.transaction_type = #{WalletTransaction.transaction_types[:inbound]}
           AND DATE(

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -64,6 +64,7 @@ module Wallets
           INNER JOIN pending_recurring_rules ON pending_recurring_rules.rule_id = recurring_transaction_rules.id
           INNER JOIN wallets ON wallets.id = recurring_transaction_rules.wallet_id
           INNER JOIN customers ON customers.id = wallets.customer_id
+          INNER JOIN billing_entities ON billing_entities.id = customers.billing_entity_id
           INNER JOIN organizations ON organizations.id = customers.organization_id
           LEFT JOIN already_applied_today ON already_applied_today.wallet_id = wallets.id
         WHERE
@@ -83,6 +84,7 @@ module Wallets
         FROM recurring_transaction_rules
           INNER JOIN wallets ON wallets.id = recurring_transaction_rules.wallet_id
           INNER JOIN customers ON customers.id = wallets.customer_id
+          INNER JOIN billing_entities ON billing_entities.id = customers.billing_entity_id
           INNER JOIN organizations ON organizations.id = customers.organization_id
         WHERE wallets.status = #{Wallet.statuses[:active]}
           AND recurring_transaction_rules.status = #{RecurringTransactionRule.statuses[:active]}

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -217,12 +217,13 @@ module Wallets
         FROM wallet_transactions
           INNER JOIN wallets AS wal ON wallet_transactions.wallet_id = wal.id
           INNER JOIN customers AS cus ON wal.customer_id = cus.id
+          INNER JOIN billing_entities ON cus.billing_entity_id = billing_entities.id
           INNER JOIN organizations AS org ON cus.organization_id = org.id
         WHERE wallet_transactions.source = #{WalletTransaction.sources[:interval]}
           AND wallet_transactions.transaction_type = #{WalletTransaction.transaction_types[:inbound]}
           AND DATE(
-            (wallet_transactions.created_at)#{at_time_zone(customer: "cus", organization: "org")}
-          ) = DATE(:today#{at_time_zone(customer: "cus", organization: "org")})
+            (wallet_transactions.created_at)#{at_time_zone(customer: "cus", billing_entity: "billing_entities")}
+          ) = DATE(:today#{at_time_zone(customer: "cus", billing_entity: "billing_entities")})
         GROUP BY wallet_transactions.wallet_id
       SQL
     end

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe DailyUsages::ComputeAllService, type: :service do
     context "when the organization has a timezone" do
       let(:organization) { create(:organization, timezone: "America/Sao_Paulo", premium_integrations:) }
 
+      before do
+        organization.default_billing_entity.update(timezone: "America/Sao_Paulo")
+      end
+
       it "takes the timezone into account" do
         expect(compute_service.call).to be_success
         expect(DailyUsages::ComputeJob).not_to have_been_enqueued


### PR DESCRIPTION
## Context

Since we're removing timezone from organization, when performing billing or other jobs, the customer's timezone should be taken from the billing entity, not from the organization

## Description

- Updated `at_time_zone` helper to use billing_entity
- updated includes where this helper is used to not load organization where not needed
