### PR TITLE
chore(optimization): remove n+1 query from invoices controller

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -76,7 +76,7 @@ module Api
         if result.success?
           render(
             json: ::CollectionSerializer.new(
-              result.invoices.includes(:metadata, :applied_taxes),
+              result.invoices.includes(:metadata, :applied_taxes, :billing_entity, :applied_usage_thresholds),
               ::V1::InvoiceSerializer,
               collection_name: "invoices",
               meta: pagination_metadata(result.invoices),


### PR DESCRIPTION
## Context

We’ve been seeing Sentry EU alerts related to N+1 queries when serializing invoices.
This PR addresses one of those issues:
 [Sentry Issue #44595609](https://lago-eu.sentry.io/issues/44595609/?project=4508291321233488&query=is%3Aunresolved&referrer=issue-stream&stream_index=3)

## Description

Updated the render call to eager load additional associations for invoices.
This change ensures that billing_entity and applied_usage_thresholds are preloaded when rendering the collection.