### PR TITLE
Reapply "chore(organization): Not null organization_id" (#3838)

### DIFF
--- a/app/models/add_on/applied_tax.rb
+++ b/app/models/add_on/applied_tax.rb
@@ -6,7 +6,7 @@ class AddOn
 
     belongs_to :add_on
     belongs_to :tax
-    belongs_to :organization, optional: true
+    belongs_to :organization
   end
 end
 

--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -7,7 +7,7 @@ class AdjustedFee < ApplicationRecord
   belongs_to :charge, optional: true
   belongs_to :group, optional: true
   belongs_to :charge_filter, optional: true
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   ADJUSTED_FEE_TYPES = [
     :adjusted_units,

--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -6,7 +6,7 @@ class AppliedCoupon < ApplicationRecord
 
   belongs_to :coupon
   belongs_to :customer
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   has_many :credits
 

--- a/app/models/applied_invoice_custom_section.rb
+++ b/app/models/applied_invoice_custom_section.rb
@@ -2,7 +2,7 @@
 
 class AppliedInvoiceCustomSection < ApplicationRecord
   belongs_to :invoice
-  belongs_to :organization, optional: true
+  belongs_to :organization
 end
 
 # == Schema Information

--- a/app/models/applied_usage_threshold.rb
+++ b/app/models/applied_usage_threshold.rb
@@ -3,7 +3,7 @@
 class AppliedUsageThreshold < ApplicationRecord
   belongs_to :usage_threshold, -> { with_discarded }
   belongs_to :invoice
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   validates :usage_threshold_id, uniqueness: {scope: :invoice_id}
 

--- a/app/models/billable_metric_filter.rb
+++ b/app/models/billable_metric_filter.rb
@@ -6,7 +6,7 @@ class BillableMetricFilter < ApplicationRecord
   self.discard_column = :deleted_at
 
   belongs_to :billable_metric, -> { with_discarded }
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   has_many :filter_values, class_name: "ChargeFilterValue", dependent: :destroy
   has_many :charge_filters, through: :filter_values

--- a/app/models/billing_entity/applied_tax.rb
+++ b/app/models/billing_entity/applied_tax.rb
@@ -6,7 +6,7 @@ class BillingEntity
 
     belongs_to :billing_entity
     belongs_to :tax
-    belongs_to :organization, optional: true
+    belongs_to :organization
 
     validates :tax_id, uniqueness: {scope: :billing_entity_id}
   end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -7,7 +7,7 @@ class Charge < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
-  belongs_to :organization, optional: true
+  belongs_to :organization
   belongs_to :plan, -> { with_discarded }, touch: true
   belongs_to :billable_metric, -> { with_discarded }
   belongs_to :parent, class_name: "Charge", optional: true

--- a/app/models/charge/applied_tax.rb
+++ b/app/models/charge/applied_tax.rb
@@ -6,7 +6,7 @@ class Charge
 
     belongs_to :charge
     belongs_to :tax
-    belongs_to :organization, optional: true
+    belongs_to :organization
   end
 end
 

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -7,7 +7,7 @@ class ChargeFilter < ApplicationRecord
   self.discard_column = :deleted_at
 
   belongs_to :charge, -> { with_discarded }, touch: true
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   has_many :values, class_name: "ChargeFilterValue", dependent: :destroy
   has_many :billable_metric_filters, through: :values

--- a/app/models/charge_filter_value.rb
+++ b/app/models/charge_filter_value.rb
@@ -9,7 +9,7 @@ class ChargeFilterValue < ApplicationRecord
 
   belongs_to :charge_filter, -> { with_discarded }
   belongs_to :billable_metric_filter, -> { with_discarded }
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   validates :values, presence: true
   validate :validate_values

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -2,7 +2,7 @@
 
 class Commitment < ApplicationRecord
   belongs_to :plan
-  belongs_to :organization, optional: true
+  belongs_to :organization
   has_many :applied_taxes, class_name: "Commitment::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes
 

--- a/app/models/commitment/applied_tax.rb
+++ b/app/models/commitment/applied_tax.rb
@@ -6,7 +6,7 @@ class Commitment
 
     belongs_to :commitment
     belongs_to :tax
-    belongs_to :organization, optional: true
+    belongs_to :organization
   end
 end
 

--- a/app/models/coupon_target.rb
+++ b/app/models/coupon_target.rb
@@ -8,7 +8,7 @@ class CouponTarget < ApplicationRecord
   belongs_to :coupon
   belongs_to :plan, optional: true
   belongs_to :billable_metric, optional: true
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   default_scope -> { kept }
 end

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -7,7 +7,7 @@ class Credit < ApplicationRecord
   belongs_to :applied_coupon, optional: true
   belongs_to :credit_note, optional: true
   belongs_to :progressive_billing_invoice, class_name: "Invoice", optional: true
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   has_one :coupon, -> { with_discarded }, through: :applied_coupon
 

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -11,9 +11,8 @@ class CreditNote < ApplicationRecord
 
   belongs_to :customer, -> { with_discarded }
   belongs_to :invoice
-  # TODO: belongs_to :organization, optional: true
+  belongs_to :organization
 
-  has_one :organization, through: :invoice
   has_one :billing_entity, through: :invoice
 
   has_many :items, class_name: "CreditNoteItem", dependent: :destroy

--- a/app/models/credit_note/applied_tax.rb
+++ b/app/models/credit_note/applied_tax.rb
@@ -8,7 +8,7 @@ class CreditNote
 
     belongs_to :credit_note
     belongs_to :tax, optional: true
-    belongs_to :organization, optional: true
+    belongs_to :organization
 
     monetize :amount_cents
     monetize :base_amount_cents, with_model_currency: :amount_currency

--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -3,7 +3,7 @@
 class CreditNoteItem < ApplicationRecord
   belongs_to :credit_note
   belongs_to :fee
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   monetize :amount_cents
 

--- a/app/models/customer/applied_tax.rb
+++ b/app/models/customer/applied_tax.rb
@@ -8,7 +8,7 @@ class Customer
 
     belongs_to :customer
     belongs_to :tax
-    belongs_to :organization, optional: true
+    belongs_to :organization
   end
 end
 

--- a/app/models/data_export_part.rb
+++ b/app/models/data_export_part.rb
@@ -2,7 +2,7 @@
 
 class DataExportPart < ApplicationRecord
   belongs_to :data_export
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   scope :completed, -> { where(completed: true) }
 end

--- a/app/models/dunning_campaign_threshold.rb
+++ b/app/models/dunning_campaign_threshold.rb
@@ -7,7 +7,7 @@ class DunningCampaignThreshold < ApplicationRecord
   self.discard_column = :deleted_at
 
   belongs_to :dunning_campaign
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   validates :amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :currency, inclusion: {in: currency_list}

--- a/app/models/fee/applied_tax.rb
+++ b/app/models/fee/applied_tax.rb
@@ -8,7 +8,7 @@ class Fee
 
     belongs_to :fee
     belongs_to :tax, optional: true
-    belongs_to :organization, optional: true
+    belongs_to :organization
   end
 end
 

--- a/app/models/integration_collection_mappings/base_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/base_collection_mapping.rb
@@ -8,7 +8,7 @@ module IntegrationCollectionMappings
     self.table_name = "integration_collection_mappings"
 
     belongs_to :integration, class_name: "Integrations::BaseIntegration"
-    belongs_to :organization, optional: true
+    belongs_to :organization
 
     MAPPING_TYPES = %i[
       fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit credit_note account

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -9,7 +9,7 @@ module IntegrationCustomers
 
     belongs_to :customer
     belongs_to :integration, class_name: "Integrations::BaseIntegration"
-    belongs_to :organization, optional: true
+    belongs_to :organization
 
     TAX_INTEGRATION_TYPES = %w[
       IntegrationCustomers::AnrokCustomer

--- a/app/models/integration_item.rb
+++ b/app/models/integration_item.rb
@@ -4,7 +4,7 @@ class IntegrationItem < ApplicationRecord
   include PaperTrailTraceable
 
   belongs_to :integration, class_name: "Integrations::BaseIntegration"
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   ITEM_TYPES = [
     :standard,

--- a/app/models/integration_mappings/base_mapping.rb
+++ b/app/models/integration_mappings/base_mapping.rb
@@ -9,7 +9,7 @@ module IntegrationMappings
 
     belongs_to :integration, class_name: "Integrations::BaseIntegration"
     belongs_to :mappable, polymorphic: true
-    belongs_to :organization, optional: true
+    belongs_to :organization
 
     MAPPABLE_TYPES = %i[AddOn BillableMetric].freeze
 

--- a/app/models/integration_resource.rb
+++ b/app/models/integration_resource.rb
@@ -5,7 +5,7 @@ class IntegrationResource < ApplicationRecord
 
   belongs_to :syncable, polymorphic: true
   belongs_to :integration, class_name: "Integrations::BaseIntegration"
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   RESOURCE_TYPES = %i[invoice sales_order_deprecated payment credit_note subscription].freeze
 

--- a/app/models/invoice/applied_tax.rb
+++ b/app/models/invoice/applied_tax.rb
@@ -8,7 +8,7 @@ class Invoice
 
     belongs_to :invoice
     belongs_to :tax, optional: true
-    belongs_to :organization, optional: true
+    belongs_to :organization
 
     monetize :amount_cents,
       :fees_amount_cents,

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -5,7 +5,7 @@ class InvoiceSubscription < ApplicationRecord
 
   belongs_to :invoice
   belongs_to :subscription
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   has_one :customer, through: :subscription
 

--- a/app/models/metadata/customer_metadata.rb
+++ b/app/models/metadata/customer_metadata.rb
@@ -5,7 +5,7 @@ module Metadata
     COUNT_PER_CUSTOMER = 5
 
     belongs_to :customer
-    belongs_to :organization, optional: true
+    belongs_to :organization
 
     validates :key, presence: true, uniqueness: {scope: :customer_id}, length: {maximum: 20}
     validates :value, presence: true, length: {maximum: 100}

--- a/app/models/metadata/invoice_metadata.rb
+++ b/app/models/metadata/invoice_metadata.rb
@@ -5,7 +5,7 @@ module Metadata
     COUNT_PER_INVOICE = 5
 
     belongs_to :invoice
-    belongs_to :organization, optional: true
+    belongs_to :organization
 
     validates :key, presence: true, uniqueness: {scope: :invoice_id}, length: {maximum: 20}
     validates :value, presence: true

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -29,13 +29,13 @@ class Organization < ApplicationRecord
   has_many :plans
   has_many :pricing_units
   has_many :customers
-  has_many :subscriptions, through: :customers
+  has_many :subscriptions
   has_many :invoices
-  has_many :credit_notes, through: :invoices
-  has_many :fees, through: :subscriptions
+  has_many :credit_notes
+  has_many :fees
   has_many :events
   has_many :coupons
-  has_many :applied_coupons, through: :coupons
+  has_many :applied_coupons
   has_many :add_ons
   has_many :daily_usages
   has_many :invites
@@ -43,10 +43,10 @@ class Organization < ApplicationRecord
   has_many :payment_providers, class_name: "PaymentProviders::BaseProvider"
   has_many :payment_requests
   has_many :taxes
-  has_many :wallets, through: :customers
-  has_many :wallet_transactions, through: :wallets
+  has_many :wallets
+  has_many :wallet_transactions
   has_many :webhook_endpoints
-  has_many :webhooks, through: :webhook_endpoints
+  has_many :webhooks
   has_many :cached_aggregations
   has_many :data_exports
   has_many :error_details

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -5,7 +5,7 @@ class Payment < ApplicationRecord
 
   PAYABLE_PAYMENT_STATUS = %w[pending processing succeeded failed].freeze
 
-  belongs_to :organization, optional: true
+  belongs_to :organization
   belongs_to :payable, polymorphic: true
   belongs_to :payment_provider, optional: true, class_name: "PaymentProviders::BaseProvider"
   belongs_to :payment_provider_customer, optional: true, class_name: "PaymentProviderCustomers::BaseCustomer"

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -12,7 +12,7 @@ module PaymentProviderCustomers
 
     belongs_to :customer
     belongs_to :payment_provider, optional: true, class_name: "PaymentProviders::BaseProvider"
-    belongs_to :organization, optional: true
+    belongs_to :organization
 
     has_many :payments
     has_many :refunds, foreign_key: :payment_provider_customer_id

--- a/app/models/payment_request/applied_invoice.rb
+++ b/app/models/payment_request/applied_invoice.rb
@@ -6,7 +6,7 @@ class PaymentRequest
 
     belongs_to :invoice
     belongs_to :payment_request
-    belongs_to :organization, optional: true
+    belongs_to :organization
   end
 end
 

--- a/app/models/plan/applied_tax.rb
+++ b/app/models/plan/applied_tax.rb
@@ -8,7 +8,7 @@ class Plan
 
     belongs_to :plan
     belongs_to :tax
-    belongs_to :organization, optional: true
+    belongs_to :organization
   end
 end
 

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -4,7 +4,7 @@ class RecurringTransactionRule < ApplicationRecord
   include PaperTrailTraceable
 
   belongs_to :wallet
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   STATUSES = [
     :active,

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -7,7 +7,7 @@ class Refund < ApplicationRecord
   belongs_to :credit_note
   belongs_to :payment_provider, optional: true, class_name: "PaymentProviders::BaseProvider"
   belongs_to :payment_provider_customer, class_name: "PaymentProviderCustomers::BaseCustomer"
-  belongs_to :organization, optional: true
+  belongs_to :organization
 end
 
 # == Schema Information

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -6,8 +6,8 @@ class Subscription < ApplicationRecord
   belongs_to :customer, -> { with_discarded }
   belongs_to :plan, -> { with_discarded }
   belongs_to :previous_subscription, class_name: "Subscription", optional: true
+  belongs_to :organization
 
-  has_one :organization, through: :customer
   has_one :billing_entity, through: :customer
   has_many :next_subscriptions, class_name: "Subscription", foreign_key: :previous_subscription_id
   has_many :events

--- a/app/models/usage_threshold.rb
+++ b/app/models/usage_threshold.rb
@@ -6,7 +6,7 @@ class UsageThreshold < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
-  belongs_to :organization, optional: true
+  belongs_to :organization
   belongs_to :plan
 
   has_many :applied_usage_thresholds

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   has_many :add_ons, through: :organizations
   has_many :credit_notes, through: :organizations
   has_many :wallets, through: :organizations
-  has_many :subscriptions, through: :customers
+  has_many :subscriptions, through: :organizations
 
   validates :email, presence: true
   validates :password, presence: true

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -5,8 +5,7 @@ class Wallet < ApplicationRecord
   include Currencies
 
   belongs_to :customer, -> { with_discarded }
-
-  has_one :organization, through: :customer
+  belongs_to :organization
 
   has_many :wallet_transactions
   has_many :recurring_transaction_rules

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -4,7 +4,7 @@ class WalletTransaction < ApplicationRecord
   include PaperTrailTraceable
 
   belongs_to :wallet
-  belongs_to :organization, optional: true
+  belongs_to :organization
 
   # these two relationships are populated only for outbound transactions
   belongs_to :invoice, optional: true

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -7,9 +7,7 @@ class Webhook < ApplicationRecord
 
   belongs_to :webhook_endpoint
   belongs_to :object, polymorphic: true, optional: true
-
-  # TODO: belongs_to :organization, optional: true
-  has_one :organization, through: :webhook_endpoint
+  belongs_to :organization
 
   enum :status, STATUS
 

--- a/app/queries/applied_coupons_query.rb
+++ b/app/queries/applied_coupons_query.rb
@@ -22,7 +22,7 @@ class AppliedCouponsQuery < BaseQuery
   end
 
   def with_coupon_code(scope)
-    scope.where(coupons: {code: filters.coupon_code})
+    scope.joins(:coupon).where(coupons: {code: filters.coupon_code})
   end
 
   def with_external_customer(scope)

--- a/app/services/coupons/preview_service.rb
+++ b/app/services/coupons/preview_service.rb
@@ -42,6 +42,7 @@ module Coupons
       credit_amount = AppliedCoupons::AmountService.call(applied_coupon:, base_amount_cents:).amount
       new_credit = Credit.new(
         invoice:,
+        organization_id: invoice.organization_id,
         applied_coupon:,
         amount_cents: credit_amount,
         amount_currency: invoice.currency,

--- a/app/services/invoices/preview/credits_service.rb
+++ b/app/services/invoices/preview/credits_service.rb
@@ -37,6 +37,7 @@ module Invoices
 
         credit = Credit.new(
           invoice:,
+          organization_id: invoice.organization_id,
           credit_note:,
           amount_cents: credit_amount,
           amount_currency: invoice.currency,

--- a/db/seeds/01_base.rb
+++ b/db/seeds/01_base.rb
@@ -43,6 +43,7 @@ plan = Plan.create_with(
 )
 
 Charge.create_with(
+  organization:,
   charge_model: "standard",
   amount_currency: "EUR",
   properties: {
@@ -54,6 +55,7 @@ Charge.create_with(
 )
 
 Charge.create_with(
+  organization:,
   charge_model: "standard",
   amount_currency: "EUR",
   properties: {
@@ -90,6 +92,7 @@ Charge.create_with(
   subscription_at = (Time.current - 6.months).beginning_of_month
 
   sub = Subscription.create_with(
+    organization:,
     started_at: subscription_at,
     subscription_at:,
     status: :active,

--- a/db/seeds/alerting.rb
+++ b/db/seeds/alerting.rb
@@ -16,9 +16,14 @@ ops_bm = BillableMetric.find_or_create_by!(
   field_name: "ops_count"
 )
 
-Charge.create_with(charge_model: "standard", amount_currency: "EUR", properties: {
-  amount: "500"
-}).find_or_create_by!(plan:, billable_metric: ops_bm)
+Charge.create_with(
+  organization:,
+  charge_model: "standard",
+  amount_currency: "EUR",
+  properties: {
+    amount: "500"
+  }
+).find_or_create_by!(plan:, billable_metric: ops_bm)
 
 def create_customer_with_sub(ext_id, plan:, organization:)
   customer = FactoryBot.create(:customer, organization:, external_id: "cust_#{ext_id}")
@@ -28,7 +33,8 @@ def create_customer_with_sub(ext_id, plan:, organization:)
     status: :active,
     billing_time: :calendar,
     plan:,
-    external_id: "sub_#{ext_id}"
+    external_id: "sub_#{ext_id}",
+    organization:
   )
 end
 

--- a/db/seeds/invoices.rb
+++ b/db/seeds/invoices.rb
@@ -21,6 +21,7 @@ Invoice.all.find_each do |invoice|
   next if amount.zero?
 
   credit_note = CreditNote.create!(
+    organization_id: invoice.organization_id,
     customer: invoice.customer,
     invoice:,
     credit_amount_cents: amount,
@@ -36,6 +37,7 @@ Invoice.all.find_each do |invoice|
   )
 
   credit_note.items.create!(
+    organization_id: invoice.organization_id,
     fee:,
     amount_cents: amount,
     precise_amount_cents: amount,

--- a/db/seeds/webhooks.rb
+++ b/db/seeds/webhooks.rb
@@ -9,9 +9,9 @@ ApiKey.find_or_create_by!(organization:)
 webhook_endpoint = WebhookEndpoint.find_or_create_by!(organization:, webhook_url: "http://test.lago.dev/webhook")
 
 3.times do
-  FactoryBot.create(:webhook, :succeeded, webhook_endpoint:)
-  FactoryBot.create(:webhook, :succeeded_with_retries, webhook_endpoint:)
-  FactoryBot.create(:webhook, :failed, webhook_endpoint:)
-  FactoryBot.create(:webhook, :failed_with_retries, webhook_endpoint:)
-  FactoryBot.create(:webhook, :pending, webhook_endpoint:)
+  FactoryBot.create(:webhook, :succeeded, organization:, webhook_endpoint:)
+  FactoryBot.create(:webhook, :succeeded_with_retries, organization:, webhook_endpoint:)
+  FactoryBot.create(:webhook, :failed, organization:, webhook_endpoint:)
+  FactoryBot.create(:webhook, :failed_with_retries, organization:, webhook_endpoint:)
+  FactoryBot.create(:webhook, :pending, organization:, webhook_endpoint:)
 end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -53,7 +53,6 @@ FactoryBot.define do
         subscriptions { [create(:subscription)] }
       end
 
-      invoice_type { :subscription }
       after :create do |invoice, evaluator|
         evaluator.subscriptions.each do |subscription|
           create(:invoice_subscription, :boundaries, invoice:, subscription:)

--- a/spec/factories/taxes.rb
+++ b/spec/factories/taxes.rb
@@ -16,9 +16,9 @@ FactoryBot.define do
         billing_entity { nil }
       end
 
-      before(:create) do |tax, evaluator|
+      after(:create) do |tax, evaluator|
         billing_entity = evaluator.billing_entity || tax.organization.default_billing_entity
-        billing_entity.taxes << tax
+        create(:billing_entity_applied_tax, tax:, billing_entity:, organization: tax.organization)
       end
     end
   end

--- a/spec/graphql/mutations/credit_notes/retry_tax_reporting_spec.rb
+++ b/spec/graphql/mutations/credit_notes/retry_tax_reporting_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe Mutations::CreditNotes::RetryTaxReporting, type: :graphql do
   let(:invoice) do
     create(
       :invoice,
+      :with_subscriptions,
       organization:,
       customer:,
       subscriptions: [subscription],
       currency: "EUR"
     )
   end
+
   let(:credit_note) do
     create(
       :credit_note,
@@ -27,6 +29,7 @@ RSpec.describe Mutations::CreditNotes::RetryTaxReporting, type: :graphql do
       invoice:
     )
   end
+
   let(:subscription) do
     create(
       :subscription,

--- a/spec/graphql/mutations/invoices/finalize_all_spec.rb
+++ b/spec/graphql/mutations/invoices/finalize_all_spec.rb
@@ -13,12 +13,14 @@ RSpec.describe Mutations::Invoices::FinalizeAll, type: :graphql do
     create(
       :invoice,
       :draft,
+      :with_subscriptions,
       organization:,
       customer:,
       subscriptions: [subscription],
       currency: "EUR"
     )
   end
+
   let(:subscription) do
     create(
       :subscription,

--- a/spec/graphql/mutations/invoices/retry_all_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_all_spec.rb
@@ -13,12 +13,14 @@ RSpec.describe Mutations::Invoices::RetryAll, type: :graphql do
     create(
       :invoice,
       :failed,
+      :with_subscriptions,
       organization:,
       customer:,
       subscriptions: [subscription],
       currency: "EUR"
     )
   end
+
   let(:subscription) do
     create(
       :subscription,

--- a/spec/graphql/mutations/invoices/retry_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_spec.rb
@@ -13,12 +13,14 @@ RSpec.describe Mutations::Invoices::Retry, type: :graphql do
     create(
       :invoice,
       :failed,
+      :with_subscriptions,
       organization:,
       customer:,
       subscriptions: [subscription],
       currency: "EUR"
     )
   end
+
   let(:subscription) do
     create(
       :subscription,

--- a/spec/graphql/mutations/invoices/retry_tax_provider_voiding_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_tax_provider_voiding_spec.rb
@@ -14,12 +14,14 @@ RSpec.describe Mutations::Invoices::RetryTaxProviderVoiding, type: :graphql do
       :invoice,
       :voided,
       :with_tax_voiding_error,
+      :subscription,
       organization:,
       customer:,
       subscriptions: [subscription],
       currency: "EUR"
     )
   end
+
   let(:subscription) do
     create(
       :subscription,

--- a/spec/graphql/resolvers/billing_entity_taxes_resolver_spec.rb
+++ b/spec/graphql/resolvers/billing_entity_taxes_resolver_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Resolvers::BillingEntityTaxesResolver, type: :graphql do
   let(:tax2) { create(:tax, organization: organization) }
 
   before do
-    billing_entity.taxes << [tax1, tax2]
+    create(:billing_entity_applied_tax, billing_entity:, tax: tax1, organization:)
+    create(:billing_entity_applied_tax, billing_entity:, tax: tax2, organization:)
   end
 
   it "returns billing entity taxes" do

--- a/spec/graphql/resolvers/credit_notes_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes_resolver_spec.rb
@@ -158,7 +158,10 @@ RSpec.describe Resolvers::CreditNotesResolver, type: :graphql do
     let(:arguments) { "invoiceNumber: #{credit_note.invoice.number.inspect}" }
     let!(:credit_note) { create(:credit_note, customer:) }
 
-    before { create(:credit_note, customer:) }
+    before do
+      invoice = create(:invoice, customer:, number: "FOO-01")
+      create(:credit_note, customer:, invoice:)
+    end
 
     it "returns finalized credit_notes matching invoice number" do
       expect(response_collection.pluck("id")).to contain_exactly credit_note.id
@@ -207,7 +210,10 @@ RSpec.describe Resolvers::CreditNotesResolver, type: :graphql do
     let(:arguments) { "searchTerm: #{credit_note.number.inspect}" }
     let!(:credit_note) { create(:credit_note, customer:) }
 
-    before { create(:credit_note, customer:) }
+    before do
+      invoice = create(:invoice, customer:, number: "FOO-01")
+      create(:credit_note, customer:, invoice:)
+    end
 
     it "returns finalized credit_notes matching the terms" do
       expect(response_collection.pluck("id")).to contain_exactly credit_note.id

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -11,13 +11,13 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
     let(:subscription2) { create(:subscription, ending_at: ending_at + 1.year) }
     let(:subscription3) { create(:subscription, ending_at: nil) }
     let(:webhook_started1) do
-      create(:webhook, :succeeded, object_id: subscription1.id, webhook_type: "subscription.started")
+      create(:webhook, :succeeded, object: subscription1, webhook_type: "subscription.started")
     end
     let(:webhook_started2) do
-      create(:webhook, :succeeded, object_id: subscription2.id, webhook_type: "subscription.started")
+      create(:webhook, :succeeded, object: subscription2, webhook_type: "subscription.started")
     end
     let(:webhook_started3) do
-      create(:webhook, :succeeded, object_id: subscription3.id, webhook_type: "subscription.started")
+      create(:webhook, :succeeded, object: subscription3, webhook_type: "subscription.started")
     end
 
     before do
@@ -80,7 +80,7 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
         create(
           :webhook,
           :succeeded,
-          object_id: subscription1.id,
+          object: subscription1,
           webhook_type: "subscription.termination_alert",
           created_at: Time.current + 2.months
         )
@@ -107,7 +107,7 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
         create(
           :webhook,
           :succeeded,
-          object_id: subscription1.id,
+          object: subscription1,
           webhook_type: "subscription.termination_alert",
           created_at: ending_at - 45.days
         )
@@ -134,7 +134,7 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
         create(
           :webhook,
           :succeeded,
-          object_id: subscription1.id,
+          object: subscription1,
           webhook_type: "subscription.termination_alert",
           created_at: ending_at - 45.days
         )
@@ -144,7 +144,7 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
         create(
           :webhook,
           :succeeded,
-          object_id: subscription1.id,
+          object: subscription1,
           webhook_type: "subscription.termination_alert",
           created_at: ending_at - 45.days
         )

--- a/spec/models/applied_invoice_custom_section_spec.rb
+++ b/spec/models/applied_invoice_custom_section_spec.rb
@@ -6,4 +6,5 @@ RSpec.describe AppliedInvoiceCustomSection, type: :model do
   subject(:applied_invoice_custom_section) { build(:applied_invoice_custom_section) }
 
   it { is_expected.to belong_to(:invoice) }
+  it { is_expected.to belong_to(:organization) }
 end

--- a/spec/models/applied_usage_threshold_spec.rb
+++ b/spec/models/applied_usage_threshold_spec.rb
@@ -6,4 +6,5 @@ RSpec.describe AppliedUsageThreshold, type: :model do
   subject(:applied_usage_threshold) { build(:applied_usage_threshold) }
 
   it { is_expected.to belong_to(:usage_threshold) }
+  it { is_expected.to belong_to(:organization) }
 end

--- a/spec/models/billable_metric_filter_spec.rb
+++ b/spec/models/billable_metric_filter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe BillableMetricFilter, type: :model do
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:billable_metric) }
+  it { is_expected.to belong_to(:organization) }
   it { is_expected.to have_many(:filter_values).dependent(:destroy) }
   it { is_expected.to have_many(:charge_filters).through(:filter_values) }
 

--- a/spec/models/billing_entity/applied_tax_spec.rb
+++ b/spec/models/billing_entity/applied_tax_spec.rb
@@ -7,4 +7,5 @@ RSpec.describe BillingEntity::AppliedTax, type: :model do
 
   it { is_expected.to belong_to(:billing_entity) }
   it { is_expected.to belong_to(:tax) }
+  it { is_expected.to belong_to(:organization) }
 end

--- a/spec/models/charge/applied_tax_spec.rb
+++ b/spec/models/charge/applied_tax_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe Charge::AppliedTax, type: :model do
+  subject(:charge_applied_tax) { create(:charge_applied_tax) }
+
+  it { is_expected.to belong_to(:charge) }
+  it { is_expected.to belong_to(:tax) }
+  it { is_expected.to belong_to(:organization) }
+end

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe ChargeFilter, type: :model do
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:charge) }
+  it { is_expected.to belong_to(:organization) }
   it { is_expected.to have_many(:values).dependent(:destroy) }
   it { is_expected.to have_many(:fees) }
 

--- a/spec/models/charge_filter_value_spec.rb
+++ b/spec/models/charge_filter_value_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ChargeFilterValue, type: :model do
 
   it { is_expected.to belong_to(:charge_filter) }
   it { is_expected.to belong_to(:billable_metric_filter) }
+  it { is_expected.to belong_to(:organization) }
 
   it { is_expected.to validate_presence_of(:values) }
 

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Charge, type: :model do
 
   it_behaves_like "paper_trail traceable"
 
-  it { is_expected.to belong_to(:organization).optional }
+  it { is_expected.to belong_to(:organization) }
   it { is_expected.to have_many(:filters).dependent(:destroy) }
 
   it { is_expected.to have_one(:applied_pricing_unit) }

--- a/spec/models/commitment/applied_tax_spec.rb
+++ b/spec/models/commitment/applied_tax_spec.rb
@@ -5,4 +5,5 @@ require "rails_helper"
 RSpec.describe Commitment::AppliedTax, type: :model do
   it { is_expected.to belong_to(:commitment) }
   it { is_expected.to belong_to(:tax) }
+  it { is_expected.to belong_to(:organization) }
 end

--- a/spec/models/commitment_spec.rb
+++ b/spec/models/commitment_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe Commitment, type: :model do
   it { is_expected.to belong_to(:plan) }
+  it { is_expected.to belong_to(:organization) }
   it { is_expected.to have_many(:applied_taxes).dependent(:destroy) }
   it { is_expected.to have_many(:taxes) }
 

--- a/spec/models/coupon_target_spec.rb
+++ b/spec/models/coupon_target_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe CouponTarget, type: :model do
+  subject(:coupon_target) { build(:coupon_plan) }
+
+  it { is_expected.to belong_to(:organization) }
+end

--- a/spec/models/credit_note/applied_tax_spec.rb
+++ b/spec/models/credit_note/applied_tax_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CreditNote::AppliedTax, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:credit_note) }
     it { is_expected.to belong_to(:tax).optional }
+    it { is_expected.to belong_to(:organization) }
   end
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/credit_note_item_spec.rb
+++ b/spec/models/credit_note_item_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe CreditNoteItem, type: :model do
 
   it { is_expected.to belong_to(:credit_note) }
   it { is_expected.to belong_to(:fee) }
+  it { is_expected.to belong_to(:organization) }
 
   describe "#sub_total_excluding_taxes_amount_cents" do
     let(:credit_note_item) { build(:credit_note_item, amount_cents: 100, fee: fee) }

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe CreditNote, type: :model do
 
   it_behaves_like "paper_trail traceable"
 
+  it { is_expected.to belong_to(:organization) }
   it { is_expected.to have_many(:integration_resources) }
   it { is_expected.to have_many(:error_details) }
 

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Credit, type: :model do
     it { is_expected.to belong_to(:applied_coupon).optional }
     it { is_expected.to belong_to(:credit_note).optional }
     it { is_expected.to belong_to(:progressive_billing_invoice).optional }
+    it { is_expected.to belong_to(:organization) }
   end
 
   describe "scopes" do

--- a/spec/models/customer/applied_tax_spec.rb
+++ b/spec/models/customer/applied_tax_spec.rb
@@ -6,4 +6,6 @@ RSpec.describe Customer::AppliedTax, type: :model do
   subject(:applied_tax) { create(:customer_applied_tax) }
 
   it_behaves_like "paper_trail traceable"
+
+  it { is_expected.to belong_to(:organization) }
 end

--- a/spec/models/data_export_part_spec.rb
+++ b/spec/models/data_export_part_spec.rb
@@ -4,4 +4,5 @@ require "rails_helper"
 
 RSpec.describe DataExportPart, type: :model do
   it { is_expected.to belong_to(:data_export) }
+  it { is_expected.to belong_to(:organization) }
 end

--- a/spec/models/dunning_campaign_threshold_spec.rb
+++ b/spec/models/dunning_campaign_threshold_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe DunningCampaignThreshold, type: :model do
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:dunning_campaign) }
+  it { is_expected.to belong_to(:organization) }
 
   it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than_or_equal_to(0) }
   it { is_expected.to validate_inclusion_of(:currency).in_array(described_class.currency_list) }

--- a/spec/models/fee/applied_tax_spec.rb
+++ b/spec/models/fee/applied_tax_spec.rb
@@ -6,4 +6,6 @@ RSpec.describe Fee::AppliedTax, type: :model do
   subject(:applied_tax) { create(:fee_applied_tax) }
 
   it_behaves_like "paper_trail traceable"
+
+  it { is_expected.to belong_to(:organization) }
 end

--- a/spec/models/integration_collection_mappings/base_collection_mapping_spec.rb
+++ b/spec/models/integration_collection_mappings/base_collection_mapping_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe IntegrationCollectionMappings::BaseCollectionMapping, type: :mode
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:integration) }
+  it { is_expected.to belong_to(:organization) }
 
   it { is_expected.to define_enum_for(:mapping_type).with_values(mapping_types) }
 
@@ -27,15 +28,15 @@ RSpec.describe IntegrationCollectionMappings::BaseCollectionMapping, type: :mode
         end
       end
 
-      context "when it not is unique in scope of integration" do
+      context "when it is not unique in scope of integration" do
         subject(:mapping) do
-          described_class.new(integration:, type:, mapping_type:)
+          described_class.new(integration:, type:, mapping_type:, organization: integration.organization)
         end
 
         let(:integration) { create(:netsuite_integration) }
 
         before do
-          described_class.create(integration:, type:, mapping_type:)
+          described_class.create(integration:, type:, mapping_type:, organization: integration.organization)
           mapping.valid?
         end
 

--- a/spec/models/integration_customers/base_customer_spec.rb
+++ b/spec/models/integration_customers/base_customer_spec.rb
@@ -3,15 +3,17 @@
 require "rails_helper"
 
 RSpec.describe IntegrationCustomers::BaseCustomer, type: :model do
-  subject(:integration_customer) { described_class.new(integration:, customer:, type:, external_customer_id:) }
+  subject(:integration_customer) { described_class.new(integration:, customer:, type:, external_customer_id:, organization:) }
 
   let(:integration) { create(:netsuite_integration) }
   let(:type) { "IntegrationCustomers::NetsuiteCustomer" }
   let(:customer) { create(:customer) }
+  let(:organization) { customer.organization }
   let(:external_customer_id) { "123" }
 
   it { is_expected.to belong_to(:integration) }
   it { is_expected.to belong_to(:customer) }
+  it { is_expected.to belong_to(:organization) }
 
   describe ".accounting_kind" do
     let(:netsuite_customer) { create(:netsuite_customer) }
@@ -202,13 +204,13 @@ RSpec.describe IntegrationCustomers::BaseCustomer, type: :model do
         end
       end
 
-      context "when it not is unique in scope of type" do
+      context "when it is not unique in scope of type" do
         subject(:another_integration_customer) do
-          described_class.new(integration:, customer:, type:, external_customer_id:)
+          described_class.new(integration:, customer:, type:, external_customer_id:, organization: organization)
         end
 
         before do
-          described_class.create(integration:, customer:, type:, external_customer_id:)
+          described_class.create(integration:, customer:, type:, external_customer_id:, organization: organization)
           another_integration_customer.valid?
         end
 

--- a/spec/models/integration_item_spec.rb
+++ b/spec/models/integration_item_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe IntegrationItem, type: :model do
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:integration) }
+  it { is_expected.to belong_to(:organization) }
   it { is_expected.to validate_presence_of(:external_id) }
   it { is_expected.to define_enum_for(:item_type).with_values(%i[standard tax account]) }
 

--- a/spec/models/integration_mappings/base_mapping_spec.rb
+++ b/spec/models/integration_mappings/base_mapping_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe IntegrationMappings::BaseMapping, type: :model do
   it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:integration) }
+  it { is_expected.to belong_to(:organization) }
 
   describe "#push_to_settings" do
     it "push the value into settings" do

--- a/spec/models/integration_resource_spec.rb
+++ b/spec/models/integration_resource_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe IntegrationResource, type: :model do
 
   it { is_expected.to belong_to(:syncable) }
   it { is_expected.to belong_to(:integration) }
+  it { is_expected.to belong_to(:organization) }
 
   it { is_expected.to define_enum_for(:resource_type).with_values(resource_types) }
 end

--- a/spec/models/invoice/applied_tax_spec.rb
+++ b/spec/models/invoice/applied_tax_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Invoice::AppliedTax, type: :model do
 
   it_behaves_like "paper_trail traceable"
 
+  it { is_expected.to belong_to(:organization) }
+
   describe "#applied_on_whole_invoice?" do
     subject(:applicable_on_whole_invoice) { applied_tax.applied_on_whole_invoice? }
 

--- a/spec/models/invoice_subscription_spec.rb
+++ b/spec/models/invoice_subscription_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe InvoiceSubscription, type: :model do
-  let(:invoice_subscription) do
+  subject(:invoice_subscription) do
     create(
       :invoice_subscription,
       from_datetime:,
@@ -20,6 +20,8 @@ RSpec.describe InvoiceSubscription, type: :model do
   let(:to_datetime) { "2022-01-31 23:59:59" }
   let(:charges_from_datetime) { "2022-01-01 00:00:00" }
   let(:charges_to_datetime) { "2022-01-31 23:59:59" }
+
+  it { is_expected.to belong_to(:organization) }
 
   describe "#fees" do
     it "returns corresponding fees" do

--- a/spec/models/metadata/customer_metadata_spec.rb
+++ b/spec/models/metadata/customer_metadata_spec.rb
@@ -9,8 +9,10 @@ RSpec.describe Metadata::CustomerMetadata, type: :model do
   let(:key) { "hello" }
   let(:value) { "abcdef" }
   let(:attributes) do
-    {key:, value:, customer:, display_in_invoice: true}
+    {key:, value:, customer:, display_in_invoice: true, organization: customer.organization}
   end
+
+  it { is_expected.to belong_to(:organization) }
 
   describe "key validations" do
     context "when uniqueness condition is satisfied", :tag do

--- a/spec/models/metadata/invoice_metadata_spec.rb
+++ b/spec/models/metadata/invoice_metadata_spec.rb
@@ -9,8 +9,10 @@ RSpec.describe Metadata::InvoiceMetadata, type: :model do
   let(:key) { "hello" }
   let(:value) { "abcdef" }
   let(:attributes) do
-    {key:, value:, invoice:}
+    {key:, value:, invoice:, organization: invoice.organization}
   end
+
+  it { is_expected.to belong_to(:organization) }
 
   describe "validations" do
     context "when uniqueness condition is satisfied" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -24,9 +24,17 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:billing_entities).conditions(archived_at: nil) }
   it { is_expected.to have_many(:all_billing_entities).class_name("BillingEntity") }
   it { is_expected.to have_many(:pricing_units) }
+  it { is_expected.to have_many(:customers) }
+  it { is_expected.to have_many(:subscriptions) }
+  it { is_expected.to have_many(:credit_notes) }
+  it { is_expected.to have_many(:invoices) }
+  it { is_expected.to have_many(:fees) }
+  it { is_expected.to have_many(:applied_coupons) }
+  it { is_expected.to have_many(:wallets) }
+  it { is_expected.to have_many(:wallet_transactions) }
   it { is_expected.to have_one(:default_billing_entity).class_name("BillingEntity") }
   it { is_expected.to have_many(:webhook_endpoints) }
-  it { is_expected.to have_many(:webhooks).through(:webhook_endpoints) }
+  it { is_expected.to have_many(:webhooks) }
   it { is_expected.to have_many(:hubspot_integrations) }
   it { is_expected.to have_many(:netsuite_integrations) }
   it { is_expected.to have_many(:xero_integrations) }

--- a/spec/models/payment_provider_customers/base_customer_spec.rb
+++ b/spec/models/payment_provider_customers/base_customer_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe PaymentProviderCustomers::BaseCustomer, type: :model do
+  subject(:integration_customer) { described_class.new(attributes) }
+
+  let(:attributes) { {} }
+
+  it { is_expected.to belong_to(:organization) }
+end

--- a/spec/models/payment_request/applied_invoice_spec.rb
+++ b/spec/models/payment_request/applied_invoice_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe PaymentRequest::AppliedInvoice, type: :model do
+  subject(:applied_invoice) { build(:payment_request_applied_invoice) }
+
+  it { is_expected.to belong_to(:organization) }
+end

--- a/spec/models/payment_request_spec.rb
+++ b/spec/models/payment_request_spec.rb
@@ -65,13 +65,8 @@ RSpec.describe PaymentRequest, type: :model do
   end
 
   describe "#invoice_ids" do
-    let(:payment_request) do
-      create(:payment_request, invoices:)
-    end
-
-    let(:invoices) do
-      create_list(:invoice, 2)
-    end
+    let(:payment_request) { create(:payment_request, invoices:) }
+    let(:invoices) { create_list(:invoice, 2, organization:) }
 
     it "returns a list with the applied invoice ids" do
       expect(payment_request.invoice_ids).to eq(invoices.map(&:id))

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Payment, type: :model do
   it { is_expected.to have_many(:integration_resources) }
   it { is_expected.to have_one(:payment_receipt) }
   it { is_expected.to belong_to(:payable) }
+  it { is_expected.to belong_to(:organization) }
   it { is_expected.to delegate_method(:customer).to(:payable) }
   it { is_expected.to validate_presence_of(:payment_type) }
 

--- a/spec/models/plan/applied_tax_spec.rb
+++ b/spec/models/plan/applied_tax_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Plan::AppliedTax, type: :model do
+  subject(:plan_applied_tax) { create(:plan_applied_tax) }
+
+  it { is_expected.to belong_to(:organization) }
+end

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe RecurringTransactionRule, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:wallet) }
+    it { is_expected.to belong_to(:organization) }
   end
 
   describe "enums" do

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Refund, type: :model do
+  subject(:refund) { build(:refund) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:organization) }
+  end
+end

