### PR TITLE
fix(daily-usage): Fix from and to dates in daily usages service

### DIFF
--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -34,7 +34,7 @@ module V1
       def filters(fees)
         return [] unless fees.first.charge&.filters&.any?
 
-        fees.group_by { |f| f.charge_filter&.to_h }.values.map do |grouped_fees|
+        fees.group_by { |f| f.charge_filter&.id }.values.map do |grouped_fees|
           {
             units: grouped_fees.map { |f| BigDecimal(f.units) }.sum.to_s,
             amount_cents: grouped_fees.sum(&:amount_cents),

--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -34,13 +34,13 @@ module V1
       def filters(fees)
         return [] unless fees.first.charge&.filters&.any?
 
-        fees.sort_by { |f| f.charge_filter&.display_name.to_s }.map do |f|
+        fees.group_by { |f| f.charge_filter&.to_h }.values.map do |grouped_fees|
           {
-            units: f.units,
-            amount_cents: f.amount_cents,
-            events_count: f.events_count,
-            invoice_display_name: f.charge_filter&.invoice_display_name,
-            values: f.charge_filter&.to_h
+            units: grouped_fees.map { |f| BigDecimal(f.units) }.sum.to_s,
+            amount_cents: grouped_fees.sum(&:amount_cents),
+            events_count: grouped_fees.sum(&:events_count),
+            invoice_display_name: grouped_fees.first.charge_filter&.invoice_display_name,
+            values: grouped_fees.first.charge_filter&.to_h
           }
         end.compact
       end

--- a/app/services/daily_usages/fill_from_invoice_service.rb
+++ b/app/services/daily_usages/fill_from_invoice_service.rb
@@ -25,8 +25,8 @@ module DailyUsages
             subscription: subscription,
             external_subscription_id: subscription.external_id,
             usage: ::V1::Customers::UsageSerializer.new(usage, includes: %i[charges_usage]).serialize,
-            from_datetime: invoice_subscription.from_datetime,
-            to_datetime: invoice_subscription.to_datetime,
+            from_datetime: invoice_subscription.charges_from_datetime,
+            to_datetime: invoice_subscription.charges_to_datetime,
             refreshed_at: invoice_subscription.timestamp,
             usage_date: invoice_subscription.charges_to_datetime.to_date
           )

--- a/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
     let(:charge_filter) { create(:charge_filter, charge:, invoice_display_name: nil) }
 
     let(:usage) do
-      [
+      Array.new(3) do
         OpenStruct.new(
           charge_id: charge.id,
           billable_metric:,
@@ -84,22 +84,22 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
           grouped_by: {"card_type" => "visa"},
           charge_filter:
         )
-      ]
+      end
     end
 
     it "returns filters array" do
       expect(result["charges"].first["filters"].first).to include(
-        "units" => "10.0",
-        "amount_cents" => 100,
-        "events_count" => 12,
+        "units" => "30.0",
+        "amount_cents" => 300,
+        "events_count" => 36,
         "invoice_display_name" => charge_filter.invoice_display_name,
         "values" => {}
       )
 
       expect(result["charges"].first["grouped_usage"].first["filters"].first).to include(
-        "units" => "10.0",
-        "amount_cents" => 100,
-        "events_count" => 12,
+        "units" => "30.0",
+        "amount_cents" => 300,
+        "events_count" => 36,
         "invoice_display_name" => charge_filter.invoice_display_name,
         "values" => {}
       )


### PR DESCRIPTION
## Description

This PR fixes a bug that calculates usages and pre-fills `daily_usages` table:
 - dates from to were not charges dates
 - the serializer that is used was not grouping charge filters
