### PR TITLE
feat(audit-logs): Restrict access to premium license

### DIFF
--- a/app/controllers/api/v1/activity_logs_controller.rb
+++ b/app/controllers/api/v1/activity_logs_controller.rb
@@ -65,7 +65,7 @@ module Api
       end
 
       def ensure_premium_license
-        return forbidden_error(code: "feature_unavailable") unless License.premium?
+        forbidden_error(code: "feature_unavailable") unless License.premium?
       end
     end
   end

--- a/app/graphql/resolvers/activity_log_resolver.rb
+++ b/app/graphql/resolvers/activity_log_resolver.rb
@@ -14,6 +14,8 @@ module Resolvers
     type Types::ActivityLogs::Object, null: true
 
     def resolve(activity_id: nil)
+      raise unauthorized_error unless License.premium?
+
       current_organization.activity_logs.find_by!(activity_id: activity_id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: "activity_log")

--- a/app/graphql/resolvers/activity_logs_resolver.rb
+++ b/app/graphql/resolvers/activity_logs_resolver.rb
@@ -27,6 +27,8 @@ module Resolvers
     type Types::ActivityLogs::Object.collection_type, null: true
 
     def resolve(**args)
+      raise unauthorized_error unless License.premium?
+
       result = ActivityLogsQuery.call(
         organization: current_organization,
         filters: {

--- a/spec/graphql/resolvers/activity_log_resolver_spec.rb
+++ b/spec/graphql/resolvers/activity_log_resolver_spec.rb
@@ -22,31 +22,49 @@ RSpec.describe Resolvers::ActivityLogResolver, type: :graphql, clickhouse: true 
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "audit_logs:view"
 
-  it "returns a single activity log" do
-    result = execute_graphql(
-      current_user: membership.user,
-      current_organization: organization,
-      permissions: required_permission,
-      query:,
-      variables: {activityLogId: clickhouse_activity_log.activity_id}
-    )
-
-    activity_log_response = result["data"]["activityLog"]
-
-    expect(activity_log_response["activityId"]).to eq(clickhouse_activity_log.activity_id)
-  end
-
-  context "when activity log is not found" do
+  context "without premium feature" do
     it "returns an error" do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
         permissions: required_permission,
         query:,
-        variables: {activityLogId: "invalid"}
+        variables: {activityLogId: clickhouse_activity_log.activity_id}
       )
 
-      expect_graphql_error(result:, message: "Resource not found")
+      expect_graphql_error(result:, message: "unauthorized")
+    end
+  end
+
+  context "with premium feature" do
+    around { |test| lago_premium!(&test) }
+
+    it "returns a single activity log" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {activityLogId: clickhouse_activity_log.activity_id}
+      )
+
+      activity_log_response = result["data"]["activityLog"]
+
+      expect(activity_log_response["activityId"]).to eq(clickhouse_activity_log.activity_id)
+    end
+
+    context "when activity log is not found" do
+      it "returns an error" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {activityLogId: "invalid"}
+        )
+
+        expect_graphql_error(result:, message: "Resource not found")
+      end
     end
   end
 end

--- a/spec/graphql/resolvers/activity_logs_resolver_spec.rb
+++ b/spec/graphql/resolvers/activity_logs_resolver_spec.rb
@@ -27,55 +27,72 @@ RSpec.describe Resolvers::ActivityLogsResolver, type: :graphql, clickhouse: true
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "audit_logs:view"
 
