### PR TITLE
Feat(multientities): be manage applied dunning campaign

### DIFF
--- a/app/services/billing_entities/update_applied_dunning_campaign_service.rb
+++ b/app/services/billing_entities/update_applied_dunning_campaign_service.rb
@@ -6,9 +6,11 @@ module BillingEntities
     def initialize(billing_entity:, dunning_campaign: nil)
       @billing_entity = billing_entity
       @dunning_campaign = dunning_campaign
+      super
     end
 
     def call
+      return result.not_found_failure!(resource: "billing_entity") if billing_entity.nil?
       return unless billing_entity.applied_dunning_campaign != dunning_campaign
 
       billing_entity.reset_customers_last_dunning_campaign_attempt

--- a/spec/services/billing_entities/update_applied_dunning_campaign_service_spec.rb
+++ b/spec/services/billing_entities/update_applied_dunning_campaign_service_spec.rb
@@ -16,114 +16,129 @@ RSpec.describe BillingEntities::UpdateAppliedDunningCampaignService, type: :serv
   let(:customer_4) { create(:customer, organization:, billing_entity: second_billing_entity, last_dunning_campaign_attempt: 1, last_dunning_campaign_attempt_at: 1.day.ago) }
 
   describe "#call" do
-    before do
-      customer_1
-      customer_2
-      customer_3
-      customer_4
+    context "when billing entity exists" do
+      before do
+        customer_1
+        customer_2
+        customer_3
+        customer_4
+      end
+
+      context "when updating applied dunning campaign to nil" do
+        let(:dunning_campaign) { nil }
+
+        context "when billing entity has no applied dunning campaign" do
+          it "does not update the billing entity" do
+            expect { update_service.call }.to not_change { billing_entity.reload.applied_dunning_campaign }
+          end
+
+          it "does not reset customer attempts" do
+            expect { update_service.call }.to not_change { customer_1.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_2.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_3.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_4.reload.last_dunning_campaign_attempt }
+          end
+        end
+
+        context "when billing entity has an applied dunning campaign" do
+          before do
+            billing_entity.update!(applied_dunning_campaign: dunning_campaign_1)
+          end
+
+          it "removes the applied dunning campaign" do
+            expect { update_service.call }
+              .to change { billing_entity.reload.applied_dunning_campaign }
+              .from(dunning_campaign_1)
+              .to(nil)
+          end
+
+          it "resets customer attempts only on fallback customers for this billing entity" do
+            expect {
+              update_service.call
+            }.to change { customer_1.reload.last_dunning_campaign_attempt }
+              .from(2)
+              .to(0)
+              .and not_change { customer_2.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_3.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_4.reload.last_dunning_campaign_attempt }
+          end
+        end
+      end
+
+      context "when dunning campaign is provided" do
+        let(:dunning_campaign) { dunning_campaign_2 }
+
+        context "when billing entity has no applied dunning campaign" do
+          it "sets the new dunning campaign" do
+            expect { update_service.call }
+              .to change { billing_entity.reload.applied_dunning_campaign }
+              .from(nil)
+              .to(dunning_campaign)
+          end
+
+          it "resets only fallback customers of this billing entity attempts" do
+            expect { update_service.call }
+              .to change { customer_1.reload.last_dunning_campaign_attempt }
+              .from(2)
+              .to(0)
+              .and not_change { customer_2.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_3.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_4.reload.last_dunning_campaign_attempt }
+          end
+        end
+
+        context "when billing entity has a different applied dunning campaign" do
+          before do
+            billing_entity.update!(applied_dunning_campaign: dunning_campaign_1)
+          end
+
+          it "updates to the new dunning campaign" do
+            expect { update_service.call }
+              .to change { billing_entity.reload.applied_dunning_campaign }
+              .from(dunning_campaign_1)
+              .to(dunning_campaign_2)
+          end
+
+          it "resets customer attempts only on fallback customers for this billing entity" do
+            expect { update_service.call }
+              .to change { customer_1.reload.last_dunning_campaign_attempt }
+              .from(2)
+              .to(0)
+              .and not_change { customer_2.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_3.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_4.reload.last_dunning_campaign_attempt }
+          end
+        end
+
+        context "when billing entity has the same applied dunning campaign" do
+          before do
+            billing_entity.update!(applied_dunning_campaign: dunning_campaign_2)
+          end
+
+          it "does not update the billing entity" do
+            expect { update_service.call }.not_to change { billing_entity.reload.applied_dunning_campaign }
+          end
+
+          it "does not reset customer attempts" do
+            expect { update_service.call }.to not_change { customer_1.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_2.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_3.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_4.reload.last_dunning_campaign_attempt }
+          end
+        end
+      end
     end
 
