### PR TITLE
fix(wallet): Optimistic locking for in advance events (#3720)

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -262,7 +262,6 @@ end
 #  address_line2                :string
 #  api_key                      :string
 #  city                         :string
-#  clickhouse_aggregation       :boolean          default(FALSE), not null
 #  clickhouse_events_store      :boolean          default(FALSE), not null
 #  country                      :string
 #  custom_aggregation           :boolean          default(FALSE)

--- a/db/migrate/20250526133654_drop_clickhouse_aggregation_from_organizations.rb
+++ b/db/migrate/20250526133654_drop_clickhouse_aggregation_from_organizations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DropClickhouseAggregationFromOrganizations < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      remove_column :organizations, :clickhouse_aggregation, :boolean, default: false, null: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2090,7 +2090,6 @@ CREATE TABLE public.organizations (
     document_numbering integer DEFAULT 0 NOT NULL,
     document_number_prefix character varying,
     eu_tax_management boolean DEFAULT false,
-    clickhouse_aggregation boolean DEFAULT false NOT NULL,
     premium_integrations character varying[] DEFAULT '{}'::character varying[] NOT NULL,
     custom_aggregation boolean DEFAULT false,
     finalize_zero_amount_invoice boolean DEFAULT true NOT NULL,
@@ -8416,6 +8415,7 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250526133654'),
 ('20250526111147'),
 ('20250522134155'),
 ('20250521104239'),


### PR DESCRIPTION
This PR removes the legacy `organizations.clickhouse_aggregation` column, that is not used anymore.