### PR TITLE
feat: Generate credit note validate License

### DIFF
--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -18,6 +18,7 @@ module Invoices
 
     def call
       return result.not_found_failure!(resource: "invoice") unless invoice
+      return result.forbidden_failure! if generate_credit_note && !License.premium?
       return result.not_allowed_failure!(code: "not_voidable") if invoice.voided?
       return result.not_allowed_failure!(code: "not_voidable") if !invoice.voidable? && !explicit_void_intent?
       unless valid_credit_note_amounts?

--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -18,7 +18,7 @@ module Invoices
 
     def call
       return result.not_found_failure!(resource: "invoice") unless invoice
-      return result.forbidden_failure! if generate_credit_note && !License.premium?
+      return result.forbidden_failure! unless generate_credit_note_allowed?
       return result.not_allowed_failure!(code: "not_voidable") if invoice.voided?
       return result.not_allowed_failure!(code: "not_voidable") if !invoice.voidable? && !explicit_void_intent?
       unless valid_credit_note_amounts?
@@ -75,6 +75,11 @@ module Invoices
       else
         invoice.void!
       end
+    end
+
+    def generate_credit_note_allowed?
+      return true unless generate_credit_note   # nothing requested
+      License.premium?                          # licence check
     end
 
     def flag_lifetime_usage_for_refresh

--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -78,8 +78,8 @@ module Invoices
     end
 
     def generate_credit_note_allowed?
-      return true unless generate_credit_note   # nothing requested
-      License.premium?                          # licence check
+      return true unless generate_credit_note
+      License.premium?
     end
 
     def flag_lifetime_usage_for_refresh

--- a/spec/graphql/mutations/invoices/void_spec.rb
+++ b/spec/graphql/mutations/invoices/void_spec.rb
@@ -46,8 +46,10 @@ RSpec.describe Mutations::Invoices::Void, type: :graphql do
   end
 
   context "when passing credit note parameters" do
+    around { |test| lago_premium!(&test) }
     let(:credit_amount) { 0 }
     let(:refund_amount) { 0 }
+
 
     it "calls the void service with all parameters" do
       allow(::Invoices::VoidService).to receive(:call).with(

--- a/spec/graphql/mutations/invoices/void_spec.rb
+++ b/spec/graphql/mutations/invoices/void_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe Mutations::Invoices::Void, type: :graphql do
 
   context "when passing credit note parameters" do
     around { |test| lago_premium!(&test) }
+
     let(:credit_amount) { 0 }
     let(:refund_amount) { 0 }
-
 
     it "calls the void service with all parameters" do
       allow(::Invoices::VoidService).to receive(:call).with(

--- a/spec/services/invoices/void_service_spec.rb
+++ b/spec/services/invoices/void_service_spec.rb
@@ -203,6 +203,7 @@ RSpec.describe Invoices::VoidService, type: :service do
       end
 
       context "when the invoice is voided" do
+        around { |test| lago_premium!(&test) }
         let(:invoice) { create(:invoice, status: :voided) }
 
         it "returns a failure" do

--- a/spec/services/invoices/void_service_spec.rb
+++ b/spec/services/invoices/void_service_spec.rb
@@ -204,6 +204,7 @@ RSpec.describe Invoices::VoidService, type: :service do
 
       context "when the invoice is voided" do
         around { |test| lago_premium!(&test) }
+
         let(:invoice) { create(:invoice, status: :voided) }
 
         it "returns a failure" do


### PR DESCRIPTION
## Context
Voiding an invoice with the [generate_credit_note]

flag should be exclusive to organizations on a Premium license.  
Prior to this change, non-premium tenants could still try to generate credit notes through the void-invoice path, bypassing licensing rules this would lead to a 500 error on the server 

## Description
Added a guard clause in `Invoices::VoidService#call`:

```ruby
    def generate_credit_note_allowed?
      return true unless generate_credit_note   # nothing requested
      License.premium?                          # licence check
    end
```