### PR TITLE
feat(usage): Fix history usages

### DIFF
--- a/app/services/daily_usages/fill_from_invoice_service.rb
+++ b/app/services/daily_usages/fill_from_invoice_service.rb
@@ -49,8 +49,8 @@ module DailyUsages
 
     def invoice_usage(subscription, invoice_subscription)
       OpenStruct.new(
-        from_datetime: invoice_subscription.from_datetime,
-        to_datetime: invoice_subscription.to_datetime,
+        from_datetime: invoice_subscription.charges_from_datetime,
+        to_datetime: invoice_subscription.charges_to_datetime,
         issuing_date: invoice.issuing_date.iso8601,
         currency: invoice.currency,
         amount_cents: invoice.fees_amount_cents,
@@ -66,8 +66,8 @@ module DailyUsages
 
     def existing_daily_usage(invoice_subscription)
       DailyUsage.find_by(
-        from_datetime: invoice_subscription.from_datetime,
-        to_datetime: invoice_subscription.to_datetime,
+        from_datetime: invoice_subscription.charges_from_datetime,
+        to_datetime: invoice_subscription.charges_to_datetime,
         usage_date: invoice_subscription.charges_to_datetime.to_date,
         subscription_id: invoice_subscription.subscription_id
       )

--- a/app/services/daily_usages/fill_history_service.rb
+++ b/app/services/daily_usages/fill_history_service.rb
@@ -20,8 +20,16 @@ module DailyUsages
 
         next if subscription.daily_usages.where(usage_date: datetime.to_date - 1.day).exists?
 
+        ds = Subscriptions::DatesService.new_instance(subscription, date, current_usage: true)
+
+        time_to_freeze = if ds.previous_beginning_of_period.to_date == date
+          (datetime - 1.day).end_of_day
+        else
+          datetime + 1.second
+        end
+
         Timecop.thread_safe = true
-        Timecop.freeze(datetime + 5.minutes) do
+        Timecop.freeze(time_to_freeze) do
           usage = Invoices::CustomerUsageService.call(
             customer: subscription.customer,
             subscription: subscription,


### PR DESCRIPTION
## Context

The service calculating historical daily usages used to jump to the next period in case of calculating usages for the last day of current period.

## Description

- Fix the incorrect day of usages in `FillHistoryService`
- Fix incorrect boundaries in `FillFromInvoiceService`