### PR TITLE
fix(clickhouse): Add more auto-retries on error

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -589,7 +589,7 @@ module Events
           attempts += 1
 
           yield
-        rescue Errno::ECONNRESET
+        rescue Errno::ECONNRESET, ActiveRecord::ActiveRecordError
           if attempts < MAX_RETRIES
             sleep(0.05)
             retry


### PR DESCRIPTION
## Description
Similarly to https://github.com/getlago/lago-api/pull/3733, this PR adds auto-retry for `ActiveRecord::ActiveRecordError` on Clickhouse queries
