### PR TITLE
chore(matcher): Rename `enqueue_after_commit` matcher to `have_enqueued_job_after_commit`

### DIFF
--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -276,8 +276,8 @@ RSpec.describe Invoices::UpdateService do
       context "when invoice is invisible" do
         before { invoice.update! status: :open }
 
-        it "delivers a webhook" do
-          expect { result }.not_to have_enqueued_job_after_commit(SendWebhookJob).with("invoice.payment_status_updated", invoice)
+        it "does not deliver a webhook" do
+          expect { result }.not_to have_enqueued_job(SendWebhookJob)
         end
       end
 
@@ -285,12 +285,7 @@ RSpec.describe Invoices::UpdateService do
         let(:invoice) { create(:invoice, payment_status: :succeeded) }
 
         it "does not deliver a webhook" do
-          result
-
-          expect(SendWebhookJob).not_to have_been_enqueued.with(
-            "invoice.payment_status_updated",
-            invoice
-          )
+          expect { result }.not_to have_enqueued_job(SendWebhookJob)
         end
       end
     end

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Invoices::UpdateService do
 
     context "with attached fees" do
       it "enqueues a job to update the payment_status of the fees" do
-        expect { result }.to enqueue_after_commit(Invoices::UpdateFeesPaymentStatusJob).with(invoice)
+        expect { result }.to have_enqueued_job_after_commit(Invoices::UpdateFeesPaymentStatusJob).with(invoice)
       end
     end
 
@@ -200,7 +200,7 @@ RSpec.describe Invoices::UpdateService do
       let(:invoice) { create(:invoice, customer: integration_customer.customer, organization:) }
 
       it "enqueues a job to update the hubspot invoice" do
-        expect { result }.to enqueue_after_commit(Integrations::Aggregator::Invoices::Hubspot::UpdateJob).with(invoice:)
+        expect { result }.to have_enqueued_job_after_commit(Integrations::Aggregator::Invoices::Hubspot::UpdateJob).with(invoice:)
       end
 
       context "when it should not sync hubspot invoices" do
@@ -241,7 +241,7 @@ RSpec.describe Invoices::UpdateService do
         let(:update_args) { {payment_status: "succeeded"} }
 
         it "calls Invoices::PrepaidCreditJob with the correct arguments" do
-          expect { result }.to enqueue_after_commit(Invoices::PrepaidCreditJob).with(invoice, :succeeded)
+          expect { result }.to have_enqueued_job_after_commit(Invoices::PrepaidCreditJob).with(invoice, :succeeded)
         end
       end
 
@@ -249,7 +249,7 @@ RSpec.describe Invoices::UpdateService do
         let(:update_args) { {payment_status: "failed"} }
 
         it "calls Invoices::PrepaidCreditJob with the correct arguments" do
-          expect { result }.to enqueue_after_commit(Invoices::PrepaidCreditJob).with(invoice, :failed)
+          expect { result }.to have_enqueued_job_after_commit(Invoices::PrepaidCreditJob).with(invoice, :failed)
         end
       end
     end
@@ -263,7 +263,7 @@ RSpec.describe Invoices::UpdateService do
         end
 
         it "delivers a webhook" do
-          expect { result }.to enqueue_after_commit(SendWebhookJob).with("invoice.payment_status_updated", invoice)
+          expect { result }.to have_enqueued_job_after_commit(SendWebhookJob).with("invoice.payment_status_updated", invoice)
         end
 
         it "produces an activity log" do
@@ -277,7 +277,7 @@ RSpec.describe Invoices::UpdateService do
         before { invoice.update! status: :open }
 
         it "delivers a webhook" do
-          expect { result }.not_to enqueue_after_commit(SendWebhookJob).with("invoice.payment_status_updated", invoice)
+          expect { result }.not_to have_enqueued_job_after_commit(SendWebhookJob).with("invoice.payment_status_updated", invoice)
         end
       end
 

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
     end
 
     it "enqueues the BillPaidCreditJob" do
-      expect { create_service }.to have_enqueued_job(BillPaidCreditJob)
+      expect { create_service }.to have_enqueued_job_after_commit(BillPaidCreditJob)
     end
 
     it "updates wallet balance based on granted and voided credits" do

--- a/spec/support/matchers/job_matcher.rb
+++ b/spec/support/matchers/job_matcher.rb
@@ -2,19 +2,19 @@
 
 # This matcher ensure that a job is enqueued only after a transaction is committed to ensure no race-condition may
 # happen.
-RSpec::Matchers.define :enqueue_after_commit do |job|
+RSpec::Matchers.define :have_enqueued_job_after_commit do |job|
   supports_block_expectations
-  match do |block|
+  match(notify_expectation_failures: true) do |block|
     ApplicationRecord.transaction do
       block.call
 
-      expect(job).not_to have_been_enqueued
+      expect(job).not_to have_been_enqueued, "Expected #{job} to not have been enqueued before commit, but it was."
     end
 
     args = @args || []
     kwargs = @kwargs || {}
 
-    expect(job).to have_been_enqueued.with(*args, **kwargs)
+    expect(job).to have_been_enqueued.with(*args, **kwargs), "Expected #{job} to have been enqueued with #{args} and #{kwargs}, but it was not."
   end
 
   chain :with do |*args, **kwargs|

--- a/spec/support/matchers/job_matcher.rb
+++ b/spec/support/matchers/job_matcher.rb
@@ -17,6 +17,10 @@ RSpec::Matchers.define :have_enqueued_job_after_commit do |job|
     expect(job).to have_been_enqueued.with(*args, **kwargs), "Expected #{job} to have been enqueued with #{args} and #{kwargs}, but it was not."
   end
 
+  match_when_negated do |block|
+    raise "The `have_enqueued_job_after_commit` matcher does not support negation. Use `expect { ... }.not_to have_enqueued_job` instead."
+  end
+
   chain :with do |*args, **kwargs|
     @args = args
     @kwargs = kwargs


### PR DESCRIPTION
## Description

This is a small refactor to make the matcher closer to the `have_enqueued_job` matcher and improve the error messages.

This also update the `WalletTransactions::CreateFromParamsService` to rely on this matcher after the changes introduced in 4a5e510.
