### PR TITLE
fix: cascade charge updates in batches

### DIFF
--- a/app/jobs/charges/update_children_batch_job.rb
+++ b/app/jobs/charges/update_children_batch_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Charges
+  class UpdateChildrenBatchJob < ApplicationJob
+    queue_as :default
+
+    def perform(child_ids:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
+      Rails.logger.info("Charges::UpdateChildrenBatchJob - Started the execution for parent charge with ID: #{old_parent_attrs["id"]}")
+
+      charge = Charge.find_by(id: old_parent_attrs["id"])
+
+      Charges::UpdateChildrenService.call!(
+        charge:,
+        params:,
+        old_parent_attrs:,
+        old_parent_filters_attrs:,
+        old_parent_applied_pricing_unit_attrs:,
+        child_ids:
+      )
+
+      Rails.logger.info("Charges::UpdateChildrenBatchJob - Ended the execution for parent charge with ID: #{old_parent_attrs["id"]}")
+    end
+  end
+end

--- a/app/jobs/charges/update_children_job.rb
+++ b/app/jobs/charges/update_children_job.rb
@@ -6,14 +6,17 @@ module Charges
 
     def perform(params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
       charge = Charge.find_by(id: old_parent_attrs["id"])
+      return unless charge
 
-      Charges::UpdateChildrenService.call!(
-        charge:,
-        params:,
-        old_parent_attrs:,
-        old_parent_filters_attrs:,
-        old_parent_applied_pricing_unit_attrs:
-      )
+      charge.children.order(created_at: :asc).pluck(:id).each_slice(100) do |child_ids|
+        Charges::UpdateChildrenBatchJob.perform_later(
+          child_ids:,
+          params:,
+          old_parent_attrs:,
+          old_parent_filters_attrs:,
+          old_parent_applied_pricing_unit_attrs:
+        )
+      end
     end
   end
 end

--- a/app/services/charges/update_children_service.rb
+++ b/app/services/charges/update_children_service.rb
@@ -4,11 +4,12 @@ module Charges
   class UpdateChildrenService < BaseService
     Result = BaseResult[:charge]
 
-    def initialize(charge:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
+    def initialize(charge:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:, child_ids:)
       @charge = charge
       @params = params
       @parent_filters = old_parent_filters_attrs
       @old_parent = Charge.new(old_parent_attrs)
+      @child_ids = child_ids
 
       if old_parent_applied_pricing_unit_attrs.present?
         @old_parent.build_applied_pricing_unit(old_parent_applied_pricing_unit_attrs)
@@ -21,7 +22,7 @@ module Charges
       return result unless charge
 
       ActiveRecord::Base.transaction do
-        charge.children.find_each do |child_charge|
+        charge.children.where(id: child_ids).find_each do |child_charge|
           Charges::UpdateService.call!(
             charge: child_charge,
             params:,
@@ -41,6 +42,6 @@ module Charges
 
     private
 
-    attr_reader :charge, :params, :old_parent, :parent_filters
+    attr_reader :charge, :params, :old_parent, :parent_filters, :child_ids
   end
 end

--- a/spec/jobs/charges/update_children_batch_job_spec.rb
+++ b/spec/jobs/charges/update_children_batch_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Charges::UpdateChildrenBatchJob, type: :job do
+  let(:charge) { create(:standard_charge) }
+  let(:child_charge) { create(:standard_charge, parent_id: charge.id) }
+  let(:child_charge2) { create(:standard_charge, parent_id: charge.id) }
+  let(:old_parent_attrs) { charge.attributes }
+  let(:old_parent_filters_attrs) { charge.filters.map(&:attributes) }
+  let(:old_parent_applied_pricing_unit_attrs) { charge.filters.map(&:attributes) }
+  let(:child_ids) { [child_charge.id, child_charge2.id] }
+  let(:params) do
+    {
+      properties: {}
+    }
+  end
+
+  before do
+    allow(Charges::UpdateChildrenService)
+      .to receive(:call!)
+      .with(charge:, child_ids:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
+      .and_call_original
+  end
+
+  it "calls the children service" do
+    described_class.perform_now(child_ids:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
+
+    expect(Charges::UpdateChildrenService).to have_received(:call!)
+  end
+end

--- a/spec/jobs/charges/update_children_job_spec.rb
+++ b/spec/jobs/charges/update_children_job_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 RSpec.describe Charges::UpdateChildrenJob, type: :job do
   let(:charge) { create(:standard_charge) }
+  let(:child_charge) { create(:standard_charge, parent_id: charge.id) }
+  let(:child_charge2) { create(:standard_charge, parent_id: charge.id) }
   let(:old_parent_attrs) { charge.attributes }
   let(:old_parent_filters_attrs) { charge.filters.map(&:attributes) }
   let(:old_parent_applied_pricing_unit_attrs) { charge.filters.map(&:attributes) }
@@ -14,15 +16,15 @@ RSpec.describe Charges::UpdateChildrenJob, type: :job do
   end
 
   before do
-    allow(Charges::UpdateChildrenService)
-      .to receive(:call!)
-      .with(charge:, params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
+    allow(Charges::UpdateChildrenBatchJob)
+      .to receive(:perform_later)
+      .with(child_ids: [child_charge.id, child_charge2.id], params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
       .and_call_original
   end
 
-  it "calls the service" do
+  it "calls the batch jobs" do
     described_class.perform_now(params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
 
-    expect(Charges::UpdateChildrenService).to have_received(:call!)
+    expect(Charges::UpdateChildrenBatchJob).to have_received(:perform_later).once
   end
 end

--- a/spec/services/charges/update_children_service_spec.rb
+++ b/spec/services/charges/update_children_service_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Charges::UpdateChildrenService, type: :service do
       params:,
       old_parent_attrs:,
       old_parent_filters_attrs:,
-      old_parent_applied_pricing_unit_attrs:
+      old_parent_applied_pricing_unit_attrs:,
+      child_ids:
     )
   end
 
@@ -42,6 +43,7 @@ RSpec.describe Charges::UpdateChildrenService, type: :service do
   let(:child_plan) { create(:plan, organization:, parent_id:) }
   let(:parent_id) { plan.id }
   let(:charge_parent_id) { charge.id }
+  let(:child_ids) { [child_charge&.id] }
   let(:child_charge) do
     create(
       :standard_charge,
@@ -53,7 +55,7 @@ RSpec.describe Charges::UpdateChildrenService, type: :service do
   end
   let(:params) do
     {
-      id: child_charge&.id,
+      id: charge&.id,
       billable_metric_id: billable_metric.id,
       charge_model: "standard",
       pay_in_advance: true,


### PR DESCRIPTION
## Context

Lago client has issues when passing updates to 30k child charges.

## Description

Instead of using one job to handle all children charges, this PR creates batches of 100 records where one batch is processed in one background job.

Having individual jobs for each child charge also didn't work since too many jobs could be scheduled at the same time and it can lead to OOM issues with redis, depending on the load at that particular moment.