### PR TITLE
fix(refund): Assign organization_id

### DIFF
--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -18,7 +18,7 @@ module CreditNotes
         adyen_result = create_adyen_refund
 
         refund = Refund.new(
-          organization: credit_note.organization_id,
+          organization_id: credit_note.organization_id,
           credit_note:,
           payment:,
           payment_provider: payment.payment_provider,

--- a/app/services/credit_notes/refunds/gocardless_service.rb
+++ b/app/services/credit_notes/refunds/gocardless_service.rb
@@ -22,7 +22,7 @@ module CreditNotes
         gocardless_result = create_gocardless_refund
 
         refund = Refund.new(
-          organization: credit_note.organization_id,
+          organization_id: credit_note.organization_id,
           credit_note:,
           payment:,
           payment_provider: payment.payment_provider,

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -20,7 +20,7 @@ module CreditNotes
         stripe_result = create_stripe_refund
 
         refund = Refund.new(
-          organization: credit_note.organization_id,
+          organization_id: credit_note.organization_id,
           credit_note:,
           payment:,
           payment_provider: payment.payment_provider,


### PR DESCRIPTION
## Context

Fix related to https://github.com/getlago/lago-api/pull/3674

The PR introduced a bug by trying to assign `organization_id` to the `organizaton` attribute