### PR TITLE
chore(organization): Organization factories

### DIFF
--- a/spec/factories/add_on_applied_taxes.rb
+++ b/spec/factories/add_on_applied_taxes.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :add_on_applied_tax, class: "AddOn::AppliedTax" do
     add_on
     tax
-    organization
+    organization { add_on&.organization || tax&.organization || association(:organization) }
   end
 end

--- a/spec/factories/adjusted_fees.rb
+++ b/spec/factories/adjusted_fees.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :adjusted_fee do
+    organization { invoice&.organization || fee&.organization || association(:organization) }
     invoice
     fee
     charge { nil }

--- a/spec/factories/applied_coupons.rb
+++ b/spec/factories/applied_coupons.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :applied_coupon do
     customer
     coupon
+    organization { customer&.organization || coupon&.organization || association(:organization) }
 
     amount_cents { 200 }
     amount_currency { "EUR" }

--- a/spec/factories/applied_invoice_custom_sections.rb
+++ b/spec/factories/applied_invoice_custom_sections.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :applied_invoice_custom_section do
     invoice
+    organization { invoice&.organization || association(:organization) }
     code { Faker::Lorem.words(number: 3).join("_") }
     name { Faker::Lorem.words(number: 3).join(" ") }
     display_name { Faker::Lorem.words(number: 3).join(" ") }

--- a/spec/factories/applied_usage_thresholds.rb
+++ b/spec/factories/applied_usage_thresholds.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :applied_usage_threshold do
     usage_threshold
     invoice
+    organization { invoice&.organization || usage_threshold&.organization || association(:organization) }
 
     lifetime_usage_amount_cents { 100 }
   end

--- a/spec/factories/billable_metric_filters.rb
+++ b/spec/factories/billable_metric_filters.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :billable_metric_filter do
     billable_metric
+    organization { billable_metric&.organization || association(:organization) }
     key { Faker::Name.name.underscore }
     values { [Faker::Name.name, Faker::Name.name, Faker::Name.name] }
   end

--- a/spec/factories/charge_applied_taxes.rb
+++ b/spec/factories/charge_applied_taxes.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :charge_applied_tax, class: "Charge::AppliedTax" do
     charge
     tax
+    organization { charge&.organization || tax&.organization || association(:organization) }
   end
 end

--- a/spec/factories/charge_filter_values.rb
+++ b/spec/factories/charge_filter_values.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     end
 
     charge_filter
+    organization { charge_filter&.organization || association(:organization) }
     billable_metric_filter_id { billable_metric_filter.id }
     values { [billable_metric_filter.values.sample] }
   end

--- a/spec/factories/charge_filters.rb
+++ b/spec/factories/charge_filters.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
       charge { create(:standard_charge) }
     end
 
+    organization { charge&.organization || association(:organization) }
     charge_id { charge.id }
     properties { charge.properties }
   end

--- a/spec/factories/charges.rb
+++ b/spec/factories/charges.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :charge do
     billable_metric
     plan
+    organization { billable_metric&.organization || plan&.organization || association(:organization) }
     invoice_display_name { Faker::Fantasy::Tolkien.location }
 
     factory :standard_charge do

--- a/spec/factories/commitment_applied_taxes.rb
+++ b/spec/factories/commitment_applied_taxes.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :commitment_applied_tax, class: "Commitment::AppliedTax" do
     commitment
     tax
+    organization { commitment&.organization || tax&.organization || association(:organization) }
   end
 end

--- a/spec/factories/commitments.rb
+++ b/spec/factories/commitments.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :commitment do
     plan
+    organization { plan&.organization || association(:organization) }
     commitment_type { "minimum_commitment" }
     amount_cents { 1_000 }
     invoice_display_name { Faker::Subscription.plan }

--- a/spec/factories/coupon_targets.rb
+++ b/spec/factories/coupon_targets.rb
@@ -4,10 +4,12 @@ FactoryBot.define do
   factory :coupon_plan, class: "CouponTarget" do
     coupon
     plan
+    organization { plan&.organization || coupon&.organization || association(:organization) }
   end
 
   factory :coupon_billable_metric, class: "CouponTarget" do
     coupon
     billable_metric
+    organization { billable_metric&.organization || coupon&.organization || association(:organization) }
   end
 end

--- a/spec/factories/credit_note_applied_taxes.rb
+++ b/spec/factories/credit_note_applied_taxes.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :credit_note_applied_tax, class: "CreditNote::AppliedTax" do
     credit_note
     tax
