### PR TITLE
feat(stripe): Ensure webhook specs run with multiple versions

### DIFF
--- a/spec/services/payment_providers/stripe/webhooks/charge_dispute_closed_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/charge_dispute_closed_service_spec.rb
@@ -15,146 +15,148 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::ChargeDisputeClosedService, t
 
   before { allow(::Payments::LoseDisputeService).to receive(:call).and_call_original }
 
-  describe "#call" do
-    before { payment }
+  ["2020-08-27", "2025-04-30.basil"].each do |version|
+    describe "#call" do
+      before { payment }
 
-    context "when payable is an invoice" do
-      let(:payable) { create(:invoice, customer:, organization:, status:, payment_status: "succeeded") }
+      context "when payable is an invoice" do
+        let(:payable) { create(:invoice, customer:, organization:, status:, payment_status: "succeeded") }
 
-      context "when dispute is lost" do
-        let(:event_json) do
-          get_stripe_fixtures("webhooks/charge_dispute_closed.json") do |h|
-            if h.dig(:data, :object, :payment_intent)&.starts_with? "pi_"
-              h[:data][:object][:payment_intent] = intent_id
+        context "when dispute is lost" do
+          let(:event_json) do
+            get_stripe_fixtures("webhooks/charge_dispute_closed.json", version:) do |h|
+              if h.dig(:data, :object, :payment_intent)&.starts_with? "pi_"
+                h[:data][:object][:payment_intent] = intent_id
+              end
+              h[:data][:object][:status] = "lost" if h.dig(:data, :object, :status)
             end
-            h[:data][:object][:status] = "lost" if h.dig(:data, :object, :status)
+          end
+
+          context "when invoice is draft" do
+            let(:status) { "draft" }
+
+            it "does not updates invoice payment dispute lost" do
+              expect do
+                service.call
+                payment.payable.reload
+              end.not_to change(payment.payable.reload, :payment_dispute_lost_at).from(nil)
+            end
+
+            it "does not deliver webhook" do
+              expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+            end
+          end
+
+          context "when invoice is finalized" do
+            let(:status) { "finalized" }
+
+            it "updates invoice payment dispute lost" do
+              expect do
+                service.call
+                payment.payable.reload
+              end.to change(payment.payable, :payment_dispute_lost_at).from(nil)
+            end
+
+            it "delivers a webhook" do
+              expect do
+                service.call
+                payment.payable.reload
+              end.to have_enqueued_job(SendWebhookJob).with(
+                "invoice.payment_dispute_lost",
+                payment.payable,
+                provider_error: "fraudulent"
+              )
+            end
           end
         end
 
-        context "when invoice is draft" do
-          let(:status) { "draft" }
-
-          it "does not updates invoice payment dispute lost" do
-            expect do
-              service.call
-              payment.payable.reload
-            end.not_to change(payment.payable.reload, :payment_dispute_lost_at).from(nil)
+        context "when dispute is won" do
+          let(:event_json) do
+            get_stripe_fixtures("webhooks/charge_dispute_closed.json", version:) do |h|
+              if h.dig(:data, :object, :payment_intent)&.starts_with? "pi_"
+                h[:data][:object][:payment_intent] = intent_id
+              end
+              h[:data][:object][:status] = "won" if h.dig(:data, :object, :status)
+            end
           end
 
-          it "does not deliver webhook" do
-            expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+          context "when invoice is draft" do
+            let(:status) { "draft" }
+
+            it "does not updates invoice payment dispute lost" do
+              expect do
+                service.call
+                payment.payable.reload
+              end.not_to change(payment.payable.reload, :payment_dispute_lost_at).from(nil)
+            end
+
+            it "does not deliver webhook" do
+              expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+            end
           end
-        end
 
-        context "when invoice is finalized" do
-          let(:status) { "finalized" }
+          context "when invoice is finalized" do
+            let(:status) { "finalized" }
 
-          it "updates invoice payment dispute lost" do
-            expect do
-              service.call
-              payment.payable.reload
-            end.to change(payment.payable, :payment_dispute_lost_at).from(nil)
-          end
+            it "does not updates invoice payment dispute lost" do
+              expect do
+                service.call
+                payment.payable.reload
+              end.not_to change(payment.payable.reload, :payment_dispute_lost_at).from(nil)
+            end
 
-          it "delivers a webhook" do
-            expect do
-              service.call
-              payment.payable.reload
-            end.to have_enqueued_job(SendWebhookJob).with(
-              "invoice.payment_dispute_lost",
-              payment.payable,
-              provider_error: "fraudulent"
-            )
+            it "does not deliver webhook" do
+              expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+            end
           end
         end
       end
 
