### PR TITLE
Fix: modify managers role permission

### DIFF
--- a/app/config/permissions/role-manager.yml
+++ b/app/config/permissions/role-manager.yml
@@ -76,7 +76,7 @@ organization:
     update: false
     delete: false
 billing_entities:
-  view: false
+  view: true
   create: false
   update: false
   delete: false


### PR DESCRIPTION
## Context

Account Manager should be able to view billing_entities in order to create customers associated to a billing_entity
