### PR TITLE
chore(organization): Add organization_id to refunds table

### DIFF
--- a/app/jobs/database_migrations/populate_refunds_with_organization_job.rb
+++ b/app/jobs/database_migrations/populate_refunds_with_organization_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DatabaseMigrations
+  class PopulateRefundsWithOrganizationJob < ApplicationJob
+    queue_as :low_priority
+    unique :until_executed
+
+    BATCH_SIZE = 1000
+
+    def perform(batch_number = 1)
+      batch = Refund.unscoped
+        .where(organization_id: nil)
+        .limit(BATCH_SIZE)
+
+      if batch.exists?
+        # rubocop:disable Rails/SkipsModelValidations
+        batch.update_all("organization_id = (SELECT organization_id FROM credit_notes WHERE credit_notes.id = refunds.credit_note_id)")
+        # rubocop:enable Rails/SkipsModelValidations
+
+        # Queue the next batch
+        self.class.perform_later(batch_number + 1)
+      else
+        Rails.logger.info("Finished the execution")
+      end
+    end
+
+    def lock_key_arguments
+      [arguments]
+    end
+  end
+end

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -7,6 +7,7 @@ class Refund < ApplicationRecord
   belongs_to :credit_note
   belongs_to :payment_provider, optional: true, class_name: "PaymentProviders::BaseProvider"
   belongs_to :payment_provider_customer, class_name: "PaymentProviderCustomers::BaseCustomer"
+  belongs_to :organization, optional: true
 end
 
 # == Schema Information
@@ -20,6 +21,7 @@ end
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  credit_note_id               :uuid             not null
+#  organization_id              :uuid
 #  payment_id                   :uuid             not null
 #  payment_provider_customer_id :uuid             not null
 #  payment_provider_id          :uuid
@@ -28,6 +30,7 @@ end
 # Indexes
 #
 #  index_refunds_on_credit_note_id                (credit_note_id)
+#  index_refunds_on_organization_id               (organization_id)
 #  index_refunds_on_payment_id                    (payment_id)
 #  index_refunds_on_payment_provider_customer_id  (payment_provider_customer_id)
 #  index_refunds_on_payment_provider_id           (payment_provider_id)
@@ -35,6 +38,7 @@ end
 # Foreign Keys
 #
 #  fk_rails_...  (credit_note_id => credit_notes.id)
+#  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_id => payments.id)
 #  fk_rails_...  (payment_provider_customer_id => payment_provider_customers.id)
 #  fk_rails_...  (payment_provider_id => payment_providers.id)

--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -18,6 +18,7 @@ module CreditNotes
         adyen_result = create_adyen_refund
 
         refund = Refund.new(
+          organization: credit_note.organization_id,
           credit_note:,
           payment:,
           payment_provider: payment.payment_provider,

--- a/app/services/credit_notes/refunds/gocardless_service.rb
+++ b/app/services/credit_notes/refunds/gocardless_service.rb
@@ -22,6 +22,7 @@ module CreditNotes
         gocardless_result = create_gocardless_refund
 
         refund = Refund.new(
+          organization: credit_note.organization_id,
           credit_note:,
           payment:,
           payment_provider: payment.payment_provider,

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -20,6 +20,7 @@ module CreditNotes
         stripe_result = create_stripe_refund
 
         refund = Refund.new(
+          organization: credit_note.organization_id,
           credit_note:,
           payment:,
           payment_provider: payment.payment_provider,

--- a/db/migrate/20250519092051_add_organization_id_to_refunds.rb
+++ b/db/migrate/20250519092051_add_organization_id_to_refunds.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToRefunds < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :refunds, :organization, type: :uuid, index: {algorithm: :concurrently}
+  end
+end

--- a/db/migrate/20250519092052_add_organization_id_fk_to_refunds.rb
+++ b/db/migrate/20250519092052_add_organization_id_fk_to_refunds.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdFkToRefunds < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :refunds, :organizations, validate: false
+  end
+end

--- a/db/migrate/20250519092053_validate_refunds_organizations_foreign_key.rb
+++ b/db/migrate/20250519092053_validate_refunds_organizations_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateRefundsOrganizationsForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :refunds, :organizations
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -89,6 +89,7 @@ ALTER TABLE IF EXISTS ONLY public.applied_add_ons DROP CONSTRAINT IF EXISTS fk_r
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_78f6642ddf;
 ALTER TABLE IF EXISTS ONLY public.groups DROP CONSTRAINT IF EXISTS fk_rails_7886e1bc34;
 ALTER TABLE IF EXISTS ONLY public.credit_notes_taxes DROP CONSTRAINT IF EXISTS fk_rails_77f2d4440d;
+ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_778360c382;
 ALTER TABLE IF EXISTS ONLY public.commitments DROP CONSTRAINT IF EXISTS fk_rails_76ceb88c74;
 ALTER TABLE IF EXISTS ONLY public.integrations DROP CONSTRAINT IF EXISTS fk_rails_755d734f25;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS fk_rails_75577c354e;
@@ -237,6 +238,7 @@ DROP INDEX IF EXISTS public.index_search_quantified_events;
 DROP INDEX IF EXISTS public.index_refunds_on_payment_provider_id;
 DROP INDEX IF EXISTS public.index_refunds_on_payment_provider_customer_id;
 DROP INDEX IF EXISTS public.index_refunds_on_payment_id;
+DROP INDEX IF EXISTS public.index_refunds_on_organization_id;
 DROP INDEX IF EXISTS public.index_refunds_on_credit_note_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_wallet_id;
 DROP INDEX IF EXISTS public.index_recurring_transaction_rules_on_started_at;
@@ -3291,7 +3293,8 @@ CREATE TABLE public.refunds (
     status character varying NOT NULL,
     provider_refund_id character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    organization_id uuid
 );
 
 
@@ -6222,6 +6225,13 @@ CREATE INDEX index_refunds_on_credit_note_id ON public.refunds USING btree (cred
 
 
 --
+-- Name: index_refunds_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_refunds_on_organization_id ON public.refunds USING btree (organization_id);
+
+
+--
 -- Name: index_refunds_on_payment_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7299,6 +7309,14 @@ ALTER TABLE ONLY public.commitments
 
 
 --
+-- Name: refunds fk_rails_778360c382; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.refunds
+    ADD CONSTRAINT fk_rails_778360c382 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: credit_notes_taxes fk_rails_77f2d4440d; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7945,6 +7963,9 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250519092053'),
+('20250519092052'),
+('20250519092051'),
 ('20250519085911'),
 ('20250519085910'),
 ('20250519085909'),

--- a/spec/organization_id_column_spec.rb
+++ b/spec/organization_id_column_spec.rb
@@ -25,12 +25,6 @@ Rspec.describe "All tables must have an organization_id" do
     ]
   end
 
-  let(:tables_to_migrate) do
-    %w[
-      refunds
-    ]
-  end
-
   it do
     query = <<~SQL
       SELECT DISTINCT
@@ -55,6 +49,6 @@ Rspec.describe "All tables must have an organization_id" do
       .reject { |table| internal_tables.include?(table) || tables_to_skip.include?(table) }
       .sort
 
-    expect(tables_without_organization_id).to match_array(tables_to_migrate)
+    expect(tables_without_organization_id).to be_empty
   end
 end


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is adding the field to the `refunds` table.
For now the field allows null values. A job to back-fill it  has been added.
In a later pull request the not null constraint will be added

