### PR TITLE
feat(stripe): Fix Stripe.api_version to `2025-04-30.basil`

### DIFF
--- a/app/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service.rb
+++ b/app/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service.rb
@@ -42,8 +42,7 @@ module PaymentProviderCustomers
 
       def request_options
         {
-          api_key:,
-          stripe_version: ::Stripe.api_version || "2024-09-30.acacia" # TODO: Remove once Stripe.api_version is fully locked
+          api_key:
         }
       end
 

--- a/app/services/payment_providers/stripe/payments/authorize_service.rb
+++ b/app/services/payment_providers/stripe/payments/authorize_service.rb
@@ -71,8 +71,7 @@ module PaymentProviders
             },
             {
               api_key:,
-              idempotency_key: "auth-#{provider_customer.id}-#{unique_id}",
-              stripe_version: ::Stripe.api_version || "2024-09-30.acacia" # TODO: Remove once Stripe.api_version is fully locked
+              idempotency_key: "auth-#{provider_customer.id}-#{unique_id}"
             }
           )
         end

--- a/app/services/payment_providers/stripe/register_webhook_service.rb
+++ b/app/services/payment_providers/stripe/register_webhook_service.rb
@@ -5,7 +5,7 @@ module PaymentProviders
     class RegisterWebhookService < BaseService
       def call
         params = webhook_endpoint_shared_params
-        params[:api_version] = ::Stripe.api_version if ::Stripe.api_version
+        params[:api_version] = ::Stripe.api_version
 
         stripe_webhook = ::Stripe::WebhookEndpoint.create(
           params,

--- a/app/services/payments/set_payment_method_data_service.rb
+++ b/app/services/payments/set_payment_method_data_service.rb
@@ -38,8 +38,7 @@ module Payments
 
     def retrieve_stripe_payment_method_data
       pm = ::Stripe::PaymentMethod.retrieve(provider_payment_method_id, {
-        api_key: payment_provider.secret_key,
-        stripe_version: ::Stripe.api_version || "2024-09-30.acacia" # TODO: Remove once Stripe.api_version is fully locked
+        api_key: payment_provider.secret_key
       })
 
       data = {

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+Stripe.api_version = ENV.fetch("STRIPE_API_VERSION", "2025-04-30.basil")
+
 # Lago uses the key from PaymentProvider.secret_key because each org should have their own keys
 # In development, we always use our sandbox key, and in the console we might need to use
 # the Stripe client directly (ex: ::Stripe::Customer.retrieve('cus_xxx')) which throws

--- a/spec/services/payment_providers/stripe/register_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/register_webhook_service_spec.rb
@@ -11,12 +11,11 @@ RSpec.describe PaymentProviders::Stripe::RegisterWebhookService do
   describe ".call" do
     let(:url) { "#{ENV["LAGO_API_URL"]}/webhooks/stripe/#{organization.id}?code=stripe_sandbox" }
     let(:expected_request_body) do
-      params = {
+      {
         enabled_events: PaymentProviders::StripeProvider::WEBHOOKS_EVENTS,
-        url:
+        url:,
+        api_version: ::Stripe.api_version
       }
-      params[:api_version] = ::Stripe.api_version if ::Stripe.api_version
-      params
     end
     let(:stripe_api_response) do
       get_stripe_fixtures("webhook_endpoint_create_response.json") do |h|


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/{{FEATURE_SLUG}}

## Context

Everything you need to know: https://github.com/getlago/lago-api/pull/3300

## Description

From now on, all Stripe API calls made by lago will be made using the API version `2025-04-30.basil`.

Lago users can continue to use Stripe in any versions they like on their side. They can keep their stripe account configured with any version too.

Until now, Lago would use the user's account version, which could lead to different response shape, breaking the code. It never did yet because we use very core and simple feature of Stripe, but it could in the future.
