### PR TITLE
feat (wallet-credit-limitations): Add precise credit notes calculation per fee

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -224,6 +224,7 @@ end
 #  payment_status                      :integer          default("pending"), not null
 #  precise_amount_cents                :decimal(40, 15)  default(0.0), not null
 #  precise_coupons_amount_cents        :decimal(30, 5)   default(0.0), not null
+#  precise_credit_notes_amount_cents   :decimal(30, 5)   default(0.0), not null
 #  precise_unit_amount                 :decimal(30, 15)  default(0.0), not null
 #  properties                          :jsonb            not null
 #  refunded_at                         :datetime

--- a/db/migrate/20250530112903_add_precise_credit_notes_amount_cents_to_fees.rb
+++ b/db/migrate/20250530112903_add_precise_credit_notes_amount_cents_to_fees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPreciseCreditNotesAmountCentsToFees < ActiveRecord::Migration[8.0]
+  def change
+    add_column :fees, :precise_credit_notes_amount_cents, :decimal, precision: 30, scale: 5, null: false, default: 0
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2247,7 +2247,8 @@ CREATE TABLE public.fees (
     taxes_precise_amount_cents numeric(40,15) DEFAULT 0.0 NOT NULL,
     taxes_base_rate double precision DEFAULT 1.0 NOT NULL,
     organization_id uuid NOT NULL,
-    billing_entity_id uuid NOT NULL
+    billing_entity_id uuid NOT NULL,
+    precise_credit_notes_amount_cents numeric(30,5) DEFAULT 0.0 NOT NULL
 );
 
 
@@ -8415,6 +8416,7 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250530112903'),
 ('20250526133654'),
 ('20250526111147'),
 ('20250522134155'),

--- a/spec/services/credits/credit_note_service_spec.rb
+++ b/spec/services/credits/credit_note_service_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Credits::CreditNoteService do
   end
 
   let(:amount_cents) { 100 }
+  let(:subscription) { create(:subscription, customer:) }
+  let(:subscription_fees) { [fee1, fee2] }
+  let(:fee1) { create(:fee, invoice:, subscription:, amount_cents: 60, taxes_amount_cents: 0) }
+  let(:fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 40, taxes_amount_cents: 0) }
   let(:customer) { create(:customer) }
   let(:context) { nil }
 
@@ -41,6 +45,7 @@ RSpec.describe Credits::CreditNoteService do
   before do
     credit_note1
     credit_note2
+    subscription_fees
   end
 
   describe ".call" do
@@ -70,6 +75,9 @@ RSpec.describe Credits::CreditNoteService do
         expect(credit_note1).to be_consumed
 
         expect(invoice.credit_notes_amount_cents).to eq(70)
+
+        expect(fee1.reload.precise_credit_notes_amount_cents).to eq(42)
+        expect(fee2.reload.precise_credit_notes_amount_cents).to eq(28)
       end
     end
 


### PR DESCRIPTION
## Context

Currently wallet credits are applied on all fee types. This feature adds possibility to limit wallet consumption on specific fee type.

## Description

This PR adds `precise_credit_notes_amount_cents` column that is responsible for calculation of weighted credit note amount per fee.

This information is needed to get the full `per fee` breakdown of credits. Wallet credits with fee limitations cannot be applied correctly after the credit notes if this information is missing.
