### PR TITLE
fix(webhooks): Fix sending of `invoice.payment_status_updated` webhook on manual payment recording

### DIFF
--- a/app/services/payments/manual_create_service.rb
+++ b/app/services/payments/manual_create_service.rb
@@ -36,7 +36,7 @@ module Payments
 
         params = {total_paid_amount_cents:}
         params[:payment_status] = "succeeded" if total_paid_amount_cents == invoice.total_amount_cents
-        Invoices::UpdateService.call!(invoice:, params:)
+        Invoices::UpdateService.call!(invoice:, params:, webhook_notification: true)
       end
 
       after_commit do

--- a/spec/services/payments/manual_create_service_spec.rb
+++ b/spec/services/payments/manual_create_service_spec.rb
@@ -169,6 +169,10 @@ RSpec.describe Payments::ManualCreateService, type: :service do
           result = service.call
 
           expect(result.payment.payable.payment_status).to eq("succeeded")
+          expect(SendWebhookJob).to have_been_enqueued.with(
+            "invoice.payment_status_updated",
+            invoice
+          )
         end
 
         it "produces an activity log" do


### PR DESCRIPTION
## Context

We didn't send the `invoice.payment_status_updated` webhook if a manual payment is recorded on an invoice and the payment status is updated.

Steps to reproduce:

1. Find an overdue invoice.
2. Select the "record a payment" option.
3. Record a payment for the amount of the overdue invoice (this changes the payment status to "succeeded").
4. No webhook is triggered.

## Description

This PR fixes sending of `invoice.payment_status_updated` webhook on manual payment recording.
