### PR TITLE
Billing entities activity logs

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -201,7 +201,10 @@ class BaseService
 
   def self.call(*, **, &)
     LagoTracer.in_span("#{name}#call") do
-      new(*, **).call(&)
+      instance = new(*, **)
+      return instance.call_with_audit_logs(&) if instance.audit_logs
+
+      instance.call(&)
     end
   end
 
@@ -220,7 +223,13 @@ class BaseService
     @source = CurrentContext&.source
   end
 
+  def audit_logs; false; end
+
   def call(**args, &block)
+    raise NotImplementedError
+  end
+
+  def call_with_audit_logs(**args, &block)
     raise NotImplementedError
   end
 

--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -7,6 +7,11 @@ module BillableMetrics
       super
     end
 
+    activity_loggable(
+      action: "billable_metric.created",
+      record: -> { result.billable_metric }
+    )
+
     def call
       organization = Organization.find_by(id: args[:organization_id])
 
@@ -38,8 +43,6 @@ module BillableMetrics
 
         result.billable_metric = metric
         track_billable_metric_created(metric)
-
-        Utils::ActivityLog.produce(metric, "billable_metric.created")
       end
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -38,6 +38,8 @@ module BillableMetrics
 
         result.billable_metric = metric
         track_billable_metric_created(metric)
+
+        Utils::ActivityLog.produce(metric, "billable_metric.created")
       end
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -27,6 +27,8 @@ module BillableMetrics
       # NOTE: Discard all related events asynchronously.
       BillableMetrics::DeleteEventsJob.perform_later(metric)
 
+      Utils::ActivityLog.produce(metric, "billable_metric.deleted")
+
       result.billable_metric = metric
       result
     end

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -7,6 +7,11 @@ module BillableMetrics
       super
     end
 
+    activity_loggable(
+      action: "billable_metric.deleted",
+      record: -> { metric }
+    )
+
     def call
       return result.not_found_failure!(resource: "billable_metric") unless metric
 
@@ -26,8 +31,6 @@ module BillableMetrics
 
       # NOTE: Discard all related events asynchronously.
       BillableMetrics::DeleteEventsJob.perform_later(metric)
-
-      Utils::ActivityLog.produce(metric, "billable_metric.deleted")
 
       result.billable_metric = metric
       result

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -50,6 +50,8 @@ module BillableMetrics
 
       billable_metric.save!
 
+      Utils::ActivityLog.produce(billable_metric, "billable_metric.updated")
+
       result.billable_metric = billable_metric
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -9,11 +9,10 @@ module BillableMetrics
       super
     end
 
-    def audit_logs; true; end
-
-    def call_with_audit_logs
-      Utils::ActivityLog.produce(billable_metric, "billable_metric.updated") { call }
-    end
+    activity_loggable(
+      action: "billable_metric.updated",
+      record: -> { billable_metric }
+    )
 
     def call
       return result.not_found_failure!(resource: "billable_metric") unless billable_metric

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -9,6 +9,12 @@ module BillableMetrics
       super
     end
 
+    def audit_logs; true; end
+
+    def call_with_audit_logs
+      Utils::ActivityLog.produce(billable_metric, "billable_metric.updated") { call }
+    end
+
     def call
       return result.not_found_failure!(resource: "billable_metric") unless billable_metric
 
@@ -49,8 +55,6 @@ module BillableMetrics
       end
 
       billable_metric.save!
-
-      Utils::ActivityLog.produce(billable_metric, "billable_metric.updated")
 
       result.billable_metric = billable_metric
       result

--- a/app/services/billing_entities/create_service.rb
+++ b/app/services/billing_entities/create_service.rb
@@ -11,6 +11,11 @@ module BillingEntities
       super
     end
 
+    activity_loggable(
+      action: "billing_entities.created",
+      record: -> { result.billing_entity }
+    )
+
     def call
       return result.forbidden_failure! unless organization.can_create_billing_entity?
 

--- a/app/services/billing_entities/update_service.rb
+++ b/app/services/billing_entities/update_service.rb
@@ -11,6 +11,11 @@ module BillingEntities
       super(nil)
     end
 
