### PR TITLE
misc(organization): Not null constraint on c* models

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -167,7 +167,7 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  billable_metric_id   :uuid
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #  parent_id            :uuid
 #  plan_id              :uuid
 #

--- a/app/models/charge/applied_tax.rb
+++ b/app/models/charge/applied_tax.rb
@@ -18,7 +18,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  charge_id       :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #  tax_id          :uuid             not null
 #
 # Indexes

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -71,7 +71,7 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  charge_id            :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #
 # Indexes
 #

--- a/app/models/charge_filter_value.rb
+++ b/app/models/charge_filter_value.rb
@@ -42,7 +42,7 @@ end
 #  updated_at                :datetime         not null
 #  billable_metric_filter_id :uuid             not null
 #  charge_filter_id          :uuid             not null
-#  organization_id           :uuid
+#  organization_id           :uuid             not null
 #
 # Indexes
 #

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -32,7 +32,7 @@ end
 #  invoice_display_name :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #  plan_id              :uuid             not null
 #
 # Indexes

--- a/app/models/commitment/applied_tax.rb
+++ b/app/models/commitment/applied_tax.rb
@@ -18,7 +18,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  commitment_id   :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #  tax_id          :uuid             not null
 #
 # Indexes

--- a/app/models/coupon_target.rb
+++ b/app/models/coupon_target.rb
@@ -23,7 +23,7 @@ end
 #  updated_at         :datetime         not null
 #  billable_metric_id :uuid
 #  coupon_id          :uuid             not null
-#  organization_id    :uuid
+#  organization_id    :uuid             not null
 #  plan_id            :uuid
 #
 # Indexes

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -87,7 +87,7 @@ end
 #  applied_coupon_id              :uuid
 #  credit_note_id                 :uuid
 #  invoice_id                     :uuid
-#  organization_id                :uuid
+#  organization_id                :uuid             not null
 #  progressive_billing_invoice_id :uuid
 #
 # Indexes

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -198,7 +198,7 @@ end
 #  updated_at                              :datetime         not null
 #  customer_id                             :uuid             not null
 #  invoice_id                              :uuid             not null
-#  organization_id                         :uuid
+#  organization_id                         :uuid             not null
 #  sequential_id                           :integer          not null
 #
 # Indexes

--- a/app/models/credit_note/applied_tax.rb
+++ b/app/models/credit_note/applied_tax.rb
@@ -30,7 +30,7 @@ end
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  credit_note_id    :uuid             not null
-#  organization_id   :uuid
+#  organization_id   :uuid             not null
 #  tax_id            :uuid
 #
 # Indexes

--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -36,7 +36,7 @@ end
 #  updated_at           :datetime         not null
 #  credit_note_id       :uuid             not null
 #  fee_id               :uuid
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #
 # Indexes
 #

--- a/app/models/customer/applied_tax.rb
+++ b/app/models/customer/applied_tax.rb
@@ -20,7 +20,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  customer_id     :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #  tax_id          :uuid             not null
 #
 # Indexes

--- a/app/models/metadata/customer_metadata.rb
+++ b/app/models/metadata/customer_metadata.rb
@@ -25,7 +25,7 @@ end
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  customer_id        :uuid             not null
-#  organization_id    :uuid
+#  organization_id    :uuid             not null
 #
 # Indexes
 #

--- a/db/migrate/20250627123958_organization_id_check_constaint_on_charge_filter_values.rb
+++ b/db/migrate/20250627123958_organization_id_check_constaint_on_charge_filter_values.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnChargeFilterValues < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :charge_filter_values,
+      "organization_id IS NOT NULL",
+      name: "charge_filter_values_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627123959_not_null_organization_id_on_charge_filter_values.rb
+++ b/db/migrate/20250627123959_not_null_organization_id_on_charge_filter_values.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnChargeFilterValues < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :charge_filter_values, name: "charge_filter_values_organization_id_null"
+    change_column_null :charge_filter_values, :organization_id, false
+    remove_check_constraint :charge_filter_values, name: "charge_filter_values_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :charge_filter_values, "organization_id IS NOT NULL", name: "charge_filter_values_organization_id_null", validate: false
+    change_column_null :charge_filter_values, :organization_id, true
+  end
+end

