### PR TITLE
misc(organization): Not null constraint on applied_usage_thresholds

### DIFF
--- a/app/models/applied_usage_threshold.rb
+++ b/app/models/applied_usage_threshold.rb
@@ -32,7 +32,7 @@ end
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  invoice_id                  :uuid             not null
-#  organization_id             :uuid
+#  organization_id             :uuid             not null
 #  usage_threshold_id          :uuid             not null
 #
 # Indexes

--- a/db/migrate/20250627084430_organization_id_check_constaint_on_applied_usage_thresholds.rb
+++ b/db/migrate/20250627084430_organization_id_check_constaint_on_applied_usage_thresholds.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnAppliedUsageThresholds < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :applied_usage_thresholds,
+      "organization_id IS NOT NULL",
+      name: "applied_usage_thresholds_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627084852_not_null_organization_id_on_applied_usage_thresholds.rb
+++ b/db/migrate/20250627084852_not_null_organization_id_on_applied_usage_thresholds.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnAppliedUsageThresholds < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :applied_usage_thresholds, name: "applied_usage_thresholds_organization_id_null"
+    change_column_null :applied_usage_thresholds, :organization_id, false
+    remove_check_constraint :applied_usage_thresholds, name: "applied_usage_thresholds_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :applied_usage_thresholds, "organization_id IS NOT NULL", name: "applied_usage_thresholds_organization_id_null", validate: false
+    change_column_null :applied_usage_thresholds, :organization_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1201,7 +1201,7 @@ CREATE TABLE public.applied_usage_thresholds (
     lifetime_usage_amount_cents bigint DEFAULT 0 NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -8613,6 +8613,8 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250627084852'),
+('20250627084430'),
 ('20250626175249'),
 ('20250611083925'),
 ('20250611072251'),

--- a/lib/generators/not_null_organization_id/not_null_organization_id_generator.rb
+++ b/lib/generators/not_null_organization_id/not_null_organization_id_generator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdGenerator < Rails::Generators::NamedBase
+  include Rails::Generators::Migration
+  source_root File.expand_path("templates", __dir__)
+
+  desc "This generator creates the migrations to add the not null constraint on the organization_id column of a database table"
+
+  def self.next_migration_number(dirname)
+    next_migration_number = current_migration_number(dirname) + 1
+    ActiveRecord::Migration.next_migration_number(next_migration_number)
+  end
+
+  def create_migrations
+    migration_template "organization_id_check_constaint.rb.erb", "db/migrate/organization_id_check_constaint_on_#{file_name}.rb"
+    migration_template "not_null_organization_id.rb.erb", "db/migrate/not_null_organization_id_on_#{file_name}.rb"
+  end
+end

--- a/lib/generators/not_null_organization_id/templates/not_null_organization_id.rb.erb
+++ b/lib/generators/not_null_organization_id/templates/not_null_organization_id.rb.erb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOn<%= class_name %> < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :<%= file_name %>, name: "<%= file_name %>_organization_id_null"
+    change_column_null :<%= file_name %>, :organization_id, false
+    remove_check_constraint :<%= file_name %>, name: "<%= file_name %>_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :<%= file_name %>, "organization_id IS NOT NULL", name: "<%= file_name %>_organization_id_null", validate: false
+    change_column_null :<%= file_name %>, :organization_id, true
+  end
+end

--- a/lib/generators/not_null_organization_id/templates/organization_id_check_constaint.rb.erb
+++ b/lib/generators/not_null_organization_id/templates/organization_id_check_constaint.rb.erb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOn<%= class_name %> < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :<%= file_name %>,
+      "organization_id IS NOT NULL",
+      name: "<%= file_name %>_organization_id_null",
+      validate: false
+  end
+end


### PR DESCRIPTION
## Context
Now that we are done with https://github.com/getlago/lago-api/pull/3687 to add a presence validation on the organization_id field), let's add a proper NOT NULL constraint at the DB level!

## Description

This PR adds:
- The not null constraint on  `theapplied_usage_thresholds` table
- Add new `not_null_organization_id` rails generator to make it easier to create the migration files

A lot of new migrations are coming :) 
