### PR TITLE
feat(pricing_group_keys): Add new `pricing_group_keys` API attribute

### DIFF
--- a/app/graphql/types/charges/properties.rb
+++ b/app/graphql/types/charges/properties.rb
@@ -5,7 +5,8 @@ module Types
     class Properties < Types::BaseObject
       # NOTE: Standard and Package charge model
       field :amount, String, null: true
-      field :grouped_by, [String], null: true
+      field :grouped_by, [String], null: true # TODO(pricing_group_keys): remove after deprecation of grouped_by
+      field :pricing_group_keys, [String], null: true
 
       # NOTE: Graduated charge model
       field :graduated_ranges, [Types::Charges::GraduatedRange], null: true
@@ -30,6 +31,11 @@ module Types
 
       # NOTE: properties for the custom aggregation
       field :custom_properties, GraphQL::Types::JSON, null: true
+
+      def pricing_group_keys
+        # TODO(pricing_group_keys): remove after deprecation of grouped_by
+        object["pricing_group_keys"].presence || object["grouped_by"]
+      end
     end
   end
 end

--- a/app/graphql/types/charges/properties_input.rb
+++ b/app/graphql/types/charges/properties_input.rb
@@ -5,7 +5,8 @@ module Types
     class PropertiesInput < Types::BaseInputObject
       # NOTE: Standard and Package charge model
       argument :amount, String, required: false
-      argument :grouped_by, [String], required: false
+      argument :grouped_by, [String], required: false  # TODO(pricing_group_keys): remove after deprecation of grouped_by
+      argument :pricing_group_keys, [String], required: false
 
       # NOTE: Graduated charge model
       argument :graduated_ranges, [Types::Charges::GraduatedRangeInput], required: false

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -59,6 +59,10 @@ class Charge < ApplicationRecord
     standard? || dynamic?
   end
 
+  def pricing_group_keys
+    properties["pricing_group_keys"].presence || properties["grouped_by"]
+  end
+
   def equal_properties?(charge)
     charge_model == charge.charge_model && properties == charge.properties
   end

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -49,6 +49,10 @@ class ChargeFilter < ApplicationRecord
     end
   end
 
+  def pricing_group_keys
+    properties["pricing_group_keys"].presence || properties["grouped_by"]
+  end
+
   private
 
   def validate_properties

--- a/app/serializers/v1/charge_filter_serializer.rb
+++ b/app/serializers/v1/charge_filter_serializer.rb
@@ -5,9 +5,25 @@ module V1
     def serialize
       {
         invoice_display_name: model.invoice_display_name,
-        properties: model.properties,
+        properties:,
         values: model.to_h
       }
+    end
+
+    private
+
+    # TODO(pricing_group_keys): remove after deprecation of grouped_by
+    def properties
+      attributes = model.properties
+      if attributes["grouped_by"].present? && attributes["pricing_group_keys"].blank?
+        attributes["pricing_group_keys"] = attributes["grouped_by"]
+      end
+
+      if attributes["pricing_group_keys"].present? && attributes["grouped_by"].blank?
+        attributes["grouped_by"] = attributes["pricing_group_keys"]
+      end
+
+      attributes
     end
   end
 end

--- a/app/serializers/v1/charge_serializer.rb
+++ b/app/serializers/v1/charge_serializer.rb
@@ -15,7 +15,7 @@ module V1
         pay_in_advance: model.pay_in_advance,
         prorated: model.prorated,
         min_amount_cents: model.min_amount_cents,
-        properties: model.properties
+        properties:
       }
 
       payload.merge!(charge_filters)
@@ -41,6 +41,20 @@ module V1
         ::V1::ChargeFilterSerializer,
         collection_name: "filters"
       ).serialize
+    end
+
+    # TODO(pricing_group_keys): remove after deprecation of grouped_by
+    def properties
+      attributes = model.properties
+      if attributes["grouped_by"].present? && attributes["pricing_group_keys"].blank?
+        attributes["pricing_group_keys"] = attributes["grouped_by"]
+      end
+
+      if attributes["pricing_group_keys"].present? && attributes["grouped_by"].blank?
+        attributes["grouped_by"] = attributes["pricing_group_keys"]
+      end
+
+      attributes
     end
   end
 end

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -29,7 +29,7 @@ module BillableMetrics
             compute_grouped_by_precise_total_amount_cents(options:)
           end
 
