### PR TITLE
feat: all invoices can be voided now

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -331,6 +331,14 @@ class Invoice < ApplicationRecord
     finalized?
   end
 
+  def voidable?
+    if payment_dispute_lost_at? || total_paid_amount_cents > 0 || credit_notes.where.not(credit_status: :voided).any?
+      return false
+    end
+
+    finalized? && (payment_pending? || payment_failed?)
+  end
+
   def all_charges_have_fees?
     return true unless subscription?
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -107,7 +107,7 @@ class Invoice < ApplicationRecord
     end
 
     event :void do
-      transitions from: :finalized, to: :voided, after: :remove_ready_for_payment_processing!
+      transitions from: :finalized, to: :voided, after: :handle_void_transition!
     end
   end
 
@@ -403,8 +403,11 @@ class Invoice < ApplicationRecord
     status_changed_to_finalized?
   end
 
-  def remove_ready_for_payment_processing!
-    update!(ready_for_payment_processing: false)
+  def handle_void_transition!
+    update!(
+      ready_for_payment_processing: false,
+      voided_at: Time.current
+    )
   end
 
   def ensure_number

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -32,7 +32,7 @@ module V1
         self_billed: model.self_billed,
         created_at: model.created_at.iso8601,
         updated_at: model.updated_at.iso8601,
-        voided_at: model.updated_at&.iso8601
+        voided_at: model.voided_at&.iso8601
       }
 
       payload.merge!(customer) if include?(:customer)

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -31,7 +31,8 @@ module V1
         version_number: model.version_number,
         self_billed: model.self_billed,
         created_at: model.created_at.iso8601,
-        updated_at: model.updated_at.iso8601
+        updated_at: model.updated_at.iso8601,
+        voided_at: model.updated_at&.iso8601
       }
 
       payload.merge!(customer) if include?(:customer)

--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -67,6 +67,7 @@ module Invoices
     attr_reader :invoice, :params, :generate_credit_note, :credit_amount, :refund_amount
 
     def generate_credit_note_allowed?
+      return true unless generate_credit_note
       License.premium?
     end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1400,7 +1400,7 @@ RSpec.describe Invoice, type: :model do
   end
 
   describe "#mark_as_voided!" do
-    subject(:force_void_call) { invoice.mark_as_voided! }
+    subject(:force_void_call) { invoice.void! }
 
     context "when invoice is finalized" do
       let(:invoice) { build(:invoice, status: :finalized, ready_for_payment_processing: true) }

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -798,9 +798,8 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       context "when the payment status is succeeded" do
         let(:payment_status) { :succeeded }
 
-        it "returns a method not allowed error" do
-          subject
-          expect(response).to have_http_status(:method_not_allowed)
+        it "voids the invoice" do
+          expect { subject }.to change { invoice.reload.status }.from("finalized").to("voided")
         end
       end
 
@@ -852,6 +851,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         expect(response).to have_http_status(:success)
         expect(json[:invoice][:lago_id]).to eq(invoice.id)
         expect(json[:invoice][:status]).to eq("voided")
+        expect(json[:invoice][:voided_at]).not_to be_nil
       end
     end
   end

--- a/spec/services/invoices/void_service_spec.rb
+++ b/spec/services/invoices/void_service_spec.rb
@@ -58,13 +58,13 @@ RSpec.describe Invoices::VoidService, type: :service do
       context "when the payment status is succeeded" do
         let(:payment_status) { :succeeded }
 
-        it "returns a failure" do
+        it "voids the invoice" do
           result = void_service.call
 
           aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-            expect(result.error.code).to eq("not_voidable")
+            expect(result).to be_success
+            expect(result.invoice).to be_voided
+            expect(result.invoice.voided_at).to be_present
           end
         end
       end


### PR DESCRIPTION
## Context

This PR addresses a limitation in the logic for voiding invoices that was causing confusion and blocking expected behaviour with some customers. Previously, certain invoice states were not allowed to be voided depending on specific internal validations, even if the user explicitly triggered a void action.

This inconsistency was particularly evident when using generate_credit_note: false, where the system applied legacy rules that no longer make sense from a user perspective.

## Description

We removed the conditional logic that prevented invoices from being voided under specific internal states.

The behaviour is now simplified:
➡️ If the user calls void, the system will proceed with the voiding process without rejecting it due to previous state-based restrictions.

Potential Downside

This is a silent breaking change for clients relying on the previous behaviour (i.e. expecting a validation error when trying to void certain invoices). However, the rationale is that if a user explicitly calls void, they intend for the invoice to be voided — so this new behaviour is more consistent and predictable.