### PR TITLE
chore(organization): Add organization_id to integration_collection_mappings table

### DIFF
--- a/app/jobs/database_migrations/populate_integration_collection_mappings_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_integration_collection_mappings_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateIntegrationCollectionMappingsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = IntegrationCollectionMappings::BaseCollectionMapping.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM integrations WHERE integrations.id = integration_collection_mappings.integration_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/integration_collection_mappings/anrok_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/anrok_collection_mapping.rb
@@ -9,20 +9,23 @@ end
 #
 # Table name: integration_collection_mappings
 #
-#  id             :uuid             not null, primary key
-#  mapping_type   :integer          not null
-#  settings       :jsonb            not null
-#  type           :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  integration_id :uuid             not null
+#  id              :uuid             not null, primary key
+#  mapping_type    :integer          not null
+#  settings        :jsonb            not null
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  integration_id  :uuid             not null
+#  organization_id :uuid
 #
 # Indexes
 #
 #  index_int_collection_mappings_on_mapping_type_and_int_id  (mapping_type,integration_id) UNIQUE
 #  index_integration_collection_mappings_on_integration_id   (integration_id)
+#  index_integration_collection_mappings_on_organization_id  (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/models/integration_collection_mappings/avalara_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/avalara_collection_mapping.rb
@@ -9,20 +9,23 @@ end
 #
 # Table name: integration_collection_mappings
 #
-#  id             :uuid             not null, primary key
-#  mapping_type   :integer          not null
-#  settings       :jsonb            not null
-#  type           :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  integration_id :uuid             not null
+#  id              :uuid             not null, primary key
+#  mapping_type    :integer          not null
+#  settings        :jsonb            not null
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  integration_id  :uuid             not null
+#  organization_id :uuid
 #
 # Indexes
 #
 #  index_int_collection_mappings_on_mapping_type_and_int_id  (mapping_type,integration_id) UNIQUE
 #  index_integration_collection_mappings_on_integration_id   (integration_id)
+#  index_integration_collection_mappings_on_organization_id  (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/models/integration_collection_mappings/base_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/base_collection_mapping.rb
@@ -8,6 +8,7 @@ module IntegrationCollectionMappings
     self.table_name = "integration_collection_mappings"
 
     belongs_to :integration, class_name: "Integrations::BaseIntegration"