-          result.aggregations.each { apply_rounding(_1) }
+          result.aggregations.each { apply_rounding(it) }
         else
           compute_aggregation(options:)
           if charge.dynamic?

--- a/app/services/charges/charge_model_factory.rb
+++ b/app/services/charges/charge_model_factory.rb
@@ -4,7 +4,11 @@ module Charges
   class ChargeModelFactory
     def self.new_instance(charge:, aggregation_result:, properties:)
       charge_model = charge_model_class(charge:)
-      if properties["grouped_by"].present? && !aggregation_result.aggregations.nil?
+
+      # TODO(pricing_group_keys): remove after deprecation of grouped_by
+      pricing_group_keys = properties["pricing_group_keys"].presence || properties["grouped_by"]
+
+      if pricing_group_keys.present? && !aggregation_result.aggregations.nil?
         Charges::ChargeModels::GroupedService.new(charge_model: charge_model, charge:, aggregation_result:, properties:)
       else
         charge_model.new(charge:, aggregation_result:, properties:)

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -44,10 +44,11 @@ module Charges
     def aggregation_filters
       filters = {event:}
 
-      properties = charge_filter&.properties || charge.properties
-      if charge.supports_grouped_by? && properties["grouped_by"].present?
-        filters[:grouped_by_values] = properties["grouped_by"].index_with do |grouped_by|
-          event.properties[grouped_by]
+      if charge.supports_grouped_by?
+        model = charge_filter.presence || charge
+
+        if model.pricing_group_keys.present?
+          filters[:grouped_by_values] = model.pricing_group_keys.index_with { event.properties[it] }
         end
       end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -7512,6 +7512,7 @@ type Properties {
   packageSize: BigInt
   perTransactionMaxAmount: String
   perTransactionMinAmount: String
+  pricingGroupKeys: [String!]
   rate: String
   volumeRanges: [VolumeRange!]
 }
@@ -7529,6 +7530,7 @@ input PropertiesInput {
   packageSize: BigInt
   perTransactionMaxAmount: String
   perTransactionMinAmount: String
+  pricingGroupKeys: [String!]
   rate: String
   volumeRanges: [VolumeRangeInput!]
 }

