### PR TITLE
feat(pricing-units): Refactor invoice PDF

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -13,7 +13,7 @@ module Admin
     def show
       service = ::Invoices::GeneratePdfService.new(invoice:)
 
-      render(html: service.render_html.html_safe)
+      render(html: service.render_html.html_safe) # rubocop:disable Rails/OutputSafety
     end
 
     private

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -13,7 +13,7 @@ module Admin
     def show
       service = ::Invoices::GeneratePdfService.new(invoice:)
 
-      render(html: service.render_html)
+      render(html: service.render_html.html_safe)
     end
 
     private

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -53,8 +53,6 @@ class Charge < ApplicationRecord
   validate :validate_min_amount_cents
   validate :validate_custom_model
 
-  monetize :min_amount_cents, with_currency: ->(charge) { charge.plan.amount_currency }
-
   default_scope -> { kept }
 
   scope :pay_in_advance, -> { where(pay_in_advance: true) }

--- a/app/views/helpers/charge_display_helper.rb
+++ b/app/views/helpers/charge_display_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChargeDisplayHelper
+  def self.format_min_amount(charge)
+    money = Money.from_cents(charge.min_amount_cents, charge.plan.amount.currency)
+    MoneyHelper.format(money)
+  end
+end

--- a/app/views/helpers/fee_display_helper.rb
+++ b/app/views/helpers/fee_display_helper.rb
@@ -14,4 +14,18 @@ class FeeDisplayHelper
 
     invoice_subscription.subscription_amount_cents.positive?
   end
+
+  def self.format_with_precision(fee, amount)
+    casted_amount = BigDecimal(amount)
+    MoneyHelper.format_with_precision(casted_amount, fee.currency)
+  end
+
+  def self.format_as_currency(fee, amount)
+    money = amount.to_money(fee.currency)
+    MoneyHelper.format(money)
+  end
+
+  def self.format_amount(fee)
+    MoneyHelper.format(fee.amount)
+  end
 end

--- a/app/views/helpers/money_helper.rb
+++ b/app/views/helpers/money_helper.rb
@@ -12,18 +12,9 @@ class MoneyHelper
   end
 
   def self.format_with_precision(amount_cents, currency)
-    amount_cents = if amount_cents < 1
-      BigDecimal("%.6g" % amount_cents)
-    else
-      amount_cents.round(6)
-    end
-
+    amount_cents = normalize_precision(amount_cents)
     money = Utils::MoneyWithPrecision.from_amount(amount_cents, currency)
-    money.format(
-      format: currency_format(money.currency),
-      decimal_mark: I18n.t("money.decimal_mark"),
-      thousands_separator: I18n.t("money.thousands_separator")
-    )
+    format(money)
   end
 
   def self.currency_format(money_currency)
@@ -31,6 +22,14 @@ class MoneyHelper
       I18n.t("money.format")
     else
       I18n.t("money.custom_format", iso_code: money_currency&.iso_code)
+    end
+  end
+
+  def self.normalize_precision(amount_cents)
+    if amount_cents < 1
+      BigDecimal("%.6g" % amount_cents)
+    else
+      amount_cents.round(6)
     end
   end
 end

--- a/app/views/templates/invoices/v2.slim
+++ b/app/views/templates/invoices/v2.slim
@@ -547,7 +547,7 @@ html
                       tr
                         td width="70%"
                           .body-1 = I18n.t('invoice.true_up_metric', metric: fee.invoice_name)
