### PR TITLE
feat(projected-usage): add projected usage data to the current usage endpoint

### DIFF
--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -65,7 +65,19 @@ module Types
         private
 
         def usage_calculator
-          @usage_calculator ||= ::Customers::FeesUsageCalculationService.new(object)
+          @usage_calculator ||= begin
+            first_fee = object.first
+            from = first_fee.properties["from_datetime"]
+            to = first_fee.properties["to_datetime"]
+            duration = first_fee.properties["charges_duration"]
+
+            ::Customers::FeesUsageCalculationService.new(
+              fees: object,
+              from_datetime: from,
+              to_datetime: to,
+              charges_duration_in_days: duration
+            )
+          end
         end
       end
     end

--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -7,9 +7,11 @@ module Types
         graphql_name "ChargeUsage"
 
         field :amount_cents, GraphQL::Types::BigInt, null: false
+        field :projected_amount_cents, GraphQL::Types::BigInt, null: false
         field :events_count, Integer, null: false
         field :id, ID, null: false
         field :units, GraphQL::Types::Float, null: false
+        field :projected_units, GraphQL::Types::Float, null: false
 
         field :billable_metric, Types::BillableMetrics::Object, null: false
         field :charge, Types::Charges::Object, null: false

--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -23,7 +23,11 @@ module Types
         end
 
         def units
-          object.map { |f| BigDecimal(f.units) }.sum
+          usage_calculator.current_units
+        end
+
+        def projected_units
+          usage_calculator.projected_units
         end
 
         def events_count
@@ -31,7 +35,11 @@ module Types
         end
 
         def amount_cents
-          object.sum(&:amount_cents)
+          usage_calculator.current_amount_cents
+        end
+
+        def projected_amount_cents
+          usage_calculator.projected_amount_cents
         end
 
         def charge
@@ -52,6 +60,12 @@ module Types
           return [] unless object.any? { |f| f.grouped_by.present? }
 
           object.group_by(&:grouped_by).values
+        end
+
+        private
+
+        def usage_calculator
+          @usage_calculator ||= ::Customers::FeesUsageCalculationService.new(object)
         end
       end
     end

--- a/app/graphql/types/customers/usage/charge_filter.rb
+++ b/app/graphql/types/customers/usage/charge_filter.rb
@@ -9,9 +9,11 @@ module Types
         field :id, ID, null: true, method: :charge_filter_id
 
         field :amount_cents, GraphQL::Types::BigInt, null: false
+        field :projected_amount_cents, GraphQL::Types::BigInt, null: false
         field :events_count, Integer, null: false
         field :invoice_display_name, String, null: true
         field :units, GraphQL::Types::Float, null: false
+        field :projected_units, GraphQL::Types::Float, null: false
         field :values, Types::ChargeFilters::Values, null: false
 
         def values

--- a/app/graphql/types/customers/usage/charge_filter.rb
+++ b/app/graphql/types/customers/usage/charge_filter.rb
@@ -16,12 +16,26 @@ module Types
         field :projected_units, GraphQL::Types::Float, null: false
         field :values, Types::ChargeFilters::Values, null: false
 
+        def projected_units
+          usage_calculator.projected_units
+        end
+
+        def projected_amount_cents
+          usage_calculator.projected_amount_cents
+        end
+
         def values
           object.charge_filter&.to_h || {} # rubocop:disable Lint/RedundantSafeNavigation
         end
 
         def invoice_display_name
           object.charge_filter&.invoice_display_name
+        end
+
+        private
+
+        def usage_calculator
+          @usage_calculator ||= ::Customers::FeesUsageCalculationService.new([object])
         end
       end
     end

--- a/app/graphql/types/customers/usage/charge_filter.rb
+++ b/app/graphql/types/customers/usage/charge_filter.rb
@@ -35,7 +35,18 @@ module Types
         private
 
         def usage_calculator
-          @usage_calculator ||= ::Customers::FeesUsageCalculationService.new([object])
+          @usage_calculator ||= begin
+            from = object.properties["from_datetime"]
+            to = object.properties["to_datetime"]
+            duration = object.properties["charges_duration"]
+
+            ::Customers::FeesUsageCalculationService.new(
+              fees: [object],
+              from_datetime: from,
+              to_datetime: to,
+              charges_duration_in_days: duration
+            )
+          end
         end
       end
     end

