### PR TITLE
fix(alerting): small QA return

### DIFF
--- a/app/models/usage_monitoring/alert.rb
+++ b/app/models/usage_monitoring/alert.rb
@@ -78,6 +78,7 @@ module UsageMonitoring
       end
 
       formatted_regular_thresholds = thresholds
+        .reject { it.recurring }
         .filter { regular_thresholds_values.include?(it.value) }
         .map { |t| {code: t.code, value: t.value, recurring: false} }
 

--- a/app/services/usage_monitoring/create_alert_service.rb
+++ b/app/services/usage_monitoring/create_alert_service.rb
@@ -51,7 +51,7 @@ module UsageMonitoring
       result.record_validation_failure!(record: e.record)
     rescue ActiveRecord::RecordNotUnique => e
       if e.message.include?("idx_alerts_code_unique_per_subscription")
-        result.single_validation_failure!(field: :code, error_code: "value_already_exists")
+        result.single_validation_failure!(field: :code, error_code: "value_already_exist")
       else
         # Only one alert per [alert_type, billable_metric] pair is allowed.
         result.single_validation_failure!(field: :base, error_code: "alert_already_exists")

--- a/spec/models/usage_monitoring/alert_spec.rb
+++ b/spec/models/usage_monitoring/alert_spec.rb
@@ -89,6 +89,17 @@ RSpec.describe UsageMonitoring::Alert, type: :model do
       )
     end
 
+    context "when there is a non-recurring and a recurring threshold with the same value" do
+      let(:alert) { create(:alert, code: "my-code", thresholds: [10, 15, 50], recurring_threshold: 10) }
+
+      it "rejects the recurring threshold" do
+        expect(alert.formatted_crossed_thresholds([10, 15])).to eq([
+          {code: "warn10", recurring: false, value: 10},
+          {code: "warn15", recurring: false, value: 15}
+        ])
+      end
+    end
+
     context "when crossed thresholds isn't part of threshold values" do
       it "assumes it's recurring" do
         expect(alert.formatted_crossed_thresholds([40, 41, 42])).to eq([

--- a/spec/services/usage_monitoring/create_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/create_alert_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe UsageMonitoring::CreateAlertService do
       it "returns a record validation failure result" do
         create(:billable_metric_usage_amount_alert, organization:, code: "first", subscription_external_id: subscription.external_id)
         expect(result).to be_failure
-        expect(result.error.messages[:code]).to eq(["value_already_exists"])
+        expect(result.error.messages[:code]).to eq(["value_already_exist"])
       end
     end
 


### PR DESCRIPTION
* Use error code `value_already_exist` instead of `value_already_exists`
* fix problem where recurring threshold has the same value as non-recurring threshold