+    activity_loggable(
+      action: "billing_entities.updated",
+      record: -> { billing_entity }
+    )
+
     def call
       return result.not_found_failure!(resource: "billing_entity") unless billing_entity
 

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -12,6 +12,11 @@ module Customers
       super
     end
 
+    activity_loggable(
+      action: "customer.created",
+      record: -> { result.customer }
+    )
+
     def call
       return result.not_found_failure!(resource: "organization") unless organization
 

--- a/app/services/customers/destroy_service.rb
+++ b/app/services/customers/destroy_service.rb
@@ -8,6 +8,11 @@ module Customers
       super
     end
 
+    activity_loggable(
+      action: "customer.deleted",
+      record: -> { customer }
+    )
+
     def call
       return result.not_found_failure!(resource: "customer") unless customer
 

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -12,6 +12,11 @@ module Customers
       super
     end
 
+    activity_loggable(
+      action: "customer.updated",
+      record: -> { customer }
+    )
+
     def call
       return result.not_found_failure!(resource: "customer") unless customer
 

--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -13,6 +13,13 @@ module Customers
       super
     end
 
+    # TODO: Split this service into multiple services (create and update)
+    #       Add activity log for update
+    activity_loggable(
+      action: "customer.created",
+      record: -> { result.customer }
+    )
+
     def call
       billing_entity = BillingEntities::ResolveService.call(
         organization:, billing_entity_code: params[:billing_entity_code]

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -7,6 +7,11 @@ module Plans
       super
     end
 
+    activity_loggable(
+      action: "plan.created",
+      record: -> { result.plan }
+    )
+
     def call
       plan = Plan.new(
         organization_id: args[:organization_id],

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -7,6 +7,11 @@ module Plans
       super
     end
 
+    activity_loggable(
+      action: "plan.deleted",
+      record: -> { plan }
+    )
+
     def call
       return result.not_found_failure!(resource: "plan") unless plan
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -8,6 +8,11 @@ module Plans
       super
     end
 
+    activity_loggable(
+      action: "plan.updated",
+      record: -> { plan }
+    )
+
     def call
       return result.not_found_failure!(resource: "plan") unless plan
 

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -40,6 +40,7 @@ module Utils
 
       def user_id
         return nil if CurrentContext.api_key_id.present?
+        return nil if CurrentContext.membership.blank?
 
         Membership.find_by(id: CurrentContext.membership.split("/").last)&.user_id
       end

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -49,6 +49,7 @@ module Utils
         "V1::#{object.class.name}Serializer".constantize.new(object).serialize
       end
 
+      # TODO: Fetch previous changes for associated objects (e.g. billable_metric.filters)
       def activity_object_changes(object)
         changes = object.previous_changes.except(*IGNORED_FIELDS).transform_values(&:to_s)
 

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -67,8 +67,6 @@ module Utils
       end
 
       def activity_object(object, activity_type)
-        return {} if activity_type.include?("deleted")
-
         object_serialized(object)
       end
 

--- a/config/initializers/activejob_traceable.rb
+++ b/config/initializers/activejob_traceable.rb
@@ -4,7 +4,8 @@ require "current_context"
 
 ActiveJob::Traceable.tracing_info_getter = lambda do
   {
-    membership: CurrentContext.membership
+    membership: CurrentContext.membership,
+    source: CurrentContext.source
   }
 end
 
@@ -12,4 +13,5 @@ ActiveJob::Traceable.tracing_info_setter = lambda do |attributes|
   return unless attributes
 
   CurrentContext.membership = attributes[:membership]
+  CurrentContext.source = attributes[:source]
 end

--- a/spec/services/base_service_spec.rb
+++ b/spec/services/base_service_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe ::BaseService, type: :service do
   it { is_expected.to be_kind_of(AfterCommitEverywhere) }
   it { is_expected.to respond_to(:call) }
   it { is_expected.to respond_to(:call_async) }
-  it { is_expected.to respond_to(:audit_logs) }
-  it { is_expected.to respond_to(:call_with_audit_logs) }
+  it { is_expected.to respond_to(:call_with_activity_log) }
 
   context "with current_user" do
     it "assigns the current_user to the result" do

--- a/spec/services/base_service_spec.rb
+++ b/spec/services/base_service_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe ::BaseService, type: :service do
   it { is_expected.to be_kind_of(AfterCommitEverywhere) }
   it { is_expected.to respond_to(:call) }
   it { is_expected.to respond_to(:call_async) }
+  it { is_expected.to respond_to(:audit_logs) }
+  it { is_expected.to respond_to(:call_with_audit_logs) }
 
   context "with current_user" do
     it "assigns the current_user to the result" do

--- a/spec/services/billable_metrics/create_service_spec.rb
+++ b/spec/services/billable_metrics/create_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe BillableMetrics::CreateService, type: :service do
   describe "create" do
     before do
       allow(SegmentTrackJob).to receive(:perform_later)
+      allow(Utils::ActivityLog).to receive(:produce)
     end
 
     let(:create_args) do
@@ -102,6 +103,12 @@ RSpec.describe BillableMetrics::CreateService, type: :service do
           organization_id: metric.organization_id
         }
       )
