### PR TITLE
fix(seeds): Fix alerting seeds when no premium license is set

### DIFF
--- a/db/seeds/alerting.rb
+++ b/db/seeds/alerting.rb
@@ -45,13 +45,33 @@ UsageMonitoring::CreateAlertService.call(organization:, subscription:, params: {
   ]
 })
 
-alert = UsageMonitoring::CreateAlertService.call(organization:, subscription:, params: {
-  alert_type: "lifetime_usage_amount",
-  code: "total",
-  thresholds: [
-    {code: "info", value: 1000_00}
-  ]
-}).alert
+if License.premium?
+  alert = UsageMonitoring::CreateAlertService.call(organization:, subscription:, params: {
+    alert_type: "lifetime_usage_amount",
+    code: "total",
+    thresholds: [
+      {code: "info", value: 1000_00}
+    ]
+  }).alert
+
+  triggered_alert = UsageMonitoring::TriggeredAlert.create!(alert:, organization:, subscription:,
+    current_value: 51,
+    previous_value: 8,
+    crossed_thresholds: [
+      {code: nil, value: 10, recurring: false}, {code: :warn, value: 25, recurring: false}, {code: :alert, value: 50, recurring: false}
+    ],
+    triggered_at: 2.months.ago)
+  SendWebhookJob.perform_later("alert.triggered", triggered_alert)
+
+  triggered_alert = UsageMonitoring::TriggeredAlert.create!(alert:, organization:, subscription:,
+    current_value: 88,
+    previous_value: 234,
+    crossed_thresholds: [
+      {code: :alert, value: 100, recurring: false}, {code: :alert, value: 150, recurring: true}, {code: :alert, value: 200, recurring: true}
+    ],
+    triggered_at: 11.days.ago)
+  SendWebhookJob.perform_later("alert.triggered", triggered_alert)
+end
 
 bm_alert = UsageMonitoring::CreateAlertService.call(organization:, subscription:, params: {
   alert_type: "billable_metric_current_usage_amount",
@@ -62,25 +82,7 @@ bm_alert = UsageMonitoring::CreateAlertService.call(organization:, subscription:
     {value: 50_00},
     {value: 10_00, recurring: true}
   ]
-})
-
-triggered_alert = UsageMonitoring::TriggeredAlert.create!(alert:, organization:, subscription:,
-  current_value: 51,
-  previous_value: 8,
-  crossed_thresholds: [
-    {code: nil, value: 10, recurring: false}, {code: :warn, value: 25, recurring: false}, {code: :alert, value: 50, recurring: false}
-  ],
-  triggered_at: 2.months.ago)
-SendWebhookJob.perform_later("alert.triggered", triggered_alert)
-
-triggered_alert = UsageMonitoring::TriggeredAlert.create!(alert:, organization:, subscription:,
-  current_value: 88,
-  previous_value: 234,
-  crossed_thresholds: [
-    {code: :alert, value: 100, recurring: false}, {code: :alert, value: 150, recurring: true}, {code: :alert, value: 200, recurring: true}
-  ],
-  triggered_at: 11.days.ago)
-SendWebhookJob.perform_later("alert.triggered", triggered_alert)
+}).alert
 
 triggered_alert = UsageMonitoring::TriggeredAlert.create!(alert: bm_alert, organization:, subscription:,
   current_value: 8,


### PR DESCRIPTION
## Context

During seeding, when no premium license is set, the `lifetime_usage_amount` alert creation fails. This results in an error when creating the related thresholds as the alert is `nil`:

```shell
> lago exec -e RAILS_ENV=test api bundle exec rake db:drop db:create db:migrate db:seed
Dropped database 'lago_test'
Dropped database 'lago_test'
Dropped database 'default_test'
Created database 'lago_test'
...
rake aborted!
ActiveRecord::RecordInvalid: Validation failed: Alert relation_must_exist (ActiveRecord::RecordInvalid)
/usr/local/bundle/gems/activerecord-8.0.2/lib/active_record/validations.rb:87:in 'ActiveRecord::Validations#raise_validation_error'
...
/app/db/seeds/alerting.rb:69:in '<main>'
/app/db/seeds.rb:4:in 'Kernel#load'
/app/db/seeds.rb:4:in 'block in <main>'
/app/db/seeds.rb:3:in 'Array#each'
/app/db/seeds.rb:3:in '<main>'
/usr/local/bundle/gems/railties-8.0.2/lib/rails/engine.rb:562:in 'Kernel#load'
...
/usr/local/bundle/bin/bundle:25:in '<main>'
Tasks: TOP => db:seed
(See full trace by running task with --trace)
```

## Description

This PR fixes it by checking whether `License.premium?` is `true`.

Once fixed, it turned out that the `billable_metric_current_usage_amount` triggered alert creation failed as well since we did not retrieve the service result properly.
