### PR TITLE
fix(netsuite): Do not create duplicate contacts in netsuite

### DIFF
--- a/app/services/integration_customers/netsuite_service.rb
+++ b/app/services/integration_customers/netsuite_service.rb
@@ -12,6 +12,11 @@ module IntegrationCustomers
     end
 
     def create
+      if existing_integration_customer.present?
+        result.integration_customer = existing_integration_customer
+        return result
+      end
+
       create_result = Integrations::Aggregator::Contacts::CreateService.call(integration:, customer:, subsidiary_id:)
       return create_result if create_result.error
 
@@ -32,5 +37,13 @@ module IntegrationCustomers
     private
 
     attr_reader :integration, :customer, :subsidiary_id, :params
+
+    def existing_integration_customer
+      @existing_integration_customer ||= IntegrationCustomers::BaseCustomer.find_by(
+        customer:,
+        integration:,
+        type: "IntegrationCustomers::NetsuiteCustomer"
+      )
+    end
   end
 end


### PR DESCRIPTION
## Context

An edge case might occur when there's already a contact created in Netsuite but there's also another job that is trying to create the same contact. In that case another contact in netsuite was created (with new external_id) but then the job failed when trying to save the duplicate in the DB

## Description

This PR fixes creating duplicate contacts in `IntegrationCustomers::NetsuiteService` by first checking if the record exists in `integration_customers`table in which case it doesn't even call the nango endpoint and returns the existing integration customer.