### PR TITLE
misc: Renew token only when expired

### DIFF
--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -89,7 +89,7 @@ class UsersService < BaseService
   def payload
     {
       sub: result.user.id,
-      exp: Time.now.to_i + 8640 # 2 hours and 24 minutes expiration
+      exp: 3.hours.from_now.to_i
     }
   end
 

--- a/spec/requests/graphql_controller_spec.rb
+++ b/spec/requests/graphql_controller_spec.rb
@@ -51,11 +51,11 @@ RSpec.describe GraphqlController, type: :request do
       let(:token) do
         UsersService.new.new_token(user).token
       end
-      let(:expired_token) do
+      let(:near_expiration_token) do
         JWT.encode(
           {
             sub: user.id,
-            exp: Time.now.to_i - 1
+            exp: 30.minutes.from_now.to_i
           },
           ENV["SECRET_KEY_BASE"],
           "HS256"
@@ -103,7 +103,7 @@ RSpec.describe GraphqlController, type: :request do
         post(
           "/graphql",
           headers: {
-            "Authorization" => "Bearer #{expired_token}"
+            "Authorization" => "Bearer #{near_expiration_token}"
           },
           params: {
             query: mutation,


### PR DESCRIPTION
## Description

We currently renew the authorisation token for each request made by users.

This is pointless in most cases because the token expires after 3 hours (2h24 to be exact).

The aim of this PR is to renew the token only when it expires.