--- a/db/migrate/20250627124007_organization_id_check_constaint_on_charge_filters.rb
+++ b/db/migrate/20250627124007_organization_id_check_constaint_on_charge_filters.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnChargeFilters < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :charge_filters,
+      "organization_id IS NOT NULL",
+      name: "charge_filters_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627124008_not_null_organization_id_on_charge_filters.rb
+++ b/db/migrate/20250627124008_not_null_organization_id_on_charge_filters.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnChargeFilters < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :charge_filters, name: "charge_filters_organization_id_null"
+    change_column_null :charge_filters, :organization_id, false
+    remove_check_constraint :charge_filters, name: "charge_filters_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :charge_filters, "organization_id IS NOT NULL", name: "charge_filters_organization_id_null", validate: false
+    change_column_null :charge_filters, :organization_id, true
+  end
+end

--- a/db/migrate/20250627124016_organization_id_check_constaint_on_charges.rb
+++ b/db/migrate/20250627124016_organization_id_check_constaint_on_charges.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnCharges < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :charges,
+      "organization_id IS NOT NULL",
+      name: "charges_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627124017_not_null_organization_id_on_charges.rb
+++ b/db/migrate/20250627124017_not_null_organization_id_on_charges.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnCharges < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :charges, name: "charges_organization_id_null"
+    change_column_null :charges, :organization_id, false
+    remove_check_constraint :charges, name: "charges_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :charges, "organization_id IS NOT NULL", name: "charges_organization_id_null", validate: false
+    change_column_null :charges, :organization_id, true
+  end
+end

--- a/db/migrate/20250627124022_organization_id_check_constaint_on_charges_taxes.rb
+++ b/db/migrate/20250627124022_organization_id_check_constaint_on_charges_taxes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnChargesTaxes < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :charges_taxes,
+      "organization_id IS NOT NULL",
+      name: "charges_taxes_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627124023_not_null_organization_id_on_charges_taxes.rb
+++ b/db/migrate/20250627124023_not_null_organization_id_on_charges_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnChargesTaxes < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :charges_taxes, name: "charges_taxes_organization_id_null"
+    change_column_null :charges_taxes, :organization_id, false
+    remove_check_constraint :charges_taxes, name: "charges_taxes_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :charges_taxes, "organization_id IS NOT NULL", name: "charges_taxes_organization_id_null", validate: false
+    change_column_null :charges_taxes, :organization_id, true
+  end
+end

--- a/db/migrate/20250627124028_organization_id_check_constaint_on_commitments.rb
+++ b/db/migrate/20250627124028_organization_id_check_constaint_on_commitments.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnCommitments < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :commitments,
+      "organization_id IS NOT NULL",
+      name: "commitments_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627124029_not_null_organization_id_on_commitments.rb
+++ b/db/migrate/20250627124029_not_null_organization_id_on_commitments.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnCommitments < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :commitments, name: "commitments_organization_id_null"
+    change_column_null :commitments, :organization_id, false
+    remove_check_constraint :commitments, name: "commitments_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :commitments, "organization_id IS NOT NULL", name: "commitments_organization_id_null", validate: false
+    change_column_null :commitments, :organization_id, true
+  end
+end

--- a/db/migrate/20250627124033_organization_id_check_constaint_on_commitments_taxes.rb
+++ b/db/migrate/20250627124033_organization_id_check_constaint_on_commitments_taxes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnCommitmentsTaxes < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :commitments_taxes,
+      "organization_id IS NOT NULL",
+      name: "commitments_taxes_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627124034_not_null_organization_id_on_commitments_taxes.rb
+++ b/db/migrate/20250627124034_not_null_organization_id_on_commitments_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnCommitmentsTaxes < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :commitments_taxes, name: "commitments_taxes_organization_id_null"
+    change_column_null :commitments_taxes, :organization_id, false
+    remove_check_constraint :commitments_taxes, name: "commitments_taxes_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :commitments_taxes, "organization_id IS NOT NULL", name: "commitments_taxes_organization_id_null", validate: false
+    change_column_null :commitments_taxes, :organization_id, true
+  end
+end

