### PR TITLE
Add PricingUnitUsage model

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -19,8 +19,9 @@ class Fee < ApplicationRecord
   belongs_to :billing_entity
 
   has_one :adjusted_fee, dependent: :nullify
-  has_one :customer, through: :subscription
   has_one :billable_metric, -> { with_discarded }, through: :charge
+  has_one :customer, through: :subscription
+  has_one :pricing_unit_usage, dependent: :destroy
   has_one :true_up_fee, class_name: "Fee", foreign_key: :true_up_parent_fee_id, dependent: :destroy
 
   has_many :credit_note_items, dependent: :destroy

--- a/app/models/pricing_unit.rb
+++ b/app/models/pricing_unit.rb
@@ -2,6 +2,7 @@
 
 class PricingUnit < ApplicationRecord
   belongs_to :organization
+  has_many :pricing_unit_usages, dependent: :destroy
 
   validates :name, :code, :short_name, presence: true
   validates :code, uniqueness: {scope: :organization_id}

--- a/app/models/pricing_unit_usage.rb
+++ b/app/models/pricing_unit_usage.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class PricingUnitUsage < ApplicationRecord
+  belongs_to :organization
+  belongs_to :fee
+  belongs_to :pricing_unit
+
+  validates :short_name, :conversion_rate, presence: true
+  validates :conversion_rate, numericality: {greater_than: 0}
+
+  def self.build_from_aggregation(aggregation, applied_pricing_unit)
+    pricing_unit = applied_pricing_unit.pricing_unit
+
+    rounded_amount = aggregation.amount.round(pricing_unit.exponent)
+    amount_cents = rounded_amount * pricing_unit.subunit_to_unit
+    precise_amount_cents = aggregation.amount * pricing_unit.subunit_to_unit.to_d
+    unit_amount_cents = aggregation.unit_amount * pricing_unit.subunit_to_unit
+
+    new(
+      organization: pricing_unit.organization,
+      pricing_unit:,
+      short_name: pricing_unit.short_name,
+      conversion_rate: applied_pricing_unit.conversion_rate,
+      amount_cents:,
+      precise_amount_cents:,
+      unit_amount_cents:
+    )
+  end
+
+  def to_fiat_currency_cents(currency)
+    adjusted_amount = amount_cents.to_d * conversion_rate / pricing_unit.subunit_to_unit
+    adjusted_unit_amount = unit_amount_cents.to_d * conversion_rate / pricing_unit.subunit_to_unit
+
+    {
+      amount_cents: adjusted_amount.round(currency.exponent) * currency.subunit_to_unit,
+      precise_amount_cents: adjusted_amount * currency.subunit_to_unit.to_d,
+      unit_amount_cents: adjusted_unit_amount * currency.subunit_to_unit,
+      precise_unit_amount: adjusted_unit_amount
+    }
+  end
+end
+
+# == Schema Information
+#
+# Table name: pricing_unit_usages
+#
+#  id                   :uuid             not null, primary key
+#  amount_cents         :bigint           not null
+#  conversion_rate      :decimal(40, 15)  default(0.0), not null
+#  precise_amount_cents :decimal(40, 15)  default(0.0), not null
+#  short_name           :string           not null
+#  unit_amount_cents    :bigint           default(0), not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  fee_id               :uuid             not null
+#  organization_id      :uuid             not null
+#  pricing_unit_id      :uuid             not null
+#
+# Indexes
+#
+#  index_pricing_unit_usages_on_fee_id           (fee_id)
+#  index_pricing_unit_usages_on_organization_id  (organization_id)
+#  index_pricing_unit_usages_on_pricing_unit_id  (pricing_unit_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (fee_id => fees.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (pricing_unit_id => pricing_units.id)
+#

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -38,7 +38,7 @@ module Fees
       return result unless result.success?
 
       ActiveRecord::Base.transaction do
-        result.fees.reject! { |f| !should_persit_fee?(f, result.fees) }
+        result.fees.reject! { |f| !should_persist_fee?(f, result.fees) }
         next if context == :invoice_preview
 
         result.fees.each do |fee|
@@ -121,10 +121,19 @@ module Fees
 
       # NOTE: amount_result should be a BigDecimal, we need to round it
       # to the currency decimals and transform it into currency cents
