### PR TITLE
misc(adyen): ignore RECURRING_CONTRACT webhook

### DIFF
--- a/app/models/payment_providers/adyen_provider.rb
+++ b/app/models/payment_providers/adyen_provider.rb
@@ -5,7 +5,7 @@ module PaymentProviders
     SUCCESS_REDIRECT_URL = "https://www.adyen.com/"
 
     WEBHOOKS_EVENTS = %w[AUTHORISATION REFUND REFUND_FAILED CHARGEBACK].freeze
-    IGNORED_WEBHOOK_EVENTS = %w[REPORT_AVAILABLE].freeze
+    IGNORED_WEBHOOK_EVENTS = %w[REPORT_AVAILABLE RECURRING_CONTRACT].freeze
 
     PROCESSING_STATUSES = %w[AuthorisedPending Received].freeze
     SUCCESS_STATUSES = %w[Authorised SentForSettle SettleScheduled Settled Refunded].freeze

--- a/spec/fixtures/adyen/webhook_recurring_contract_response.json
+++ b/spec/fixtures/adyen/webhook_recurring_contract_response.json
@@ -1,0 +1,25 @@
+{
+  "live": "false",
+  "notificationItems": [
+    {
+      "NotificationRequestItem": {
+        "additionalData": {
+          "recurring.shopperReference": "cus_0001",
+          "paymentLinkId": "XXX",
+          "recurring.recurringDetailReference": "YYY",
+          "shopperReference": "cus_0001"
+        },
+        "amount": { "currency": "USD", "value": 0 },
+        "eventCode": "RECURRING_CONTRACT",
+        "eventDate": "2025-07-01T09:21:50+02:00",
+        "merchantAccountCode": "YOUR_MERCHANT_ACCOUNT",
+        "merchantReference": "",
+        "originalReference": "WWW",
+        "paymentMethod": "visa",
+        "pspReference": "ZZZ",
+        "reason": "",
+        "success": "true"
+      }
+    }
+  ]
+}

--- a/spec/services/payment_providers/adyen/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/adyen/handle_event_service_spec.rb
@@ -142,23 +142,25 @@ RSpec.describe PaymentProviders::Adyen::HandleEventService do
           .first&.dig("NotificationRequestItem").to_json
       end
 
-      let(:event_response_json) do
-        path = Rails.root.join("spec/fixtures/adyen/webhook_report_available_response.json")
-        File.read(path)
-      end
+      %w[report_available recurring_contract].each do |event_type|
+        let(:event_response_json) do
+          path = Rails.root.join("spec/fixtures/adyen/webhook_#{event_type}_response.json")
+          File.read(path)
+        end
 
-      before do
-        allow(CreditNotes::Refunds::AdyenService).to receive(:new)
-          .and_return(refund_service)
-        allow(refund_service).to receive(:update_status)
-          .and_return(true)
-      end
+        before do
+          allow(CreditNotes::Refunds::AdyenService).to receive(:new)
+            .and_return(refund_service)
+          allow(refund_service).to receive(:update_status)
+            .and_return(true)
+        end
 
-      it "does not route the event to an other service" do
-        event_service.call
+        it "does not route the event to an other service" do
+          event_service.call
 
-        expect(CreditNotes::Refunds::AdyenService).not_to have_received(:new)
-        expect(refund_service).not_to have_received(:update_status)
+          expect(CreditNotes::Refunds::AdyenService).not_to have_received(:new)
+          expect(refund_service).not_to have_received(:update_status)
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/3863

## Description

It ignores the `RECURRING_CONTRACT` webhook type for the Adyen event provider