--- a/schema.json
+++ b/schema.json
@@ -37121,6 +37121,26 @@
               "args": []
             },
             {
+              "name": "pricingGroupKeys",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "rate",
               "description": null,
               "type": {
@@ -37178,6 +37198,26 @@
             },
             {
               "name": "groupedBy",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pricingGroupKeys",
               "description": null,
               "type": {
                 "kind": "LIST",

--- a/spec/graphql/types/charges/properties_input_spec.rb
+++ b/spec/graphql/types/charges/properties_input_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::Charges::PropertiesInput do
   it do
     expect(subject).to accept_argument(:amount).of_type("String")
     expect(subject).to accept_argument(:grouped_by).of_type("[String!]")
+    expect(subject).to accept_argument(:pricing_group_keys).of_type("[String!]")
 
     expect(subject).to accept_argument(:graduated_ranges).of_type("[GraduatedRangeInput!]")
 

--- a/spec/graphql/types/charges/properties_spec.rb
+++ b/spec/graphql/types/charges/properties_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::Charges::Properties do
   it do
     expect(subject).to have_field(:amount).of_type("String")
     expect(subject).to have_field(:grouped_by).of_type("[String!]")
+    expect(subject).to have_field(:pricing_group_keys).of_type("[String!]")
 
     expect(subject).to have_field(:graduated_ranges).of_type("[GraduatedRange!]")
 

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -424,4 +424,22 @@ RSpec.describe ChargeFilter, type: :model do
       )
     end
   end
+
+  describe "#pricing_group_keys" do
+    subject(:charge_filter) { build(:charge_filter, properties:) }
+
+    let(:properties) { {"amount_cents" => "1000", :pricing_group_keys => ["user_id"]} }
+
+    it "returns the pricing group keys" do
+      expect(charge_filter.pricing_group_keys).to eq(["user_id"])
+    end
+
+    context "with grouped_by property" do
+      let(:properties) { {"amount_cents" => "1000", :grouped_by => ["user_id"]} }
+
+      it "returns the pricing group keys" do
+        expect(charge_filter.pricing_group_keys).to eq(["user_id"])
+      end
+    end
+  end
 end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -547,6 +547,24 @@ RSpec.describe Charge, type: :model do
     end
   end
 
+  describe "#pricing_group_keys" do
+    subject(:charge) { build(:standard_charge, properties:) }
+
+    let(:properties) { {"amount_cents" => "1000", :pricing_group_keys => ["user_id"]} }
+
+    it "returns the pricing group keys" do
+      expect(charge.pricing_group_keys).to eq(["user_id"])
+    end
+
+    context "with grouped_by property" do
+      let(:properties) { {"amount_cents" => "1000", :grouped_by => ["user_id"]} }
+
+      it "returns the pricing group keys" do
+        expect(charge.pricing_group_keys).to eq(["user_id"])
+      end
+    end
+  end
+
   describe "#equal_properties?" do
     let(:charge1) { build(:standard_charge, properties: {amount: 100}) }
 

--- a/spec/serializers/v1/charge_filter_serializer_spec.rb
+++ b/spec/serializers/v1/charge_filter_serializer_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe ::V1::ChargeFilterSerializer do
   subject(:serializer) { described_class.new(charge_filter, root_name: "filter") }
 
-  let(:charge_filter) { create(:charge_filter) }
+  let(:charge_filter) { create(:charge_filter, properties:) }
+  let(:properties) { {"amount" => "1000"} }
   let(:filter) { create(:billable_metric_filter) }
 
   let(:filter_value) do
@@ -30,6 +31,27 @@ RSpec.describe ::V1::ChargeFilterSerializer do
           filter.key => filter_value.values
         }
       )
+    end
+  end
+
+  # TODO(pricing_group_keys): remove after deprecation of grouped_by
+  context "with grouped_by" do
+    let(:properties) { {"amount" => "1000", "grouped_by" => ["user_id"]} }
+
+    it "serializes the grouped_by properties" do
+      result = JSON.parse(serializer.to_json)
+      expect(result["filter"]["properties"]["grouped_by"]).to eq(["user_id"])
+      expect(result["filter"]["properties"]["pricing_group_keys"]).to eq(["user_id"])
+    end
+  end
+
+  context "with pricing_group_keys" do
+    let(:properties) { {"amount" => "1000", "pricing_group_keys" => ["user_id"]} }
+
+    it "serializes the grouped_by properties" do
+      result = JSON.parse(serializer.to_json)
+      expect(result["filter"]["properties"]["grouped_by"]).to eq(["user_id"])
+      expect(result["filter"]["properties"]["pricing_group_keys"]).to eq(["user_id"])
     end
   end
 end

--- a/spec/serializers/v1/charge_serializer_spec.rb
+++ b/spec/serializers/v1/charge_serializer_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe ::V1::ChargeSerializer do
   subject(:serializer) { described_class.new(charge, root_name: "charge", includes: %i[taxes]) }
 
-  let(:charge) { create(:standard_charge) }
+  let(:charge) { create(:standard_charge, properties:) }
+  let(:properties) { {"amount" => "1000"} }
 
   it "serializes the object" do
     result = JSON.parse(serializer.to_json)
@@ -22,6 +23,27 @@ RSpec.describe ::V1::ChargeSerializer do
       expect(result["charge"]["filters"]).to eq([])
 
       expect(result["charge"]["taxes"]).to eq([])
+    end
+  end
+
+  # TODO(pricing_group_keys): remove after deprecation of grouped_by
+  context "with grouped_by" do
+    let(:properties) { {"amount" => "1000", "grouped_by" => ["user_id"]} }
+
+    it "serializes the grouped_by properties" do
+      result = JSON.parse(serializer.to_json)
+      expect(result["charge"]["properties"]["grouped_by"]).to eq(["user_id"])
+      expect(result["charge"]["properties"]["pricing_group_keys"]).to eq(["user_id"])
+    end
+  end
+
+  context "with pricing_group_keys" do
+    let(:properties) { {"amount" => "1000", "pricing_group_keys" => ["user_id"]} }
+
+    it "serializes the grouped_by properties" do
+      result = JSON.parse(serializer.to_json)
+      expect(result["charge"]["properties"]["grouped_by"]).to eq(["user_id"])
+      expect(result["charge"]["properties"]["pricing_group_keys"]).to eq(["user_id"])
     end
   end
 end