+    organization { credit_note&.organization || tax&.organization || association(:organization) }
     tax_code { "vat-#{SecureRandom.uuid}" }
     tax_description { "French Standard VAT" }
     tax_name { "VAT" }

--- a/spec/factories/credit_note_items.rb
+++ b/spec/factories/credit_note_items.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :credit_note_item do
     credit_note
     fee
+    organization { credit_note&.organization || fee&.organization || association(:organization) }
     amount_cents { 100 }
     precise_amount_cents { 100 }
     amount_currency { "EUR" }

--- a/spec/factories/credit_notes.rb
+++ b/spec/factories/credit_notes.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :credit_note do
     customer
     invoice
+    organization { customer&.organization || invoice&.organization || association(:organization) }
 
     issuing_date { Time.zone.today }
 

--- a/spec/factories/credits.rb
+++ b/spec/factories/credits.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :credit do
     invoice
     applied_coupon
+    organization { invoice&.organization || applied_coupon&.organization || association(:organization) }
 
     amount_cents { 200 }
     amount_currency { "EUR" }
@@ -12,6 +13,7 @@ FactoryBot.define do
   factory :credit_note_credit, class: "Credit" do
     invoice
     credit_note
+    organization { invoice&.organization || credit_note&.organization || association(:organization) }
 
     amount_cents { 200 }
     amount_currency { "EUR" }
@@ -20,6 +22,7 @@ FactoryBot.define do
   factory :progressive_billing_invoice_credit, class: "Credit" do
     invoice
     progressive_billing_invoice factory: :invoice
+    organization { invoice&.organization || association(:organization) }
 
     amount_cents { 200 }
     amount_currency { "EUR" }

--- a/spec/factories/customer_applied_taxes.rb
+++ b/spec/factories/customer_applied_taxes.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :customer_applied_tax, class: "Customer::AppliedTax" do
     customer
     tax
+    organization { customer&.organization || tax&.organization || association(:organization) }
   end
 end

--- a/spec/factories/customer_metadata.rb
+++ b/spec/factories/customer_metadata.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :customer_metadata, class: "Metadata::CustomerMetadata" do
     customer
+    organization { customer&.organization || association(:organization) }
 
     key { "lead_name" }
     value { "John Doe" }

--- a/spec/factories/data_export_parts.rb
+++ b/spec/factories/data_export_parts.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :data_export_part do
     data_export
+    organization { data_export&.organization || association(:organization) }
 
     index { 0 }
     object_ids { [] }

--- a/spec/factories/dunning_campaign_thresholds.rb
+++ b/spec/factories/dunning_campaign_thresholds.rb
@@ -3,6 +3,8 @@
 FactoryBot.define do
   factory :dunning_campaign_threshold do
     dunning_campaign
+    organization { dunning_campaign&.organization || association(:organization) }
+
     currency { "USD" }
     amount_cents { 1000 }
   end

--- a/spec/factories/fee_applied_taxes.rb
+++ b/spec/factories/fee_applied_taxes.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
   factory :fee_applied_tax, class: "Fee::AppliedTax" do
     fee
     tax
+    organization { fee&.organization || tax&.organization || association(:organization) }
+
     tax_code { tax&.code.presence || "vat-#{SecureRandom.uuid}" }
     tax_description { "French Standard VAT" }
     tax_name { "VAT" }

--- a/spec/factories/idempotency_records.rb
+++ b/spec/factories/idempotency_records.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :idempotency_record do
+    organization
     idempotency_key { SecureRandom.uuid }
     resource { nil }
   end

--- a/spec/factories/integration_collection_mappings.rb
+++ b/spec/factories/integration_collection_mappings.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :netsuite_collection_mapping, class: "IntegrationCollectionMappings::NetsuiteCollectionMapping" do
     association :integration, factory: :netsuite_integration
     mapping_type { %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit].sample }
+    organization { integration&.organization || association(:organization) }
 
     settings do
       {
@@ -20,6 +21,7 @@ FactoryBot.define do
   factory :xero_collection_mapping, class: "IntegrationCollectionMappings::XeroCollectionMapping" do
     association :integration, factory: :xero_integration
     mapping_type { %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit account].sample }
