### PR TITLE
fix(wallet): Optimistic locking for in advance events

### DIFF
--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -2,6 +2,8 @@
 
 module Credits
   class AppliedPrepaidCreditService < BaseService
+    MAX_WALLET_DECREASE_ATTEMPTS = 5
+
     def initialize(invoice:, wallet:)
       @invoice = invoice
       @wallet = wallet
@@ -14,25 +16,36 @@ module Credits
         return result.service_failure!(code: "already_applied", message: "Prepaid credits already applied")
       end
 
-      wallet.with_lock("FOR UPDATE NOWAIT") do
-        amount_cents = compute_amount
-        wallet_credit = WalletCredit.from_amount_cents(wallet:, amount_cents:)
-        wallet_transaction = WalletTransactions::CreateService.call!(
-          wallet:,
-          wallet_credit:,
-          invoice_id: invoice.id,
-          transaction_type: :outbound,
-          status: :settled,
-          settled_at: Time.current,
-          transaction_status: :invoiced
-        ).wallet_transaction
+      amount_cents = compute_amount
+      wallet_credit = WalletCredit.from_amount_cents(wallet:, amount_cents:)
+      wallet_transaction = WalletTransactions::CreateService.call!(
+        wallet:,
+        wallet_credit:,
+        invoice_id: invoice.id,
+        transaction_type: :outbound,
+        status: :settled,
+        settled_at: Time.current,
+        transaction_status: :invoiced
+      ).wallet_transaction
 
-        result.wallet_transaction = wallet_transaction
+      result.wallet_transaction = wallet_transaction
+
+      decrease_attempt = 0
+      begin
+        decrease_attempt += 1
         Wallets::Balance::DecreaseService.new(wallet:, wallet_transaction: wallet_transaction).call
+      rescue ActiveRecord::StaleObjectError
+        if decrease_attempt <= MAX_WALLET_DECREASE_ATTEMPTS
+          sleep(rand(0.1..0.5))
+          wallet.reload # Make sure the wallet is reloaded before retrying
+          retry
+        end
 
-        result.prepaid_credit_amount_cents = amount_cents
-        invoice.prepaid_credit_amount_cents += amount_cents
+        raise
       end
+
+      result.prepaid_credit_amount_cents = amount_cents
+      invoice.prepaid_credit_amount_cents += amount_cents
 
       after_commit { SendWebhookJob.perform_later("wallet_transaction.created", result.wallet_transaction) }
 


### PR DESCRIPTION
## Context

This PR is a new attempt to approach the issue of parallel wallet refresh refresh in the case of in payed in advance events.

## Description

The PR moves fro pessimistic locking (`FOR UPDATE NOWAIT`) to an optimistic one using the `lock_version` already present on the wallets table.
An automatic retry logic is added around the wallet decrease logic with a random wait time between each attempt. It reduce the effect of the error to the decrease logic only instead of the all event processing like it is today.
Finally in case of error, the error is re-raised and the entire logic will be retried by Sidekiq