--- a/spec/services/charges/filter_charge_model_properties_service_spec.rb
+++ b/spec/services/charges/filter_charge_model_properties_service_spec.rb
@@ -42,10 +42,27 @@ RSpec.describe Charges::FilterChargeModelPropertiesService, type: :service do
 
       it { expect(filter_service.call.properties.keys).to include("amount", "grouped_by") }
 
+      # TODO(pricing_group_keys): remove after deprecation
       context "when grouped_by contains empty string" do
         let(:properties) { {amount: 100, grouped_by: ["", ""]} }
 
         it { expect(filter_service.call.properties[:grouped_by]).to be_empty }
+      end
+
+      context "when pricing_group_keys contains empty string" do
+        let(:properties) { {amount: 100, pricing_group_keys: ["", ""]} }
+
+        it { expect(filter_service.call.properties[:pricing_group_keys]).to be_empty }
+      end
+
+      # TODO(pricing_group_keys): remove after deprecation
+      context "with both grouped_by and pricing_group_keys" do
+        let(:properties) { {amount: 100, grouped_by: %w[location], pricing_group_keys: %w[customer]} }
+
+        it "gives precedence to pricing_group_keys" do
+          expect(filter_service.call.properties[:grouped_by]).to be_nil
+          expect(filter_service.call.properties[:pricing_group_keys]).to eq(["customer"])
+        end
       end
     end
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe Fees::ChargeService do
         end
       end
 
