### PR TITLE
feat(audit_logs): Add resource_type as an enum

### DIFF
--- a/app/graphql/resolvers/activity_logs_resolver.rb
+++ b/app/graphql/resolvers/activity_logs_resolver.rb
@@ -19,7 +19,7 @@ module Resolvers
     argument :external_subscription_id, String, required: false
     argument :from_date, GraphQL::Types::ISO8601Date, required: false
     argument :resource_ids, [String], required: false
-    argument :resource_types, [String], required: false
+    argument :resource_types, [Types::ActivityLogs::ResourceTypeEnum], required: false
     argument :to_date, GraphQL::Types::ISO8601Date, required: false
     argument :user_emails, [String], required: false
 

--- a/app/graphql/types/activity_logs/resource_type_enum.rb
+++ b/app/graphql/types/activity_logs/resource_type_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module ActivityLogs
+    class ResourceTypeEnum < Types::BaseEnum
+      description "Activity Logs resource type enums"
+
+      Clickhouse::ActivityLog::RESOURCE_TYPES.each do |key, value|
+        value key, value:, description: value
+      end
+    end
+  end
+end

--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -8,6 +8,18 @@ module Clickhouse
     belongs_to :organization
     belongs_to :resource, polymorphic: true
 
+    RESOURCE_TYPES = {
+      billable_metric: "BillableMetric",
+      plan: "Plan",
+      customer: "Customer",
+      invoice: "Invoice",
+      credit_note: "CreditNote",
+      billing_entity: "BillingEntity",
+      subscription: "Subscription",
+      wallet: "Wallet",
+      coupon: "Coupon"
+    }.freeze
+
     ACTIVITY_TYPES = {
       billable_metric_created: "billable_metric.created",
       billable_metric_updated: "billable_metric.updated",

--- a/schema.graphql
+++ b/schema.graphql
@@ -7568,7 +7568,7 @@ type Query {
   """
   Query activity logs of an organization
   """
-  activityLogs(activitySources: [ActivitySourceEnum!], activityTypes: [ActivityTypeEnum!], apiKeyIds: [String!], externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, limit: Int, page: Int, resourceIds: [String!], resourceTypes: [String!], toDate: ISO8601Date, userEmails: [String!]): ActivityLogCollection
+  activityLogs(activitySources: [ActivitySourceEnum!], activityTypes: [ActivityTypeEnum!], apiKeyIds: [String!], externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, limit: Int, page: Int, resourceIds: [String!], resourceTypes: [ResourceTypeEnum!], toDate: ISO8601Date, userEmails: [String!]): ActivityLogCollection
 
   """
   Query a single add-on of an organization
@@ -8341,6 +8341,56 @@ input ResetPasswordInput {
   clientMutationId: String
   newPassword: String!
   token: String!
+}
+
+"""
+Activity Logs resource type enums
+"""
+enum ResourceTypeEnum {
+  """
+  BillableMetric
+  """
+  billable_metric
+
+  """
+  BillingEntity
+  """
+  billing_entity
+
+  """
+  Coupon
+  """
+  coupon
+
+  """
+  CreditNote
+  """
+  credit_note
+
+  """
+  Customer
+  """
+  customer
+
+  """
+  Invoice
+  """
+  invoice
+
+  """
+  Plan
+  """
+  plan
+
+  """
+  Subscription
+  """
+  subscription
+
+  """
+  Wallet
+  """
+  wallet
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -37687,8 +37687,8 @@
                       "kind": "NON_NULL",
                       "name": null,
                       "ofType": {
-                        "kind": "SCALAR",
-                        "name": "String",
+                        "kind": "ENUM",
+                        "name": "ResourceTypeEnum",
                         "ofType": null
                       }
                     }
@@ -43396,6 +43396,71 @@
             }
           ],
           "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ResourceTypeEnum",
+          "description": "Activity Logs resource type enums",
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "billable_metric",
+              "description": "BillableMetric",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "plan",
+              "description": "Plan",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customer",
+              "description": "Customer",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoice",
+              "description": "Invoice",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "credit_note",
+              "description": "CreditNote",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billing_entity",
+              "description": "BillingEntity",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscription",
+              "description": "Subscription",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wallet",
+              "description": "Wallet",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "coupon",
+              "description": "Coupon",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
         },
         {
           "kind": "INPUT_OBJECT",

--- a/spec/graphql/types/activity_logs/resource_type_enum_spec.rb
+++ b/spec/graphql/types/activity_logs/resource_type_enum_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::ActivityLogs::ResourceTypeEnum do
+  it "enumerates the correct values" do
+    expect(described_class.values.keys).to match_array(
+      %w[
+        billable_metric
+        plan
+        customer
+        invoice
+        credit_note
+        billing_entity
+        subscription
+        wallet
+        coupon
+      ]
+    )
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context

Our users want to have visibility on what’s happening in Lago.

Examples:
- *A plan and prices have been updated: When? By whom? What?*
- *A subscription has been deleted: When? By whom? What?*

## Description

The goal of this PR is to set resource_type as an enum for activity logs resolver.