### PR TITLE
Feat(multientities-cleanup): ignore applied_to_organization at dunning campaign

### DIFF
--- a/app/graphql/types/dunning_campaigns/object.rb
+++ b/app/graphql/types/dunning_campaigns/object.rb
@@ -34,12 +34,12 @@ module Types
               applied_dunning_campaign_id = :campaign_id
               OR (
                 applied_dunning_campaign_id IS NULL
-                AND billing_entity_id = :billing_entity_id
+                AND billing_entity_id IN (:billing_entity_ids)
               )
             )
           SQL
           campaign_id: object.id,
-          billing_entity_id: object.billing_entities.ids
+          billing_entity_ids: object.billing_entities.ids
         ).count
       end
       # rubocop:enable GraphQL/ResolverMethodLength

--- a/app/graphql/types/dunning_campaigns/object.rb
+++ b/app/graphql/types/dunning_campaigns/object.rb
@@ -21,6 +21,10 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      def applied_to_organization
+        object.organization.default_billing_entity.applied_dunning_campaign_id == object.id
+      end
+
       # rubocop:disable GraphQL/ResolverMethodLength
       def customers_count
         Customer.where(
@@ -30,18 +34,12 @@ module Types
               applied_dunning_campaign_id = :campaign_id
               OR (
                 applied_dunning_campaign_id IS NULL
-                AND organization_id = :organization_id
-                AND EXISTS (
-                  SELECT 1
-                  FROM dunning_campaigns
-                  WHERE id = :campaign_id
-                  AND applied_to_organization = true
-                )
+                AND billing_entity_id = :billing_entity_id
               )
             )
           SQL
           campaign_id: object.id,
-          organization_id: object.organization_id
+          billing_entity_id: object.billing_entities.ids
         ).count
       end
       # rubocop:enable GraphQL/ResolverMethodLength

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -53,18 +53,17 @@ end
 #
 # Table name: dunning_campaigns
 #
-#  id                      :uuid             not null, primary key
-#  applied_to_organization :boolean          default(FALSE), not null
-#  bcc_emails              :string           default([]), is an Array
-#  code                    :string           not null
-#  days_between_attempts   :integer          default(1), not null
-#  deleted_at              :datetime
-#  description             :text
-#  max_attempts            :integer          default(1), not null
-#  name                    :string           not null
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  organization_id         :uuid             not null
+#  id                    :uuid             not null, primary key
+#  bcc_emails            :string           default([]), is an Array
+#  code                  :string           not null
+#  days_between_attempts :integer          default(1), not null
+#  deleted_at            :datetime
+#  description           :text
+#  max_attempts          :integer          default(1), not null
+#  name                  :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  organization_id       :uuid             not null
 #
 # Indexes
 #

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -4,6 +4,7 @@ class DunningCampaign < ApplicationRecord
   include PaperTrailTraceable
   include Discard::Model
   self.discard_column = :deleted_at
+  self.ignored_columns += %w[applied_to_organization]
 
   ORDERS = %w[name code].freeze
 

--- a/app/queries/dunning_campaigns_query.rb
+++ b/app/queries/dunning_campaigns_query.rb
@@ -39,6 +39,8 @@ class DunningCampaignsQuery < BaseQuery
     DunningCampaign::ORDERS.include?(@order) ? @order : DEFAULT_ORDER
   end
 
+  # TODO: remove this method when we not apply dunning campaign on organization anymore
+  # will we need a way to filter by billing_entity_id?
   def with_applied_to_organization(scope)
     if filters.applied_to_organization
       scope.joins(:billing_entities).where(billing_entities: {id: organization.default_billing_entity.id})

--- a/app/queries/dunning_campaigns_query.rb
+++ b/app/queries/dunning_campaigns_query.rb
@@ -40,7 +40,14 @@ class DunningCampaignsQuery < BaseQuery
   end
 
   def with_applied_to_organization(scope)
-    scope.where(applied_to_organization: filters.applied_to_organization)
+    if filters.applied_to_organization
+      scope.joins(:billing_entities).where(billing_entities: {id: organization.default_billing_entity.id})
+    else
+      scope.left_joins(:billing_entities).where(
+        "billing_entities.id IS NULL OR billing_entities.id != ?",
+        organization.default_billing_entity.id
+      )
+    end
   end
 
   def with_currency_threshold(scope)

