### PR TITLE
misc(organization): Exclude remove clickhouse_aggregation column

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -5,6 +5,8 @@ class Organization < ApplicationRecord
   include OrganizationTimezone
   include Currencies
 
+  self.ignored_columns += [:clickhouse_aggregation]
+
   EMAIL_SETTINGS = [
     "invoice.finalized",
     "credit_note.created",


### PR DESCRIPTION
## Description

This PR follows https://github.com/getlago/lago-api/pull/3722.

The `clickhouse_aggregation` was recently removed from the organization table.
Because the deploy of this change lead to a lot of issues as we are relying on `ApplicationRecord#ignored_columns` to avoid `ActiveRecord::PreparedStatementCacheExpired`, this PR mark the removed column as ignored_columns to reduce the risk of error.

For future columns removal, this approach will be done before pushing the migration.
