### PR TITLE
fix(customer): Fix array parameters in `GET /api/v1/customers`

### DIFF
--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -114,15 +114,14 @@ RSpec.describe Api::V1::CustomersController, type: :request do
           expect(json[:customer][:external_id]).to eq(create_params[:external_id])
 
           billing = json[:customer][:billing_configuration]
-          aggregate_failures do
-            expect(billing).to be_present
-            expect(billing[:payment_provider]).to eq("stripe")
-            expect(billing[:payment_provider_code]).to eq(stripe_provider.code)
-            expect(billing[:provider_customer_id]).to eq("stripe_id")
-            expect(billing[:invoice_grace_period]).to eq(3)
-            expect(billing[:document_locale]).to eq("fr")
-            expect(billing[:provider_payment_methods]).to eq(%w[card])
-          end
+
+          expect(billing).to be_present
+          expect(billing[:payment_provider]).to eq("stripe")
+          expect(billing[:payment_provider_code]).to eq(stripe_provider.code)
+          expect(billing[:provider_customer_id]).to eq("stripe_id")
+          expect(billing[:invoice_grace_period]).to eq(3)
+          expect(billing[:document_locale]).to eq("fr")
+          expect(billing[:provider_payment_methods]).to eq(%w[card])
         end
       end
 
@@ -136,15 +135,14 @@ RSpec.describe Api::V1::CustomersController, type: :request do
           expect(json[:customer][:external_id]).to eq(create_params[:external_id])
 
           billing = json[:customer][:billing_configuration]
-          aggregate_failures do
-            expect(billing).to be_present
-            expect(billing[:payment_provider]).to eq("stripe")
-            expect(billing[:payment_provider_code]).to eq(stripe_provider.code)
-            expect(billing[:provider_customer_id]).to eq("stripe_id")
-            expect(billing[:invoice_grace_period]).to eq(3)
-            expect(billing[:document_locale]).to eq("fr")
-            expect(billing[:provider_payment_methods]).to eq(%w[card sepa_debit])
-          end
+
+          expect(billing).to be_present
+          expect(billing[:payment_provider]).to eq("stripe")
+          expect(billing[:payment_provider_code]).to eq(stripe_provider.code)
+          expect(billing[:provider_customer_id]).to eq("stripe_id")
+          expect(billing[:invoice_grace_period]).to eq(3)
+          expect(billing[:document_locale]).to eq("fr")
+          expect(billing[:provider_payment_methods]).to eq(%w[card sepa_debit])
         end
       end
 
@@ -158,15 +156,14 @@ RSpec.describe Api::V1::CustomersController, type: :request do
           expect(json[:customer][:external_id]).to eq(create_params[:external_id])
 
           billing = json[:customer][:billing_configuration]
-          aggregate_failures do
-            expect(billing).to be_present
-            expect(billing[:payment_provider]).to eq("stripe")
-            expect(billing[:payment_provider_code]).to eq(stripe_provider.code)
-            expect(billing[:provider_customer_id]).to eq("stripe_id")
-            expect(billing[:invoice_grace_period]).to eq(3)
-            expect(billing[:document_locale]).to eq("fr")
-            expect(billing[:provider_payment_methods]).to eq(%w[card])
-          end
+
+          expect(billing).to be_present
+          expect(billing[:payment_provider]).to eq("stripe")
+          expect(billing[:payment_provider_code]).to eq(stripe_provider.code)
+          expect(billing[:provider_customer_id]).to eq("stripe_id")
+          expect(billing[:invoice_grace_period]).to eq(3)
+          expect(billing[:document_locale]).to eq("fr")
+          expect(billing[:provider_payment_methods]).to eq(%w[card])
         end
       end
 
@@ -180,15 +177,14 @@ RSpec.describe Api::V1::CustomersController, type: :request do
           expect(json[:customer][:external_id]).to eq(create_params[:external_id])
 
           billing = json[:customer][:billing_configuration]
-          aggregate_failures do
-            expect(billing).to be_present
-            expect(billing[:payment_provider]).to eq("stripe")
-            expect(billing[:payment_provider_code]).to eq(stripe_provider.code)
-            expect(billing[:provider_customer_id]).to eq("stripe_id")
-            expect(billing[:invoice_grace_period]).to eq(3)
-            expect(billing[:document_locale]).to eq("fr")
-            expect(billing[:provider_payment_methods]).to eq(%w[sepa_debit])
-          end
+
+          expect(billing).to be_present
+          expect(billing[:payment_provider]).to eq("stripe")
+          expect(billing[:payment_provider_code]).to eq(stripe_provider.code)
+          expect(billing[:provider_customer_id]).to eq("stripe_id")
+          expect(billing[:invoice_grace_period]).to eq(3)
+          expect(billing[:document_locale]).to eq("fr")
+          expect(billing[:provider_payment_methods]).to eq(%w[sepa_debit])
         end
       end
     end
@@ -341,10 +337,8 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     it "returns the portal url" do
       subject
 
-      aggregate_failures do
-        expect(response).to have_http_status(:success)
-        expect(json[:customer][:portal_url]).to include("/customer-portal/")
-      end
+      expect(response).to have_http_status(:success)
+      expect(json[:customer][:portal_url]).to include("/customer-portal/")
     end
 
     context "when customer does not belongs to the organization" do
@@ -370,11 +364,9 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     it "returns all customers from organization" do
       subject
 