+    end
+
+    it "produces an activity log" do
+      metric = create_service.call.billable_metric
+
+      expect(Utils::ActivityLog).to have_received(:produce).with(metric, "billable_metric.created")
     end
 
     context "with validation error" do

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
 
     allow(BillableMetrics::DeleteEventsJob).to receive(:perform_later).and_call_original
     allow(Invoices::RefreshDraftService).to receive(:call)
-    allow(Utils::ActivityLog).to receive(:produce)
+    allow(Utils::ActivityLog).to receive(:produce).and_call_original
   end
 
   describe ".call" do

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
 
     allow(BillableMetrics::DeleteEventsJob).to receive(:perform_later).and_call_original
     allow(Invoices::RefreshDraftService).to receive(:call)
+    allow(Utils::ActivityLog).to receive(:produce)
   end
 
   describe "#call" do
@@ -58,6 +59,12 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
       create(:invoice_subscription, subscription:, invoice:)
 
       expect { destroy_service.call }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
+    end
+
+    it "produces an activity log" do
+      destroy_service.call
+
+      expect(Utils::ActivityLog).to have_received(:produce).with(billable_metric, "billable_metric.deleted")
     end
 
     context "when billable metric is not found" do

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe BillableMetrics::DestroyService, type: :service do
-  subject(:destroy_service) { described_class.new(metric: billable_metric) }
-
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:billable_metric) { create(:billable_metric, organization:) }
@@ -27,30 +25,30 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
     allow(Utils::ActivityLog).to receive(:produce)
   end
 
-  describe "#call" do
+  describe ".call" do
     it "soft deletes the billable metric" do
       freeze_time do
-        expect { destroy_service.call }.to change(BillableMetric, :count).by(-1)
+        expect { described_class.call(metric: billable_metric) }.to change(BillableMetric, :count).by(-1)
           .and change { billable_metric.reload.deleted_at }.from(nil).to(Time.current)
       end
     end
 
     it "soft deletes all the related charges" do
       freeze_time do
-        expect { destroy_service.call }.to change { charge.reload.deleted_at }.from(nil).to(Time.current)
+        expect { described_class.call(metric: billable_metric) }.to change { charge.reload.deleted_at }.from(nil).to(Time.current)
       end
     end
 
     it "soft deletes all related filters" do
       freeze_time do
-        expect { destroy_service.call }.to change { billable_metric.filters.reload.kept.count }.from(2).to(0)
+        expect { described_class.call(metric: billable_metric) }.to change { billable_metric.filters.reload.kept.count }.from(2).to(0)
           .and change { filter_value.reload.reload.deleted_at }.from(nil).to(Time.current)
       end
     end
 
     it "enqueues a BillableMetrics::DeleteEventsJob" do
       expect do
-        destroy_service.call
+        described_class.call(metric: billable_metric)
       end.to have_enqueued_job(BillableMetrics::DeleteEventsJob).with(billable_metric)
     end
 