--- a/app/graphql/types/customers/usage/current.rb
+++ b/app/graphql/types/customers/usage/current.rb
@@ -19,6 +19,10 @@ module Types
 
         field :charges_usage, [Types::Customers::Usage::Charge], null: false
 
+        def projected_amount_cents
+          object.projected_fees_amount_cents
+        end
+
         def charges_usage
           object.fees.group_by(&:charge_id).values
         end

--- a/app/graphql/types/customers/usage/current.rb
+++ b/app/graphql/types/customers/usage/current.rb
@@ -20,7 +20,7 @@ module Types
         field :charges_usage, [Types::Customers::Usage::Charge], null: false
 
         def projected_amount_cents
-          object.projected_fees_amount_cents
+          object.projected_amount_cents
         end
 
         def charges_usage

--- a/app/graphql/types/customers/usage/current.rb
+++ b/app/graphql/types/customers/usage/current.rb
@@ -13,6 +13,7 @@ module Types
         field :issuing_date, GraphQL::Types::ISO8601Date, null: false
 
         field :amount_cents, GraphQL::Types::BigInt, null: false
+        field :projected_amount_cents, GraphQL::Types::BigInt, null: false
         field :taxes_amount_cents, GraphQL::Types::BigInt, null: false
         field :total_amount_cents, GraphQL::Types::BigInt, null: false
 

--- a/app/graphql/types/customers/usage/grouped_usage.rb
+++ b/app/graphql/types/customers/usage/grouped_usage.rb
@@ -53,7 +53,19 @@ module Types
         private
 
         def usage_calculator
-          @usage_calculator ||= ::Customers::FeesUsageCalculationService.new(object)
+          @usage_calculator ||= begin
+            first_fee = object.first
+            from = first_fee.properties["from_datetime"]
+            to = first_fee.properties["to_datetime"]
+            duration = first_fee.properties["charges_duration"]
+
+            ::Customers::FeesUsageCalculationService.new(
+              fees: object,
+              from_datetime: from,
+              to_datetime: to,
+              charges_duration_in_days: duration
+            )
+          end
         end
       end
     end

--- a/app/graphql/types/customers/usage/grouped_usage.rb
+++ b/app/graphql/types/customers/usage/grouped_usage.rb
@@ -7,9 +7,11 @@ module Types
         graphql_name "GroupedChargeUsage"
 
         field :amount_cents, GraphQL::Types::BigInt, null: false
+        field :projected_amount_cents, GraphQL::Types::BigInt, null: false
         field :events_count, Integer, null: false
         field :id, ID, null: false
         field :units, GraphQL::Types::Float, null: false
+        field :projected_units, GraphQL::Types::Float, null: false
 
         field :filters, [Types::Customers::Usage::ChargeFilter], null: true
         field :grouped_by, GraphQL::Types::JSON, null: true

--- a/app/graphql/types/customers/usage/grouped_usage.rb
+++ b/app/graphql/types/customers/usage/grouped_usage.rb
@@ -21,7 +21,11 @@ module Types
         end
 
         def amount_cents
-          object.sum(&:amount_cents)
+          usage_calculator.current_amount_cents
+        end
+
+        def projected_amount_cents
+          usage_calculator.projected_amount_cents
         end
 
         def events_count
@@ -29,7 +33,11 @@ module Types
         end
 
         def units
-          object.map { |f| BigDecimal(f.units) }.sum
+          usage_calculator.current_units
+        end
+
+        def projected_units
+          usage_calculator.projected_units
         end
 
         def grouped_by
@@ -40,6 +48,12 @@ module Types
           return [] unless object.first.has_charge_filters?
 
           object.sort_by { |f| f.charge_filter&.display_name.to_s }
+        end
+
+        private
+
+        def usage_calculator
+          @usage_calculator ||= ::Customers::FeesUsageCalculationService.new(object)
         end
       end
     end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -409,30 +409,6 @@ class Invoice < ApplicationRecord
     update!(status: "voided", ready_for_payment_processing: false, voided_at: Time.current)
   end
 