+    organization { integration&.organization || association(:organization) }
 
     settings do
       {

--- a/spec/factories/integration_customers.rb
+++ b/spec/factories/integration_customers.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :netsuite_customer, class: "IntegrationCustomers::NetsuiteCustomer" do
     association :integration, factory: :netsuite_integration
     customer
+    organization { customer&.organization || integration&.organization || association(:organization) }
     type { "IntegrationCustomers::NetsuiteCustomer" }
     external_customer_id { SecureRandom.uuid }
 
@@ -15,6 +16,7 @@ FactoryBot.define do
   factory :anrok_customer, class: "IntegrationCustomers::AnrokCustomer" do
     association :integration, factory: :anrok_integration
     customer
+    organization { customer&.organization || integration&.organization || association(:organization) }
     type { "IntegrationCustomers::AnrokCustomer" }
     external_customer_id { SecureRandom.uuid }
 
@@ -26,6 +28,7 @@ FactoryBot.define do
   factory :avalara_customer, class: "IntegrationCustomers::AvalaraCustomer" do
     association :integration, factory: :avalara_integration
     customer
+    organization { customer&.organization || integration&.organization || association(:organization) }
     type { "IntegrationCustomers::AvalaraCustomer" }
     external_customer_id { SecureRandom.uuid }
 
@@ -37,6 +40,7 @@ FactoryBot.define do
   factory :xero_customer, class: "IntegrationCustomers::XeroCustomer" do
     association :integration, factory: :xero_integration
     customer
+    organization { customer&.organization || integration&.organization || association(:organization) }
     type { "IntegrationCustomers::XeroCustomer" }
     external_customer_id { SecureRandom.uuid }
 
@@ -48,6 +52,7 @@ FactoryBot.define do
   factory :hubspot_customer, class: "IntegrationCustomers::HubspotCustomer" do
     association :integration, factory: :hubspot_integration
     customer
+    organization { customer&.organization || integration&.organization || association(:organization) }
     type { "IntegrationCustomers::HubspotCustomer" }
     external_customer_id { SecureRandom.uuid }
 
@@ -63,6 +68,7 @@ FactoryBot.define do
   factory :salesforce_customer, class: "IntegrationCustomers::SalesforceCustomer" do
     association :integration, factory: :salesforce_integration
     customer
+    organization { customer&.organization || integration&.organization || association(:organization) }
     type { "IntegrationCustomers::SalesforceCustomer" }
     external_customer_id { SecureRandom.uuid }
     settings { {} }

--- a/spec/factories/integration_items.rb
+++ b/spec/factories/integration_items.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :integration_item do
     association :integration, factory: :netsuite_integration
+    organization { integration&.organization || association(:organization) }
     item_type { "standard" }
     external_name { "test name" }
     external_account_code { "test_code" }

--- a/spec/factories/integration_mappings.rb
+++ b/spec/factories/integration_mappings.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :netsuite_mapping, class: "IntegrationMappings::NetsuiteMapping" do
     association :integration, factory: :netsuite_integration
     association :mappable, factory: :add_on
+    organization { integration&.organization || association(:organization) }
 
     settings do
       {
@@ -17,6 +18,7 @@ FactoryBot.define do
   factory :xero_mapping, class: "IntegrationMappings::XeroMapping" do
     association :integration, factory: :xero_integration
     association :mappable, factory: :add_on
+    organization { integration&.organization || association(:organization) }
 
     settings do
       {

--- a/spec/factories/integration_resources.rb
+++ b/spec/factories/integration_resources.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :integration_resource do
     association :syncable, factory: %i[invoice payment credit_note].sample
     association :integration, factory: :netsuite_integration
+    organization { integration&.organization || association(:organization) }
     external_id { SecureRandom.uuid }
   end
 end

--- a/spec/factories/invoice_applied_taxes.rb
+++ b/spec/factories/invoice_applied_taxes.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :invoice_applied_tax, class: "Invoice::AppliedTax" do
     invoice
     tax
+    organization { invoice&.organization || tax&.organization || association(:organization) }
     tax_code { tax&.code.presence || "vat-#{SecureRandom.uuid}" }
     tax_description { "French Standard VAT" }
     tax_name { "VAT" }

--- a/spec/factories/invoice_metadata.rb
+++ b/spec/factories/invoice_metadata.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :invoice_metadata, class: "Metadata::InvoiceMetadata" do
     invoice
+    organization { invoice&.organization || association(:organization) }
 
     key { Faker::Commerce.color }
     value { rand(100) }

--- a/spec/factories/invoice_subscriptions.rb
+++ b/spec/factories/invoice_subscriptions.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :invoice_subscription do
     subscription
     invoice
+    organization { subscription&.organization || invoice&.organization || association(:organization) }
 
     recurring { false }
 

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :invoice do
     customer
     # TODO: change building invoices from billing_entity by default
-    organization
+    organization { customer&.organization || association(:organization) }
 
     issuing_date { Time.zone.now - 1.day }
     payment_due_date { issuing_date }

--- a/spec/factories/payment_request_applied_invoices.rb
+++ b/spec/factories/payment_request_applied_invoices.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :payment_request_applied_invoice, class: "PaymentRequest::AppliedInvoice" do
     payment_request
     invoice
+    organization { invoice&.organization || payment_request&.organization || association(:organization) }
   end
 end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     association :payable, factory: :invoice
     association :payment_provider, factory: :stripe_provider
     association :payment_provider_customer, factory: :stripe_customer
+    organization { payable&.organization || payment_provider&.organization || association(:organization) }
 
     amount_cents { 200 }
     amount_currency { "EUR" }

--- a/spec/factories/plan_applied_taxes.rb
+++ b/spec/factories/plan_applied_taxes.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :plan_applied_tax, class: "Plan::AppliedTax" do
     plan
     tax
+    organization { plan&.organization || tax&.organization || association(:organization) }
   end
 end

--- a/spec/factories/recurring_transaction_rules.rb
+++ b/spec/factories/recurring_transaction_rules.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :recurring_transaction_rule do
     wallet
+    organization { wallet&.organization || association(:organization) }
     paid_credits { "10.00" }
     granted_credits { "10.00" }
     interval { "monthly" }

--- a/spec/factories/refunds.rb
+++ b/spec/factories/refunds.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :refund do
     credit_note
     payment
+    organization { credit_note&.organization || payment&.organization || association(:organization) }
     association :payment_provider, factory: :stripe_provider
     association :payment_provider_customer, factory: :stripe_customer
 

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :subscription do
     customer
     plan
+    organization { customer&.organization || plan&.organization || association(:organization) }
     status { :active }
     external_id { SecureRandom.uuid }
     started_at { 1.day.ago }

--- a/spec/factories/usage_thresholds.rb
+++ b/spec/factories/usage_thresholds.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :usage_threshold do
     plan
+    organization { plan&.organization || association(:organization) }
     threshold_display_name { Faker::Name.name }
     amount_cents { 100 }
     recurring { false }

--- a/spec/factories/wallet_transactions.rb
+++ b/spec/factories/wallet_transactions.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :wallet_transaction do
     wallet
+    organization { wallet&.organization || association(:organization) }
     transaction_type { "inbound" }
     status { "settled" }
     amount { "1.00" }

--- a/spec/factories/wallets.rb
+++ b/spec/factories/wallets.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :wallet do
     customer
+    organization { customer&.organization || association(:organization) }
     name { Faker::Name.name }
     status { "active" }
     rate_amount { "1.00" }

--- a/spec/factories/webhooks.rb
+++ b/spec/factories/webhooks.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :webhook do
     association :webhook_endpoint, factory: :webhook_endpoint
     association :object, factory: :invoice
+    organization { webhook_endpoint&.organization || object&.organization || association(:organization) }
 
     payload { Faker::Types.rb_hash(number: 3) }
     webhook_type { "invoice.created" }

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -383,7 +383,7 @@ RSpec.describe Subscription, type: :model do
   describe "#invoice_name" do
     subject(:subscription_invoice_name) { subscription.invoice_name }
 
-    let(:subscription) { build_stubbed(:subscription, plan:, name:) }
+    let(:subscription) { build(:subscription, plan:, name:, organization: plan.organization) }
 
     context "when plan invoice display name is blank" do
       let(:plan) { build_stubbed(:plan, invoice_display_name: [nil, ""].sample) }
@@ -626,13 +626,13 @@ RSpec.describe Subscription, type: :model do
   describe "#next_subscription" do
     subject { subscription.next_subscription }
 
-    let(:subscription) { build_stubbed(:subscription, next_subscriptions:) }
+    let(:subscription) { build(:subscription, next_subscriptions:, organization: plan.organization) }
 
     let(:next_subscriptions) do
       [
-        build_stubbed(:subscription, :canceled),
-        build_stubbed(:subscription, created_at: 1.day.ago),
-        build_stubbed(:subscription, created_at: 2.days.ago)
+        build(:subscription, :canceled, organization: plan.organization),
+        build(:subscription, created_at: 1.day.ago, organization: plan.organization),
+        build(:subscription, created_at: 2.days.ago, organization: plan.organization)
       ]
     end
 


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is making sure that all factories used in the spec suite are defining the organization association, in most cases by re-using a pre-existing one