### PR TITLE
feat(pricing-units): Add GQL for PricingUnitUsage model

### DIFF
--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -33,6 +33,7 @@ module Types
       field :adjusted_fee_type, Types::AdjustedFees::AdjustedFeeTypeEnum, null: true
 
       field :charge_filter, Types::ChargeFilters::Object, null: true
+      field :pricing_unit_usage, Types::PricingUnitUsages::Object, null: true
 
       def item_type
         object.fee_type

--- a/app/graphql/types/pricing_unit_usages/object.rb
+++ b/app/graphql/types/pricing_unit_usages/object.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  module PricingUnitUsages
+    class Object < Types::BaseObject
+      graphql_name "PricingUnitUsage"
+
+      field :id, ID, null: false
+
+      field :amount_cents, GraphQL::Types::BigInt, null: false
+      field :conversion_rate, GraphQL::Types::Float, null: false
+      field :precise_amount_cents, GraphQL::Types::Float, null: false
+      field :pricing_unit, Types::PricingUnits::Object, null: false
+      field :short_name, String, null: false
+      field :unit_amount_cents, GraphQL::Types::BigInt, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4901,6 +4901,7 @@ type Fee implements InvoiceItem {
   itemName: String!
   itemType: String!
   preciseUnitAmount: Float!
+  pricingUnitUsage: PricingUnitUsage
   subscription: Subscription
   succeededAt: ISO8601DateTime
   taxesAmountCents: BigInt!
@@ -7605,6 +7606,18 @@ type PricingUnitCollection {
   Pagination Metadata for navigating the Pagination
   """
   metadata: CollectionMetadata!
+}
+
+type PricingUnitUsage {
+  amountCents: BigInt!
+  conversionRate: Float!
+  createdAt: ISO8601DateTime!
+  id: ID!
+  preciseAmountCents: Float!
+  pricingUnit: PricingUnit!
+  shortName: String!
+  unitAmountCents: BigInt!
+  updatedAt: ISO8601DateTime!
 }
 
 type Properties {

--- a/schema.json
+++ b/schema.json
@@ -22901,6 +22901,18 @@
               "args": []
             },
             {
+              "name": "pricingUnitUsage",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "PricingUnitUsage",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "subscription",
               "description": null,
               "type": {
@@ -37678,6 +37690,161 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PricingUnitUsage",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "conversionRate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "preciseAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "pricingUnit",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PricingUnit",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "shortName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "unitAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
                   "ofType": null
                 }
               },

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -24,5 +24,6 @@ RSpec.describe Types::Fees::Object do
     expect(subject).to have_field(:grouped_by).of_type("JSON!")
 
     expect(subject).to have_field(:charge_filter).of_type("ChargeFilter")
+    expect(subject).to have_field(:pricing_unit_usage).of_type("PricingUnitUsage")
   end
 end

--- a/spec/graphql/types/pricing_unit_usages/object_spec.rb
+++ b/spec/graphql/types/pricing_unit_usages/object_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::PricingUnitUsages::Object do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:id).of_type("ID!")
+
+    expect(subject).to have_field(:amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:conversion_rate).of_type("Float!")
+    expect(subject).to have_field(:precise_amount_cents).of_type("Float!")
+    expect(subject).to have_field(:short_name).of_type("String!")
+    expect(subject).to have_field(:unit_amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:pricing_unit).of_type("PricingUnit!")
+
+    expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+  end
+end


### PR DESCRIPTION
## Context

These changes will allow to receive info about Fee's amounts in pricing units.

## Description

Add PricingUnitUsage type
Add optional pricing unit usage field for Fee type
