### PR TITLE
fix: Use transaction id for event resolver

### DIFF
--- a/app/graphql/resolvers/event_resolver.rb
+++ b/app/graphql/resolvers/event_resolver.rb
@@ -7,16 +7,13 @@ module Resolvers
 
     description "Query a single event of an organization"
 
-    argument :id, ID, required: true, description: "Uniq ID of the event"
+    argument :transaction_id, ID, required: true, description: "Transaction ID of the event"
 
     type Types::Events::Object, null: true
 
-    def resolve(id: nil)
-      if current_organization.clickhouse_events_store?
-        Clickhouse::EventsRaw.where(organization_id: current_organization.id).find(id)
-      else
-        Event.where(organization_id: current_organization.id).find(id)
-      end
+    def resolve(transaction_id: nil)
+      event_scope = current_organization.clickhouse_events_store? ? Clickhouse::EventsRaw : Event
+      event_scope.find_by!(organization_id: current_organization.id, transaction_id:)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: "event")
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -7871,9 +7871,9 @@ type Query {
   """
   event(
     """
-    Uniq ID of the event
+    Transaction ID of the event
     """
-    id: ID!
+    transactionId: ID!
   ): Event
 
   """

--- a/schema.json
+++ b/schema.json
@@ -40432,8 +40432,8 @@
               "deprecationReason": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": "Uniq ID of the event",
+                  "name": "transactionId",
+                  "description": "Transaction ID of the event",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,


### PR DESCRIPTION
On Clickhouse, we don't store any `id` for an `Event`.
The goal of this PR is to be able to retrieve a specific event from GraphQL, even for Clickhouse.