### PR TITLE
chore(gql): remove deprecated field (see #3627)

### DIFF
--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -33,9 +33,6 @@ module Types
       field :next_subscription_at, GraphQL::Types::ISO8601DateTime
       field :next_subscription_type, Types::Subscriptions::NextSubscriptionTypeEnum
 
-      # TODO: Remove once frontend is updated
-      field :next_pending_start_date, GraphQL::Types::ISO8601Date, method: :downgrade_plan_date # Deprecated
-
       field :fees, [Types::Fees::Object], null: true
 
       field :lifetime_usage, Types::Subscriptions::LifetimeUsageObject, null: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -8525,7 +8525,6 @@ type Subscription {
   lifetimeUsage: SubscriptionLifetimeUsage
   name: String
   nextName: String
-  nextPendingStartDate: ISO8601Date
   nextPlan: Plan
   nextSubscription: Subscription
   nextSubscriptionAt: ISO8601DateTime

--- a/schema.json
+++ b/schema.json
@@ -44412,18 +44412,6 @@
               "args": []
             },
             {
-              "name": "nextPendingStartDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
               "name": "nextPlan",
               "description": null,
               "type": {

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Types::Subscriptions::Object do
 
     expect(subject).to have_field(:name).of_type("String")
     expect(subject).to have_field(:next_name).of_type("String")
-    expect(subject).to have_field(:next_pending_start_date).of_type("ISO8601Date")
     expect(subject).to have_field(:period_end_date).of_type("ISO8601Date")
     expect(subject).to have_field(:status).of_type("StatusTypeEnum")
 


### PR DESCRIPTION

Replaced by `next_subscription*` attributes in #3627
