### PR TITLE
misc(currency): Add Ghanaian Cedi (GHS) currency

### DIFF
--- a/app/models/concerns/currencies.rb
+++ b/app/models/concerns/currencies.rb
@@ -49,6 +49,7 @@ module Currencies
     FKP: "Falkland Pound",
     GBP: "British Pound",
     GEL: "Georgian Lari",
+    GHS: "Ghanaian Cedi",
     GIP: "Gibraltar Pound",
     GMD: "Gambian Dalasi",
     GNF: "Guinean Franc",

--- a/schema.graphql
+++ b/schema.graphql
@@ -3292,6 +3292,11 @@ enum CurrencyEnum {
   GEL
 
   """
+  Ghanaian Cedi
+  """
+  GHS
+
+  """
   Gibraltar Pound
   """
   GIP

--- a/schema.json
+++ b/schema.json
@@ -14534,6 +14534,12 @@
               "deprecationReason": null
             },
             {
+              "name": "GHS",
+              "description": "Ghanaian Cedi",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "GIP",
               "description": "Gibraltar Pound",
               "isDeprecated": false,


### PR DESCRIPTION
## Context

A customer reported that the Ghanaian Cedis appears to be missing from our list of supported currencies.

## Description

This PR adds the currency code to allow it for validation, it also updates the GraphQL schema to allow the front-end to use this new value