### PR TITLE
fix(invoice-preview): Support preview for subscription during upgrade or downgrade

### DIFF
--- a/app/services/invoices/preview/find_subscriptions_service.rb
+++ b/app/services/invoices/preview/find_subscriptions_service.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Preview
+    class FindSubscriptionsService < BaseService
+      Result = BaseResult[:subscriptions]
+
+      def initialize(subscriptions:)
+        @subscriptions = subscriptions
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: "subscription") if subscriptions.empty?
+
+        result.subscriptions = subscriptions.flat_map do |subscription|
+          if subscription.next_subscription
+            [
+              terminated_subscription(subscription),
+              (adjusted_next_subscription(subscription) if subscription.next_subscription.plan.pay_in_advance?)
+            ].compact
+          else
+            subscription
+          end
+        end
+
+        result
+      end
+
+      private
+
+      attr_reader :subscriptions
+
+      def terminated_subscription(subscription)
+        subscription.terminated_at = termination_date(subscription)
+        subscription.status = :terminated
+
+        subscription.next_subscriptions.build(
+          **adjusted_next_subscription(subscription).attributes
+        )
+
+        subscription
+      end
+
+      def adjusted_next_subscription(subscription)
+        subscription.next_subscription.assign_attributes(
+          status: :active,
+          started_at: subscription.upgraded? ? Time.current : termination_date(subscription),
+        )
+
+        subscription.next_subscription
+      end
+
+      def termination_date(subscription)
+        @termination_date ||= if subscription.upgraded?
+          Time.current
+        else
+          Subscriptions::DatesService
+            .new_instance(subscription, Time.current, current_usage: true)
+            .end_of_period + 1.day
+        end
+      end
+    end
+  end
+end

--- a/app/services/invoices/preview/find_subscriptions_service.rb
+++ b/app/services/invoices/preview/find_subscriptions_service.rb
@@ -14,10 +14,12 @@ module Invoices
         return result.not_found_failure!(resource: "subscription") if subscriptions.empty?
 
         result.subscriptions = subscriptions.flat_map do |subscription|
-          if subscription.next_subscription
+          if subscription.downgraded?
+            sub = adjusted_subscription(subscription)
+
             [
-              terminated_subscription(subscription),
-              (adjusted_next_subscription(subscription) if subscription.next_subscription.plan.pay_in_advance?)
+              sub,
+              (sub.next_subscription if sub.next_subscription.plan.pay_in_advance?)
             ].compact
           else
             subscription
@@ -31,34 +33,22 @@ module Invoices
 
       attr_reader :subscriptions
 
-      def terminated_subscription(subscription)
-        subscription.terminated_at = termination_date(subscription)
+      def adjusted_subscription(subscription)
+        subscription.terminated_at = rotation_date(subscription)
         subscription.status = :terminated
 
