### PR TITLE
Fix(wallet balance): failed transaction and voided invoice

### DIFF
--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -24,7 +24,7 @@ module Invoices
         Rails.logger.warn("Recrediting credit #{credit.id} failed for invoice #{invoice.id}") unless res.success?
       end
 
-      invoice.wallet_transactions.each do |wallet_transaction|
+      invoice.wallet_transactions.outbound.each do |wallet_transaction|
         res = WalletTransactions::RecreditService.call(wallet_transaction:)
 
         unless res.success?

--- a/app/services/wallet_transactions/mark_as_failed_service.rb
+++ b/app/services/wallet_transactions/mark_as_failed_service.rb
@@ -12,7 +12,7 @@ module WalletTransactions
       return result if wallet_transaction.status == "failed"
 
       ActiveRecord::Base.transaction do
-        if wallet_transaction.settled?
+        if wallet_transaction.settled? && wallet_transaction.inbound?
           Wallets::Balance::DecreaseService
             .new(wallet: wallet_transaction.wallet, wallet_transaction: wallet_transaction).call
         end

--- a/spec/services/invoices/void_service_spec.rb
+++ b/spec/services/invoices/void_service_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Invoices::VoidService, type: :service do
 
         context "when the invoice has applied credits from the wallet" do
           let(:wallet) { create(:wallet, credits_balance: 100, balance_cents: 100) }
-          let(:wallet_transaction) { create(:wallet_transaction, wallet:, invoice:, transaction_type: 'outbound', amount: 100, credit_amount: 100) }
+          let(:wallet_transaction) { create(:wallet_transaction, wallet:, invoice:, transaction_type: "outbound", amount: 100, credit_amount: 100) }
 
           before do
             wallet_transaction
@@ -120,7 +120,7 @@ RSpec.describe Invoices::VoidService, type: :service do
           let(:invoice) { create(:invoice, :credit, status: :finalized, payment_status:, payment_overdue: true) }
           let(:payment_status) { [:pending, :failed].sample }
           let(:wallet) { create(:wallet, credits_balance: 100, balance_cents: 100) }
-          let(:wallet_transaction) { create(:wallet_transaction, wallet:, invoice:, transaction_type: 'inbound', amount: 100, credit_amount: 100) }
+          let(:wallet_transaction) { create(:wallet_transaction, wallet:, invoice:, transaction_type: "inbound", amount: 100, credit_amount: 100) }
 
           before do
             wallet_transaction

--- a/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
+++ b/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe WalletTransactions::MarkAsFailedService, type: :service do
         it "decreases the wallet balance" do
           expect {
             service.call
-          }.to change { wallet.reload.balance_cents }.by(-100).and change { wallet_transaction.reload.status }.
-            from("settled").to("failed")
+          }.to change { wallet.reload.balance_cents }.by(-100).and change { wallet_transaction.reload.status }
+            .from("settled").to("failed")
         end
       end
     end

--- a/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
+++ b/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
@@ -50,11 +50,10 @@ RSpec.describe WalletTransactions::MarkAsFailedService, type: :service do
           wallet_transaction
         end
 
-        it "decreases the wallet balance" do
+        it "does not do anything" do
           expect {
             service.call
-          }.to change { wallet.reload.balance_cents }.by(-100).and change { wallet_transaction.reload.status }
-            .from("settled").to("failed")
+          }.not_to change(wallet_transaction, :status)
         end
       end
     end


### PR DESCRIPTION
## Context

we got a bug where:
1. a credit was purchased (1$)
2. invoice marked as succeeded -> wallet transaction marked as settled,
3. wallet balance is updated to 1$
4. invoice payment status updated to failed -> wallet transaction marked as failed
5. wallet balance WAS NOT updated (still 1$) - FIRST ISSUE
6. invoice is voided -> recredit wallet_transaction is created - SECOND ISSUE
7. wallet balance increases to 2$

## Description

- when fail a wallet transaction, if a transaction was settled before, it will stay settled, the credits should be voided manually
- when recredit wallet_transactions when voiding an invoice, only recredit outbound wallet transaction (exactly "applied" credits from the wallet)