-  def ratio
-    return 0 if fees.empty?
-    fee = fees.first
-    from_date = fee.properties["from_datetime"].to_date
-    to_date = fee.properties["to_datetime"].to_date
-    current_date = Date.current
-
-    total_days = (to_date - from_date).to_i + 1
-
-    charges_duration = fee.properties["charges_duration"] || total_days
-
-    return 1.0 if current_date >= to_date
-    return 0.0 if current_date < from_date
-
-    days_passed = (current_date - from_date).to_i + 1
-
-    ratio = days_passed.to_f / charges_duration
-    ratio.clamp(0.0, 1.0)
-  end
-
-  def projected_fees_amount_cents
-    projected_amount_cents = ratio > 0 ? (fees_amount_cents / BigDecimal(ratio.to_s)).round.to_i : 0
-  end
-
   private
 
   def should_assign_sequential_id?

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -405,6 +405,34 @@ class Invoice < ApplicationRecord
     fees.any? && should_finalize_invoice
   end
 
+  def mark_as_voided!
+    update!(status: "voided", ready_for_payment_processing: false, voided_at: Time.current)
+  end
+
+  def ratio
+    return 0 if fees.empty?
+    fee = fees.first
+    from_date = fee.properties["from_datetime"].to_date
+    to_date = fee.properties["to_datetime"].to_date
+    current_date = Date.current
+
+    total_days = (to_date - from_date).to_i + 1
+
+    charges_duration = fee.properties["charges_duration"] || total_days
+
+    return 1.0 if current_date >= to_date
+    return 0.0 if current_date < from_date
+
+    days_passed = (current_date - from_date).to_i + 1
+
+    ratio = days_passed.to_f / charges_duration
+    ratio.clamp(0.0, 1.0)
+  end
+
+  def projected_fees_amount_cents
+    projected_amount_cents = ratio > 0 ? (fees_amount_cents / BigDecimal(ratio.to_s)).round.to_i : 0
+  end
+
   private
 
   def should_assign_sequential_id?

--- a/app/models/subscription_usage.rb
+++ b/app/models/subscription_usage.rb
@@ -6,6 +6,7 @@ SubscriptionUsage = Struct.new(
   :issuing_date,
   :currency,
   :amount_cents,
+  :projected_amount_cents,
   :total_amount_cents,
   :taxes_amount_cents,
   :fees

--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -6,63 +6,30 @@ module V1
       def serialize
         model.group_by(&:charge_id).map do |charge_id, fees|
           fee = fees.first
-          ratio = calculate_time_ratio(fee)
-          usage_data = calculate_usage_data(fees, ratio)
+          usage_data = calculate_usage_data(fees)
 
           {
             **usage_data,
             charge: charge_data(fee),
             billable_metric: billable_metric_data(fee),
-            filters: filters(fees, ratio),
-            grouped_usage: grouped_usage(fees, ratio)
+            filters: filters(fees),
+            grouped_usage: grouped_usage(fees)
           }
         end
       end
 
       private
 
-      def calculate_time_ratio(fee)
-        from_date = fee.properties["from_datetime"].to_date
-        to_date = fee.properties["to_datetime"].to_date
-        current_date = Date.current
-
-        total_days = (to_date - from_date).to_i + 1
-
-        charges_duration = fee.properties["charges_duration"] || total_days
-
-        return 1.0 if current_date >= to_date
-        return 0.0 if current_date < from_date
-
-        days_passed = (current_date - from_date).to_i + 1
-
-        ratio = days_passed.to_f / charges_duration
-        ratio.clamp(0.0, 1.0)
-      end
-
-      def calculate_usage_data(fees, ratio)
-        current_units = sum_units(fees)
-        current_amount_cents = fees.sum(&:amount_cents)
-
-        if fees.first.charge.billable_metric.recurring?
-          projected_units = current_units
-          projected_amount_cents = current_amount_cents
-        else
-          projected_units = ratio > 0 ? (current_units / BigDecimal(ratio.to_s)).round(2) : BigDecimal('0')
-          projected_amount_cents = ratio > 0 ? (current_amount_cents / BigDecimal(ratio.to_s)).round.to_i : 0
-        end
-
+      def calculate_usage_data(fees)
+        usage_calculator = ::Customers::FeesUsageCalculationService.new(fees)
         {
-          units: current_units.to_s,
-          projected_units: projected_units.to_s,
+          units: usage_calculator.current_units.to_s,
+          projected_units: usage_calculator.projected_units.to_s,
           events_count: fees.sum(&:events_count),
-          amount_cents: current_amount_cents,
-          projected_amount_cents: projected_amount_cents.to_i,
+          amount_cents: usage_calculator.current_amount_cents,
+          projected_amount_cents: usage_calculator.projected_amount_cents.to_i,
           amount_currency: fees.first.amount_currency
         }
-      end
-
-      def sum_units(fees)
-        fees.sum { |f| BigDecimal(f.units) }
       end
 
       def charge_data(fee)
@@ -83,19 +50,19 @@ module V1
         }
       end
 
