### PR TITLE
feat(audit_logs): Activity log for credit notes

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -4,11 +4,10 @@ module Api
   module V1
     class CreditNotesController < Api::BaseController
       def create
-        service = CreditNotes::CreateService.new(
+        result = CreditNotes::CreateService.call(
           invoice: current_organization.invoices.visible.find_by(id: input_params[:invoice_id]),
           **input_params
         )
-        result = service.call
 
         if result.success?
           render(

--- a/app/graphql/mutations/credit_notes/create.rb
+++ b/app/graphql/mutations/credit_notes/create.rb
@@ -26,11 +26,10 @@ module Mutations
         args[:items].map!(&:to_h)
 
         result = ::CreditNotes::CreateService
-          .new(
+          .call(
             invoice: current_organization.invoices.visible.find_by(id: args[:invoice_id]),
             **args
           )
-          .call
 
         result.success? ? result.credit_note : result_error(result)
       end

--- a/app/graphql/mutations/credit_notes/download.rb
+++ b/app/graphql/mutations/credit_notes/download.rb
@@ -16,9 +16,9 @@ module Mutations
       type Types::CreditNotes::Object
 
       def resolve(**args)
-        result = ::CreditNotes::GenerateService.new(
+        result = ::CreditNotes::GenerateService.call(
           credit_note: context[:current_user].credit_notes.find_by(id: args[:id])
-        ).call
+        )
 
         result.success? ? result.credit_note : result_error(result)
       end

--- a/app/jobs/credit_notes/generate_pdf_job.rb
+++ b/app/jobs/credit_notes/generate_pdf_job.rb
@@ -5,7 +5,7 @@ module CreditNotes
     queue_as "invoices"
 
     def perform(credit_note)
-      result = CreditNotes::GenerateService.new(credit_note:, context: "api").call
+      result = CreditNotes::GenerateService.call(credit_note:, context: "api")
       result.raise_if_error!
     end
   end

--- a/app/mailers/credit_note_mailer.rb
+++ b/app/mailers/credit_note_mailer.rb
@@ -37,6 +37,6 @@ class CreditNoteMailer < ApplicationMailer
   def ensure_pdf
     credit_note = params[:credit_note]
 
-    CreditNotes::GenerateService.new(credit_note:).call
+    CreditNotes::GenerateService.call(credit_note:)
   end
 end

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -39,6 +39,8 @@ class WalletTransaction < ApplicationRecord
   enum :transaction_type, TRANSACTION_TYPES
   enum :source, SOURCES
 
+  delegate :customer, to: :wallet
+
   scope :pending, -> { where(status: :pending) }
 
   def amount_cents

--- a/app/services/credit_notes/create_from_progressive_billing_invoice.rb
+++ b/app/services/credit_notes/create_from_progressive_billing_invoice.rb
@@ -17,13 +17,13 @@ module CreditNotes
       # Important to call this method as it modifies @amount if needed
       items = calculate_items!
 
-      CreditNotes::CreateService.new(
+      CreditNotes::CreateService.call(
         invoice: progressive_billing_invoice,
         credit_amount_cents: creditable_amount_cents(amount, items),
         items:,
         reason:,
         automatic: true
-      ).call.raise_if_error!
+      ).raise_if_error!
     end
 
     private

--- a/app/services/credit_notes/create_from_progressive_billing_invoice.rb
+++ b/app/services/credit_notes/create_from_progressive_billing_invoice.rb
@@ -17,13 +17,13 @@ module CreditNotes
       # Important to call this method as it modifies @amount if needed
       items = calculate_items!
 
-      CreditNotes::CreateService.call(
+      CreditNotes::CreateService.call!(
         invoice: progressive_billing_invoice,
         credit_amount_cents: creditable_amount_cents(amount, items),
         items:,
         reason:,
         automatic: true
-      ).raise_if_error!
+      )
     end
 
     private

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -19,6 +19,11 @@ module CreditNotes
       super
     end
 
+    activity_loggable(
+      action: "credit_note.created",
+      record: -> { result.credit_note }
+    )
+
     def call
       return result.not_found_failure!(resource: "invoice") unless invoice
       return result.forbidden_failure! unless should_create_credit_note?

--- a/app/services/credit_notes/generate_service.rb
+++ b/app/services/credit_notes/generate_service.rb
@@ -9,6 +9,11 @@ module CreditNotes
       super
     end
 
+    activity_loggable(
+      action: "credit_note.generated",
+      record: -> { credit_note }
+    )
+
     def call
       return result.not_found_failure!(resource: "credit_note") if credit_note.blank? || !credit_note.finalized?
 

--- a/app/services/credit_notes/generate_service.rb
+++ b/app/services/credit_notes/generate_service.rb
@@ -18,6 +18,7 @@ module CreditNotes
       return result.not_found_failure!(resource: "credit_note") if credit_note.blank? || !credit_note.finalized?
 
       if should_generate_pdf?
+        # TODO.
         generate_pdf(credit_note)
         SendWebhookJob.perform_later("credit_note.generated", credit_note)
       end

--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -51,6 +51,7 @@ module CreditNotes
 
         if status.to_sym == :failed
           deliver_error_webhook(message: "Payment refund failed", code: nil)
+          Utils::ActivityLog.produce(credit_note, "credit_note.refund_failed")
           result.service_failure!(code: "refund_failed", message: "Refund failed to perform")
         end
 
@@ -95,6 +96,7 @@ module CreditNotes
       rescue Adyen::AdyenError => e
         deliver_error_webhook(message: e.msg, code: e.code)
         update_credit_note_status(:failed)
+        Utils::ActivityLog.produce(credit_note, "credit_note.refund_failed")
 
         raise
       end

--- a/app/services/credit_notes/refunds/gocardless_service.rb
+++ b/app/services/credit_notes/refunds/gocardless_service.rb
@@ -42,6 +42,7 @@ module CreditNotes
       rescue GoCardlessPro::Error, GoCardlessPro::ValidationError => e
         deliver_error_webhook(message: e.message, code: e.code)
         update_credit_note_status(:failed)
+        Utils::ActivityLog.produce(credit_note, "credit_note.refund_failed")
 
         if e.is_a?(GoCardlessPro::ValidationError)
           result
@@ -64,6 +65,7 @@ module CreditNotes
 
         if FAILED_STATUSES.include?(status.to_s)
           deliver_error_webhook(message: "Payment refund failed", code: nil)
+          Utils::ActivityLog.produce(credit_note, "credit_note.refund_failed")
           result.service_failure!(code: "refund_failed", message: "Refund failed to perform")
         end
 

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -40,6 +40,7 @@ module CreditNotes
       rescue ::Stripe::InvalidRequestError => e
         deliver_error_webhook(message: e.message, code: e.code)
         update_credit_note_status(:failed)
+        Utils::ActivityLog.produce(credit_note, "credit_note.refund_failed")
         return result if e.code == INVALID_PAYMENT_METHOD_ERROR
 
         result.service_failure!(code: "stripe_error", message: e.message)
@@ -59,6 +60,7 @@ module CreditNotes
 
         if status.to_sym == :failed
           deliver_error_webhook(message: "Payment refund failed", code: nil)
+          Utils::ActivityLog.produce(credit_note, "credit_note.refund_failed")
           result.service_failure!(code: "refund_failed", message: "Refund failed to perform")
         end
 

--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -43,6 +43,7 @@ module Invoices
         invoice.credit_notes.each do |credit_note|
           track_credit_note_created(credit_note)
           SendWebhookJob.perform_later("credit_note.created", credit_note)
+          Utils::ActivityLog.produce(credit_note, "credit_note.created")
           CreditNotes::GeneratePdfJob.perform_later(credit_note)
         end
       end

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -4,6 +4,7 @@ module Utils
   class ActivityLog
     class << self
       IGNORED_FIELDS = %w[updated_at].freeze
+      IGNORED_EXTERNAL_CUSTOMER_ID_CLASSES = %w[BillableMetric Coupon Plan BillingEntity].freeze
 
       def produce(object, activity_type, activity_id: SecureRandom.uuid, changes: nil)
         return yield if object.nil? && block_given?
@@ -104,17 +105,16 @@ module Utils
       end
 
       def external_customer_id(activity_object)
+        return nil if IGNORED_EXTERNAL_CUSTOMER_ID_CLASSES.include?(activity_object.class.name)
         return activity_object.external_id if activity_object.is_a?(Customer)
-        return nil unless activity_object.respond_to?(:customer)
 
-        activity_object.customer.external_id
+        activity_object.customer&.external_id
       end
 
       def external_subscription_id(activity_object)
-        return activity_object.external_id if activity_object.is_a?(Subscription)
-        return nil unless activity_object.respond_to?(:subscription)
+        return nil unless activity_object.is_a?(Subscription)
 
-        activity_object.subscription.external_id
+        activity_object.external_id
       end
     end
   end

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -4,7 +4,6 @@ module Utils
   class ActivityLog
     class << self
       IGNORED_FIELDS = %w[updated_at].freeze
-      IGNORED_EXTERNAL_CUSTOMER_ID_CLASSES = %w[BillableMetric Coupon Plan BillingEntity].freeze
 
       def produce(object, activity_type, activity_id: SecureRandom.uuid, changes: nil)
         return yield if object.nil? && block_given?
@@ -105,15 +104,17 @@ module Utils
       end
 
       def external_customer_id(activity_object)
-        return nil if IGNORED_EXTERNAL_CUSTOMER_ID_CLASSES.include?(activity_object.class.name)
         return activity_object.external_id if activity_object.is_a?(Customer)
+        return nil unless activity_object.respond_to?(:customer)
 
-        resource(activity_object).customer&.external_id
+        activity_object.customer.external_id
       end
 
       def external_subscription_id(activity_object)
-        # TODO: Implement me.
-        nil
+        return activity_object.external_id if activity_object.is_a?(Subscription)
+        return nil unless activity_object.respond_to?(:subscription)
+
+        activity_object.subscription.external_id
       end
     end
   end

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -138,15 +138,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
     end
 
     it "produces an activity log" do
-      result = described_class.call(
-        invoice:,
-        items:,
-        description: nil,
-        credit_amount_cents:,
-        refund_amount_cents:,
-        automatic:,
-        context:
-      )
+      result = create_service.call
 
       expect(Utils::ActivityLog).to have_received(:produce).with(result.credit_note, "credit_note.created")
     end

--- a/spec/services/credit_notes/generate_service_spec.rb
+++ b/spec/services/credit_notes/generate_service_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe CreditNotes::GenerateService, type: :service do
     end
 
     it "produces an activity log" do
-      described_class.call(credit_note:)
+      result = credit_note_generate_service.call
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.generated")
+      expect(Utils::ActivityLog).to have_received(:produce).with(result.credit_note, "credit_note.generated")
     end
 
     context "when credit note is for self billed invoice" do

--- a/spec/services/credit_notes/generate_service_spec.rb
+++ b/spec/services/credit_notes/generate_service_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe CreditNotes::GenerateService, type: :service do
 
     stub_pdf_generation
     allow(Utils::PdfGenerator).to receive(:call).and_call_original
+    allow(Utils::ActivityLog).to receive(:produce)
   end
 
   describe ".call" do
@@ -31,6 +32,12 @@ RSpec.describe CreditNotes::GenerateService, type: :service do
       credit_note_generate_service.call
 
       expect(Utils::PdfGenerator).to have_received(:call).with(template: "credit_notes/credit_note", context: credit_note)
+    end
+
+    it "produces an activity log" do
+      described_class.call(credit_note:)
+
+      expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.generated")
     end
 
     context "when credit note is for self billed invoice" do

--- a/spec/services/credit_notes/refunds/adyen_service_spec.rb
+++ b/spec/services/credit_notes/refunds/adyen_service_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
       before do
         allow(modifications_api).to receive(:refund_captured_payment)
           .and_raise(Adyen::AdyenError.new(nil, nil, "error"))
+        allow(Utils::ActivityLog).to receive(:produce)
       end
 
       it "delivers an error webhook" do
@@ -108,6 +109,13 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
               error_code: nil
             }
           )
+      end
+
+      it "produces an activity log" do
+        expect { adyen_service.create }
+          .to raise_error(Adyen::AdyenError)
+
+        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failed")
       end
     end
 
@@ -278,7 +286,10 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
     end
 
     context "when status is failed" do
-      before { adyen_customer }
+      before do
+        adyen_customer
+        allow(Utils::ActivityLog).to receive(:produce)
+      end
 
       it "delivers an error webhook" do
         result = adyen_service.update_status(
@@ -304,6 +315,15 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
               }
             )
         end
