### PR TITLE
reload invoice also before creating the payment

### DIFF
--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -13,7 +13,7 @@ module Invoices
       end
 
       def call
-        result.invoice = invoice
+        result.invoice = invoice.reload
         return result unless should_process_payment?
 
         unless invoice.total_amount_cents.positive?

--- a/app/services/payment_requests/payments/create_service.rb
+++ b/app/services/payment_requests/payments/create_service.rb
@@ -16,7 +16,7 @@ module PaymentRequests
       def call
         return result.not_found_failure!(resource: "payment_provider") unless provider
 
-        result.payable = payable
+        result.payable = payable.reload
         return result unless should_process_payment?
 
         unless payable.total_amount_cents.positive?


### PR DESCRIPTION
## Context

Since we retry payment_create_job, and we pass the object in this job, if object is updated but not relaoded, we might have old data, and checking `if_should process_payment` will not make sence
