### PR TITLE
feat(pricing_group_keys): Add grouped_by logic for per event aggregations

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -3,6 +3,8 @@
 module BillableMetrics
   module Aggregations
     class BaseService < ::BaseService
+      PerEventAggregationResult = BaseResult[:event_aggregation]
+
       def initialize(event_store_class:, charge:, subscription:, boundaries:, filters: {}, bypass_aggregation: false)
         super(nil)
         @event_store_class = event_store_class
@@ -57,9 +59,11 @@ module BillableMetrics
         raise NotImplementedError
       end
 
-      def per_event_aggregation(exclude_event: false)
-        Result.new.tap do |result|
-          result.event_aggregation = compute_per_event_aggregation(exclude_event:)
+      def per_event_aggregation(exclude_event: false, grouped_by_values: nil)
+        PerEventAggregationResult.new.tap do |result|
+          result.event_aggregation = event_store.with_grouped_by_values(grouped_by_values) do
+            compute_per_event_aggregation(exclude_event:)
+          end
         end
       end
 

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -92,10 +92,12 @@ module BillableMetrics
         result
       end
 
-      def per_event_aggregation
-        period_aggregation = event_store.prorated_unique_count_breakdown.map { |row| row["prorated_value"].ceil(5) }
+      def per_event_aggregation(grouped_by_values: nil)
+        period_aggregation = event_store.with_grouped_by_values(grouped_by_values) do
+          event_store.prorated_unique_count_breakdown.map { |row| row["prorated_value"].ceil(5) }
+        end
 
-        Result.new.tap do |result|
+        ProratedPerEventAggregationResult.new.tap do |result|
           result.event_aggregation = Array.new(period_aggregation.count) { 1 }
           result.event_prorated_aggregation = period_aggregation
         end

--- a/app/services/charges/charge_models/base_service.rb
+++ b/app/services/charges/charge_models/base_service.rb
@@ -49,6 +49,7 @@ module Charges
       attr_accessor :charge, :aggregation_result, :properties
 
       delegate :units, to: :result
+      delegate :grouped_by, to: :aggregation_result
 
       def compute_amount
         raise NotImplementedError

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -126,7 +126,10 @@ module Charges
         # NOTE: when performing aggregation for pay in advance, we have to ignore the current event
         #       for computing the diff between event included and excluded
         #       see app/services/charges/apply_pay_in_advance_charge_model_service.rb:18
-        aggregation_result.aggregator.per_event_aggregation(exclude_event: properties[:exclude_event]).event_aggregation
+        aggregation_result.aggregator.per_event_aggregation(
+          exclude_event: properties[:exclude_event],
+          grouped_by_values: grouped_by
+        ).event_aggregation
       end
 
       def compute_amount_with_transaction_min_max

--- a/app/services/charges/charge_models/prorated_graduated_service.rb
+++ b/app/services/charges/charge_models/prorated_graduated_service.rb
@@ -11,8 +11,14 @@ module Charges
 
       def compute_amount
         full_units = per_event_aggregation_result.event_aggregation
-        prorated_units = per_event_aggregation_result.event_prorated_aggregation
+
+        prorated_units = if per_event_aggregation_result.respond_to?(:event_prorated_aggregation)
+          per_event_aggregation_result.event_prorated_aggregation
+        else
+          []
+        end
         units_count = prorated_units.count
+
         index = 0
         overflow = 0
         full_sum = 0
@@ -122,7 +128,9 @@ module Charges
       end
 
       def per_event_aggregation_result
-        @per_event_aggregation_result ||= aggregation_result.aggregator.per_event_aggregation
+        @per_event_aggregation_result ||= aggregation_result.aggregator.per_event_aggregation(
+          grouped_by_values: grouped_by
+        )
       end
 
       def prorated_coefficient(prorated_value, full_value)

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -27,6 +27,8 @@ module Events
 
       def with_grouped_by_values(grouped_by_values, &block)
         previous_grouped_by_values = @grouped_by_values
+        return yield block if grouped_by_values.nil?
+
         @grouped_by_values = grouped_by_values
         yield block
       ensure

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -25,6 +25,14 @@ module Events
         grouped_by_values.present?
       end
 
+      def with_grouped_by_values(grouped_by_values, &block)
+        previous_grouped_by_values = @grouped_by_values
+        @grouped_by_values = grouped_by_values
+        yield block
+      ensure
+        @grouped_by_values = previous_grouped_by_values
+      end
+
       def events(force_from: false)
         raise NotImplementedError
       end

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -18,7 +18,7 @@ module Events
           scope = scope.where("events_enriched.timestamp <= ?", to_datetime) if to_datetime
           scope = scope.limit_by(1, "events_enriched.transaction_id")
 
-          scope = with_grouped_by_values(scope) if grouped_by_values?
+          scope = apply_grouped_by_values(scope) if grouped_by_values?
           filters_scope(scope)
         end
       end
@@ -526,7 +526,7 @@ module Events
         scope
       end
 
-      def with_grouped_by_values(scope)
+      def apply_grouped_by_values(scope)
         grouped_by_values.each do |grouped_by, grouped_by_value|
           scope = if grouped_by_value.present?
             scope.where("events_enriched.properties[?] = ?", grouped_by, grouped_by_value)

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -18,7 +18,7 @@ module Events
             .where(numeric_condition)
         end
 
-        scope = with_grouped_by_values(scope) if grouped_by_values?
+        scope = apply_grouped_by_values(scope) if grouped_by_values?
         filters_scope(scope)
       end
 
@@ -359,13 +359,13 @@ module Events
             )
           end.join(" AND ")
         end
