### PR TITLE
fix(migrations): Disable transaction for wallet_transaction migration

### DIFF
--- a/db/migrate/20250512081332_add_lock_version_to_wallet_transactions.rb
+++ b/db/migrate/20250512081332_add_lock_version_to_wallet_transactions.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AddLockVersionToWalletTransactions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
   def change
     add_column :wallet_transactions, :lock_version, :integer, default: 0, null: false
   end


### PR DESCRIPTION
We don't need transaction when adding a table.

> ERROR: current transaction is aborted, commands ignored until end of transaction block.