-      def filters(fees, ratio)
+      def filters(fees)
         return [] unless fees.first.charge&.filters&.any?
 
         fees.group_by { |f| f.charge_filter&.id }
             .values
-            .filter_map { |grouped_fees| build_filter_data(grouped_fees, ratio) }
+            .filter_map { |grouped_fees| build_filter_data(grouped_fees) }
       end
 
-      def build_filter_data(grouped_fees, ratio)
+      def build_filter_data(grouped_fees)
         charge_filter = grouped_fees.first.charge_filter
         return nil unless charge_filter
 
-        usage_data = calculate_usage_data(grouped_fees, ratio)
+        usage_data = calculate_usage_data(grouped_fees)
 
         {
           **usage_data.except(:amount_currency),
@@ -104,21 +71,21 @@ module V1
         }
       end
 
-      def grouped_usage(fees, ratio)
+      def grouped_usage(fees)
         return [] unless fees.any? { |f| f.grouped_by.present? }
 
         fees.group_by(&:grouped_by)
             .values
-            .map { |grouped_fees| build_grouped_usage_data(grouped_fees, ratio) }
+            .map { |grouped_fees| build_grouped_usage_data(grouped_fees) }
       end
 
-      def build_grouped_usage_data(grouped_fees, ratio)
-        usage_data = calculate_usage_data(grouped_fees, ratio)
+      def build_grouped_usage_data(grouped_fees)
+        usage_data = calculate_usage_data(grouped_fees)
 
         {
           **usage_data.except(:amount_currency),
           grouped_by: grouped_fees.first.grouped_by,
-          filters: filters(grouped_fees, ratio)
+          filters: filters(grouped_fees)
         }
       end
     end

--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -6,57 +6,120 @@ module V1
       def serialize
         model.group_by(&:charge_id).map do |charge_id, fees|
           fee = fees.first
+          ratio = calculate_time_ratio(fee)
+          usage_data = calculate_usage_data(fees, ratio)
 
           {
-            units: fees.map { |f| BigDecimal(f.units) }.sum.to_s,
-            events_count: fees.sum(0) { |f| f.events_count.to_i },
-            amount_cents: fees.sum(&:amount_cents),
-            amount_currency: fee.amount_currency,
-            charge: {
-              lago_id: charge_id,
-              charge_model: fee.charge.charge_model,
-              invoice_display_name: fee.charge.invoice_display_name
-            },
-            billable_metric: {
-              lago_id: fee.billable_metric.id,
-              name: fee.billable_metric.name,
-              code: fee.billable_metric.code,
-              aggregation_type: fee.billable_metric.aggregation_type
-            },
-            filters: filters(fees),
-            grouped_usage: grouped_usage(fees)
+            **usage_data,
+            charge: charge_data(fee),
+            billable_metric: billable_metric_data(fee),
+            filters: filters(fees, ratio),
+            grouped_usage: grouped_usage(fees, ratio)
           }
         end
       end
 
       private
 