-                          .body-3 = I18n.t('invoice.true_up_details', min_amount: fee.charge.min_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator')))
+                          .body-3 = I18n.t('invoice.true_up_details', min_amount: ChargeDisplayHelper.format_min_amount(fee.charge))
                         td.body-1 width="30%" = fee.true_up_fee.amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
                   - else
                     tr
@@ -563,7 +563,7 @@ html
                       tr
                         td width="70%"
                           .body-1 = I18n.t('invoice.true_up_metric', metric: fee.invoice_name)
-                          .body-3 = I18n.t('invoice.true_up_details', min_amount: fee.charge.min_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator')))
+                          .body-3 = I18n.t('invoice.true_up_details', min_amount: ChargeDisplayHelper.format_min_amount(fee.charge))
                         td.body-1 width="30%" = fee.true_up_fee.amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
 
               .charge-details-resume

--- a/app/views/templates/invoices/v3/_true_up_fee.slim
+++ b/app/views/templates/invoices/v3/_true_up_fee.slim
@@ -1,7 +1,7 @@
 tr
   td
     .body-1 = I18n.t('invoice.true_up_metric', metric: true_up_fee.true_up_parent_fee.invoice_name)
-    .body-3 = I18n.t('invoice.true_up_details', min_amount: MoneyHelper.format(charge.min_amount))
+    .body-3 = I18n.t('invoice.true_up_details', min_amount: ChargeDisplayHelper.format_min_amount(charge))
   td.body-2 = true_up_fee.units
   td.body-2 == TaxHelper.applied_taxes(true_up_fee)
   td.body-2 = MoneyHelper.format(true_up_fee.amount)

--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -228,7 +228,7 @@ html
       .invoice-information-table tr td:last-child {
         width: 55%;
       }
-      .invoice-information-table, tr td{
+      .invoice-information-table, tr td {
         text-wrap: normal;
         word-wrap: break-word;
         vertical-align: top;
@@ -244,15 +244,9 @@ html
         width: 50%;
       }
 
-      .invoice-resume-table tr.first_child td {
-        color: #66758F;
-      }
-      .invoice-resume-table tr {
-        border-bottom: 1px solid var(--border-color);
-      }
       .invoice-resume-table tr td {
-        padding-top: 8px;
-        padding-bottom: 8px;
+        padding-top: 4px;
+        padding-bottom: 4px;
         text-align: right;
         word-wrap: break-word;
       }
@@ -275,6 +269,52 @@ html
         width: 12.5%;
         max-width: 10vw;
       }
+
+      .invoice-resume-table tr.first_child td {
+        color: #66758F;
+      }
+
+      .invoice-resume-table tr.charge-name td {
+        padding-bottom: 0;
+        color: #19212e;
+      }
+
+      .invoice-resume-table tr.details td {
+        color: #66758F;
+        padding-top: 4px;
+        padding-bottom: 4px;
+      }
+
+      .invoice-resume-table tr.details td:first-child {
+        padding-left: 8px;
+      }
+
+      .invoice-resume-table tr.details.subtotal td {
+        color: #19212e;
+      }
+
+      .invoice-resume-table tr.fee:first-child {
+        border-top: none;
+      }
+      /* Each first tr representing fee draws border above it */
+      .invoice-resume-table tr.fee {
+        border-top: 1px solid var(--border-color);
+      }
+      .invoice-resume-table tr:last-child {
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      .invoice-resume-table tr.fee td {
+        padding-top: 8px;
+      }
+      /* If tr has next element tr.fee means that current fee info ended and we need bigger padding */
+      .invoice-resume-table tr:has(+ tr.fee) td {
+        padding-bottom: 8px;
+      }
+      .invoice-resume-table tr:last-child td {
+        padding-bottom: 8px;
+      }
+
       .invoice-resume table {
         border-collapse: collapse;
       }
@@ -350,26 +390,6 @@ html
         gap: 16px;
         background: #F3F4F6;
         border-radius: 12px;
-      }
-      .invoice-resume-table tr.details, .invoice-resume-table tr.charge-name {
-        border: none;
-      }
-      .invoice-resume-table tr.charge-name td {
-        padding-bottom: 0;
-        color: #19212e;
-      }
-      .invoice-resume-table tr.details td {
-        color: #66758F;
-        padding-top: 4px;
-        padding-bottom: 4px;
-      }
-      .invoice-resume-table tr.details td:first-child {
-        padding-left: 8px;
-      }
-      .invoice-resume-table tr.details.subtotal td {
-        padding-bottom: 8px;
-        border-bottom: 1px solid var(--border-color);
-        color: #19212e;
       }
 
     .wrapper

--- a/app/views/templates/invoices/v4/_charge.slim
+++ b/app/views/templates/invoices/v4/_charge.slim
@@ -6,36 +6,36 @@ table.invoice-resume-table width="100%"
     td.body-2 = I18n.t('invoice.tax_rate')
     td.body-2 = I18n.t('invoice.amount')
   - fees.order(:succeeded_at, :created_at).each do |fee|
-    tr
-      - if fee.charge.percentage? && fee.amount_details.present?
-        - if fee.basic_rate_percentage?
-          tr
-            td.body-1
-              = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
-            td.body-2 = fee.amount_details['paid_units']
-            td.body-2 = fee.amount_details['rate'] + '%'
-            td.body-2 == TaxHelper.applied_taxes(fee)
-            td.body-2 = FeeDisplayHelper.format_as_currency(fee, fee.amount_details['per_unit_total_amount'])
-        - else
-          tr.charge-name
-            td.body-1
-              = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
-              - if fee.charge_filter_id?
-                = ' • ' + fee.filter_display_name(separator: ' • ')
-              - if fee.billable_metric.weighted_sum_agg?
-                .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(fee.subscription.plan.interval))
-              - if fee.succeeded_at.present?
-                .body-3 = I18n.l(fee.succeeded_at.to_date, format: :default) + ' • ' + I18n.t('invoice.total_events', count: fee.events_count)
-              - else
-                .body-3 = I18n.t('invoice.total_events', count: fee.events_count)
-              - if fee.charge.prorated?
-                .body-3 = I18n.t('invoice.fee_prorated')
-            td.body-2
-            td.body-2
-            td.body-2
-            td.body-2
-          == SlimHelper.render('templates/invoices/v4/_charge_percentage', fee)
+    - if fee.charge.percentage? && fee.amount_details.present?
+      - if fee.basic_rate_percentage?
+        tr.fee
+          td.body-1
+            = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
+          td.body-2 = fee.amount_details['paid_units']
+          td.body-2 = fee.amount_details['rate'] + '%'
+          td.body-2 == TaxHelper.applied_taxes(fee)
+          td.body-2 = FeeDisplayHelper.format_as_currency(fee, fee.amount_details['per_unit_total_amount'])
       - else
+        tr.charge-name.fee
+          td.body-1
+            = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
+            - if fee.charge_filter_id?
+              = ' • ' + fee.filter_display_name(separator: ' • ')
+            - if fee.billable_metric.weighted_sum_agg?
+              .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(fee.subscription.plan.interval))
+            - if fee.succeeded_at.present?
+              .body-3 = I18n.l(fee.succeeded_at.to_date, format: :default) + ' • ' + I18n.t('invoice.total_events', count: fee.events_count)
+            - else
+              .body-3 = I18n.t('invoice.total_events', count: fee.events_count)
+            - if fee.charge.prorated?
+              .body-3 = I18n.t('invoice.fee_prorated')
+          td.body-2
+          td.body-2
+          td.body-2
+          td.body-2
+        == SlimHelper.render('templates/invoices/v4/_charge_percentage', fee)
+    - else
+      tr.fee
         - if !fee.charge.invoiceable? # TODO: edit with `invoicing_strategy`
           td
             .body-1