-        subscription.next_subscriptions.build(
-          **adjusted_next_subscription(subscription).attributes
+        subscription.next_subscription.assign_attributes(
+          status: :active,
+          started_at: rotation_date(subscription)
         )
 
         subscription
       end
 
-      def adjusted_next_subscription(subscription)
-        subscription.next_subscription.assign_attributes(
-          status: :active,
-          started_at: subscription.upgraded? ? Time.current : termination_date(subscription),
-        )
-
-        subscription.next_subscription
-      end
-
-      def termination_date(subscription)
-        @termination_date ||= if subscription.upgraded?
-          Time.current
-        else
-          Subscriptions::DatesService
-            .new_instance(subscription, Time.current, current_usage: true)
-            .end_of_period + 1.day
-        end
+      def rotation_date(subscription)
+        @rotation_date ||= Subscriptions::DatesService
+          .new_instance(subscription, Time.current, current_usage: true)
+          .end_of_period + 1.day
       end
     end
   end

--- a/app/services/invoices/preview/subscription_plan_change_service.rb
+++ b/app/services/invoices/preview/subscription_plan_change_service.rb
@@ -31,7 +31,7 @@ module Invoices
 
       private
 
-      attr_reader :current_subscription, :target_plan_code, :context
+      attr_reader :current_subscription, :target_plan_code
 
       delegate :organization, :customer, to: :current_subscription
 

--- a/app/services/invoices/preview/subscriptions_service.rb
+++ b/app/services/invoices/preview/subscriptions_service.rb
@@ -16,6 +16,13 @@ module Invoices
         return result.not_found_failure!(resource: "organization") unless organization
         return result.not_found_failure!(resource: "customer") unless customer
 
+        if context != :proposal && customer.new_record?
+          return result.single_validation_failure!(
+            error_code: "must_be_persisted",
+            field: :customer
+          )
+        end
+
         if [:termination, :plan_change].include?(context)
           if customer_subscriptions.size > 1
             return result.single_validation_failure!(

--- a/app/services/invoices/preview/subscriptions_service.rb
+++ b/app/services/invoices/preview/subscriptions_service.rb
@@ -49,9 +49,9 @@ module Invoices
             params:
           )
         when :projection
-          self.class::Result.new.tap do |r|
-            r.subscriptions = customer_subscriptions
-          end
+          FindSubscriptionsService.call(
+            subscriptions: customer_subscriptions
+          )
         end
       end
 
@@ -69,7 +69,7 @@ module Invoices
         elsif target_plan_code
           :plan_change
         else
-          :projection # Preview for existing subscriptions without any modifications
+          :projection # Preview for existing subscriptions including their next subscriptions
         end
       end
 

--- a/spec/services/invoices/preview/find_subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/find_subscriptions_service_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Invoices::Preview::FindSubscriptionsService, type: :service do
+  describe ".call" do
+    subject(:result) { described_class.call(subscriptions:) }
+
+    let(:subscriptions_result) { result.subscriptions }
+
+    context "when subscriptions are missing" do
+      let(:subscriptions) { [] }
+
+      it "fails with subscription not found error" do
+        expect(result).to be_failure
+        expect(result.error.error_code).to eq("subscription_not_found")
+      end
+    end
+
+    context "when subscriptions are present" do
+      let(:organization) { create(:organization) }
+      let(:customer) { create(:customer, organization:) }
+
+      context "when subscriptions has no next subscription" do
+        let(:subscriptions) { create_pair(:subscription, organization:, customer:) }
+
+        it "returns the subscriptions as is" do
+          expect(result).to be_success
+          expect(subscriptions_result).to match_array subscriptions
+        end
+      end
+
+      context "when subscription has a next subscription" do
+        let(:current_plan) { create(:plan, organization:, pay_in_advance: true) }
+        let(:next_plan) { create(:plan, organization:, pay_in_advance:, amount_cents:) }
+        let(:subscription) { create(:subscription, plan: current_plan, customer:, organization:, next_subscriptions: [next_subscription]) }
+        let(:next_subscription) { create(:subscription, :pending, plan: next_plan, customer:, organization:) }
+
+        let(:subscriptions) { [subscription] }
+
+        before { travel_to Time.zone.parse("05-02-2025 12:34:56") }
+
+        context "when next plan is pay in advance" do
+          let(:pay_in_advance) { true }
+
+          context "when next plan is same price or more expensive (upgrade)" do
+            let(:amount_cents) { current_plan.amount_cents + 100 }
+
+            it "returns array containing terminated current and adjusted next subscription" do
+              expect(result).to be_success
+              expect(subscriptions_result.count).to eq(2)
+
+              expect(subscriptions_result.first).to have_attributes(
+                id: subscription.id,
+                status: "terminated",
+                terminated_at: Time.current
+              )
+
+              expect(subscriptions_result.second).to have_attributes(
+                id: next_subscription.id,
+                status: "active",
+                started_at: Time.current
+              )
+            end
+
+            it "does not persist any changes to the subscriptions" do
+              expect { subject }.not_to change { subscription.reload.attributes }
+              expect { subject }.not_to change { next_subscription.reload.attributes }
+            end
+          end
+
+          context "when next plan is cheaper (downgrade)" do
+            let(:amount_cents) { current_plan.amount_cents - 100 }
+            let(:end_of_period) { Time.zone.parse("01-03-2025").end_of_day }
+
+            it "returns array containing terminated current and adjusted next subscription" do
+              expect(result).to be_success
+              expect(subscriptions_result.count).to eq(2)
+
+              expect(subscriptions_result.first).to have_attributes(
+                id: subscription.id,
+                status: "terminated",
+                terminated_at: end_of_period
+              )
+
+              expect(subscriptions_result.second).to have_attributes(
+                id: next_subscription.id,
+                status: "active",
+                started_at: end_of_period
+              )
+            end
+
+            it "does not persist any changes to the subscriptions" do
+              expect { subject }.not_to change { subscription.reload.attributes }
+              expect { subject }.not_to change { next_subscription.reload.attributes }
+            end
+          end
+        end
+
+        context "when next plan is pay in arrears" do
+          let(:pay_in_advance) { false }
+
+          context "when next plan is same price or more expensive (upgrade)" do
+            let(:amount_cents) { current_plan.amount_cents + 100 }
+
+            it "returns array containing only terminated current subscription" do
+              expect(result).to be_success
+              expect(subscriptions_result.count).to eq(1)
+
+              expect(subscriptions_result.first).to have_attributes(
+                id: subscription.id,
+                status: "terminated",
+                terminated_at: Time.current
+              )
+            end
+
+            it "does not persist any changes to the subscriptions" do
+              expect { subject }.not_to change { subscription.reload.attributes }
+              expect { subject }.not_to change { next_subscription.reload.attributes }
+            end
+          end
+
+          context "when next plan is cheaper (downgrade)" do
+            let(:amount_cents) { current_plan.amount_cents - 100 }
+            let(:end_of_period) { Time.zone.parse("01-03-2025").end_of_day }
+
+            it "returns array containing only terminated current subscription" do
+              expect(result).to be_success
+              expect(subscriptions_result.count).to eq(1)
+
+              expect(subscriptions_result.first).to have_attributes(
+                id: subscription.id,
+                status: "terminated",
+                terminated_at: end_of_period
+              )
+            end
+
+            it "does not persist any changes to the subscriptions" do
+              expect { subject }.not_to change { subscription.reload.attributes }
+              expect { subject }.not_to change { next_subscription.reload.attributes }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/preview/find_subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/find_subscriptions_service_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe Invoices::Preview::FindSubscriptionsService, type: :service do
           expect(result).to be_success
           expect(subscriptions_result).to match_array subscriptions
         end
+
+        it "does not persist any changes to the subscriptions" do
+          expect { subject }.not_to change { subscriptions.map { |s| s.reload.attributes } }
+        end
       end
 
       context "when subscription has a next subscription" do
@@ -46,21 +50,9 @@ RSpec.describe Invoices::Preview::FindSubscriptionsService, type: :service do
           context "when next plan is same price or more expensive (upgrade)" do
             let(:amount_cents) { current_plan.amount_cents + 100 }
 
-            it "returns array containing terminated current and adjusted next subscription" do
+            it "returns the subscriptions as is" do
               expect(result).to be_success
-              expect(subscriptions_result.count).to eq(2)
-
-              expect(subscriptions_result.first).to have_attributes(
-                id: subscription.id,
-                status: "terminated",
-                terminated_at: Time.current
-              )
-
-              expect(subscriptions_result.second).to have_attributes(
-                id: next_subscription.id,
-                status: "active",
-                started_at: Time.current
-              )
+              expect(subscriptions_result).to match_array subscriptions
             end
 
             it "does not persist any changes to the subscriptions" do
@@ -103,15 +95,9 @@ RSpec.describe Invoices::Preview::FindSubscriptionsService, type: :service do
           context "when next plan is same price or more expensive (upgrade)" do
             let(:amount_cents) { current_plan.amount_cents + 100 }
 
-            it "returns array containing only terminated current subscription" do
+            it "returns the subscriptions as is" do
               expect(result).to be_success
-              expect(subscriptions_result.count).to eq(1)
-
-              expect(subscriptions_result.first).to have_attributes(
-                id: subscription.id,
-                status: "terminated",
-                terminated_at: Time.current
-              )
+              expect(subscriptions_result).to match_array subscriptions
             end
 
             it "does not persist any changes to the subscriptions" do


### PR DESCRIPTION
## Context

Current logic for invoice preview does not take into account if existing subscription is in the process of downgrade or upgrade. To generate proper invoice preview we need to slightly adjust data so that subscription state matches one of a new bill run.

## Description

Add validation for customer persistence. It improves UX by providing more precise error message for some invalid params.
Add support for proper preview of subscription in a process of being downgraded.
