### PR TITLE
feat(audit-logs): Add relations to activity logs

### DIFF
--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -58,6 +58,7 @@ module Types
       field :billing_entity, Types::BillingEntities::Object, null: false
       field :invoices, [Types::Invoices::Object]
 
+      field :activity_logs, [Types::ActivityLogs::Object], null: true
       field :applied_add_ons, [Types::AppliedAddOns::Object], null: true
       field :applied_coupons, [Types::AppliedCoupons::Object], null: true
       field :taxes, [Types::Taxes::Object], null: true

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -57,6 +57,7 @@ module Types
       field :file_url, String, null: true
       field :metadata, [Types::Invoices::Metadata::Object], null: true
 
+      field :activity_logs, [Types::ActivityLogs::Object], null: true
       field :applied_taxes, [Types::Invoices::AppliedTaxes::Object]
       field :credit_notes, [Types::CreditNotes::Object], null: true
       field :error_details, [Types::ErrorDetails::Object], null: true

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -33,6 +33,7 @@ module Types
       field :next_subscription_at, GraphQL::Types::ISO8601DateTime
       field :next_subscription_type, Types::Subscriptions::NextSubscriptionTypeEnum
 
+      field :activity_logs, [Types::ActivityLogs::Object], null: true
       field :fees, [Types::Fees::Object], null: true
 
       field :lifetime_usage, Types::Subscriptions::LifetimeUsageObject, null: true

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -18,7 +18,10 @@ class BillableMetric < ApplicationRecord
   has_many :groups, dependent: :delete_all
   has_many :filters, -> { order(:key) }, dependent: :delete_all, class_name: "BillableMetricFilter"
 
