### PR TITLE
feat(pricing-units): Add GQL for AppliedPricingUnit model

### DIFF
--- a/app/graphql/types/applied_pricing_units/input.rb
+++ b/app/graphql/types/applied_pricing_units/input.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  module AppliedPricingUnits
+    class Input < Types::BaseInputObject
+      graphql_name "AppliedPricingUnitInput"
+
+      argument :code, String, required: true
+      argument :conversion_rate, GraphQL::Types::Float, required: true
+    end
+  end
+end

--- a/app/graphql/types/applied_pricing_units/object.rb
+++ b/app/graphql/types/applied_pricing_units/object.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Types
+  module AppliedPricingUnits
+    class Object < Types::BaseObject
+      graphql_name "AppliedPricingUnit"
+
+      field :id, ID, null: false
+
+      field :conversion_rate, GraphQL::Types::Float, null: false
+      field :pricing_unit, Types::PricingUnits::Object, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    end
+  end
+end

--- a/app/graphql/types/charges/input.rb
+++ b/app/graphql/types/charges/input.rb
@@ -18,6 +18,7 @@ module Types
       argument :filters, [Types::ChargeFilters::Input], required: false
       argument :properties, Types::Charges::PropertiesInput, required: false
 
+      argument :applied_pricing_unit, Types::AppliedPricingUnits::Input, required: false
       argument :tax_codes, [String], required: false
     end
   end

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -23,6 +23,7 @@ module Types
       field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      field :applied_pricing_unit, Types::AppliedPricingUnits::Object, null: true
       field :taxes, [Types::Taxes::Object]
 
       def properties

--- a/schema.graphql
+++ b/schema.graphql
@@ -514,6 +514,19 @@ type AppliedCoupon {
   terminatedAt: ISO8601DateTime!
 }
 
