### PR TITLE
ftr(wallet-limitations): apply wallet with limitations on the invoice

### DIFF
--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -70,7 +70,17 @@ module Credits
     end
 
     def compute_amount
-      [balance_cents, invoice.total_amount_cents].min
+      if wallet.limited_fee_types?
+        applicable_fees = invoice.fees.where(fee_type: wallet.allowed_fee_types)
+
+        total = 0
+        applicable_fees.each do |f|
+          total += f.sub_total_excluding_taxes_amount_cents + f.taxes_amount_cents - f.precise_credit_notes_amount_cents
+        end
+        [balance_cents, total].min
+      else
+        [balance_cents, invoice.total_amount_cents].min
+      end
     end
   end
 end

--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -71,7 +71,7 @@ module Credits
 
     def compute_amount
       if wallet.limited_fee_types?
-        applicable_fees = invoice.fees.where(fee_type: wallet.allowed_fee_types)
+        applicable_fees = invoice.fees.filter { |fee| wallet.allowed_fee_types.include?(fee.fee_type) }
 
         total = 0
         applicable_fees.each do |f|

--- a/spec/services/credits/applied_prepaid_credit_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credit_service_spec.rb
@@ -103,5 +103,68 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
         end
       end
     end
+
+    context "with fee type limitations" do
+      let(:subscription_fees) { [fee1, fee2] }
+      let(:fee1) { create(:fee, invoice:, subscription:, amount_cents: 60, taxes_amount_cents: 6) }
+      let(:fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 40, taxes_amount_cents: 4) }
+      let(:wallet) { create(:wallet, customer:, balance_cents: 1000, credits_balance: 10.0, allowed_fee_types: %w[charge]) }
+
+      before { subscription_fees }
+
+      it "calculates prepaid credit" do
+        result = credit_service.call
+
+        expect(result).to be_success
+        expect(result.prepaid_credit_amount_cents).to eq(44)
+        expect(invoice.prepaid_credit_amount_cents).to eq(44)
+      end
+
+      it "creates wallet transaction" do
+        result = credit_service.call
+
+        expect(result).to be_success
+        expect(result.wallet_transaction).to be_present
+        expect(result.wallet_transaction.amount).to eq(0.44)
+        expect(result.wallet_transaction).to be_invoiced
+      end
+
+      it "updates wallet balance" do
+        result = credit_service.call
+        wallet = result.wallet_transaction.wallet
+
+        expect(wallet.balance_cents).to eq(956)
+        expect(wallet.credits_balance).to eq(9.56)
+      end
+
+      context "when wallet credits are less than invoice amount" do
+        let(:amount_cents) { 10_000 }
+        let(:fee1) { create(:fee, invoice:, subscription:, amount_cents: 6_000, taxes_amount_cents: 600) }
+        let(:fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 4_000, taxes_amount_cents: 400) }
+
+        it "calculates prepaid credit" do
+          result = credit_service.call
+
+          expect(result).to be_success
+          expect(result.prepaid_credit_amount_cents).to eq(1000)
+        end
+
+        it "creates wallet transaction" do
+          result = credit_service.call
+
+          expect(result).to be_success
+          expect(result.wallet_transaction).to be_present
+          expect(result.wallet_transaction.amount).to eq(10.0)
+        end
+
+        it "updates wallet balance" do
+          result = credit_service.call
+          wallet = result.wallet_transaction.wallet
+
+          expect(wallet.balance).to eq(0.0)
+          expect(wallet.credits_balance).to eq(0.0)
+        end
+      end
+    end
   end
 end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -1613,14 +1613,14 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
     context "with all types of credits" do
       let(:plan) { create(:plan, organization:, interval:, pay_in_advance:, trial_period:, amount_cents: 10_000) }
       let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 10) }
