### PR TITLE
fix(audit-logs): Prevent payment receipt duplicate logs

### DIFF
--- a/spec/services/payment_receipts/generate_pdf_service_spec.rb
+++ b/spec/services/payment_receipts/generate_pdf_service_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe PaymentReceipts::GeneratePdfService, type: :service do
     end
 
     it "produces an activity log" do
-      payment_receipt = described_class.call(payment_receipt:, context:).payment_receipt
+      receipt = described_class.call(payment_receipt:, context:).payment_receipt
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(payment_receipt, "payment_receipt.generated")
+      expect(Utils::ActivityLog).to have_received(:produce).with(receipt, "payment_receipt.generated")
     end
 
     context "with not found payment receipt" do


### PR DESCRIPTION
The goal of this PR is to prevent creating duplicate activity logs when:
- creating a payment receipt (we can receive multiple stripe events)
- generating the pdf of a payment receipt (only create the activity log when the pdf were not present)