@@ -58,18 +56,18 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
       invoice = create(:invoice, :draft)
       create(:invoice_subscription, subscription:, invoice:)
 
-      expect { destroy_service.call }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
+      expect { described_class.call(metric: billable_metric) }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
     end
 
     it "produces an activity log" do
-      destroy_service.call
+      described_class.call(metric: billable_metric)
 
       expect(Utils::ActivityLog).to have_received(:produce).with(billable_metric, "billable_metric.deleted")
     end
 
     context "when billable metric is not found" do
       it "returns an error" do
-        result = described_class.new(metric: nil).call
+        result = described_class.call(metric: nil)
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq("billable_metric_not_found")

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -47,8 +47,9 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
     end
 
     it "produces an activity log" do
-      expect(Utils::ActivityLog).to receive(:produce).with(billable_metric, "billable_metric.updated")
       update_service.call
+
+      expect(Utils::ActivityLog).to have_received(:produce).with(billable_metric, "billable_metric.updated")
     end
 
     context "with filters arguments" do

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe BillableMetrics::UpdateService, type: :service do
-  subject(:update_service) { described_class.new(billable_metric:, params:) }
-
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
@@ -25,13 +23,13 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
   end
   let(:filters) { nil }
 
-  describe "#call" do
+  describe ".call" do
     before do
-      allow(Utils::ActivityLog).to receive(:produce)
+      allow(Utils::ActivityLog).to receive(:produce).and_call_original
     end
 
     it "updates the billable metric" do
-      result = update_service.call
+      result = described_class.call(billable_metric:, params:)
       expect(result).to be_success
 
       metric = result.billable_metric
@@ -47,7 +45,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
     end
 
     it "produces an activity log" do
-      update_service.call
+      described_class.call(billable_metric:, params:)
 
       expect(Utils::ActivityLog).to have_received(:produce).with(billable_metric, "billable_metric.updated")
     end
@@ -63,7 +61,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       end
 
       it "updates billable metric's filters" do
-        expect { update_service.call }.to change { billable_metric.filters.reload.count }.from(0).to(1)
+        expect { described_class.call(billable_metric:, params:) }.to change { billable_metric.filters.reload.count }.from(0).to(1)
       end
     end
 
@@ -78,7 +76,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       end
 
       it "returns an error" do
-        result = update_service.call
+        result = described_class.call(billable_metric:, params:)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)
@@ -90,7 +88,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       let(:billable_metric) { nil }
 
       it "returns an error" do
-        result = update_service.call
+        result = described_class.call(billable_metric:, params:)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::NotFoundFailure)
@@ -102,7 +100,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       let(:params) { {aggregation_type: "custom_agg"} }
 
       it "returns a forbidden failure" do
-        result = update_service.call
+        result = described_class.call(billable_metric:, params:)
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ForbiddenFailure)
@@ -116,7 +114,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       before { charge }
 
       it "updates only name and description" do
-        result = update_service.call
+        result = described_class.call(billable_metric:, params:)
 
         expect(result).to be_success
 

--- a/spec/services/billing_entities/create_service_spec.rb
+++ b/spec/services/billing_entities/create_service_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe BillingEntities::CreateService, type: :service do
     }
   end
 
+  before do
+    allow(Utils::ActivityLog).to receive(:produce)
+  end
+
+  it "produces an activity log" do
+    billing_entity = result.billing_entity
+
+    expect(Utils::ActivityLog).to have_received(:produce).with(billing_entity, "billing_entities.created")
+  end
+
   context "when lago freemium" do
     it "returns an error" do
       expect(result).to be_failure

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe BillingEntities::UpdateService do
     }
   end
 
+  before do
+    allow(Utils::ActivityLog).to receive(:produce)
+  end
+
   describe "#call" do
     it "updates the billing_entity" do
       result = update_service.call
@@ -58,6 +62,12 @@ RSpec.describe BillingEntities::UpdateService do
 
       expect(result.billing_entity.invoice_footer).to eq("invoice footer")
       expect(result.billing_entity.document_locale).to eq("fr")