-      aggregate_failures do
-        expect(response).to have_http_status(:ok)
-        expect(json[:meta][:total_count]).to eq(2)
-        expect(json[:customers][0][:taxes]).not_to be_nil
-      end
+      expect(response).to have_http_status(:ok)
+      expect(json[:meta][:total_count]).to eq(2)
+      expect(json[:customers][0][:taxes]).not_to be_nil
     end
 
     context "with account_type filters" do
@@ -420,6 +412,30 @@ RSpec.describe Api::V1::CustomersController, type: :request do
           expect(json[:code]).to eq("billing_entity_not_found")
         end
       end
+
+      context "with invalid billing entity codes" do
+        let(:params) { {billing_entity_codes: "invalid_code"} }
+
+        it "ignores the parameter" do
+          subject
+
+          expect(response).to have_http_status(:ok)
+          expect(json[:customers].count).to eq(3)
+          expect(json[:customers].first[:lago_id]).to eq(customer.id)
+        end
+      end
+
+      context "with two identical billing entity codes" do
+        let(:params) { {billing_entity_codes: [billing_entity.code, billing_entity.code]} }
+
+        it "returns customers for the specified billing entity" do
+          subject
+
+          expect(response).to have_http_status(:ok)
+          expect(json[:customers].count).to eq(1)
+          expect(json[:customers].first[:lago_id]).to eq(customer.id)
+        end
+      end
     end
   end
 
@@ -436,11 +452,9 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       it "returns the customer" do
         subject
 
-        aggregate_failures do
-          expect(response).to have_http_status(:ok)
-          expect(json[:customer][:lago_id]).to eq(customer.id)
-          expect(json[:customer][:taxes]).not_to be_nil
-        end
+        expect(response).to have_http_status(:ok)
+        expect(json[:customer][:lago_id]).to eq(customer.id)
+        expect(json[:customer][:taxes]).not_to be_nil
       end
     end
 
@@ -470,12 +484,10 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     it "returns deleted customer" do
       subject
 
-      aggregate_failures do
-        expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:success)
 
-        expect(json[:customer][:lago_id]).to eq(customer.id)
-        expect(json[:customer][:external_id]).to eq(customer.external_id)
-      end
+      expect(json[:customer][:lago_id]).to eq(customer.id)
+      expect(json[:customer][:external_id]).to eq(customer.external_id)
     end
 
     context "when customer does not exist" do
@@ -515,11 +527,9 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     it "returns the new generated checkout url" do
       subject
 
-      aggregate_failures do
-        expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:success)
 
-        expect(json[:customer][:checkout_url]).to eq("https://example.com")
-      end
+      expect(json[:customer][:checkout_url]).to eq("https://example.com")
     end
   end
 end


### PR DESCRIPTION
## Context

While testing the `GET /api/v1/customers` endpoint, I noticed that [the documentation](https://github.com/getlago/lago-openapi/blob/11d325bf076e6381c00674ca3b03de3c4eca845c/src/resources/customers.yaml#L36-L58) mentions `account_type` and `billing_entity_codes` parameters as arrays, but document them without the trailing `[]` brackets. This was different from other endpoints such as [the subscription one](https://github.com/getlago/lago-openapi/blob/11d325bf076e6381c00674ca3b03de3c4eca845c/src/resources/subscriptions.yaml#L54-L68).

So I tested the endpoint with `?billing_entity_codes=hooli&billing_entity_codes=gan` and `?billing_entity_codes=hooli,gan` and it returned a 500 error.

Using `?billing_entity_codes[]=hooli&billing_entity_codes[]=gan` did work though. So it turned out to be a documentation issue, along with a missing sanitization on the parameter. The fix for the doc can be found here: https://github.com/getlago/lago-openapi/pull/388.

## Description

I fixed the sanitization on the `billing_entity_codes` parameter and then added a test to ensure it does not return a 500 error without the trailing `[]` brackets.

When doing so, I noticed that passing multiple identical billing entity codes did return a 404 error instead of a 200 one. So I fixed this as well along with a test.

Below are the outputs of the tests without the fixes:

```
1) Api::V1::CustomersController GET /api/v1/customers when filtering by billing_entity_code with invalid billing entity codes ignores the parameter
Failure/Error: return not_found_error(resource: "billing_entity") if params[:billing_entity_codes].present? && billing_entities.count != params[:billing_entity_codes].count

ArgumentError:
  wrong number of arguments (given 0, expected 1+)

2) Api::V1::CustomersController GET /api/v1/customers when filtering by billing_entity_code with two identical billing entity codes returns customers for the specified billing entity
Got 1 failure and 1 other error:

2.1) Failure/Error: expect(response).to have_http_status(:ok)
       expected the response to have status code :ok (200) but it was :not_found (404)
     # ./spec/requests/api/v1/customers_controller_spec.rb:434:in 'block (5 levels) in <top (required)>'
     # ...
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'

2.2) Failure/Error: expect(json[:customers].count).to eq(1)

     NoMethodError:
       undefined method 'count' for nil
     # ./spec/requests/api/v1/customers_controller_spec.rb:435:in 'block (5 levels) in <top (required)>'
     # ....
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'

51/51 |================================================ 100 ================================================>| Time: 00:00:02

Finished in 2.7 seconds (files took 2.47 seconds to load)
51 examples, 2 failures

Failed examples:

rspec ./spec/requests/api/v1/customers_controller_spec.rb:419 # Api::V1::CustomersController GET /api/v1/customers when filtering by billing_entity_code with invalid billing entity codes ignores the parameter
rspec ./spec/requests/api/v1/customers_controller_spec.rb:431 # Api::V1::CustomersController GET /api/v1/customers when filtering by billing_entity_code with two identical billing entity codes returns customers for the specified billing entity
```