-  it "returns the list of activity logs" do
-    result = execute_graphql(
-      current_user: membership.user,
-      current_organization: organization,
-      permissions: required_permission,
-      query:
-    )
-
-    activity_logs_response = result["data"]["activityLogs"]
-
-    expect(activity_logs_response["collection"].count).to eq(organization.activity_logs.count)
-    expect(activity_logs_response["collection"].first["activityId"]).to eq(clickhouse_activity_log.activity_id)
-
-    expect(activity_logs_response["metadata"]["currentPage"]).to eq(1)
-    expect(activity_logs_response["metadata"]["totalCount"]).to eq(1)
-  end
-
-  context "with filters" do
-    let(:filters) do
-      {
-        from_date: nil,
-        to_date: nil,
-        api_key_ids: nil,
-        activity_ids: nil,
-        activity_types: nil,
-        activity_sources: nil,
-        user_emails: nil,
-        external_customer_id: nil,
-        external_subscription_id: nil,
-        resource_ids: nil,
-        resource_types: nil
-      }
-    end
-
-    it "sends all possible filters to query" do
-      allow(ActivityLogsQuery).to receive(:call).and_call_original
-
-      execute_graphql(
+  context "without premium feature" do
+    it "returns an error" do
+      result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
         permissions: required_permission,
         query:
       )
 
-      expect(ActivityLogsQuery).to have_received(:call).with(
-        organization: organization,
-        pagination: {limit: 5, page: nil},
-        filters:
+      expect_graphql_error(result:, message: "unauthorized")
+    end
+  end
+
+  context "with premium feature" do
+    around { |test| lago_premium!(&test) }
+
+    it "returns the list of activity logs" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
       )
+
+      activity_logs_response = result["data"]["activityLogs"]
+
+      expect(activity_logs_response["collection"].count).to eq(organization.activity_logs.count)
+      expect(activity_logs_response["collection"].first["activityId"]).to eq(clickhouse_activity_log.activity_id)
+
+      expect(activity_logs_response["metadata"]["currentPage"]).to eq(1)
+      expect(activity_logs_response["metadata"]["totalCount"]).to eq(1)
+    end
+
+    context "with filters" do
+      let(:filters) do
+        {
+          from_date: nil,
+          to_date: nil,
+          api_key_ids: nil,
+          activity_ids: nil,
+          activity_types: nil,
+          activity_sources: nil,
+          user_emails: nil,
+          external_customer_id: nil,
+          external_subscription_id: nil,
+          resource_ids: nil,
+          resource_types: nil
+        }
+      end
+
+      it "sends all possible filters to query" do
+        allow(ActivityLogsQuery).to receive(:call).and_call_original
+
+        execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:
+        )
+
+        expect(ActivityLogsQuery).to have_received(:call).with(
+          organization: organization,
+          pagination: {limit: 5, page: nil},
+          filters:
+        )
+      end
     end
   end
 end

--- a/spec/requests/api/v1/activity_logs_controller_spec.rb
+++ b/spec/requests/api/v1/activity_logs_controller_spec.rb
@@ -46,135 +46,135 @@ RSpec.describe Api::V1::ActivityLogsController, type: :request, clickhouse: true
 
       it "returns activity logs" do
         subject
-  
+
         expect(response).to have_http_status(:success)
         expect(json[:activity_logs].count).to eq(2)
         expect(json[:activity_logs].map { |l| l[:activity_id] }).to include(activity_log.activity_id, invoice_activity_log.activity_id)
       end
-  
+
       context "when filtering by external_customer_id" do
         let(:params) { {external_customer_id: activity_log.external_customer_id} }
-  
+
         it "returns activity logs for the specified external customer" do
           subject
-  
+
           expect(response).to have_http_status(:success)
           expect(json[:activity_logs].count).to eq(1)
           expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
           expect(json[:activity_logs].first[:external_customer_id]).to eq(activity_log.external_customer_id)
         end
       end
-  
+
       context "when filtering by external_subscription_id" do
         let(:params) { {external_subscription_id: activity_log.external_subscription_id} }
-  
+
         it "returns activity logs for the specified external subscription" do
           subject
-  
+
           expect(response).to have_http_status(:success)
           expect(json[:activity_logs].count).to eq(1)
           expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
           expect(json[:activity_logs].first[:external_subscription_id]).to eq(activity_log.external_subscription_id)
         end
       end
-  
+
       context "when filtering by resource_id" do
         let(:params) { {resource_ids: [activity_log.resource_id]} }
