### PR TITLE
Activity log fixes

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -4,13 +4,13 @@ module Api
   module V1
     class InvoicesController < Api::BaseController
       def create
-        result = Invoices::CreateOneOffService.new(
+        result = Invoices::CreateOneOffService.call(
           customer:,
           currency: create_params[:currency],
           fees: create_params[:fees],
           timestamp: Time.current.to_i,
           skip_psp: create_params[:skip_psp]
-        ).call
+        )
 
         if result.success?
           render_invoice(result.invoice)

--- a/app/graphql/mutations/invoices/create.rb
+++ b/app/graphql/mutations/invoices/create.rb
@@ -21,12 +21,12 @@ module Mutations
           organization_id: current_organization.id
         )
 
-        result = ::Invoices::CreateOneOffService.new(
+        result = ::Invoices::CreateOneOffService.call(
           customer:,
           currency: args[:currency],
           fees: args[:fees],
           timestamp: Time.current.to_i
-        ).call
+        )
 
         result.success? ? result.invoice : result_error(result)
       end

--- a/app/graphql/types/activity_logs/object.rb
+++ b/app/graphql/types/activity_logs/object.rb
@@ -21,7 +21,7 @@ module Types
       field :user_email, String
 
       def user_email
-        object.user.email
+        object.user&.email
       end
 
       # TODO: remove this once we have a proper way to handle JSON in Clickhouse

--- a/app/jobs/invoices/prepaid_credit_job.rb
+++ b/app/jobs/invoices/prepaid_credit_job.rb
@@ -21,7 +21,7 @@ module Invoices
         Wallets::ApplyPaidCreditsService.call(wallet_transaction:)
         Invoices::FinalizeOpenCreditService.call(invoice:)
       elsif payment_status.to_sym == :failed
-        WalletTransactions::MarkAsFailedService.new(wallet_transaction:).call
+        WalletTransactions::MarkAsFailedService.call(wallet_transaction:)
       end
     end
   end

--- a/app/models/payment_receipt.rb
+++ b/app/models/payment_receipt.rb
@@ -5,6 +5,8 @@ class PaymentReceipt < ApplicationRecord
   belongs_to :organization
   belongs_to :billing_entity
 
+  delegate :customer, to: :payment
+
   has_one_attached :file
 
   def file_url

--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -51,7 +51,7 @@ module CreditNotes
 
         if status.to_sym == :failed
           deliver_error_webhook(message: "Payment refund failed", code: nil)
-          Utils::ActivityLog.produce(credit_note, "credit_note.refund_failed")
+          Utils::ActivityLog.produce(credit_note, "credit_note.refund_failure")
           result.service_failure!(code: "refund_failed", message: "Refund failed to perform")
         end
 
@@ -96,7 +96,7 @@ module CreditNotes
       rescue Adyen::AdyenError => e
         deliver_error_webhook(message: e.msg, code: e.code)
         update_credit_note_status(:failed)
-        Utils::ActivityLog.produce(credit_note, "credit_note.refund_failed")
+        Utils::ActivityLog.produce(credit_note, "credit_note.refund_failure")
 
         raise
       end

--- a/app/services/credit_notes/refunds/gocardless_service.rb
+++ b/app/services/credit_notes/refunds/gocardless_service.rb
@@ -42,7 +42,7 @@ module CreditNotes
       rescue GoCardlessPro::Error, GoCardlessPro::ValidationError => e
         deliver_error_webhook(message: e.message, code: e.code)
         update_credit_note_status(:failed)
-        Utils::ActivityLog.produce(credit_note, "credit_note.refund_failed")
+        Utils::ActivityLog.produce(credit_note, "credit_note.refund_failure")
 
         if e.is_a?(GoCardlessPro::ValidationError)
           result
@@ -65,7 +65,7 @@ module CreditNotes
 
         if FAILED_STATUSES.include?(status.to_s)
           deliver_error_webhook(message: "Payment refund failed", code: nil)
-          Utils::ActivityLog.produce(credit_note, "credit_note.refund_failed")
+          Utils::ActivityLog.produce(credit_note, "credit_note.refund_failure")
           result.service_failure!(code: "refund_failed", message: "Refund failed to perform")
         end
 

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -40,7 +40,7 @@ module CreditNotes
       rescue ::Stripe::InvalidRequestError => e
         deliver_error_webhook(message: e.message, code: e.code)
         update_credit_note_status(:failed)
-        Utils::ActivityLog.produce(credit_note, "credit_note.refund_failed")
+        Utils::ActivityLog.produce(credit_note, "credit_note.refund_failure")
         return result if e.code == INVALID_PAYMENT_METHOD_ERROR
 
         result.service_failure!(code: "stripe_error", message: e.message)