-      def filters(fees)
-        return [] unless fees.first.charge&.filters&.any?
+      def calculate_time_ratio(fee)
+        from_date = fee.properties["from_datetime"].to_date
+        to_date = fee.properties["to_datetime"].to_date
+        current_date = Date.current
 
-        fees.group_by { |f| f.charge_filter&.id }.values.map do |grouped_fees|
-          {
-            units: grouped_fees.map { |f| BigDecimal(f.units) }.sum.to_s,
-            amount_cents: grouped_fees.sum(&:amount_cents),
-            events_count: grouped_fees.sum(&:events_count),
-            invoice_display_name: grouped_fees.first.charge_filter&.invoice_display_name,
-            values: grouped_fees.first.charge_filter&.to_h
-          }
-        end.compact
+        total_days = (to_date - from_date).to_i + 1
+
+        charges_duration = fee.properties["charges_duration"] || total_days
+
+        return 1.0 if current_date >= to_date
+        return 0.0 if current_date < from_date
+
+        days_passed = (current_date - from_date).to_i + 1
+
+        ratio = days_passed.to_f / charges_duration
+        ratio.clamp(0.0, 1.0)
       end
 
-      def grouped_usage(fees)
+      def calculate_usage_data(fees, ratio)
+        current_units = sum_units(fees)
+        current_amount_cents = fees.sum(&:amount_cents)
+
+        if fees.first.charge.billable_metric.recurring?
+          projected_units = current_units
+          projected_amount_cents = current_amount_cents
+        else
+          projected_units = ratio > 0 ? (current_units / BigDecimal(ratio.to_s)).round(2) : BigDecimal('0')
+          projected_amount_cents = ratio > 0 ? (current_amount_cents / BigDecimal(ratio.to_s)).round.to_i : 0
+        end
+
+        {
+          units: current_units.to_s,
+          projected_units: projected_units.to_s,
+          events_count: fees.sum(&:events_count),
+          amount_cents: current_amount_cents,
+          projected_amount_cents: projected_amount_cents.to_i,
+          amount_currency: fees.first.amount_currency
+        }
+      end
+
+      def sum_units(fees)
+        fees.sum { |f| BigDecimal(f.units) }
+      end
+
+      def charge_data(fee)
+        {
+          lago_id: fee.charge_id,
+          charge_model: fee.charge.charge_model,
+          invoice_display_name: fee.charge.invoice_display_name
+        }
+      end
+
+      def billable_metric_data(fee)
+        metric = fee.billable_metric
+        {
+          lago_id: metric.id,
+          name: metric.name,
+          code: metric.code,
+          aggregation_type: metric.aggregation_type
+        }
+      end
+
+      def filters(fees, ratio)
+        return [] unless fees.first.charge&.filters&.any?
+
+        fees.group_by { |f| f.charge_filter&.id }
+            .values
+            .filter_map { |grouped_fees| build_filter_data(grouped_fees, ratio) }
+      end
+
+      def build_filter_data(grouped_fees, ratio)
+        charge_filter = grouped_fees.first.charge_filter
+        return nil unless charge_filter
+
+        usage_data = calculate_usage_data(grouped_fees, ratio)
+
+        {
+          **usage_data.except(:amount_currency),
+          invoice_display_name: charge_filter.invoice_display_name,
+          values: charge_filter.to_h
+        }
+      end
+
+      def grouped_usage(fees, ratio)
         return [] unless fees.any? { |f| f.grouped_by.present? }
 
-        fees.group_by(&:grouped_by).values.map do |grouped_fees|
-          {
-            amount_cents: grouped_fees.sum(&:amount_cents),
-            events_count: grouped_fees.sum(&:events_count),
-            units: grouped_fees.map { |f| BigDecimal(f.units) }.sum.to_s,
-            grouped_by: grouped_fees.first.grouped_by,
-            filters: filters(grouped_fees)
-          }
-        end
+        fees.group_by(&:grouped_by)
+            .values
+            .map { |grouped_fees| build_grouped_usage_data(grouped_fees, ratio) }
+      end
+
+      def build_grouped_usage_data(grouped_fees, ratio)
+        usage_data = calculate_usage_data(grouped_fees, ratio)
+
+        {
+          **usage_data.except(:amount_currency),
+          grouped_by: grouped_fees.first.grouped_by,
+          filters: filters(grouped_fees, ratio)
+        }
       end
     end
   end

