### PR TITLE
misc(organization): Not null constraint on d* models

### DIFF
--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -78,7 +78,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  membership_id   :uuid
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/data_export_part.rb
+++ b/app/models/data_export_part.rb
@@ -19,7 +19,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  data_export_id  :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/dunning_campaign_threshold.rb
+++ b/app/models/dunning_campaign_threshold.rb
@@ -29,7 +29,7 @@ end
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  dunning_campaign_id :uuid             not null
-#  organization_id     :uuid
+#  organization_id     :uuid             not null
 #
 # Indexes
 #

--- a/db/migrate/20250627134915_organization_id_check_constaint_on_data_export_parts.rb
+++ b/db/migrate/20250627134915_organization_id_check_constaint_on_data_export_parts.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnDataExportParts < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :data_export_parts,
+      "organization_id IS NOT NULL",
+      name: "data_export_parts_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627134916_not_null_organization_id_on_data_export_parts.rb
+++ b/db/migrate/20250627134916_not_null_organization_id_on_data_export_parts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnDataExportParts < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :data_export_parts, name: "data_export_parts_organization_id_null"
+    change_column_null :data_export_parts, :organization_id, false
+    remove_check_constraint :data_export_parts, name: "data_export_parts_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :data_export_parts, "organization_id IS NOT NULL", name: "data_export_parts_organization_id_null", validate: false
+    change_column_null :data_export_parts, :organization_id, true
+  end
+end

--- a/db/migrate/20250627134925_organization_id_check_constaint_on_data_exports.rb
+++ b/db/migrate/20250627134925_organization_id_check_constaint_on_data_exports.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnDataExports < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :data_exports,
+      "organization_id IS NOT NULL",
+      name: "data_exports_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627134926_not_null_organization_id_on_data_exports.rb
+++ b/db/migrate/20250627134926_not_null_organization_id_on_data_exports.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnDataExports < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :data_exports, name: "data_exports_organization_id_null"
+    change_column_null :data_exports, :organization_id, false
+    remove_check_constraint :data_exports, name: "data_exports_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :data_exports, "organization_id IS NOT NULL", name: "data_exports_organization_id_null", validate: false
+    change_column_null :data_exports, :organization_id, true
+  end
+end

--- a/db/migrate/20250627134932_organization_id_check_constaint_on_dunning_campaign_thresholds.rb
+++ b/db/migrate/20250627134932_organization_id_check_constaint_on_dunning_campaign_thresholds.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnDunningCampaignThresholds < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :dunning_campaign_thresholds,
+      "organization_id IS NOT NULL",
+      name: "dunning_campaign_thresholds_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250627134933_not_null_organization_id_on_dunning_campaign_thresholds.rb
+++ b/db/migrate/20250627134933_not_null_organization_id_on_dunning_campaign_thresholds.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnDunningCampaignThresholds < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :dunning_campaign_thresholds, name: "dunning_campaign_thresholds_organization_id_null"
+    change_column_null :dunning_campaign_thresholds, :organization_id, false
+    remove_check_constraint :dunning_campaign_thresholds, name: "dunning_campaign_thresholds_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :dunning_campaign_thresholds, "organization_id IS NOT NULL", name: "dunning_campaign_thresholds_organization_id_null", validate: false
+    change_column_null :dunning_campaign_thresholds, :organization_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1748,7 +1748,7 @@ CREATE TABLE public.data_export_parts (
     csv_lines text,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1768,7 +1768,7 @@ CREATE TABLE public.data_exports (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     membership_id uuid,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1784,7 +1784,7 @@ CREATE TABLE public.dunning_campaign_thresholds (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp without time zone,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -8613,6 +8613,12 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250627134933'),
+('20250627134932'),
+('20250627134926'),
+('20250627134925'),
+('20250627134916'),
+('20250627134915'),
 ('20250627124153'),
 ('20250627124152'),
 ('20250627124144'),


### PR DESCRIPTION
## Context

Let's continue with not null constraint on organization_id column after https://github.com/getlago/lago-api/pull/3879

## Description

This PR adds the not null constraint on new tables:
- `data_export_parts`
- `data_exports`
- `dunning_campaign_thresholds`