### PR TITLE
feat(alerting): Add LifetimeUsageAmount and BillableMetricUsageUnits alerts

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -143,6 +143,10 @@ class Organization < ApplicationRecord
     end
   end
 
+  def using_lifetime_usage?
+    lifetime_usage_enabled? || progressive_billing_enabled?
+  end
+
   def admins
     users.joins(:memberships).merge!(memberships.admin)
   end

--- a/app/models/usage_monitoring/alert.rb
+++ b/app/models/usage_monitoring/alert.rb
@@ -9,11 +9,14 @@ module UsageMonitoring
 
     STI_MAPPING = {
       "usage_amount" => "UsageMonitoring::UsageAmountAlert",
-      "billable_metric_usage_amount" => "UsageMonitoring::BillableMetricUsageAmountAlert"
+      "billable_metric_usage_amount" => "UsageMonitoring::BillableMetricUsageAmountAlert",
+      "billable_metric_usage_units" => "UsageMonitoring::BillableMetricUsageUnitsAlert",
+
+      "lifetime_usage_amount" => "UsageMonitoring::LifetimeUsageAmountAlert"
     }
 
-    CURRENT_USAGE_TYPES = %w[usage_amount billable_metric_usage_amount]
-    BILLABLE_METRIC_TYPES = %w[billable_metric_usage_amount]
+    CURRENT_USAGE_TYPES = %w[usage_amount billable_metric_usage_amount billable_metric_usage_units]
+    BILLABLE_METRIC_TYPES = %w[billable_metric_usage_amount billable_metric_usage_units]
 
     default_scope -> { kept }
 

--- a/app/models/usage_monitoring/alert.rb
+++ b/app/models/usage_monitoring/alert.rb
@@ -37,6 +37,9 @@ module UsageMonitoring
     validates :billable_metric, presence: true, if: :need_billable_metric?
     validates :billable_metric, absence: true, unless: :need_billable_metric?
 
+    scope :using_current_usage, -> { where(alert_type: CURRENT_USAGE_TYPES) }
+    scope :using_lifetime_usage, -> { where(alert_type: "lifetime_usage_amount") }
+
     def self.find_sti_class(type_name)
       STI_MAPPING.fetch(type_name).constantize
     end

