### PR TITLE
misc: Add events database read replica

### DIFF
--- a/app/models/events_record.rb
+++ b/app/models/events_record.rb
@@ -3,5 +3,6 @@
 class EventsRecord < ApplicationRecord
   self.abstract_class = true
 
-  connects_to database: {writing: :events, reading: :events}
+  reading_db = ActiveModel::Type::Boolean.new.cast(ENV["USE_READ_REPLICA"]) ? :events_replica : :events
+  connects_to database: {writing: :events, reading: reading_db}
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -83,6 +83,12 @@ production:
     prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
     schema_search_path: <%= ENV.fetch('POSTGRES_SCHEMA', 'public') %>
     database_tasks: false
+  events_replica:
+    <<: *default
+    url: <%= ENV['DATABASE_REPLICA_URL'] %>
+    pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
+    prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
+    replica: true
   clickhouse:
     adapter: clickhouse
     database: <%= ENV['LAGO_CLICKHOUSE_DATABASE'] %>


### PR DESCRIPTION
## Description

This PR is introducing a read replica connection for the events database.

Enabling the connection will require to provide:
- The `USE_READ_REPLICA` boolean environment variable
- The `DATABASE_REPLICA_URL` connection string

This config will ensure that all read query related to the `EventRecord` (`Event` model) will be routed to the configured read replica