### PR TITLE
ftr(wallet-limitations): add support for limitations in wallet services

### DIFF
--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -23,6 +23,10 @@ module Wallets
         attributes[:invoice_requires_successful_payment] = ActiveModel::Type::Boolean.new.cast(params[:invoice_requires_successful_payment])
       end
 
+      if params.key?(:applies_to)
+        attributes[:allowed_fee_types] = params[:applies_to][:fee_types] if params[:applies_to].key?(:fee_types)
+      end
+
       wallet = Wallet.new(attributes)
 
       ActiveRecord::Base.transaction do

--- a/app/services/wallets/validate_limitations_service.rb
+++ b/app/services/wallets/validate_limitations_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Wallets
+  class ValidateLimitationsService < BaseValidator
+    def valid?
+      return true unless args[:applies_to]
+
+      valid_allowed_fee_types?
+
+      if errors?
+        result.validation_failure!(errors:)
+        return false
+      end
+
+      true
+    end
+
+    private
+
+    def valid_allowed_fee_types?
+      fee_types = args[:applies_to][:fee_types]
+
+      return true if fee_types.blank?
+
+      valid_types = Fee.fee_types.keys
+      incoming = Array(fee_types).map(&:to_s)
+      invalid = incoming - valid_types
+
+      add_error(field: :allowed_fee_types, error_code: "invalid_fee_types") if invalid.any?
+    end
+  end
+end

--- a/app/services/wallets/validate_service.rb
+++ b/app/services/wallets/validate_service.rb
@@ -9,6 +9,7 @@ module Wallets
       valid_expiration_at? if args[:expiration_at]
       valid_recurring_transaction_rules? if args[:recurring_transaction_rules].present?
       valid_metadata? if args[:transaction_metadata]
+      valid_limitations? if args[:applies_to]
 
       if errors?
         result.validation_failure!(errors:)
@@ -74,6 +75,14 @@ module Wallets
       end
 
       true
+    end
+
+    def valid_limitations?
+      return true if Wallets::ValidateLimitationsService.new(BaseService::Result.new, **args).valid?
+
+      add_error(field: :applies_to, error_code: "invalid_limitations")
+
+      false
     end
   end
 end

--- a/spec/services/wallets/validate_limitations_service_spec.rb
+++ b/spec/services/wallets/validate_limitations_service_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Wallets::ValidateLimitationsService, type: :service do
+  subject(:validate_service) { described_class.new(result, **args) }
+
+  let(:result) { BaseService::Result.new }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:args) do
+    {
+      applies_to: limitations
+    }
+  end
+
+  describe ".valid?" do
+    context "when there is no applies_to attribute" do
+      let(:args) do
+        {}
+      end
+
+      it "returns true" do
+        expect(validate_service).to be_valid
+      end
+    end
+
+    context "when there is wrong fee type" do
+      let(:limitations) do
+        {
+          fee_types: %w[invalid_fee_type charge],
+        }
+      end
+
+      it "returns false and result has errors" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:allowed_fee_types]).to eq(["invalid_fee_types"])
+      end
+    end
+
+    context "when limitations are valid" do
+      let(:limitations) do
+        {
+          fee_types: %w[charge subscription],
+        }
+      end
+
+      it "returns true and result has no errors" do
+        expect(validate_service).to be_valid
+        expect(result.error).not_to be
+      end
+    end
+  end
+end

--- a/spec/services/wallets/validate_limitations_service_spec.rb
+++ b/spec/services/wallets/validate_limitations_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Wallets::ValidateLimitationsService, type: :service do
     context "when there is wrong fee type" do
       let(:limitations) do
         {
-          fee_types: %w[invalid_fee_type charge],
+          fee_types: %w[invalid_fee_type charge]
         }
       end
 
@@ -41,13 +41,13 @@ RSpec.describe Wallets::ValidateLimitationsService, type: :service do
     context "when limitations are valid" do
       let(:limitations) do
         {
-          fee_types: %w[charge subscription],
+          fee_types: %w[charge subscription]
         }
       end
 
       it "returns true and result has no errors" do
         expect(validate_service).to be_valid
-        expect(result.error).not_to be
+        expect(result.error).to be_nil
       end
     end
   end

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
 
         it "returns true and result has no errors" do
           expect(validate_service).to be_valid
-          expect(result.error).not_to be
+          expect(result.error).to be_nil
         end
       end
     end

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -157,5 +157,40 @@ RSpec.describe Wallets::ValidateService, type: :service do
         expect(result.error.messages[:recurring_transaction_rules]).to eq(["invalid_number_of_recurring_rules"])
       end
     end
+
+    context "with limitations" do
+      let(:limitations) do
+        {
+          fee_types: %w[invalid charge]
+        }
+      end
+      let(:args) do
+        {
+          customer:,
+          organization_id: organization.id,
+          paid_credits:,
+          granted_credits:,
+          applies_to: limitations
+        }
+      end
+
+      it "returns false and result has errors if fee type is invalid" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:applies_to]).to eq(["invalid_limitations"])
+      end
+
+      context "when limitations are valid" do
+        let(:limitations) do
+          {
+            fee_types: %w[charge]
+          }
+        end
+
+        it "returns true and result has no errors" do
+          expect(validate_service).to be_valid
+          expect(result.error).not_to be
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Currently wallet credits are applied on all fee types. This feature adds possibility to limit wallet consumption on specific fee type.

## Description

This PR adds support for new `applies_to` attribute which is the main object for various limitations. The first limitation will be the one related to fee type, but in the future `applies_to` will be extended with more limitations
