### PR TITLE
fix(payment_request): Prevent payment creation when invoices are payment succeeded

### DIFF
--- a/app/services/payment_requests/payments/create_service.rb
+++ b/app/services/payment_requests/payments/create_service.rb
@@ -101,8 +101,9 @@ module PaymentRequests
       def should_process_payment?
         return false if payable.payment_succeeded?
         return false if current_payment_provider.blank?
+        return false unless current_payment_provider_customer&.provider_customer_id
 
-        current_payment_provider_customer&.provider_customer_id
+        payable.invoices.all?(&:ready_for_payment_processing)
       end
 
       def current_payment_provider

--- a/spec/services/payment_requests/payments/create_service_spec.rb
+++ b/spec/services/payment_requests/payments/create_service_spec.rb
@@ -348,6 +348,29 @@ RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
       end
     end
 
+    context "when some invoices are already paid" do
+      let(:invoice_1) do
+        create(
+          :invoice,
+          organization:,
+          customer:,
+          total_amount_cents: 200,
+          currency: "USD",
+          ready_for_payment_processing: false
+        )
+      end
+
+      it "does not create a stripe payment" do
+        result = create_service.call
+
+        expect(result).to be_success
+
+        expect(result.payable).to eq(payment_request)
+        expect(result.payment).to be_nil
+        expect(provider_class).not_to have_received(:new)
+      end
+    end
+
     context "when provider service raises a service failure" do
       let(:service_result) do
         BaseService::Result.new.tap do |r|


### PR DESCRIPTION
## Context

When retrying a failed `PaymentRequests::Payments::CreateJob` (manually or automatically), we are not checking if the attached invoices are still ready for payment processing. This lead to a risk of duplicated payments.

## Description

This pull request adds a new guard to the `PaymentRequests::Payments::CreateService` to early return when one of the invoice of the `PaymentRequest` is not flagged as `ready_for_payment_processing`
