### PR TITLE
feat: Fallback to organization country for EU bank transfers

### DIFF
--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -25,6 +25,7 @@ module PaymentProviders
     ].freeze
     SUCCESS_STATUSES = %w[succeeded].freeze
     FAILED_STATUSES = %w[canceled requires_payment_method].freeze
+    SUPPORTED_EU_BANK_TRANSFER_COUNTRIES = %w[BE DE ES FR IE NL].freeze
 
     validates :secret_key, presence: true
     validates :success_redirect_url, url: true, allow_nil: true, length: {maximum: 1024}

--- a/app/services/payment_provider_customers/stripe/sync_funding_instructions_service.rb
+++ b/app/services/payment_provider_customers/stripe/sync_funding_instructions_service.rb
@@ -86,7 +86,7 @@ module PaymentProviderCustomers
 
       def eu_bank_transfer_payload
         customer_country = customer.country&.upcase
-        organization_country = customer.organization.country&.upcase
+        organization_country = customer.billing_entity.country&.upcase
 
         country =
           if SUPPORTED_EU_BANK_TRANSFER_COUNTRIES.include?(customer_country)
@@ -94,10 +94,10 @@ module PaymentProviderCustomers
           elsif SUPPORTED_EU_BANK_TRANSFER_COUNTRIES.include?(organization_country)
             organization_country
           else