--- a/app/models/usage_monitoring/billable_metric_usage_units_alert.rb
+++ b/app/models/usage_monitoring/billable_metric_usage_units_alert.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module UsageMonitoring
+  class BillableMetricUsageUnitsAlert < Alert
+    def find_value(current_usage)
+      charge_ids = current_usage.fees.map(&:charge_id)
+      matching_charge_ids = Charge.where(id: charge_ids, billable_metric_id: billable_metric_id).ids
+      current_usage.fees.select { |fee| matching_charge_ids.include? fee.charge_id }.map(&:units).max
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: usage_monitoring_alerts
+#
+#  id                       :uuid             not null, primary key
+#  alert_type               :enum             not null
+#  code                     :string           not null
+#  deleted_at               :datetime
+#  last_processed_at        :datetime
+#  name                     :string
+#  previous_value           :decimal(30, 5)   default(0.0), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  billable_metric_id       :uuid
+#  organization_id          :uuid             not null
+#  subscription_external_id :string           not null
+#
+# Indexes
+#
+#  idx_alerts_code_unique_per_subscription                    (code,subscription_external_id,organization_id) UNIQUE WHERE (deleted_at IS NULL)
+#  idx_alerts_unique_per_type_per_subscription                (subscription_external_id,organization_id,alert_type) UNIQUE WHERE ((billable_metric_id IS NULL) AND (deleted_at IS NULL))
+#  idx_alerts_unique_per_type_per_subscription_with_bm        (subscription_external_id,organization_id,alert_type,billable_metric_id) UNIQUE WHERE ((billable_metric_id IS NOT NULL) AND (deleted_at IS NULL))
+#  index_usage_monitoring_alerts_on_billable_metric_id        (billable_metric_id)
+#  index_usage_monitoring_alerts_on_organization_id           (organization_id)
+#  index_usage_monitoring_alerts_on_subscription_external_id  (subscription_external_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (billable_metric_id => billable_metrics.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/models/usage_monitoring/lifetime_usage_amount_alert.rb
+++ b/app/models/usage_monitoring/lifetime_usage_amount_alert.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module UsageMonitoring
+  class LifetimeUsageAmountAlert < Alert
+    def find_value(lifetime_usage)
+      lifetime_usage.total_amount_cents
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: usage_monitoring_alerts
+#
+#  id                       :uuid             not null, primary key
+#  alert_type               :enum             not null
+#  code                     :string           not null
+#  deleted_at               :datetime
+#  last_processed_at        :datetime
+#  name                     :string
+#  previous_value           :decimal(30, 5)   default(0.0), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  billable_metric_id       :uuid
+#  organization_id          :uuid             not null
+#  subscription_external_id :string           not null
+#
+# Indexes
+#
+#  idx_alerts_code_unique_per_subscription                    (code,subscription_external_id,organization_id) UNIQUE WHERE (deleted_at IS NULL)
+#  idx_alerts_unique_per_type_per_subscription                (subscription_external_id,organization_id,alert_type) UNIQUE WHERE ((billable_metric_id IS NULL) AND (deleted_at IS NULL))
+#  idx_alerts_unique_per_type_per_subscription_with_bm        (subscription_external_id,organization_id,alert_type,billable_metric_id) UNIQUE WHERE ((billable_metric_id IS NOT NULL) AND (deleted_at IS NULL))
+#  index_usage_monitoring_alerts_on_billable_metric_id        (billable_metric_id)
+#  index_usage_monitoring_alerts_on_organization_id           (organization_id)
+#  index_usage_monitoring_alerts_on_subscription_external_id  (subscription_external_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (billable_metric_id => billable_metrics.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/app/services/usage_monitoring/create_alert_service.rb
+++ b/app/services/usage_monitoring/create_alert_service.rb
@@ -14,6 +14,10 @@ module UsageMonitoring
     end
 
     def call
+      if params[:alert_type] == "lifetime_usage_amount" && !organization.using_lifetime_usage?
+        return result.single_validation_failure!(field: :alert_type, error_code: "feature_not_available")
+      end
+
       if params[:thresholds].blank?
         return result.single_validation_failure!(field: :thresholds, error_code: "value_is_mandatory")
       end

--- a/app/services/usage_monitoring/process_subscription_activity_service.rb
+++ b/app/services/usage_monitoring/process_subscription_activity_service.rb
@@ -38,11 +38,11 @@ module UsageMonitoring
           organization_id: subscription_activity.organization_id
         ).includes(:thresholds)
 
-        alerts.where(alert_type: Alert::CURRENT_USAGE_TYPES).find_each do |alert|
+        alerts.using_current_usage.find_each do |alert|
           ProcessAlertService.call(alert:, subscription:, current_metrics: current_usage)
         end
 
-        alerts.where(alert_type: "lifetime_usage_amount").find_each do |alert|
+        alerts.using_lifetime_usage.find_each do |alert|
           ProcessAlertService.call(alert:, subscription:, current_metrics: lifetime_usage)
         end
       rescue => e

--- a/app/services/usage_monitoring/update_alert_service.rb
+++ b/app/services/usage_monitoring/update_alert_service.rb
@@ -15,6 +15,10 @@ module UsageMonitoring
     def call
       return result.not_found_failure!(resource: "alert") unless alert
 
+      if params.has_key?(:thresholds) && params[:thresholds].size > AlertThreshold::SOFT_LIMIT
+        return result.single_validation_failure!(field: :thresholds, error_code: "too_many_thresholds")
+      end
+
       result.alert = alert
 
       billable_metric = find_billable_metric_from_params!

