### PR TITLE
feat(audit-logs): Return activity_object for deleted log

### DIFF
--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -67,8 +67,6 @@ module Utils
       end
 
       def activity_object(object, activity_type)
-        return {} if activity_type.include?("deleted")
-
         object_serialized(object)
       end
 

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Utils::ActivityLog, type: :service do
       end
 
       context "when the object is deleted" do
-        it "does not set activity_object and activity_object_changes" do
+        it "does not set activity_object_changes" do
           allow(CurrentContext).to receive(:source).and_return(nil)
           activity_log.produce(invoice, "invoice.deleted", activity_id: "activity-id") { BaseService::Result.new }
 
@@ -78,7 +78,7 @@ RSpec.describe Utils::ActivityLog, type: :service do
               resource_id: invoice.id,
               resource_type: "Invoice",
               organization_id: organization.id,
-              activity_object: {},
+              activity_object: V1::InvoiceSerializer.new(invoice).serialize,
               activity_object_changes: {},
               external_customer_id: invoice.customer.external_id,
               external_subscription_id: nil


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context

Our users want to have visibility on what’s happening in Lago.

Examples:
- *A plan and prices have been updated: When? By whom? What?*
- *A subscription has been deleted: When? By whom? What?*

## Description

The goal of this PR is to return deleted activity object for activity logs.