### PR TITLE
fix: adjust batch size for cascade feature

### DIFF
--- a/app/jobs/charges/create_children_job.rb
+++ b/app/jobs/charges/create_children_job.rb
@@ -8,7 +8,7 @@ module Charges
       plan = charge.plan
       return unless plan&.children&.any?
 
-      plan.children.order(created_at: :asc).pluck(:id).each_slice(100) do |child_ids|
+      plan.children.order(created_at: :asc).pluck(:id).each_slice(20) do |child_ids|
         Charges::CreateChildrenBatchJob.perform_later(
           child_ids:,
           charge:,

--- a/app/jobs/charges/update_children_job.rb
+++ b/app/jobs/charges/update_children_job.rb
@@ -8,7 +8,7 @@ module Charges
       charge = Charge.find_by(id: old_parent_attrs["id"])
       return unless charge
 
-      charge.children.order(created_at: :asc).pluck(:id).each_slice(100) do |child_ids|
+      charge.children.order(created_at: :asc).pluck(:id).each_slice(20) do |child_ids|
         Charges::UpdateChildrenBatchJob.perform_later(
           child_ids:,
           params:,


### PR DESCRIPTION
## Context

We have monitored cascade feature on production and it can be really slow to create/update charge with huge number of filters.

## Description

We should investigate in detail performance in used services, but the first step could be to reduce batch size