--- a/db/migrate/20250627124039_organization_id_check_constaint_on_coupon_targets.rb
+++ b/db/migrate/20250627124039_organization_id_check_constaint_on_coupon_targets.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnCouponTargets < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :coupon_targets,
+      "organization_id IS NOT NULL",
+      name: "coupon_targets_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627124040_not_null_organization_id_on_coupon_targets.rb
+++ b/db/migrate/20250627124040_not_null_organization_id_on_coupon_targets.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnCouponTargets < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :coupon_targets, name: "coupon_targets_organization_id_null"
+    change_column_null :coupon_targets, :organization_id, false
+    remove_check_constraint :coupon_targets, name: "coupon_targets_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :coupon_targets, "organization_id IS NOT NULL", name: "coupon_targets_organization_id_null", validate: false
+    change_column_null :coupon_targets, :organization_id, true
+  end
+end

--- a/db/migrate/20250627124048_organization_id_check_constaint_on_credit_note_items.rb
+++ b/db/migrate/20250627124048_organization_id_check_constaint_on_credit_note_items.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnCreditNoteItems < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :credit_note_items,
+      "organization_id IS NOT NULL",
+      name: "credit_note_items_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627124049_not_null_organization_id_on_credit_note_items.rb
+++ b/db/migrate/20250627124049_not_null_organization_id_on_credit_note_items.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnCreditNoteItems < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :credit_note_items, name: "credit_note_items_organization_id_null"
+    change_column_null :credit_note_items, :organization_id, false
+    remove_check_constraint :credit_note_items, name: "credit_note_items_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :credit_note_items, "organization_id IS NOT NULL", name: "credit_note_items_organization_id_null", validate: false
+    change_column_null :credit_note_items, :organization_id, true
+  end
+end

--- a/db/migrate/20250627124055_organization_id_check_constaint_on_credit_notes.rb
+++ b/db/migrate/20250627124055_organization_id_check_constaint_on_credit_notes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnCreditNotes < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :credit_notes,
+      "organization_id IS NOT NULL",
+      name: "credit_notes_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627124056_not_null_organization_id_on_credit_notes.rb
+++ b/db/migrate/20250627124056_not_null_organization_id_on_credit_notes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnCreditNotes < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :credit_notes, name: "credit_notes_organization_id_null"
+    change_column_null :credit_notes, :organization_id, false
+    remove_check_constraint :credit_notes, name: "credit_notes_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :credit_notes, "organization_id IS NOT NULL", name: "credit_notes_organization_id_null", validate: false
+    change_column_null :credit_notes, :organization_id, true
+  end
+end

--- a/db/migrate/20250627124118_organization_id_check_constaint_on_credit_notes_taxes.rb
+++ b/db/migrate/20250627124118_organization_id_check_constaint_on_credit_notes_taxes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnCreditNotesTaxes < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :credit_notes_taxes,
+      "organization_id IS NOT NULL",
+      name: "credit_notes_taxes_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627124119_not_null_organization_id_on_credit_notes_taxes.rb
+++ b/db/migrate/20250627124119_not_null_organization_id_on_credit_notes_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnCreditNotesTaxes < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :credit_notes_taxes, name: "credit_notes_taxes_organization_id_null"
+    change_column_null :credit_notes_taxes, :organization_id, false
+    remove_check_constraint :credit_notes_taxes, name: "credit_notes_taxes_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :credit_notes_taxes, "organization_id IS NOT NULL", name: "credit_notes_taxes_organization_id_null", validate: false
+    change_column_null :credit_notes_taxes, :organization_id, true
+  end
+end

--- a/db/migrate/20250627124129_organization_id_check_constaint_on_credits.rb
+++ b/db/migrate/20250627124129_organization_id_check_constaint_on_credits.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnCredits < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :credits,
+      "organization_id IS NOT NULL",
+      name: "credits_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627124130_not_null_organization_id_on_credits.rb
+++ b/db/migrate/20250627124130_not_null_organization_id_on_credits.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnCredits < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :credits, name: "credits_organization_id_null"
+    change_column_null :credits, :organization_id, false
+    remove_check_constraint :credits, name: "credits_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :credits, "organization_id IS NOT NULL", name: "credits_organization_id_null", validate: false
+    change_column_null :credits, :organization_id, true
+  end
+end

--- a/db/migrate/20250627124143_organization_id_check_constaint_on_customer_metadata.rb
+++ b/db/migrate/20250627124143_organization_id_check_constaint_on_customer_metadata.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnCustomerMetadata < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :customer_metadata,
+      "organization_id IS NOT NULL",
+      name: "customer_metadata_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627124144_not_null_organization_id_on_customer_metadata.rb
+++ b/db/migrate/20250627124144_not_null_organization_id_on_customer_metadata.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnCustomerMetadata < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :customer_metadata, name: "customer_metadata_organization_id_null"
+    change_column_null :customer_metadata, :organization_id, false
+    remove_check_constraint :customer_metadata, name: "customer_metadata_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :customer_metadata, "organization_id IS NOT NULL", name: "customer_metadata_organization_id_null", validate: false
+    change_column_null :customer_metadata, :organization_id, true
+  end
+end