+      end
+
+      it "produces an activity log" do
+        adyen_service.update_status(
+          provider_refund_id: refund.provider_refund_id,
+          status: "failed"
+        )
+
+        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failed")
       end
     end
   end

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
       end
 
       it "produces an activity log" do
-        result = stripe_service.update_status(
+        stripe_service.update_status(
           provider_refund_id: refund.provider_refund_id,
           status: "failed"
         )

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
       before do
         allow(Stripe::Refund).to receive(:create)
           .and_raise(::Stripe::InvalidRequestError.new(error_message, {}, code: error_message))
+        allow(Utils::ActivityLog).to receive(:produce)
       end
 
       it "delivers an error webhook" do
@@ -151,6 +152,12 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
               error_code: "error"
             }
           )
+      end
+
+      it "produces an activity log" do
+        stripe_service.create
+
+        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failed")
       end
 
       context "when error is about non refundable payment method" do
@@ -345,7 +352,10 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
     end
 
     context "when status is failed" do
-      before { stripe_customer }
+      before do
+        stripe_customer
+        allow(Utils::ActivityLog).to receive(:produce)
+      end
 
       it "delivers an error webhook" do
         result = stripe_service.update_status(
@@ -371,6 +381,15 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
               }
             )
         end
+      end
+
+      it "produces an activity log" do
+        result = stripe_service.update_status(
+          provider_refund_id: refund.provider_refund_id,
+          status: "failed"
+        )
+
+        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failed")
       end
     end
   end

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
     context "with credit notes" do
       before do
         create(:credit_note_item, credit_note:, fee:)
+        allow(Utils::ActivityLog).to receive(:produce)
       end
 
       it "marks the credit notes as finalized" do
@@ -210,6 +211,12 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
         expect do
           finalize_service.call
         end.to have_enqueued_job(SendWebhookJob).with("credit_note.created", CreditNote)
+      end
+
+      it "produces an activity log" do
+        result = finalize_service.call
+
+        expect(Utils::ActivityLog).to have_received(:produce).with(result.invoice.credit_notes.first, "credit_note.created")
       end
 
       it "enqueues CreditNotes::GeneratePdfJob" do


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context

Our users want to have visibility on what’s happening in Lago.

Examples:
- *A plan and prices have been updated: When? By whom? What?*
- *A subscription has been deleted: When? By whom? What?*

## Description

The goal of this PR is to create activity logs for credit notes.