--- a/db/migrate/20250520155108_add_billable_metric_usage_units_alert_type_to_enum.rb
+++ b/db/migrate/20250520155108_add_billable_metric_usage_units_alert_type_to_enum.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddBillableMetricUsageUnitsAlertTypeToEnum < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      add_enum_value :usage_monitoring_alert_types, "billable_metric_usage_units", if_not_exists: true
+    end
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20250520170402_add_lifetime_usage_amount_alert_type_to_enum.rb
+++ b/db/migrate/20250520170402_add_lifetime_usage_amount_alert_type_to_enum.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddLifetimeUsageAmountAlertTypeToEnum < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      add_enum_value :usage_monitoring_alert_types, "lifetime_usage_amount", if_not_exists: true
+    end
+  end
+
+  def down
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -929,7 +929,9 @@ CREATE TYPE public.tax_status AS ENUM (
 
 CREATE TYPE public.usage_monitoring_alert_types AS ENUM (
     'usage_amount',
-    'billable_metric_usage_amount'
+    'billable_metric_usage_amount',
+    'billable_metric_usage_units',
+    'lifetime_usage_amount'
 );
 
 
@@ -8393,6 +8395,8 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250521104239'),
 ('20250521095733'),
+('20250520170402'),
+('20250520155108'),
 ('20250520143628'),
 ('20250520080000'),
 ('20250519092053'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -452,6 +452,8 @@ type AlertThreshold {
 
 enum AlertTypeEnum {
   billable_metric_usage_amount
+  billable_metric_usage_units
+  lifetime_usage_amount
   usage_amount
 }
 

--- a/schema.json
+++ b/schema.json
@@ -1942,6 +1942,18 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "billable_metric_usage_units",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lifetime_usage_amount",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/factories/usage_monitoring/alerts.rb
+++ b/spec/factories/usage_monitoring/alerts.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     alert_type { "usage_amount" }
 
     transient do
-      thresholds { nil }
+      thresholds { [15_00] }
       recurring_threshold { nil }
     end
 
@@ -35,10 +35,23 @@ FactoryBot.define do
     alert_type { "usage_amount" }
   end
 
+  factory :lifetime_usage_amount_alert,
+    class: "UsageMonitoring::LifetimeUsageAmountAlert",
+    parent: :alert do
+    alert_type { "lifetime_usage_amount" }
+  end
+
   factory :billable_metric_usage_amount_alert,
     class: "UsageMonitoring::BillableMetricUsageAmountAlert",
     parent: :alert do
     alert_type { "billable_metric_usage_amount" }
+    billable_metric { association(:billable_metric, organization: organization) }
+  end
+
+  factory :billable_metric_usage_units_alert,
+    class: "UsageMonitoring::BillableMetricUsageUnitsAlert",
+    parent: :alert do
+    alert_type { "billable_metric_usage_units" }
     billable_metric { association(:billable_metric, organization: organization) }
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -324,6 +324,18 @@ RSpec.describe Organization, type: :model do
     end
   end
 
+  describe "#using_lifetime_usage?" do
+    around { |test| lago_premium!(&test) }
+
+    it do
+      expect(build(:organization, premium_integrations: ["lifetime_usage"])).to be_using_lifetime_usage
+      expect(build(:organization, premium_integrations: ["progressive_billing"])).to be_using_lifetime_usage
+      expect(build(:organization, premium_integrations: ["lifetime_usage", "progressive_billing"])).to be_using_lifetime_usage
+      expect(build(:organization, premium_integrations: [])).not_to be_using_lifetime_usage
+      expect(build(:organization, premium_integrations: ["okta"])).not_to be_using_lifetime_usage
+    end
+  end
+
   describe "#admins" do
     subject { organization.admins }
 

--- a/spec/models/usage_monitoring/billable_metric_usage_amount_alert_spec.rb
+++ b/spec/models/usage_monitoring/billable_metric_usage_amount_alert_spec.rb
@@ -3,21 +3,22 @@
 require "rails_helper"
 
 RSpec.describe UsageMonitoring::BillableMetricUsageAmountAlert, type: :model do
-  let(:alert) { create(:billable_metric_usage_amount_alert) }
-  let(:subscription) { create(:subscription) }
-  let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric: alert.billable_metric) }
+  subject { alert.find_value(current_usage) }
+
+  let(:alert) { create(:billable_metric_usage_amount_alert, subscription_external_id: "test") }
+  let(:current_usage) { instance_double(SubscriptionUsage, amount_cents: 100, fees:) }
+  let(:charge) { create(:standard_charge, billable_metric: alert.billable_metric) }
   let(:fees) do
     [
-      create(:charge_fee, charge: charge, amount_cents: 12),
-      create(:charge_fee)
+      create(:charge_fee, charge:, amount_cents: 8),
+      create(:charge_fee, charge:, amount_cents: 4), # will ensure that we're using max not min
+      create(:charge_fee, amount_cents: 12) # ensure that we look only within correct charge fees
     ]
   end
 
   describe "#find_value" do
-    it do
-      charge
-      current_usage = double(amount_cents: 100, fees:) # rubocop:disable RSpec/VerifiedDoubles
-      expect(alert.find_value(current_usage)).to eq(12)
+    it "returns biggest units among fees related to the alert's billable metric" do
+      expect(subject).to eq(8)
     end
   end
 end

--- a/spec/models/usage_monitoring/billable_metric_usage_units_alert_spec.rb
+++ b/spec/models/usage_monitoring/billable_metric_usage_units_alert_spec.rb
@@ -3,21 +3,22 @@
 require "rails_helper"
 
 RSpec.describe UsageMonitoring::BillableMetricUsageUnitsAlert, type: :model do
-  let(:alert) { create(:billable_metric_usage_units_alert) }
-  let(:subscription) { create(:subscription) }
-  let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric: alert.billable_metric) }
+  subject { alert.find_value(current_usage) }
+
+  let(:alert) { create(:billable_metric_usage_units_alert, subscription_external_id: "test") }
+  let(:current_usage) { instance_double(SubscriptionUsage, amount_cents: 100, fees:) }
+  let(:charge) { create(:standard_charge, billable_metric: alert.billable_metric) }
   let(:fees) do
     [
-      create(:charge_fee, charge: charge, amount_cents: 12, units: 8),
-      create(:charge_fee)
+      create(:charge_fee, charge:, units: 8),
+      create(:charge_fee, charge:, units: 4), # will ensure that we're using max not min
+      create(:charge_fee, units: 12) # ensure that we look only within correct charge fees
     ]
   end
 
   describe "#find_value" do