--- a/app/views/templates/invoices/v4/_charge.slim
+++ b/app/views/templates/invoices/v4/_charge.slim
@@ -15,7 +15,7 @@ table.invoice-resume-table width="100%"
             td.body-2 = fee.amount_details['paid_units']
             td.body-2 = fee.amount_details['rate'] + '%'
             td.body-2 == TaxHelper.applied_taxes(fee)
-            td.body-2 = MoneyHelper.format(fee.amount_details['per_unit_total_amount'].to_money(fee.amount_currency))
+            td.body-2 = FeeDisplayHelper.format_as_currency(fee, fee.amount_details['per_unit_total_amount'])
         - else
           tr.charge-name
             td.body-1
@@ -59,9 +59,9 @@ table.invoice-resume-table width="100%"
             - if fee.charge_filter_id?
               = ' • ' + fee.filter_display_name(separator: ' • ')
         td.body-2 = RoundingHelper.round_decimal_part(fee.units)
-        td.body-2 = MoneyHelper.format_with_precision(fee.precise_unit_amount, fee.unit_amount.currency)
+        td.body-2 = FeeDisplayHelper.format_with_precision(fee, fee.precise_unit_amount)
         td.body-2 == TaxHelper.applied_taxes(fee)
-        td.body-2 = MoneyHelper.format(fee.amount)
+        td.body-2 = FeeDisplayHelper.format_amount(fee)
 
 
 table.total-table width="100%"

--- a/app/views/templates/invoices/v4/_charge_percentage.slim
+++ b/app/views/templates/invoices/v4/_charge_percentage.slim
@@ -1,4 +1,3 @@
-
 - if amount_details['free_units'].to_f.positive? || amount_details['free_events'].to_f.positive?
   / Free units per transaction
   tr.details
