### PR TITLE
fix(payment-providers): Fix uniqueness validation

### DIFF
--- a/app/models/payment_providers/base_provider.rb
+++ b/app/models/payment_providers/base_provider.rb
@@ -22,7 +22,7 @@ module PaymentProviders
     has_many :payments, dependent: :nullify, foreign_key: :payment_provider_id
     has_many :refunds, dependent: :nullify, foreign_key: :payment_provider_id
 
-    validates :code, uniqueness: {scope: :organization_id}
+    validates :code,  uniqueness: {conditions: -> { kept }, scope: :organization_id}
     validates :name, presence: true
 
     settings_accessors :webhook_secret, :success_redirect_url


### PR DESCRIPTION
## Context

For unknown reasons rails validatios was written in a way that it will count in `code` from discarded records which prevent from using the same `code` even if payment provider was deleted.
DB has proper index looking for unique code only within non-discarded records so we need only update rails validation.

## Description

Add condition to the validation and respective tests.
