### PR TITLE
fix(aggregator): Add auto-retry logic on SSL error

### DIFF
--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -77,7 +77,7 @@ module Integrations
       end
 
       def http_client
-        LagoHttpClient::Client.new(endpoint_url)
+        LagoHttpClient::Client.new(endpoint_url, retries_on: [OpenSSL::SSL::SSLError])
       end
 
       def endpoint_url

--- a/spec/graphql/mutations/credit_notes/retry_tax_reporting_spec.rb
+++ b/spec/graphql/mutations/credit_notes/retry_tax_reporting_spec.rb
@@ -86,7 +86,9 @@ RSpec.describe Mutations::CreditNotes::RetryTaxReporting, type: :graphql do
 
     integration_customer
 
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
     allow(lago_client).to receive(:post_with_response).and_return(response)
     allow(response).to receive(:body).and_return(body)
   end

--- a/spec/graphql/mutations/integrations/fetch_draft_invoice_taxes_spec.rb
+++ b/spec/graphql/mutations/integrations/fetch_draft_invoice_taxes_spec.rb
@@ -81,7 +81,9 @@ RSpec.describe Mutations::Integrations::FetchDraftInvoiceTaxes, type: :graphql d
     integration_collection_mapping1
     integration_mapping_add_on
 
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
     allow(lago_client).to receive(:post_with_response).and_return(response)
     allow(response).to receive(:body).and_return(body)
   end

--- a/spec/graphql/mutations/invoices/retry_all_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_all_spec.rb
@@ -83,7 +83,9 @@ RSpec.describe Mutations::Invoices::RetryAll, type: :graphql do
 
     integration_customer
 
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
     allow(lago_client).to receive(:post_with_response).and_return(response)
     allow(response).to receive(:body).and_return(body)
   end

--- a/spec/graphql/mutations/invoices/retry_tax_provider_voiding_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_tax_provider_voiding_spec.rb
@@ -79,7 +79,9 @@ RSpec.describe Mutations::Invoices::RetryTaxProviderVoiding, type: :graphql do
 
     integration_customer
 
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
     allow(lago_client).to receive(:post_with_response).and_return(response)
     allow(response).to receive(:body).and_return(body)
   end

--- a/spec/graphql/resolvers/integrations/subsidiaries_resolver_spec.rb
+++ b/spec/graphql/resolvers/integrations/subsidiaries_resolver_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Resolvers::Integrations::SubsidiariesResolver, type: :graphql do
 
   before do
     allow(LagoHttpClient::Client).to receive(:new)
-      .with(subsidiaries_endpoint)
+      .with(subsidiaries_endpoint, retries_on: [OpenSSL::SSL::SSLError])
       .and_return(lago_client)
     allow(lago_client).to receive(:get)
       .with(headers:)

--- a/spec/jobs/invoices/finalize_all_job_spec.rb
+++ b/spec/jobs/invoices/finalize_all_job_spec.rb
@@ -45,7 +45,9 @@ RSpec.describe Invoices::FinalizeAllJob, type: :job do
     before do
       integration_collection_mapping
 
-      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+        .and_return(lago_client)
       allow(lago_client).to receive(:post_with_response).and_return(response)
       allow(response).to receive(:body).and_return(body)
     end

--- a/spec/jobs/invoices/finalize_job_spec.rb
+++ b/spec/jobs/invoices/finalize_job_spec.rb
@@ -45,7 +45,9 @@ RSpec.describe Invoices::FinalizeJob, type: :job do
     before do
       integration_collection_mapping
 
-      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+        .and_return(lago_client)
       allow(lago_client).to receive(:post_with_response).and_return(response)
       allow(response).to receive(:body).and_return(body)
     end

--- a/spec/jobs/invoices/refresh_draft_job_spec.rb
+++ b/spec/jobs/invoices/refresh_draft_job_spec.rb
@@ -59,7 +59,9 @@ RSpec.describe Invoices::RefreshDraftJob, type: :job do
     before do
       integration_collection_mapping
 
-      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+        .and_return(lago_client)
       allow(lago_client).to receive(:post_with_response).and_return(response)
       allow(response).to receive(:body).and_return(body)
     end