--- a/spec/models/usage_threshold_spec.rb
+++ b/spec/models/usage_threshold_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe UsageThreshold, type: :model do
 
   it_behaves_like "paper_trail traceable"
 
+  it { is_expected.to belong_to(:organization) }
   it { is_expected.to have_many(:applied_usage_thresholds) }
   it { is_expected.to have_many(:invoices).through(:applied_usage_thresholds) }
 

--- a/spec/models/wallet_transaction_spec.rb
+++ b/spec/models/wallet_transaction_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe WalletTransaction, type: :model do
     it { is_expected.to belong_to(:wallet) }
     it { is_expected.to belong_to(:invoice).optional }
     it { is_expected.to belong_to(:credit_note).optional }
+    it { is_expected.to belong_to(:organization) }
   end
 
   describe "enums" do

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Webhook, type: :model do
 
   it { is_expected.to belong_to(:webhook_endpoint) }
   it { is_expected.to belong_to(:object).optional }
-  it { is_expected.to have_one(:organization).through(:webhook_endpoint) }
+  it { is_expected.to belong_to(:organization) }
 
   describe "#payload" do
     subject { webhook.payload }

--- a/spec/queries/credit_notes_query_spec.rb
+++ b/spec/queries/credit_notes_query_spec.rb
@@ -202,7 +202,10 @@ RSpec.describe CreditNotesQuery, type: :query do
 
     let!(:matching_credit_note) { create(:credit_note, customer:) }
 
