### PR TITLE
update tests

### DIFF
--- a/app/config/permissions/definition.yml
+++ b/app/config/permissions/definition.yml
@@ -115,6 +115,8 @@ billing_entities:
   emails:
     view:
     update:
+  dunning_campaigns:
+    manage:
 payment_requests:
   view: true
   create:

--- a/app/config/permissions/role-finance.yml
+++ b/app/config/permissions/role-finance.yml
@@ -89,6 +89,8 @@ billing_entities:
   emails:
     view: true
     update: true
+  dunning_campaigns:
+    manage: true
 payment_requests:
   view: true
   create: true

--- a/app/config/permissions/role-manager.yml
+++ b/app/config/permissions/role-manager.yml
@@ -89,6 +89,8 @@ billing_entities:
   emails:
     view: false
     update: false
+  dunning_campaigns:
+    manage: false
 payment_requests:
   view: true
   create: true

--- a/app/graphql/mutations/billing_entities/update_applied_dunning_campaign.rb
+++ b/app/graphql/mutations/billing_entities/update_applied_dunning_campaign.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Mutations
+  module BillingEntities
+    class UpdateAppliedDunningCampaign < ::Mutations::BaseMutation
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      REQUIRED_PERMISSION = "billing_entities:dunning_campaigns:manage"
+
+      argument :billing_entity_id, ID, required: true
+      argument :applied_dunning_campaign_id, String, required: false
+
+      type Types::BillingEntities::Object
+
+      def resolve(billing_entity_id:, applied_dunning_campaign_id:)
+        billing_entity = current_organization.billing_entities.find_by(id: billing_entity_id)
+        result = ::BillingEntities::UpdateAppliedDunningCampaignService.call(billing_entity:, applied_dunning_campaign_id:)
+
+        result.success? ? result.billing_entity : result_error(result)
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -12,10 +12,11 @@ module Types
     field :update_billable_metric, mutation: Mutations::BillableMetrics::Update
 
     field :billing_entity_apply_taxes, mutation: Mutations::BillingEntities::ApplyTaxes
+    field :billing_entity_apply_dunning_campaign, mutation: Mutations::BillingEntities::UpdateAppliedDunningCampaign
     field :billing_entity_remove_taxes, mutation: Mutations::BillingEntities::RemoveTaxes
     field :create_billing_entity, mutation: Mutations::BillingEntities::Create
     field :destroy_billing_entity, mutation: Mutations::BillingEntities::Destroy
-    field :update_billing_entity, mutation: Mutations::BillingEntities::Update
+    field :update_applied_dunning_campaign, mutation: Mutations::BillingEntities::UpdateAppliedDunningCampaign
 
     field :create_adjusted_fee, mutation: Mutations::AdjustedFees::Create
     field :destroy_adjusted_fee, mutation: Mutations::AdjustedFees::Destroy

--- a/app/services/billing_entities/update_applied_dunning_campaign_service.rb
+++ b/app/services/billing_entities/update_applied_dunning_campaign_service.rb
@@ -3,22 +3,27 @@
 module BillingEntities
   class UpdateAppliedDunningCampaignService < BaseService
     Result = BaseResult[:billing_entity]
-    def initialize(billing_entity:, dunning_campaign: nil)
+    def initialize(billing_entity:, applied_dunning_campaign_id: nil)
       @billing_entity = billing_entity
-      @dunning_campaign = dunning_campaign
+      @applied_dunning_campaign_id = applied_dunning_campaign_id
       super
     end
 
     def call
       return result.not_found_failure!(resource: "billing_entity") if billing_entity.nil?
-      return unless billing_entity.applied_dunning_campaign != dunning_campaign
+      return if billing_entity.applied_dunning_campaign_id == applied_dunning_campaign_id
 
+      dunning_campaign = DunningCampaign.find(applied_dunning_campaign_id) if applied_dunning_campaign_id
       billing_entity.reset_customers_last_dunning_campaign_attempt
       billing_entity.update!(applied_dunning_campaign: dunning_campaign)
