### PR TITLE
fix(billable_metric): Destroy when attached to a lot of charges

### DIFF
--- a/app/jobs/billable_metric_filters/destroy_all_job.rb
+++ b/app/jobs/billable_metric_filters/destroy_all_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module BillableMetricFilters
+  class DestroyAllJob < ApplicationJob
+    queue_as :low_priority
+
+    def perform(billable_metric_id)
+      billable_metric = BillableMetric.with_discarded.find_by(id: billable_metric_id)
+      BillableMetricFilters::DestroyAllService.call!(billable_metric)
+    end
+  end
+end

--- a/app/services/billable_metric_filters/destroy_all_service.rb
+++ b/app/services/billable_metric_filters/destroy_all_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module BillableMetricFilters
+  class DestroyAllService < BaseService
+    Result = BaseResult[:billable_metric]
+
+    def initialize(billable_metric)
+      @billable_metric = billable_metric
+      super
+    end
+
+    def call
+      return result unless billable_metric
+      return result unless billable_metric.discarded?
+
+      deleted_at = Time.current
+
+      billable_metric.filters.find_each do |filter|
+        # rubocop:disable Rails/SkipsModelValidations
+        filter.filter_values.update_all(deleted_at: deleted_at)
+        filter.charge_filters.update_all(deleted_at: deleted_at)
+        # rubocop:enable Rails/SkipsModelValidations
+
+        filter.discard!
+      end
+
+      result.billable_metric = billable_metric
+      result
+    end
+
+    private
+
+    attr_reader :billable_metric
+  end
+end

--- a/spec/jobs/billable_metric_filters/destroy_all_job_spec.rb
+++ b/spec/jobs/billable_metric_filters/destroy_all_job_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe BillableMetricFilters::DestroyAllJob, type: :job do
+  let(:billable_metric) { create(:billable_metric, :discarded) }
+
+  it "destroys all filters and filter values" do
+    allow(BillableMetricFilters::DestroyAllService)
+      .to receive(:call!)
+      .with(billable_metric)
+      .and_return(BillableMetricFilters::DestroyAllService::Result.new)
+
+    described_class.perform_now(billable_metric.id)
+
+    expect(BillableMetricFilters::DestroyAllService).to have_received(:call!)
+  end
+end

--- a/spec/services/billable_metric_filters/destroy_all_service_spec.rb
+++ b/spec/services/billable_metric_filters/destroy_all_service_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe BillableMetricFilters::DestroyAllService, type: :service do
+  subject(:destroy_service) { described_class.new(billable_metric) }
+
+  let(:billable_metric) { create(:billable_metric, :deleted) }
+  let(:plan) { create(:plan, organization: billable_metric.organization) }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:) }
+  let(:filters) { create_list(:billable_metric_filter, 2, billable_metric:) }
+  let(:charge_filter) { create(:charge_filter, charge:) }
+  let(:filter_value) do
+    create(:charge_filter_value, charge_filter:, billable_metric_filter: filters.first)
+  end
+
+  before { filter_value }
+
+  describe "#call" do
+    it "soft deletes all related filters" do
+      freeze_time do
+        expect { destroy_service.call }.to change { billable_metric.filters.reload.kept.count }.from(2).to(0)
+          .and change { filter_value.reload.reload.deleted_at }.from(nil).to(Time.current)
+      end
+    end
+
+    context "when the billable metric is not deleted" do
+      let(:billable_metric) { create(:billable_metric) }
+
+      it "does not delete the filters" do
+        expect { destroy_service.call }.not_to change { billable_metric.filters.reload.kept.count }
+      end
+    end
+
+    context "when the billable metric is nil" do
+      let(:billable_metric) { nil }
+      let(:filter_value) { nil }
+
+      it "returns an empty result" do
+        result = destroy_service.call
+        expect(result).to be_success
+        expect(result.billable_metric).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -11,16 +11,8 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
   let(:subscription) { create(:subscription) }
   let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:) }
 
-  let(:filters) { create_list(:billable_metric_filter, 2, billable_metric:) }
-  let(:charge_filter) { create(:charge_filter, charge:) }
-  let(:filter_value) do
-    create(:charge_filter_value, charge_filter:, billable_metric_filter: filters.first)
-  end
-
   before do
     charge
-
-    filter_value
 
     allow(BillableMetrics::DeleteEventsJob).to receive(:perform_later).and_call_original
     allow(Invoices::RefreshDraftService).to receive(:call)
@@ -40,11 +32,9 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
       end
     end
 
-    it "soft deletes all related filters" do
-      freeze_time do
-        expect { destroy_service.call }.to change { billable_metric.filters.reload.kept.count }.from(2).to(0)
-          .and change { filter_value.reload.reload.deleted_at }.from(nil).to(Time.current)
-      end
+    it "enqueues a BillableMetricFilters::DestroyAllJob" do
+      expect { destroy_service.call }
+        .to have_enqueued_job(BillableMetricFilters::DestroyAllJob).with(billable_metric.id)
     end
 
     it "enqueues a BillableMetrics::DeleteEventsJob" do


### PR DESCRIPTION
## Context

Deleting a billable metric attached to a lot of charges and filters may lead to a Timeout error because:
- The soft deletion of sub-resources is done synchronously
- It is using `discard_all` witch is not scalable as it is using a DB call per record...

## Description

This PR is moving the filter deletion to a dedicated job and is replacing `discard_all` calls with `update_all(deleted_at:)`
