### PR TITLE
feat(multientities): Update billing entity Invoice custom sections REST

### DIFF
--- a/app/controllers/api/v1/billing_entities_controller.rb
+++ b/app/controllers/api/v1/billing_entities_controller.rb
@@ -19,7 +19,11 @@ module Api
         return not_found_error(resource: "billing_entity") if entity.blank?
 
         render(
-          json: ::V1::BillingEntitySerializer.new(entity, root_name: "billing_entity", includes: [:taxes])
+          json: ::V1::BillingEntitySerializer.new(
+            entity,
+            root_name: "billing_entity",
+            includes: [:taxes, :selected_invoice_custom_sections]
+          )
         )
       end
 
@@ -52,7 +56,7 @@ module Api
             json: ::V1::BillingEntitySerializer.new(
               result.billing_entity,
               root_name: "billing_entity",
-              includes: [:taxes]
+              includes: [:taxes, :selected_invoice_custom_sections]
             )
           )
         else
@@ -120,7 +124,8 @@ module Api
             :invoice_grace_period,
             :document_locale
           ],
-          tax_codes: []
+          tax_codes: [],
+          invoice_custom_section_codes: []
         )
       end
     end

--- a/app/serializers/v1/billing_entity_serializer.rb
+++ b/app/serializers/v1/billing_entity_serializer.rb
@@ -35,6 +35,7 @@ module V1
       }
 
       payload = payload.merge(taxes) if include?(:taxes)
+      payload = payload.merge(selected_invoice_custom_sections) if include?(:selected_invoice_custom_sections)
 
       payload
     end
@@ -46,6 +47,14 @@ module V1
         model.taxes,
         ::V1::TaxSerializer,
         collection_name: "taxes"
+      ).serialize
+    end
+
+    def selected_invoice_custom_sections
+      ::CollectionSerializer.new(
+        model.selected_invoice_custom_sections,
+        ::V1::InvoiceCustomSectionSerializer,
+        collection_name: "selected_invoice_custom_sections"
       ).serialize
     end
   end

--- a/app/services/billing_entities/update_service.rb
+++ b/app/services/billing_entities/update_service.rb
@@ -68,7 +68,7 @@ module BillingEntities
           BillingEntities::Taxes::ManageTaxesService.call!(billing_entity:, tax_codes: params[:tax_codes])
         end
 
-        handle_invoice_custom_sections if params.key?(:invoice_custom_section_ids)
+        handle_invoice_custom_sections if params.key?(:invoice_custom_section_ids) || params.key?(:invoice_custom_section_codes)
 
         assign_premium_attributes
         handle_base64_logo if params.key?(:logo)
@@ -123,7 +123,7 @@ module BillingEntities
 
     def handle_invoice_custom_sections
       existing_section_ids = billing_entity.selected_invoice_custom_sections.ids
-      new_section_ids = params[:invoice_custom_section_ids]
+      new_section_ids = params[:invoice_custom_section_ids] || InvoiceCustomSection.where(code: params[:invoice_custom_section_codes]).ids
 
       billing_entity.applied_invoice_custom_sections.where.not(invoice_custom_section_id: new_section_ids).destroy_all
 

--- a/spec/requests/api/v1/billing_entities_controller_spec.rb
+++ b/spec/requests/api/v1/billing_entities_controller_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Api::V1::BillingEntitiesController, type: :request do
       subject
       expect(response).to be_successful
       expect(json[:billing_entity][:lago_id]).to eq(billing_entity1.id)
+      expect(json[:billing_entity]).to have_key :selected_invoice_custom_sections
     end
 
     context "when the billing entity has applied taxes" do
@@ -282,6 +283,27 @@ RSpec.describe Api::V1::BillingEntitiesController, type: :request do
       expect(json[:billing_entity][:document_locale]).to eq("es")
       expect(json[:billing_entity][:invoice_grace_period]).to eq(10)
       expect(json[:billing_entity][:logo_url]).to match(%r{.*/rails/active_storage/blobs/redirect/.*/logo})
+    end
+
+    context "when updating the applicable invoice custom sections" do
+      let(:update_params) do
+        {
+          billing_entity: {
+            invoice_custom_section_codes: [custom_section.code]
+          }
+        }
+      end
+
+      let(:custom_section) { create(:invoice_custom_section, organization:) }
+
+      it "updates the applicable invoice custom sections" do
+        subject
+
+        expect(response).to be_successful
+        expect(billing_entity1.reload.selected_invoice_custom_sections.count).to eq(1)
+        expect(billing_entity1.selected_invoice_custom_sections.first.code).to eq(custom_section.code)
+        expect(json[:billing_entity][:selected_invoice_custom_sections].count).to eq(1)
+      end
     end
 
     context "when updating billing_entity taxes" do

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -281,6 +281,56 @@ RSpec.describe BillingEntities::UpdateService do
           expect(result.billing_entity.selected_invoice_custom_sections).to be_empty
         end
       end
+
+      context "when invoice_custom_section_codes are provided" do
+        let(:params) do
+          {invoice_custom_section_codes: [invoice_custom_section_1.code, invoice_custom_section_2.code]}
+        end
+
+        it "updates the billing_entity" do
+          result = update_service.call
+
+          expect(result.billing_entity.selected_invoice_custom_sections).to contain_exactly(invoice_custom_section_1, invoice_custom_section_2)
+        end
+
+        context "when removing a section" do
+          let(:params) { {invoice_custom_section_codes: [invoice_custom_section_1.code]} }
+
+          before do
+            create(:billing_entity_applied_invoice_custom_section, organization:, billing_entity:, invoice_custom_section: invoice_custom_section_2)
+          end
+
+          it "removes the section" do
+            result = update_service.call
+
+            expect(result.billing_entity.selected_invoice_custom_sections).to contain_exactly(invoice_custom_section_1)
+          end
+        end
+
+        context "when adding a section" do
+          let(:params) { {invoice_custom_section_codes: [invoice_custom_section_1.code, invoice_custom_section_2.code]} }
+
+          before do
+            create(:billing_entity_applied_invoice_custom_section, billing_entity:, invoice_custom_section: invoice_custom_section_2)
+          end
+
+          it "adds the section" do
+            result = update_service.call
+
+            expect(result.billing_entity.selected_invoice_custom_sections).to contain_exactly(invoice_custom_section_1, invoice_custom_section_2)
+          end
+        end
+
+        context "when removing all sections" do
+          let(:params) { {invoice_custom_section_cods: []} }
+
+          it "removes all sections" do
+            result = update_service.call
+
+            expect(result.billing_entity.selected_invoice_custom_sections).to be_empty
+          end
+        end
+      end
     end
 
     context "when billing_entity is not provided" do


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/support-billing-from-multiple-entities

 ## Context

Users who invoice the same products across multiple entities face the challenge of managing separate Lago organizations.

This requires duplicating all billable metrics, plans, and setup, while also implementing additional logic to handle two different API keys and ensure the correct one is used for each affiliated entity. This process adds complexity and overhead to their billing operations.

 ## Description

PUT /api/v1/billing_entities/:code endpoint now accepts invoice_custom_section_codes param to update the billing entity selected custom sections.