@@ -14,27 +13,27 @@
     td.body-2 = amount_details['paid_units']
     td.body-2 = amount_details['rate'] + '%'
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(amount_details['per_unit_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, amount_details['per_unit_total_amount'])
 - if amount_details['fixed_fee_total_amount'].to_f.positive?
   / Fixed fee per transaction
   tr.details
     td.body-2 = I18n.t('invoice.percentage.fee_per_transaction')
     td.body-2 = amount_details['paid_events']
-    td.body-2 = MoneyHelper.format(amount_details['fixed_fee_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, amount_details['fixed_fee_total_amount'])
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(amount_details['fixed_fee_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, amount_details['fixed_fee_total_amount'])
 - unless amount_details['min_max_adjustment_total_amount'].to_f.zero?
   / Adjustment for min/max per transaction
   tr.details
     td.body-2 = I18n.t('invoice.percentage.adjustment_per_transaction')
     td.body-2 = 1
-    td.body-2 = MoneyHelper.format(amount_details['min_max_adjustment_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, amount_details['min_max_adjustment_total_amount'])
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(amount_details['min_max_adjustment_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, amount_details['min_max_adjustment_total_amount'])
 / Sub total
 tr.details.subtotal
   td.body-2 = I18n.t('invoice.sub_total')
   td.body-2
   td.body-2
   td.body-2
-  td.body-2 = MoneyHelper.format(amount)
+  td.body-2 = FeeDisplayHelper.format_amount(self)

--- a/app/views/templates/invoices/v4/_default_fee.slim
+++ b/app/views/templates/invoices/v4/_default_fee.slim
@@ -1,5 +1,5 @@
 - fee = self
-tr
+tr.fee
   td
     .body-1
       = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
@@ -12,6 +12,6 @@ tr
     - if fee.charge.prorated?
       .body-3 = I18n.t('invoice.fee_prorated')
   td.body-2 = RoundingHelper.round_decimal_part(fee.units)
-  td.body-2 = MoneyHelper.format_with_precision(fee.precise_unit_amount, fee.unit_amount.currency)
+  td.body-2 = FeeDisplayHelper.format_with_precision(fee, fee.precise_unit_amount)
   td.body-2 == TaxHelper.applied_taxes(fee)
-  td.body-2 = MoneyHelper.format(fee.amount)
+  td.body-2 = FeeDisplayHelper.format_amount(fee)

--- a/app/views/templates/invoices/v4/_default_fee_with_filters.slim
+++ b/app/views/templates/invoices/v4/_default_fee_with_filters.slim
@@ -1,4 +1,4 @@
-tr
+tr.fee
   td
     .body-1 = self.invoice_name + FeeDisplayHelper.grouped_by_display(self) + ' • ' + self.filter_display_name(separator: ' • ')
     - if self.billable_metric.weighted_sum_agg?
@@ -8,6 +8,6 @@ tr
     - if self.charge.prorated?
       .body-3 = I18n.t('invoice.fee_prorated')
   td.body-2 = RoundingHelper.round_decimal_part(self.units)
-  td.body-2 = MoneyHelper.format_with_precision(self.precise_unit_amount, self.unit_amount.currency)
+  td.body-2 = FeeDisplayHelper.format_with_precision(self, self.precise_unit_amount)
   td.body-2 == TaxHelper.applied_taxes(self)
-  td.body-2 = MoneyHelper.format(self.amount)
+  td.body-2 = FeeDisplayHelper.format_amount(self)

--- a/app/views/templates/invoices/v4/_fee_with_filters.slim
+++ b/app/views/templates/invoices/v4/_fee_with_filters.slim
@@ -1,4 +1,4 @@
-tr.charge-name
+tr.charge-name.fee
   td.body-1
     = self.invoice_name + FeeDisplayHelper.grouped_by_display(self) + ' • ' + self.filter_display_name(separator: ' • ')
     - if self.billable_metric.weighted_sum_agg?

--- a/app/views/templates/invoices/v4/_fees_without_filters.slim
+++ b/app/views/templates/invoices/v4/_fees_without_filters.slim
@@ -3,7 +3,7 @@
 - if fee.amount.zero? || fee.amount_details.blank?
   == SlimHelper.render('templates/invoices/v4/_default_fee', fee)
 - else
-  tr.charge-name
+  tr.charge-name.fee
     td.body-1
       = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
       - if fee.charge_filter_id?

--- a/app/views/templates/invoices/v4/_graduated.slim
+++ b/app/views/templates/invoices/v4/_graduated.slim
@@ -8,53 +8,53 @@
   tr.details
     td.body-2 = I18n.t('invoice.graduated.fee_per_unit_for_the_first', to: first_range['to_value'])
     td.body-2 = first_range['units']
-    td.body-2 = MoneyHelper.format_with_precision(BigDecimal(first_range['per_unit_amount']), amount_currency)
+    td.body-2 = FeeDisplayHelper.format_with_precision(self, first_range['per_unit_amount'])
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(first_range['per_unit_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, first_range['per_unit_total_amount'])
 
 - next_ranges.each do |range|
   tr.details
     td.body-2 = I18n.t('invoice.graduated.fee_per_unit_for_the_next', from: range['from_value'], to: range['to_value'])
     td.body-2 = range['units']
-    td.body-2 = MoneyHelper.format_with_precision(BigDecimal(range['per_unit_amount']), amount_currency)
+    td.body-2 = FeeDisplayHelper.format_with_precision(self, range['per_unit_amount'])
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(range['per_unit_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, range['per_unit_total_amount'])
 
 - if last_range
   / Last graduated range
   tr.details
     td.body-2 = I18n.t('invoice.graduated.fee_per_unit_for_the_last', from: last_range['from_value'])
     td.body-2 = last_range['units']
-    td.body-2 = MoneyHelper.format_with_precision(BigDecimal(last_range['per_unit_amount']), amount_currency)
+    td.body-2 = FeeDisplayHelper.format_with_precision(self, last_range['per_unit_amount'])
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(last_range['per_unit_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, last_range['per_unit_total_amount'])
 
 - if first_range && first_range['flat_unit_amount'].to_f.positive?
   / First flat fee
   tr.details
     td.body-2 = I18n.t('invoice.graduated.flat_fee_for_the_first', to: first_range['to_value'])
     td.body-2 = 1
-    td.body-2 = MoneyHelper.format(first_range['flat_unit_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, first_range['flat_unit_amount'])
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(first_range['flat_unit_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, first_range['flat_unit_amount'])
 
 - next_ranges.each do |range|
   - if range['flat_unit_amount'].to_f.positive?
     tr.details
       td.body-2 = I18n.t('invoice.graduated.flat_fee_for_the_next', from: range['from_value'], to: range['to_value'])
       td.body-2 = 1
-      td.body-2 = MoneyHelper.format(range['flat_unit_amount'].to_money(amount_currency))
+      td.body-2 = FeeDisplayHelper.format_as_currency(self, range['flat_unit_amount'])
       td.body-2 == TaxHelper.applied_taxes(self)
-      td.body-2 = MoneyHelper.format(range['flat_unit_amount'].to_money(amount_currency))
+      td.body-2 = FeeDisplayHelper.format_as_currency(self, range['flat_unit_amount'])
 
 - if last_range && last_range['flat_unit_amount'].to_f.positive?
   / Last flat fee
   tr.details
     td.body-2 = I18n.t('invoice.graduated.flat_fee_for_the_last', from: last_range['from_value'])
     td.body-2 = 1
-    td.body-2 = MoneyHelper.format(last_range['flat_unit_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, last_range['flat_unit_amount'])
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(last_range['flat_unit_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, last_range['flat_unit_amount'])
 
 / Sub total
 tr.details.subtotal
@@ -62,4 +62,4 @@ tr.details.subtotal
   td.body-2
   td.body-2
   td.body-2
-  td.body-2 = MoneyHelper.format(amount)
+  td.body-2 = FeeDisplayHelper.format_amount(self)

--- a/app/views/templates/invoices/v4/_graduated_percentage.slim
+++ b/app/views/templates/invoices/v4/_graduated_percentage.slim
@@ -10,7 +10,7 @@
     td.body-2 = first_range['units']
     td.body-2 = first_range['rate'] + '%'
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(first_range['per_unit_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, first_range['per_unit_total_amount'])
 
 - next_ranges.each do |range|
   tr.details
@@ -18,7 +18,7 @@
     td.body-2 = range['units']
     td.body-2 = range['rate'] + '%'
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(range['per_unit_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, range['per_unit_total_amount'])
 
 - if last_range
   / Last graduated range
@@ -27,34 +27,34 @@
     td.body-2 = last_range['units']
     td.body-2 = last_range['rate'] + '%'
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(last_range['per_unit_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, last_range['per_unit_total_amount'])
 
 - if first_range && first_range['flat_unit_amount'].to_f.positive?
   / First flat fee
   tr.details
     td.body-2 = I18n.t('invoice.graduated.flat_fee_for_the_first', to: first_range['to_value'])
     td.body-2 = 1
-    td.body-2 = MoneyHelper.format(first_range['flat_unit_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, first_range['flat_unit_amount'])
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(first_range['flat_unit_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, first_range['flat_unit_amount'])
 
 - next_ranges.each do |range|
   - if range['flat_unit_amount'].to_f.positive?
     tr.details
       td.body-2 = I18n.t('invoice.graduated.flat_fee_for_the_next', from: range['from_value'], to: range['to_value'])
       td.body-2 = 1
-      td.body-2 = MoneyHelper.format(range['flat_unit_amount'].to_money(amount_currency))
+      td.body-2 = FeeDisplayHelper.format_as_currency(self, range['flat_unit_amount'])
       td.body-2 == TaxHelper.applied_taxes(self)
-      td.body-2 = MoneyHelper.format(range['flat_unit_amount'].to_money(amount_currency))
+      td.body-2 = FeeDisplayHelper.format_as_currency(self, range['flat_unit_amount'])
 
 - if last_range && last_range['flat_unit_amount'].to_f.positive?
   / Last flat fee
   tr.details
     td.body-2 = I18n.t('invoice.graduated.flat_fee_for_the_last', from: last_range['from_value'])
     td.body-2 = 1
-    td.body-2 = MoneyHelper.format(last_range['flat_unit_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, last_range['flat_unit_amount'])
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(last_range['flat_unit_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, last_range['flat_unit_amount'])
 
 / Sub total
 tr.details.subtotal
@@ -62,4 +62,4 @@ tr.details.subtotal
   td.body-2
   td.body-2
   td.body-2
-  td.body-2 = MoneyHelper.format(amount)
+  td.body-2 = FeeDisplayHelper.format_amount(self)

--- a/app/views/templates/invoices/v4/_one_off.slim
+++ b/app/views/templates/invoices/v4/_one_off.slim
@@ -14,7 +14,7 @@ table.invoice-resume-table width="100%"
         td.body-2 = RoundingHelper.round_decimal_part(fee.units)
         td.body-2 = MoneyHelper.format(fee.unit_amount)
         td.body-2 == TaxHelper.applied_taxes(fee)
-        td.body-2 = MoneyHelper.format(fee.amount)
+        td.body-2 = FeeDisplayHelper.format_amount(fee)
 
 table.total-table width="100%"
   tr

--- a/app/views/templates/invoices/v4/_package.slim
+++ b/app/views/templates/invoices/v4/_package.slim
@@ -10,13 +10,13 @@
 tr.details
   td.body-2 = I18n.t('invoice.package.fee_per_package')
   td.body-2 = amount_details['paid_units']
-  td.body-2 = I18n.t('invoice.package.fee_per_package_unit_price', amount: MoneyHelper.format_with_precision(BigDecimal(amount_details['per_package_unit_amount']), amount_currency), package_size: amount_details['per_package_size'])
+  td.body-2 = I18n.t('invoice.package.fee_per_package_unit_price', amount: FeeDisplayHelper.format_with_precision(self, amount_details['per_package_unit_amount']), package_size: amount_details['per_package_size'])
   td.body-2 == TaxHelper.applied_taxes(self)
-  td.body-2 = MoneyHelper.format(amount)
+  td.body-2 = FeeDisplayHelper.format_amount(self)
 / Sub total
 tr.details.subtotal
   td.body-2 = I18n.t('invoice.sub_total')
   td.body-2
   td.body-2
   td.body-2
-  td.body-2 = MoneyHelper.format(amount)
+  td.body-2 = FeeDisplayHelper.format_amount(self)

--- a/app/views/templates/invoices/v4/_percentage.slim
+++ b/app/views/templates/invoices/v4/_percentage.slim
@@ -12,27 +12,27 @@ tr.details
   td.body-2 = amount_details['paid_units']
   td.body-2 = amount_details['rate'] + '%'
   td.body-2 == TaxHelper.applied_taxes(self)
-  td.body-2 = MoneyHelper.format(amount_details['per_unit_total_amount'].to_money(amount_currency))
+  td.body-2 = FeeDisplayHelper.format_as_currency(self, amount_details['per_unit_total_amount'])
 - if amount_details['fixed_fee_unit_amount'].to_f.positive?
   / Fixed fee per transaction
   tr.details
     td.body-2 = I18n.t('invoice.percentage.fee_per_transaction')
     td.body-2 = amount_details['paid_events']
-    td.body-2 = MoneyHelper.format(amount_details['fixed_fee_unit_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, amount_details['fixed_fee_unit_amount'])
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(amount_details['fixed_fee_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, amount_details['fixed_fee_total_amount'])
 - unless amount_details['min_max_adjustment_total_amount'].to_f.zero?
   / Adjustment for min/max per transaction
   tr.details
     td.body-2 = I18n.t('invoice.percentage.adjustment_per_transaction')
     td.body-2 = 1
-    td.body-2 = MoneyHelper.format(amount_details['min_max_adjustment_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, amount_details['min_max_adjustment_total_amount'])
     td.body-2 == TaxHelper.applied_taxes(self)
-    td.body-2 = MoneyHelper.format(amount_details['min_max_adjustment_total_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, amount_details['min_max_adjustment_total_amount'])
 / Sub total
 tr.details.subtotal
   td.body-2 = I18n.t('invoice.sub_total')
   td.body-2
   td.body-2
   td.body-2
-  td.body-2 = MoneyHelper.format(amount)
+  td.body-2 = FeeDisplayHelper.format_amount(self)

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -17,7 +17,7 @@
           td.body-2 = I18n.t('invoice.amount')
 
         - if FeeDisplayHelper.should_display_subscription_fee?(invoice_subscription)
-          tr
+          tr.fee
             - if subscription_fee&.invoice_display_name&.present?
               td.body-1 = subscription_fee&.invoice_display_name
             - else
@@ -90,7 +90,7 @@
 
       - if commitment_fee
         table.invoice-resume-table width="100%"
-          tr
+          tr.fee
             td.body-1 = commitment_fee.invoice_name
             td.body-2 = 1
             td.body-2 = MoneyHelper.format(commitment_fee.amount)

--- a/app/views/templates/invoices/v4/_true_up_fee.slim
+++ b/app/views/templates/invoices/v4/_true_up_fee.slim
@@ -1,8 +1,8 @@
 tr.fee
   td
     .body-1 = I18n.t('invoice.true_up_metric', metric: true_up_fee.true_up_parent_fee.invoice_name)
-    .body-3 = I18n.t('invoice.true_up_details', min_amount: MoneyHelper.format(charge.min_amount))
+    .body-3 = I18n.t('invoice.true_up_details', min_amount: ChargeDisplayHelper.format_min_amount(charge))
   td.body-2 = 1
-  td.body-2 = MoneyHelper.format(true_up_fee.amount)
+  td.body-2 = FeeDisplayHelper.format_amount(true_up_fee)
   td.body-2 == TaxHelper.applied_taxes(true_up_fee)
-  td.body-2 = MoneyHelper.format(true_up_fee.amount)
+  td.body-2 = FeeDisplayHelper.format_amount(true_up_fee)

--- a/app/views/templates/invoices/v4/_true_up_fee.slim
+++ b/app/views/templates/invoices/v4/_true_up_fee.slim
@@ -1,4 +1,4 @@
-tr
+tr.fee
   td
     .body-1 = I18n.t('invoice.true_up_metric', metric: true_up_fee.true_up_parent_fee.invoice_name)
     .body-3 = I18n.t('invoice.true_up_details', min_amount: MoneyHelper.format(charge.min_amount))

--- a/app/views/templates/invoices/v4/_volume.slim
+++ b/app/views/templates/invoices/v4/_volume.slim
@@ -2,15 +2,15 @@
 tr.details
   td.body-2 = I18n.t('invoice.volume.fee_per_unit')
   td.body-2 = RoundingHelper.round_decimal_part(units)
-  td.body-2 = MoneyHelper.format_with_precision(BigDecimal(amount_details['per_unit_amount']), amount_currency)
+  td.body-2 = FeeDisplayHelper.format_with_precision(self, amount_details['per_unit_amount'])
   td.body-2 == TaxHelper.applied_taxes(self)
-  td.body-2 = MoneyHelper.format(amount_details['per_unit_total_amount'].to_money(amount_currency))
+  td.body-2 = FeeDisplayHelper.format_as_currency(self, amount_details['per_unit_total_amount'])
 - if amount_details['flat_unit_amount'].to_f.positive?
   / Flat fee for all units
   tr.details
     td.body-2 = I18n.t('invoice.volume.flat_fee_for_all_units')
     td.body-2 = 1
-    td.body-2 = MoneyHelper.format(amount_details['flat_unit_amount'].to_money(amount_currency))
+    td.body-2 = FeeDisplayHelper.format_as_currency(self, amount_details['flat_unit_amount'])
     td.body-2 == TaxHelper.applied_taxes(self)
     td.body-2 = MoneyHelper.format(amount_details['flat_unit_amount'].to_money(amount_currency))
 / Sub total
@@ -19,4 +19,4 @@ tr.details.subtotal
   td.body-2
   td.body-2
   td.body-2
-  td.body-2 = MoneyHelper.format(amount)
+  td.body-2 = FeeDisplayHelper.format_amount(self)

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -222,7 +222,7 @@ html
       .invoice-information-table tr td:last-child {
         width: 55%;
       }
-      .invoice-information-table, tr td{
+      .invoice-information-table, tr td {
         text-wrap: normal;
         word-wrap: break-word;
         vertical-align: top;
@@ -243,8 +243,8 @@ html
       }
 
       .invoice-resume-table tr td {
-        padding-top: 8px;
-        padding-bottom: 8px;
+        padding-top: 4px;
+        padding-bottom: 4px;
         text-align: right;
         word-wrap: break-word;
       }
@@ -268,15 +268,8 @@ html
         max-width: 10vw;
       }
 
-      .invoice-resume-table tr {
-        border-bottom: 1px solid #D9DEE7;
-      }
-      .invoice-resume table {
-        border-collapse: collapse;
-      }
-
-      .invoice-resume-table tr.details, .invoice-resume-table tr.charge-name {
-        border: none;
+      .invoice-resume-table tr.first_child td {
+        color: #66758F;
       }
 
       .invoice-resume-table tr.charge-name td {
@@ -295,9 +288,37 @@ html
       }
 
       .invoice-resume-table tr.details.subtotal td {
-        padding-bottom: 8px;
-        border-bottom: 1px solid #d9dee7;
         color: #19212e;
+      }
+
+      .invoice-resume-table tr.fee:first-child {
+        border-top: none;
+      }
+
+      /* Each first tr representing fee draws border above it */
+      .invoice-resume-table tr.fee {
+        border-top: 1px solid #D9DEE7;
+      }
+
+      .invoice-resume-table tr:last-child {
+        border-bottom: 1px solid #D9DEE7;
+      }
+
+      .invoice-resume-table tr.fee td {
+        padding-top: 8px;
+      }
+
+      /* If tr has next element tr.fee means that current fee info ended and we need bigger padding */
+      .invoice-resume-table tr:has(+ tr.fee) td {
+        padding-bottom: 8px;
+      }
+
+      .invoice-resume-table tr:last-child td {
+        padding-bottom: 8px;
+      }
+
+      .invoice-resume table {
+        border-collapse: collapse;
       }
 
       .invoice-resume .total-table tr td {

--- a/spec/views/helpers/charge_display_helper_spec.rb
+++ b/spec/views/helpers/charge_display_helper_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChargeDisplayHelper do
+  subject(:helper) { described_class }
+
+  describe ".format_min_amount" do
+    subject { helper.format_min_amount(charge) }
+
+    let(:plan) { create(:plan, amount_currency: "USD") }
+    let(:charge) { create(:standard_charge, plan:, min_amount_cents: 500) }
+
+    it "returns the min amount with the appropriate currency symbol" do
+      expect(subject).to eq "$5.00"
+    end
+  end
+end

--- a/spec/views/helpers/fee_display_helper_spec.rb
+++ b/spec/views/helpers/fee_display_helper_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe FeeDisplayHelper do
       }
     end
 
-    context "when it is standard charge fee with grouped_by property" do
-      it "returns valid response" do
+    context "when a standard charge fee has grouped_by property" do
+      it "formats the grouped_by values with bullet points" do
         expect(helper.grouped_by_display(fee)).to eq(" • mercredi • week_01 • 2024")
       end
     end
 
-    context "when missing grouped_by property" do
+    context "when the charge properties are missing the grouped_by property" do
       let(:properties) do
         {
           "amount" => "5"
@@ -40,7 +40,7 @@ RSpec.describe FeeDisplayHelper do
       end
     end
 
-    context "when some values are nil" do
+    context "when some grouped_by values are nil" do
       let(:grouped_by) do
         {
           "key_1" => nil,
@@ -49,9 +49,41 @@ RSpec.describe FeeDisplayHelper do
         }
       end
 
-      it "returns valid response" do
+      it "skips nil values and formats only the present values" do
         expect(helper.grouped_by_display(fee)).to eq(" • week_01 • 2024")
       end
+    end
+  end
+
+  describe ".format_with_precision" do
+    subject { helper.format_with_precision(fee, amount) }
+
+    let(:fee) { create(:fee, amount_currency: "USD") }
+    let(:amount) { "0.12345678" }
+
+    it "returns the rounded amount with currency symbol" do
+      expect(subject).to eq "$0.123457"
+    end
+  end
+
+  describe ".format_as_currency" do
+    subject { helper.format_as_currency(fee, amount) }
+
+    let(:fee) { create(:fee, amount_currency: "USD") }
+    let(:amount) { "10.5" }
+
+    it "returns the amount with the appropriate currency symbol" do
+      expect(subject).to eq "$10.50"
+    end
+  end
+
+  describe ".format_amount" do
+    subject { helper.format_amount(fee) }
+
+    let(:fee) { create(:fee, amount_cents: 1000, amount_currency: "USD") }
+
+    it "returns fee amount with the appropriate currency symbol" do
+      expect(subject).to eq "$10.00"
     end
   end
 end


### PR DESCRIPTION
## Context

It's refactoring changes needed for adjusting PDF for pricing units extracted into separate PR for ease of testing and reviewing. You can check next step changes in [this PR](https://github.com/getlago/lago-api/pull/3867).

Border and paddings between fees re-worked in order to better adapt to varying amounts of table rows (tr) representing one fee. With pricing units changes there will be one more optional row for conversion from pricing units to fiat currency. So 1 fee could be represented in 1, 3, 5 rows.

Another changes is expanding FeeDisplayHelper with more format method, for now they are just redirecting the all to MoneyHelper but in next step it will have a logic to display either values in fiat currency or in pricing units.

## Description

CSS refactoring
Expanding FeeDisplayHelper with more methods