+type AppliedPricingUnit {
+  conversionRate: Float!
+  createdAt: ISO8601DateTime!
+  id: ID!
+  pricingUnit: PricingUnit!
+  updatedAt: ISO8601DateTime!
+}
+
+input AppliedPricingUnitInput {
+  code: String!
+  conversionRate: Float!
+}
+
 interface AppliedTax {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
@@ -770,6 +783,7 @@ type CashfreeProvider {
 }
 
 type Charge {
+  appliedPricingUnit: AppliedPricingUnit
   billableMetric: BillableMetric!
   chargeModel: ChargeModelEnum!
   createdAt: ISO8601DateTime!
@@ -818,6 +832,7 @@ type ChargeFilterUsage {
 scalar ChargeFilterValues
 
 input ChargeInput {
+  appliedPricingUnit: AppliedPricingUnitInput
   billableMetricId: ID!
   chargeModel: ChargeModelEnum!
   filters: [ChargeFilterInput!]

--- a/schema.json
+++ b/schema.json
@@ -2544,6 +2544,140 @@
           "enumValues": null
         },
         {
+          "kind": "OBJECT",
+          "name": "AppliedPricingUnit",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "conversionRate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "pricingUnit",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PricingUnit",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AppliedPricingUnitInput",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "conversionRate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
           "kind": "INTERFACE",
           "name": "AppliedTax",
           "description": null,
@@ -4509,6 +4643,18 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "appliedPricingUnit",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "AppliedPricingUnit",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "billableMetric",
               "description": null,
               "type": {
@@ -5129,6 +5275,18 @@
               "type": {
                 "kind": "INPUT_OBJECT",
                 "name": "PropertiesInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "appliedPricingUnit",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AppliedPricingUnitInput",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
             id,
             chargeModel,
             billableMetric { id name code },
+            appliedPricingUnit {
+              id
+              conversionRate
+              pricingUnit { id code name }
+            },
             properties {
               amount,
               freeUnits,
@@ -74,6 +79,7 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
   end
 
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:) }
+  let(:pricing_unit) { create(:pricing_unit, organization:) }
 
   let(:graphql) do
     {
@@ -100,6 +106,10 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
               billableMetricId: billable_metrics[0].id,
               chargeModel: "standard",
               properties: {amount: "100.00"},
+              appliedPricingUnit: {
+                code: pricing_unit.code,
+                conversionRate: 0.1
+              },
               filters: [
                 {
                   invoiceDisplayName: "Payment method",
@@ -200,150 +210,146 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
 
     it "updates a plan" do
       result = execute_graphql(**graphql)
-
       result_data = result["data"]["updatePlan"]
 
-      aggregate_failures do
-        expect(result_data["id"]).to be_present
-        expect(result_data["name"]).to eq("Updated plan")
-        expect(result_data["invoiceDisplayName"]).to eq("Updated plan invoice name")
-        expect(result_data["code"]).to eq("new_plan")
-        expect(result_data["interval"]).to eq("monthly")
-        expect(result_data["payInAdvance"]).to eq(false)
-        expect(result_data["amountCents"]).to eq("200")
-        expect(result_data["amountCurrency"]).to eq("EUR")
-        expect(result_data["charges"].count).to eq(5)
-        expect(result_data["usageThresholds"].count).to eq(3)
+      expect(result_data["id"]).to be_present
+      expect(result_data["name"]).to eq("Updated plan")
+      expect(result_data["invoiceDisplayName"]).to eq("Updated plan invoice name")
+      expect(result_data["code"]).to eq("new_plan")
+      expect(result_data["interval"]).to eq("monthly")
+      expect(result_data["payInAdvance"]).to eq(false)
+      expect(result_data["amountCents"]).to eq("200")
+      expect(result_data["amountCurrency"]).to eq("EUR")
+      expect(result_data["charges"].count).to eq(5)
+      expect(result_data["usageThresholds"].count).to eq(3)
 
-        standard_charge = result_data["charges"][0]
-        expect(standard_charge["properties"]["amount"]).to eq("100.00")
-        expect(standard_charge["chargeModel"]).to eq("standard")
+      standard_charge = result_data["charges"][0]
+      expect(standard_charge["properties"]["amount"]).to eq("100.00")
+      expect(standard_charge["chargeModel"]).to eq("standard")
 
-        filter = standard_charge["filters"].first
-        expect(filter["invoiceDisplayName"]).to eq("Payment method")
-        expect(filter["properties"]["amount"]).to eq("10.00")
-        expect(filter["values"]).to eq("payment_method" => %w[card])
+      applied_pricing_unit = standard_charge["appliedPricingUnit"]
+      expect(applied_pricing_unit).to be_present
+      expect(applied_pricing_unit["conversionRate"]).to eq(0.1)
+      expect(applied_pricing_unit["pricingUnit"]["code"]).to eq(pricing_unit.code)
+      expect(applied_pricing_unit["pricingUnit"]["name"]).to eq(pricing_unit.name)
 
-        package_charge = result_data["charges"][1]
-        expect(package_charge["chargeModel"]).to eq("package")
-        package_properties = package_charge["properties"]
-        expect(package_properties["amount"]).to eq("300.00")
-        expect(package_properties["freeUnits"]).to eq("10")
-        expect(package_properties["packageSize"]).to eq("10")
+      filter = standard_charge["filters"].first
+      expect(filter["invoiceDisplayName"]).to eq("Payment method")
+      expect(filter["properties"]["amount"]).to eq("10.00")
+      expect(filter["values"]).to eq("payment_method" => %w[card])
 
-        percentage_charge = result_data["charges"][2]
-        expect(percentage_charge["chargeModel"]).to eq("percentage")
-        percentage_properties = percentage_charge["properties"]
-        expect(percentage_properties["rate"]).to eq("0.25")
-        expect(percentage_properties["fixedAmount"]).to eq("2")
-        expect(percentage_properties["freeUnitsPerEvents"]).to eq("5")
-        expect(percentage_properties["freeUnitsPerTotalAggregation"]).to eq("50")
+      package_charge = result_data["charges"][1]
+      expect(package_charge["chargeModel"]).to eq("package")
+      package_properties = package_charge["properties"]
+      expect(package_properties["amount"]).to eq("300.00")
+      expect(package_properties["freeUnits"]).to eq("10")
+      expect(package_properties["packageSize"]).to eq("10")
 
-        graduated_charge = result_data["charges"][3]
-        expect(graduated_charge["chargeModel"]).to eq("graduated")
-        expect(graduated_charge["properties"]["graduatedRanges"].count).to eq(2)
+      percentage_charge = result_data["charges"][2]
+      expect(percentage_charge["chargeModel"]).to eq("percentage")
+      percentage_properties = percentage_charge["properties"]
+      expect(percentage_properties["rate"]).to eq("0.25")
+      expect(percentage_properties["fixedAmount"]).to eq("2")
+      expect(percentage_properties["freeUnitsPerEvents"]).to eq("5")
+      expect(percentage_properties["freeUnitsPerTotalAggregation"]).to eq("50")
 
-        volume_charge = result_data["charges"][4]
-        expect(volume_charge["chargeModel"]).to eq("volume")
-        expect(volume_charge["properties"]["volumeRanges"].count).to eq(2)
+      graduated_charge = result_data["charges"][3]
+      expect(graduated_charge["chargeModel"]).to eq("graduated")
+      expect(graduated_charge["properties"]["graduatedRanges"].count).to eq(2)
 
-        expect(result_data["minimumCommitment"]).to include(
-          "invoiceDisplayName" => minimum_commitment_invoice_display_name,
-          "amountCents" => minimum_commitment_amount_cents.to_s
-        )
-        expect(result_data["minimumCommitment"]["taxes"].count).to eq(1)
+      volume_charge = result_data["charges"][4]
+      expect(volume_charge["chargeModel"]).to eq("volume")
+      expect(volume_charge["properties"]["volumeRanges"].count).to eq(2)
 
-        thresholds = result_data["usageThresholds"].sort_by { |threshold| threshold["thresholdDisplayName"] }
-        expect(thresholds).to include hash_including(
-          "thresholdDisplayName" => "Threshold 1",
-          "amountCents" => "100",
-          "recurring" => false
-        )
-        expect(thresholds).to include hash_including(
-          "thresholdDisplayName" => "Threshold 2",
-          "amountCents" => "200",
-          "recurring" => false
-        )
-        expect(thresholds).to include hash_including(
-          "thresholdDisplayName" => "Threshold 3 Recurring",
-          "amountCents" => "1",
-          "recurring" => true
-        )
-      end
+      expect(result_data["minimumCommitment"]).to include(
+        "invoiceDisplayName" => minimum_commitment_invoice_display_name,
+        "amountCents" => minimum_commitment_amount_cents.to_s
+      )
+      expect(result_data["minimumCommitment"]["taxes"].count).to eq(1)
+
+      thresholds = result_data["usageThresholds"].sort_by { |threshold| threshold["thresholdDisplayName"] }
+      expect(thresholds).to include hash_including(
+        "thresholdDisplayName" => "Threshold 1",
+        "amountCents" => "100",
+        "recurring" => false
+      )
+      expect(thresholds).to include hash_including(
+        "thresholdDisplayName" => "Threshold 2",
+        "amountCents" => "200",
+        "recurring" => false
+      )
+      expect(thresholds).to include hash_including(
+        "thresholdDisplayName" => "Threshold 3 Recurring",
+        "amountCents" => "1",
+        "recurring" => true
+      )
     end
 
     it "updates minimum commitment" do
       result = execute_graphql(**graphql)
-
       result_data = result["data"]["updatePlan"]
 
-      aggregate_failures do
-        expect(result_data["minimumCommitment"]).to include(
-          "invoiceDisplayName" => minimum_commitment_invoice_display_name,
-          "amountCents" => minimum_commitment_amount_cents.to_s
-        )
-        expect(result_data["minimumCommitment"]["taxes"].count).to eq(1)
-      end
+      expect(result_data["minimumCommitment"]).to include(
+        "invoiceDisplayName" => minimum_commitment_invoice_display_name,
+        "amountCents" => minimum_commitment_amount_cents.to_s
+      )
+      expect(result_data["minimumCommitment"]["taxes"].count).to eq(1)
     end
   end
 
   context "without premium license" do
     it "updates a plan" do
       result = execute_graphql(**graphql)
-
       result_data = result["data"]["updatePlan"]
 
-      aggregate_failures do
-        expect(result_data["id"]).to be_present
-        expect(result_data["name"]).to eq("Updated plan")
-        expect(result_data["invoiceDisplayName"]).to eq("Updated plan invoice name")
-        expect(result_data["code"]).to eq("new_plan")
-        expect(result_data["interval"]).to eq("monthly")
-        expect(result_data["payInAdvance"]).to eq(false)
-        expect(result_data["amountCents"]).to eq("200")
-        expect(result_data["amountCurrency"]).to eq("EUR")
-        expect(result_data["charges"].count).to eq(5)
+      expect(result_data["id"]).to be_present
+      expect(result_data["name"]).to eq("Updated plan")
+      expect(result_data["invoiceDisplayName"]).to eq("Updated plan invoice name")
+      expect(result_data["code"]).to eq("new_plan")
+      expect(result_data["interval"]).to eq("monthly")
+      expect(result_data["payInAdvance"]).to eq(false)
+      expect(result_data["amountCents"]).to eq("200")
+      expect(result_data["amountCurrency"]).to eq("EUR")
+      expect(result_data["charges"].count).to eq(5)
 
-        standard_charge = result_data["charges"][0]
-        expect(standard_charge["properties"]["amount"]).to eq("100.00")
-        expect(standard_charge["chargeModel"]).to eq("standard")
+      standard_charge = result_data["charges"][0]
+      expect(standard_charge["properties"]["amount"]).to eq("100.00")
+      expect(standard_charge["chargeModel"]).to eq("standard")
 
-        package_charge = result_data["charges"][1]
-        expect(package_charge["chargeModel"]).to eq("package")
-        package_properties = package_charge["properties"]
-        expect(package_properties["amount"]).to eq("300.00")
-        expect(package_properties["freeUnits"]).to eq("10")
-        expect(package_properties["packageSize"]).to eq("10")
+      expect(standard_charge["appliedPricingUnit"]).to be_nil
 
-        percentage_charge = result_data["charges"][2]
-        expect(percentage_charge["chargeModel"]).to eq("percentage")
-        percentage_properties = percentage_charge["properties"]
-        expect(percentage_properties["rate"]).to eq("0.25")
-        expect(percentage_properties["fixedAmount"]).to eq("2")
-        expect(percentage_properties["freeUnitsPerEvents"]).to eq("5")
-        expect(percentage_properties["freeUnitsPerTotalAggregation"]).to eq("50")
+      package_charge = result_data["charges"][1]
+      expect(package_charge["chargeModel"]).to eq("package")
+      package_properties = package_charge["properties"]
+      expect(package_properties["amount"]).to eq("300.00")
+      expect(package_properties["freeUnits"]).to eq("10")
+      expect(package_properties["packageSize"]).to eq("10")
 
-        graduated_charge = result_data["charges"][3]
-        expect(graduated_charge["chargeModel"]).to eq("graduated")
-        expect(graduated_charge["properties"]["graduatedRanges"].count).to eq(2)
+      percentage_charge = result_data["charges"][2]
+      expect(percentage_charge["chargeModel"]).to eq("percentage")
+      percentage_properties = percentage_charge["properties"]
+      expect(percentage_properties["rate"]).to eq("0.25")
+      expect(percentage_properties["fixedAmount"]).to eq("2")
+      expect(percentage_properties["freeUnitsPerEvents"]).to eq("5")
+      expect(percentage_properties["freeUnitsPerTotalAggregation"]).to eq("50")
 
-        volume_charge = result_data["charges"][4]
-        expect(volume_charge["chargeModel"]).to eq("volume")
-        expect(volume_charge["properties"]["volumeRanges"].count).to eq(2)
-      end
+      graduated_charge = result_data["charges"][3]
+      expect(graduated_charge["chargeModel"]).to eq("graduated")
+      expect(graduated_charge["properties"]["graduatedRanges"].count).to eq(2)
+
+      volume_charge = result_data["charges"][4]
+      expect(volume_charge["chargeModel"]).to eq("volume")
+      expect(volume_charge["properties"]["volumeRanges"].count).to eq(2)
     end
 
     it "does not update minimum commitment" do
       result = execute_graphql(**graphql)
-
       result_data = result["data"]["updatePlan"]
 
-      aggregate_failures do
-        expect(result_data["minimumCommitment"]).to include(
-          "invoiceDisplayName" => minimum_commitment.invoice_display_name,
-          "amountCents" => minimum_commitment.amount_cents.to_s
-        )
-      end
+      expect(result_data["minimumCommitment"]).to include(
+        "invoiceDisplayName" => minimum_commitment.invoice_display_name,
+        "amountCents" => minimum_commitment.amount_cents.to_s
+      )
     end
   end
 end

--- a/spec/graphql/types/applied_pricing_units/input_spec.rb
+++ b/spec/graphql/types/applied_pricing_units/input_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::AppliedPricingUnits::Input do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:code).of_type("String!")
+    expect(subject).to accept_argument(:conversion_rate).of_type("Float!")
+  end
+end

--- a/spec/graphql/types/applied_pricing_units/object_spec.rb
+++ b/spec/graphql/types/applied_pricing_units/object_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::AppliedPricingUnits::Object do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:id).of_type("ID!")
+
+    expect(subject).to have_field(:conversion_rate).of_type("Float!")
+    expect(subject).to have_field(:pricing_unit).of_type("PricingUnit!")
+
+    expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+  end
+end

--- a/spec/graphql/types/charges/input_spec.rb
+++ b/spec/graphql/types/charges/input_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Types::Charges::Input do
     expect(subject).to accept_argument(:filters).of_type("[ChargeFilterInput!]")
     expect(subject).to accept_argument(:properties).of_type("PropertiesInput")
 
+    expect(subject).to accept_argument(:applied_pricing_unit).of_type("AppliedPricingUnitInput")
     expect(subject).to accept_argument(:tax_codes).of_type("[String!]")
   end
 end

--- a/spec/graphql/types/charges/object_spec.rb
+++ b/spec/graphql/types/charges/object_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Types::Charges::Object do
     expect(subject).to have_field(:deleted_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:taxes).of_type("[Tax!]")
+    expect(subject).to have_field(:applied_pricing_unit).of_type("AppliedPricingUnit")
     expect(subject).to have_field(:filters).of_type("[ChargeFilter!]")
   end
 end


### PR DESCRIPTION
## Context

Adding GQL interface to link charge with a pricing unit and update applied pricing units.

## Description

Add AppliedPricingUnit type
Modify Charge type and input object to accept applied pricing units
Modify plan create and update mutations to also test for applied pricing unit creation/update
