### PR TITLE
feat(wallet-credit-limitation): add migration for precise credits values

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -208,48 +208,50 @@ end
 #
 # Table name: fees
 #
-#  id                                  :uuid             not null, primary key
-#  amount_cents                        :bigint           not null
-#  amount_currency                     :string           not null
-#  amount_details                      :jsonb            not null
-#  deleted_at                          :datetime
-#  description                         :string
-#  events_count                        :integer
-#  failed_at                           :datetime
-#  fee_type                            :integer
-#  grouped_by                          :jsonb            not null
-#  invoice_display_name                :string
-#  invoiceable_type                    :string
-#  pay_in_advance                      :boolean          default(FALSE), not null
-#  payment_status                      :integer          default("pending"), not null
-#  precise_amount_cents                :decimal(40, 15)  default(0.0), not null
-#  precise_coupons_amount_cents        :decimal(30, 5)   default(0.0), not null
-#  precise_unit_amount                 :decimal(30, 15)  default(0.0), not null
-#  properties                          :jsonb            not null
-#  refunded_at                         :datetime
-#  succeeded_at                        :datetime
-#  taxes_amount_cents                  :bigint           not null
-#  taxes_base_rate                     :float            default(1.0), not null
-#  taxes_precise_amount_cents          :decimal(40, 15)  default(0.0), not null
-#  taxes_rate                          :float            default(0.0), not null
-#  total_aggregated_units              :decimal(, )
-#  unit_amount_cents                   :bigint           default(0), not null
-#  units                               :decimal(, )      default(0.0), not null
-#  created_at                          :datetime         not null
-#  updated_at                          :datetime         not null
-#  add_on_id                           :uuid
-#  applied_add_on_id                   :uuid
-#  billing_entity_id                   :uuid             not null
-#  charge_filter_id                    :uuid
-#  charge_id                           :uuid
-#  group_id                            :uuid
-#  invoice_id                          :uuid
-#  invoiceable_id                      :uuid
-#  organization_id                     :uuid             not null
-#  pay_in_advance_event_id             :uuid
-#  pay_in_advance_event_transaction_id :string
-#  subscription_id                     :uuid
-#  true_up_parent_fee_id               :uuid
+#  id                                       :uuid             not null, primary key
+#  amount_cents                             :bigint           not null
+#  amount_currency                          :string           not null
+#  amount_details                           :jsonb            not null
+#  deleted_at                               :datetime
+#  description                              :string
+#  events_count                             :integer
+#  failed_at                                :datetime
+#  fee_type                                 :integer
+#  grouped_by                               :jsonb            not null
+#  invoice_display_name                     :string
+#  invoiceable_type                         :string
+#  pay_in_advance                           :boolean          default(FALSE), not null
+#  payment_status                           :integer          default("pending"), not null
+#  precise_amount_cents                     :decimal(40, 15)  default(0.0), not null
+#  precise_coupons_amount_cents             :decimal(30, 5)   default(0.0), not null
+#  precise_credit_notes_amount_cents        :decimal(30, 5)   default(0.0), not null
+#  precise_progressive_credits_amount_cents :decimal(30, 5)   default(0.0), not null
+#  precise_unit_amount                      :decimal(30, 15)  default(0.0), not null
+#  properties                               :jsonb            not null
+#  refunded_at                              :datetime
+#  succeeded_at                             :datetime
+#  taxes_amount_cents                       :bigint           not null
+#  taxes_base_rate                          :float            default(1.0), not null
+#  taxes_precise_amount_cents               :decimal(40, 15)  default(0.0), not null
+#  taxes_rate                               :float            default(0.0), not null
+#  total_aggregated_units                   :decimal(, )
+#  unit_amount_cents                        :bigint           default(0), not null
+#  units                                    :decimal(, )      default(0.0), not null
+#  created_at                               :datetime         not null
+#  updated_at                               :datetime         not null
+#  add_on_id                                :uuid
+#  applied_add_on_id                        :uuid
+#  billing_entity_id                        :uuid             not null
+#  charge_filter_id                         :uuid
+#  charge_id                                :uuid
+#  group_id                                 :uuid
+#  invoice_id                               :uuid
+#  invoiceable_id                           :uuid
+#  organization_id                          :uuid             not null
+#  pay_in_advance_event_id                  :uuid
+#  pay_in_advance_event_transaction_id      :string
+#  subscription_id                          :uuid
+#  true_up_parent_fee_id                    :uuid
 #
 # Indexes
 #

--- a/db/migrate/20250522132106_add_precise_credit_columns_to_fees.rb
+++ b/db/migrate/20250522132106_add_precise_credit_columns_to_fees.rb
@@ -2,7 +2,11 @@
 
 class AddPreciseCreditColumnsToFees < ActiveRecord::Migration[8.0]
   def change
-    add_column :fees, :precise_progressive_credits_amount_cents, :decimal, precision: 30, scale: 5, null: false, default: 0
-    add_column :fees, :precise_credit_notes_amount_cents, :decimal, precision: 30, scale: 5, null: false, default: 0
+    safety_assured do
+      change_table :fees, bulk: true do |t|
+        t.decimal :precise_progressive_credits_amount_cents, precision: 30, scale: 5, null: false, default: 0
+        t.decimal :precise_credit_notes_amount_cents, precision: 30, scale: 5, null: false, default: 0
+      end
+    end
   end
 end

--- a/db/migrate/20250522132106_add_precise_credit_columns_to_fees.rb
+++ b/db/migrate/20250522132106_add_precise_credit_columns_to_fees.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddPreciseCreditColumnsToFees < ActiveRecord::Migration[8.0]
+  def change
+    add_column :fees, :precise_progressive_credits_amount_cents, :decimal, precision: 30, scale: 5, null: false, default: 0
+    add_column :fees, :precise_credit_notes_amount_cents, :decimal, precision: 30, scale: 5, null: false, default: 0
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2247,7 +2247,9 @@ CREATE TABLE public.fees (
     taxes_precise_amount_cents numeric(40,15) DEFAULT 0.0 NOT NULL,
     taxes_base_rate double precision DEFAULT 1.0 NOT NULL,
     organization_id uuid NOT NULL,
-    billing_entity_id uuid NOT NULL
+    billing_entity_id uuid NOT NULL,
+    precise_progressive_credits_amount_cents numeric(30,5) DEFAULT 0.0 NOT NULL,
+    precise_credit_notes_amount_cents numeric(30,5) DEFAULT 0.0 NOT NULL
 );
 
 
@@ -8418,6 +8420,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250526133654'),
 ('20250526111147'),
 ('20250522134155'),
+('20250522132106'),
 ('20250521151540'),
 ('20250521135607'),
 ('20250521104239'),


### PR DESCRIPTION
## Context

New feature for limiting wallet credits on certain fee type is currently being made.

## Description

This PR adds necessary fields where weighted credits values will be stored for progressive billing and credit notes.

We already have similar fields that calculates weighted coupon value applied on certain fee - `precise_coupons_amount_cents`

Let's say that with new feature we want to apply prepaid credits only on subscription fees; weighted values are needed in order to calculate correctly what is the total fee amount before applying prepaid credits for certain subscription fee. It wouldn't be possibly to apply anymore prepaid credits on total amount.