### PR TITLE
fix(alerting): Better All SubscriptionActivity job

### DIFF
--- a/app/jobs/usage_monitoring/process_organization_subscription_activities_job.rb
+++ b/app/jobs/usage_monitoring/process_organization_subscription_activities_job.rb
@@ -8,13 +8,7 @@ module UsageMonitoring
       return unless License.premium?
 
       organization = Organization.find(organization_id)
-      result = UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService.call!(organization:)
-
-      if result.nb_jobs_enqueued > 0
-        Rails.logger.info(
-          "[#{organization.id}] ProcessOrganizationSubscriptionActivitiesService enqueued #{result.nb_jobs_enqueued} jobs"
-        )
-      end
+      UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService.call!(organization:)
     end
   end
 end

--- a/app/services/usage_monitoring/process_all_subscription_activities_service.rb
+++ b/app/services/usage_monitoring/process_all_subscription_activities_service.rb
@@ -9,17 +9,8 @@ module UsageMonitoring
       #     This is also where we should report metrics
       #     That's why it's a dedicated service and not just done in the job
 
-      now = Time.current.iso8601
-
       SubscriptionActivity.group(:organization_id).count.each do |organization_id, count|
         ProcessOrganizationSubscriptionActivitiesJob.perform_later(organization_id)
-
-        Rails.logger.info({
-          metric: "usage_monitoring.subscription_activities_size",
-          value: count,
-          timestamp: now,
-          organization_id: organization_id
-        }.to_json)
       end
 
       result

--- a/spec/jobs/usage_monitoring/process_organization_subscription_activities_job_spec.rb
+++ b/spec/jobs/usage_monitoring/process_organization_subscription_activities_job_spec.rb
@@ -4,11 +4,9 @@ require "rails_helper"
 
 RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob, type: :job do
   let(:organization) { create(:organization) }
-  let(:result_double) { instance_double("UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService::Result", nb_jobs_enqueued: 5) }
 
   before do
-    allow(UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService).to receive(:call!).and_return(result_double)
-    allow(Rails.logger).to receive(:info)
+    allow(UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService).to receive(:call!)
   end
 
   context "when license is premium" do
@@ -18,18 +16,12 @@ RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob, ty
       described_class.perform_now(organization.id)
       expect(UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService).to have_received(:call!).with(organization:)
     end
-
-    it "logs the number of jobs enqueued" do
-      described_class.perform_now(organization.id)
-      expect(Rails.logger).to have_received(:info).with("[#{organization.id}] ProcessOrganizationSubscriptionActivitiesService enqueued 5 jobs")
-    end
   end
 
   context "when license is not premium" do
     it "does not call the service or log" do
       described_class.perform_now(organization.id)
       expect(UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService).not_to have_received(:call!)
-      expect(Rails.logger).not_to have_received(:info)
     end
   end
 end

--- a/spec/services/usage_monitoring/process_all_subscription_activities_service_spec.rb
+++ b/spec/services/usage_monitoring/process_all_subscription_activities_service_spec.rb
@@ -24,9 +24,6 @@ RSpec.describe UsageMonitoring::ProcessAllSubscriptionActivitiesService, type: :
       expect(UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob).to have_received(:perform_later).with(organization1.id)
       expect(UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob).to have_received(:perform_later).with(organization2.id)
       expect(UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob).not_to have_received(:perform_later).with(organization3.id)
-
-      expect(Rails.logger).to have_received(:info).with(including('"value":2'))
-      expect(Rails.logger).to have_received(:info).with(including('"value":3'))
     end
   end
 end

--- a/spec/services/usage_monitoring/process_all_subscription_activities_service_spec.rb
+++ b/spec/services/usage_monitoring/process_all_subscription_activities_service_spec.rb
@@ -8,19 +8,25 @@ RSpec.describe UsageMonitoring::ProcessAllSubscriptionActivitiesService, type: :
 
     before do
       allow(UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob).to receive(:perform_later)
+      allow(Rails.logger).to receive(:info)
     end
 
-    it "enqueues ProcessOrganizationSubscriptionActivitiesJob for all organizations" do
+    it "enqueues ProcessOrganizationSubscriptionActivitiesJob for organizations with SubscriptionActivity" do
       organization1 = create(:organization, premium_integrations: [])
       organization2 = create(:organization, premium_integrations: ["progressive_billing"])
       organization3 = create(:organization, premium_integrations: ["salesforce"])
+      create_list(:subscription_activity, 2, organization: organization1)
+      create_list(:subscription_activity, 3, organization: organization2)
 
       result = service.call
 
       expect(result).to be_success
       expect(UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob).to have_received(:perform_later).with(organization1.id)
       expect(UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob).to have_received(:perform_later).with(organization2.id)
-      expect(UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob).to have_received(:perform_later).with(organization3.id)
+      expect(UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob).not_to have_received(:perform_later).with(organization3.id)
+
+      expect(Rails.logger).to have_received(:info).with(including('"value":2'))
+      expect(Rails.logger).to have_received(:info).with(including('"value":3'))
     end
   end
 end


### PR DESCRIPTION
## Context

Alerting is not a premium integration, any premium organization can use it.

## Description

Instead of enqueueing a job for all organizations, we use the db to get a list of organization and a count of jobs.
The previous log is moved the clock jobs and more importantly: it's formatted.