--- a/app/serializers/v1/customers/usage_serializer.rb
+++ b/app/serializers/v1/customers/usage_serializer.rb
@@ -10,6 +10,7 @@ module V1
           issuing_date: model.issuing_date,
           currency: model.currency,
           amount_cents: model.amount_cents,
+          projected_amount_cents: model.projected_amount_cents,
           total_amount_cents: model.total_amount_cents,
           taxes_amount_cents: model.taxes_amount_cents,
           lago_invoice_id: nil

--- a/app/services/customers/fees_usage_calculation_service.rb
+++ b/app/services/customers/fees_usage_calculation_service.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Customers
+  class FeesUsageCalculationService
+    attr_reader :fees
+
+    def initialize(fees)
+      @fees = fees
+    end
+    
+    def current_amount_cents
+      fees.sum(&:amount_cents)
+    end
+
+    def projected_amount_cents
+      ratio = calculate_time_ratio(fees.first.properties["from_datetime"], fees.first.properties["to_datetime"])
+
+      return current_amount_cents if recurring?
+      ratio > 0 ? (current_amount_cents / BigDecimal(ratio.to_s)).round.to_i : 0
+    end
+
+    def current_units
+      fees.sum { |f| BigDecimal(f.units) }
+    end
+
+    def projected_units
+      ratio = calculate_time_ratio(fees.first.properties["from_datetime"], fees.first.properties["to_datetime"])
+      current_units = fees.sum { |f| BigDecimal(f.units) }
+
+      return current_units if recurring?
+      ratio > 0 ? (current_units / BigDecimal(ratio.to_s)).round(2) : BigDecimal('0')
+    end
+
+    private
+
+    def calculate_time_ratio(from_datetime, to_datetime, charges_duration_in_days)
+      from_date = from_datetime.to_date
+      to_date = to_datetime.to_date
+      current_date = Date.current
+
+      total_days = (to_date - from_date).to_i + 1
+
+      charges_duration = charges_duration_in_days || total_days
+
+      return 1.0 if current_date >= to_date
+      return 0.0 if current_date < from_date
+
+      days_passed = (current_date - from_date).to_i + 1
+
+      ratio = days_passed.to_f / charges_duration
+      ratio.clamp(0.0, 1.0)
+    end
+
+    def recurring?
+      fees.first.charge.billable_metric.recurring?
+    end
+  end
+end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -181,11 +181,17 @@ module Invoices
         issuing_date: invoice.issuing_date.iso8601,
         currency: invoice.currency,
         amount_cents: invoice.fees_amount_cents,
-        projected_amount_cents: invoice.projected_fees_amount_cents,
+        projected_amount_cents: projected_fees_amount_cents,
         total_amount_cents: invoice.total_amount_cents,
         taxes_amount_cents: invoice.taxes_amount_cents,
         fees: invoice.fees
       )
+    end
+
+    def projected_fees_amount_cents
+      calculation_service = ::Customers::FeesUsageCalculationService.new(invoice.fees)
+      ratio = calculation_service.calculate_time_ratio(boundaries[:charges_from_datetime], boundaries[:charges_to_datetime], boundaries[:charges_duration])
+      ratio > 0 ? (invoice.fees_amount_cents / BigDecimal(ratio.to_s)).round.to_i : 0
     end
 
     def customer_provider_taxation?

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -181,6 +181,7 @@ module Invoices
         issuing_date: invoice.issuing_date.iso8601,
         currency: invoice.currency,
         amount_cents: invoice.fees_amount_cents,
+        projected_amount_cents: invoice.projected_fees_amount_cents,
         total_amount_cents: invoice.total_amount_cents,
         taxes_amount_cents: invoice.taxes_amount_cents,
         fees: invoice.fees

--- a/schema.graphql
+++ b/schema.graphql
@@ -862,6 +862,8 @@ type ChargeFilterUsage {
   eventsCount: Int!
   id: ID
   invoiceDisplayName: String
+  projectedAmountCents: BigInt!
+  projectedUnits: Float!
   units: Float!
   values: ChargeFilterValues!
 }
