### PR TITLE
feat(alerting): new field for alert.triggered webhook payload

### DIFF
--- a/app/serializers/v1/usage_monitoring/triggered_alert_serializer.rb
+++ b/app/serializers/v1/usage_monitoring/triggered_alert_serializer.rb
@@ -6,18 +6,24 @@ module V1
       def serialize
         {
           lago_id: model.id,
-          lago_alert_id: model.alert.id,
+          lago_organization_id: model.organization_id,
+          lago_alert_id: alert.id,
           lago_subscription_id: model.subscription_id,
-          billable_metric_code: model.alert.billable_metric&.code,
-          alert_name: model.alert.name,
-          alert_code: model.alert.code,
-          alert_type: model.alert.alert_type,
+          subscription_external_id: alert.subscription_external_id,
+          billable_metric_code: alert.billable_metric&.code,
+          alert_name: alert.name,
+          alert_code: alert.code,
+          alert_type: alert.alert_type,
           current_value: model.current_value,
           previous_value: model.previous_value,
           crossed_thresholds: model.crossed_thresholds,
           triggered_at: model.triggered_at.iso8601
         }
       end
+
+      private
+
+      delegate :alert, to: :model
     end
   end
 end

--- a/spec/serializers/v1/usage_monitoring/triggered_alert_serializer_spec.rb
+++ b/spec/serializers/v1/usage_monitoring/triggered_alert_serializer_spec.rb
@@ -18,8 +18,10 @@ RSpec.describe ::V1::UsageMonitoring::TriggeredAlertSerializer do
 
       payload = result["triggered_alert"]
       expect(payload["lago_id"]).to eq(triggered_alert.id)
+      expect(payload["lago_organization_id"]).to eq(triggered_alert.organization_id)
       expect(payload["lago_alert_id"]).to eq(triggered_alert.alert.id)
       expect(payload["lago_subscription_id"]).to eq(triggered_alert.subscription.id)
+      expect(payload["subscription_external_id"]).to eq("ext-id")
       expect(payload["billable_metric_code"]).to be_nil
       expect(payload["alert_name"]).to eq("General Alert")
       expect(payload["alert_code"]).to eq("first")


### PR DESCRIPTION
As I'm documenting this `alert.triggered` webhook I realize there was some field that could be better.
* `subscription_external_id` is how you can retrieve subscription via the API (instead of lago_id)
* `organization_id` in case you receive webhooks from multiple organizations? It should be everywhere.

I also edited the seeder to seed some TriggeredAlert.