-      context "when dispute is won" do
-        let(:event_json) do
-          get_stripe_fixtures("webhooks/charge_dispute_closed.json") do |h|
-            if h.dig(:data, :object, :payment_intent)&.starts_with? "pi_"
-              h[:data][:object][:payment_intent] = intent_id
+      context "when payable is a payment request" do
+        let(:payment) { create(:payment, payable:, provider_payment_id: intent_id) }
+        let(:payable) { create(:payment_request, customer:, organization:, invoices: [invoice_1, invoice_2]) }
+        let(:invoice_1) { create(:invoice, customer:, organization:, status: "finalized", payment_status: "succeeded") }
+        let(:invoice_2) { create(:invoice, customer:, organization:, status: "finalized", payment_status: "succeeded") }
+
+        context "when dispute is lost" do
+          let(:event_json) do
+            get_stripe_fixtures("webhooks/charge_dispute_closed.json", version:) do |h|
+              if h.dig(:data, :object, :payment_intent)&.starts_with? "pi_"
+                h[:data][:object][:payment_intent] = intent_id
+              end
+              h[:data][:object][:status] = "lost" if h.dig(:data, :object, :status)
             end
-            h[:data][:object][:status] = "won" if h.dig(:data, :object, :status)
+          end
+
+          it "flags all the invoices of the PaymentRequests" do
+            service.call
+            expect(::Payments::LoseDisputeService).to have_received(:call)
+            expect(invoice_1.reload.payment_dispute_lost_at).to eq Time.zone.at(event.created)
+            expect(invoice_2.reload.payment_dispute_lost_at).to eq Time.zone.at(event.created)
+
+            expect(SendWebhookJob).to have_been_enqueued.once
+              .with("invoice.payment_dispute_lost", invoice_1, provider_error: "fraudulent")
+            expect(SendWebhookJob).to have_been_enqueued.once
+              .with("invoice.payment_dispute_lost", invoice_2, provider_error: "fraudulent")
+
+            expect(Invoices::ProviderTaxes::VoidJob).to have_been_enqueued.twice
           end
         end
 
-        context "when invoice is draft" do
-          let(:status) { "draft" }
-
-          it "does not updates invoice payment dispute lost" do
-            expect do
-              service.call
-              payment.payable.reload
-            end.not_to change(payment.payable.reload, :payment_dispute_lost_at).from(nil)
-          end
-
-          it "does not deliver webhook" do
-            expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
-          end
-        end
-
-        context "when invoice is finalized" do
-          let(:status) { "finalized" }
-
-          it "does not updates invoice payment dispute lost" do
-            expect do
-              service.call
-              payment.payable.reload
-            end.not_to change(payment.payable.reload, :payment_dispute_lost_at).from(nil)
-          end
-
-          it "does not deliver webhook" do
-            expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
-          end
-        end
-      end
-    end
-
-    context "when payable is a payment request" do
-      let(:payment) { create(:payment, payable:, provider_payment_id: intent_id) }
-      let(:payable) { create(:payment_request, customer:, organization:, invoices: [invoice_1, invoice_2]) }
-      let(:invoice_1) { create(:invoice, customer:, organization:, status: "finalized", payment_status: "succeeded") }
-      let(:invoice_2) { create(:invoice, customer:, organization:, status: "finalized", payment_status: "succeeded") }
-
-      context "when dispute is lost" do
-        let(:event_json) do
-          get_stripe_fixtures("webhooks/charge_dispute_closed.json") do |h|
-            if h.dig(:data, :object, :payment_intent)&.starts_with? "pi_"
-              h[:data][:object][:payment_intent] = intent_id
+        context "when dispute is won" do
+          let(:event_json) do
+            get_stripe_fixtures("webhooks/charge_dispute_closed.json", version:) do |h|
+              if h.dig(:data, :object, :payment_intent)&.starts_with? "pi_"
+                h[:data][:object][:payment_intent] = intent_id
+              end
+              h[:data][:object][:status] = "won" if h.dig(:data, :object, :status)
             end
-            h[:data][:object][:status] = "lost" if h.dig(:data, :object, :status)
           end
-        end
 
-        it "flags all the invoices of the PaymentRequests" do
-          service.call
-          expect(::Payments::LoseDisputeService).to have_received(:call)
-          expect(invoice_1.reload.payment_dispute_lost_at).to eq Time.zone.at(event.created)
-          expect(invoice_2.reload.payment_dispute_lost_at).to eq Time.zone.at(event.created)
-
-          expect(SendWebhookJob).to have_been_enqueued.once
-            .with("invoice.payment_dispute_lost", invoice_1, provider_error: "fraudulent")
-          expect(SendWebhookJob).to have_been_enqueued.once
-            .with("invoice.payment_dispute_lost", invoice_2, provider_error: "fraudulent")
-
-          expect(Invoices::ProviderTaxes::VoidJob).to have_been_enqueued.twice
-        end
-      end
-
-      context "when dispute is won" do
-        let(:event_json) do
-          get_stripe_fixtures("webhooks/charge_dispute_closed.json") do |h|
-            if h.dig(:data, :object, :payment_intent)&.starts_with? "pi_"
-              h[:data][:object][:payment_intent] = intent_id
-            end
-            h[:data][:object][:status] = "won" if h.dig(:data, :object, :status)
+          it "does not call LoseDisputeService" do
+            service.call
+            expect(::Payments::LoseDisputeService).not_to have_received(:call)
           end
