### PR TITLE
Chore/add delete pdf command

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -92,6 +92,7 @@ Rails.application.console do
     {organization:, invite_url: result.invite_url}
   end
 
+  # Often this procedure is called "regenerate invoice"
   def delete_invoice_pdf(id)
     inv = Invoice.find(id)
     puts "Going to delete invoice pdf from org `#{inv.organization.name}` (id: #{inv.id})"

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -91,4 +91,9 @@ Rails.application.console do
     puts "Organization `#{org_name}` created with admin invite: #{result.invite_url}" # rubocop:disable Rails/Output
     {organization:, invite_url: result.invite_url}
   end
+
+  def delete_invoice_pdf(id)
+    inv = Invoice.find(id)
+    inv.file.destroy
+  end
 end

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -94,6 +94,12 @@ Rails.application.console do
 
   def delete_invoice_pdf(id)
     inv = Invoice.find(id)
-    inv.file.destroy
+    puts "Going to delete invoice pdf from org `#{inv.organization.name}` (id: #{inv.id})"
+    unless inv.finalized?
+      puts "Invoice is not finalized. Skipping."
+      return
+    end
+
+    inv.file&.destroy
   end
 end


### PR DESCRIPTION
## Context

On the support we're often asked to regenerate invoice, what they mean is that we should delete the generated invoice PDF, so organizations can trigger a new PDF generation and download a changed invoice

## Description

- added a new console helper to delete invoice pdf