--- a/app/services/dunning_campaigns/create_service.rb
+++ b/app/services/dunning_campaigns/create_service.rb
@@ -22,7 +22,6 @@ module DunningCampaigns
         end
 
         dunning_campaign = organization.dunning_campaigns.create!(
-          applied_to_organization: params[:applied_to_organization],
           code: params[:code],
           bcc_emails: Array.wrap(params[:bcc_emails]),
           days_between_attempts: params[:days_between_attempts],

--- a/spec/factories/dunning_campaigns.rb
+++ b/spec/factories/dunning_campaigns.rb
@@ -7,6 +7,5 @@ FactoryBot.define do
     code { SecureRandom.uuid }
     days_between_attempts { Faker::Number.number(digits: 2) }
     max_attempts { Faker::Number.number(digits: 2) }
-    applied_to_organization { false }
   end
 end

--- a/spec/graphql/resolvers/dunning_campaign_resolver_spec.rb
+++ b/spec/graphql/resolvers/dunning_campaign_resolver_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Resolvers::DunningCampaignResolver, type: :graphql do
     )
   end
 
-  context "when the campaign is applied on 2 out of 3 billing enitties of the organization" do
+  context "when the campaign is applied on 2 out of 3 billing entities of the organization" do
     let(:dunning_campaign) { create(:dunning_campaign, organization:) }
     let(:another_dunning_campaign) { create(:dunning_campaign, organization:) }
     let(:billing_entity_2) { create(:billing_entity, organization:) }

--- a/spec/graphql/resolvers/dunning_campaign_resolver_spec.rb
+++ b/spec/graphql/resolvers/dunning_campaign_resolver_spec.rb
@@ -50,14 +50,14 @@ RSpec.describe Resolvers::DunningCampaignResolver, type: :graphql do
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "dunning_campaigns:view"
 