-        end
-
-        it "does not call LoseDisputeService" do
-          service.call
-          expect(::Payments::LoseDisputeService).not_to have_received(:call)
         end
       end
     end

--- a/spec/services/payment_providers/stripe/webhooks/customer_updated_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/customer_updated_service_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerUpdatedService, type:
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:fixtures) { get_stripe_fixtures("webhooks/customer_updated.json") }
-  let(:event_json) { fixtures }
 
   let(:event) { Stripe::Event.construct_from(JSON.parse(event_json)) }
   let(:provider_customer_id) { event.data.object.id }
@@ -21,28 +19,19 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerUpdatedService, type:
 
   before { stripe_customer }
 
-  describe "#call" do
-    it "updates the customer payment method" do
-      result = webhook_service.call
+  ["2020-08-27", "2025-04-30.basil"].each do |version|
+    describe "#call" do
+      let(:event_json) { get_stripe_fixtures("webhooks/customer_updated.json", version:) }
 
-      expect(result).to be_success
-      expect(result.stripe_customer.payment_method_id).to eq(payment_method_id)
-    end
-
-    context "when customer is not found" do
-      let(:provider_customer_id) { "cus_InvaLid" }
-
-      it "returns an empty result" do
+      it "updates the customer payment method" do
         result = webhook_service.call
 
         expect(result).to be_success
-        expect(result.stripe_customer).to be_nil
+        expect(result.stripe_customer.payment_method_id).to eq(payment_method_id)
       end
 
-      context "when stripe customer is deleted" do
-        let(:stripe_customer) do
-          create(:stripe_customer, :deleted, payment_provider: stripe_provider, customer:, provider_customer_id:)
-        end
+      context "when customer is not found" do
+        let(:provider_customer_id) { "cus_InvaLid" }
 
         it "returns an empty result" do
           result = webhook_service.call
@@ -50,42 +39,55 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerUpdatedService, type:
           expect(result).to be_success
           expect(result.stripe_customer).to be_nil
         end
-      end
 
-      context "when customer in metadata is not found" do
-        let(:event_json) do
-          h = JSON.parse(fixtures)
-          h["data"]["object"]["metadata"] = {
-            lago_customer_id: "123456-1234-1234-1234-1234567890",
-            customer_id: "test_5"
-          }
-          h.to_json
+        context "when stripe customer is deleted" do
+          let(:stripe_customer) do
+            create(:stripe_customer, :deleted, payment_provider: stripe_provider, customer:, provider_customer_id:)
+          end
+
+          it "returns an empty result" do
+            result = webhook_service.call
+
+            expect(result).to be_success
+            expect(result.stripe_customer).to be_nil
+          end
         end
 
-        it "returns an empty response" do
-          result = webhook_service.call
+        context "when customer in metadata is not found" do
+          let(:event_json) do
+            get_stripe_fixtures("webhooks/customer_updated.json", version:) do |h|
+              h["data"]["object"]["metadata"] = {
+                lago_customer_id: "123456-1234-1234-1234-1234567890",
+                customer_id: "test_5"
+              }
+            end
+          end
 
-          expect(result).to be_success
-          expect(result.stripe_customer).to be_nil
+          it "returns an empty response" do
+            result = webhook_service.call
+
+            expect(result).to be_success
+            expect(result.stripe_customer).to be_nil
+          end
         end
-      end
 
-      context "when customer in metadata exists" do
-        let(:event_json) do
-          h = JSON.parse(fixtures)
-          h["data"]["object"]["metadata"] = {
-            lago_customer_id: customer.id,
-            customer_id: "test_5"
-          }
-          h.to_json
-        end
+        context "when customer in metadata exists" do
+          let(:event_json) do
+            get_stripe_fixtures("webhooks/customer_updated.json", version:) do |h|
+              h["data"]["object"]["metadata"] = {
+                lago_customer_id: customer.id,
+                customer_id: "test_5"
+              }
+            end
+          end
 
-        it "returns a not found error" do
-          result = webhook_service.call
+          it "returns a not found error" do
+            result = webhook_service.call
 
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::NotFoundFailure)
-          expect(result.error.message).to eq("stripe_customer_not_found")
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.message).to eq("stripe_customer_not_found")
+          end
         end
       end
     end