@@ -60,7 +60,7 @@ module CreditNotes
 
         if status.to_sym == :failed
           deliver_error_webhook(message: "Payment refund failed", code: nil)
-          Utils::ActivityLog.produce(credit_note, "credit_note.refund_failed")
+          Utils::ActivityLog.produce(credit_note, "credit_note.refund_failure")
           result.service_failure!(code: "refund_failed", message: "Refund failed to perform")
         end
 

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -50,6 +50,7 @@ module Subscriptions
       # NOTE: Wait to ensure job is performed at the end of the database transaction.
       # See https://github.com/getlago/lago-api/blob/main/app/services/subscriptions/create_service.rb#L46.
       SendWebhookJob.set(wait: 2.seconds).perform_later("subscription.terminated", subscription)
+      Utils::ActivityLog.produce(subscription, "subscription.terminated")
 
       result.subscription = subscription
       result

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -94,7 +94,7 @@ module Utils
       def resource(activity_object)
         case activity_object.class.name
         when "Payment"
-          activity_object.invoice
+          activity_object.payable
         when "AppliedCoupon"
           activity_object.coupon
         when "WalletTransaction"

--- a/spec/services/credit_notes/refunds/adyen_service_spec.rb
+++ b/spec/services/credit_notes/refunds/adyen_service_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
         expect { adyen_service.create }
           .to raise_error(Adyen::AdyenError)
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failed")
+        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failure")
       end
     end
 
@@ -323,7 +323,7 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
           status: "failed"
         )
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failed")
+        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failure")
       end
     end
   end

--- a/spec/services/credit_notes/refunds/gocardless_service_spec.rb
+++ b/spec/services/credit_notes/refunds/gocardless_service_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe CreditNotes::Refunds::GocardlessService, type: :service do
         expect { gocardless_service.create }
           .to raise_error(GoCardlessPro::Error)
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failed")
+        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failure")
       end
     end
 
@@ -314,7 +314,7 @@ RSpec.describe CreditNotes::Refunds::GocardlessService, type: :service do
           status: "failed"
         )
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failed")
+        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failure")
       end
     end
   end

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
       it "produces an activity log" do
         stripe_service.create
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failed")
+        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failure")
       end
 
       context "when error is about non refundable payment method" do
@@ -389,7 +389,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
           status: "failed"
         )
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failed")
+        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failure")
       end
     end
   end


### PR DESCRIPTION
Some fixes for the Activity Logs.


```
 "billable_metric.created" => OK
 "billable_metric.updated" => OK
 "billable_metric.deleted" => OK
 "plan.created" => OK
 "plan.updated" => OK
 "plan.deleted" => OK
 "customer.created" => OK
 "customer.updated" => OK
 "customer.deleted" => OK
 "invoice.drafted"
 "invoice.failed"
 "invoice.created"
 "invoice.one_off_created" => FIXED OK
 "invoice.paid_credit_added"
 "invoice.generated" => OK
 "invoice.payment_status_updated" => OK
 "invoice.payment_overdue"
 "invoice.voided" => OK
 "invoice.payment_failure"
 "payment_receipt.created" => FIXED OK / *** PaymentReceipt does not have a customer associated
 "payment_receipt.generated" => FIXED OK / *** same as "payment_receipt.created"
 "credit_note.created" => OK
 "credit_note.generated" => OK
 "credit_note.refund_failure" => FIXED OK
 "billing_entities.created"
 "billing_entities.updated"
 "billing_entities.deleted" => NOT IMPLEMENTED
 "subscription.started" => OK
 "subscription.terminated" => FIXED OK
 "subscription.updated" => OK
 "wallet.created" => OK / *** Front has to fix ".id" to use ".lago_id" or use wallet ".name"
 "wallet.updated" => OK / *** same as "wallet.created" 
 "wallet_transaction.payment_failure"
 "wallet_transaction.created" => OK / *** same as "wallet.created" 
 "wallet_transaction.updated" => FIXED OK / *** same as "wallet.created" 
 "payment.recorded" => FIXED OK / *** The activity_object is a Payment. Resouce can be an Invoice or PaymentRequest. Front expects to activity_object to have "invoice_number".
 "coupon.created" => OK
 "coupon.updated" => OK
 "coupon.deleted" => OK / *** Maybe add "coupon.terminated" ?
 "applied_coupon.created" => OK / *** Front is broken, it expects activity_object have ".code" but its ".coupon_code" 
 "applied_coupon.deleted" => OK / *** same as "applied_coupon.created"
```