### PR TITLE
Feat(multientities): dunning campaing - reset associated customers

### DIFF
--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -120,6 +120,15 @@ class BillingEntity < ApplicationRecord
     ENV["LAGO_FROM_EMAIL"]
   end
 
+  def reset_customers_last_dunning_campaign_attempt
+    customers
+      .falling_back_to_default_dunning_campaign
+      .update_all( # rubocop:disable Rails/SkipsModelValidations
+        last_dunning_campaign_attempt: 0,
+        last_dunning_campaign_attempt_at: nil
+      )
+  end
+
   private
 
   def generate_document_number_prefix

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -44,7 +44,7 @@ class DunningCampaign < ApplicationRecord
     )
 
     # NOTE: Reset last attempt on customers falling back to the billing_entity campaign
-    billing_entities.map(&:reset_customers_last_dunning_campaign_attempt)
+    billing_entities.includes(:customers).map(&:reset_customers_last_dunning_campaign_attempt)
   end
 end
 

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -43,8 +43,8 @@ class DunningCampaign < ApplicationRecord
       last_dunning_campaign_attempt_at: nil
     )
 
-    # NOTE: Reset last attempt on customers falling back to the organization campaign
-    organization.reset_customers_last_dunning_campaign_attempt if applied_to_organization?
+    # NOTE: Reset last attempt on customers falling back to the billing_entity campaign
+    billing_entities.map(&:reset_customers_last_dunning_campaign_attempt)
   end
 end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -187,15 +187,6 @@ class Organization < ApplicationRecord
     super(value&.upcase)
   end
 
-  def reset_customers_last_dunning_campaign_attempt
-    customers
-      .falling_back_to_default_dunning_campaign
-      .update_all( # rubocop:disable Rails/SkipsModelValidations
-        last_dunning_campaign_attempt: 0,
-        last_dunning_campaign_attempt_at: nil
-      )
-  end
-
   def from_email_address
     return email if from_email_enabled?
 

--- a/app/services/dunning_campaigns/create_service.rb
+++ b/app/services/dunning_campaigns/create_service.rb
@@ -18,7 +18,7 @@ module DunningCampaigns
           organization.dunning_campaigns.applied_to_organization
             .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
 