--- a/spec/services/credit_notes/provider_taxes/report_service_spec.rb
+++ b/spec/services/credit_notes/provider_taxes/report_service_spec.rb
@@ -91,7 +91,9 @@ RSpec.describe CreditNotes::ProviderTaxes::ReportService, type: :service do
       fee_charge
       integration_customer
 
-      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+        .and_return(lago_client)
       allow(lago_client).to receive(:post_with_response).and_return(response)
       allow(response).to receive(:body).and_return(body)
     end
@@ -137,7 +139,7 @@ RSpec.describe CreditNotes::ProviderTaxes::ReportService, type: :service do
         aggregate_failures do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+          expect(LagoHttpClient::Client).to have_received(:new).with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
           expect(credit_note.reload.integration_resources.where(integration_id: integration.id).count).to eq(0)
         end
       end

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -127,7 +127,9 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
         integration_collection_mapping
         integration_customer
 
-        allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+        allow(LagoHttpClient::Client).to receive(:new)
+          .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+          .and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
         allow_any_instance_of(Fee).to receive(:id).and_return("lago_fee_id") # rubocop:disable RSpec/AnyInstance

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -172,7 +172,9 @@ RSpec.describe Fees::OneOffService do
         integration_collection_mapping
         integration_customer
 
-        allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+        allow(LagoHttpClient::Client).to receive(:new)
+          .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+          .and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
         allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args| # rubocop:disable RSpec/AnyInstance

--- a/spec/services/integrations/aggregator/account_information_service_spec.rb
+++ b/spec/services/integrations/aggregator/account_information_service_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe Integrations::Aggregator::AccountInformationService do
     end
 
     before do
-      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+        .and_return(lago_client)
       allow(lago_client).to receive(:get).with(headers:).and_return(aggregator_response)
     end
 
@@ -34,7 +36,7 @@ RSpec.describe Integrations::Aggregator::AccountInformationService do
       account_information = result.account_information
 
       aggregate_failures do
-        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(lago_client).to have_received(:get)
         expect(account_information.id).to eq("1234567890")
       end

