### PR TITLE
Feat forecasted usage

### DIFF
--- a/app/graphql/resolvers/data_api/usages/forecasted_resolver.rb
+++ b/app/graphql/resolvers/data_api/usages/forecasted_resolver.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module DataApi
+    module Usages
+      class ForecastedResolver < Resolvers::BaseResolver
+        include AuthenticableApiUser
+        include RequiredOrganization
+
+        REQUIRED_PERMISSION = "data_api:view"
+
+        graphql_name "DataApiUsagesForecasted"
+        description "Query forecasted usages of an organization"
+
+        argument :currency, Types::CurrencyEnum, required: false
+
+        argument :customer_country, Types::CountryCodeEnum, required: false
+        argument :customer_type, Types::Customers::CustomerTypeEnum, required: false
+
+        argument :from_date, GraphQL::Types::ISO8601Date, required: false
+        argument :to_date, GraphQL::Types::ISO8601Date, required: false
+
+        argument :time_granularity, Types::DataApi::TimeGranularityEnum, required: false
+
+        argument :external_customer_id, String, required: false
+        argument :external_subscription_id, String, required: false
+
+        argument :billing_entity_code, String, required: false
+        argument :plan_code, String, required: false
+
+        type Types::DataApi::Usages::Forecasted::Object.collection_type, null: false
+
+        def resolve(**args)
+          result = ::DataApi::Usages::ForecastedService.call(current_organization, **args)
+          result.forecasted_usages
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/data_api/usages/forecasted/object.rb
+++ b/app/graphql/types/data_api/usages/forecasted/object.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Types
+  module DataApi
+    module Usages
+      module Forecasted
+        class Object < Types::BaseObject
+          graphql_name "DataApiUsageForecasted"
+
+          field :amount_cents, GraphQL::Types::BigInt, null: false
+          field :amount_cents_forecast_10th_percentile, GraphQL::Types::BigInt, null: false
+          field :amount_cents_forecast_50th_percentile, GraphQL::Types::BigInt, null: false
+          field :amount_cents_forecast_90th_percentile, GraphQL::Types::BigInt, null: false
+          field :amount_currency, Types::CurrencyEnum, null: false
+
+          field :units, Float, null: false
+          field :units_forecast_10th_percentile, Float, null: false
+          field :units_forecast_50th_percentile, Float, null: false
+          field :units_forecast_90th_percentile, Float, null: false
+
+          field :end_of_period_dt, GraphQL::Types::ISO8601Date, null: false
+          field :start_of_period_dt, GraphQL::Types::ISO8601Date, null: false
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -101,6 +101,7 @@ module Types
     field :data_api_revenue_streams_plans, resolver: Resolvers::DataApi::RevenueStreams::PlansResolver
     field :data_api_usages, resolver: Resolvers::DataApi::UsagesResolver
     field :data_api_usages_aggregated_amounts, resolver: Resolvers::DataApi::Usages::AggregatedAmountsResolver
+    field :data_api_usages_forecasted, resolver: Resolvers::DataApi::Usages::ForecastedResolver
     field :data_api_usages_invoiced, resolver: Resolvers::DataApi::Usages::InvoicedResolver
   end
 end

--- a/app/services/data_api/usages/forecasted_service.rb
+++ b/app/services/data_api/usages/forecasted_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module DataApi
+  module Usages
+    class ForecastedService < DataApi::BaseService
+      Result = BaseResult[:forecasted_usages]
+
+      def call
+        return result.forbidden_failure! unless License.premium?
+
+        result.forecasted_usages = http_client.get(headers:, params:)
+        result
+      end
+
+      private
+
+      def action_path
+        "usages/#{organization.id}/forecasted/"
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4326,6 +4326,35 @@ type DataApiUsageCollection {
   metadata: CollectionMetadata!
 }
 