+      result.billing_entity = billing_entity
+      result
+    rescue ActiveRecord::RecordNotFound => e
+      result.not_found_failure!(resource: "dunning_campaign")
     end
 
     private
 
-    attr_reader :billing_entity, :dunning_campaign
+    attr_reader :billing_entity, :applied_dunning_campaign_id
   end
 end

--- a/spec/graphql/mutations/billing_entities/update_applied_dunning_campaign_spec.rb
+++ b/spec/graphql/mutations/billing_entities/update_applied_dunning_campaign_spec.rb
@@ -1,0 +1,138 @@
+require "rails_helper"
+
+RSpec.describe Mutations::BillingEntities::UpdateAppliedDunningCampaign, type: :graphql do
+  let(:required_permission) { "billing_entities:dunning_campaigns:manage" }
+  let(:membership) { create(:membership, organization:) }
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity, organization:, applied_dunning_campaign:) }
+  let(:dunning_campaign) { create(:dunning_campaign, organization:) }
+  let(:applied_dunning_campaign) { create(:dunning_campaign, organization:) }
+  let(:mutation) do
+    <<~graphql
+      mutation UpdateAppliedDunningCampaign($input: UpdateAppliedDunningCampaignInput!) {
+        updateAppliedDunningCampaign(input: $input) {
+          id
+          appliedDunningCampaign {
+            id
+          }
+        }
+      }
+    graphql
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "billing_entities:dunning_campaigns:manage"
+
+  before do
+    allow_any_instance_of(Mutations::BillingEntities::UpdateAppliedDunningCampaign)
+      .to receive(:current_organization).and_return(organization)
+  end
+
+  context "when the user has the required permission" do
+    it "changes the applied dunning campaign successfully" do
+      result = execute_graphql(
+      current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            billingEntityId: billing_entity.id,
+            appliedDunningCampaignId: dunning_campaign.id
+          }
+        }
+      )
+
+      data = result["data"]["updateAppliedDunningCampaign"]
+      expect(data["id"]).to eq(billing_entity.id.to_s)
+      expect(data["appliedDunningCampaign"]["id"]).to eq(dunning_campaign.id.to_s)
+    end
+
+    it "removes the applied dunning campaign when ID is nil" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            billingEntityId: billing_entity.id,
+            appliedDunningCampaignId: nil
+          }
+        }
+      )
+
+      data = result["data"]["updateAppliedDunningCampaign"]
+
+      expect(data["id"]).to eq(billing_entity.id.to_s)
+      expect(data["appliedDunningCampaign"]).to be_nil
+    end
+  end
+
+  context "when the user does not have the required permission" do
+    it "returns an authorization error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: [],
+        query: mutation,
+        variables: {
+          input: {
+            billingEntityId: billing_entity.id,
+            appliedDunningCampaignId: dunning_campaign.id
+          }
+        }
+      )
+
+      errors = result["errors"]
+
+      expect(errors).not_to be_empty
+      expect(errors.first["message"]).to eq("Missing permissions")
+    end
+  end
+
+  context "when the billing entity does not exist" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            billingEntityId: "nonexistent-id",
+            appliedDunningCampaignId: dunning_campaign.id
+          }
+        }
+      )
+
+      errors = result["errors"]
+
+      expect(errors).not_to be_empty
+      expect(errors.first["message"]).to eq("Resource not found")
+    end
+  end
+
+  context "when the dunning campaign does not exist" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            billingEntityId: billing_entity.id,
+            appliedDunningCampaignId: "nonexistent-id"
+          }
+        }
+      )
+
+      errors = result["errors"]
+
+      expect(errors).not_to be_empty
+      expect(errors.first["message"]).to eq("Resource not found")
+    end
+  end
+end


### PR DESCRIPTION
## Context

since we're switching dunning campaigns on billing entities, we need a way to manage the dunning campaigns on billing entities. This PR adds a Graphql mutation to update applied_dunning_campaign on provided billing entity

## Description

- Added a graphql mutation to update applied_dunning_campaign on billing entity
- added small fixes in service that changes applied dunning campaign on billing entity