-      rounded_amount = amount_result.amount.round(currency.exponent)
-      amount_cents = rounded_amount * currency.subunit_to_unit
-      precise_amount_cents = amount_result.amount * currency.subunit_to_unit.to_d
-      unit_amount_cents = amount_result.unit_amount * currency.subunit_to_unit
+      if charge.applied_pricing_unit
+        pricing_unit_usage = PricingUnitUsage.build_from_aggregation(amount_result, charge.applied_pricing_unit)
+        amount_cents, precise_amount_cents, unit_amount_cents, precise_unit_amount = pricing_unit_usage
+          .to_fiat_currency_cents(currency)
+          .values_at(:amount_cents, :precise_amount_cents, :unit_amount_cents, :precise_unit_amount)
+      else
+        pricing_unit_usage = nil
+        rounded_amount = amount_result.amount.round(currency.exponent)
+        amount_cents = rounded_amount * currency.subunit_to_unit
+        precise_amount_cents = amount_result.amount * currency.subunit_to_unit.to_d
+        unit_amount_cents = amount_result.unit_amount * currency.subunit_to_unit
+        precise_unit_amount = amount_result.unit_amount
+      end
 
       units = if current_usage && (charge.pay_in_advance? || charge.prorated?)
         amount_result.current_usage_units
@@ -154,10 +163,11 @@ module Fees
         taxes_amount_cents: 0,
         taxes_precise_amount_cents: 0.to_d,
         unit_amount_cents:,
-        precise_unit_amount: amount_result.unit_amount,
+        precise_unit_amount:,
         amount_details: amount_result.amount_details,
         grouped_by: amount_result.grouped_by || {},
-        charge_filter_id: charge_filter&.id
+        charge_filter_id: charge_filter&.id,
+        pricing_unit_usage:
       )
 
       unless charge.invoiceable?
@@ -176,7 +186,7 @@ module Fees
       new_fee
     end
 
-    def should_persit_fee?(fee, fees)
+    def should_persist_fee?(fee, fees)
       return true if context == :recurring
       return true if organization.zero_amount_fees_enabled?
       return true if fee.units != 0 || fee.amount_cents != 0 || fee.events_count != 0

--- a/db/migrate/20250610063400_create_pricing_unit_usages.rb
+++ b/db/migrate/20250610063400_create_pricing_unit_usages.rb
@@ -11,7 +11,7 @@ class CreatePricingUnitUsages < ActiveRecord::Migration[8.0]
       t.bigint :amount_cents, null: false
       t.decimal :precise_amount_cents, precision: 40, scale: 15, default: 0.0, null: false
       t.bigint :unit_amount_cents, default: 0, null: false
-      t.decimal :conversion_rate, precision: 40, scale: 15, default: "0.0", null: false
+      t.decimal :conversion_rate, precision: 40, scale: 15, default: 0.0, null: false
 
       t.timestamps
     end

--- a/db/migrate/20250610063400_create_pricing_unit_usages.rb
+++ b/db/migrate/20250610063400_create_pricing_unit_usages.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreatePricingUnitUsages < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pricing_unit_usages, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :fee, null: false, foreign_key: true, type: :uuid
+      t.references :pricing_unit, null: false, foreign_key: true, type: :uuid
+
+      t.string :short_name, null: false
+      t.bigint :amount_cents, null: false
+      t.decimal :precise_amount_cents, precision: 40, scale: 15, default: 0.0, null: false
+      t.bigint :unit_amount_cents, default: 0, null: false
+      t.decimal :conversion_rate, precision: 40, scale: 15, default: "0.0", null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -45,6 +45,7 @@ ALTER TABLE IF EXISTS ONLY public.plans DROP CONSTRAINT IF EXISTS fk_rails_cbf70
 ALTER TABLE IF EXISTS ONLY public.usage_thresholds DROP CONSTRAINT IF EXISTS fk_rails_caeb5a3949;
 ALTER TABLE IF EXISTS ONLY public.invites DROP CONSTRAINT IF EXISTS fk_rails_c71f4b2026;
 ALTER TABLE IF EXISTS ONLY public.customers_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_c64033bcb0;
+ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS fk_rails_c545103d57;
 ALTER TABLE IF EXISTS ONLY public.active_storage_attachments DROP CONSTRAINT IF EXISTS fk_rails_c3b3935057;
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_bff25bb1bb;
 ALTER TABLE IF EXISTS ONLY public.charge_filter_values DROP CONSTRAINT IF EXISTS fk_rails_bf661ef73d;
@@ -56,6 +57,7 @@ ALTER TABLE IF EXISTS ONLY public.lifetime_usages DROP CONSTRAINT IF EXISTS fk_r
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_b50dc82c1e;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_b283a89721;
 ALTER TABLE IF EXISTS ONLY public.daily_usages DROP CONSTRAINT IF EXISTS fk_rails_b07fc711f7;
+ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS fk_rails_aea6422e6a;
 ALTER TABLE IF EXISTS ONLY public.charges_taxes DROP CONSTRAINT IF EXISTS fk_rails_ac146c9541;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_subscription_activities DROP CONSTRAINT IF EXISTS fk_rails_ab16de0b32;
 ALTER TABLE IF EXISTS ONLY public.commitments_taxes DROP CONSTRAINT IF EXISTS fk_rails_aaa12f7d3e;
@@ -115,6 +117,7 @@ ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rai
 ALTER TABLE IF EXISTS ONLY public.billing_entities_taxes DROP CONSTRAINT IF EXISTS fk_rails_651eadaaa4;
 ALTER TABLE IF EXISTS ONLY public.memberships DROP CONSTRAINT IF EXISTS fk_rails_64267aab58;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS fk_rails_63d3df128b;
+ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS fk_rails_63ca8e33c5;
 ALTER TABLE IF EXISTS ONLY public.applied_invoice_custom_sections DROP CONSTRAINT IF EXISTS fk_rails_63ac282e70;
 ALTER TABLE IF EXISTS ONLY public.invoice_metadata DROP CONSTRAINT IF EXISTS fk_rails_63683837a2;
 ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS fk_rails_62d18ea517;
@@ -275,6 +278,9 @@ DROP INDEX IF EXISTS public.index_quantified_events_on_charge_filter_id;
 DROP INDEX IF EXISTS public.index_quantified_events_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_pricing_units_on_organization_id;
 DROP INDEX IF EXISTS public.index_pricing_units_on_code_and_organization_id;
+DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_pricing_unit_id;
+DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_organization_id;
+DROP INDEX IF EXISTS public.index_pricing_unit_usages_on_fee_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_tax_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_plan_id_and_tax_id;
 DROP INDEX IF EXISTS public.index_plans_taxes_on_plan_id;
@@ -595,6 +601,7 @@ ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS refunds_pkey
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS recurring_transaction_rules_pkey;
 ALTER TABLE IF EXISTS ONLY public.quantified_events DROP CONSTRAINT IF EXISTS quantified_events_pkey;
 ALTER TABLE IF EXISTS ONLY public.pricing_units DROP CONSTRAINT IF EXISTS pricing_units_pkey;
+ALTER TABLE IF EXISTS ONLY public.pricing_unit_usages DROP CONSTRAINT IF EXISTS pricing_unit_usages_pkey;
 ALTER TABLE IF EXISTS ONLY public.plans_taxes DROP CONSTRAINT IF EXISTS plans_taxes_pkey;
 ALTER TABLE IF EXISTS ONLY public.plans DROP CONSTRAINT IF EXISTS plans_pkey;
 ALTER TABLE IF EXISTS ONLY public.payments DROP CONSTRAINT IF EXISTS payments_pkey;
@@ -687,6 +694,7 @@ DROP TABLE IF EXISTS public.refunds;
 DROP TABLE IF EXISTS public.recurring_transaction_rules;
 DROP TABLE IF EXISTS public.quantified_events;
 DROP TABLE IF EXISTS public.pricing_units;
+DROP TABLE IF EXISTS public.pricing_unit_usages;
 DROP TABLE IF EXISTS public.payments;
 DROP TABLE IF EXISTS public.payment_requests;
 DROP TABLE IF EXISTS public.payment_receipts;