-    before { create(:credit_note, customer:) }
+    before do
+      invoice = create(:invoice, customer:, number: "FOO-01")
+      create(:credit_note, customer:, invoice:)
+    end
 
     it "returns credit notes with matching invoice number" do
       expect(result).to be_success
@@ -413,7 +416,10 @@ RSpec.describe CreditNotesQuery, type: :query do
       let(:search_term) { matching_credit_note.number.first(10) }
       let!(:matching_credit_note) { create(:credit_note, customer:) }
 
-      before { create(:credit_note, customer:) }
+      before do
+        invoice = create(:invoice, customer:, number: "FOO-01")
+        create(:credit_note, customer:, invoice:)
+      end
 
       it "returns credit notes by partially matching number" do
         expect(result).to be_success

--- a/spec/requests/api/v1/billing_entities_controller_spec.rb
+++ b/spec/requests/api/v1/billing_entities_controller_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe Api::V1::BillingEntitiesController, type: :request do
       end
 
       before do
-        billing_entity1.taxes << tax1
+        create(:billing_entity_applied_tax, billing_entity: billing_entity1, tax: tax1)
       end
 
       it "updates the taxes" do

--- a/spec/requests/api/v1/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes_controller_spec.rb
@@ -341,7 +341,10 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
       let(:params) { {invoice_number: matching_credit_note.invoice.number} }
       let!(:matching_credit_note) { create(:credit_note, customer:) }
 
