### PR TITLE
Feat(multientities): billing_entity source of dunning campaign

### DIFF
--- a/app/services/dunning_campaigns/bulk_process_service.rb
+++ b/app/services/dunning_campaigns/bulk_process_service.rb
@@ -24,7 +24,7 @@ module DunningCampaigns
     class CustomerDunningEvaluator < BaseService
       def initialize(customer)
         @customer = customer
-        @organization = customer.organization
+        @billing_entity = customer.billing_entity
         @dunning_campaign = applicable_dunning_campaign
         @threshold = applicable_dunning_campaign_threshold
       end
@@ -41,10 +41,10 @@ module DunningCampaigns
 
       private
 
-      attr_reader :customer, :dunning_campaign, :threshold, :organization
+      attr_reader :customer, :dunning_campaign, :threshold, :billing_entity
 
       def applicable_dunning_campaign
-        customer.applied_dunning_campaign || organization.applied_dunning_campaign
+        customer.applied_dunning_campaign || billing_entity.applied_dunning_campaign
       end
 
       def applicable_dunning_campaign_threshold

--- a/app/services/dunning_campaigns/process_attempt_service.rb
+++ b/app/services/dunning_campaigns/process_attempt_service.rb
@@ -7,6 +7,7 @@ module DunningCampaigns
       @dunning_campaign_threshold = dunning_campaign_threshold
       @dunning_campaign = dunning_campaign_threshold.dunning_campaign
       @organization = customer.organization
+      @billing_entity = customer.billing_entity
 
       super
     end
@@ -43,13 +44,13 @@ module DunningCampaigns
 
     private
 
-    attr_reader :customer, :dunning_campaign, :dunning_campaign_threshold, :organization
+    attr_reader :customer, :dunning_campaign, :dunning_campaign_threshold, :organization, :billing_entity
 
     def applicable_dunning_campaign?
       return false if customer.exclude_from_dunning_campaign?
 
       custom_campaign = customer.applied_dunning_campaign
-      default_campaign = organization.applied_dunning_campaign
+      default_campaign = billing_entity.applied_dunning_campaign
 
       custom_campaign == dunning_campaign || (!custom_campaign && default_campaign == dunning_campaign)
     end

--- a/app/services/dunning_campaigns/update_service.rb
+++ b/app/services/dunning_campaigns/update_service.rb
@@ -102,10 +102,6 @@ module DunningCampaigns
         .update_all(applied_to_organization: false) # rubocop:disable Rails/SkipsModelValidations
 
       organization.default_billing_entity.reset_customers_last_dunning_campaign_attempt
-      organization.default_billing_entity.update(applied_dunning_campaign: dunning_campaign)
-
-      new_applied_dunning_campaign = dunning_campaign.applied_to_organization ? dunning_campaign : nil
-      organization.default_billing_entity.update!(applied_dunning_campaign: new_applied_dunning_campaign)
 
       new_applied_dunning_campaign = dunning_campaign.applied_to_organization ? dunning_campaign : nil
       organization.default_billing_entity.update!(applied_dunning_campaign: new_applied_dunning_campaign)

--- a/db/migrate/20250526130953_populate_billing_entity_applied_dunning_campaign.rb
+++ b/db/migrate/20250526130953_populate_billing_entity_applied_dunning_campaign.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class PopulateBillingEntityAppliedDunningCampaign < ActiveRecord::Migration[8.0]
-  class DunningCampaign < ActiveRecord::Base
-    self.table_name = "dunning_campaigns"
-    belongs_to :organization, class_name: "Organization"
-  end
-
   def up
     # rubocop:disable Rails/SkipsModelValidations
     DunningCampaign.where(applied_to_organization: true).find_each do |dunning_campaign|

--- a/db/migrate/20250526130953_populate_billing_entity_applied_dunning_campaign.rb
+++ b/db/migrate/20250526130953_populate_billing_entity_applied_dunning_campaign.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class PopulateBillingEntityAppliedDunningCampaign < ActiveRecord::Migration[8.0]
+  class DunningCampaign < ActiveRecord::Base
+    self.table_name = "dunning_campaigns"
+    belongs_to :organization, class_name: "Organization"
+  end
+
   def up
     # rubocop:disable Rails/SkipsModelValidations
     DunningCampaign.where(applied_to_organization: true).find_each do |dunning_campaign|

--- a/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
+++ b/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
@@ -8,12 +8,12 @@ describe "Dunning Campaign v1", :scenarios, type: :request do
   end
 
   let(:billing_entity) do
-    create(:billing_entity, organization:, name: "ACME Corp", email_settings: [])
+    create(:billing_entity, organization:, name: "ACME Corp", email_settings: [], applied_dunning_campaign: dunning_campaign)
   end
 
   let(:dunning_campaign) do
     create(:dunning_campaign, organization:,
-      applied_to_organization: true, max_attempts: 2, days_between_attempts: 2)
+      max_attempts: 2, days_between_attempts: 2)
   end
   let(:dunning_campaign_threshold) do
     create(:dunning_campaign_threshold, dunning_campaign:, amount_cents: 150_00, currency: "EUR")

--- a/spec/services/dunning_campaigns/bulk_process_service_spec.rb
+++ b/spec/services/dunning_campaigns/bulk_process_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
   context "when premium features are enabled" do
     let(:organization) { create :organization, premium_integrations: %w[auto_dunning] }
     let(:billing_entity) { organization.default_billing_entity }
