### PR TITLE
fix(adjusted_fees): Avoid NaN precise amount cents on fees when 0 units

### DIFF
--- a/app/services/fees/init_from_adjusted_charge_fee_service.rb
+++ b/app/services/fees/init_from_adjusted_charge_fee_service.rb
@@ -62,7 +62,7 @@ module Fees
         unit_amount_cents = unit_precise_amount_cents.round
         precise_amount_cents = units * unit_precise_amount_cents
         amount_cents = precise_amount_cents.round
-        precise_unit_amount = precise_amount_cents / (currency.subunit_to_unit * units)
+        precise_unit_amount = units.zero? ? 0 : precise_amount_cents / (currency.subunit_to_unit * units)
         amount_details = {}
       end
 

--- a/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
+++ b/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
@@ -119,6 +119,45 @@ RSpec.describe Fees::InitFromAdjustedChargeFeeService, type: :service do
         payment_status: "pending"
       )
     end
+
+    context "when units are 0" do
+      let(:adjusted_fee) do
+        create(
+          :adjusted_fee,
+          invoice:,
+          subscription:,
+          charge:,
+          properties:,
+          fee_type: :charge,
+          adjusted_units: false,
+          adjusted_amount: true,
+          units: 0,
+          unit_amount_cents: 0,
+          unit_precise_amount_cents: 0.0
+        )
+      end
+
+      it "initializes a fee" do
+        result = init_service.call
+
+        expect(result).to be_success
+        expect(result.fee).to be_a(Fee)
+        expect(result.fee).to have_attributes(
+          id: nil,
+          invoice:,
+          charge:,
+          amount_cents: 0,
+          precise_amount_cents: 0.0,
+          taxes_precise_amount_cents: 0.0,
+          amount_currency: invoice.currency,
+          units: 0,
+          unit_amount_cents: 0,
+          precise_unit_amount: 0,
+          events_count: 0,
+          payment_status: "pending"
+        )
+      end
+    end
   end
 
   context "with charge model error" do


### PR DESCRIPTION
## Context

Adjusting the amount on a fee with 0 units leads to `NaN` value set on `fees.precise_unit_amount`

## Description

This PR makes sure that fees.precise_unit_amount fallback to 0 when the number of units is 0
