### PR TITLE
revert(gql): disable lookahead to confirm memory bloat origin

### DIFF
--- a/app/graphql/resolvers/usage_monitoring/subscription_alerts_resolver.rb
+++ b/app/graphql/resolvers/usage_monitoring/subscription_alerts_resolver.rb
@@ -10,7 +10,7 @@ module Resolvers
 
       description "Query alerts of a subscription"
 
-      extras [:lookahead]
+      # extras [:lookahead]
 
       argument :subscription_external_id, String, required: true, description: "External id of a subscription"
 
@@ -19,8 +19,8 @@ module Resolvers
 
       type Types::UsageMonitoring::Alerts::Object.collection_type, null: false
 
-      def resolve(subscription_external_id:, lookahead:, limit: nil, page: nil)
-        alerts_query = ::UsageMonitoring::AlertsQuery.call(
+      def resolve(subscription_external_id:, limit: nil, page: nil)
+        ::UsageMonitoring::AlertsQuery.call(
           organization: current_organization,
           filters: {
             subscription_external_id:
@@ -31,15 +31,13 @@ module Resolvers
           }
         ).alerts
 
-        if lookahead.selection(:collection).selects?(:thresholds)
-          alerts_query = alerts_query.includes(:thresholds)
-        end
-
-        if lookahead.selection(:collection).selects?(:billable_metric)
-          alerts_query = alerts_query.includes(:billable_metric)
-        end
-
-        alerts_query
+        # if lookahead.selection(:collection).selects?(:thresholds)
+        #   alerts_query = alerts_query.includes(:thresholds)
+        # end
+        #
+        # if lookahead.selection(:collection).selects?(:billable_metric)
+        #   alerts_query = alerts_query.includes(:billable_metric)
+        # end
       end
     end
   end

--- a/spec/graphql/resolvers/usage_monitoring/subscription_alerts_resolver_spec.rb
+++ b/spec/graphql/resolvers/usage_monitoring/subscription_alerts_resolver_spec.rb
@@ -101,32 +101,32 @@ RSpec.describe Resolvers::UsageMonitoring::SubscriptionAlertsResolver, type: :gr
       expect(metadata["totalCount"]).to eq(2)
     end
   end
-
-  context "when requesting relationships" do
-    let(:query) do
-      <<~GQL
-        query($subscriptionExternalId: String!) {
-          alerts(subscriptionExternalId: $subscriptionExternalId) {
-            collection { code billableMetric { id } thresholds { value } }
-          }
-        }
-      GQL
-    end
-
-    it "eager loads the relationships", with_bullet: true do
-      create_list(:billable_metric_current_usage_amount_alert, 3, organization:, subscription_external_id: subscription.external_id, thresholds: [10])
-
-      Bullet.start_request
-
-      execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        permissions: required_permission,
-        query:,
-        variables: {subscriptionExternalId: subscription.external_id}
-      )
-
-      expect(Bullet.notification?).to eq false
-    end
-  end
+  #
+  # context "when requesting relationships" do
+  #   let(:query) do
+  #     <<~GQL
+  #       query($subscriptionExternalId: String!) {
+  #         alerts(subscriptionExternalId: $subscriptionExternalId) {
+  #           collection { code billableMetric { id } thresholds { value } }
+  #         }
+  #       }
+  #     GQL
+  #   end
+  #
+  #   it "eager loads the relationships", with_bullet: true do
+  #     create_list(:billable_metric_current_usage_amount_alert, 3, organization:, subscription_external_id: subscription.external_id, thresholds: [10])
+  #
+  #     Bullet.start_request
+  #
+  #     execute_graphql(
+  #       current_user: membership.user,
+  #       current_organization: organization,
+  #       permissions: required_permission,
+  #       query:,
+  #       variables: {subscriptionExternalId: subscription.external_id}
+  #     )
+  #
+  #     expect(Bullet.notification?).to eq false
+  #   end
+  # end
 end


### PR DESCRIPTION
We see unexpected memory consumption. We disable lookahead to see if it's the origin of the issue.

See #3695 for original work