### PR TITLE
feat(wallet-limitations): add api support for wallet limitations

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -106,6 +106,9 @@ module Api
               :key,
               :value
             ]
+          ],
+          applies_to: [
+            fee_types: []
           ]
         )
       end
@@ -135,6 +138,9 @@ module Api
               :key,
               :value
             ]
+          ],
+          applies_to: [
+            fee_types: []
           ]
         )
       end
@@ -148,7 +154,7 @@ module Api
           json: ::V1::WalletSerializer.new(
             wallet,
             root_name: "wallet",
-            includes: %i[recurring_transaction_rules]
+            includes: %i[recurring_transaction_rules limitations]
           )
         )
       end

--- a/app/serializers/v1/wallet_serializer.rb
+++ b/app/serializers/v1/wallet_serializer.rb
@@ -45,7 +45,7 @@ module V1
     def limitations
       {
         applies_to: {
-          fee_types: model.allowed_fee_types,
+          fee_types: model.allowed_fee_types
         }
       }
     end

--- a/app/serializers/v1/wallet_serializer.rb
+++ b/app/serializers/v1/wallet_serializer.rb
@@ -27,6 +27,7 @@ module V1
       }
 
       payload.merge!(recurring_transaction_rules) if include?(:recurring_transaction_rules)
+      payload.merge!(limitations) if include?(:limitations)
 
       payload
     end
@@ -39,6 +40,14 @@ module V1
         ::V1::Wallets::RecurringTransactionRuleSerializer,
         collection_name: "recurring_transaction_rules"
       ).serialize
+    end
+
+    def limitations
+      {
+        applies_to: {
+          fee_types: model.allowed_fee_types,
+        }
+      }
     end
   end
 end

--- a/spec/serializers/v1/wallet_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_serializer_spec.rb
@@ -3,9 +3,12 @@
 require "rails_helper"
 
 RSpec.describe ::V1::WalletSerializer do
-  subject(:serializer) { described_class.new(wallet, root_name: "wallet", includes: %i[limitations]) }
+  subject(:serializer) { described_class.new(wallet, root_name: "wallet", includes: %i[limitations recurring_transaction_rules]) }
 
   let(:wallet) { create(:wallet, allowed_fee_types: %w[charge]) }
+  let(:recurring_transaction_rule) { create(:recurring_transaction_rule, wallet:) }
+
+  before { recurring_transaction_rule }
 
   it "serializes the object" do
     result = JSON.parse(serializer.to_json)
@@ -33,7 +36,8 @@ RSpec.describe ::V1::WalletSerializer do
         "consumed_credits" => wallet.consumed_credits.to_s,
         "invoice_requires_successful_payment" => wallet.invoice_requires_successful_payment
       )
-      expect(result["wallet"]["applies_to"]["fee_types"]).to include("charge")
+      expect(result["wallet"]["applies_to"]["fee_types"]).to eq(%w[charge])
+      expect(result["wallet"]["recurring_transaction_rules"].first["lago_id"]).to eq(recurring_transaction_rule.id)
     end
   end
 end

--- a/spec/serializers/v1/wallet_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_serializer_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe ::V1::WalletSerializer do
-  subject(:serializer) { described_class.new(wallet, root_name: "wallet") }
+  subject(:serializer) { described_class.new(wallet, root_name: "wallet", includes: %i[limitations]) }
 
-  let(:wallet) { create(:wallet) }
+  let(:wallet) { create(:wallet, allowed_fee_types: %w[charge]) }
 
   it "serializes the object" do
     result = JSON.parse(serializer.to_json)
@@ -33,6 +33,7 @@ RSpec.describe ::V1::WalletSerializer do
         "consumed_credits" => wallet.consumed_credits.to_s,
         "invoice_requires_successful_payment" => wallet.invoice_requires_successful_payment
       )
+      expect(result["wallet"]["applies_to"]["fee_types"]).to include("charge")
     end
   end
 end


### PR DESCRIPTION
## Context

Currently wallet credits are applied on all fee types. This feature adds possibility to limit wallet consumption on specific fee type.

## Description

This PR adds API support for creating and updating wallet with fee type limitation.