--- a/spec/services/integrations/aggregator/accounts_service_spec.rb
+++ b/spec/services/integrations/aggregator/accounts_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Integrations::Aggregator::AccountsService do
 
     before do
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(accounts_endpoint)
+        .with(accounts_endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(lago_client)
       allow(lago_client).to receive(:get)
         .with(headers:, params:)
@@ -42,7 +42,7 @@ RSpec.describe Integrations::Aggregator::AccountsService do
       account = result.accounts.first
 
       aggregate_failures do
-        expect(LagoHttpClient::Client).to have_received(:new).with(accounts_endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(accounts_endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(lago_client).to have_received(:get)
         expect(result.accounts.count).to eq(3)
         expect(account.external_id).to eq("12ec4c59-ad56-4a4f-93eb-fb0a7740f4e2")

--- a/spec/services/integrations/aggregator/companies/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/companies/create_service_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe Integrations::Aggregator::Companies::CreateService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
   end
 
   describe "#initialize" do

--- a/spec/services/integrations/aggregator/companies/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/companies/update_service_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe Integrations::Aggregator::Companies::UpdateService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
     allow(service).to receive(:throttle!)
   end
 

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
   end
 
   describe "#call" do

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
   end
 
   describe "#call" do

--- a/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
@@ -175,7 +175,9 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
   let(:description) { credit_note.invoice.credits.coupon_kind.map(&:item_name).join(",") }
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
 
     integration_customer
     charge

--- a/spec/services/integrations/aggregator/custom_object_service_spec.rb
+++ b/spec/services/integrations/aggregator/custom_object_service_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe Integrations::Aggregator::CustomObjectService do
     end
 
     before do
-      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+        .and_return(lago_client)
       allow(lago_client).to receive(:get).with(headers:, body:).and_return(aggregator_response)
     end
 
@@ -41,7 +43,7 @@ RSpec.describe Integrations::Aggregator::CustomObjectService do
       custom_object = result.custom_object
 
       aggregate_failures do
-        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(lago_client).to have_received(:get)
         expect(custom_object.id).to eq("35482707")
         expect(custom_object.objectTypeId).to eq("2-35482707")

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -223,7 +223,9 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
 
     integration_customer
     charge

--- a/spec/services/integrations/aggregator/invoices/hubspot/create_customer_association_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/create_customer_association_service_spec.rb
@@ -46,7 +46,9 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssoci
     integration_customer
     integration_invoice
 
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
     allow(lago_client).to receive(:put_with_response).with(params, headers)
   end
 

--- a/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/create_service_spec.rb
@@ -42,7 +42,9 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
 
     integration_customer
     integration.sync_invoices = true

--- a/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/update_service_spec.rb
@@ -42,7 +42,9 @@ RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
 
     integration_customer
     integration.sync_invoices = true

--- a/spec/services/integrations/aggregator/items_service_spec.rb
+++ b/spec/services/integrations/aggregator/items_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Integrations::Aggregator::ItemsService do
 
     before do
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(items_endpoint)
+        .with(items_endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(lago_client)
       allow(lago_client).to receive(:get)
         .with(headers:, params:)
@@ -40,7 +40,7 @@ RSpec.describe Integrations::Aggregator::ItemsService do
       result = items_service.call
 
       aggregate_failures do
-        expect(LagoHttpClient::Client).to have_received(:new).with(items_endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(items_endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(lago_client).to have_received(:get)
         expect(result.items.pluck("external_id")).to eq(%w[755 745 753 484 828])
         expect(IntegrationItem.count).to eq(5)

--- a/spec/services/integrations/aggregator/payments/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/payments/create_service_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe Integrations::Aggregator::Payments::CreateService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
 
     integration_customer
     integration.sync_payments = true

--- a/spec/services/integrations/aggregator/send_restlet_endpoint_service_spec.rb
+++ b/spec/services/integrations/aggregator/send_restlet_endpoint_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Integrations::Aggregator::SendRestletEndpointService do
 
     before do
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(endpoint)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(lago_client)
       allow(lago_client).to receive(:post_with_response)
 
@@ -26,7 +26,7 @@ RSpec.describe Integrations::Aggregator::SendRestletEndpointService do
 
       aggregate_failures do
         expect(LagoHttpClient::Client).to have_received(:new)
-          .with(endpoint)
+          .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(lago_client).to have_received(:post_with_response) do |payload|
           expect(payload[:restletEndpoint]).to eq("https://example.com")
         end

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/create_customer_association_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/create_customer_association_service_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateCustomerA
     integration_customer
     integration_subscription
 
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
     allow(lago_client).to receive(:put_with_response).with(params, headers)
   end
 

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/create_service_spec.rb
@@ -30,8 +30,12 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateService d
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
-    allow(LagoHttpClient::Client).to receive(:new).with(properties_endpoint).and_return(lago_properties_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(properties_endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_properties_client)
 
     integration_customer
     integration.sync_subscriptions = true

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/update_service_spec.rb
@@ -34,8 +34,10 @@ RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::UpdateService d
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
-    allow(LagoHttpClient::Client).to receive(:new).with(properties_endpoint).and_return(lago_properties_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new).with(properties_endpoint, retries_on: [OpenSSL::SSL::SSLError]).and_return(lago_properties_client)
 
     integration_customer
     integration.sync_subscriptions = true

--- a/spec/services/integrations/aggregator/subsidiaries_service_spec.rb
+++ b/spec/services/integrations/aggregator/subsidiaries_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Integrations::Aggregator::SubsidiariesService do
 
     before do
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(subsidiaries_endpoint)
+        .with(subsidiaries_endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(lago_client)
       allow(lago_client).to receive(:get)
         .with(headers:)
@@ -36,7 +36,7 @@ RSpec.describe Integrations::Aggregator::SubsidiariesService do
       result = subsidiaries_service.call
 
       aggregate_failures do
-        expect(LagoHttpClient::Client).to have_received(:new).with(subsidiaries_endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(subsidiaries_endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(lago_client).to have_received(:get)
         expect(result.subsidiaries.count).to eq(4)
         expect(result.subsidiaries.first.external_id).to eq("1")

--- a/spec/services/integrations/aggregator/sync_service_spec.rb
+++ b/spec/services/integrations/aggregator/sync_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Integrations::Aggregator::SyncService do
 
     before do
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(sync_endpoint)
+        .with(sync_endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(lago_client)
       allow(lago_client).to receive(:post_with_response)
     end
@@ -27,7 +27,7 @@ RSpec.describe Integrations::Aggregator::SyncService do
       sync_service.call
 
       expect(LagoHttpClient::Client).to have_received(:new)
-        .with(sync_endpoint)
+        .with(sync_endpoint, retries_on: [OpenSSL::SSL::SSLError])
       expect(lago_client).to have_received(:post_with_response) do |payload|
         expect(payload[:provider_config_key]).to eq("netsuite-tba")
         expect(payload[:syncs]).to eq(syncs_list)

--- a/spec/services/integrations/aggregator/taxes/avalara/fetch_company_id_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/avalara/fetch_company_id_service_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe Integrations::Aggregator::Taxes::Avalara::FetchCompanyIdService d
 
   before do
     integration
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
   end
 
   describe "#call" do

--- a/spec/services/integrations/aggregator/taxes/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/credit_notes/create_service_spec.rb
@@ -114,7 +114,9 @@ RSpec.describe Integrations::Aggregator::Taxes::CreditNotes::CreateService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
 
     integration_customer
     integration_collection_mapping1

--- a/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
@@ -99,7 +99,9 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
 
     integration_customer
     integration_collection_mapping1

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -100,7 +100,9 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
 
     integration_customer
     integration_collection_mapping1

--- a/spec/services/integrations/aggregator/taxes/invoices/negate_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/negate_service_spec.rb
@@ -48,7 +48,9 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::NegateService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
 
     integration_customer
     integration_collection_mapping1

--- a/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
@@ -47,7 +47,9 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
   end
 
   before do
-    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      .and_return(lago_client)
 
     integration_customer
     integration_collection_mapping1

--- a/spec/services/integrations/hubspot/companies/deploy_properties_service_spec.rb
+++ b/spec/services/integrations/hubspot/companies/deploy_properties_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Integrations::Hubspot::Companies::DeployPropertiesService do
 
     before do
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(endpoint)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(http_client)
       allow(http_client).to receive(:post_with_response).and_return(response)
 
@@ -26,7 +26,7 @@ RSpec.describe Integrations::Hubspot::Companies::DeployPropertiesService do
       deploy_properties_service.call
 
       aggregate_failures do
-        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(http_client).to have_received(:post_with_response) do |payload, headers|
           expect(payload[:objectType]).to eq("companies")
           expect(headers["Authorization"]).to include("Bearer")

--- a/spec/services/integrations/hubspot/contacts/deploy_properties_service_spec.rb
+++ b/spec/services/integrations/hubspot/contacts/deploy_properties_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Integrations::Hubspot::Contacts::DeployPropertiesService do
 
     before do
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(endpoint)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(http_client)
       allow(http_client).to receive(:post_with_response).and_return(response)
 
@@ -26,7 +26,7 @@ RSpec.describe Integrations::Hubspot::Contacts::DeployPropertiesService do
       deploy_properties_service.call
 
       aggregate_failures do
-        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(http_client).to have_received(:post_with_response) do |payload, headers|
           expect(payload[:objectType]).to eq("contacts")
           expect(headers["Authorization"]).to include("Bearer")

--- a/spec/services/integrations/hubspot/invoices/deploy_object_service_spec.rb
+++ b/spec/services/integrations/hubspot/invoices/deploy_object_service_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe Integrations::Hubspot::Invoices::DeployObjectService do
 
     before do
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(endpoint)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(http_client)
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(customer_object_endpoint)
+        .with(customer_object_endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(http_client_get)
       allow(http_client).to receive(:post_with_response).and_return(response)
       allow(http_client_get).to receive(:get).and_raise LagoHttpClient::HttpError.new("error", "error", nil)
@@ -38,7 +38,7 @@ RSpec.describe Integrations::Hubspot::Invoices::DeployObjectService do
       deploy_object_service.call
 
       aggregate_failures do
-        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(http_client).to have_received(:post_with_response) do |payload, headers|
           expect(payload[:name]).to eq("LagoInvoices")
           expect(headers["Authorization"]).to include("Bearer")
@@ -101,7 +101,7 @@ RSpec.describe Integrations::Hubspot::Invoices::DeployObjectService do
         deploy_object_service.call
 
         aggregate_failures do
-          expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+          expect(LagoHttpClient::Client).to have_received(:new).with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
           expect(http_client).to have_received(:post_with_response)
           expect(integration.reload.invoices_properties_version).to eq(described_class::VERSION)
         end

--- a/spec/services/integrations/hubspot/invoices/deploy_properties_service_spec.rb
+++ b/spec/services/integrations/hubspot/invoices/deploy_properties_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Integrations::Hubspot::Invoices::DeployPropertiesService do
 
     before do
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(endpoint)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(http_client)
       allow(http_client).to receive(:post_with_response).and_return(response)
 
@@ -26,7 +26,7 @@ RSpec.describe Integrations::Hubspot::Invoices::DeployPropertiesService do
       deploy_properties_service.call
 
       aggregate_failures do
-        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(http_client).to have_received(:post_with_response) do |payload, headers|
           expect(payload[:objectType]).to eq("LagoInvoices")
           expect(headers["Authorization"]).to include("Bearer")

--- a/spec/services/integrations/hubspot/subscriptions/deploy_object_service_spec.rb
+++ b/spec/services/integrations/hubspot/subscriptions/deploy_object_service_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe Integrations::Hubspot::Subscriptions::DeployObjectService do
 
     before do
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(endpoint)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(http_client)
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(customer_object_endpoint)
+        .with(customer_object_endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(http_client_get)
       allow(http_client).to receive(:post_with_response).and_return(response)
       allow(http_client_get).to receive(:get).and_raise LagoHttpClient::HttpError.new("error", "error", nil)
@@ -38,7 +38,7 @@ RSpec.describe Integrations::Hubspot::Subscriptions::DeployObjectService do
       deploy_object_service.call
 
       aggregate_failures do
-        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(http_client).to have_received(:post_with_response) do |payload, headers|
           expect(payload[:name]).to eq("LagoSubscriptions")
           expect(headers["Authorization"]).to include("Bearer")

--- a/spec/services/integrations/hubspot/subscriptions/deploy_properties_service_spec.rb
+++ b/spec/services/integrations/hubspot/subscriptions/deploy_properties_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Integrations::Hubspot::Subscriptions::DeployPropertiesService do
 
     before do
       allow(LagoHttpClient::Client).to receive(:new)
-        .with(endpoint)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         .and_return(http_client)
       allow(http_client).to receive(:post_with_response).and_return(response)
 
@@ -26,7 +26,7 @@ RSpec.describe Integrations::Hubspot::Subscriptions::DeployPropertiesService do
       deploy_properties_service.call
 
       aggregate_failures do
-        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(http_client).to have_received(:post_with_response) do |payload, headers|
           expect(payload[:objectType]).to eq("LagoSubscriptions")
           expect(headers["Authorization"]).to include("Bearer")

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -149,7 +149,9 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
         integration_collection_mapping
         integration_customer
 
-        allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+        allow(LagoHttpClient::Client).to receive(:new)
+          .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+          .and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
         allow_any_instance_of(Fee).to receive(:id).and_wrap_original do |m, *args| # rubocop:disable RSpec/AnyInstance

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -224,7 +224,9 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
         integration_collection_mapping
         integration_customer
 
-        allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+        allow(LagoHttpClient::Client).to receive(:new)
+          .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+          .and_return(lago_client)
         allow(lago_client).to receive(:post_with_response).and_return(response)
         allow(response).to receive(:body).and_return(body)
         allow_any_instance_of(Fee).to receive(:id).and_return("lago_fee_id") # rubocop:disable RSpec/AnyInstance

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -99,8 +99,10 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
 
       integration_customer_tax
 
-      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
-      allow(LagoHttpClient::Client).to receive(:new).with(endpoint_draft).and_return(lago_client)
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(endpoint, retries_on: [OpenSSL::SSL::SSLError])
+        .and_return(lago_client)
+      allow(LagoHttpClient::Client).to receive(:new).with(endpoint_draft, retries_on: [OpenSSL::SSL::SSLError]).and_return(lago_client)
       allow(lago_client).to receive(:post_with_response).and_return(response)
       allow(response).to receive(:body).and_return(body)
     end

--- a/spec/services/invoices/provider_taxes/void_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/void_service_spec.rb
@@ -90,11 +90,17 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
       fee_charge
       integration_customer
 
-      allow(LagoHttpClient::Client).to receive(:new).with(void_endpoint).and_return(lago_client1)
+      allow(LagoHttpClient::Client)
+        .to receive(:new)
+        .with(void_endpoint, retries_on: [OpenSSL::SSL::SSLError])
+        .and_return(lago_client1)
       allow(lago_client1).to receive(:post_with_response).and_return(response1)
       allow(response1).to receive(:body).and_return(body_void)
 
-      allow(LagoHttpClient::Client).to receive(:new).with(negate_endpoint).and_return(lago_client2)
+      allow(LagoHttpClient::Client)
+        .to receive(:new)
+        .with(negate_endpoint, retries_on: [OpenSSL::SSL::SSLError])
+        .and_return(lago_client2)
       allow(lago_client2).to receive(:post_with_response).and_return(response2)
       allow(response2).to receive(:body).and_return(body_negate)
     end
@@ -143,8 +149,8 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
         result = void_service.call
 
         expect(result).not_to be_success
-        expect(LagoHttpClient::Client).to have_received(:new).with(void_endpoint)
-        expect(LagoHttpClient::Client).not_to have_received(:new).with(negate_endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(void_endpoint, retries_on: [OpenSSL::SSL::SSLError])
+        expect(LagoHttpClient::Client).not_to have_received(:new).with(negate_endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(result.error).to be_a(BaseService::ValidationFailure)
         expect(invoice.reload.status).to eq("voided")
       end
@@ -174,8 +180,8 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
         result = void_service.call
 
         expect(result).not_to be_success
-        expect(LagoHttpClient::Client).to have_received(:new).with(void_endpoint)
-        expect(LagoHttpClient::Client).to have_received(:new).with(negate_endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(void_endpoint, retries_on: [OpenSSL::SSL::SSLError])
+        expect(LagoHttpClient::Client).to have_received(:new).with(negate_endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(result.error).to be_a(BaseService::ValidationFailure)
         expect(invoice.reload.status).to eq("voided")
       end
@@ -209,8 +215,8 @@ RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
         result = void_service.call
 
         expect(result).not_to be_success
-        expect(LagoHttpClient::Client).to have_received(:new).with(void_endpoint)
-        expect(LagoHttpClient::Client).to have_received(:new).with(negate_endpoint)
+        expect(LagoHttpClient::Client).to have_received(:new).with(void_endpoint, retries_on: [OpenSSL::SSL::SSLError])
+        expect(LagoHttpClient::Client).to have_received(:new).with(negate_endpoint, retries_on: [OpenSSL::SSL::SSLError])
         expect(result.error).to be_a(BaseService::ValidationFailure)
         expect(invoice.reload.status).to eq("voided")
       end


### PR DESCRIPTION
## Context

Many calls to external aggregators are failing with errors like `OpenSSL::SSL::SSLError`, leading to a failure of caller service. Most of the time this error is just a transient "bad luck" error and can just be retries automatically.

The Lago HTTP client is lacking the ability to retry the query automatically on this kind of error

## Description

This PR adds a new `reties_on` keyword argument on the `LagoHttpClient` to allow us to define a list of error class that can be rescued and retried automatically.
For now, it reties 3 times at most before re-raising the error, if it's not enough, we might extend this approach to allow us to define the number of retries for each type of error.

This PR also plug this system in the base http_client of aggregator services