### PR TITLE
chore(clickhouse): Enable charge caching

### DIFF
--- a/app/models/clickhouse/base_record.rb
+++ b/app/models/clickhouse/base_record.rb
@@ -3,6 +3,7 @@
 module Clickhouse
   class BaseRecord < ApplicationRecord
     self.abstract_class = true
+    self.ignored_columns = [] # Override ApplicationRecord settings
 
     connects_to database: {writing: :clickhouse, reading: :clickhouse}
   end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -99,7 +99,7 @@ module Invoices
         charge:,
         to_datetime: boundaries[:charges_to_datetime],
         # NOTE: Will be turned on for clickhouse in the future
-        cache: organization.clickhouse_events_store? ? false : with_cache
+        cache: with_cache
       )
 
       applied_boundaries = boundaries

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -98,7 +98,6 @@ module Invoices
         subscription:,
         charge:,
         to_datetime: boundaries[:charges_to_datetime],
-        # NOTE: Will be turned on for clickhouse in the future
         cache: with_cache
       )
 

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -175,8 +175,7 @@ module Invoices
               cache_middleware = Subscriptions::ChargeCacheMiddleware.new(
                 subscription:,
                 charge:,
-                to_datetime: boundaries[:charges_to_datetime],
-                cache: !organization.clickhouse_events_store?
+                to_datetime: boundaries[:charges_to_datetime]
               )
 
               Fees::ChargeService


### PR DESCRIPTION
## Description

Following the work done in https://github.com/getlago/lago/pull/542, this PR enable the caching logic for organization relying on the Clickhouse event store.

The cache expiration will be handled in the events-processor service.