### PR TITLE
chore(specs): Fix `DatabaseCleaner` for `events` database

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,6 +110,8 @@ RSpec.configure do |config|
   # NOTE: Database cleaner config to turn off/on transactional mode
   config.before(:suite) do
     DatabaseCleaner.clean_with(:deletion)
+    # No need for `DatabaseCleaner[:active_record, db: EventsRecord].clean_with(:deletion)`
+    # because both connections are using the same database.
   end
 
   config.include_context "with Time travel enabled", :time_travel
@@ -151,11 +153,15 @@ RSpec.configure do |config|
 
   config.around do |example|
     # Important to set the strategy in this block as otherwise the cleaning will always use the transaction strategy
-    DatabaseCleaner.strategy = if example.metadata[:transaction] == false
+    strategy = if example.metadata[:transaction] == false
       :deletion
     else
       :transaction
     end
+    DatabaseCleaner.strategy = strategy
+    # We need to set the strategy for the `events` connection as well to properly rollback changes done using the `events` connection.
+    # DO NOT CHANGE `:db` to `:events` as it will not work properly with `:transaction` strategy.
+    DatabaseCleaner[:active_record, db: EventsRecord].strategy = strategy
     DatabaseCleaner.cleaning do
       example.run
     end


### PR DESCRIPTION
## Context

`events` database cleanup currently does not work properly if the `transaction` strategy is used. This is because `DatabaseCleaner` will only apply the strategy on the default database connection. Since `events` is using a separate connection, the connection will not be rolled back.

Take the following spec:

```ruby
require "rails_helper"

RSpec.describe DatabaseCleaner do
  it "has zero events" do
    expect(Event.count).to eq(0)

    create(:event)

    expect(Event.count).to eq(1)
  end

  it "also has zero events" do
    # This should work if each example is wrapped in a transaction
    expect(Event.count).to eq(0)
  end
end
```

This will fail with the following error:

```shell
⋊> lago exec api bundle exec rspec --color --format documentation spec/database_cleaner_spec.rb

DatabaseCleaner
  has zero events
  also has zero events (FAILED - 1)

Failures:

  1) DatabaseCleaner also has zero events
     Failure/Error: expect(Event.count).to eq(0)

       expected: 0
            got: 1

       (compared using ==)
     # ./spec/database_cleaner_spec.rb:16:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:160:in 'block (3 levels) in <top (required)>'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in 'DatabaseCleaner::Cleaners#cleaning'
     # ./spec/spec_helper.rb:159:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'

Finished in 0.58037 seconds (files took 2.43 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/database_cleaner_spec.rb:14 # DatabaseCleaner also has zero events
```

The only reason it works with `deletion` strategy is because `events` table is within the same database as the `default` (`primary`) connection and gets deleted/truncated when `DatabaseCleaner` cleans the `default` database.

## Description

The fix is to define a specific strategy for `events` database:

```ruby
DatabaseCleaner[:active_record, db: EventsRecord].strategy = :transaction
```

Note that we have to use `EventsRecord` instead of `events` as `db`. The reason is that `DatabaseCleaner` tries to retrieve the first active record class whose connection is matching the database name. This will be `ApplicationRecord` since its connection (`primary`/`default`) uses the same database name as the `events` connection. Then `DatabaseCleaner` will use the connection from that class to handle the cleanup. In this case, the cleanup (`transaction`) will happen on the `default` database instead of the `events`. See https://github.com/DatabaseCleaner/database_cleaner-active_record/blob/912acbe1facddfe1b14f21107f6ddc9df290de53/lib/database_cleaner/active_record/base.rb#L82.
