### PR TITLE
fix(invoice): Fix race-condition in invoice update jobs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,4 +2,21 @@
 
 class ApplicationJob < ActiveJob::Base
   sidekiq_options retry: 0
+
+  # This method is used to perform a job after a commit.
+  #
+  # It is meant to avoid race-conditions where a job run before changes are commited to the DB and we end up with stale
+  # data in the job.
+  #
+  # It is also possible to rely on `ActiveJob::Base.enqueue_after_transaction_commit` but this doesn't allow incremental
+  # changes.
+  #
+  # Note that this method is not compatible with configured jobs, e.g.
+  # `Invoices::UpdateFeesPaymentStatusJob.set(wait: 30.seconds).perform_later(invoice)`.
+  #
+  def self.perform_after_commit(...)
+    AfterCommitEverywhere.after_commit do
+      perform_later(...)
+    end
+  end
 end

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -18,6 +18,16 @@ module Utils
       new(*, **, &).produce
     end
 
+    # This method is used to produce an activity log after a commit.
+    #
+    # It is meant to avoid race-conditions where a asynchronous post-processing run before changes are commited to the DB.
+    def self.produce_after_commit(object, activity_type, activity_id: nil, &)
+      AfterCommitEverywhere.after_commit do
+        kwargs = {activity_id:}.compact
+        produce(object, activity_type, **kwargs, &)
+      end
+    end
+
     def initialize(object, activity_type, activity_id: SecureRandom.uuid, &block)
       @object = object
       @activity_type = activity_type

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationJob, type: :job do
+  let(:job_class) do
+    Class.new(ApplicationJob) do
+      def perform(arg1, arg2, option: "default")
+      end
+    end
+  end
+
+  describe "#perform_after_commit" do
+    it "performs the job after the commit" do
+      ApplicationRecord.transaction do
+        job_class.perform_after_commit(1, 2, option: "custom")
+        expect(job_class).not_to have_been_enqueued
+      end
+
+      expect(job_class).to have_been_enqueued.with(1, 2, option: "custom")
+    end
+  end
+end

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe Invoices::UpdateService do
   let(:result) { invoice_service.call }
 
   describe "call" do
-    before do
-      allow(Invoices::PrepaidCreditJob).to receive(:perform_later)
-    end
-
     it "updates the invoice" do
       aggregate_failures do
         expect(result).to be_success
@@ -102,11 +98,7 @@ RSpec.describe Invoices::UpdateService do
 
     context "with attached fees" do
       it "enqueues a job to update the payment_status of the fees" do
-        result
-
-        expect(Invoices::UpdateFeesPaymentStatusJob)
-          .to have_been_enqueued
-          .with(invoice)
+        expect { result }.to enqueue_after_commit(Invoices::UpdateFeesPaymentStatusJob).with(invoice)
       end
     end
 
@@ -199,6 +191,29 @@ RSpec.describe Invoices::UpdateService do
       end
     end
 
+    context "when invoice has hubspot integration" do
+      let(:sync_invoices) { true }
+      let(:organization) { create(:organization) }
+      let(:customer) { create(:customer, organization:) }
+      let(:integration) { create(:hubspot_integration, organization:, sync_invoices:) }
+      let(:integration_customer) { create(:hubspot_customer, integration:, customer:, organization:) }
+      let(:invoice) { create(:invoice, customer: integration_customer.customer, organization:) }
+
+      it "enqueues a job to update the hubspot invoice" do
+        expect { result }.to enqueue_after_commit(Integrations::Aggregator::Invoices::Hubspot::UpdateJob).with(invoice:)
+      end
+
+      context "when it should not sync hubspot invoices" do
+        let(:sync_invoices) { false }
+
+        it "does not enqueue a job to update the hubspot invoice" do
+          result
+
+          expect(Integrations::Aggregator::Invoices::Hubspot::UpdateJob).not_to have_been_enqueued
+        end
+      end
+    end
+
     context "when invoice type is credit" do
       let(:subscription) { create(:subscription, customer: invoice.customer) }
       let(:wallet) { create(:wallet, customer: invoice.customer, balance: 10.0, credits_balance: 10.0) }
