### PR TITLE
misc(organization): Not null constraint on b* models

### DIFF
--- a/app/models/billable_metric_filter.rb
+++ b/app/models/billable_metric_filter.rb
@@ -28,7 +28,7 @@ end
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  billable_metric_id :uuid             not null
-#  organization_id    :uuid
+#  organization_id    :uuid             not null
 #
 # Indexes
 #

--- a/app/models/billing_entity/applied_tax.rb
+++ b/app/models/billing_entity/applied_tax.rb
@@ -20,7 +20,7 @@ end
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  billing_entity_id :uuid             not null
-#  organization_id   :uuid
+#  organization_id   :uuid             not null
 #  tax_id            :uuid             not null
 #
 # Indexes

--- a/db/migrate/20250627091010_organization_id_check_constaint_on_billable_metric_filters.rb
+++ b/db/migrate/20250627091010_organization_id_check_constaint_on_billable_metric_filters.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnBillableMetricFilters < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :billable_metric_filters,
+      "organization_id IS NOT NULL",
+      name: "billable_metric_filters_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627091011_not_null_organization_id_on_billable_metric_filters.rb
+++ b/db/migrate/20250627091011_not_null_organization_id_on_billable_metric_filters.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnBillableMetricFilters < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :billable_metric_filters, name: "billable_metric_filters_organization_id_null"
+    change_column_null :billable_metric_filters, :organization_id, false
+    remove_check_constraint :billable_metric_filters, name: "billable_metric_filters_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :billable_metric_filters, "organization_id IS NOT NULL", name: "billable_metric_filters_organization_id_null", validate: false
+    change_column_null :billable_metric_filters, :organization_id, true
+  end
+end

--- a/db/migrate/20250627091212_organization_id_check_constaint_on_billing_entities_taxes.rb
+++ b/db/migrate/20250627091212_organization_id_check_constaint_on_billing_entities_taxes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnBillingEntitiesTaxes < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :billing_entities_taxes,
+      "organization_id IS NOT NULL",
+      name: "billing_entities_taxes_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627091213_not_null_organization_id_on_billing_entities_taxes.rb
+++ b/db/migrate/20250627091213_not_null_organization_id_on_billing_entities_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnBillingEntitiesTaxes < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :billing_entities_taxes, name: "billing_entities_taxes_organization_id_null"
+    change_column_null :billing_entities_taxes, :organization_id, false
+    remove_check_constraint :billing_entities_taxes, name: "billing_entities_taxes_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :billing_entities_taxes, "organization_id IS NOT NULL", name: "billing_entities_taxes_organization_id_null", validate: false
+    change_column_null :billing_entities_taxes, :organization_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1229,7 +1229,7 @@ CREATE TABLE public.billable_metric_filters (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1341,7 +1341,7 @@ CREATE TABLE public.billing_entities_taxes (
     tax_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -8613,6 +8613,10 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250627091213'),
+('20250627091212'),
+('20250627091011'),
+('20250627091010'),
 ('20250627084852'),
 ('20250627084430'),
 ('20250626175249'),


### PR DESCRIPTION
## Context

Let's continue with not null constraint on organization_id column after https://github.com/getlago/lago-api/pull/3879

## Description

This PR adds the not null constraint on  `billable_metric_filters` and `billing_entities_taxes` tables