@@ -3369,6 +3377,25 @@ CREATE TABLE public.payments (
 
 
 --
+-- Name: pricing_unit_usages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.pricing_unit_usages (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    fee_id uuid NOT NULL,
+    pricing_unit_id uuid NOT NULL,
+    short_name character varying NOT NULL,
+    amount_cents bigint NOT NULL,
+    precise_amount_cents numeric(40,15) DEFAULT 0.0 NOT NULL,
+    unit_amount_cents bigint DEFAULT 0 NOT NULL,
+    conversion_rate numeric(40,15) DEFAULT 0.0 NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: pricing_units; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4255,6 +4282,14 @@ ALTER TABLE ONLY public.plans
 
 ALTER TABLE ONLY public.plans_taxes
     ADD CONSTRAINT plans_taxes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pricing_unit_usages pricing_unit_usages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pricing_unit_usages
+    ADD CONSTRAINT pricing_unit_usages_pkey PRIMARY KEY (id);
 
 
 --
@@ -6516,6 +6551,27 @@ CREATE INDEX index_plans_taxes_on_tax_id ON public.plans_taxes USING btree (tax_
 
 
 --
+-- Name: index_pricing_unit_usages_on_fee_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pricing_unit_usages_on_fee_id ON public.pricing_unit_usages USING btree (fee_id);
+
+
+--
+-- Name: index_pricing_unit_usages_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pricing_unit_usages_on_organization_id ON public.pricing_unit_usages USING btree (organization_id);
+
+
+--
+-- Name: index_pricing_unit_usages_on_pricing_unit_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pricing_unit_usages_on_pricing_unit_id ON public.pricing_unit_usages USING btree (pricing_unit_id);
+
+
+--
 -- Name: index_pricing_units_on_code_and_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7669,6 +7725,14 @@ ALTER TABLE ONLY public.applied_invoice_custom_sections
 
 
 --
+-- Name: pricing_unit_usages fk_rails_63ca8e33c5; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pricing_unit_usages
+    ADD CONSTRAINT fk_rails_63ca8e33c5 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: subscriptions fk_rails_63d3df128b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8141,6 +8205,14 @@ ALTER TABLE ONLY public.charges_taxes
 
 
 --
+-- Name: pricing_unit_usages fk_rails_aea6422e6a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pricing_unit_usages
+    ADD CONSTRAINT fk_rails_aea6422e6a FOREIGN KEY (fee_id) REFERENCES public.fees(id);
+
+
+--
 -- Name: daily_usages fk_rails_b07fc711f7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8226,6 +8298,14 @@ ALTER TABLE ONLY public.customers
 
 ALTER TABLE ONLY public.active_storage_attachments
     ADD CONSTRAINT fk_rails_c3b3935057 FOREIGN KEY (blob_id) REFERENCES public.active_storage_blobs(id);
+
+
+--
+-- Name: pricing_unit_usages fk_rails_c545103d57; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pricing_unit_usages
+    ADD CONSTRAINT fk_rails_c545103d57 FOREIGN KEY (pricing_unit_id) REFERENCES public.pricing_units(id);
 
 
 --
@@ -8523,6 +8603,7 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250610063400'),
 ('20250609121102'),
 ('20250602145535'),
 ('20250602075710'),

--- a/spec/factories/pricing_unit_usages.rb
+++ b/spec/factories/pricing_unit_usages.rb
@@ -2,11 +2,12 @@
 
 FactoryBot.define do
   factory :pricing_unit_usage do
+    organization { fee&.organization || pricing_unit&.organization || association(:organization) }
     fee
     pricing_unit
     short_name { pricing_unit.short_name }
     amount_cents { 200 }
-    precise_amount_cents { 200.0000000001 }
+    precise_amount_cents { BigDecimal("200.0000000001") }
     unit_amount_cents { 10 }
     conversion_rate { 1.0 }
   end

--- a/spec/factories/pricing_unit_usages.rb
+++ b/spec/factories/pricing_unit_usages.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :pricing_unit_usage do
+    fee
+    pricing_unit
+    short_name { pricing_unit.short_name }
+    amount_cents { 200 }
+    precise_amount_cents { 200.0000000001 }
+    unit_amount_cents { 10 }
+    conversion_rate { 1.0 }
+  end
+end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -3,14 +3,18 @@
 require "rails_helper"
 
 RSpec.describe Fee, type: :model do
-  subject(:fee_model) { described_class }
+  it { is_expected.to have_one(:adjusted_fee).dependent(:nullify) }
+  it { is_expected.to have_one(:billable_metric).through(:charge) }
+  it { is_expected.to have_one(:customer).through(:subscription) }
+  it { is_expected.to have_one(:pricing_unit_usage).dependent(:destroy) }
+  it { is_expected.to have_one(:true_up_fee).with_foreign_key(:true_up_parent_fee_id).class_name("Fee").dependent(:destroy) }
 
-  describe ".item_code" do
+  describe "#item_code" do
     context "when it is a subscription fee" do
       let(:subscription) { create(:subscription) }
 
       it "returns related subscription code" do
-        expect(fee_model.new(subscription:, fee_type: "subscription").item_code)
+        expect(described_class.new(subscription:, fee_type: "subscription").item_code)
           .to eq(subscription.plan.code)
       end
     end
@@ -19,7 +23,7 @@ RSpec.describe Fee, type: :model do
       let(:charge) { create(:standard_charge) }
 
       it "returns related billable metric code" do
-        expect(fee_model.new(charge:, fee_type: "charge").item_code)
+        expect(described_class.new(charge:, fee_type: "charge").item_code)
           .to eq(charge.billable_metric.code)
       end
     end
@@ -28,14 +32,14 @@ RSpec.describe Fee, type: :model do
       let(:applied_add_on) { create(:applied_add_on) }
 
       it "returns add on code" do
-        expect(fee_model.new(applied_add_on:, fee_type: "add_on").item_code)
+        expect(described_class.new(applied_add_on:, fee_type: "add_on").item_code)
           .to eq(applied_add_on.add_on.code)
       end
     end
 
     context "when it is a credit fee" do
       it "returns add on code" do
-        expect(fee_model.new(fee_type: "credit").item_code).to eq("credit")
+        expect(described_class.new(fee_type: "credit").item_code).to eq("credit")
       end
     end
 
@@ -43,7 +47,7 @@ RSpec.describe Fee, type: :model do
       let(:charge) { create(:standard_charge, :pay_in_advance) }
 
       it "returns related billable metric code" do
-        expect(fee_model.new(charge:, fee_type: "charge").item_code)
+        expect(described_class.new(charge:, fee_type: "charge").item_code)
           .to eq(charge.billable_metric.code)
       end
     end
@@ -133,12 +137,12 @@ RSpec.describe Fee, type: :model do
     end
   end
 
-  describe ".item_name" do
+  describe "#item_name" do
     context "when it is a subscription fee" do
       let(:subscription) { create(:subscription) }
 
       it "returns related subscription name" do
-        expect(fee_model.new(subscription:, fee_type: "subscription").item_name)
+        expect(described_class.new(subscription:, fee_type: "subscription").item_name)
           .to eq(subscription.plan.name)
       end
     end
@@ -147,7 +151,7 @@ RSpec.describe Fee, type: :model do
       let(:charge) { create(:standard_charge) }
 
       it "returns related billable metric name" do
-        expect(fee_model.new(charge:, fee_type: "charge").item_name)
+        expect(described_class.new(charge:, fee_type: "charge").item_name)
           .to eq(charge.billable_metric.name)
       end
     end
@@ -156,14 +160,14 @@ RSpec.describe Fee, type: :model do
       let(:applied_add_on) { create(:applied_add_on) }
 
       it "returns add on name" do
-        expect(fee_model.new(applied_add_on:, fee_type: "add_on").item_name)
+        expect(described_class.new(applied_add_on:, fee_type: "add_on").item_name)
           .to eq(applied_add_on.add_on.name)
       end
     end
 
     context "when it is a credit fee" do
       it "returns 'credit'" do
-        expect(fee_model.new(fee_type: "credit").item_name).to eq("credit")
+        expect(described_class.new(fee_type: "credit").item_name).to eq("credit")
       end
     end
 
@@ -171,18 +175,18 @@ RSpec.describe Fee, type: :model do
       let(:charge) { create(:standard_charge, :pay_in_advance) }
 
       it "returns related billable metric name" do
-        expect(fee_model.new(charge:, fee_type: "charge").item_name)
+        expect(described_class.new(charge:, fee_type: "charge").item_name)
           .to eq(charge.billable_metric.name)
       end
     end
   end
 
-  describe ".item_description" do
+  describe "#item_description" do
     context "when it is a subscription fee" do
       let(:subscription) { create(:subscription) }
 
       it "returns related subscription description" do
-        expect(fee_model.new(subscription:, fee_type: "subscription").item_description)
+        expect(described_class.new(subscription:, fee_type: "subscription").item_description)
           .to eq(subscription.plan.description)
       end
     end
@@ -191,7 +195,7 @@ RSpec.describe Fee, type: :model do
       let(:charge) { create(:standard_charge) }
 
       it "returns related billable metric description" do
-        expect(fee_model.new(charge:, fee_type: "charge").item_description)
+        expect(described_class.new(charge:, fee_type: "charge").item_description)
           .to eq(charge.billable_metric.description)
       end
     end
@@ -200,14 +204,14 @@ RSpec.describe Fee, type: :model do
       let(:applied_add_on) { create(:applied_add_on) }
 
       it "returns add on description" do
-        expect(fee_model.new(applied_add_on:, fee_type: "add_on").item_description)
+        expect(described_class.new(applied_add_on:, fee_type: "add_on").item_description)
           .to eq(applied_add_on.add_on.description)
       end
     end
 
     context "when it is a credit fee" do
       it "returns 'credit'" do
-        expect(fee_model.new(fee_type: "credit").item_description).to eq("credit")
+        expect(described_class.new(fee_type: "credit").item_description).to eq("credit")
       end
     end
 
@@ -215,7 +219,7 @@ RSpec.describe Fee, type: :model do
       let(:charge) { create(:standard_charge, :pay_in_advance) }
 
       it "returns related billable metric description" do
-        expect(fee_model.new(charge:, fee_type: "charge").item_description)
+        expect(described_class.new(charge:, fee_type: "charge").item_description)
           .to eq(charge.billable_metric.description)
       end
     end
@@ -226,7 +230,7 @@ RSpec.describe Fee, type: :model do
       let(:subscription) { create(:subscription) }
 
       it "returns subscription" do
-        expect(fee_model.new(subscription:, fee_type: "subscription").item_type)
+        expect(described_class.new(subscription:, fee_type: "subscription").item_type)
           .to eq("Subscription")
       end
     end
@@ -235,7 +239,7 @@ RSpec.describe Fee, type: :model do
       let(:charge) { create(:standard_charge) }
 
       it "returns billable metric" do
-        expect(fee_model.new(charge:, fee_type: "charge").item_type)
+        expect(described_class.new(charge:, fee_type: "charge").item_type)
           .to eq("BillableMetric")
       end
     end
@@ -244,14 +248,14 @@ RSpec.describe Fee, type: :model do
       let(:applied_add_on) { create(:applied_add_on) }
 
       it "returns add on" do
-        expect(fee_model.new(applied_add_on:, fee_type: "add_on").item_type)
+        expect(described_class.new(applied_add_on:, fee_type: "add_on").item_type)
           .to eq("AddOn")
       end
     end
 
     context "when it is a credit fee" do
       it "returns wallet transaction" do
-        expect(fee_model.new(fee_type: "credit").item_type).to eq("WalletTransaction")
+        expect(described_class.new(fee_type: "credit").item_type).to eq("WalletTransaction")
       end
     end
 
@@ -259,7 +263,7 @@ RSpec.describe Fee, type: :model do
       let(:charge) { create(:standard_charge, :pay_in_advance) }
 
       it "returns billable metric" do
-        expect(fee_model.new(charge:, fee_type: "charge").item_type)
+        expect(described_class.new(charge:, fee_type: "charge").item_type)
           .to eq("BillableMetric")
       end
     end
@@ -270,7 +274,7 @@ RSpec.describe Fee, type: :model do
       let(:subscription) { create(:subscription) }
 
       it "returns the subscription id" do
-        expect(fee_model.new(subscription:, fee_type: "subscription").item_id)
+        expect(described_class.new(subscription:, fee_type: "subscription").item_id)
           .to eq(subscription.id)
       end
     end
@@ -279,7 +283,7 @@ RSpec.describe Fee, type: :model do
       let(:charge) { create(:standard_charge) }
 
       it "returns the billable metric id" do
-        expect(fee_model.new(charge:, fee_type: "charge").item_id)
+        expect(described_class.new(charge:, fee_type: "charge").item_id)
           .to eq(charge.billable_metric.id)
       end
     end
@@ -288,7 +292,7 @@ RSpec.describe Fee, type: :model do
       let(:applied_add_on) { create(:applied_add_on) }
 
       it "returns the add on id" do
-        expect(fee_model.new(applied_add_on:, fee_type: "add_on").item_id)
+        expect(described_class.new(applied_add_on:, fee_type: "add_on").item_id)
           .to eq(applied_add_on.add_on_id)
       end
     end
@@ -297,7 +301,7 @@ RSpec.describe Fee, type: :model do
       let(:wallet_transaction) { create(:wallet_transaction) }
 
       it "returns the wallet transaction id" do
-        expect(fee_model.new(fee_type: "credit", invoiceable: wallet_transaction).item_id)
+        expect(described_class.new(fee_type: "credit", invoiceable: wallet_transaction).item_id)
           .to eq(wallet_transaction.id)
       end
     end
@@ -306,7 +310,7 @@ RSpec.describe Fee, type: :model do
       let(:charge) { create(:standard_charge, :pay_in_advance) }
 
       it "returns the billable metric id" do
-        expect(fee_model.new(charge:, fee_type: "charge").item_id)
+        expect(described_class.new(charge:, fee_type: "charge").item_id)
           .to eq(charge.billable_metric.id)
       end
     end
@@ -348,7 +352,7 @@ RSpec.describe Fee, type: :model do
 
   describe "#invoice_sorting_clause" do
     let(:charge) { create(:standard_charge, properties:) }
-    let(:fee) { fee_model.new(charge:, fee_type: "charge", grouped_by:) }
+    let(:fee) { described_class.new(charge:, fee_type: "charge", grouped_by:) }
     let(:grouped_by) do
       {
         "key_1" => "mercredi",
@@ -383,7 +387,7 @@ RSpec.describe Fee, type: :model do
     end
   end
 
-  describe ".has_charge_filter?" do
+  describe "#has_charge_filter?" do
     subject(:fee) { create(:add_on_fee) }
 
     it { expect(fee).not_to be_has_charge_filters }
@@ -403,21 +407,32 @@ RSpec.describe Fee, type: :model do
     end
   end
 
-  describe "compute_precise_credit_amount_cents" do
-    subject(:fee) { create(:add_on_fee, amount_cents: 500, precise_coupons_amount_cents: 100) }
+  describe "#compute_precise_credit_amount_cents" do
+    subject { fee.compute_precise_credit_amount_cents(credit_amount, base_amount_cents) }
 
-    it "returns correct value" do
-      expect(fee.compute_precise_credit_amount_cents(10, 5)).to eq(800)
+    let(:fee) { create(:add_on_fee, amount_cents: 500, precise_coupons_amount_cents: 100) }
+    let(:credit_amount) { 10 }
+
+    context "when base amount cents is non-zero" do
+      let(:base_amount_cents) { 5 }
+
+      it "returns correct value" do
+        expect(subject).to eq(800)
+      end
     end
 
-    context "when base_amount_cents is zero" do
+    context "when base amount cents is zero" do
+      let(:base_amount_cents) { 0 }
+
       it "returns zero" do
-        expect(fee.compute_precise_credit_amount_cents(10, 0)).to eq(0)
+        expect(subject).to eq(0)
       end
     end
   end
 
   describe "#creditable_amount_cents" do
+    subject { fee.creditable_amount_cents }
+
     let(:fee) { create(:fee, fee_type:, amount_cents:, invoice:) }
     let(:invoice) { create(:invoice, invoice_type: :credit) }
     let(:amount_cents) { 1000 }
@@ -426,7 +441,7 @@ RSpec.describe Fee, type: :model do
       let(:fee_type) { "subscription" }
 
       it "returns the correct creditable amount" do
-        expect(fee.creditable_amount_cents).to eq(1000)
+        expect(subject).to eq(1000)
       end
     end
 
@@ -435,7 +450,7 @@ RSpec.describe Fee, type: :model do
       let(:wallet_transaction) { create(:wallet_transaction, wallet:) }
 
       it "returns the correct creditable amount when no associated wallet is found" do
-        expect(fee.creditable_amount_cents).to eq(0)
+        expect(subject).to eq(0)
       end
 
       context "when associated walled exists" do
@@ -445,7 +460,7 @@ RSpec.describe Fee, type: :model do
           let(:wallet) { create(:wallet, balance_cents: 500, customer: invoice.customer) }
 
           it "returns the wallet balance" do
-            expect(fee.creditable_amount_cents).to eq(500)
+            expect(subject).to eq(500)
           end
         end
 
@@ -453,7 +468,7 @@ RSpec.describe Fee, type: :model do
           let(:wallet) { create(:wallet, balance_cents: 1500, customer: invoice.customer) }
 
           it "returns the wallet balance" do
-            expect(fee.creditable_amount_cents).to eq(1000)
+            expect(subject).to eq(1000)
           end
         end
 
@@ -461,7 +476,7 @@ RSpec.describe Fee, type: :model do
           let(:wallet) { create(:wallet, balance_cents: 1500, status: :terminated, customer: invoice.customer) }
 
           it "returns the wallet balance" do
-            expect(fee.creditable_amount_cents).to eq(0)
+            expect(subject).to eq(0)
           end
         end
       end

--- a/spec/models/pricing_unit_usage_spec.rb
+++ b/spec/models/pricing_unit_usage_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PricingUnitUsage, type: :model do
+  subject { build(:pricing_unit_usage) }
+
+  it { is_expected.to belong_to(:organization) }
+  it { is_expected.to belong_to(:fee) }
+  it { is_expected.to belong_to(:pricing_unit) }
+
+  it { is_expected.to validate_presence_of(:short_name) }
+  it { is_expected.to validate_presence_of(:conversion_rate) }
+  it { is_expected.to validate_numericality_of(:conversion_rate).is_greater_than(0) }
+
+  describe ".build_from_aggregation" do
+    subject { described_class.build_from_aggregation(aggregation, applied_pricing_unit) }
+
+    let(:pricing_unit) { create(:pricing_unit) }
+    let(:applied_pricing_unit) { create(:applied_pricing_unit, pricing_unit:, conversion_rate: 3.0150695) }
+    let(:aggregation) { Struct.new(:amount, :unit_amount).new(10655.243249, 5.5) }
+
+    let(:expected_attributes) do
+      {
+        organization: pricing_unit.organization,
+        pricing_unit:,
+        short_name: pricing_unit.short_name,
+        conversion_rate: applied_pricing_unit.conversion_rate,
+        amount_cents: 1065524,
+        precise_amount_cents: 1065524.3249,
+        unit_amount_cents: 550
+      }
+    end
+
+    it "builds a new pricing unit usage with normalized amounts" do
+      expect(subject)
+        .to be_a(described_class)
+        .and be_new_record
+        .and have_attributes(expected_attributes)
+    end
+  end
+
+  describe "#to_fiat_currency_cents" do
+    subject { pricing_unit_usage.to_fiat_currency_cents(fiat_currency) }
+
+    let(:pricing_unit_usage) do
+      build(
+        :pricing_unit_usage,
+        amount_cents: 1065524,
+        precise_amount_cents: 1065524.3249,
+        unit_amount_cents: 550,
+        conversion_rate: 0.0075
+      )
+    end
+
+    let(:fiat_currency) { Money::Currency.new("USD") }
+
+    it "returns a hash with converted amounts" do
+      expect(subject).to be_a(Hash)
+      expect(subject[:amount_cents]).to eq(7991)
+      expect(subject[:precise_amount_cents]).to eq(7991.43)
+      expect(subject[:unit_amount_cents]).to eq(4.125)
+      expect(subject[:precise_unit_amount]).to eq(0.04125)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Another step towards PricingUnit feature, this time adding new model PricingUnitUsage. It will store usage in pricing units for a Fee, leaving Fee model itself not changed.

## Description

Add PricingUnitUsage model.
Adjustments to the Fees::ChargeService.