@@ -226,8 +241,7 @@ RSpec.describe Invoices::UpdateService do
         let(:update_args) { {payment_status: "succeeded"} }
 
         it "calls Invoices::PrepaidCreditJob with the correct arguments" do
-          result
-          expect(Invoices::PrepaidCreditJob).to have_received(:perform_later).with(invoice, :succeeded)
+          expect { result }.to enqueue_after_commit(Invoices::PrepaidCreditJob).with(invoice, :succeeded)
         end
       end
 
@@ -235,8 +249,7 @@ RSpec.describe Invoices::UpdateService do
         let(:update_args) { {payment_status: "failed"} }
 
         it "calls Invoices::PrepaidCreditJob with the correct arguments" do
-          result
-          expect(Invoices::PrepaidCreditJob).to have_received(:perform_later).with(invoice, :failed)
+          expect { result }.to enqueue_after_commit(Invoices::PrepaidCreditJob).with(invoice, :failed)
         end
       end
     end
@@ -250,12 +263,7 @@ RSpec.describe Invoices::UpdateService do
         end
 
         it "delivers a webhook" do
-          result
-
-          expect(SendWebhookJob).to have_been_enqueued.with(
-            "invoice.payment_status_updated",
-            invoice
-          )
+          expect { result }.to enqueue_after_commit(SendWebhookJob).with("invoice.payment_status_updated", invoice)
         end
 
         it "produces an activity log" do
@@ -269,12 +277,7 @@ RSpec.describe Invoices::UpdateService do
         before { invoice.update! status: :open }
 
         it "delivers a webhook" do
-          result
-
-          expect(SendWebhookJob).not_to have_been_enqueued.with(
-            "invoice.payment_status_updated",
-            invoice
-          )
+          expect { result }.not_to enqueue_after_commit(SendWebhookJob).with("invoice.payment_status_updated", invoice)
         end
       end
 

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -6,56 +6,75 @@ RSpec.describe Utils::ActivityLog, type: :service do
   let(:membership) { create(:membership) }
   let(:api_key) { create(:api_key) }
 
+  let(:organization) { create(:organization) }
+  let(:coupon) { create(:coupon, organization:) }
+  let(:karafka_producer) { instance_double(WaterDrop::Producer) }
+
+  let(:serialized_coupon) do
+    {topic: "activity_logs",
+     key: "#{organization.id}--activity-id",
+     payload: {
+       activity_source: "api",
+       api_key_id: api_key.id,
+       user_id: nil,
+       activity_type: "coupon.created",
+       activity_id: "activity-id",
+       logged_at: Time.current.iso8601[...-1],
+       created_at: Time.current.iso8601[...-1],
+       resource_id: coupon.id,
+       resource_type: "Coupon",
+       organization_id: organization.id,
+       activity_object: V1::CouponSerializer.new(coupon).serialize,
+       activity_object_changes: {},
+       external_customer_id: nil,
+       external_subscription_id: nil
+     }.to_json}
+  end
+
   before do
     allow(CurrentContext).to receive(:membership).and_return(membership.id)
     allow(CurrentContext).to receive(:api_key_id).and_return(api_key.id)
     allow(CurrentContext).to receive(:source).and_return("api")
     travel_to(Time.zone.parse("2023-03-22 12:00:00"))
