### PR TITLE
fix(warnings): Fix warnings caused by `order` and `find_each` combination

### DIFF
--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -46,7 +46,7 @@ module BillableMetricFilters
         end
 
         # NOTE: discard all filters that were not created or updated
-        billable_metric.filters.where.not(id: result.filters.map(&:id)).find_each do
+        billable_metric.filters.where.not(id: result.filters.map(&:id)).unscope(:order).find_each do
           discard_filter(it)
         end
       end

--- a/app/services/billable_metric_filters/destroy_all_service.rb
+++ b/app/services/billable_metric_filters/destroy_all_service.rb
@@ -15,7 +15,7 @@ module BillableMetricFilters
 
       deleted_at = Time.current
 
-      billable_metric.filters.find_each do |filter|
+      billable_metric.filters.unscope(:order).find_each do |filter|
         # rubocop:disable Rails/SkipsModelValidations
         filter.filter_values.update_all(deleted_at: deleted_at)
         filter.charge_filters.update_all(deleted_at: deleted_at)

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -88,7 +88,7 @@ module ChargeFilters
         # NOTE: remove old filters that were not created or updated
         remove_query = charge.filters
         remove_query = remove_query.where(id: inherited_filter_ids) if cascade_updates && parent_filters
-        remove_query.where.not(id: result.filters.map(&:id)).find_each do
+        remove_query.where.not(id: result.filters.map(&:id)).unscope(:order).find_each do
           remove_filter(it)
         end
       end
@@ -115,7 +115,7 @@ module ChargeFilters
     def remove_all
       ActiveRecord::Base.transaction do
         if cascade_updates
-          charge.filters.where(id: inherited_filter_ids).find_each { remove_filter(it) }
+          charge.filters.where(id: inherited_filter_ids).unscope(:order).find_each { remove_filter(it) }
         else
           charge.filters.each { remove_filter(it) }
         end
@@ -134,7 +134,7 @@ module ChargeFilters
 
       return @inherited_filter_ids if parent_filters.blank? || !cascade_updates
 
-      parent_filters.find_each do |pf|
+      parent_filters.unscope(:order).find_each do |pf|
         value = pf.to_h_with_discarded.sort
 
         match = filters.find do |f|

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,10 @@ Rails.application.configure do
   config.active_record.encryption.deterministic_key = "test"
   config.active_record.encryption.key_derivation_salt = "test"
 
+  # Ensures we raise an error when we call `scope.order(...).find_each` as it could potentially
+  # log a lot of warnings on production.
+  config.active_record.error_on_ignored_order = true
+
   config.active_job.queue_adapter = :test
   config.license_url = "http://license.lago"
 


### PR DESCRIPTION
## Context

As we use some default scopes on models and/or associations using `order`, a warning is logged when we call `find_each` on them.

## Description

This PR fixes the warnings by using `unscope(:order)` before calling `find_each`. It also changes the `config.active_record.error_on_ignored_order` to `true` in the test environment to ensure we raise an error instead of logging.
