### PR TITLE
feat: Ability to resolve customer and subscription by external id

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -126,10 +126,12 @@ module Api
       end
 
       def show
-        subscription = current_organization.subscriptions.find_by(
-          external_id: params[:external_id],
-          status: params[:status] || :active
-        )
+        subscription = current_organization.subscriptions
+          .order("terminated_at DESC NULLS FIRST, started_at DESC")
+          .find_by(
+            external_id: params[:external_id],
+            status: params[:status] || :active
+          )
         return not_found_error(resource: "subscription") unless subscription
 
         render_subscription(subscription)

--- a/app/graphql/resolvers/customer_resolver.rb
+++ b/app/graphql/resolvers/customer_resolver.rb
@@ -9,8 +9,8 @@ module Resolvers
 
     description "Query a single customer of an organization"
 
-    argument :id, ID, required: false, description: "Lago ID of the customer"
     argument :external_id, ID, required: false, description: "External ID of the customer"
+    argument :id, ID, required: false, description: "Lago ID of the customer"
 
     type Types::Customers::Object, null: true
 

--- a/app/graphql/resolvers/customer_resolver.rb
+++ b/app/graphql/resolvers/customer_resolver.rb
@@ -9,12 +9,18 @@ module Resolvers
 
     description "Query a single customer of an organization"
 
-    argument :id, ID, required: true, description: "Uniq ID of the customer"
+    argument :id, ID, required: false, description: "Lago ID of the customer"
+    argument :external_id, ID, required: false, description: "External ID of the customer"
 
     type Types::Customers::Object, null: true
 
-    def resolve(id: nil)
-      current_organization.customers.find(id)
+    def resolve(id: nil, external_id: nil)
+      if id.nil? && external_id.nil?
+        raise GraphQL::ExecutionError, "You must provide either `id` or `external_id`."
+      end
+
+      return current_organization.customers.find(id) if id.present?
+      current_organization.customers.find_by!(external_id:)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: "customer")
     end

--- a/app/graphql/resolvers/subscription_resolver.rb
+++ b/app/graphql/resolvers/subscription_resolver.rb
@@ -20,7 +20,10 @@ module Resolvers
       end
 
       return current_organization.subscriptions.find(id) if id.present?
-      current_organization.subscriptions.find_by!(external_id:)
+
+      current_organization.subscriptions
+        .order("terminated_at DESC NULLS FIRST, started_at DESC")
+        .find_by!(external_id:)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: "subscription")
     end

--- a/app/graphql/resolvers/subscription_resolver.rb
+++ b/app/graphql/resolvers/subscription_resolver.rb
@@ -9,12 +9,18 @@ module Resolvers
 
     description "Query a single subscription of an organization"
 
-    argument :id, ID, required: true, description: "Uniq ID of the subscription"
+    argument :external_id, ID, required: false, description: "External ID of the subscription"
+    argument :id, ID, required: false, description: "Lago ID of the subscription"
 
     type Types::Subscriptions::Object, null: true
 
-    def resolve(id: nil)
-      current_organization.subscriptions.find(id)
+    def resolve(id: nil, external_id: nil)
+      if id.nil? && external_id.nil?
+        raise GraphQL::ExecutionError, "You must provide either `id` or `external_id`."
+      end
+
+      return current_organization.subscriptions.find(id) if id.present?
+      current_organization.subscriptions.find_by!(external_id:)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: "subscription")
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -8178,9 +8178,14 @@ type Query {
   """
   subscription(
     """
-    Uniq ID of the subscription
+    External ID of the subscription
     """
-    id: ID!
+    externalId: ID
+
+    """
+    Lago ID of the subscription
+    """
+    id: ID
   ): Subscription
 
   """

--- a/schema.graphql
+++ b/schema.graphql
@@ -7782,9 +7782,14 @@ type Query {
   """
   customer(
     """
-    Uniq ID of the customer
+    External ID of the customer
     """
-    id: ID!
+    externalId: ID
+
+    """
+    Lago ID of the customer
+    """
+    id: ID
   ): Customer
 
   """

--- a/schema.json
+++ b/schema.json
@@ -39032,8 +39032,8 @@
               "deprecationReason": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": "Lago ID of the customer",
+                  "name": "externalId",
+                  "description": "External ID of the customer",
                   "type": {
                     "kind": "SCALAR",
                     "name": "ID",
@@ -39044,8 +39044,8 @@
                   "deprecationReason": null
                 },
                 {
-                  "name": "externalId",
-                  "description": "External ID of the customer",
+                  "name": "id",
+                  "description": "Lago ID of the customer",
                   "type": {
                     "kind": "SCALAR",
                     "name": "ID",
@@ -42533,16 +42533,24 @@
               "deprecationReason": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": "Uniq ID of the subscription",
+                  "name": "externalId",
+                  "description": "External ID of the subscription",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "id",
+                  "description": "Lago ID of the subscription",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -39033,15 +39033,23 @@
               "args": [
                 {
                   "name": "id",
-                  "description": "Uniq ID of the customer",
+                  "description": "Lago ID of the customer",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "externalId",
+                  "description": "External ID of the customer",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -577,6 +577,39 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
         )
       end
     end
+
+    context "when there are multiple terminated subscriptions" do
+      let(:subscription) do
+        create(:subscription, customer:, plan:, status: :terminated, terminated_at: 10.days.ago)
+      end
+
+      let(:matching_subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan:,
+          external_id: subscription.external_id,
+          terminated_at: 5.days.ago,
+          status: :terminated
+        )
+      end
+
+      let(:params) { {status: "terminated"} }
+
+      before do
+        matching_subscription
+      end
+
+      it "returns the latest terminated subscription" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscription]).to include(
+          lago_id: matching_subscription.id,
+          external_id: matching_subscription.external_id
+        )
+      end
+    end
   end
 
   describe "GET /api/v1/subscriptions" do


### PR DESCRIPTION
The goal of this PR is to be able to:
- Resolve a customer by `external_id`
- Resolve a subscription by `external_id`

It will be used for audit logs for instance, to display a link to the related customer and subscription.