### PR TITLE
chore(gems): Fix `rails generate` task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,6 +117,10 @@ group :development, :test do
   gem "pry"
   gem "knapsack_pro", "~> 8.1"
 
+  gem "database_cleaner-active_record"
+  gem "rspec-graphql_matchers"
+  gem "shoulda-matchers"
+
   gem "i18n-tasks", git: "https://github.com/glebm/i18n-tasks.git", require: false
   gem "rubocop-rails", require: false
   gem "rubocop-graphql", require: false
@@ -126,10 +130,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "database_cleaner-active_record"
   gem "guard-rspec", require: false
-  gem "rspec-graphql_matchers"
-  gem "shoulda-matchers"
   gem "karafka-testing"
 end
 


### PR DESCRIPTION
I'm moving to dependencies to both dev and test because it breaks the `rails generate` task.

![CleanShot 2025-06-12 at 17 18 25@2x](https://github.com/user-attachments/assets/44be2889-03bc-423b-b96c-4599d7e6719b)
![CleanShot 2025-06-12 at 17 18 54@2x](https://github.com/user-attachments/assets/fed66535-cd51-47bd-82f1-7389495ff0a9)