-      before { create(:credit_note, customer:) }
+      before do
+        invoice = create(:invoice, customer:, number: "FOO-01")
+        create(:credit_note, customer:, invoice:)
+      end
 
       it "returns credit notes with matching invoice number" do
         subject
@@ -449,7 +452,10 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
       let(:params) { {search_term: matching_credit_note.invoice.number} }
       let!(:matching_credit_note) { create(:credit_note, customer:) }
 
-      before { create(:credit_note, customer:) }
+      before do
+        invoice = create(:invoice, customer:, number: "FOO-01")
+        create(:credit_note, customer:, invoice:)
+      end
 
       it "returns credit notes matching the search terms" do
         subject

--- a/spec/requests/api/v1/payment_receipts_controller_spec.rb
+++ b/spec/requests/api/v1/payment_receipts_controller_spec.rb
@@ -98,14 +98,10 @@ RSpec.describe Api::V1::PaymentReceiptsController, type: :request do
     end
 
     context "when payment for a payment request exists" do
-      let(:payment_request) { create(:payment_request, customer:, organization:) }
+      let(:payment_request) { create(:payment_request, customer:, organization:, invoices: [invoice]) }
       let(:payment) { create(:payment, payable: payment_request) }
       let(:payment_receipt) { create(:payment_receipt, payment:, organization:) }
       let(:id) { payment_receipt.id }