-            return result.service_failure!(
+            result.service_failure!(
               code: "missing_country",
               message: "No country found for customer or organization supported for EU bank transfer payload"
-            )
+            ).raise_if_error!
           end
 
         {

--- a/app/services/payment_provider_customers/stripe/sync_funding_instructions_service.rb
+++ b/app/services/payment_provider_customers/stripe/sync_funding_instructions_service.rb
@@ -4,7 +4,6 @@ module PaymentProviderCustomers
   module Stripe
     class SyncFundingInstructionsService < BaseService
       Result = BaseResult[:funding_instructions]
-      SUPPORTED_EU_BANK_TRANSFER_COUNTRIES = %w[BE DE ES FR IE NL].freeze
 
       def initialize(stripe_customer)
         @stripe_customer = stripe_customer
@@ -86,13 +85,13 @@ module PaymentProviderCustomers
 
       def eu_bank_transfer_payload
         customer_country = customer.country&.upcase
-        organization_country = customer.billing_entity.country&.upcase
+        billing_entity_country = customer.billing_entity.country&.upcase
 
         country =
-          if SUPPORTED_EU_BANK_TRANSFER_COUNTRIES.include?(customer_country)
+          if PaymentProviders::StripeProvider::SUPPORTED_EU_BANK_TRANSFER_COUNTRIES.include?(customer_country)
             customer_country
-          elsif SUPPORTED_EU_BANK_TRANSFER_COUNTRIES.include?(organization_country)
-            organization_country
+          elsif PaymentProviders::StripeProvider::SUPPORTED_EU_BANK_TRANSFER_COUNTRIES.include?(billing_entity_country)
+            billing_entity_country
           else
             result.service_failure!(
               code: "missing_country",

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -182,6 +182,7 @@ module PaymentProviders
           customer_country = payment.customer.country.upcase
           {type: "eu_bank_transfer", eu_bank_transfer: {country: customer_country}}
         end
+
         def handle_eu_bank_transfer_new
           customer_country = payment.customer.country&.upcase
           organization_country = invoice.organization.country&.upcase

--- a/app/services/payment_providers/stripe/payments/create_service.rb
+++ b/app/services/payment_providers/stripe/payments/create_service.rb
@@ -4,8 +4,6 @@ module PaymentProviders
   module Stripe
     module Payments
       class CreateService < BaseService
-        SUPPORTED_EU_BANK_TRANSFER_COUNTRIES = %w[BE DE ES FR IE NL].freeze
-
         def initialize(payment:, reference:, metadata:)
           @payment = payment
           @reference = reference
@@ -180,13 +178,13 @@ module PaymentProviders
 
         def handle_eu_bank_transfer
           customer_country = payment.customer.country&.upcase
-          organization_country = payment.customer.billing_entity.country&.upcase
+          billing_entity_country = payment.customer.billing_entity.country&.upcase
 
           country =
-            if SUPPORTED_EU_BANK_TRANSFER_COUNTRIES.include?(customer_country)
+            if PaymentProviders::StripeProvider::SUPPORTED_EU_BANK_TRANSFER_COUNTRIES.include?(customer_country)
               customer_country
-            elsif SUPPORTED_EU_BANK_TRANSFER_COUNTRIES.include?(organization_country)
-              organization_country
+            elsif PaymentProviders::StripeProvider::SUPPORTED_EU_BANK_TRANSFER_COUNTRIES.include?(billing_entity_country)
+              billing_entity_country
             else
               result.service_failure!(
                 code: "missing_country",

--- a/spec/services/payment_provider_customers/stripe/sync_funding_instructions_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/sync_funding_instructions_service_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe PaymentProviderCustomers::Stripe::SyncFundingInstructionsService 
       end
     end
 
-    context "when customer country is unsupported but organization country is supported" do
-      let(:organization) { create(:organization, country: "IE") }
-      let(:customer) { create(:customer, organization:, currency: "EUR", country: "SE") }
+    context "when customer country is unsupported but billing entity country is supported" do
+      let(:billing_entity) { create(:billing_entity, organization:, country: "IE") }
+      let(:customer) { create(:customer, organization:, currency: "EUR", country: "SE", billing_entity:) }
       let(:bank_transfer_data) { instance_double("BankTransfer", to_hash: {some: "details"}) }
       let(:funding_instructions) { instance_double("FundingInstructions", bank_transfer: bank_transfer_data) }
       let(:invoice_custom_section) { build_stubbed(:invoice_custom_section, organization:) }
@@ -74,7 +74,7 @@ RSpec.describe PaymentProviderCustomers::Stripe::SyncFundingInstructionsService 
         allow(payment_provider).to receive(:secret_key).and_return("sk_test_123")
       end
 
-      it "uses organization country" do
+      it "uses billing entity country" do
         sync_funding_service.call
 
         expect(::Stripe::Customer).to have_received(:create_funding_instructions).with(

--- a/spec/services/payment_provider_customers/stripe/sync_funding_instructions_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/sync_funding_instructions_service_spec.rb
@@ -56,5 +56,35 @@ RSpec.describe PaymentProviderCustomers::Stripe::SyncFundingInstructionsService 
         expect(Customers::ManageInvoiceCustomSectionsService).to have_received(:call)
       end
     end
+
+    context "when customer country is unsupported but organization country is supported" do
+      let(:organization) { create(:organization, country: "IE") }
+      let(:customer) { create(:customer, organization:, currency: "EUR", country: "SE") }
+      let(:bank_transfer_data) { instance_double("BankTransfer", to_hash: {some: "details"}) }
+      let(:funding_instructions) { instance_double("FundingInstructions", bank_transfer: bank_transfer_data) }
+      let(:invoice_custom_section) { create(:invoice_custom_section, organization:) }
+
+      before do
+        allow(::Stripe::Customer).to receive(:create_funding_instructions).and_return(funding_instructions)
+        allow(InvoiceCustomSections::FundingInstructionsFormatterService).to receive(:call)
+          .and_return(instance_double("FormatterResult", details: "formatted"))
+        allow(InvoiceCustomSections::CreateService).to receive(:call)
+          .and_return(instance_double("CreateResult", invoice_custom_section:))
+        allow(Customers::ManageInvoiceCustomSectionsService).to receive(:call)
+        allow(payment_provider).to receive(:secret_key).and_return("sk_test_123")
+      end
+
+      it "uses organization country" do
+        sync_funding_service.call
+
+        expect(::Stripe::Customer).to have_received(:create_funding_instructions).with(
+          provider_customer_id,
+          hash_including(
+            bank_transfer: {type: "eu_bank_transfer", eu_bank_transfer: {country: "IE"}}
+          ),
+          anything
+        )
+      end
+    end
   end
 end

--- a/spec/services/payment_provider_customers/stripe/sync_funding_instructions_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/sync_funding_instructions_service_spec.rb
@@ -65,25 +65,28 @@ RSpec.describe PaymentProviderCustomers::Stripe::SyncFundingInstructionsService 
       let(:invoice_custom_section) { create(:invoice_custom_section, organization:) }
 
       before do
-        allow(::Stripe::Customer).to receive(:create_funding_instructions).and_return(funding_instructions)
         allow(InvoiceCustomSections::FundingInstructionsFormatterService).to receive(:call)
           .and_return(instance_double("FormatterResult", details: "formatted"))
         allow(InvoiceCustomSections::CreateService).to receive(:call)
-          .and_return(instance_double("CreateResult", invoice_custom_section:))
+         .and_return(instance_double("CreateResult", invoice_custom_section:))
         allow(Customers::ManageInvoiceCustomSectionsService).to receive(:call)
         allow(payment_provider).to receive(:secret_key).and_return("sk_test_123")
       end
 
       it "uses organization country" do
-        sync_funding_service.call
+        expect(::Stripe::Customer).to receive(:create_funding_instructions) do |customer_id, params, options|
+          expect(customer_id).to eq(provider_customer_id)
+          expect(params[:bank_transfer]).to eq(
+            type: "eu_bank_transfer",
+            eu_bank_transfer: {country: "IE"}
+          )
+          expect(params[:currency]).to eq("eur")
+          expect(params[:funding_type]).to eq("bank_transfer")
+          expect(options).to eq(api_key: "sk_test_123")
+          funding_instructions
+        end
 
-        expect(::Stripe::Customer).to have_received(:create_funding_instructions).with(
-          provider_customer_id,
-          hash_including(
-            bank_transfer: {type: "eu_bank_transfer", eu_bank_transfer: {country: "IE"}}
-          ),
-          anything
-        )
+        sync_funding_service.call
       end
     end
   end

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service do
   subject(:create_service) { described_class.new(payment:, reference:, metadata:) }
 
-  let(:customer) { create(:customer, payment_provider_code: code, country: "CA") }
+  let(:customer) { create(:customer, payment_provider_code: code, country:) }
+  let(:country) { "CA" }
   let(:organization) { customer.organization }
   let(:stripe_payment_provider) { create(:stripe_provider, organization:, code:) }
   let(:stripe_customer) { create(:stripe_customer, customer:, payment_method_id: "pm_123456", payment_provider: stripe_payment_provider) }
@@ -419,13 +420,14 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service
 
         context "when currency is EUR" do
           let(:currency) { "EUR" }
+          let(:country) { "DE" }
 
           it "includes EU bank transfer details" do
             expected_payload = base_payload.deep_merge(
               payment_method_options: {
                 customer_balance: {
                   bank_transfer: {
-                    eu_bank_transfer: {country: "CA"},
+                    eu_bank_transfer: {country: },
                     type: "eu_bank_transfer"
                   }
                 }

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service
               payment_method_options: {
                 customer_balance: {
                   bank_transfer: {
-                    eu_bank_transfer: {country: },
+                    eu_bank_transfer: {country:},
                     type: "eu_bank_transfer"
                   }
                 }


### PR DESCRIPTION
## Context

Stripe only supports a limited list of countries when creating `eu_bank_transfer` funding instructions. If a customer's country is not in that list, the request fails with a 400 error.

This feature request aims to allow accepting bank transfers from any European country by defaulting to the organization if that country is supported.

## Description

- A fallback mechanism was added when creating Stripe funding instructions for the type `eu_bank_transfer`.
- If the customer's country is unsupported, the system checks whether the organization's country is supported.
