### PR TITLE
fix: auto retry throttling errors for wallet refresh job

### DIFF
--- a/app/jobs/wallets/refresh_ongoing_balance_job.rb
+++ b/app/jobs/wallets/refresh_ongoing_balance_job.rb
@@ -7,6 +7,7 @@ module Wallets
     unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
 
     retry_on ActiveRecord::StaleObjectError, wait: :polynomially_longer, attempts: 6
+    retry_on BaseService::TooManyProviderRequestsFailure, wait: :exponentially_longer, attempts: 25
 
     def perform(wallet)
       return unless wallet.ready_to_be_refreshed?


### PR DESCRIPTION
## Context

For Current usage, taxes are fetched in the sync way. Recently throttling error was rescued there in order to display a bit more user friendly message in the API side.

However, wallet refresh job, that is consuming current usage service, does not auto retry new error, that is actually just a wrapper around Throttling Error.

## Description

This PR auto retry wallet refresh job for described case