+      # TODO(pricing_group_keys): remove after deprecation of grouped_by
       context "with grouped standard charge" do
         let(:charge) do
           create(
@@ -116,6 +117,202 @@ RSpec.describe Fees::ChargeService do
             properties: {
               amount: "20",
               grouped_by: ["cloud"]
+            }
+          )
+        end
+
+        let(:billable_metric) do
+          create(:billable_metric, organization:, aggregation_type: "sum_agg", field_name: "value")
+        end
+
+        context "without events" do
+          it "does not create a fee" do
+            result = charge_subscription_service.call
+            expect(result).to be_success
+            expect(result.fees.count).to eq(0)
+          end
+
+          context "when organization as zero_amount_fees premium integration" do
+            before do
+              organization.update!(premium_integrations: ["zero_amount_fees"])
+            end
+
+            it "creates a fee" do
+              result = charge_subscription_service.call
+              expect(result).to be_success
+              expect(result.fees.count).to eq(1)
+            end
+          end
+        end
+
+        context "with events" do
+          before do
+            create(
+              :event,
+              organization: subscription.organization,
+              subscription:,
+              code: charge.billable_metric.code,
+              timestamp: Time.zone.parse("2022-03-16"),
+              properties: {cloud: "aws", value: 10}
+            )
+
+            create(
+              :event,
+              organization: subscription.organization,
+              subscription:,
+              code: charge.billable_metric.code,
+              timestamp: Time.zone.parse("2022-03-16"),
+              properties: {cloud: "aws", value: 5}
+            )
+
+            create(
+              :event,
+              organization: subscription.organization,
+              subscription:,
+              code: charge.billable_metric.code,
+              timestamp: Time.zone.parse("2022-03-16"),
+              properties: {cloud: "gcp", value: 10}
+            )
+          end
+
+          it "creates a fee for each group" do
+            result = charge_subscription_service.call
+            expect(result).to be_success
+            expect(result.fees.count).to eq(2)
+
+            fee1 = result.fees.find { |f| f.grouped_by["cloud"] == "aws" }
+            expect(fee1).to have_attributes(
+              id: String,
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_cents: 30_000,
+              precise_amount_cents: 30_000.0,
+              taxes_precise_amount_cents: 0.0,
+              amount_currency: "EUR",
+              units: 15,
+              unit_amount_cents: 2000,
+              precise_unit_amount: 20,
+              grouped_by: {"cloud" => "aws"}
+            )
+
+            fee2 = result.fees.find { |f| f.grouped_by["cloud"] == "gcp" }
+            expect(fee2).to have_attributes(
+              id: String,
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_cents: 20_000,
+              precise_amount_cents: 20_000.0,
+              taxes_precise_amount_cents: 0.0,
+              amount_currency: "EUR",
+              units: 10,
+              unit_amount_cents: 2000,
+              precise_unit_amount: 20,
+              grouped_by: {"cloud" => "gcp"}
+            )
+          end
+
+          context "with adjusted fee" do
+            let(:adjusted_fee) do
+              create(
+                :adjusted_fee,
+                invoice:,
+                subscription:,
+                charge:,
+                properties:,
+                fee_type: :charge,
+                adjusted_units: true,
+                adjusted_amount: false,
+                units: 3,
+                grouped_by: {"cloud" => "aws"}
+              )
+            end
+
+            let(:properties) do
+              {
+                charges_from_datetime: boundaries[:charges_from_datetime],
+                charges_to_datetime: boundaries[:charges_to_datetime]
+              }
+            end
+
+            before do
+              adjusted_fee
+              invoice.draft!
+            end
+
+            it "creates a fee for each group" do
+              result = charge_subscription_service.call
+              expect(result).to be_success
+              expect(result.fees.count).to eq(2)
+
+              fee1 = result.fees.find { |f| f.grouped_by["cloud"] == "aws" }
+              expect(fee1).to have_attributes(
+                id: String,
+                invoice_id: invoice.id,
+                charge_id: charge.id,
+                amount_cents: 6_000,
+                precise_amount_cents: 6_000.0,
+                taxes_precise_amount_cents: 0.0,
+                amount_currency: "EUR",
+                units: 3,
+                unit_amount_cents: 2000,
+                precise_unit_amount: 20,
+                grouped_by: {"cloud" => "aws"}
+              )
+
+              fee2 = result.fees.find { |f| f.grouped_by["cloud"] == "gcp" }
+              expect(fee2).to have_attributes(
+                id: String,
+                invoice_id: invoice.id,
+                charge_id: charge.id,
+                amount_cents: 20_000,
+                precise_amount_cents: 20_000.0,
+                taxes_precise_amount_cents: 0.0,
+                amount_currency: "EUR",
+                units: 10,
+                unit_amount_cents: 2000,
+                precise_unit_amount: 20,
+                grouped_by: {"cloud" => "gcp"}
+              )
+            end
+          end
+
+          context "with recurring weighted sum aggregation" do
+            let(:billable_metric) { create(:weighted_sum_billable_metric, :recurring, organization:) }
+
+            it "creates a fee and a cached aggregation per group" do
+              result = charge_subscription_service.call
+              expect(result).to be_success
+
+              expect(result.fees.count).to eq(2)
+              expect(result.cached_aggregations.count).to eq(2)
+            end
+          end
+
+          context "with custom aggregation" do
+            let(:billable_metric) do
+              create(:custom_aggregation_billable_metric, organization:)
+
+              it "creates a fee and a cached aggregation" do
+                result = charge_subscription_service.call
+                expect(result).to be_success
+
+                expect(result.fees.count).to eq(2)
+                expect(result.cached_aggregation.count).to eq(2)
+              end
+            end
+          end
+        end
+      end
+
+      context "with pricing_group_keys and standard charge" do
+        let(:charge) do
+          create(
+            :standard_charge,
+            plan: subscription.plan,
+            billable_metric:,
+            properties: {
+              amount: "20",
+              pricing_group_keys: ["cloud"]
             }
           )
         end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/3666 and is part of an epic to add grouped_by feature on all charge models and not only on the standard one like today. 

## Description

This PR is the second step:
- It updates the GraphQL and the Rest APIs to accept and return the new `pricing_group_keys` attribute
- It makes sure that the deprecated `grouped_by` attribute is still accepted and returned
- It adapt the aggregation logic to use the `pricing_group_keys` or the `grouped_by` attributes

For now the grouped aggregation remains remains whitelisted only on the standard and dynamic charge model. This will remain like this until the logic is applied to all charge model