+    end
+
+    it "produces an activity log" do
+      described_class.call(billing_entity:, params:)
+
+      expect(Utils::ActivityLog).to have_received(:produce).with(billing_entity, "billing_entities.updated")
     end
 
     context "when document_number_prefix is sent" do

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Customers::CreateService, type: :service do
   before do
     allow(SendWebhookJob).to receive(:perform_later)
     allow(CurrentContext).to receive(:source).and_return("graphql")
+    allow(Utils::ActivityLog).to receive(:produce)
   end
 
   it "creates a new customer" do
@@ -61,6 +62,12 @@ RSpec.describe Customers::CreateService, type: :service do
     result
 
     expect(SendWebhookJob).to have_received(:perform_later).with("customer.created", result.customer)
+  end
+
+  it "produces an activity log" do
+    result
+
+    expect(Utils::ActivityLog).to have_received(:produce).with(result.customer, "customer.created")
   end
 
   context "when organization has multiple billing entities" do

--- a/spec/services/customers/destroy_service_spec.rb
+++ b/spec/services/customers/destroy_service_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe Customers::DestroyService, type: :service do
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
 
-  before { customer }
+  before do
+    customer
+    allow(Utils::ActivityLog).to receive(:produce)
+  end
 
   describe "#call" do
     it "soft deletes the customer" do
@@ -24,6 +27,12 @@ RSpec.describe Customers::DestroyService, type: :service do
 
       expect(Customers::TerminateRelationsJob).to have_been_enqueued
         .with(customer_id: customer.id)
+    end
+
+    it "produces an activity log" do
+      described_class.call(customer:)
+
+      expect(Utils::ActivityLog).to have_received(:produce).with(customer, "customer.deleted")
     end
 
     context "when customer is not found" do

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Customers::UpsertFromApiService, type: :service do
   before do
     allow(SendWebhookJob).to receive(:perform_later)
     allow(CurrentContext).to receive(:source).and_return("api")
+    allow(Utils::ActivityLog).to receive(:produce)
   end
 
   it "creates a new customer" do
@@ -94,6 +95,12 @@ RSpec.describe Customers::UpsertFromApiService, type: :service do
     customer = result.customer
 
     expect(SendWebhookJob).to have_received(:perform_later).with("customer.created", customer)
+  end
+
+  it "produces an activity log" do
+    result = described_class.call(organization:, params: create_args)
+
+    expect(Utils::ActivityLog).to have_received(:produce).with(result.customer, "customer.created")
   end
 
   context "when organization has multiple billing entities" do

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe Plans::DestroyService, type: :service do
   let(:organization) { membership.organization }
   let(:plan) { create(:plan, organization:, pending_deletion: true) }
 
-  before { plan }
+  before do
+    plan
+    allow(Utils::ActivityLog).to receive(:produce).and_call_original
+  end
 
   describe "#call" do
     it "soft deletes the plan" do
@@ -23,16 +26,20 @@ RSpec.describe Plans::DestroyService, type: :service do
       expect { destroy_service.call }.to change { plan.reload.pending_deletion }.from(true).to(false)
     end
 
+    it "produces an activity log" do
+      described_class.call(plan:)
+
+      expect(Utils::ActivityLog).to have_received(:produce).with(plan, "plan.deleted")
+    end
+
     context "when plan is not found" do
       let(:plan) { nil }
 
       it "returns an error" do
         result = destroy_service.call
 
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error.error_code).to eq("plan_not_found")
-        end
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq("plan_not_found")
       end
     end
 
@@ -44,12 +51,10 @@ RSpec.describe Plans::DestroyService, type: :service do
       it "terminates the subscriptions" do
         result = destroy_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
+        expect(result).to be_success
 
-          subscriptions.each do |subscription|
-            expect(subscription.reload).to be_terminated
-          end
+        subscriptions.each do |subscription|
+          expect(subscription.reload).to be_terminated
         end
       end
     end
@@ -62,12 +67,10 @@ RSpec.describe Plans::DestroyService, type: :service do
       it "cancels the subscriptions" do
         result = destroy_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
