### PR TITLE
fix(progressive_billing): Avoid checking threshold on terminated subscriptions

### DIFF
--- a/app/services/lifetime_usages/check_thresholds_service.rb
+++ b/app/services/lifetime_usages/check_thresholds_service.rb
@@ -11,6 +11,8 @@ module LifetimeUsages
     end
 
     def call
+      return result unless subscription.active?
+
       usage_thresholds = LifetimeUsages::UsageThresholds::CheckService.call!(lifetime_usage:, progressive_billed_amount:).passed_thresholds
 
       if usage_thresholds.any?

--- a/spec/services/lifetime_usages/check_thresholds_service_spec.rb
+++ b/spec/services/lifetime_usages/check_thresholds_service_spec.rb
@@ -179,4 +179,13 @@ RSpec.describe LifetimeUsages::CheckThresholdsService, type: :service, transacti
       expect(subscription.invoices.progressive_billing).to be_empty
     end
   end
+
+  context "when subscription is terminated" do
+    let(:subscription) { create(:subscription, :terminated, customer: customer) }
+
+    it "does not create an invoice for the current usage" do
+      expect { service.call }.not_to change(Invoice, :count)
+      expect(subscription.invoices.progressive_billing).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## Context

We are receiving ` Idempotency::IdempotencyError` for progressive billing invoices generation on terminated subscriptions.

## Description

We should not generate progressive billing invoices for terminated subscriptions as the usage will be billed anyway with the termination invoice.

This PR simply adds a check on the subscription status before proceeding with the invoice generation.