### PR TITLE
Chore: dead jobs small fixes

### DIFF
--- a/app/models/payment_providers/adyen_provider.rb
+++ b/app/models/payment_providers/adyen_provider.rb
@@ -5,6 +5,7 @@ module PaymentProviders
     SUCCESS_REDIRECT_URL = "https://www.adyen.com/"
 
     WEBHOOKS_EVENTS = %w[AUTHORISATION REFUND REFUND_FAILED CHARGEBACK].freeze
+    IGNORED_WEBHOOK_EVENTS = %w[REPORT_AVAILABLE].freeze
 
     PROCESSING_STATUSES = %w[AuthorisedPending Received].freeze
     SUCCESS_STATUSES = %w[Authorised SentForSettle SettleScheduled Settled Refunded].freeze

--- a/app/services/payment_providers/adyen/handle_event_service.rb
+++ b/app/services/payment_providers/adyen/handle_event_service.rb
@@ -16,7 +16,7 @@ module PaymentProviders
       end
 
       def call
-        if PaymentProviders::AdyenProvider::IGNORED_WEBHOOKS_EVENTS.include?(event["eventCode"])
+        if PaymentProviders::AdyenProvider::IGNORED_WEBHOOK_EVENTS.include?(event["eventCode"])
           return result
         end
 

--- a/app/services/payment_providers/adyen/handle_event_service.rb
+++ b/app/services/payment_providers/adyen/handle_event_service.rb
@@ -16,6 +16,10 @@ module PaymentProviders
       end
 
       def call
+        if PaymentProviders::AdyenProvider::IGNORED_WEBHOOKS_EVENTS.include?(event["eventCode"])
+          return result
+        end
+
         unless PaymentProviders::AdyenProvider::WEBHOOKS_EVENTS.include?(event["eventCode"])
           return result.service_failure!(
             code: "webhook_error",

--- a/app/views/templates/payment_receipts/v1.slim
+++ b/app/views/templates/payment_receipts/v1.slim
@@ -120,7 +120,7 @@ html
         - if payment.payable.progressive_billing?
           p.body-3.mb-24
             - applied_usage_threshold = payment.payable.applied_usage_thresholds.order(created_at: :asc).last
-            = I18n.t('invoice.reached_usage_threshold', usage_amount: MoneyHelper.format(payment.payable.applied_usage_threshold.lifetime_usage_amount), threshold_amount: MoneyHelper.format(applied_usage_threshold.passed_threshold_amount))
+            = I18n.t('invoice.reached_usage_threshold', usage_amount: MoneyHelper.format(applied_usage_threshold.lifetime_usage_amount), threshold_amount: MoneyHelper.format(applied_usage_threshold.passed_threshold_amount))
 
         - if payment.payable.applied_invoice_custom_sections.present?
           == SlimHelper.render('templates/invoices/v4/_custom_sections', payment.payable)

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -73,5 +73,13 @@ FactoryBot.define do
     trait :invisible do
       status { Invoice::INVISIBLE_STATUS.keys.sample }
     end
+
+    trait :progressive_billing_invoice do
+      invoice_type { :progressive_billing }
+      with_subscriptions
+      after :create do |invoice|
+        create(:applied_usage_threshold, invoice:, organization: invoice.organization)
+      end
+    end
   end
 end

--- a/spec/fixtures/adyen/webhook_report_available_response.json
+++ b/spec/fixtures/adyen/webhook_report_available_response.json
@@ -1,0 +1,23 @@
+{
+  "live": "false",
+  "notificationItems": [
+    {
+      "NotificationRequestItem": {
+        "additionalData": {
+          "hmacSignature": "b0ea55c2fe60d4d1d605e9c385e0e7..."
+        },
+        "amount": {
+          "currency": "EUR",
+          "value": 1000
+        },
+        "eventCode": "REPORT_AVAILABLE",
+        "eventDate": "2021-01-01T01:00:00+01:00",
+        "merchantAccountCode": "YOUR_MERCHANT_ACCOUNT",
+        "merchantReference": "",
+        "pspReference": "QFQTPCQ8HXSKGK82",
+        "reason": "URL_TO_DOWNLOAD_REPORT",
+        "success": "true"
+      }
+    }
+  ]
+}

--- a/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
@@ -66,5 +66,19 @@ RSpec.describe PaymentProviderCustomers::Stripe::UpdatePaymentMethodService, typ
         end
       end
     end
+
+    context "when customer is deleted" do
+      let(:customer) { create(:customer, organization:, deleted_at: Time.current) }
+
+      it "Fails with deleted_customer error" do
+        stripe_customer.reload
+        result = update_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code).to eq(:deleted_customer)
+        expect(result.error.message).to include("Customer associated to this stripe customer was deleted")
+      end
+    end
   end
 end

--- a/spec/services/payment_receipts/generate_pdf_service_spec.rb
+++ b/spec/services/payment_receipts/generate_pdf_service_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe PaymentReceipts::GeneratePdfService, type: :service do
       end
     end
 
+    context "when related to a progressive billing invoice" do
+      let(:invoice) do
+        create(:invoice, :progressive_billing_invoice, customer:, status: :finalized, organization:)
+      end
+
+      it "successfully generates the payment receipt" do
+        result = payment_receipt_generate_service.call
+
+        expect(result.payment_receipt.file).to be_present
+      end
+    end
+
     context "with already generated file" do
       before do
         payment_receipt.file.attach(


### PR DESCRIPTION
## Context

During investigation of dead jobs, we found small issues that can be easily fixed

## Description

- Ignore `REPORT_AVAILABLE` Adyen event
- Ignore deleted customer on stripe webhook `customer.updated`
- Fix PDF for payment receipt for progressive billing invoice