-
-      before do
-        create(:payment_request_applied_invoice, invoice:, payment_request:)
-      end
 
       include_examples "requires API permission", "invoice", "read"
 

--- a/spec/requests/api/v1/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/payment_requests_controller_spec.rb
@@ -97,9 +97,8 @@ RSpec.describe Api::V1::PaymentRequestsController, type: :request do
       let(:customer) { create(:customer, organization:) }
 
       it "returns customer's payment requests", :aggregate_failures do
-        first_payment_request = create(:payment_request, customer:)
         invoice = create(:invoice, customer:)
-        create(:payment_request_applied_invoice, invoice:, payment_request: first_payment_request)
+        first_payment_request = create(:payment_request, customer:, invoices: [invoice])
         create(:payment_request)
 
         subject

--- a/spec/requests/api/v1/payments_controller_spec.rb
+++ b/spec/requests/api/v1/payments_controller_spec.rb
@@ -127,13 +127,9 @@ RSpec.describe Api::V1::PaymentsController, type: :request do
     end
 
     context "when payment for a payment request exits" do
-      let(:payment_request) { create(:payment_request, customer:, organization:) }
+      let(:payment_request) { create(:payment_request, customer:, organization:, invoices: [invoice]) }
       let(:payment) { create(:payment, payable: payment_request) }
       let(:id) { payment.id }