+
+    allow(Karafka).to receive(:producer).and_return(karafka_producer)
+    allow(karafka_producer).to receive(:produce_async)
+  end
+
+  around do |example|
+    if example.metadata[:kafka_configured]
+      ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = "kafka"
+      ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"] = "activity_logs"
+    end
+    example.run
+  ensure
+    ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = nil
+    ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"] = nil
+  end
+
+  describe ".produce_after_commit" do
+    context "when kafka is configured", :kafka_configured do
+      it "produces the event on kafka after the commit" do
+        ApplicationRecord.transaction do
+          activity_log.produce_after_commit(coupon, "coupon.created", activity_id: "activity-id") { BaseService::Result.new }
+
+          expect(karafka_producer).not_to have_received(:produce_async)
+        end
+
+        expect(karafka_producer).to have_received(:produce_async).with(
+          **serialized_coupon
+        )
+      end
+    end
   end
 
   describe ".produce" do
-    let(:organization) { create(:organization) }
-    let(:coupon) { create(:coupon, organization:) }
-    let(:karafka_producer) { instance_double(WaterDrop::Producer) }
-
-    before do
-      allow(Karafka).to receive(:producer).and_return(karafka_producer)
-      allow(karafka_producer).to receive(:produce_async)
-    end
-
-    context "when kafka is configured" do
-      before do
-        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = "kafka"
-        ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"] = "activity_logs"
-      end
-
-      after do
-        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = nil
-        ENV["LAGO_KAFKA_ACTIVITY_LOGS_TOPIC"] = nil
-      end
-
+    context "when kafka is configured", :kafka_configured do
       it "produces the event on kafka" do
         activity_log.produce(coupon, "coupon.created", activity_id: "activity-id") { BaseService::Result.new }
 
         expect(karafka_producer).to have_received(:produce_async).with(
-          topic: "activity_logs",
-          key: "#{organization.id}--activity-id",
-          payload: {
-            activity_source: "api",
-            api_key_id: api_key.id,
-            user_id: nil,
-            activity_type: "coupon.created",
-            activity_id: "activity-id",
-            logged_at: Time.current.iso8601[...-1],
-            created_at: Time.current.iso8601[...-1],
-            resource_id: coupon.id,
-            resource_type: "Coupon",
-            organization_id: organization.id,
-            activity_object: V1::CouponSerializer.new(coupon).serialize,
-            activity_object_changes: {},
-            external_customer_id: nil,
-            external_subscription_id: nil
-          }.to_json
+          **serialized_coupon
         )
       end
 

--- a/spec/support/matchers/job_matcher.rb
+++ b/spec/support/matchers/job_matcher.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This matcher ensure that a job is enqueued only after a transaction is committed to ensure no race-condition may
+# happen.
+RSpec::Matchers.define :enqueue_after_commit do |job|
+  supports_block_expectations
+  match do |block|
+    ApplicationRecord.transaction do
+      block.call
+
+      expect(job).not_to have_been_enqueued
+    end
+
+    args = @args || []
+    kwargs = @kwargs || {}
+
+    expect(job).to have_been_enqueued.with(*args, **kwargs)
+  end
+
+  chain :with do |*args, **kwargs|
+    @args = args
+    @kwargs = kwargs
+  end
+end


### PR DESCRIPTION
## Context

When doing a manual payment, it will update the invoice payment status. When doing so, we're supposed to do a few things asynchronously like sending a webhook.

Unfortunately, the way it is working right now, our server will sometimes process those asynchronous jobs before the database transaction ends, and therefore before we actually update the invoice. We end up with not up-to-date data within those different actions.

For instance, the webhook might be triggered with `payment_status: 'pending'` in the payload instead of `payment_status: 'succeeded'`.

## Description

This commit fixes this issue by ensuring the jobs run after the transaction is committed. This is done by using `AfterCommitEverywhere.after_commit` callbacks.

To reduce the risk of mistakes, two new class methods were added:

- `ApplicationJob.perform_after_commit`
- `Utils::ActivityLog.produce_after_commit`

Doing this, we make the intention clear that the job should run after the transaction is committed.

Test were added for the new methods, and existing tests were updated to properly test that jobs are enqueued after the transaction is committed. To do so, a `expect {}.to enqueue_after_commit` matcher was added.
