### PR TITLE
fix(estimate fees): return 1 unit for estimate count_aggr

### DIFF
--- a/app/services/fees/estimate_instant/base_service.rb
+++ b/app/services/fees/estimate_instant/base_service.rb
@@ -22,7 +22,10 @@ module Fees
         # Todo: perhaps this should live in its own service
         Events::CalculateExpressionService.call(organization:, event:)
         billable_metric = charge.billable_metric
-        units = BigDecimal(event.properties[charge.billable_metric.field_name] || 0)
+        base_unit = 0
+        # in case for the aggregations we do not use field_name, we count each event as 1 unit
+        base_unit = 1 if charge.billable_metric.field_name.nil?
+        units = BigDecimal(event.properties[charge.billable_metric.field_name] || base_unit)
         units = BillableMetrics::Aggregations::ApplyRoundingService.call!(billable_metric:, units:).units
 
         estimate_result = estimate_class(charge).call!(properties:, units:)

--- a/spec/services/fees/estimate_instant/batch_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/estimate_instant/batch_pay_in_advance_service_spec.rb
@@ -186,6 +186,23 @@ RSpec.describe Fees::EstimateInstant::BatchPayInAdvanceService do
           end
         end
       end
+
+      context "when billable metric does not have field name to run aggregation on" do
+        let(:billable_metric) { create(:billable_metric, organization:) }
+        let(:charge) { create(:percentage_charge, :pay_in_advance, plan:, billable_metric:, properties: {rate: "10", fixed_amount: "0"}) }
+        let(:properties) { {} }
+
+        it "takes the whole event as one unit" do
+          result = subject.call
+
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+
+          fee = result.fees.first
+          expect(fee[:amount_cents]).to eq(10)
+          expect(fee[:units]).to eq(1)
+        end
+      end
     end
   end
 

--- a/spec/services/fees/estimate_instant/pay_in_advance_service_spec.rb
+++ b/spec/services/fees/estimate_instant/pay_in_advance_service_spec.rb
@@ -74,6 +74,24 @@ RSpec.describe Fees::EstimateInstant::PayInAdvanceService do
 
         fee = result.fees.first
         expect(fee[:amount_cents]).to eq(50)
+        expect(fee[:units]).to eq(500)
+      end
+
+      context "when billable metric aggregation does not support field name" do
+        let(:billable_metric) { create(:billable_metric, organization:) }
+        let(:charge) { create(:percentage_charge, :pay_in_advance, plan:, billable_metric:, properties: {rate: "10", fixed_amount: "0"}) }
+        let(:properties) { {} }
+
+        it "calculates the fee correctly" do
+          result = subject.call
+
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+
+          fee = result.fees.first
+          expect(fee[:amount_cents]).to eq(10)
+          expect(fee[:units]).to eq(1)
+        end
       end
     end
 


### PR DESCRIPTION
## Context

when estimating instant fees, we're using a new service, and there we're assuming that amount of units is sent in the event, but some aggregation types do not contain units in properties, because we consider the whole event as unit

## Description

- If charge billable_metric does not support field name, we should consider the whole event as one unit
- small additional fix: when generating progressive billing invoice, this process can fail because of idempotency, if it was triggered multiple times, so  we don't want to send the webhook if the invoice generation failed 