@@ -914,6 +916,8 @@ type ChargeUsage {
   filters: [ChargeFilterUsage!]
   groupedUsage: [GroupedChargeUsage!]!
   id: ID!
+  projectedAmountCents: BigInt!
+  projectedUnits: Float!
   units: Float!
 }
 
@@ -5235,6 +5239,8 @@ type GroupedChargeUsage {
   filters: [ChargeFilterUsage!]
   groupedBy: JSON
   id: ID!
+  projectedAmountCents: BigInt!
+  projectedUnits: Float!
   units: Float!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -5337,6 +5337,38 @@
               "args": []
             },
             {
+              "name": "projectedAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "projectedUnits",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "units",
               "description": null,
               "type": {
@@ -5883,6 +5915,38 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "projectedAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "projectedUnits",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
                   "ofType": null
                 }
               },
@@ -25217,6 +25281,38 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "projectedAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "projectedUnits",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
                   "ofType": null
                 }
               },

--- a/spec/graphql/types/customers/usage/charge_filter_spec.rb
+++ b/spec/graphql/types/customers/usage/charge_filter_spec.rb
@@ -8,9 +8,11 @@ RSpec.describe Types::Customers::Usage::ChargeFilter do
   it do
     expect(subject).to have_field(:id).of_type("ID")
     expect(subject).to have_field(:amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:projected_amount_cents).of_type("BigInt!")
     expect(subject).to have_field(:events_count).of_type("Int!")
     expect(subject).to have_field(:invoice_display_name).of_type("String")
     expect(subject).to have_field(:units).of_type("Float!")
+    expect(subject).to have_field(:projected_units).of_type("Float!")
     expect(subject).to have_field(:values).of_type("ChargeFilterValues!")
   end
 end

--- a/spec/graphql/types/customers/usage/charge_spec.rb
+++ b/spec/graphql/types/customers/usage/charge_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe Types::Customers::Usage::Charge do
   it do
     expect(subject).to have_field(:id).of_type("ID!")
     expect(subject).to have_field(:amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:projected_amount_cents).of_type("BigInt!")
     expect(subject).to have_field(:events_count).of_type("Int!")
     expect(subject).to have_field(:units).of_type("Float!")
+    expect(subject).to have_field(:projected_units).of_type("Float!")
     expect(subject).to have_field(:billable_metric).of_type("BillableMetric!")
     expect(subject).to have_field(:charge).of_type("Charge!")
     expect(subject).to have_field(:grouped_usage).of_type("[GroupedChargeUsage!]!")

--- a/spec/graphql/types/customers/usage/grouped_usage_spec.rb
+++ b/spec/graphql/types/customers/usage/grouped_usage_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe Types::Customers::Usage::GroupedUsage do
 
   it do
     expect(subject).to have_field(:amount_cents).of_type("BigInt!")
+    expect(subject).to have_field(:projected_amount_cents).of_type("BigInt!")
     expect(subject).to have_field(:events_count).of_type("Int!")
     expect(subject).to have_field(:units).of_type("Float!")
+    expect(subject).to have_field(:projected_units).of_type("Float!")
     expect(subject).to have_field(:filters).of_type("[ChargeFilterUsage!]")
     expect(subject).to have_field(:grouped_by).of_type("JSON")
   end

--- a/spec/serializers/v1/customers/usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/usage_serializer_spec.rb
@@ -5,11 +5,21 @@ require "rails_helper"
 RSpec.describe ::V1::Customers::UsageSerializer do
   subject(:serializer) { described_class.new(usage, root_name: "customer_usage", includes: [:charges_usage]) }
 
