### PR TITLE
fix(wallet_transaction): Enqueue BillPaidCreditJob after commit

### DIFF
--- a/app/services/wallet_transactions/create_from_params_service.rb
+++ b/app/services/wallet_transactions/create_from_params_service.rb
@@ -102,7 +102,7 @@ module WalletTransactions
         metadata:
       ).wallet_transaction
 
-      BillPaidCreditJob.perform_later(wallet_transaction, Time.current.to_i)
+      BillPaidCreditJob.perform_after_commit(wallet_transaction, Time.current.to_i)
 
       wallet_transaction
     end


### PR DESCRIPTION
## Context
This PR fixes a regression introduced by https://github.com/getlago/lago-api/pull/3895

The wallet transaction processing was performed in a single database transaction. I the process a `BillPaidCreditJob` is enqueued. Since it's now in the DB transaction, it leads in some situation to an `ActiveJob::DeserializationError`. 

## Description

This PR fixes the situation by enqueuing the job after the the commit of the DB transaction