-    it do
-      charge
-      current_usage = double(amount_cents: 100, fees:) # rubocop:disable RSpec/VerifiedDoubles
-      expect(alert.find_value(current_usage)).to eq(8)
+    it "returns biggest units among fees related to the alert's billable metric" do
+      expect(subject).to eq(8)
     end
   end
 end

--- a/spec/models/usage_monitoring/billable_metric_usage_units_alert_spec.rb
+++ b/spec/models/usage_monitoring/billable_metric_usage_units_alert_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UsageMonitoring::BillableMetricUsageUnitsAlert, type: :model do
+  let(:alert) { create(:billable_metric_usage_units_alert) }
+  let(:subscription) { create(:subscription) }
+  let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric: alert.billable_metric) }
+  let(:fees) do
+    [
+      create(:charge_fee, charge: charge, amount_cents: 12, units: 8),
+      create(:charge_fee)
+    ]
+  end
+
+  describe "#find_value" do
+    it do
+      charge
+      current_usage = double(amount_cents: 100, fees:) # rubocop:disable RSpec/VerifiedDoubles
+      expect(alert.find_value(current_usage)).to eq(8)
+    end
+  end
+end

--- a/spec/models/usage_monitoring/lifetime_usage_amount_alert_spec.rb
+++ b/spec/models/usage_monitoring/lifetime_usage_amount_alert_spec.rb
@@ -3,12 +3,14 @@
 require "rails_helper"
 
 RSpec.describe UsageMonitoring::LifetimeUsageAmountAlert, type: :model do
