### PR TITLE
revert(email): Failed webhook notification

### DIFF
--- a/app/services/webhooks/send_http_service.rb
+++ b/app/services/webhooks/send_http_service.rb
@@ -29,7 +29,8 @@ module Webhooks
       mark_webhook_as_failed(e)
 
       if webhook.retries >= ENV.fetch("LAGO_WEBHOOK_ATTEMPTS", 3).to_i
-        Webhooks::NotifyFailureService.call(webhook: webhook)
+        # Revert until completely removed or fixed
+        # Webhooks::NotifyFailureService.call(webhook: webhook)
       else
         SendHttpWebhookJob.set(wait: wait_value).perform_later(webhook)
       end

--- a/spec/services/webhooks/send_http_service_spec.rb
+++ b/spec/services/webhooks/send_http_service_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Webhooks::SendHttpService, type: :service do
           service.call
           expect(webhook.reload.retries).to eq 3
           expect(SendHttpWebhookJob).not_to have_received(:set)
-          expect(Webhooks::NotifyFailureService).to have_received(:call).with(webhook:)
+          expect(Webhooks::NotifyFailureService).not_to have_received(:call).with(webhook:)
         end
       end
     end


### PR DESCRIPTION
Let's revert until it's improved or removed completely.

It's unclear which organization is failing (could be staging or dev env) is failing and the webhook endpoint affected is even more unclear!