### PR TITLE
ftr(wallets-with-fee-limitations): add model and db changes for wallets with fee limitations

### DIFF
--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -43,6 +43,10 @@ class Wallet < ApplicationRecord
   def currency
     balance_currency
   end
+
+  def limited_fee_types?
+    allowed_fee_types.present?
+  end
 end
 
 # == Schema Information
@@ -50,6 +54,7 @@ end
 # Table name: wallets
 #
 #  id                                  :uuid             not null, primary key
+#  allowed_fee_types                   :string           default([]), not null, is an Array
 #  balance_cents                       :bigint           default(0), not null
 #  balance_currency                    :string           not null
 #  consumed_amount_cents               :bigint           default(0), not null

--- a/db/migrate/20250526111147_add_allowed_fee_types_to_wallets.rb
+++ b/db/migrate/20250526111147_add_allowed_fee_types_to_wallets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAllowedFeeTypesToWallets < ActiveRecord::Migration[8.0]
+  def change
+    add_column :wallets, :allowed_fee_types, :string, array: true, null: false, default: []
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2843,7 +2843,8 @@ CREATE TABLE public.wallets (
     invoice_requires_successful_payment boolean DEFAULT false NOT NULL,
     lock_version integer DEFAULT 0 NOT NULL,
     ready_to_be_refreshed boolean DEFAULT false NOT NULL,
-    organization_id uuid
+    organization_id uuid,
+    allowed_fee_types character varying[] DEFAULT '{}'::character varying[] NOT NULL
 );
 
 
@@ -8415,6 +8416,7 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250526111147'),
 ('20250522134155'),
 ('20250521104239'),
 ('20250521095733'),

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -31,4 +31,22 @@ RSpec.describe Wallet, type: :model do
       expect(wallet.currency).to eq(wallet.balance_currency)
     end
   end
+
+  describe "limited_fee_types?" do
+    context "when allowed_fee_types is present" do
+      before { wallet.allowed_fee_types = %w[charge] }
+
+      it "returns true" do
+        expect(wallet.limited_fee_types?).to be true
+      end
+    end
+
+    context "when allowed_fee_types is empty" do
+      before { wallet.allowed_fee_types = [] }
+
+      it "returns false" do
+        expect(wallet.limited_fee_types?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Currently, wallet credits are applied to all type of fees in the invoice. With this feature, users will be able to limit spending on specific fee type.

## Description

This PR adds basic model and DB changes