-  let(:alert) { create(:lifetime_usage_amount_alert) }
-  let(:lifetime_usage) { create(:lifetime_usage, invoiced_usage_amount_cents: 6, current_usage_amount_cents: 3) }
-
   describe "#find_value" do
-    it do
-      expect(alert.find_value(lifetime_usage)).to eq(9)
+    subject { alert.find_value(lifetime_usage) }
+
+    let(:alert) { build_stubbed(:lifetime_usage_amount_alert, subscription_external_id: "test") }
+    let(:lifetime_usage) { build(:lifetime_usage, invoiced_usage_amount_cents: 6, current_usage_amount_cents: 3) }
+
+    it "returns lifetime usage's total amount cents" do
+      expect(subject).to eq(9)
     end
   end
 end

--- a/spec/models/usage_monitoring/lifetime_usage_amount_alert_spec.rb
+++ b/spec/models/usage_monitoring/lifetime_usage_amount_alert_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UsageMonitoring::LifetimeUsageAmountAlert, type: :model do
+  let(:alert) { create(:lifetime_usage_amount_alert) }
+  let(:lifetime_usage) { create(:lifetime_usage, invoiced_usage_amount_cents: 6, current_usage_amount_cents: 3) }
+
+  describe "#find_value" do
+    it do
+      expect(alert.find_value(lifetime_usage)).to eq(9)
+    end
+  end
+end

--- a/spec/services/usage_monitoring/create_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/create_alert_service_spec.rb
@@ -149,9 +149,12 @@ RSpec.describe UsageMonitoring::CreateAlertService do
     end
 
     context "when creating lifetime_usage alert" do
-      context "without required premium_integrations" do
+      let(:params) { {alert_type: "lifetime_usage_amount", thresholds:, code: "first"} }
+
+      around { |test| lago_premium!(&test) }
+
+      context "when organization using lifetime usage" do
         let(:premium_integrations) { [] }
-        let(:params) { {alert_type: "lifetime_usage_amount", thresholds:, code: "first"} }
 
         it "returns a record validation failure result" do
           expect(result).to be_failure
@@ -159,14 +162,12 @@ RSpec.describe UsageMonitoring::CreateAlertService do
         end
       end
 
-      context "with required premium_integrations" do
+      context "when organization does not use lifetime usage" do
         let(:premium_integrations) { ["lifetime_usage"] }
-        let(:params) { {alert_type: "lifetime_usage_amount", thresholds:, code: "first"} }
-
-        around { |test| lago_premium!(&test) }
 
         it "creates the alert" do
           expect(result).to be_success
+          expect(result.alert).to be_persisted
           expect(result.alert.alert_type).to eq "lifetime_usage_amount"
         end
       end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -207,6 +207,7 @@ module ScenariosHelper
     Clock::SubscriptionsBillerJob.perform_later
     Clock::FreeTrialSubscriptionsBillerJob.perform_later
     perform_all_enqueued_jobs
+    perform_usage_update
   end
 
   def perform_invoices_refresh


### PR DESCRIPTION
## Context

We're adding Alerting feature, see #3528, #3535, #3554, #3600

## Description

We introducing 2 new types of alerts:
* LifetimeUsageAmount: to define alert based on lifetime total usage
* BillableMetricUsageUnits: same as BillableMetricUsageAmount but with a number "used units" instead of currency amount.

Creating a new alert is essentially creating a new child class of `UsageMonitoring::Alert` and implementing `find_value`. 🙌