### PR TITLE
feat(data-api): Add is_billable_metric_deleted argument

### DIFF
--- a/app/graphql/types/data_api/usages/object.rb
+++ b/app/graphql/types/data_api/usages/object.rb
@@ -11,6 +11,8 @@ module Types
         field :billable_metric_code, String, null: false
         field :units, Float, null: false
 
+        field :is_billable_metric_deleted, Boolean, null: false
+
         field :end_of_period_dt, GraphQL::Types::ISO8601Date, null: false
         field :start_of_period_dt, GraphQL::Types::ISO8601Date, null: false
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4182,6 +4182,7 @@ type DataApiUsage {
   amountCurrency: CurrencyEnum!
   billableMetricCode: String!
   endOfPeriodDt: ISO8601Date!
+  isBillableMetricDeleted: Boolean!
   startOfPeriodDt: ISO8601Date!
   units: Float!
 }

--- a/schema.json
+++ b/schema.json
@@ -19102,6 +19102,22 @@
               "args": []
             },
             {
+              "name": "isBillableMetricDeleted",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "startOfPeriodDt",
               "description": null,
               "type": {

--- a/spec/factories/billable_metrics.rb
+++ b/spec/factories/billable_metrics.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
     trait :recurring do
       recurring { true }
     end
+
+    trait :discarded do
+      deleted_at { Time.current }
+    end
   end
 
   factory :sum_billable_metric, parent: :billable_metric do

--- a/spec/graphql/types/data_api/usages/object_spec.rb
+++ b/spec/graphql/types/data_api/usages/object_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Types::DataApi::Usages::Object do
     expect(subject).to have_field(:billable_metric_code).of_type("String!")
     expect(subject).to have_field(:units).of_type("Float!")
 
+    expect(subject).to have_field(:is_billable_metric_deleted).of_type("Boolean!")
+
     expect(subject).to have_field(:end_of_period_dt).of_type("ISO8601Date!")
     expect(subject).to have_field(:start_of_period_dt).of_type("ISO8601Date!")
   end


### PR DESCRIPTION
## Context

We need to add `is_billable_metric_deleted` attribute for usages so that users can filter on that in the UI.

## Description

Add `is_billable_metric_deleted` to `DataApiUsages` resolver.