-          organization.reset_customers_last_dunning_campaign_attempt
+          organization.default_billing_entity.reset_customers_last_dunning_campaign_attempt
         end
 
         dunning_campaign = organization.dunning_campaigns.create!(

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -102,7 +102,11 @@ module DunningCampaigns
         .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
 
       organization.reset_customers_last_dunning_campaign_attempt
-      organization.default_billing_entity.update(applied_dunning_campaign: dunning_campaign)
+      if dunning_campaign.applied_to_organization
+        organization.default_billing_entity.update(applied_dunning_campaign: dunning_campaign)
+      else
+        organization.default_billing_entity.update(applied_dunning_campaign: nil)
+      end
 
       new_applied_dunning_campaign = dunning_campaign.applied_to_organization ? dunning_campaign : nil
       organization.default_billing_entity.update!(applied_dunning_campaign: new_applied_dunning_campaign)

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -104,7 +104,7 @@ module DunningCampaigns
       organization.reset_customers_last_dunning_campaign_attempt
 
       new_applied_dunning_campaign = dunning_campaign.applied_to_organization ? dunning_campaign : nil
-      organization.default_billing_entity.update(applied_dunning_campaign: new_applied_dunning_campaign)
+      organization.default_billing_entity.update!(applied_dunning_campaign: new_applied_dunning_campaign)
 
       new_applied_dunning_campaign = dunning_campaign.applied_to_organization ? dunning_campaign : nil
       organization.default_billing_entity.update!(applied_dunning_campaign: new_applied_dunning_campaign)

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -101,7 +101,7 @@ module DunningCampaigns
         .applied_to_organization
         .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
 
-      organization.reset_customers_last_dunning_campaign_attempt
+      organization.default_billing_entity.reset_customers_last_dunning_campaign_attempt
       organization.default_billing_entity.update(applied_dunning_campaign: dunning_campaign)
 
       new_applied_dunning_campaign = dunning_campaign.applied_to_organization ? dunning_campaign : nil

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -102,11 +102,9 @@ module DunningCampaigns
         .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
 
       organization.reset_customers_last_dunning_campaign_attempt
-      if dunning_campaign.applied_to_organization
-        organization.default_billing_entity.update(applied_dunning_campaign: dunning_campaign)
-      else
-        organization.default_billing_entity.update(applied_dunning_campaign: nil)
-      end
+
+      new_applied_dunning_campaign = dunning_campaign.applied_to_organization ? dunning_campaign : nil
+      organization.default_billing_entity.update(applied_dunning_campaign: new_applied_dunning_campaign)
 
       new_applied_dunning_campaign = dunning_campaign.applied_to_organization ? dunning_campaign : nil
       organization.default_billing_entity.update!(applied_dunning_campaign: new_applied_dunning_campaign)

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -102,6 +102,7 @@ module DunningCampaigns
         .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
 
       organization.reset_customers_last_dunning_campaign_attempt
+      organization.default_billing_entity.update(applied_dunning_campaign: dunning_campaign)
 
       new_applied_dunning_campaign = dunning_campaign.applied_to_organization ? dunning_campaign : nil
       organization.default_billing_entity.update!(applied_dunning_campaign: new_applied_dunning_campaign)

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -88,7 +88,7 @@ module DunningCampaigns
     end
 
     def customers_fallback_campaign
-      organization.customers.falling_back_to_default_dunning_campaign
+      organization.customers.falling_back_to_default_dunning_campaign.where(billing_entity_id: dunning_campaign.billing_entities.ids)
     end
 
     def handle_applied_to_organization_update

--- a/db/migrate/20250526130953_populate_billing_entity_applied_dunning_campaign.rb
+++ b/db/migrate/20250526130953_populate_billing_entity_applied_dunning_campaign.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class PopulateBillingEntityAppliedDunningCampaign < ActiveRecord::Migration[8.0]
-  class DunningCampaign < ActiveRecord::Base
-    self.table_name = "dunning_campaigns"
-    belongs_to :organization, class_name: "Organization"
-  end
-
   def up
     # rubocop:disable Rails/SkipsModelValidations
     DunningCampaign.where(applied_to_organization: true).find_each do |dunning_campaign|

--- a/db/migrate/20250526130953_populate_billing_entity_applied_dunning_campaign.rb
+++ b/db/migrate/20250526130953_populate_billing_entity_applied_dunning_campaign.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class PopulateBillingEntityAppliedDunningCampaign < ActiveRecord::Migration[8.0]
+  class DunningCampaign < ActiveRecord::Base
+    self.table_name = "dunning_campaigns"
+    belongs_to :organization, class_name: "Organization"
+  end
+
   def up
     # rubocop:disable Rails/SkipsModelValidations
     DunningCampaign.where(applied_to_organization: true).find_each do |dunning_campaign|

--- a/spec/graphql/mutations/dunning_campaigns/update_spec.rb
+++ b/spec/graphql/mutations/dunning_campaigns/update_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Mutations::DunningCampaigns::Update, type: :graphql do
   let(:organization) { create(:organization, premium_integrations: ["auto_dunning"]) }
   let(:membership) { create(:membership, organization:) }
   let(:dunning_campaign) do
-    create(:dunning_campaign, organization:, applied_to_organization: true)
+    create(:dunning_campaign, organization:)
   end
   let(:dunning_campaign_threshold) do
     create(:dunning_campaign_threshold, dunning_campaign:)
@@ -48,7 +48,7 @@ RSpec.describe Mutations::DunningCampaigns::Update, type: :graphql do
   around { |test| lago_premium!(&test) }
 
   before do
-    dunning_campaign
+    organization.default_billing_entity.update!(applied_dunning_campaign: dunning_campaign)
   end
 
   it_behaves_like "requires current user"

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -295,13 +295,13 @@ RSpec.describe BillingEntity, type: :model do
 
   describe "#reset_customers_last_dunning_campaign_attempt" do
     let(:last_dunning_campaign_attempt_at) { 1.day.ago }
-    let(:campaign) { create(:dunning_campaign, organization:) }
+    let(:campaign) { create(:dunning_campaign, organization: billing_entity.organization) }
 
     it "resets the last dunning campaign attempt for customers with fallback dunning_campaign" do
       customer1 = create(:customer, billing_entity:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at:)
       customer2 = create(:customer, billing_entity:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at:, applied_dunning_campaign: campaign)
 
-      expect { organization.reset_customers_last_dunning_campaign_attempt }
+      expect { billing_entity.reset_customers_last_dunning_campaign_attempt }
         .to change { customer1.reload.last_dunning_campaign_attempt }.from(1).to(0)
         .and change(customer1, :last_dunning_campaign_attempt_at).from(last_dunning_campaign_attempt_at).to(nil)
       expect(customer2.reload.last_dunning_campaign_attempt).to eq(1)

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -292,4 +292,19 @@ RSpec.describe BillingEntity, type: :model do
       end
     end
   end
+
+  describe "#reset_customers_last_dunning_campaign_attempt" do
+    let(:last_dunning_campaign_attempt_at) { 1.day.ago }
+    let(:campaign) { create(:dunning_campaign, organization:) }
+
+    it "resets the last dunning campaign attempt for customers with fallback dunning_campaign" do
+      customer1 = create(:customer, billing_entity:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at:)
+      customer2 = create(:customer, billing_entity:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at:, applied_dunning_campaign: campaign)
+
+      expect { organization.reset_customers_last_dunning_campaign_attempt }
+        .to change { customer1.reload.last_dunning_campaign_attempt }.from(1).to(0)
+        .and change(customer1, :last_dunning_campaign_attempt_at).from(last_dunning_campaign_attempt_at).to(nil)
+      expect(customer2.reload.last_dunning_campaign_attempt).to eq(1)
+    end
+  end
 end

--- a/spec/models/dunning_campaign_spec.rb
+++ b/spec/models/dunning_campaign_spec.rb
@@ -88,10 +88,12 @@ RSpec.describe DunningCampaign, type: :model do
         .and change { customer.last_dunning_campaign_attempt_at }.from(last_dunning_campaign_attempt_at).to(nil)
     end
 
-    context "when applied to organization" do
-      subject(:dunning_campaign) { create(:dunning_campaign, applied_to_organization: true) }
+    context "when applied to billing entity" do
+      subject(:dunning_campaign) { create(:dunning_campaign) }
 
-      it "resets last attempt on customers falling back to the organization campaign" do
+      before { organization.default_billing_entity.update!(applied_dunning_campaign: dunning_campaign) }
+
+      it "resets last attempt on customers falling back to the billing_entity campaign" do
         customer = create(
           :customer,
           organization:,

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -249,21 +249,6 @@ RSpec.describe Organization, type: :model do
     end
   end
 
-  describe "#reset_customers_last_dunning_campaign_attempt" do
-    let(:last_dunning_campaign_attempt_at) { 1.day.ago }
-    let(:campaign) { create(:dunning_campaign, organization:) }
-
-    it "resets the last dunning campaign attempt for customers" do
-      customer1 = create(:customer, organization:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at:)
-      customer2 = create(:customer, organization:, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at:, applied_dunning_campaign: campaign)
-
-      expect { organization.reset_customers_last_dunning_campaign_attempt }
-        .to change { customer1.reload.last_dunning_campaign_attempt }.from(1).to(0)
-        .and change(customer1, :last_dunning_campaign_attempt_at).from(last_dunning_campaign_attempt_at).to(nil)
-      expect(customer2.reload.last_dunning_campaign_attempt).to eq(1)
-    end
-  end
-
   describe "#can_create_billing_entity?" do
     subject { organization.can_create_billing_entity? }
 

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
     subject(:result) { update_service.call }
 
     before do
-      dunning_campaign
       billing_entity.update!(applied_dunning_campaign: dunning_campaign)
     end
 
@@ -119,7 +118,7 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
         end
 
         context "when bcc_emails is set and should be reset" do
-          let(:dunning_campaign) { create(:dunning_campaign, organization:, applied_to_organization: true, bcc_emails: ["earl@example.com"]) }
+          let(:dunning_campaign) { create(:dunning_campaign, organization:, bcc_emails: ["earl@example.com"]) }
           let(:params) do
             {
               name: "Updated Dunning Campaign",
@@ -188,13 +187,13 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the campaign is assigned to the customer" do
             let(:dunning_campaign) do
-              create(:dunning_campaign, organization:, applied_to_organization: false)
+              create(:dunning_campaign, organization:)
             end
 
             include_examples "resets customer last dunning campaign attempt fields", :customer_assigned
           end
 
-          context "when the customer defaults to the campaign applied to organization" do
+          context "when the customer defaults to the campaign applied to billing entity" do
             include_examples "resets customer last dunning campaign attempt fields", :customer_defaulting
           end
         end
@@ -223,7 +222,7 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the campaign is assigned to the customer" do
             let(:dunning_campaign) do
-              create(:dunning_campaign, organization:, applied_to_organization: false)
+              create(:dunning_campaign, organization:)
             end
 
             include_examples "resets customer last dunning campaign attempt fields", :customer_assigned
@@ -260,7 +259,7 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the campaign is assigned to the customer" do
             let(:dunning_campaign) do
-              create(:dunning_campaign, organization:, applied_to_organization: false)
+              create(:dunning_campaign, organization:)
             end
 
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_assigned
@@ -304,7 +303,7 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the campaign is assigned to the customer" do
             let(:dunning_campaign) do
-              create(:dunning_campaign, organization:, applied_to_organization: false)
+              create(:dunning_campaign, organization:)
             end
 
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_assigned
@@ -331,7 +330,7 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the campaign is assigned to the customer" do
             let(:dunning_campaign) do
-              create(:dunning_campaign, organization:, applied_to_organization: false)
+              create(:dunning_campaign, organization:)
             end
 
             include_examples "resets customer last dunning campaign attempt fields", :customer_assigned
@@ -367,7 +366,7 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the campaign is assigned to the customer" do
             let(:dunning_campaign) do
-              create(:dunning_campaign, organization:, applied_to_organization: false)
+              create(:dunning_campaign, organization:)
             end
 
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_assigned
@@ -411,7 +410,7 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           let(:params) { {applied_to_organization: true} }
 
           let(:dunning_campaign) do
-            create(:dunning_campaign, organization:, applied_to_organization: false)
+            create(:dunning_campaign, organization:)
           end
 
           before do
@@ -434,7 +433,6 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
             end
 
             before do
-              dunning_campaign_2
               billing_entity.update!(applied_dunning_campaign: dunning_campaign_2)
             end
 

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -87,7 +87,8 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
             applied_dunning_campaign: nil,
             last_dunning_campaign_attempt: 4,
             last_dunning_campaign_attempt_at: 1.day.ago,
-            organization: organization
+            organization: organization,
+            billing_entity: billing_entity
           )
         end
         let(:customer_assigned) do
@@ -97,7 +98,8 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
             applied_dunning_campaign: dunning_campaign,
             last_dunning_campaign_attempt: 4,
             last_dunning_campaign_attempt_at: 1.day.ago,
-            organization: organization
+            organization: organization,
+            billing_entity: billing_entity
           )
         end
 


### PR DESCRIPTION
## Context

Since source of applied dunning campaign is billing entity, when resetting dunning campaign, we should reset customers through billing_entity
