### PR TITLE
Fix daily usages

### DIFF
--- a/app/services/daily_usages/fill_from_invoice_service.rb
+++ b/app/services/daily_usages/fill_from_invoice_service.rb
@@ -50,7 +50,7 @@ module DailyUsages
     def invoice_usage(subscription, invoice_subscription)
       in_adv_fees = in_advance_fees(subscription, invoice_subscription)
 
-      fees = in_adv_fees.to_a +
+      fees = in_adv_fees +
         invoice.fees.charge.select { |f| f.subscription_id == subscription.id && f.units.positive? }
 
       amount_cents = in_adv_fees.sum(:amount_cents) + invoice.fees.charge.sum(:amount_cents)


### PR DESCRIPTION
## Context

We did not include in advance charges in daily usages.
Also the boundaries and the sums were not correct.
These sum included the subscriptions fees which are now excluded.

## Description

This PR addresses these issues and fixes `DailyUsages::FillFromInvoiceService`.