### PR TITLE
fix(audit-logs): Add payment request resource type

### DIFF
--- a/app/graphql/types/activity_logs/resource_object.rb
+++ b/app/graphql/types/activity_logs/resource_object.rb
@@ -15,7 +15,8 @@ module Types
         Types::BillingEntities::Object,
         Types::Subscriptions::Object,
         Types::Wallets::Object,
-        Types::Coupons::Object
+        Types::Coupons::Object,
+        Types::PaymentRequests::Object
 
       def self.resolve_type(object, _context)
         case object.class.to_s
@@ -37,6 +38,8 @@ module Types
           Types::Wallets::Object
         when "Coupon"
           Types::Coupons::Object
+        when "PaymentRequest"
+          Types::PaymentRequests::Object
         else
           raise "Unexpected activity log resource type: #{object.inspect}"
         end

--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -78,7 +78,8 @@ module Clickhouse
       coupon_updated: "coupon.updated",
       coupon_deleted: "coupon.deleted",
       applied_coupon_created: "applied_coupon.created",
-      applied_coupon_deleted: "applied_coupon.deleted"
+      applied_coupon_deleted: "applied_coupon.deleted",
+      payment_request_created: "payment_request.created"
     }
 
     before_save :ensure_activity_id

--- a/app/models/clickhouse/activity_log.rb
+++ b/app/models/clickhouse/activity_log.rb
@@ -33,7 +33,8 @@ module Clickhouse
       billing_entity: "BillingEntity",
       subscription: "Subscription",
       wallet: "Wallet",
-      coupon: "Coupon"
+      coupon: "Coupon",
+      payment_request: "PaymentRequest"
     }.freeze
 
     ACTIVITY_TYPES = {

--- a/app/services/payment_requests/create_service.rb
+++ b/app/services/payment_requests/create_service.rb
@@ -36,6 +36,7 @@ module PaymentRequests
 
       after_commit do
         SendWebhookJob.perform_later("payment_request.created", payment_request)
+        Utils::ActivityLog.produce(payment_request, "payment_request.created")
 
         payment_result = PaymentRequests::Payments::CreateService.call_async(payable: payment_request)
         PaymentRequestMailer.with(payment_request:).requested.deliver_later unless payment_result.success?

--- a/schema.graphql
+++ b/schema.graphql
@@ -52,7 +52,7 @@ type ActivityLogCollection {
 """
 Activity log resource
 """
-union ActivityLogResourceObject = BillableMetric | BillingEntity | Coupon | CreditNote | Customer | Invoice | Plan | Subscription | Wallet
+union ActivityLogResourceObject = BillableMetric | BillingEntity | Coupon | CreditNote | Customer | Invoice | PaymentRequest | Plan | Subscription | Wallet
 
 """
 Activity Logs source enums
@@ -8419,6 +8419,11 @@ enum ResourceTypeEnum {
   Invoice
   """
   invoice
+
+  """
+  PaymentRequest
+  """
+  payment_request
 
   """
   Plan

--- a/schema.graphql
+++ b/schema.graphql
@@ -218,6 +218,11 @@ enum ActivityTypeEnum {
   payment_recorded
 
   """
+  payment_request.created
+  """
+  payment_request_created
+
+  """
   plan.created
   """
   plan_created

--- a/schema.json
+++ b/schema.json
@@ -662,6 +662,12 @@
               "description": "applied_coupon.deleted",
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "payment_request_created",
+              "description": "payment_request.created",
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/schema.json
+++ b/schema.json
@@ -356,6 +356,11 @@
             },
             {
               "kind": "OBJECT",
+              "name": "PaymentRequest",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Plan",
               "ofType": null
             },
@@ -43932,6 +43937,12 @@
             {
               "name": "coupon",
               "description": "Coupon",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "payment_request",
+              "description": "PaymentRequest",
               "isDeprecated": false,
               "deprecationReason": null
             }

--- a/spec/graphql/types/activity_logs/activity_type_enum_spec.rb
+++ b/spec/graphql/types/activity_logs/activity_type_enum_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Types::ActivityLogs::ActivityTypeEnum do
         coupon_deleted
         applied_coupon_created
         applied_coupon_deleted
+        payment_request_created
       ]
     )
   end

--- a/spec/graphql/types/activity_logs/resource_object_spec.rb
+++ b/spec/graphql/types/activity_logs/resource_object_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Types::ActivityLogs::ResourceObject do
       Types::BillingEntities::Object,
       Types::Subscriptions::Object,
       Types::Wallets::Object,
-      Types::Coupons::Object
+      Types::Coupons::Object,
+      Types::PaymentRequests::Object
     )
   end
 
@@ -33,6 +34,7 @@ RSpec.describe Types::ActivityLogs::ResourceObject do
     let(:subscription) { create(:subscription) }
     let(:wallet) { create(:wallet) }
     let(:coupon) { create(:coupon) }
+    let(:payment_request) { create(:payment_request) }
 
     it "returns Types::BillableMetrics::Object for BillableMetric objects" do
       expect(subject.resolve_type(billable_metric, {})).to eq(Types::BillableMetrics::Object)
@@ -72,6 +74,10 @@ RSpec.describe Types::ActivityLogs::ResourceObject do
 
     it "raises an error for unexpected types" do
       expect { subject.resolve_type("Unexpected", {}) }.to raise_error(StandardError)
+    end
+
+    it "returns Types::PaymentRequests::Object for PaymentRequest objects" do
+      expect(subject.resolve_type(payment_request, {})).to eq(Types::PaymentRequests::Object)
     end
   end
 end

--- a/spec/graphql/types/activity_logs/resource_type_enum_spec.rb
+++ b/spec/graphql/types/activity_logs/resource_type_enum_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Types::ActivityLogs::ResourceTypeEnum do
         subscription
         wallet
         coupon
+        payment_request
       ]
     )
   end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/access-audit-logs](https://getlago.canny.io/feature-requests/p/access-audit-logs)

## Context

Our users want to have visibility on what’s happening in Lago.

Examples:
- *A plan and prices have been updated: When? By whom? What?*
- *A subscription has been deleted: When? By whom? What?*

## Description

The goal of this PR is to
- add payment request resource type
- add `payment_request.created` activity log