-
-      before do
-        create(:payment_request_applied_invoice, invoice:, payment_request:)
-      end
 
       include_examples "requires API permission", "payment", "read"
 

--- a/spec/scenarios/customers/customer_eu_taxes_spec.rb
+++ b/spec/scenarios/customers/customer_eu_taxes_spec.rb
@@ -208,7 +208,8 @@ describe "Add customer-specific taxes", :scenarios, type: :request do
     it "does not affect the customer taxes" do
       enable_eu_tax_management!
       billable_metric = create(:billable_metric, organization:, field_name: "item_id")
-      create(:standard_charge, :pay_in_advance, billable_metric:, plan:, taxes: [Tax.find_by(code: "lago_eu_fr_standard")])
+      charge = create(:standard_charge, :pay_in_advance, billable_metric:, plan:)
+      create(:charge_applied_tax, charge:, tax: Tax.find_by(code: "lago_eu_fr_standard"))
 
       mock_vies_check!("IT12345678901")
       create_or_update_customer(italian_attributes.merge(

--- a/spec/serializers/v1/payment_request_serializer_spec.rb
+++ b/spec/serializers/v1/payment_request_serializer_spec.rb
@@ -12,11 +12,7 @@ RSpec.describe ::V1::PaymentRequestSerializer do
   end
 
   let(:invoice) { create(:invoice) }
-  let(:payment_request) { create(:payment_request) }
-
-  before do
-    create(:payment_request_applied_invoice, invoice:, payment_request:)
-  end
+  let(:payment_request) { create(:payment_request, invoices: [invoice]) }
 
   it "serializes the object" do
     result = JSON.parse(serializer.to_json)

--- a/spec/services/billing_entities/taxes/apply_taxes_service_spec.rb
+++ b/spec/services/billing_entities/taxes/apply_taxes_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe BillingEntities::Taxes::ApplyTaxesService do
 
       context "when billing_entity already have taxes applied" do
         before do
-          billing_entity.applied_taxes.create!(tax: tax1)
+          billing_entity.applied_taxes.create!(tax: tax1, organization:)
         end
 
         it "does not create duplicate applied taxes" do

--- a/spec/services/billing_entities/taxes/manage_taxes_service_spec.rb
+++ b/spec/services/billing_entities/taxes/manage_taxes_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe BillingEntities::Taxes::ManageTaxesService do
         let(:tax3) { create(:tax, organization:, code: "TAX_CODE_3") }
 
         before do
-          billing_entity.taxes << tax3
+          create(:billing_entity_applied_tax, billing_entity:, tax: tax3)
         end
 
         it "removes the other tax and applies the new ones" do
@@ -94,7 +94,8 @@ RSpec.describe BillingEntities::Taxes::ManageTaxesService do
       let(:tax_codes) { [] }
 
       before do
-        billing_entity.taxes = [tax1, tax2]
+        create(:billing_entity_applied_tax, billing_entity:, tax: tax1)
+        create(:billing_entity_applied_tax, billing_entity:, tax: tax2)
       end
 
       it "removes taxes from the billing entity" do
@@ -112,7 +113,8 @@ RSpec.describe BillingEntities::Taxes::ManageTaxesService do
       let(:tax_codes) { nil }
 
       before do
-        billing_entity.taxes = [tax1, tax2]
+        create(:billing_entity_applied_tax, billing_entity:, tax: tax1)
+        create(:billing_entity_applied_tax, billing_entity:, tax: tax2)
       end
 
       it "removes taxes from the billing entity" do

--- a/spec/services/billing_entities/taxes/remove_taxes_service_spec.rb
+++ b/spec/services/billing_entities/taxes/remove_taxes_service_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe BillingEntities::Taxes::RemoveTaxesService do
       let(:tax2) { create(:tax, organization:, code: "TAX_CODE_2") }
 
       before do
-        billing_entity.applied_taxes.create!(tax: tax1)
-        billing_entity.applied_taxes.create!(tax: tax2)
+        billing_entity.applied_taxes.create!(tax: tax1, organization_id: organization.id)
+        billing_entity.applied_taxes.create!(tax: tax2, organization_id: organization.id)
       end
 
       it "removes the specified taxes from the billing entity" do

--- a/spec/services/credit_notes/provider_taxes/report_service_spec.rb
+++ b/spec/services/credit_notes/provider_taxes/report_service_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe CreditNotes::ProviderTaxes::ReportService, type: :service do
       create(
         :invoice,
         :voided,
+        :with_subscriptions,
         customer:,
         organization:,
         subscriptions: [subscription],

--- a/spec/services/credits/progressive_billing_service_spec.rb
+++ b/spec/services/credits/progressive_billing_service_spec.rb
@@ -43,6 +43,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
     let(:progressive_billing_invoice) do
       create(
         :invoice,
+        :with_subscriptions,
         organization:,
         customer:,
         status: "finalized",
@@ -104,6 +105,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
     let(:progressive_billing_invoice) do
       create(
         :invoice,
+        :with_subscriptions,
         organization:,
         customer:,
         status: "finalized",
@@ -118,6 +120,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
     let(:progressive_billing_invoice2) do
       create(
         :invoice,
+        :with_subscriptions,
         organization:,
         customer:,
         status: "finalized",
@@ -163,6 +166,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
     let(:progressive_billing_invoice) do
       create(
         :invoice,
+        :with_subscriptions,
         organization:,
         customer:,
         status: "finalized",
@@ -177,6 +181,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
     let(:progressive_billing_invoice2) do
       create(
         :invoice,
+        :with_subscriptions,
         organization:,
         customer:,
         status: "finalized",
@@ -222,6 +227,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
     let(:progressive_billing_invoice) do
       create(
         :invoice,
+        :with_subscriptions,
         organization:,
         customer:,
         status: "finalized",
@@ -236,6 +242,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
     let(:progressive_billing_invoice2) do
       create(
         :invoice,
+        :with_subscriptions,
         organization:,
         customer:,
         status: "finalized",
@@ -250,6 +257,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
     let(:progressive_billing_invoice3) do
       create(
         :invoice,
+        :with_subscriptions,
         organization:,
         customer:,
         status: "finalized",
@@ -321,6 +329,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
     let(:progressive_billing_invoice) do
       create(
         :invoice,
+        :with_subscriptions,
         organization:,
         customer:,
         status: "finalized",
@@ -362,6 +371,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
     let(:progressive_billing_invoice) do
       create(
         :invoice,
+        :with_subscriptions,
         organization:,
         customer:,
         status: "finalized",
@@ -397,6 +407,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
     let(:progressive_billing_invoice) do
       create(
         :invoice,
+        :with_subscriptions,
         organization:,
         customer:,
         status: "finalized",

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DataExports::Csv::InvoiceFees do
   end
 
   let(:data_export_part) do
-    data_export.data_export_parts.create(index: 1, object_ids: [invoice.id])
+    data_export.data_export_parts.create(index: 1, object_ids: [invoice.id], organization_id: data_export.organization_id)
   end
 
   let(:resource_query) do

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe DataExports::Csv::Invoices do
   let(:data_export) { create :data_export, :processing, resource_query:, organization: }
 
-  let(:data_export_part) { data_export.data_export_parts.create(object_ids: [invoice.id], index: 1) }
+  let(:data_export_part) { data_export.data_export_parts.create(object_ids: [invoice.id], index: 1, organization:) }
 
   let(:resource_query) do
     {

--- a/spec/services/fees/apply_taxes_service_spec.rb
+++ b/spec/services/fees/apply_taxes_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Fees::ApplyTaxesService, type: :service do
     tax1
     tax2
     tax3
-    billing_entity.taxes << tax3
+    create(:billing_entity_applied_tax, billing_entity:, tax: tax3)
   end
 
   describe "call" do
@@ -62,7 +62,7 @@ RSpec.describe Fees::ApplyTaxesService, type: :service do
         )
       end
 
-      before { commitment.taxes << tax2 }
+      before { create(:commitment_applied_tax, commitment:, tax: tax2) }
 
       it "creates applied_taxes based on the commitment taxes" do
         result = apply_service.call

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Fees::ChargeService do
   let(:subscription) do
     create(
       :subscription,
+      organization:,
       status: :active,
       started_at: Time.zone.parse("2022-03-15"),
       customer:

--- a/spec/services/fees/commitments/minimum/create_service_spec.rb
+++ b/spec/services/fees/commitments/minimum/create_service_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Fees::Commitments::Minimum::CreateService do
         let(:taxes_amount_cents) { (commitment_fee.amount_cents * commitment_tax.rate / 100.to_f).round }
 
         before do
-          plan.minimum_commitment.taxes << commitment_tax
+          create(:commitment_applied_tax, commitment: plan.minimum_commitment, tax: commitment_tax)
         end
 
         it "creates a commitment fee" do

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -23,13 +23,14 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       organization:,
       currency: "EUR",
       issuing_date: Time.zone.at(timestamp).to_date,
-      customer: subscription.customer
+      customer:
     )
   end
 
   let(:subscription) do
     create(
       :subscription,
+      organization:,
       plan:,
       customer:,
       billing_time:,
@@ -64,7 +65,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
   let(:invoice_subscriptions) { [invoice_subscription] }
 
-  let(:billable_metric) { create(:billable_metric, aggregation_type: "count_agg") }
+  let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: "count_agg") }
   let(:timestamp) { Time.zone.now.beginning_of_month }
   let(:started_at) { Time.zone.now - 2.years }
   let(:created_at) { started_at }
@@ -146,6 +147,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         let(:progressive_invoice) do
           create(
             :invoice,
+            :with_subscriptions,
             customer:,
             status: "finalized",
             invoice_type: :progressive_billing,
@@ -262,6 +264,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             :standard_charge,
             :pay_in_advance,
             plan: subscription.plan,
+            organization:,
             charge_model: "standard",
             invoiceable: true
           )
@@ -287,6 +290,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             :standard_charge,
             :pay_in_advance,
             plan: subscription.plan,
+            organization:,
             charge_model: "standard",
             invoiceable: true,
             billable_metric:
@@ -310,6 +314,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             :standard_charge,
             :pay_in_advance,
             plan: subscription.plan,
+            organization:,
             charge_model: "standard",
             invoiceable: false
           )
@@ -328,7 +333,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
       context "when charge is pay_in_advance, recurring and not invoiceable" do
         let(:billable_metric) do
-          create(:billable_metric, aggregation_type: "unique_count_agg", recurring: true, field_name: "item_id")
+          create(:billable_metric, organization:, aggregation_type: "unique_count_agg", recurring: true, field_name: "item_id")
         end
         let(:charge) do
           create(
@@ -354,6 +359,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           create(
             :standard_charge,
             plan: subscription.plan,
+            organization:,
             charge_model: "standard",
             invoiceable: false
           )
@@ -423,7 +429,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             plan: subscription.plan,
             charge_model: "standard",
             invoiceable: false,
-            billable_metric: create(:billable_metric, aggregation_type: "unique_count_agg", recurring: true, field_name: "item_id")
+            billable_metric: create(:billable_metric, organization:, aggregation_type: "unique_count_agg", recurring: true, field_name: "item_id")
           )
         end
 

--- a/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
+++ b/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Invoices::ComputeTaxesAndTotalsService, type: :service do
       create(
         :invoice,
         :finalized,
+        :with_subscriptions,
         customer:,
         organization:,
         subscriptions: [subscription],

--- a/spec/services/invoices/create_generating_service_spec.rb
+++ b/spec/services/invoices/create_generating_service_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Invoices::CreateGeneratingService, type: :service do
       it "creates an invoice" do
         result = create_service.call do |invoice|
           invoice.invoice_subscriptions.create!(
+            organization: customer.organization,
             subscription:,
             recurring:,
             from_datetime: datetime.beginning_of_month,

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
   let(:customer) { create(:customer, organization:) }
   let(:customer_id) { customer&.id }
   let(:subscription_id) { subscription&.id }
-  let(:plan) { create(:plan, interval: "monthly") }
+  let(:plan) { create(:plan, organization:, interval: "monthly") }
   let(:timestamp) { Time.current }
   let(:apply_taxes) { true }
 

--- a/spec/services/invoices/preview_context_service_spec.rb
+++ b/spec/services/invoices/preview_context_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
     end
 
     before do
-      create(:coupon, organization:) { |coupon| customer.coupons << coupon }
+      create(:coupon, organization:) { create(:applied_coupon, coupon: it, customer:) }
     end
 
     it "assigns customer, plan, and applied coupons to result" do
@@ -251,7 +251,7 @@ RSpec.describe Invoices::PreviewContextService, type: :service do
       let(:customer) { create(:customer, organization:) }
 
       before do
-        create(:coupon, organization:) { |coupon| customer.coupons << coupon }
+        create(:coupon, organization:) { create(:applied_coupon, coupon: it, customer:) }
       end
 
       context "when coupons are provided" do

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service, transaction:
       before do
         invoice = create(
           :invoice,
+          :with_subscriptions,
           organization:,
           customer:,
           status: "finalized",

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
         :invoice,
         :pending,
         :with_tax_error,
+        :with_subscriptions,
         customer:,
         billing_entity:,
         organization:,

--- a/spec/services/invoices/provider_taxes/void_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/void_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
         :invoice,
         :voided,
         :with_tax_voiding_error,
+        :with_subscriptions,
         customer:,
         organization:,
         subscriptions: [subscription],

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
       create(
         :invoice,
         :draft,
+        :with_subscriptions,
         organization:,
         customer:,
         subscriptions: [subscription],
@@ -290,6 +291,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
         create(
           :invoice,
           :failed,
+          :with_subscriptions,
           customer:,
           subscriptions: [subscription],
           currency: "EUR",

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Invoices::RetryService, type: :service do
         :invoice,
         :failed,
         :with_tax_error,
+        :subscription,
         customer:,
         organization:,
         subscriptions: [subscription],

--- a/spec/services/lifetime_usages/check_thresholds_service_spec.rb
+++ b/spec/services/lifetime_usages/check_thresholds_service_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe LifetimeUsages::CheckThresholdsService, type: :service, transacti
     let(:progressive_billing_invoice) do
       create(
         :invoice,
+        :with_subscriptions,
         organization:,
         customer:,
         status: "finalized",

--- a/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
+++ b/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe LifetimeUsages::UsageThresholds::CheckService, type: :service do
 
   def create_thresholds(subscription, amounts:, recurring: nil)
     amounts.each do |amount|
-      subscription.plan.usage_thresholds.create!(amount_cents: amount)
+      subscription.plan.usage_thresholds.create!(amount_cents: amount, organization:)
     end
     if recurring
-      subscription.plan.usage_thresholds.create!(amount_cents: recurring, recurring: true)
+      subscription.plan.usage_thresholds.create!(amount_cents: recurring, recurring: true, organization:)
     end
   end
 


### PR DESCRIPTION
Reapply #3838 that was rollbacked to allow a non blocking release

## Context

This PR is part of the epic to add `organization_id` on all tables of the application

## Description

The current one is removing the `optional` attribute on all `belongs_to :organization` relations. In a next step the presence will be enforced at database level with a not null constraint

The PR also updates the relations from customer and organization table to make sure it uses the organization_id column.

**NOTE**: Since this change will require all tables to be updated before the release, a migration guide will be added (See https://getlago.com/docs/guide/migration/migration-to-v1.29.0 as an example). The guide will state that customer will have to first run the [migrations:fill_organization_id rake task](https://github.com/getlago/lago-api/blob/main/lib/tasks/migrations/organization_id.rake)