-    let(:customer) { create :customer, organization:, currency: }
+    let(:customer) { create :customer, organization:, billing_entity:, currency: }
 
     let(:invoice_1) do
       create(
@@ -77,7 +77,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
         end
 
         context "when maximum attempts are reached" do
-          let(:customer) { create :customer, billing_entity:, last_dunning_campaign_attempt: 5 }
+          let(:customer) { create :customer, organization:, billing_entity:, last_dunning_campaign_attempt: 5 }
 
           let(:dunning_campaign) do
             create(
@@ -96,7 +96,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
         end
 
         context "when not enough days have passed since last attempt" do
-          let(:customer) { create :customer, billing_entity:, last_dunning_campaign_attempt_at: 3.days.ago }
+          let(:customer) { create :customer, organization:, billing_entity:, last_dunning_campaign_attempt_at: 3.days.ago }
 
           let(:dunning_campaign) do
             create(
@@ -115,14 +115,13 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
         end
 
         context "when enough days have passed since last attempt" do
-          let(:customer) { create :customer, billing_entity:, last_dunning_campaign_attempt_at: 4.days.ago - 1.second }
+          let(:customer) { create :customer, organization:, billing_entity:, last_dunning_campaign_attempt_at: 4.days.ago - 1.second }
 
           let(:dunning_campaign) do
             create(
               :dunning_campaign,
               organization:,
-              days_between_attempts: 4,
-              applied_to_organization: true
+              days_between_attempts: 4
             )
           end
 
@@ -172,6 +171,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
         let(:customer) do
           create(
             :customer,
+            organization:,
             billing_entity:,
             currency:,
             applied_dunning_campaign: customer_dunning_campaign
@@ -242,7 +242,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
       end
 
       context "when customer is excluded from dunning campaigns" do
-        let(:customer) { create :customer, organization:, currency:, exclude_from_dunning_campaign: true }
+        let(:customer) { create :customer, organization:, billing_entity:, currency:, exclude_from_dunning_campaign: true }
 
         context "when a customer has overdue balance exceeding threshold in same currency" do
           before do
@@ -262,6 +262,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
       let(:customer) do
         create(
           :customer,
+          organization:,
           billing_entity:,
           currency:,
           applied_dunning_campaign: dunning_campaign
@@ -308,7 +309,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
         end
 
         context "when maximum attempts are reached" do
-          let(:customer) { create :customer, billing_entity:, last_dunning_campaign_attempt: 5 }
+          let(:customer) { create :customer, organization:, billing_entity:, last_dunning_campaign_attempt: 5 }
 
           let(:dunning_campaign) do
             create(
@@ -327,7 +328,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
         end
 
         context "when not enough days have passed since last attempt" do
-          let(:customer) { create :customer, billing_entity:, last_dunning_campaign_attempt_at: 3.days.ago }
+          let(:customer) { create :customer, organization:, billing_entity:, last_dunning_campaign_attempt_at: 3.days.ago }
 
           let(:dunning_campaign) do
             create(
@@ -346,7 +347,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
         end
 
         context "when enough days have passed since last attempt" do
-          let(:customer) { create :customer, billing_entity:, last_dunning_campaign_attempt_at: 4.days.ago - 1.second }
+          let(:customer) { create :customer, organization:, billing_entity:, last_dunning_campaign_attempt_at: 4.days.ago - 1.second }
 
           let(:dunning_campaign) do
             create(

--- a/spec/services/dunning_campaigns/process_attempt_service_spec.rb
+++ b/spec/services/dunning_campaigns/process_attempt_service_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe DunningCampaigns::ProcessAttemptService, type: :service, aggregat
 
   let(:customer) { create :customer, organization:, currency: }
   let(:organization) { create :organization }
+  let(:billing_entity) { create :billing_entity, organization: }
   let(:currency) { "EUR" }
-  let(:dunning_campaign) { create :dunning_campaign, organization:, applied_to_organization: true }
+  let(:dunning_campaign) { create :dunning_campaign, organization: }
   let(:dunning_campaign_threshold) do
     create :dunning_campaign_threshold, dunning_campaign:, currency:, amount_cents: 99_00
   end
@@ -23,6 +24,7 @@ RSpec.describe DunningCampaigns::ProcessAttemptService, type: :service, aggregat
   end
 
   before do
+    billing_entity.update!(applied_dunning_campaign: dunning_campaign)
     allow(PaymentRequests::CreateService)
       .to receive(:call)
       .and_return(payment_request_result)

--- a/spec/services/dunning_campaigns/process_attempt_service_spec.rb
+++ b/spec/services/dunning_campaigns/process_attempt_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DunningCampaigns::ProcessAttemptService, type: :service, aggregat
 
   let(:customer) { create :customer, organization:, currency: }
   let(:organization) { create :organization }
-  let(:billing_entity) { create :billing_entity, organization: }
+  let(:billing_entity) { organization.default_billing_entity }
   let(:currency) { "EUR" }
   let(:dunning_campaign) { create :dunning_campaign, organization: }
   let(:dunning_campaign_threshold) do


### PR DESCRIPTION
## Context

As default billing_entity follows organization's applied dunning campaign, we want to use billing_entity.applied_dunning_campaign to process dunning campaign