-  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+  has_many :activity_logs,
+    -> { order(logged_at: :desc) },
+    class_name: "Clickhouse::ActivityLog",
+    as: :resource
 
   AGGREGATION_TYPES = {
     count_agg: 0,

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -30,7 +30,10 @@ class BillingEntity < ApplicationRecord
   has_many :wallets, through: :customers
   has_many :wallet_transactions, through: :wallets
 
-  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+  has_many :activity_logs,
+    -> { order(logged_at: :desc) },
+    class_name: "Clickhouse::ActivityLog",
+    as: :resource
 
   belongs_to :applied_dunning_campaign, class_name: "DunningCampaign", optional: true
 

--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -8,6 +8,16 @@ module Clickhouse
     belongs_to :organization
     belongs_to :resource, polymorphic: true
 
+    belongs_to :customer,
+      primary_key: :external_id,
+      foreign_key: :external_customer_id,
+      optional: true
+
+    belongs_to :subscription,
+      primary_key: :external_id,
+      foreign_key: :external_subscription_id,
+      optional: true
+
     RESOURCE_TYPES = {
       billable_metric: "BillableMetric",
       plan: "Plan",

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -14,7 +14,10 @@ class Coupon < ApplicationRecord
   has_many :plans, through: :coupon_targets
   has_many :billable_metrics, through: :coupon_targets
 
-  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+  has_many :activity_logs,
+    -> { order(logged_at: :desc) },
+    class_name: "Clickhouse::ActivityLog",
+    as: :resource
 
   STATUSES = [
     :active,

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -25,7 +25,10 @@ class CreditNote < ApplicationRecord
   has_many :integration_resources, as: :syncable
   has_many :error_details, as: :owner, dependent: :destroy
 
-  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+  has_many :activity_logs,
+    -> { order(logged_at: :desc) },
+    class_name: "Clickhouse::ActivityLog",
+    as: :resource
 
   has_one_attached :file
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -75,6 +75,7 @@ class Customer < ApplicationRecord
     source: :invoice_custom_section
 
   has_many :activity_logs,
+    -> { order(logged_at: :desc) },
     class_name: "Clickhouse::ActivityLog",
     foreign_key: :external_customer_id,
     primary_key: :external_id

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -74,7 +74,10 @@ class Customer < ApplicationRecord
     through: :invoice_custom_section_selections,
     source: :invoice_custom_section
 
-  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+  has_many :activity_logs,
+    class_name: "Clickhouse::ActivityLog",
+    foreign_key: :external_customer_id,
+    primary_key: :external_id
 
   has_one :stripe_customer, class_name: "PaymentProviderCustomers::StripeCustomer"
   has_one :gocardless_customer, class_name: "PaymentProviderCustomers::GocardlessCustomer"

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -45,7 +45,10 @@ class Invoice < ApplicationRecord
   has_many :usage_thresholds, through: :applied_usage_thresholds
   has_many :applied_invoice_custom_sections
 
-  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+  has_many :activity_logs,
+    -> { order(logged_at: :desc) },
+    class_name: "Clickhouse::ActivityLog",
+    as: :resource
 
   has_one_attached :file
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -25,7 +25,10 @@ class Plan < ApplicationRecord
   has_many :applied_taxes, class_name: "Plan::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes
 
-  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+  has_many :activity_logs,
+    -> { order(logged_at: :desc) },
+    class_name: "Clickhouse::ActivityLog",
+    as: :resource
 
   INTERVALS = %i[
     weekly

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -18,7 +18,10 @@ class Subscription < ApplicationRecord
   has_many :daily_usages
   has_many :usage_thresholds, through: :plan
 
-  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+  has_many :activity_logs,
+    -> { order(logged_at: :desc) },
+    class_name: "Clickhouse::ActivityLog",
+    as: :resource
 
   has_one :lifetime_usage, autosave: true
   has_one :subscription_activity, class_name: "UsageMonitoring::SubscriptionActivity"

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -11,7 +11,10 @@ class Wallet < ApplicationRecord
   has_many :wallet_transactions
   has_many :recurring_transaction_rules
 
-  has_many :activity_logs, class_name: "Clickhouse::ActivityLog", as: :resource
+  has_many :activity_logs,
+    -> { order(logged_at: :desc) },
+    class_name: "Clickhouse::ActivityLog",
+    as: :resource
 
   monetize :balance_cents
   monetize :consumed_amount_cents

--- a/schema.graphql
+++ b/schema.graphql
@@ -3733,6 +3733,7 @@ type Customer {
   Number of active subscriptions per customer
   """
   activeSubscriptionsCount: Int!
+  activityLogs: [ActivityLog!]
   addressLine1: String
   addressLine2: String
   anrokCustomer: AnrokCustomer
@@ -8569,6 +8570,7 @@ type StripeProvider {
 }
 
 type Subscription {
+  activityLogs: [ActivityLog!]
   billingTime: BillingTimeEnum
   canceledAt: ISO8601DateTime
   createdAt: ISO8601DateTime!

--- a/schema.graphql
+++ b/schema.graphql
@@ -5295,6 +5295,7 @@ enum InviteStatusTypeEnum {
 Invoice
 """
 type Invoice {
+  activityLogs: [ActivityLog!]
   allChargesHaveFees: Boolean!
   appliedTaxes: [InvoiceAppliedTax!]
   associatedActiveWalletPresent: Boolean!

--- a/schema.json
+++ b/schema.json
@@ -15095,6 +15095,26 @@
               "args": []
             },
             {
+              "name": "activityLogs",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActivityLog",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "addressLine1",
               "description": null,
               "type": {
@@ -44380,6 +44400,26 @@
           "interfaces": [],
           "possibleTypes": null,
           "fields": [
+            {
+              "name": "activityLogs",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActivityLog",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
             {
               "name": "billingTime",
               "description": null,

--- a/schema.json
+++ b/schema.json
@@ -25607,6 +25607,26 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "activityLogs",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActivityLog",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "allChargesHaveFees",
               "description": null,
               "type": {

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Types::Customers::Object do
 
     expect(subject).to have_field(:invoices).of_type("[Invoice!]")
 
+    expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
     expect(subject).to have_field(:applied_add_ons).of_type("[AppliedAddOn!]")
     expect(subject).to have_field(:applied_coupons).of_type("[AppliedCoupon!]")
     expect(subject).to have_field(:taxes).of_type("[Tax!]")

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Types::Invoices::Object do
     expect(subject).to have_field(:file_url).of_type("String")
     expect(subject).to have_field(:metadata).of_type("[InvoiceMetadata!]")
 
+    expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
     expect(subject).to have_field(:applied_taxes).of_type("[InvoiceAppliedTax!]")
     expect(subject).to have_field(:credit_notes).of_type("[CreditNote!]")
     expect(subject).to have_field(:fees).of_type("[Fee!]")

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Types::Subscriptions::Object do
     expect(subject).to have_field(:next_subscription_type).of_type("NextSubscriptionTypeEnum")
     expect(subject).to have_field(:next_subscription_at).of_type("ISO8601DateTime")
 
+    expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
     expect(subject).to have_field(:fees).of_type("[Fee!]")
 
     expect(subject).to have_field(:lifetime_usage).of_type("SubscriptionLifetimeUsage")

--- a/spec/models/clickhouse/activity_log_spec.rb
+++ b/spec/models/clickhouse/activity_log_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Clickhouse::ActivityLog, type: :model, clickhouse: true do
 
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:resource) }
+  it { is_expected.to belong_to(:customer).optional }
+  it { is_expected.to belong_to(:subscription).optional }
 
   describe "#ensure_activity_id" do
     it "sets the activity_id if it is not set" do


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context

Our users want to have visibility on what’s happening in Lago.

Examples:
- *A plan and prices have been updated: When? By whom? What?*
- *A subscription has been deleted: When? By whom? What?*

## Description

The goal of this PR is to add relations to activity logs.
It will be useful for displaying activity logs tab on several objects (customer / invoice / subscription / ...)