### PR TITLE
feat(alerting): Serialize `customer_external_id` to TriggeredAlerts

### DIFF
--- a/app/serializers/v1/usage_monitoring/triggered_alert_serializer.rb
+++ b/app/serializers/v1/usage_monitoring/triggered_alert_serializer.rb
@@ -10,6 +10,7 @@ module V1
           lago_alert_id: alert.id,
           lago_subscription_id: model.subscription_id,
           subscription_external_id: alert.subscription_external_id,
+          customer_external_id: model.subscription.customer.external_id,
           billable_metric_code: alert.billable_metric&.code,
           alert_name: alert.name,
           alert_code: alert.code,

--- a/spec/serializers/v1/usage_monitoring/triggered_alert_serializer_spec.rb
+++ b/spec/serializers/v1/usage_monitoring/triggered_alert_serializer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ::V1::UsageMonitoring::TriggeredAlertSerializer do
   subject(:serializer) { described_class.new(triggered_alert, root_name: "triggered_alert") }
 
   let(:triggered_alert) { create(:triggered_alert, alert:, subscription:, triggered_at: DateTime.new(2000, 1, 1, 12, 0, 0)) }
-  let(:subscription) { create(:subscription, external_id: "ext-id") }
+  let(:subscription) { create(:subscription, external_id: "ext-id", customer: create(:customer, external_id: "cust-ext-id")) }
 
   before { triggered_alert }
 
@@ -22,6 +22,7 @@ RSpec.describe ::V1::UsageMonitoring::TriggeredAlertSerializer do
       expect(payload["lago_alert_id"]).to eq(triggered_alert.alert.id)
       expect(payload["lago_subscription_id"]).to eq(triggered_alert.subscription.id)
       expect(payload["subscription_external_id"]).to eq("ext-id")
+      expect(payload["customer_external_id"]).to eq("cust-ext-id")
       expect(payload["billable_metric_code"]).to be_nil
       expect(payload["alert_name"]).to eq("General Alert")
       expect(payload["alert_code"]).to eq("first")


### PR DESCRIPTION
A TriggeredAlert is saved to DB when the current usage of the subscription crosses an alerting thresholds.

It's sent over webhooks (serialized once and saved to `webhooks.payload` column). There is no API or graphql resolver to access triggered alerts.

This adds 2 queries to the serialization. Nowhere in the code we serialize multiple triggered alert, so no "eager load" to edit.

This is done to help customer easily retrieve the customer to warn.

![CleanShot 2025-06-12 at 09 45 15@2x](https://github.com/user-attachments/assets/d3443021-887b-4f44-8550-5260b78d51e0)
