### PR TITLE
fix(daily-usages): Retry job on ActiveRecordError

### DIFF
--- a/app/jobs/daily_usages/compute_job.rb
+++ b/app/jobs/daily_usages/compute_job.rb
@@ -4,6 +4,8 @@ module DailyUsages
   class ComputeJob < ApplicationJob
     queue_as "low_priority"
 
+    retry_on ActiveRecord::ActiveRecordError, wait: :polynomially_longer, attempts: 6
+
     def perform(subscription, timestamp:)
       DailyUsages::ComputeService.call(subscription:, timestamp:).raise_if_error!
     end


### PR DESCRIPTION
## Context

Clickhouse raises an error instead of autoscaling when `DailyUsages::ComputeJob` is running on the old pod during the rollout.

## Description

Retry the job when this happens.