--- a/spec/services/payment_providers/stripe/webhooks/payment_intent_payment_failed_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/payment_intent_payment_failed_service_spec.rb
@@ -8,63 +8,63 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedSer
   let(:event) { ::Stripe::Event.construct_from(JSON.parse(event_json)) }
   let(:organization) { create(:organization) }
 
-  context "when payment intent event" do
-    let(:event_json) { get_stripe_fixtures("webhooks/payment_intent_payment_failed.json") }
+  ["2020-08-27", "2025-04-30.basil"].each do |version|
+    context "when payment intent event" do
+      let(:event_json) { get_stripe_fixtures("webhooks/payment_intent_payment_failed.json", version:) }
 
-    it "updates the payment status and save the payment method" do
-      expect_any_instance_of(Invoices::Payments::StripeService).to receive(:update_payment_status) # rubocop:disable RSpec/AnyInstance
-        .with(
-          organization_id: organization.id,
-          status: "failed",
-          stripe_payment: PaymentProviders::StripeProvider::StripePayment
-        ).and_call_original
+      it "updates the payment status and save the payment method" do
+        expect_any_instance_of(Invoices::Payments::StripeService).to receive(:update_payment_status) # rubocop:disable RSpec/AnyInstance
+          .with(
+            organization_id: organization.id,
+            status: "failed",
+            stripe_payment: PaymentProviders::StripeProvider::StripePayment
+          ).and_call_original
 
-      create(:payment, provider_payment_id: event.data.object.id)
+        create(:payment, provider_payment_id: event.data.object.id)
 
-      result = event_service.call
+        result = event_service.call
 
-      expect(result).to be_success
-    end
-  end
-
-  context "when payment intent event for a payment request" do
-    let(:event_json) do
-      json = get_stripe_fixtures("webhooks/payment_intent_payment_failed.json")
-      h = JSON.parse(json)
-      h["data"]["object"]["metadata"] = {
-        lago_payable_type: "PaymentRequest",
-        lago_payment_request_id: "a587e552-36bc-4334-81f2-abcbf034ad3f"
-      }
-      h.to_json
+        expect(result).to be_success
+      end
     end
 
-    it "routes the event to an other service" do
-      expect_any_instance_of(PaymentRequests::Payments::StripeService).to receive(:update_payment_status) # rubocop:disable RSpec/AnyInstance
-        .with(
-          organization_id: organization.id,
-          status: "failed",
-          stripe_payment: PaymentProviders::StripeProvider::StripePayment
-        ).and_call_original
+    context "when payment intent event for a payment request" do
+      let(:event_json) do
+        get_stripe_fixtures("webhooks/payment_intent_payment_failed.json", version:) do |h|
+          h["data"]["object"]["metadata"] = {
+            lago_payable_type: "PaymentRequest",
+            lago_payment_request_id: "a587e552-36bc-4334-81f2-abcbf034ad3f"
+          }
+        end
+      end
 
-      payment = create(:payment, provider_payment_id: event.data.object.id)
-      create(:payment_request, customer: create(:customer, organization:), payments: [payment])
+      it "routes the event to an other service" do
+        expect_any_instance_of(PaymentRequests::Payments::StripeService).to receive(:update_payment_status) # rubocop:disable RSpec/AnyInstance
+          .with(
+            organization_id: organization.id,
+            status: "failed",
+            stripe_payment: PaymentProviders::StripeProvider::StripePayment
+          ).and_call_original
 
-      result = event_service.call
+        payment = create(:payment, provider_payment_id: event.data.object.id)
+        create(:payment_request, customer: create(:customer, organization:), payments: [payment])
 
-      expect(result).to be_success
+        result = event_service.call
+
+        expect(result).to be_success
+      end
     end
-  end
 
-  context "when payment intent event with an invalid payable type" do
-    let(:event_json) do
-      json = get_stripe_fixtures("webhooks/payment_intent_payment_failed.json")
-      h = JSON.parse(json)
-      h["data"]["object"]["metadata"]["lago_payable_type"] = "InvalidPayableTypeName"
-      h.to_json
-    end
+    context "when payment intent event with an invalid payable type" do
+      let(:event_json) do
+        get_stripe_fixtures("webhooks/payment_intent_payment_failed.json", version:) do |h|
+          h["data"]["object"]["metadata"]["lago_payable_type"] = "InvalidPayableTypeName"
+        end
+      end
 
-    it do
-      expect { event_service.call }.to raise_error(NameError, "Invalid lago_payable_type: InvalidPayableTypeName")
+      it do
+        expect { event_service.call }.to raise_error(NameError, "Invalid lago_payable_type: InvalidPayableTypeName")
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

See https://github.com/getlago/lago-api/pull/3300

## Description

When upgrading stripe versions, your app will continue to receive older version of the webhook for while (exactly like when running rails db migrations) so all modifications made to webhooks processing need to be backward compatible.

We run tests with all versions to ensure compat'.