### PR TITLE
fix(multientities): Broken DB migration

### DIFF
--- a/db/migrate/20250521135607_create_customer_applied_invoice_custom_section_records.rb
+++ b/db/migrate/20250521135607_create_customer_applied_invoice_custom_section_records.rb
@@ -3,17 +3,29 @@
 class CreateCustomerAppliedInvoiceCustomSectionRecords < ActiveRecord::Migration[8.0]
   def up
     Customer::AppliedInvoiceCustomSection.insert_all( # rubocop:disable Rails/SkipsModelValidations
-      InvoiceCustomSectionSelection.where.not(customer_id: nil).includes(:customer).map do |selection|
-        {
-          id: selection.id,
-          organization_id: selection.customer.organization_id,
-          billing_entity_id: selection.customer.billing_entity_id,
-          customer_id: selection.customer_id,
-          invoice_custom_section_id: selection.invoice_custom_section_id,
-          created_at: selection.created_at,
-          updated_at: selection.updated_at
-        }
-      end
+      InvoiceCustomSectionSelection
+        .joins("LEFT JOIN customers ON customers.id = invoice_custom_section_selections.customer_id")
+        .where("invoice_custom_section_selections.customer_id IS NOT NULL AND customers.id IS NOT NULL AND customers.deleted_at IS NULL")
+        .select(
+          "invoice_custom_section_selections.id",
+          "invoice_custom_section_selections.customer_id",
+          "invoice_custom_section_selections.invoice_custom_section_id",
+          "invoice_custom_section_selections.created_at",
+          "invoice_custom_section_selections.updated_at",
+          "customers.organization_id",
+          "customers.billing_entity_id"
+        )
+        .map do |selection|
+          {
+            id: selection.id,
+            organization_id: selection.organization_id,
+            billing_entity_id: selection.billing_entity_id,
+            customer_id: selection.customer_id,
+            invoice_custom_section_id: selection.invoice_custom_section_id,
+            created_at: selection.created_at,
+            updated_at: selection.updated_at
+          }
+        end
     )
   end
 


### PR DESCRIPTION
DB migration to create Customer Applied invoice custom sections breaks as it is unable to find customers that are soft deleted as we do not currently delete the join model InvoiceCustomSectionSelections records on customer soft deletion (we only do it on InvoiceCustomSection soft deletion).