### PR TITLE
feat(ongoing-balance): Save last_balance_sync_at on wallets also when updating ongoing balance

### DIFF
--- a/app/graphql/types/wallets/object.rb
+++ b/app/graphql/types/wallets/object.rb
@@ -28,6 +28,7 @@ module Types
 
       field :last_balance_sync_at, GraphQL::Types::ISO8601DateTime, null: true
       field :last_consumed_credit_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :last_ongoing_balance_sync_at, GraphQL::Types::ISO8601DateTime, null: true
 
       field :activity_logs, [Types::ActivityLogs::Object], null: true
       field :recurring_transaction_rules, [Types::Wallets::RecurringTransactionRules::Object], null: true

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -71,6 +71,7 @@ end
 #  invoice_requires_successful_payment :boolean          default(FALSE), not null
 #  last_balance_sync_at                :datetime
 #  last_consumed_credit_at             :datetime
+#  last_ongoing_balance_sync_at        :datetime
 #  lock_version                        :integer          default(0), not null
 #  name                                :string
 #  ongoing_balance_cents               :bigint           default(0), not null

--- a/app/services/wallets/balance/update_ongoing_service.rb
+++ b/app/services/wallets/balance/update_ongoing_service.rb
@@ -7,7 +7,7 @@ module Wallets
         super
 
         @wallet = wallet
-        update_params[:last_balance_sync_at] = Time.current
+        update_params[:last_ongoing_balance_sync_at] = Time.current
         @update_params = update_params
       end
 

--- a/db/migrate/20250611072251_add_last_ongoing_balance_sync_at_to_wallets.rb
+++ b/db/migrate/20250611072251_add_last_ongoing_balance_sync_at_to_wallets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastOngoingBalanceSyncAtToWallets < ActiveRecord::Migration[8.0]
+  def change
+    add_column :wallets, :last_ongoing_balance_sync_at, :timestamp, null: true, default: nil
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2877,7 +2877,8 @@ CREATE TABLE public.wallets (
     lock_version integer DEFAULT 0 NOT NULL,
     ready_to_be_refreshed boolean DEFAULT false NOT NULL,
     organization_id uuid,
-    allowed_fee_types character varying[] DEFAULT '{}'::character varying[] NOT NULL
+    allowed_fee_types character varying[] DEFAULT '{}'::character varying[] NOT NULL,
+    last_ongoing_balance_sync_at timestamp without time zone
 );
 
 
@@ -8603,6 +8604,7 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250611072251'),
 ('20250610063400'),
 ('20250609121102'),
 ('20250602145535'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -10361,6 +10361,7 @@ type Wallet {
   invoiceRequiresSuccessfulPayment: Boolean!
   lastBalanceSyncAt: ISO8601DateTime
   lastConsumedCreditAt: ISO8601DateTime
+  lastOngoingBalanceSyncAt: ISO8601DateTime
   name: String
   ongoingBalanceCents: BigInt!
   ongoingUsageBalanceCents: BigInt!

--- a/schema.json
+++ b/schema.json
@@ -52925,6 +52925,18 @@
               "args": []
             },
             {
+              "name": "lastOngoingBalanceSyncAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "name",
               "description": null,
               "type": {

--- a/spec/graphql/types/wallets/object_spec.rb
+++ b/spec/graphql/types/wallets/object_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Types::Wallets::Object do
 
     expect(subject).to have_field(:last_balance_sync_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:last_consumed_credit_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:last_ongoing_balance_sync_at).of_type("ISO8601DateTime")
 
     expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
     expect(subject).to have_field(:recurring_transaction_rules).of_type("[RecurringTransactionRule!]")

--- a/spec/services/wallets/balance/update_ongoing_service_spec.rb
+++ b/spec/services/wallets/balance/update_ongoing_service_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe Wallets::Balance::UpdateOngoingService, type: :service do
           .and change(wallet, :ongoing_balance_cents).from(800).to(450)
           .and change(wallet, :credits_ongoing_balance).from(8.0).to(4.5)
           .and change(wallet, :ready_to_be_refreshed).from(true).to(false)
-          .and change(wallet, :last_balance_sync_at).from(nil).to(Time.current)
+          .and change(wallet, :last_ongoing_balance_sync_at).from(nil).to(Time.current)
+          .and not_change(wallet, :last_balance_sync_at)
 
         expect(wallet).not_to be_depleted_ongoing_balance
       end


### PR DESCRIPTION
## Context

Currently `last_balance_sync_at` is not updated when we're updating ongoing balance of a wallet.
We'll add another column to store this information: `last_ongoing)balance_sync_at`.

## Description

- Add `last_ongoing_balance_sync_at` column to `wallets` table.
- Add `last_ongoing_balance_sync_at` to wallet GQL type.
- Modify `Wallets::Balance::UpdateOngoingService` so that it updates that column every time.