-        sql = conditions.compact_blank.map { "(#{_1})" }.join(" OR ")
+        sql = conditions.compact_blank.map { "(#{it})" }.join(" OR ")
         scope = scope.where.not(sql) if sql.present?
 
         scope
       end
 
-      def with_grouped_by_values(scope)
+      def apply_grouped_by_values(scope)
         grouped_by_values.each do |grouped_by, grouped_by_value|
           scope = if grouped_by_value.present?
             scope.where("events.properties @> ?", {grouped_by.to_s => grouped_by_value.to_s}.to_json)
@@ -395,7 +395,7 @@ module Events
       end
 
       def sanitized_grouped_by
-        grouped_by.map { sanitized_property_name(_1) }
+        grouped_by.map { sanitized_property_name(it) }
       end
 
       # NOTE: Compute pro-rata of the duration in days between the datetimes over the duration of the billing period

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -167,6 +167,18 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
 
       expect(result.event_aggregation).to eq([1, 1, 1, 1])
     end
+
+    context "with grouped_by_values" do
+      before do
+        event_list.first.update!(properties: {"scheme" => "visa"})
+      end
+
+      it "takes the groups into account" do
+        result = count_service.per_event_aggregation(grouped_by_values: {"scheme" => "visa"})
+
+        expect(result.event_aggregation).to eq([1])
+      end
+    end
   end
 
   describe ".grouped_by_aggregation" do

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -244,6 +244,20 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
 
       expect(result.event_aggregation).to eq([0, 0, 0, 0, 12])
     end
+
+    context "with grouped_by_values" do
+      let(:event) { events.first }
+
+      before do
+        event.update!(properties: event.properties.merge(scheme: "visa"))
+      end
+
+      it "takes the groups into account" do
+        result = max_service.per_event_aggregation(grouped_by_values: {"scheme" => "visa"})
+
+        expect(result.event_aggregation).to eq([event.properties["total_count"]])
+      end
+    end
   end
 
   describe ".grouped_by_aggregation" do

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -761,6 +761,20 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
 
       expect(result.event_aggregation).to eq([12, 12, 12, 12])
     end
+
+    context "with grouped_by_values" do
+      let(:event) { latest_events.first }
+
+      before do
+        event.update!(properties: event.properties.merge(scheme: "visa"))
+      end
+
+      it "takes the groups into account" do
+        result = sum_service.per_event_aggregation(grouped_by_values: {"scheme" => "visa"})
+
+        expect(result.event_aggregation).to eq([12])
+      end
+    end
   end
 
   describe ".grouped_by aggregation" do

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -768,5 +768,17 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
 
       expect(result.event_aggregation).to eq([1])
     end
+
+    context "with grouped_by_values" do
+      before do
+        unique_count_event.update!(properties: unique_count_event.properties.merge(scheme: "visa"))
+      end
+
+      it "takes the groups into account" do
+        result = count_service.per_event_aggregation(grouped_by_values: {"scheme" => "visa"})
+
+        expect(result.event_aggregation).to eq([1])
+      end
+    end
   end
 end

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -572,6 +572,24 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       expect(result.event_aggregation).to eq([5, 12, 12])
       expect(result.event_prorated_aggregation.map { |el| el.round(5) }).to eq([5, 2.32258, 2.32258])
     end
+
+    context "with grouped_by_values" do
+      let(:old_event) { old_events.first }
+      let(:latest_event) { latest_events.last }
+
+      before do
+        latest_event.update!(properties: latest_event.properties.merge(scheme: "visa"))
+        old_event.update!(properties: old_event.properties.merge(scheme: "visa"))
+      end
+
+      it "takes the groups into account" do
+        sum_service.options = {}
+        result = sum_service.per_event_aggregation(grouped_by_values: {"scheme" => "visa"})
+
+        expect(result.event_aggregation).to eq([5, 12])
+        expect(result.event_prorated_aggregation.map { |el| el.round(5) }).to eq([5, 2.32258])
+      end
+    end
   end
 
   describe ".grouped_by aggregation" do

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
   let(:grouped_by) { nil }
   let(:grouped_by_values) { nil }
+  let(:with_grouped_by_values) { nil }
   let(:matching_filters) { {} }
   let(:ignored_filters) { [] }
 
@@ -48,8 +49,10 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
       if i.even?
         matching_filters.each { |key, values| properties[key] = values.first }
 
-        if grouped_by_values.present?
-          grouped_by_values.each { |grouped_by, value| properties[grouped_by] = value }
+        applied_grouped_by_values = grouped_by_values || with_grouped_by_values
+
+        if applied_grouped_by_values.present?
+          applied_grouped_by_values.each { |grouped_by, value| properties[grouped_by] = value }
         elsif grouped_by.present?
           grouped_by.each do |group|
             properties[group] = "#{Faker::Fantasy::Tolkien.character.delete("'")}_#{i}"
@@ -118,6 +121,16 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
       it "returns a list of events" do
         expect(event_store.count).to eq(2) # 1st event is ignored
+      end
+    end
+  end
+
+  describe "#with_grouped_by_values" do
+    let(:with_grouped_by_values) { {"region" => "europe"} }
+
+    it "applies the grouped_by_values in the block" do
+      event_store.with_grouped_by_values(with_grouped_by_values) do
+        expect(event_store.count).to eq(3)
       end
     end
   end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/3666 and https://github.com/getlago/lago-api/pull/3681 as part of the epic to add grouped_by feature on all charge models and not only on the standard one like today. 

## Description

This PR is the second step:
- Adds the ability to inject a set of  grouped_by values when fetching events in an event store implementation (with_grouped_by_values)
- Takes advantage of this ability to change the implementation of all "per event" aggregation logic making sure it always targets the right pricing_group.


For now the grouped aggregation remains remains whitelisted only on the standard and dynamic charge model. This will change in the next step of this feature.