+    belongs_to :organization, optional: true
 
     MAPPING_TYPES = %i[
       fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit credit_note account
@@ -25,20 +26,23 @@ end
 #
 # Table name: integration_collection_mappings
 #
-#  id             :uuid             not null, primary key
-#  mapping_type   :integer          not null
-#  settings       :jsonb            not null
-#  type           :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  integration_id :uuid             not null
+#  id              :uuid             not null, primary key
+#  mapping_type    :integer          not null
+#  settings        :jsonb            not null
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  integration_id  :uuid             not null
+#  organization_id :uuid
 #
 # Indexes
 #
 #  index_int_collection_mappings_on_mapping_type_and_int_id  (mapping_type,integration_id) UNIQUE
 #  index_integration_collection_mappings_on_integration_id   (integration_id)
+#  index_integration_collection_mappings_on_organization_id  (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/models/integration_collection_mappings/netsuite_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/netsuite_collection_mapping.rb
@@ -10,20 +10,23 @@ end
 #
 # Table name: integration_collection_mappings
 #
-#  id             :uuid             not null, primary key
-#  mapping_type   :integer          not null
-#  settings       :jsonb            not null
-#  type           :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  integration_id :uuid             not null
+#  id              :uuid             not null, primary key
+#  mapping_type    :integer          not null
+#  settings        :jsonb            not null
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  integration_id  :uuid             not null
+#  organization_id :uuid
 #
 # Indexes
 #
 #  index_int_collection_mappings_on_mapping_type_and_int_id  (mapping_type,integration_id) UNIQUE
 #  index_integration_collection_mappings_on_integration_id   (integration_id)
+#  index_integration_collection_mappings_on_organization_id  (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/models/integration_collection_mappings/xero_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/xero_collection_mapping.rb
@@ -9,20 +9,23 @@ end
 #
 # Table name: integration_collection_mappings
 #
-#  id             :uuid             not null, primary key
-#  mapping_type   :integer          not null
-#  settings       :jsonb            not null
-#  type           :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  integration_id :uuid             not null
+#  id              :uuid             not null, primary key
+#  mapping_type    :integer          not null
+#  settings        :jsonb            not null
+#  type            :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  integration_id  :uuid             not null
+#  organization_id :uuid
 #
 # Indexes
 #
 #  index_int_collection_mappings_on_mapping_type_and_int_id  (mapping_type,integration_id) UNIQUE
 #  index_integration_collection_mappings_on_integration_id   (integration_id)
+#  index_integration_collection_mappings_on_organization_id  (organization_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (integration_id => integrations.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #

--- a/app/services/integration_collection_mappings/create_service.rb
+++ b/app/services/integration_collection_mappings/create_service.rb
@@ -16,6 +16,7 @@ module IntegrationCollectionMappings
       return result.not_found_failure!(resource: "integration") unless integration
 
       integration_collection_mapping = IntegrationCollectionMappings::Factory.new_instance(integration:).new(
+        organization_id: params[:organization_id],
         integration_id: params[:integration_id],
         mapping_type: params[:mapping_type]
       )

--- a/db/migrate/20250519085909_add_organization_id_to_integration_collection_mappings.rb
+++ b/db/migrate/20250519085909_add_organization_id_to_integration_collection_mappings.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToIntegrationCollectionMappings < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :integration_collection_mappings, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250519085910_add_organization_id_fk_to_integration_collection_mappings.rb
+++ b/db/migrate/20250519085910_add_organization_id_fk_to_integration_collection_mappings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToIntegrationCollectionMappings < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :integration_collection_mappings, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250519085911_validate_integration_collection_mappings_organizations_foreign_key.rb
+++ b/db/migrate/20250519085911_validate_integration_collection_mappings_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateIntegrationCollectionMappingsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :integration_collection_mappings, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -24,6 +24,7 @@ ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF
 ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS fk_rails_e88403f4b9;
 ALTER TABLE IF EXISTS ONLY public.customers_taxes DROP CONSTRAINT IF EXISTS fk_rails_e86903e081;
 ALTER TABLE IF EXISTS ONLY public.charge_filters DROP CONSTRAINT IF EXISTS fk_rails_e711e8089e;
+ALTER TABLE IF EXISTS ONLY public.integration_collection_mappings DROP CONSTRAINT IF EXISTS fk_rails_e148d17c1f;
 ALTER TABLE IF EXISTS ONLY public.customer_metadata DROP CONSTRAINT IF EXISTS fk_rails_dfac602b2c;
 ALTER TABLE IF EXISTS ONLY public.credit_note_items DROP CONSTRAINT IF EXISTS fk_rails_dea748e529;
 ALTER TABLE IF EXISTS ONLY public.coupon_targets DROP CONSTRAINT IF EXISTS fk_rails_de6b3c3138;
@@ -343,6 +344,7 @@ DROP INDEX IF EXISTS public.index_integration_customers_on_integration_id;
 DROP INDEX IF EXISTS public.index_integration_customers_on_external_customer_id;
 DROP INDEX IF EXISTS public.index_integration_customers_on_customer_id_and_type;
 DROP INDEX IF EXISTS public.index_integration_customers_on_customer_id;
+DROP INDEX IF EXISTS public.index_integration_collection_mappings_on_organization_id;
 DROP INDEX IF EXISTS public.index_integration_collection_mappings_on_integration_id;
 DROP INDEX IF EXISTS public.index_int_items_on_external_id_and_int_id_and_type;
 DROP INDEX IF EXISTS public.index_int_collection_mappings_on_mapping_type_and_int_id;
@@ -2853,7 +2855,8 @@ CREATE TABLE public.integration_collection_mappings (
     type character varying NOT NULL,
     settings jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -5463,6 +5466,13 @@ CREATE INDEX index_integration_collection_mappings_on_integration_id ON public.i
 
 
 --
+-- Name: index_integration_collection_mappings_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_integration_collection_mappings_on_organization_id ON public.integration_collection_mappings USING btree (organization_id);
+
+
+--
 -- Name: index_integration_customers_on_customer_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7801,6 +7811,14 @@ ALTER TABLE ONLY public.customer_metadata
 
 
 --
+-- Name: integration_collection_mappings fk_rails_e148d17c1f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.integration_collection_mappings
+    ADD CONSTRAINT fk_rails_e148d17c1f FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: charge_filters fk_rails_e711e8089e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7927,6 +7945,9 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250519085911'),
+('20250519085910'),
+('20250519085909'),
 ('20250519084649'),
 ('20250519084648'),
 ('20250519084647'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -21,14 +21,13 @@ Rspec.describe "All tables must have an organization_id" do
       group_properties
       groups
       password_resets
+      versions
     ]
   end
 
   let(:tables_to_migrate) do
     %w[
-      integration_collection_mappings
       refunds
-      versions
     ]
   end
 


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `integration_collection_mappings` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added