+  let(:fixed_date) { Date.new(2025, 7, 2) }
+  let(:from_datetime) { fixed_date.beginning_of_month }
+  let(:to_datetime) { fixed_date.end_of_month }
+  let(:issuing_date) { fixed_date.end_of_month }
+
+  before do
+    allow(Date).to receive(:current).and_return(fixed_date)
+    allow(Time).to receive(:current).and_return(fixed_date.to_time)
+  end
+
   let(:usage) do
     SubscriptionUsage.new(
-      from_datetime: Time.current.beginning_of_month.iso8601,
-      to_datetime: Time.current.end_of_month.iso8601,
-      issuing_date: Time.current.end_of_month.iso8601,
+      from_datetime: from_datetime.iso8601,
+      to_datetime: to_datetime.iso8601,
+      issuing_date: issuing_date.iso8601,
       amount_cents: 5,
       currency: "EUR",
       total_amount_cents: 6,
@@ -20,15 +30,29 @@ RSpec.describe ::V1::Customers::UsageSerializer do
             id: SecureRandom.uuid,
             name: "Charge",
             code: "charge",
-            aggregation_type: "count_agg"
+            aggregation_type: "count_agg",
+            recurring: false
           ),
           charge: OpenStruct.new(
             id: SecureRandom.uuid,
-            charge_model: "graduated"
+            charge_model: "graduated",
+            charge_id: SecureRandom.uuid,
+            invoice_display_name: "Test Charge",
+            filters: [],
+            billable_metric: OpenStruct.new(recurring: false)
           ),
+          charge_id: SecureRandom.uuid,
           units: "4.0",
           amount_cents: 5,
-          amount_currency: "EUR"
+          amount_currency: "EUR",
+          events_count: 1,
+          charge_filter: nil,
+          grouped_by: {},
+          properties: {
+            "from_datetime" => from_datetime.iso8601,
+            "to_datetime" => to_datetime.iso8601,
+            "charges_duration" => 30
+          }
         )
       ]
     )
@@ -38,9 +62,9 @@ RSpec.describe ::V1::Customers::UsageSerializer do
 
   it "serializes the customer usage" do
     aggregate_failures do
-      expect(result["customer_usage"]["from_datetime"]).to eq(Time.current.beginning_of_month.iso8601)
-      expect(result["customer_usage"]["to_datetime"]).to eq(Time.current.end_of_month.iso8601)
-      expect(result["customer_usage"]["issuing_date"]).to eq(Time.current.end_of_month.iso8601)
+      expect(result["customer_usage"]["from_datetime"]).to eq(from_datetime.iso8601)
+      expect(result["customer_usage"]["to_datetime"]).to eq(to_datetime.iso8601)
+      expect(result["customer_usage"]["issuing_date"]).to eq(issuing_date.iso8601)
       expect(result["customer_usage"]["currency"]).to eq("EUR")
       expect(result["customer_usage"]["taxes_amount_cents"]).to eq(1)
       expect(result["customer_usage"]["amount_cents"]).to eq(5)
@@ -52,7 +76,9 @@ RSpec.describe ::V1::Customers::UsageSerializer do
       expect(charge_usage["billable_metric"]["aggregation_type"]).to eq("count_agg")
       expect(charge_usage["charge"]["charge_model"]).to eq("graduated")
       expect(charge_usage["units"]).to eq("4.0")
+      expect(charge_usage["projected_units"]).to eq("60.0")
       expect(charge_usage["amount_cents"]).to eq(5)
+      expect(charge_usage["projected_amount_cents"]).to eq(75)
       expect(charge_usage["amount_currency"]).to eq("EUR")
     end
   end


### PR DESCRIPTION
## Context

We offer a endpoint and a UI for the current usage of the customers of our users. They can see in real time the consumption of each feature for the current period. However, there is no way to calculate the projected usage. So we need to add this feature on our platform.
Here is the [spec document](https://www.notion.so/getlago/Spec-Projected-usage-for-current-periods-218ef63110d280df877bfcb0be4045c4).
Here is the [dive in document](https://www.notion.so/getlago/BE-Dive-In-Projected-usage-for-current-periods-WIP-21cef63110d280318540fe4310df8048).

## Description

There are many changes in this PR:

- Add a service for calculating projected usage data based on the fees and the boundary dates.
- Change the serializer for the API to use this new service to calculate the projected usage values added to the response.
- Change the graphql types to use this new service to calculate the projected usage values added to the response.
- Made several specs to test the behavior and modified existing ones, because there were changes to an existing endpoint.