+        expect(result).to be_success
 
-          subscriptions.each do |subscription|
-            expect(subscription.reload).to be_canceled
-          end
+        subscriptions.each do |subscription|
+          expect(subscription.reload).to be_canceled
         end
       end
     end
@@ -84,12 +87,10 @@ RSpec.describe Plans::DestroyService, type: :service do
       it "finalizes draft invoices" do
         result = destroy_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
+        expect(result).to be_success
 
-          invoices.each do |invoice|
-            expect(invoice.reload).to be_finalized
-          end
+        invoices.each do |invoice|
+          expect(invoice.reload).to be_finalized
         end
       end
     end

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe Plans::UpdateService, type: :service do
   describe "call" do
     before do
       applied_tax
+      allow(Utils::ActivityLog).to receive(:produce)
     end
 
     it "updates a plan" do
@@ -136,6 +137,12 @@ RSpec.describe Plans::UpdateService, type: :service do
       create(:invoice_subscription, invoice:, subscription:)
 
       expect { plans_service.call }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
+    end
+
+    it "produces an activity log" do
+      described_class.call(plan:, params: update_args)
+
+      expect(Utils::ActivityLog).to have_received(:produce).with(plan, "plan.updated")
     end
 
     context "with cascade option" do

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Utils::ActivityLog, type: :service do
       end
 
       context "when the object is deleted" do
-        it "does not set activity_object and activity_object_changes" do
+        it "does not set activity_object_changes" do
           allow(CurrentContext).to receive(:source).and_return(nil)
           activity_log.produce(invoice, "invoice.deleted", activity_id: "activity-id") { BaseService::Result.new }
 
@@ -78,7 +78,7 @@ RSpec.describe Utils::ActivityLog, type: :service do
               resource_id: invoice.id,
               resource_type: "Invoice",
               organization_id: organization.id,
-              activity_object: {},
+              activity_object: V1::InvoiceSerializer.new(invoice).serialize,
               activity_object_changes: {},
               external_customer_id: invoice.customer.external_id,
               external_subscription_id: nil

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -52,7 +52,9 @@ RSpec.describe Utils::ActivityLog, type: :service do
             resource_type: "Invoice",
             organization_id: organization.id,
             activity_object: V1::InvoiceSerializer.new(invoice).serialize,
-            activity_object_changes: {}
+            activity_object_changes: {},
+            external_customer_id: invoice.customer.external_id,
+            external_subscription_id: nil
           }.to_json
         )
       end
@@ -77,7 +79,9 @@ RSpec.describe Utils::ActivityLog, type: :service do
               resource_type: "Invoice",
               organization_id: organization.id,
               activity_object: {},
-              activity_object_changes: {}
+              activity_object_changes: {},
+              external_customer_id: invoice.customer.external_id,
+              external_subscription_id: nil
             }.to_json
           )
         end

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -56,6 +56,31 @@ RSpec.describe Utils::ActivityLog, type: :service do
           }.to_json
         )
       end
+
+      context "when the object is deleted" do
+        it "does not set activity_object and activity_object_changes" do
+          activity_log.produce(invoice, "invoice.deleted", activity_id: "activity-id")
+
+          expect(karafka_producer).to have_received(:produce_async).with(
+            topic: "activity_logs",
+            key: "#{organization.id}--activity-id",
+            payload: {
+              activity_source: "api",
+              api_key_id: api_key.id,
+              user_id: nil,
+              activity_type: "invoice.deleted",
+              activity_id: "activity-id",
+              logged_at: Time.current.iso8601[...-1],
+              created_at: Time.current.iso8601[...-1],
+              resource_id: invoice.id,
+              resource_type: "Invoice",
+              organization_id: organization.id,
+              activity_object: nil,
+              activity_object_changes: nil
+            }.to_json
+          )
+        end
+      end
     end
 
     context "when kafka is not configured" do


### PR DESCRIPTION
BillingEntities activity logs

`billing_entities.deleted` is not implemented yet and, if necessary, will have to handled manually using the console.