### PR TITLE
misc(organization): Ensure organization_id is set everywhere

### DIFF
--- a/app/services/fees/apply_provider_taxes_service.rb
+++ b/app/services/fees/apply_provider_taxes_service.rb
@@ -22,6 +22,7 @@ module Fees
         tax_rate = tax.rate.to_f * 100
 
         applied_tax = Fee::AppliedTax.new(
+          organization_id: fee.organization_id,
           tax_description: tax.type,
           tax_code: tax.name.parameterize(separator: "_"),
           tax_name: tax.name,

--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -19,7 +19,7 @@ module Fees
 
       applicable_taxes.each do |tax|
         applied_tax = Fee::AppliedTax.new(
-          organization: fee.organization,
+          organization_id: fee.organization_id,
           fee:,
           tax:,
           tax_description: tax.description,

--- a/app/services/integrations/aggregator/taxes/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_service.rb
@@ -55,6 +55,7 @@ module Integrations
 
           def create_integration_resource
             IntegrationResource.create!(
+              organization_id: integration.organization_id,
               syncable_id: invoice.id,
               syncable_type: "Invoice",
               external_id: result.succeeded_id,

--- a/app/services/invoices/sync_salesforce_id_service.rb
+++ b/app/services/invoices/sync_salesforce_id_service.rb
@@ -18,7 +18,7 @@ module Invoices
         syncable_id: invoice.id,
         syncable_type: "Invoice",
         resource_type: :invoice
-      )
+      ) { it.organization_id = invoice.organization_id }
 
       if integration_resource.new_record?
         integration_resource.save!


### PR DESCRIPTION
## Description

This PR ensures that the newly added `organization_id` field is correctly set on all models