-      let(:billable_metric1) { create(:billable_metric, aggregation_type: "count_agg") }
-      let(:billable_metric2) { create(:billable_metric, aggregation_type: "count_agg") }
-      let(:billable_metric3) { create(:billable_metric, aggregation_type: "count_agg") }
-      let(:billable_metric4) { create(:billable_metric, aggregation_type: "count_agg") }
-      let(:coupon1) { create(:coupon, coupon_type: "percentage", limited_billable_metrics: true, percentage_rate: 50.00) }
+      let(:billable_metric1) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+      let(:billable_metric2) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+      let(:billable_metric3) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+      let(:billable_metric4) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
+      let(:coupon1) { create(:coupon, organization:, coupon_type: "percentage", limited_billable_metrics: true, percentage_rate: 50.00) }
       let(:coupon2) { create(:coupon, organization:) }
       let(:coupon_target) { create(:coupon_billable_metric, coupon: coupon1, billable_metric: billable_metric1) }
-      let(:wallet) { create(:wallet, customer: subscription.customer, balance: "50_000", credits_balance: "50_000", allowed_fee_types: %w[charge]) }
+      let(:wallet) { create(:wallet, organization:, customer: subscription.customer, balance: "50_000", credits_balance: "50_000", allowed_fee_types: %w[charge]) }
       let(:applied_coupon) do
         create(
           :applied_coupon,
@@ -1642,6 +1642,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         create(
           :standard_charge,
           plan: subscription.plan,
+          organization:,
           charge_model: "standard",
           billable_metric: billable_metric1,
           properties: {amount: "10"}
@@ -1660,6 +1661,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         create(
           :standard_charge,
           plan: subscription.plan,
+          organization:,
           charge_model: "standard",
           billable_metric: billable_metric2,
           properties: {amount: "20"}
@@ -1678,6 +1680,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         create(
           :standard_charge,
           plan: subscription.plan,
+          organization:,
           charge_model: "standard",
           billable_metric: billable_metric3,
           properties: {amount: "30"}
@@ -1696,6 +1699,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         create(
           :standard_charge,
           plan: subscription.plan,
+          organization:,
           charge_model: "standard",
           billable_metric: billable_metric4,
           properties: {amount: "40"}
@@ -1713,6 +1717,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       let(:progressive_invoice) do
         create(
           :invoice,
+          :with_subscriptions,
           customer:,
           status: "finalized",
           invoice_type: :progressive_billing,

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -1621,18 +1621,6 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       let(:coupon2) { create(:coupon, organization:) }
       let(:coupon_target) { create(:coupon_billable_metric, coupon: coupon1, billable_metric: billable_metric1) }
       let(:wallet) { create(:wallet, customer: subscription.customer, balance: "50_000", credits_balance: "50_000", allowed_fee_types: %w[charge]) }
-      let(:credit_note) do
-        create(
-          :credit_note,
-          customer: subscription.customer,
-          total_amount_cents: 10,
-          total_amount_currency: plan.amount_currency,
-          balance_amount_cents: 10,
-          balance_amount_currency: plan.amount_currency,
-          credit_amount_cents: 10,
-          credit_amount_currency: plan.amount_currency
-        )
-      end
       let(:applied_coupon) do
         create(
           :applied_coupon,

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -1609,5 +1609,185 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         end
       end
     end
+
+    context "with all types of credits" do
+      let(:plan) { create(:plan, organization:, interval:, pay_in_advance:, trial_period:, amount_cents: 10_000) }
+      let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 10) }
+      let(:billable_metric1) { create(:billable_metric, aggregation_type: "count_agg") }
+      let(:billable_metric2) { create(:billable_metric, aggregation_type: "count_agg") }
+      let(:billable_metric3) { create(:billable_metric, aggregation_type: "count_agg") }
+      let(:billable_metric4) { create(:billable_metric, aggregation_type: "count_agg") }
+      let(:coupon1) { create(:coupon, coupon_type: "percentage", limited_billable_metrics: true, percentage_rate: 50.00) }
+      let(:coupon2) { create(:coupon, organization:) }
+      let(:coupon_target) { create(:coupon_billable_metric, coupon: coupon1, billable_metric: billable_metric1) }
+      let(:wallet) { create(:wallet, customer: subscription.customer, balance: "50_000", credits_balance: "50_000", allowed_fee_types: %w[charge]) }
+      let(:credit_note) do
+        create(
+          :credit_note,
+          customer: subscription.customer,
+          total_amount_cents: 10,
+          total_amount_currency: plan.amount_currency,
+          balance_amount_cents: 10,
+          balance_amount_currency: plan.amount_currency,
+          credit_amount_cents: 10,
+          credit_amount_currency: plan.amount_currency
+        )
+      end
+      let(:applied_coupon) do
+        create(
+          :applied_coupon,
+          coupon: coupon1,
+          customer: subscription.customer,
+          percentage_rate: 50.00
+        )
+      end
+      let(:applied_coupon2) do
+        create(
+          :applied_coupon,
+          coupon: coupon2,
+          customer: subscription.customer,
+          amount_cents: 1_000
+        )
+      end
+
+      let(:charge1) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          charge_model: "standard",
+          billable_metric: billable_metric1,
+          properties: {amount: "10"}
+        )
+      end
+      let(:event1) do
+        create(
+          :event,
+          organization: organization,
+          subscription: subscription,
+          code: billable_metric1.code,
+          timestamp: event_timestamp
+        )
+      end
+      let(:charge2) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          charge_model: "standard",
+          billable_metric: billable_metric2,
+          properties: {amount: "20"}
+        )
+      end
+      let(:event2) do
+        create(
+          :event,
+          organization: organization,
+          subscription: subscription,
+          code: billable_metric2.code,
+          timestamp: event_timestamp
+        )
+      end
+      let(:charge3) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          charge_model: "standard",
+          billable_metric: billable_metric3,
+          properties: {amount: "30"}
+        )
+      end
+      let(:event3) do
+        create(
+          :event,
+          organization: organization,
+          subscription: subscription,
+          code: billable_metric3.code,
+          timestamp: event_timestamp
+        )
+      end
+      let(:charge4) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          charge_model: "standard",
+          billable_metric: billable_metric4,
+          properties: {amount: "40"}
+        )
+      end
+      let(:event4) do
+        create(
+          :event,
+          organization: organization,
+          subscription: subscription,
+          code: billable_metric4.code,
+          timestamp: event_timestamp
+        )
+      end
+      let(:progressive_invoice) do
+        create(
+          :invoice,
+          customer:,
+          status: "finalized",
+          invoice_type: :progressive_billing,
+          subscriptions: [subscription],
+          fees_amount_cents: 3_000,
+          issuing_date: timestamp - 5.days,
+          created_at: timestamp - 5.days
+        )
+      end
+      let(:progressive_fee) do
+        create(:charge_fee, amount_cents: 3_000, invoice: progressive_invoice)
+      end
+      let(:credit_note) do
+        create(
+          :credit_note,
+          customer: subscription.customer,
+          total_amount_cents: 1_000,
+          total_amount_currency: plan.amount_currency,
+          balance_amount_cents: 1_000,
+          balance_amount_currency: plan.amount_currency,
+          credit_amount_cents: 1_000,
+          credit_amount_currency: plan.amount_currency
+        )
+      end
+
+      let(:event) { nil }
+
+      before do
+        charge1
+        charge2
+        charge3
+        charge4
+        event1
+        event2
+        event3
+        event4
+        progressive_invoice
+        progressive_fee
+        progressive_invoice.invoice_subscriptions.first.update!(
+          charges_from_datetime: progressive_invoice.issuing_date - 1.month,
+          charges_to_datetime: progressive_invoice.issuing_date,
+          timestamp: progressive_invoice.issuing_date
+        )
+        applied_coupon
+        applied_coupon2
+        coupon_target
+        credit_note
+        wallet
+      end
+
+      it "updates the invoice accordingly" do
+        result = invoice_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice.fees_amount_cents).to eq(20_000)
+          expect(result.invoice.taxes_amount_cents).to eq(1_565)
+          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(15_650)
+          expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(17_215)
+          expect(result.invoice.progressive_billing_credit_amount_cents).to eq(3_000)
+          expect(result.invoice.total_amount_cents).to eq(9_738) # 17_215 - 1_000 (credit note) - 6_477 (wallet)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Currently wallet credits are applied on all fee types. This feature adds possibility to limit wallet consumption on specific fee type.

## Description

This PR adds logic that applies wallet credits with fee limitations on certain invoice. Other pieces and pre-requirements are already implemented.