### PR TITLE
fix(dates): Fix validation of impossible dates

### DIFF
--- a/app/controllers/concerns/common.rb
+++ b/app/controllers/concerns/common.rb
@@ -8,10 +8,9 @@ module Common
   def valid_date?(date)
     return false unless date
 
-    parsed_date = Date._strptime(date)
-
-    return false unless parsed_date
-
+    Date.strptime(date)
     true
+  rescue Date::Error
+    false
   end
 end

--- a/spec/controllers/concerns/common_spec.rb
+++ b/spec/controllers/concerns/common_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Common do
-  subject(:controller) { klass.new }
+  let(:controller) { klass.new }
 
   let(:klass) do
     Class.new do
@@ -11,25 +11,45 @@ RSpec.describe Common do
   end
 
   describe "#valid_date?" do
+    subject(:method_call) { controller.valid_date?(date) }
+
     context "when date is nil" do
+      let(:date) { nil }
+
       it "returns false" do
-        expect(controller.valid_date?(nil)).to be false
+        expect(subject).to be false
+      end
+    end
+
+    context "when date is empty string" do
+      let(:date) { "" }
+
+      it "returns false" do
+        expect(subject).to be false
       end
     end
 
     context "when a valid date string is provided" do
+      let(:date) { "2021-01-01" }
+
       it "returns true" do
-        expect(controller.valid_date?("2021-02-28")).to be true
+        expect(subject).to be true
       end
     end
 
     context "when an invalid date string is provided" do
-      it "returns false for an impossible date" do
-        expect(controller.valid_date?("2021-02-30")).to be false
-      end
+      let(:date) { "2021-02-30" }
 
-      it "returns false for a malformed date string" do
-        expect(controller.valid_date?("not-a-date")).to be false
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "when a malformed date sis provided" do
+      let(:date) { "not-a-date" }
+
+      it "returns false " do
+        expect(subject).to be false
       end
     end
   end

--- a/spec/controllers/concerns/common_spec.rb
+++ b/spec/controllers/concerns/common_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Common do
+  subject(:controller) { klass.new }
+
+  let(:klass) do
+    Class.new do
+      include Common
+      public :valid_date? # expose for testing
+    end
+  end
+
+  describe "#valid_date?" do
+    context "when date is nil" do
+      it "returns false" do
+        expect(controller.valid_date?(nil)).to be false
+      end
+    end
+
+    context "when a valid date string is provided" do
+      it "returns true" do
+        expect(controller.valid_date?("2021-02-28")).to be true
+      end
+    end
+
+    context "when an invalid date string is provided" do
+      it "returns false for an impossible date" do
+        expect(controller.valid_date?("2021-02-30")).to be false
+      end
+
+      it "returns false for a malformed date string" do
+        expect(controller.valid_date?("not-a-date")).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

It was possible to call `GET /api/v1/invoices` API endpoint with impossible `issuing_date_from`, `issuing_date_to` params e.g.: `2025-02-30`

## Description

Fix the validation method: `Common#valid_date?`