### PR TITLE
feat(audit-logs): Add activity ids filter

### DIFF
--- a/app/graphql/resolvers/activity_logs_resolver.rb
+++ b/app/graphql/resolvers/activity_logs_resolver.rb
@@ -12,6 +12,7 @@ module Resolvers
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
 
+    argument :activity_ids, [String], required: false
     argument :activity_sources, [Types::ActivityLogs::ActivitySourceEnum], required: false
     argument :activity_types, [Types::ActivityLogs::ActivityTypeEnum], required: false
     argument :api_key_ids, [String], required: false
@@ -31,6 +32,8 @@ module Resolvers
         filters: {
           from_date: args[:from_date],
           to_date: args[:to_date],
+          api_key_ids: args[:api_key_ids],
+          activity_ids: args[:activity_ids],
           activity_types: args[:activity_types],
           activity_sources: args[:activity_sources],
           user_emails: args[:user_emails],

--- a/app/queries/activity_logs_query.rb
+++ b/app/queries/activity_logs_query.rb
@@ -5,6 +5,8 @@ class ActivityLogsQuery < BaseQuery
   Filters = BaseFilters[
     :from_date,
     :to_date,
+    :api_key_ids,
+    :activity_ids,
     :activity_types,
     :activity_sources,
     :user_emails,
@@ -22,6 +24,8 @@ class ActivityLogsQuery < BaseQuery
     activity_logs = activity_logs.order(logged_at: :desc)
 
     activity_logs = with_logged_at_range(activity_logs) if filters.from_date || filters.to_date
+    activity_logs = with_api_key_ids(activity_logs) if filters.api_key_ids.present?
+    activity_logs = with_activity_ids(activity_logs) if filters.activity_ids.present?
     activity_logs = with_activity_types(activity_logs) if filters.activity_types.present?
     activity_logs = with_activity_sources(activity_logs) if filters.activity_sources.present?
     activity_logs = with_user_emails(activity_logs) if filters.user_emails.present?
@@ -40,6 +44,14 @@ class ActivityLogsQuery < BaseQuery
     scope = scope.where(logged_at: from_date..) if filters.from_date
     scope = scope.where(logged_at: ..to_date) if filters.to_date
     scope
+  end
+
+  def with_api_key_ids(scope)
+    scope.where(api_key_id: filters.api_key_ids)
+  end
+
+  def with_activity_ids(scope)
+    scope.where(activity_id: filters.activity_ids)
   end
 
   def with_activity_types(scope)

--- a/schema.graphql
+++ b/schema.graphql
@@ -7570,7 +7570,7 @@ type Query {
   """
   Query activity logs of an organization
   """
-  activityLogs(activitySources: [ActivitySourceEnum!], activityTypes: [ActivityTypeEnum!], apiKeyIds: [String!], externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, limit: Int, page: Int, resourceIds: [String!], resourceTypes: [ResourceTypeEnum!], toDate: ISO8601Date, userEmails: [String!]): ActivityLogCollection
+  activityLogs(activityIds: [String!], activitySources: [ActivitySourceEnum!], activityTypes: [ActivityTypeEnum!], apiKeyIds: [String!], externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, limit: Int, page: Int, resourceIds: [String!], resourceTypes: [ResourceTypeEnum!], toDate: ISO8601Date, userEmails: [String!]): ActivityLogCollection
 
   """
   Query a single add-on of an organization

--- a/schema.json
+++ b/schema.json
@@ -37574,6 +37574,26 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "activityIds",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "activitySources",
                   "description": null,
                   "type": {

--- a/spec/graphql/resolvers/activity_logs_resolver_spec.rb
+++ b/spec/graphql/resolvers/activity_logs_resolver_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe Resolvers::ActivityLogsResolver, type: :graphql, clickhouse: true
       {
         from_date: nil,
         to_date: nil,
+        api_key_ids: nil,
+        activity_ids: nil,
         activity_types: nil,
         activity_sources: nil,
         user_emails: nil,

--- a/spec/queries/activity_logs_query_spec.rb
+++ b/spec/queries/activity_logs_query_spec.rb
@@ -64,6 +64,26 @@ RSpec.describe ActivityLogsQuery, type: :query, clickhouse: true do
     end
   end
 
+  context "with api_key_ids filter" do
+    it "returns expected activity logs" do
+      filters = {api_key_ids: [activity_log.api_key_id]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {api_key_ids: ["other"]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
+  context "with activity_ids filter" do
+    it "returns expected activity logs" do
+      filters = {activity_ids: [activity_log.activity_id]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs.first.activity_id).to eq(activity_log.activity_id)
+
+      filters = {activity_ids: ["other"]}
+      expect(described_class.call(organization:, pagination:, filters:).activity_logs).to be_empty
+    end
+  end
+
   context "with activity_types filter" do
     it "returns expected activity logs" do
       filters = {activity_types: [activity_log.activity_type]}


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context

Our users want to have visibility on what’s happening in Lago.

Examples:
- *A plan and prices have been updated: When? By whom? What?*
- *A subscription has been deleted: When? By whom? What?*

## Description

The goal of this PR is to add `activityIds` to the activity logs resolver.