-  
+
         it "returns activity logs for the specified resource" do
           subject
-  
+
           expect(response).to have_http_status(:success)
           expect(json[:activity_logs].count).to eq(1)
           expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
           expect(json[:activity_logs].first[:resource_id]).to eq(activity_log.resource_id)
         end
       end
-  
+
       context "when filtering by resource_type" do
         let(:params) { {resource_types: [activity_log.resource_type]} }
-  
+
         it "returns activity logs for the specified resource type" do
           subject
-  
+
           expect(response).to have_http_status(:success)
           expect(json[:activity_logs].count).to eq(1)
           expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
           expect(json[:activity_logs].first[:resource_type]).to eq(activity_log.resource_type)
         end
       end
-  
+
       context "when filtering by user_email" do
         let(:params) { {user_emails: [activity_log.user.email]} }
-  
+
         it "returns activity logs for the specified user email" do
           subject
-  
+
           expect(response).to have_http_status(:success)
           expect(json[:activity_logs].count).to eq(1)
           expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
           expect(json[:activity_logs].first[:user_email]).to eq(activity_log.user.email)
         end
       end
-  
+
       context "when filtering by activity_type" do
         let(:params) { {activity_types: [activity_log.activity_type]} }
-  
+
         it "returns activity logs for the specified activity type" do
           subject
-  
+
           expect(response).to have_http_status(:success)
           expect(json[:activity_logs].count).to eq(1)
           expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
           expect(json[:activity_logs].first[:activity_type]).to eq(activity_log.activity_type)
         end
       end
-  
+
       context "when filtering by activity_source" do
         let(:params) { {activity_sources: [activity_log.activity_source]} }
-  
+
         it "returns activity logs for the specified activity source" do
           subject
-  
+
           expect(response).to have_http_status(:success)
           expect(json[:activity_logs].count).to eq(1)
           expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
           expect(json[:activity_logs].first[:activity_source]).to eq(activity_log.activity_source)
         end
       end
-  
+
       context "when filtering by from_date" do
         let(:params) { {from_date: activity_log.logged_at.iso8601} }
-  
+
         it "returns activity logs for the specified date range" do
           subject
-  
+
           expect(response).to have_http_status(:success)
           expect(json[:activity_logs].count).to eq(1)
           expect(json[:activity_logs].first[:activity_id]).to eq(activity_log.activity_id)
           expect(json[:activity_logs].first[:logged_at]).to eq(activity_log.logged_at.iso8601)
         end
       end
-  
+
       context "when filtering by to_date" do
         let(:params) { {to_date: activity_log.logged_at.iso8601} }
-  
+
         it "returns activity logs for the specified date range" do
           subject
-  
+
           expect(response).to have_http_status(:success)
           expect(json[:activity_logs].count).to eq(1)
           expect(json[:activity_logs].first[:activity_id]).to eq(invoice_activity_log.activity_id)
           expect(json[:activity_logs].first[:logged_at]).to eq(invoice_activity_log.logged_at.iso8601)
         end
       end
-  
+
       context "with pagination" do
         let(:params) { {page: 1, per_page: 1} }
-  
+
         it "returns activity logs with correct meta data" do
           subject
-  
+
           expect(response).to have_http_status(:success)
           expect(json[:activity_logs].count).to eq(1)
           expect(json[:meta][:current_page]).to eq(1)
@@ -186,7 +186,7 @@ RSpec.describe Api::V1::ActivityLogsController, type: :request, clickhouse: true
       end
     end
   end
-  
+
   describe "GET /api/v1/activity_logs/:activity_id" do
     subject { get_with_token(organization, "/api/v1/activity_logs/#{activity_log.activity_id}", params) }
 


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context

Our users want to have visibility on what’s happening in Lago.

Examples:
- *A plan and prices have been updated: When? By whom? What?*
- *A subscription has been deleted: When? By whom? What?*

## Description

The goal of this PR is to avoid fetching activity logs if organization is not premium.