### PR TITLE
feat(audit-logs): Return resource as an object for graphql

### DIFF
--- a/app/graphql/types/activity_logs/object.rb
+++ b/app/graphql/types/activity_logs/object.rb
@@ -17,8 +17,7 @@ module Types
       field :external_subscription_id, String
       field :logged_at, GraphQL::Types::ISO8601DateTime, null: false
       field :organization, Types::Organizations::OrganizationType
-      field :resource_id, String, null: false
-      field :resource_type, String, null: false
+      field :resource, Types::ActivityLogs::ResourceObject, null: true
       field :user_email, String
 
       def user_email

--- a/app/graphql/types/activity_logs/resource_object.rb
+++ b/app/graphql/types/activity_logs/resource_object.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Types
+  module ActivityLogs
+    class ResourceObject < Types::BaseUnion
+      graphql_name "ActivityLogResourceObject"
+
+      description "Activity log resource"
+
+      possible_types Types::BillableMetrics::Object,
+        Types::Plans::Object,
+        Types::Customers::Object,
+        Types::Invoices::Object,
+        Types::CreditNotes::Object,
+        Types::BillingEntities::Object,
+        Types::Subscriptions::Object,
+        Types::Wallets::Object,
+        Types::Coupons::Object
+
+      def self.resolve_type(object, _context)
+        case object.class.to_s
+        when "BillableMetric"
+          Types::BillableMetrics::Object
+        when "Plan"
+          Types::Plans::Object
+        when "Customer"
+          Types::Customers::Object
+        when "Invoice"
+          Types::Invoices::Object
+        when "CreditNote"
+          Types::CreditNotes::Object
+        when "BillingEntity"
+          Types::BillingEntities::Object
+        when "Subscription"
+          Types::Subscriptions::Object
+        when "Wallet"
+          Types::Wallets::Object
+        when "Coupon"
+          Types::Coupons::Object
+        else
+          raise "Unexpected activity log resource type: #{object.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -30,8 +30,7 @@ type ActivityLog {
   externalSubscriptionId: String
   loggedAt: ISO8601DateTime!
   organization: Organization
-  resourceId: String!
-  resourceType: String!
+  resource: ActivityLogResourceObject
   userEmail: String
 }
 
@@ -49,6 +48,11 @@ type ActivityLogCollection {
   """
   metadata: CollectionMetadata!
 }
+
+"""
+Activity log resource
+"""
+union ActivityLogResourceObject = BillableMetric | BillingEntity | Coupon | CreditNote | Customer | Invoice | Plan | Subscription | Wallet
 
 """
 Activity Logs source enums

--- a/schema.json
+++ b/schema.json
@@ -240,32 +240,12 @@
               "args": []
             },
             {
-              "name": "resourceId",
+              "name": "resource",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": []
-            },
-            {
-              "name": "resourceType",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "UNION",
+                "name": "ActivityLogResourceObject",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -335,6 +315,62 @@
               "args": []
             }
           ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "UNION",
+          "name": "ActivityLogResourceObject",
+          "description": "Activity log resource",
+          "interfaces": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "BillableMetric",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "BillingEntity",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Coupon",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "CreditNote",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Customer",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Invoice",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Plan",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Subscription",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Wallet",
+              "ofType": null
+            }
+          ],
+          "fields": null,
           "inputFields": null,
           "enumValues": null
         },

--- a/spec/graphql/types/activity_logs/object_spec.rb
+++ b/spec/graphql/types/activity_logs/object_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe Types::ActivityLogs::Object do
     expect(subject).to have_field(:external_subscription_id).of_type("String")
     expect(subject).to have_field(:logged_at).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:organization).of_type("Organization")
-    expect(subject).to have_field(:resource_id).of_type("String!")
-    expect(subject).to have_field(:resource_type).of_type("String!")
+    expect(subject).to have_field(:resource).of_type("ActivityLogResourceObject")
     expect(subject).to have_field(:user_email).of_type("String")
   end
 end

--- a/spec/graphql/types/activity_logs/resource_object_spec.rb
+++ b/spec/graphql/types/activity_logs/resource_object_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::ActivityLogs::ResourceObject do
+  subject { described_class }
+
+  it "has the correct graphql name" do
+    expect(subject.graphql_name).to eq("ActivityLogResourceObject")
+  end
+
+  it "includes the correct possible types" do
+    expect(subject.possible_types).to include(
+      Types::BillableMetrics::Object,
+      Types::Plans::Object,
+      Types::Customers::Object,
+      Types::Invoices::Object,
+      Types::CreditNotes::Object,
+      Types::BillingEntities::Object,
+      Types::Subscriptions::Object,
+      Types::Wallets::Object,
+      Types::Coupons::Object
+    )
+  end
+
+  describe ".resolve_type" do
+    let(:billable_metric) { create(:billable_metric) }
+    let(:plan) { create(:plan) }
+    let(:customer) { create(:customer) }
+    let(:invoice) { create(:invoice) }
+    let(:credit_note) { create(:credit_note) }
+    let(:billing_entity) { create(:billing_entity) }
+    let(:subscription) { create(:subscription) }
+    let(:wallet) { create(:wallet) }
+    let(:coupon) { create(:coupon) }
+
+    it "returns Types::BillableMetrics::Object for BillableMetric objects" do
+      expect(subject.resolve_type(billable_metric, {})).to eq(Types::BillableMetrics::Object)
+    end
+
+    it "returns Types::Plans::Object for Plan objects" do
+      expect(subject.resolve_type(plan, {})).to eq(Types::Plans::Object)
+    end
+
+    it "returns Types::Customers::Object for Customer objects" do
+      expect(subject.resolve_type(customer, {})).to eq(Types::Customers::Object)
+    end
+
+    it "returns Types::Invoices::Object for Invoice objects" do
+      expect(subject.resolve_type(invoice, {})).to eq(Types::Invoices::Object)
+    end
+
+    it "returns Types::CreditNotes::Object for CreditNote objects" do
+      expect(subject.resolve_type(credit_note, {})).to eq(Types::CreditNotes::Object)
+    end
+
+    it "returns Types::BillingEntities::Object for BillingEntity objects" do
+      expect(subject.resolve_type(billing_entity, {})).to eq(Types::BillingEntities::Object)
+    end
+
+    it "returns Types::Subscriptions::Object for Subscription objects" do
+      expect(subject.resolve_type(subscription, {})).to eq(Types::Subscriptions::Object)
+    end
+
+    it "returns Types::Wallets::Object for Wallet objects" do
+      expect(subject.resolve_type(wallet, {})).to eq(Types::Wallets::Object)
+    end
+
+    it "returns Types::Coupons::Object for Coupon objects" do
+      expect(subject.resolve_type(coupon, {})).to eq(Types::Coupons::Object)
+    end
+
+    it "raises an error for unexpected types" do
+      expect { subject.resolve_type("Unexpected", {}) }.to raise_error(StandardError)
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context

Our users want to have visibility on what’s happening in Lago.

Examples:
- *A plan and prices have been updated: When? By whom? What?*
- *A subscription has been deleted: When? By whom? What?*

## Description

The goal of this PR is to return activity log resource as an object.