-  it "returns a single dunning campaign", :aggregate_failures do
+  it "returns a single dunning campaign" do
     dunning_campaign_response = result["data"]["dunningCampaign"]
 
     expect(dunning_campaign_response).to include(
       {
         "id" => dunning_campaign.id,
         "customersCount" => 0,
-        "appliedToOrganization" => dunning_campaign.applied_to_organization,
+        "appliedToOrganization" => organization.default_billing_entity.applied_dunning_campaign_id == dunning_campaign.id,
         "bccEmails" => dunning_campaign.bcc_emails,
         "code" => dunning_campaign.code,
         "daysBetweenAttempts" => dunning_campaign.days_between_attempts,
@@ -74,24 +74,32 @@ RSpec.describe Resolvers::DunningCampaignResolver, type: :graphql do
     )
   end
 
-  context "when the campaign is the organization's default campaign" do
-    let(:dunning_campaign) { create(:dunning_campaign, organization:, applied_to_organization: true) }
+  context "when the campaign is applied on 2 out of 3 billing enitties of the organization" do
+    let(:dunning_campaign) { create(:dunning_campaign, organization:) }
     let(:another_dunning_campaign) { create(:dunning_campaign, organization:) }
+    let(:billing_entity_2) { create(:billing_entity, organization:) }
+    let(:billing_entity_3) { create(:billing_entity, organization:) }
 
     before do
       create(:customer, organization:, exclude_from_dunning_campaign: true)
       create(:customer, organization:, applied_dunning_campaign: dunning_campaign)
       create(:customer, organization:, applied_dunning_campaign: another_dunning_campaign)
       create(:customer, organization:)
+      create(:customer, organization:, billing_entity: billing_entity_2)
+      create(:customer, organization:, billing_entity: billing_entity_3)
+
+      organization.default_billing_entity.update!(applied_dunning_campaign: dunning_campaign)
+      billing_entity_2.update!(applied_dunning_campaign: dunning_campaign)
+      billing_entity_3.update!(applied_dunning_campaign: another_dunning_campaign)
     end
 
-    it "includes all customers defaulting to organizations default in customers_count" do
-      expect(result["data"]["dunningCampaign"]["customersCount"]).to eq(2)
+    it "includes all customers defaulting to billing entities with the campaign applied in customers_count" do
+      expect(result["data"]["dunningCampaign"]["customersCount"]).to eq(3)
     end
   end
 
-  context "when the campaign is not the organization's default campaign" do
-    let(:dunning_campaign) { create(:dunning_campaign, organization:, applied_to_organization: false) }
+  context "when the campaign is not applied on any billing entity" do
+    let(:dunning_campaign) { create(:dunning_campaign, organization:) }
     let(:another_dunning_campaign) { create(:dunning_campaign, organization:) }
 
     before do

--- a/spec/services/dunning_campaigns/bulk_process_service_spec.rb
+++ b/spec/services/dunning_campaigns/bulk_process_service_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
         end
       end
 
-      context "when customer has an applied dunning campaign overwriting organization's default campaign" do
+      context "when customer has an applied dunning campaign overwriting billing entity's default campaign" do
         let(:customer) do
           create(
             :customer,
@@ -179,7 +179,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
         end
 
         let(:customer_dunning_campaign) do
-          create(:dunning_campaign, organization:, applied_to_organization: false)
+          create(:dunning_campaign, organization:)
         end
 
         let(:customer_dunning_campaign_threshold) do
@@ -270,7 +270,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
       end
 
       let(:dunning_campaign) do
-        create(:dunning_campaign, organization:, applied_to_organization: false)
+        create(:dunning_campaign, organization:)
       end
 
       let(:dunning_campaign_threshold) do
@@ -401,7 +401,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
     end
 
     context "when neither billing_entity nor customer has an applied dunning campaign" do
-      let(:dunning_campaign) { create :dunning_campaign, organization:, applied_to_organization: false }
+      let(:dunning_campaign) { create :dunning_campaign, organization: }
 
       let(:dunning_campaign_threshold) do
         create(

--- a/spec/services/dunning_campaigns/create_service_spec.rb
+++ b/spec/services/dunning_campaigns/create_service_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe DunningCampaigns::CreateService, type: :service do
         context "with applied_to_organization true" do
           let(:applied_to_organization) { true }
 
-          it "updates the default billing entity with applieddunning campaign" do
+          it "updates the default billing entity with applied_dunning_campaign" do
             result = create_service.call
 
             expect(result).to be_success

--- a/spec/services/dunning_campaigns/process_attempt_service_spec.rb
+++ b/spec/services/dunning_campaigns/process_attempt_service_spec.rb
@@ -150,9 +150,12 @@ RSpec.describe DunningCampaigns::ProcessAttemptService, type: :service, aggregat
         create(
           :dunning_campaign,
           organization:,
-          applied_to_organization: true,
           days_between_attempts: 10
         )
+      end
+
+      before do
+        billing_entity.update!(applied_dunning_campaign: dunning_campaign)
       end
 
       it "does nothing" do

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -446,7 +446,7 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           it "resets the defaulting customers last dunning campaign attempt fields" do
             expect { result }.to change { customer_defaulting.reload.last_dunning_campaign_attempt }.to(0)
-              .and change { customer_defaulting.last_dunning_campaign_attempt_at }.to(nil)
+              .and change(customer_defaulting, :last_dunning_campaign_attempt_at).to(nil)
           end
 
           it "does not reset the customers from another billing entity last dunning campaign attempt fields" do

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
   let(:organization) { create(:organization) }
   let(:billing_entity) { organization.default_billing_entity }
+  let(:billing_entity_2) { create(:billing_entity, organization:) }
   let(:membership) { create(:membership, organization:) }
   let(:dunning_campaign) do
-    create(:dunning_campaign, organization:, applied_to_organization: true)
+    create(:dunning_campaign, organization:)
   end
 
   let(:params) { {applied_to_organization: false} }
@@ -27,8 +28,8 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
         expect(result.error).to be_a(BaseService::ForbiddenFailure)
       end
 
-      it "does not update the dunning campaign" do
-        expect { result }.not_to change(dunning_campaign, :applied_to_organization)
+      it "does not change the applied dunning campaign on the billing entity" do
+        expect { result }.to not_change(billing_entity, :applied_dunning_campaign_id)
       end
     end
 
@@ -41,8 +42,8 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           expect(result.error).to be_a(BaseService::ForbiddenFailure)
         end
 
-        it "does not update the dunning campaign" do
-          expect { result }.not_to change(dunning_campaign, :applied_to_organization)
+        it "does not change the applied dunning campaign on the billing entity" do
+          expect { result }.to not_change(billing_entity, :applied_dunning_campaign_id)
         end
       end
 
@@ -100,6 +101,17 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
             last_dunning_campaign_attempt_at: 1.day.ago,
             organization: organization,
             billing_entity: billing_entity
+          )
+        end
+        let(:customer_from_another_billing_entity) do
+          create(
+            :customer,
+            currency: dunning_campaign_threshold.currency,
+            applied_dunning_campaign: nil,
+            last_dunning_campaign_attempt: 4,
+            last_dunning_campaign_attempt_at: 1.day.ago,
+            organization: organization,
+            billing_entity: billing_entity_2
           )
         end
 
@@ -198,6 +210,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           context "when the customer defaults to the campaign applied to billing entity" do
             include_examples "resets customer last dunning campaign attempt fields", :customer_defaulting
           end
+
+          context "when the customer defaults to the campaign applied to another billing entity" do
+            include_examples "does not reset customer last dunning campaign attempt fields", :customer_from_another_billing_entity
+          end
         end
 
         context "when threshold currency changes and does not apply anymore to the customer" do
@@ -232,6 +248,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the customer defaults to the campaign applied to organization" do
             include_examples "resets customer last dunning campaign attempt fields", :customer_defaulting
+          end
+
+          context "when the customer defaults to the campaign applied to another billing entity" do
+            include_examples "does not reset customer last dunning campaign attempt fields", :customer_from_another_billing_entity
           end
         end
 
@@ -269,6 +289,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the customer defaults to the campaign applied to organization" do
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_defaulting
+          end
+
+          context "when the customer defaults to the campaign applied to another billing entity" do
+            include_examples "does not reset customer last dunning campaign attempt fields", :customer_from_another_billing_entity
           end
         end
 
@@ -314,6 +338,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           context "when the customer defaults to the campaign applied to organization" do
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_defaulting
           end
+
+          context "when the customer defaults to the campaign applied to another billing entity" do
+            include_examples "does not reset customer last dunning campaign attempt fields", :customer_from_another_billing_entity
+          end
         end
 
         context "when a threshold is discarded and the campaign does not apply anymore to the customer" do
@@ -340,6 +368,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
 
           context "when the customer defaults to the campaign applied to organization" do
             include_examples "resets customer last dunning campaign attempt fields", :customer_defaulting
+          end
+
+          context "when the customer defaults to the campaign applied to another billing entity" do
+            include_examples "does not reset customer last dunning campaign attempt fields", :customer_from_another_billing_entity
           end
         end
 
@@ -377,6 +409,10 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
           context "when the customer defaults to the campaign applied to organization" do
             include_examples "does not reset customer last dunning campaign attempt fields", :customer_defaulting
           end
+
+          context "when the customer defaults to the campaign applied to another billing entity" do
+            include_examples "does not reset customer last dunning campaign attempt fields", :customer_from_another_billing_entity
+          end
         end
 
         context "when the input does not include a thresholds" do
@@ -397,14 +433,30 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
         context "with applied_to_organization false" do
           let(:params) { {applied_to_organization: false} }
 
-          it "updates the dunning campaign" do
-            expect(result).to be_success
-            expect(result.dunning_campaign.applied_to_organization).to eq(false)
+          before do
+            customer_assigned.reload
+            customer_defaulting.reload
+            customer_from_another_billing_entity.reload
           end
 
           it "unassigns dunning_campaign from the default billing entity" do
-            expect(result).to be_success
-            expect(organization.default_billing_entity.applied_dunning_campaign).to be_nil
+            expect { result }.to change { organization.default_billing_entity.applied_dunning_campaign_id }
+              .from(dunning_campaign.id).to(nil)
+          end
+
+          it "resets the defaulting customers last dunning campaign attempt fields" do
+            expect { result }.to change { customer_defaulting.reload.last_dunning_campaign_attempt }.to(0)
+              .and change { customer_defaulting.last_dunning_campaign_attempt_at }.to(nil)
+          end
+
+          it "does not reset the customers from another billing entity last dunning campaign attempt fields" do
+            expect { result }.to not_change { customer_from_another_billing_entity.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_from_another_billing_entity.last_dunning_campaign_attempt_at }
+          end
+
+          it "does not reset the assigned customers last dunning campaign attempt fields" do
+            expect { result }.to not_change { customer_assigned.reload.last_dunning_campaign_attempt }
+              .and not_change { customer_assigned.last_dunning_campaign_attempt_at }
           end
         end
 
@@ -419,35 +471,23 @@ RSpec.describe DunningCampaigns::UpdateService, type: :service do
             billing_entity.update!(applied_dunning_campaign: nil)
           end
 
-          it "updates the dunning campaign" do
-            expect(result).to be_success
-            expect(result.dunning_campaign.applied_to_organization).to eq(true)
-          end
-
           it "updates applied_dunning_campaign_id on the default billing entity" do
-            expect(result).to be_success
-            expect(organization.default_billing_entity.applied_dunning_campaign).to eq(result.dunning_campaign)
+            expect { result }.to change { organization.default_billing_entity.applied_dunning_campaign_id }
+              .from(nil).to(dunning_campaign.id)
           end
 
-          context "with a previous dunning campaign set as applied_to_organization" do
+          context "with a previous dunning campaign is applied to the default billing entity" do
             let(:dunning_campaign_2) do
-              create(:dunning_campaign, organization:, applied_to_organization: true)
+              create(:dunning_campaign, organization:)
             end
 
             before do
               billing_entity.update!(applied_dunning_campaign: dunning_campaign_2)
             end
 
-            it "removes applied_to_organization from previous dunning campaign" do
-              expect { result }
-                .to change { dunning_campaign_2.reload.applied_to_organization }
-                .from(true)
-                .to(false)
-            end
-
             it "changes applied_dunning_campaign_id on the default billing entity" do
-              expect(result).to be_success
-              expect(organization.default_billing_entity.applied_dunning_campaign).to eq(result.dunning_campaign)
+              expect { result }.to change { organization.default_billing_entity.applied_dunning_campaign_id }
+                .from(dunning_campaign_2.id).to(dunning_campaign.id)
             end
           end
 


### PR DESCRIPTION
## Context

We're planning to clean up a lot of data in the database for the columns that are not in use anymore. To do so we'll start introducing ignored columns on the models

## Description

This PR adds ignored_column on dunning campaign's applied_to_organization
