### PR TITLE
chore(organization): Add organization_id to recurring_transaction_rules

### DIFF
--- a/app/jobs/database_migrations/populate_recurring_transaction_rules_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_recurring_transaction_rules_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateRecurringTransactionRulesWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = RecurringTransactionRule.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT wallets FROM wallets WHERE wallets.id = recurring_transaction_rules.wallet_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/pricing_unit.rb
+++ b/app/models/pricing_unit.rb
@@ -21,17 +21,18 @@ end
 # Table name: pricing_units
 #
 #  id              :uuid             not null, primary key
-#  code            :string
-#  description     :string
-#  name            :string
-#  short_name      :string
+#  code            :string           not null
+#  description     :text
+#  name            :string           not null
+#  short_name      :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :uuid             not null
 #
 # Indexes
 #
-#  index_pricing_units_on_organization_id  (organization_id)
+#  index_pricing_units_on_code_and_organization_id  (code,organization_id) UNIQUE
+#  index_pricing_units_on_organization_id           (organization_id)
 #
 # Foreign Keys
 #

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -4,6 +4,7 @@ class RecurringTransactionRule < ApplicationRecord
   include PaperTrailTraceable
 
   belongs_to :wallet
+  belongs_to :organization, optional: true
 
   STATUSES = [
     :active,
@@ -65,15 +66,18 @@ end
 #  trigger                             :integer          default("interval"), not null
 #  created_at                          :datetime         not null
 #  updated_at                          :datetime         not null
+#  organization_id                     :uuid
 #  wallet_id                           :uuid             not null
 #
 # Indexes
 #
-#  index_recurring_transaction_rules_on_expiration_at  (expiration_at)
-#  index_recurring_transaction_rules_on_started_at     (started_at)
-#  index_recurring_transaction_rules_on_wallet_id      (wallet_id)
+#  index_recurring_transaction_rules_on_expiration_at    (expiration_at)
+#  index_recurring_transaction_rules_on_organization_id  (organization_id)
+#  index_recurring_transaction_rules_on_started_at       (started_at)
+#  index_recurring_transaction_rules_on_wallet_id        (wallet_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (wallet_id => wallets.id)
 #

--- a/app/services/wallets/recurring_transaction_rules/create_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/create_service.rb
@@ -19,6 +19,7 @@ module Wallets
         end
 
         attributes = {
+          organization_id: wallet.organization_id,
           paid_credits: rule_params[:paid_credits] || paid_credits || 0.0,
           granted_credits: rule_params[:granted_credits] || granted_credits || 0.0,
           threshold_credits: rule_params[:threshold_credits] || 0.0,

--- a/app/services/wallets/recurring_transaction_rules/update_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/update_service.rb
@@ -29,7 +29,8 @@ module Wallets
           unless rule.key?(:invoice_requires_successful_payment)
             rule[:invoice_requires_successful_payment] = wallet.invoice_requires_successful_payment
           end
-          created_recurring_rule = wallet.recurring_transaction_rules.create!(rule)
+          created_recurring_rule = wallet.recurring_transaction_rules
+            .create!(rule.merge(organization_id: wallet.organization_id))
           created_recurring_rules_ids.push(created_recurring_rule.id)
         end
 

--- a/db/migrate/20250519084647_add_organization_id_to_recurring_transaction_rules.rb
+++ b/db/migrate/20250519084647_add_organization_id_to_recurring_transaction_rules.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToRecurringTransactionRules < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :recurring_transaction_rules, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250519084648_add_organization_id_fk_to_recurring_transaction_rules.rb
+++ b/db/migrate/20250519084648_add_organization_id_fk_to_recurring_transaction_rules.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToRecurringTransactionRules < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :recurring_transaction_rules, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250519084649_validate_recurring_transaction_rules_organizations_foreign_key.rb
+++ b/db/migrate/20250519084649_validate_recurring_transaction_rules_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateRecurringTransactionRulesOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :recurring_transaction_rules, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -118,6 +118,7 @@ ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rai
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_5628a713de;
 ALTER TABLE IF EXISTS ONLY public.applied_usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_52b72c9b0e;
 ALTER TABLE IF EXISTS ONLY public.password_resets DROP CONSTRAINT IF EXISTS fk_rails_526379cd99;
+ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS fk_rails_52370612ae;
 ALTER TABLE IF EXISTS ONLY public.credits DROP CONSTRAINT IF EXISTS fk_rails_521b5240ed;
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_51ac39a0c6;
 ALTER TABLE IF EXISTS ONLY public.billable_metric_filters DROP CONSTRAINT IF EXISTS fk_rails_51077e7c0e;
@@ -238,6 +239,7 @@ DROP INDEX IF EXISTS public.index_refunds_on_payment_id;
 DROP INDEX IF EXISTS public.index_refunds_on_credit_note_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_wallet_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_started_at;
+DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_organization_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_expiration_at;
 DROP INDEX IF EXISTS public.index_quantified_events_on_organization_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_group_id;
@@ -3266,7 +3268,8 @@ CREATE TABLE public.recurring_transaction_rules (
     transaction_metadata jsonb DEFAULT '[]'::jsonb,
     expiration_at timestamp(6) without time zone,
     terminated_at timestamp(6) without time zone,
-    status integer DEFAULT 0
+    status integer DEFAULT 0,
+    organization_id uuid
 );
 
 
@@ -6181,6 +6184,13 @@ CREATE INDEX index_recurring_transaction_rules_on_expiration_at ON public.recurr
 
 
 --
+-- Name: index_recurring_transaction_rules_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_recurring_transaction_rules_on_organization_id ON public.recurring_transaction_rules USING btree (organization_id);
+
+
+--
 -- Name: index_recurring_transaction_rules_on_started_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7028,6 +7038,14 @@ ALTER TABLE ONLY public.commitments
 
 ALTER TABLE ONLY public.credits
     ADD CONSTRAINT fk_rails_521b5240ed FOREIGN KEY (invoice_id) REFERENCES public.invoices(id);
+
+
+--
+-- Name: recurring_transaction_rules fk_rails_52370612ae; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recurring_transaction_rules
+    ADD CONSTRAINT fk_rails_52370612ae FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
 
 
 --
@@ -7909,6 +7927,9 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250519084649'),
+('20250519084648'),
+('20250519084647'),
 ('20250517100023'),
 ('20250516115757'),
 ('20250516115756'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -27,7 +27,6 @@ Rspec.describe "All tables must have an organization_id" do
   let(:tables_to_migrate) do
     %w[
       integration_collection_mappings
-      recurring_transaction_rules
       refunds
       versions
     ]


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `recurring_transaction_rules` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added