+type DataApiUsageForecasted {
+  amountCents: BigInt!
+  amountCentsForecast10thPercentile: BigInt!
+  amountCentsForecast50thPercentile: BigInt!
+  amountCentsForecast90thPercentile: BigInt!
+  amountCurrency: CurrencyEnum!
+  endOfPeriodDt: ISO8601Date!
+  startOfPeriodDt: ISO8601Date!
+  units: Float!
+  unitsForecast10thPercentile: Float!
+  unitsForecast50thPercentile: Float!
+  unitsForecast90thPercentile: Float!
+}
+
+"""
+DataApiUsageForecastedCollection type
+"""
+type DataApiUsageForecastedCollection {
+  """
+  A collection of paginated DataApiUsageForecastedCollection
+  """
+  collection: [DataApiUsageForecasted!]!
+
+  """
+  Pagination Metadata for navigating the Pagination
+  """
+  metadata: CollectionMetadata!
+}
+
 type DataApiUsageInvoiced {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
@@ -8052,6 +8081,11 @@ type Query {
   Query usages of an organization
   """
   dataApiUsagesAggregatedAmounts(billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, isBillableMetricRecurring: Boolean, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiUsageAggregatedAmountCollection!
+
+  """
+  Query forecasted usages of an organization
+  """
+  dataApiUsagesForecasted(billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiUsageForecastedCollection!
 
   """
   Query invoiced usages of an organization

--- a/schema.json
+++ b/schema.json
@@ -20065,6 +20065,244 @@
         },
         {
           "kind": "OBJECT",
+          "name": "DataApiUsageForecasted",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "amountCentsForecast10thPercentile",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "amountCentsForecast50thPercentile",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "amountCentsForecast90thPercentile",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "endOfPeriodDt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "startOfPeriodDt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "units",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "unitsForecast10thPercentile",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "unitsForecast50thPercentile",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "unitsForecast90thPercentile",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "DataApiUsageForecastedCollection",
+          "description": "DataApiUsageForecastedCollection type",
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": "A collection of paginated DataApiUsageForecastedCollection",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DataApiUsageForecasted",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "metadata",
+              "description": "Pagination Metadata for navigating the Pagination",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "DataApiUsageInvoiced",
           "description": null,
           "interfaces": [],
@@ -41635,6 +41873,143 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "timeGranularity",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "TimeGranularityEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "externalCustomerId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "externalSubscriptionId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "billingEntityCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "planCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "dataApiUsagesForecasted",
+              "description": "Query forecasted usages of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "DataApiUsageForecastedCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "customerCountry",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CountryCode",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "customerType",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CustomerTypeEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "fromDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601Date",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "toDate",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601Date",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/spec/fixtures/lago_data_api/usages_forecasted.json
+++ b/spec/fixtures/lago_data_api/usages_forecasted.json
@@ -1,0 +1,30 @@
+[
+    {
+        "organization_id": "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+        "start_of_period_dt": "2025-06-23",
+        "end_of_period_dt": "2025-06-23",
+        "amount_currency": "EUR",
+        "units": 100,
+        "amount_cents": 1000,
+        "units_forecast_10th_percentile": 20,
+        "units_forecast_50th_percentile": 30,
+        "units_forecast_90th_percentile": 50,
+        "amount_cents_forecast_10th_percentile": 200,
+        "amount_cents_forecast_50th_percentile": 300,
+        "amount_cents_forecast_90th_percentile": 500
+    },
+    {
+        "organization_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "start_of_period_dt": "2025-05-23",
+        "end_of_period_dt": "2025-05-23",
+        "amount_currency": "EUR",
+        "units": 200,
+        "amount_cents": 2000,
+        "units_forecast_10th_percentile": 40,
+        "units_forecast_50th_percentile": 60,
+        "units_forecast_90th_percentile": 100,
+        "amount_cents_forecast_10th_percentile": 400,
+        "amount_cents_forecast_50th_percentile": 600,
+        "amount_cents_forecast_90th_percentile": 1000
+    }
+]

--- a/spec/graphql/resolvers/data_api/usages/forecasted_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/usages/forecasted_resolver_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::DataApi::Usages::ForecastedResolver, type: :graphql do
+  let(:required_permission) { "data_api:view" }
+  let(:query) do
+    <<~GQL
+      query($currency: CurrencyEnum) {
+        dataApiUsagesForecasted(currency: $currency) {
+          collection {
+            startOfPeriodDt
+            endOfPeriodDt
+            amountCents
+            amountCurrency
+            amountCentsForecast10thPercentile
+            amountCentsForecast50thPercentile
+            amountCentsForecast90thPercentile
+            units
+            unitsForecast10thPercentile
+            unitsForecast50thPercentile
+            unitsForecast90thPercentile
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/usages_forecasted.json") }
+
+  around { |test| lago_premium!(&test) }
+
+  before do
+    stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/usages/#{organization.id}/forecasted/")
+      .to_return(status: 200, body: body_response, headers: {})
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "data_api:view"
+
+  it "returns a list of usages forecasted" do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:
+    )
+
+    usages_forecasted_response = result["data"]["dataApiUsagesForecasted"]
+    expect(usages_forecasted_response["collection"].first).to include(
+      {
+        "startOfPeriodDt" => "2025-06-23",
+        "endOfPeriodDt" => "2025-06-23",
+        "amountCurrency" => "EUR",
+        "amountCents" => "1000"
+      }
+    )
+  end
+end

--- a/spec/graphql/types/data_api/usages/forecasted/object_spec.rb
+++ b/spec/graphql/types/data_api/usages/forecasted/object_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::DataApi::Usages::Forecasted::Object do
+  subject { described_class }
+
+  it do
+    expect(subject.graphql_name).to eq("DataApiUsageForecasted")
+    expect(subject).to have_field(:amount_currency).of_type("CurrencyEnum!")
+    expect(subject).to have_field(:amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:amount_cents_forecast_10th_percentile).of_type("BigInt!")
+    expect(subject).to have_field(:amount_cents_forecast_50th_percentile).of_type("BigInt!")
+    expect(subject).to have_field(:amount_cents_forecast_90th_percentile).of_type("BigInt!")
+
+    expect(subject).to have_field(:units).of_type("Float!")
+    expect(subject).to have_field(:units_forecast_10th_percentile).of_type("Float!")
+    expect(subject).to have_field(:units_forecast_50th_percentile).of_type("Float!")
+    expect(subject).to have_field(:units_forecast_90th_percentile).of_type("Float!")
+
+    expect(subject).to have_field(:end_of_period_dt).of_type("ISO8601Date!")
+    expect(subject).to have_field(:start_of_period_dt).of_type("ISO8601Date!")
+  end
+end

--- a/spec/services/data_api/usages/forecasted_service_spec.rb
+++ b/spec/services/data_api/usages/forecasted_service_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DataApi::Usages::ForecastedService, type: :service do
+  let(:service) { described_class.new(organization, **params) }
+  let(:customer) { create(:customer, organization:) }
+  let(:organization) { create(:organization) }
+  let(:body_response) { File.read("spec/fixtures/lago_data_api/usages_forecasted.json") }
+  let(:params) { {} }
+
+  before do
+    stub_request(:get, "#{ENV["LAGO_DATA_API_URL"]}/usages/#{organization.id}/forecasted/")
+      .to_return(status: 200, body: body_response, headers: {})
+  end
+
+  describe "#call" do
+    subject(:service_call) { service.call }
+
+    context "when licence is not premium" do
+      it "returns an error" do
+        expect(service_call).not_to be_success
+        expect(service_call.error.code).to eq("feature_unavailable")
+      end
+    end
+
+    context "when licence is premium" do
+      around { |test| lago_premium!(&test) }
+
+      it "returns expected forecasted usage" do
+        expect(service_call).to be_success
+        expect(service_call.forecasted_usages.count).to eq(2)
+        expect(service_call.forecasted_usages.first).to eq(
+          {
+            "organization_id" => "2537afc4-0e7c-4abb-89b7-d9b28c35780b",
+            "start_of_period_dt" => "2025-06-23",
+            "end_of_period_dt" => "2025-06-23",
+            "amount_currency" => "EUR",
+            "units" => 100,
+            "amount_cents" => 1000,
+            "units_forecast_10th_percentile" => 20,
+            "units_forecast_50th_percentile" => 30,
+            "units_forecast_90th_percentile" => 50,
+            "amount_cents_forecast_10th_percentile" => 200,
+            "amount_cents_forecast_50th_percentile" => 300,
+            "amount_cents_forecast_90th_percentile" => 500
+          }
+        )
+      end
+    end
+  end
+
+  describe "#action_path" do
+    subject(:action_path) { service.send(:action_path) }
+
+    let(:params) { {} }
+
+    it "returns the correct API path for the organization" do
+      expect(action_path).to eq("usages/#{organization.id}/forecasted/")
+    end
+  end
+end


### PR DESCRIPTION
## Context

We need to calculate prices (amounts) based on usage (units) from Data API.
In order to do the we'll be fetching paginated data sets and after we perform the calculations via charge models we'll update the Data API records (in batches).

## Description

This PR contains GQL types, resolvers and also services
that will be used by the FE to render that data.