### PR TITLE
feat(audit-logs):extract mark invoice payment overdue service

### DIFF
--- a/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
+++ b/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
@@ -10,8 +10,7 @@ module Clock
         .where(payment_dispute_lost_at: nil)
         .where(payment_due_date: ...Time.current)
         .find_each do |invoice|
-          invoice.update!(payment_overdue: true)
-          SendWebhookJob.perform_later("invoice.payment_overdue", invoice)
+          Invoices::Payments::MarkOverdueService.call(invoice:)
         end
     end
   end

--- a/app/services/invoices/payments/mark_overdue_service.rb
+++ b/app/services/invoices/payments/mark_overdue_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Payments
+    class MarkOverdueService < BaseService
+      def initialize(invoice:)
+        @invoice = invoice
+
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: "invoice") unless invoice
+        return result.not_allowed_failure!(code: "invoice_not_finalized") unless invoice.finalized?
+        return result.not_allowed_failure!(code: "invoice_payment_already_succeeded") if invoice.payment_succeeded?
+        return result.not_allowed_failure!(code: "invoice_due_date_in_future") if invoice.payment_due_date > Time.current
+        return result.not_allowed_failure!(code: "invoice_dispute_lost") if invoice.payment_dispute_lost_at
+
+        invoice.update!(payment_overdue: true)
+
+        result.invoice = invoice
+
+        SendWebhookJob.perform_later("invoice.payment_overdue", invoice)
+        result
+      end
+
+      private
+
+      attr_reader :invoice
+    end
+  end
+end

--- a/spec/services/invoices/payments/mark_overdue_service_spec.rb
+++ b/spec/services/invoices/payments/mark_overdue_service_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::Payments::MarkOverdueService, type: :service do
+  let(:result) { described_class.call(invoice:) }
+
+  let(:invoice) do
+    create(:invoice,
+      payment_due_date: invoice_due_date,
+      status: invoice_status,
+      payment_status: invoice_payment_status,
+      payment_dispute_lost_at: invoice_dispute_lost_at)
+  end
+  let(:invoice_payment_status) { :pending }
+  let(:invoice_due_date) { 1.day.ago }
+  let(:invoice_status) { :finalized }
+  let(:invoice_dispute_lost_at) { nil }
+
+  describe "#call" do
+    it "mark the invoice as payment_overdue" do
+      expect(result.invoice.payment_overdue).to be_truthy
+    end
+
+    it "sends invoice.payment_overdue hook" do
+      invoice = result.invoice
+
+      expect(SendWebhookJob).to have_been_enqueued.with("invoice.payment_overdue", invoice)
+    end
+
+    context "when invoice is nil" do
+      let(:invoice) { nil }
+
+      it "returns a not found error" do
+        expect(result.success?).to be(false)
+        expect(result.error.error_code).to eq("invoice_not_found")
+      end
+    end
+
+    context "when invoice is not finalized" do
+      let(:invoice_status) { :draft }
+
+      it "returns not allowed failure" do
+        expect(result.success?).to be(false)
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("invoice_not_finalized")
+      end
+    end
+
+    context "when invoice payment succeeded" do
+      let(:invoice_payment_status) { :succeeded }
+
+      it "returns not allowed failure" do
+        expect(result.success?).to be(false)
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("invoice_payment_already_succeeded")
+      end
+    end
+
+    context "when invoice due date is in future" do
+      let(:invoice_due_date) { 5.days.from_now }
+
+      it "returns not allowed failure" do
+        expect(result.success?).to be(false)
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("invoice_due_date_in_future")
+      end
+    end
+
+    context "when invoice is disputed and lost" do
+      let(:invoice_dispute_lost_at) { 1.day.ago }
+
+      it "returns not allowed failure" do
+        expect(result.success?).to be(false)
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("invoice_dispute_lost")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR extract the action to mark an invoice as payment overdue to a service.