### PR TITLE
feat: handle canceled stripe payments

### DIFF
--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -11,6 +11,7 @@ module PaymentProviders
       setup_intent.succeeded
       payment_intent.payment_failed
       payment_intent.succeeded
+      payment_intent.canceled
       payment_method.detached
       charge.refund.updated
       customer.updated

--- a/app/services/payment_providers/stripe/handle_event_service.rb
+++ b/app/services/payment_providers/stripe/handle_event_service.rb
@@ -8,7 +8,8 @@ module PaymentProviders
         "payment_intent.succeeded" => PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService,
         "payment_intent.payment_failed" => PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedService,
         "customer.updated" => PaymentProviders::Stripe::Webhooks::CustomerUpdatedService,
-        "charge.dispute.closed" => PaymentProviders::Stripe::Webhooks::ChargeDisputeClosedService
+        "charge.dispute.closed" => PaymentProviders::Stripe::Webhooks::ChargeDisputeClosedService,
+        "payment_intent.canceled" =>  PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedService
       }.freeze
 
       def initialize(organization:, event_json:)

--- a/app/services/payment_providers/stripe/handle_event_service.rb
+++ b/app/services/payment_providers/stripe/handle_event_service.rb
@@ -9,7 +9,7 @@ module PaymentProviders
         "payment_intent.payment_failed" => PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedService,
         "customer.updated" => PaymentProviders::Stripe::Webhooks::CustomerUpdatedService,
         "charge.dispute.closed" => PaymentProviders::Stripe::Webhooks::ChargeDisputeClosedService,
-        "payment_intent.canceled" =>  PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedService
+        "payment_intent.canceled" => PaymentProviders::Stripe::Webhooks::PaymentIntentPaymentFailedService
       }.freeze
 
       def initialize(organization:, event_json:)


### PR DESCRIPTION
## Context
This PR ensures that cancelled Stripe payments (e.g. due to uncompleted 3DS authentication) correctly update the corresponding Lago payment status.

Previously, Lago only updated statuses on "failed" payments. As a result, "cancelled" Stripe payments remained stuck in a "pending" state on our side, making it impossible for users to retry them without manual intervention.

## Description

Stripe webhook handling now includes logic for payment_intent.canceled events.
Cancelled payments are treated as "failed" in Lago (same as other unrecoverable errors).
This allows users to retry cancelled payments 