### PR TITLE
fix(filter): Matching in advance events with ALL_FILTER_VALUES

### DIFF
--- a/app/services/charge_filters/event_matching_service.rb
+++ b/app/services/charge_filters/event_matching_service.rb
@@ -13,7 +13,8 @@ module ChargeFilters
       # NOTE: Find all filters matching event properties
       matching_filters = filters.select do |filter|
         filter.to_h.all? do |key, values|
-          applicable_event_properties.key?(key) && applicable_event_properties[key].to_s.in?(values)
+          applicable_event_properties.key?(key) &&
+            (applicable_event_properties[key].to_s.in?(values) || values == [ChargeFilterValue::ALL_FILTER_VALUES])
         end
       end
 

--- a/spec/services/charge_filters/event_matching_service_spec.rb
+++ b/spec/services/charge_filters/event_matching_service_spec.rb
@@ -84,4 +84,25 @@ RSpec.describe ChargeFilters::EventMatchingService, type: :service do
       expect(service_result.charge_filter).to be_nil
     end
   end
+
+  context "with an ALL_FILTER_VALUES filter" do
+    let(:filter2_values) do
+      [
+        create(:charge_filter_value, values: ["card"], billable_metric_filter: payment_method, charge_filter: filter2),
+        create(:charge_filter_value, values: ["domestic"], billable_metric_filter: card_location, charge_filter: filter2),
+        create(
+          :charge_filter_value,
+          values: [ChargeFilterValue::ALL_FILTER_VALUES],
+          billable_metric_filter: scheme,
+          charge_filter: filter2
+        ),
+        create(:charge_filter_value, values: ["credit"], billable_metric_filter: card_type, charge_filter: filter2),
+        create(:charge_filter_value, values: ["2"], billable_metric_filter: card_number, charge_filter: filter2)
+      ]
+    end
+
+    it "returns the filter matching the most properties" do
+      expect(service_result.charge_filter).to eq(filter2)
+    end
+  end
 end


### PR DESCRIPTION
## Description

This PR fixes the in advance filter matching for filters defined using the `ALL_FILTER_VALUES`

Today if a filter is defined with the following structure
```json
{
  "scheme": ["visa", "mastercard"],
  "card_type": ["__ALL_FILTER_VALUES__"]
}
```

it should match an event sent with the following properties: `{"scheme": "visa", "card_type": "debit" }` but it's not