### PR TITLE
feat: Admin add organization 

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -14,7 +14,7 @@ module Admin
 
       if auth_header&.start_with?("Bearer ")
         begin
-          token   = auth_header.split(" ").second
+          token = auth_header.split(" ").second
           payload = Google::Auth::IDTokens.verify_oidc(
             token,
             aud: ENV["GOOGLE_AUTH_CLIENT_ID"]
@@ -28,7 +28,7 @@ module Admin
       end
 
       # Fallback to X-Admin-API-Key header
-      key_header   = request.headers["X-Admin-API-Key"]
+      key_header = request.headers["X-Admin-API-Key"]
       expected_key = ENV["ADMIN_API_KEY"]
 
       if key_header.present? && expected_key.present? && ActiveSupport::SecurityUtils.secure_compare(key_header, expected_key)

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -12,18 +12,30 @@ module Admin
     def authenticate
       auth_header = request.headers["Authorization"]
 
-      return unauthorized_error unless auth_header
+      if auth_header&.start_with?("Bearer ")
+        begin
+          token   = auth_header.split(" ").second
+          payload = Google::Auth::IDTokens.verify_oidc(
+            token,
+            aud: ENV["GOOGLE_AUTH_CLIENT_ID"]
+          )
 
-      token = auth_header.split(" ").second
-      payload = Google::Auth::IDTokens.verify_oidc(
-        token,
-        aud: ENV["GOOGLE_AUTH_CLIENT_ID"]
-      )
+          CurrentContext.email = payload["email"]
+          return true
+        rescue Google::Auth::IDTokens::SignatureError
+          return unauthorized_error
+        end
+      end
 
-      CurrentContext.email = payload["email"]
+      # Fallback to X-Admin-API-Key header
+      key_header   = request.headers["X-Admin-API-Key"]
+      expected_key = ENV["ADMIN_API_KEY"]
 
-      true
-    rescue Google::Auth::IDTokens::SignatureError
+      if key_header.present? && expected_key.present? && ActiveSupport::SecurityUtils.secure_compare(key_header, expected_key)
+        CurrentContext.email = nil
+        return true
+      end
+
       unauthorized_error
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,7 +110,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :memberships, only: %i[create]
-    resources :organizations, only: %i[update]
+    resources :organizations, only: %i[update create]
     resources :invoices do
       post :regenerate, on: :member
     end

--- a/spec/requests/admin/organizations_controller_spec.rb
+++ b/spec/requests/admin/organizations_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Admin::OrganizationsController, type: [:request, :admin] do
 
     context "with a valid admin key" do
       it "creates an organization and returns 201" do
-        headers = { "X-Admin-API-Key" => "super-secret" }
+        headers = {"X-Admin-API-Key" => "super-secret"}
         expect do
           admin_post_without_bearer("/admin/organizations", create_params, headers)
         end.to change(Organization, :count).by(1)
@@ -55,7 +55,7 @@ RSpec.describe Admin::OrganizationsController, type: [:request, :admin] do
 
     context "with an invalid admin key" do
       it "returns unauthorized" do
-        headers = { "X-Admin-API-Key" => "wrong" }
+        headers = {"X-Admin-API-Key" => "wrong"}
         admin_post_without_bearer("/admin/organizations", create_params, headers)
         expect(response).to have_http_status(:unauthorized)
       end

--- a/spec/requests/admin/organizations_controller_spec.rb
+++ b/spec/requests/admin/organizations_controller_spec.rb
@@ -26,4 +26,39 @@ RSpec.describe Admin::OrganizationsController, type: [:request, :admin] do
       end
     end
   end
+
+  describe "POST /admin/organizations" do
+    let(:create_params) do
+      {
+        name: "NewCo",
+        email: "admin@newco.test"
+      }
+    end
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("ADMIN_API_KEY").and_return("super-secret")
+    end
+
+    context "with a valid admin key" do
+      it "creates an organization and returns 201" do
+        headers = { "X-Admin-API-Key" => "super-secret" }
+        expect do
+          admin_post_without_bearer("/admin/organizations", create_params, headers)
+        end.to change(Organization, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(json[:organization][:name]).to eq("NewCo")
+        expect(json[:invite_url]).to be_present
+      end
+    end
+
+    context "with an invalid admin key" do
+      it "returns unauthorized" do
+        headers = { "X-Admin-API-Key" => "wrong" }
+        admin_post_without_bearer("/admin/organizations", create_params, headers)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end

--- a/spec/support/admin_helper.rb
+++ b/spec/support/admin_helper.rb
@@ -19,6 +19,12 @@ module AdminHelper
     post(path, params: params.to_json, headers:)
   end
 
+  def admin_post_without_bearer(path, params = {}, headers = {})
+    apply_headers(headers)
+    headers.delete("Authorization")
+    post(path, params: params.to_json, headers:)
+  end
+
   def json
     return response.body unless response.media_type.include?("json")
 


### PR DESCRIPTION
## Context

This pr adds the create Organization endpoint for admin 

## Description
It adds a lightweight admin endpoint to create organizations via API, which is useful for self-hosted users and on-duty ops. POST /admin/organizations takes name and email, spins up the org with an admin invite, and returns both in the response.

Authentication in Admin::BaseController now accepts either the existing Google ID token (Authorization: Bearer …) or a static admin key passed as X-Admin-API-Key, read from ADMIN_API_KEY
