### PR TITLE
misc(organization): Ensure organization_id is added everywhere

### DIFF
--- a/app/services/billing_entities/taxes/manage_taxes_service.rb
+++ b/app/services/billing_entities/taxes/manage_taxes_service.rb
@@ -3,7 +3,8 @@
 module BillingEntities
   module Taxes
     class ManageTaxesService < BaseService
-      Result = BaseResult[:taxes]
+      Result = BaseResult[:taxes, :applied_taxes]
+
       def initialize(billing_entity:, tax_codes:)
         @billing_entity = billing_entity
         @tax_codes = tax_codes || []
@@ -32,10 +33,15 @@ module BillingEntities
 
         if taxes.count != unique_tax_codes.count
           result.not_found_failure!(resource: "tax")
+          return
+        end
+
+        billing_entity.applied_taxes = taxes.map do |tax|
+          BillingEntity::AppliedTax.new(billing_entity:, tax:, organization:)
         end
 
         result.taxes = taxes
-        billing_entity.taxes = taxes
+        result.applied_taxes = billing_entity.applied_taxes
       end
     end
   end

--- a/app/services/integration_collection_mappings/create_service.rb
+++ b/app/services/integration_collection_mappings/create_service.rb
@@ -21,6 +21,7 @@ module IntegrationCollectionMappings
         mapping_type: params[:mapping_type]
       )
 
+      integration_collection_mapping.organization = integration.organization
       integration_collection_mapping.external_id = params[:external_id] if params.key?(:external_id)
       if params.key?(:external_account_code)
         integration_collection_mapping.external_account_code = params[:external_account_code]

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -84,6 +84,7 @@ module Invoices
         increment_payment_attempts
 
         payment = Payment.find_or_initialize_by(
+          organization: @invoice.organization,
           payable: @invoice,
           payment_provider_id: stripe_payment_provider.id,
           payment_provider_customer_id: customer.stripe_customer.id,

--- a/spec/factories/billing_entity_applied_taxes.rb
+++ b/spec/factories/billing_entity_applied_taxes.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :billing_entity_applied_tax, class: "BillingEntity::AppliedTax" do
     billing_entity
     tax
+    organization { billing_entity&.organization || tax&.organization || association(:organization) }
   end
 end

--- a/spec/factories/charge_applied_taxes.rb
+++ b/spec/factories/charge_applied_taxes.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :charge_applied_tax, class: "Charge::AppliedTax" do
-    charge
+    association :charge, factory: :standard_charge
     tax
     organization { charge&.organization || tax&.organization || association(:organization) }
   end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
       status { :pending }
     end
 
-    trait :subscription do
+    trait :with_subscriptions do
       transient do
         subscriptions { [create(:subscription)] }
       end
@@ -59,6 +59,11 @@ FactoryBot.define do
           create(:invoice_subscription, :boundaries, invoice:, subscription:)
         end
       end
+    end
+
+    trait :subscription do
+      invoice_type { :subscription }
+      with_subscriptions
     end
 
     trait :self_billed do

--- a/spec/factories/payment_requests.rb
+++ b/spec/factories/payment_requests.rb
@@ -11,5 +11,15 @@ FactoryBot.define do
     payment_status { "pending" }
     ready_for_payment_processing { true }
     payment_attempts { 0 }
+
+    transient do
+      invoices { [] }
+    end
+
+    after(:create) do |payment_request, evaluator|
+      evaluator.invoices.each do |invoice|
+        create(:payment_request_applied_invoice, payment_request:, invoice:)
+      end
+    end
   end
 end

--- a/spec/factories/usage_monitoring/alerts.rb
+++ b/spec/factories/usage_monitoring/alerts.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :alert, class: "UsageMonitoring::Alert" do
     association :organization
-    subscription_external_id { create(:subscription, organization_id: organization.id).external_id }
+    subscription_external_id { create(:subscription, organization: organization).external_id }
     name { "General Alert" }
     sequence(:code) { |n| "default#{n}" }
     alert_type { "current_usage_amount" }

--- a/spec/services/billing_entities/taxes/manage_taxes_service_spec.rb
+++ b/spec/services/billing_entities/taxes/manage_taxes_service_spec.rb
@@ -79,9 +79,13 @@ RSpec.describe BillingEntities::Taxes::ManageTaxesService do
         let(:tax_codes) { ["tax_code_1", "TAX_CODE_2"] }
 
         it "matches tax codes case-insensitively" do
-          service.call
+          result = service.call
 
-          expect(billing_entity.taxes).to eq([tax1, tax2])
+          expect(result).to be_success
+          expect(result.taxes).to eq([tax1, tax2])
+          expect(result.applied_taxes.count).to eq(2)
+
+          expect(billing_entity.applied_taxes.pluck(:organization_id).uniq).to eq([organization.id])
         end
       end
     end
@@ -94,9 +98,13 @@ RSpec.describe BillingEntities::Taxes::ManageTaxesService do
       end
 
       it "removes taxes from the billing entity" do
-        service.call
+        result = service.call
 
-        expect(billing_entity.taxes).to be_empty
+        expect(result).to be_success
+        expect(result.taxes).to be_empty
+        expect(result.applied_taxes).to be_empty
+
+        expect(billing_entity.applied_taxes).to be_empty
       end
     end
 
@@ -108,9 +116,13 @@ RSpec.describe BillingEntities::Taxes::ManageTaxesService do
       end
 
       it "removes taxes from the billing entity" do
-        service.call
+        result = service.call
 
-        expect(billing_entity.taxes).to be_empty
+        expect(result).to be_success
+        expect(result.taxes).to be_empty
+        expect(result.applied_taxes).to be_empty
+
+        expect(billing_entity.applied_taxes).to be_empty
       end
     end
 

--- a/spec/services/integration_collection_mappings/create_service_spec.rb
+++ b/spec/services/integration_collection_mappings/create_service_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe IntegrationCollectionMappings::CreateService, type: :service do
           IntegrationCollectionMappings::NetsuiteCollectionMapping.order(:created_at).last
 
         aggregate_failures do
+          expect(integration_collection_mapping.organization).to eq(organization)
           expect(integration_collection_mapping.mapping_type).to eq("fallback_item")
           expect(integration_collection_mapping.integration_id).to eq(integration.id)
           expect(integration_collection_mapping.tax_nexus).to eq(create_args[:tax_nexus])

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -234,6 +234,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
 
         aggregate_failures do
           expect(result).to be_success
+          expect(result.payment.organization).to eq(organization)
           expect(result.payment.status).to eq("succeeded")
           expect(result.payment.payable_payment_status).to eq("succeeded")
           expect(result.invoice.reload).to have_attributes(


### PR DESCRIPTION
## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is refactoring some factories and ensures that all created records received the correct organization_id. The next step of this epic will be to mark the `organization_id` as required