--- a/db/migrate/20250627124152_organization_id_check_constaint_on_customers_taxes.rb
+++ b/db/migrate/20250627124152_organization_id_check_constaint_on_customers_taxes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnCustomersTaxes < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :customers_taxes,
+      "organization_id IS NOT NULL",
+      name: "customers_taxes_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627124153_not_null_organization_id_on_customers_taxes.rb
+++ b/db/migrate/20250627124153_not_null_organization_id_on_customers_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnCustomersTaxes < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :customers_taxes, name: "customers_taxes_organization_id_null"
+    change_column_null :customers_taxes, :organization_id, false
+    remove_check_constraint :customers_taxes, name: "customers_taxes_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :customers_taxes, "organization_id IS NOT NULL", name: "customers_taxes_organization_id_null", validate: false
+    change_column_null :customers_taxes, :organization_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1381,7 +1381,7 @@ CREATE TABLE public.charge_filter_values (
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
     "values" character varying[] DEFAULT '{}'::character varying[] NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1397,7 +1397,7 @@ CREATE TABLE public.charge_filters (
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
     invoice_display_name character varying,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1422,7 +1422,7 @@ CREATE TABLE public.charges (
     invoice_display_name character varying,
     regroup_paid_fees integer,
     parent_id uuid,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1436,7 +1436,7 @@ CREATE TABLE public.charges_taxes (
     tax_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1452,7 +1452,7 @@ CREATE TABLE public.commitments (
     invoice_display_name character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1466,7 +1466,7 @@ CREATE TABLE public.commitments_taxes (
     tax_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1482,7 +1482,7 @@ CREATE TABLE public.coupon_targets (
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
     billable_metric_id uuid,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1528,7 +1528,7 @@ CREATE TABLE public.credit_note_items (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     precise_amount_cents numeric(30,5) NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1566,7 +1566,7 @@ CREATE TABLE public.credit_notes (
     precise_coupons_adjustment_amount_cents numeric(30,5) DEFAULT 0.0 NOT NULL,
     precise_taxes_amount_cents numeric(30,5) DEFAULT 0.0 NOT NULL,
     taxes_rate double precision DEFAULT 0.0 NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1587,7 +1587,7 @@ CREATE TABLE public.credit_notes_taxes (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     base_amount_cents bigint DEFAULT 0 NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1606,7 +1606,7 @@ CREATE TABLE public.credits (
     before_taxes boolean DEFAULT false NOT NULL,
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     progressive_billing_invoice_id uuid,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1622,7 +1622,7 @@ CREATE TABLE public.customer_metadata (
     display_in_invoice boolean DEFAULT false NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1710,7 +1710,7 @@ CREATE TABLE public.customers_taxes (
     tax_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -8613,6 +8613,32 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250627124153'),
+('20250627124152'),
+('20250627124144'),
+('20250627124143'),
+('20250627124130'),
+('20250627124129'),
+('20250627124119'),
+('20250627124118'),
+('20250627124056'),
+('20250627124055'),
+('20250627124049'),
+('20250627124048'),
+('20250627124040'),
+('20250627124039'),
+('20250627124034'),
+('20250627124033'),
+('20250627124029'),
+('20250627124028'),
+('20250627124023'),
+('20250627124022'),
+('20250627124017'),
+('20250627124016'),
+('20250627124008'),
+('20250627124007'),
+('20250627123959'),
+('20250627123958'),
 ('20250627091213'),
 ('20250627091212'),
 ('20250627091011'),


### PR DESCRIPTION
## Context

Let's continue with not null constraint on organization_id column after https://github.com/getlago/lago-api/pull/3879

## Description

This PR adds the not null constraint on new tables:
- `charges`
- `charges_applied_taxes`
- `charge_filters`
- `charge_filter_values`
- `commitments`
- `commitment_applied_taxes`
- `coupon_targets`
- `credits`
- `credit_notes`
- `credit_notes_applied_taxes`
- `customers_applied_taxes`
- `customer_metadata`