-    context "when updating applied dunning campaign to nil" do
-      let(:dunning_campaign) { nil }
+    context "when billing entity is nil" do
+      let(:billing_entity) { nil }
+      let(:organization) { create(:organization) }
+      let(:dunning_campaign) { dunning_campaign_1 }
 
-      context "when billing entity has no applied dunning campaign" do
-        it "does not update the billing entity" do
-          expect { update_service.call }.to not_change { billing_entity.reload.applied_dunning_campaign }
-        end
-
-        it "does not reset customer attempts" do
-          expect { update_service.call }.to not_change { customer_1.reload.last_dunning_campaign_attempt }
-            .and not_change { customer_2.reload.last_dunning_campaign_attempt }
-            .and not_change { customer_3.reload.last_dunning_campaign_attempt }
-            .and not_change { customer_4.reload.last_dunning_campaign_attempt }
-        end
-      end
-
-      context "when billing entity has an applied dunning campaign" do
-        before do
-          billing_entity.update!(applied_dunning_campaign: dunning_campaign_1)
-        end
-
-        it "removes the applied dunning campaign" do
-          expect { update_service.call }
-            .to change { billing_entity.reload.applied_dunning_campaign }
-            .from(dunning_campaign_1)
-            .to(nil)
-        end
-
-        it "resets customer attempts only on fallback customers for this billing entity" do
-          expect {
-            update_service.call
-          }.to change { customer_1.reload.last_dunning_campaign_attempt }
-            .from(2)
-            .to(0)
-            .and not_change { customer_2.reload.last_dunning_campaign_attempt }
-            .and not_change { customer_3.reload.last_dunning_campaign_attempt }
-            .and not_change { customer_4.reload.last_dunning_campaign_attempt }
-        end
-      end
-    end
-
-    context "when dunning campaign is provided" do
-      let(:dunning_campaign) { dunning_campaign_2 }
-
-      context "when billing entity has no applied dunning campaign" do
-        it "sets the new dunning campaign" do
-          expect { update_service.call }
-            .to change { billing_entity.reload.applied_dunning_campaign }
-            .from(nil)
-            .to(dunning_campaign)
-        end
-
-        it "resets only fallback customers of this billing entity attempts" do
-          expect { update_service.call }
-            .to change { customer_1.reload.last_dunning_campaign_attempt }
-            .from(2)
-            .to(0)
-            .and not_change { customer_2.reload.last_dunning_campaign_attempt }
-            .and not_change { customer_3.reload.last_dunning_campaign_attempt }
-            .and not_change { customer_4.reload.last_dunning_campaign_attempt }
-        end
-      end
-
-      context "when billing entity has a different applied dunning campaign" do
-        before do
-          billing_entity.update!(applied_dunning_campaign: dunning_campaign_1)
-        end
-
-        it "updates to the new dunning campaign" do
-          expect { update_service.call }
-            .to change { billing_entity.reload.applied_dunning_campaign }
-            .from(dunning_campaign_1)
-            .to(dunning_campaign_2)
-        end
-
-        it "resets customer attempts only on fallback customers for this billing entity" do
-          expect { update_service.call }
-            .to change { customer_1.reload.last_dunning_campaign_attempt }
-            .from(2)
-            .to(0)
-            .and not_change { customer_2.reload.last_dunning_campaign_attempt }
-            .and not_change { customer_3.reload.last_dunning_campaign_attempt }
-            .and not_change { customer_4.reload.last_dunning_campaign_attempt }
-        end
-      end
-
-      context "when billing entity has the same applied dunning campaign" do
-        before do
-          billing_entity.update!(applied_dunning_campaign: dunning_campaign_2)
-        end
-
-        it "does not update the billing entity" do
-          expect { update_service.call }.not_to change { billing_entity.reload.applied_dunning_campaign }
-        end
-
-        it "does not reset customer attempts" do
-          expect { update_service.call }.to not_change { customer_1.reload.last_dunning_campaign_attempt }
-            .and not_change { customer_2.reload.last_dunning_campaign_attempt }
-            .and not_change { customer_3.reload.last_dunning_campaign_attempt }
-            .and not_change { customer_4.reload.last_dunning_campaign_attempt }
-        end
+      it "returns a not found failure" do
+        result = update_service.call
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq("billing_entity_not_found")
       end
     end
   end


### PR DESCRIPTION
## Context

We're planning to manage applied dunning campaigns on billing entities, not using the "applied_to_organization" flag

## Description

Added service that update applied_dunning_campaign on billing_entity