### PR TITLE
fix(specs): Run specs using `parallel_tests` in CI if PR is from a community member

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -52,7 +52,7 @@ jobs:
       LAGO_CLICKHOUSE_USERNAME: ""
       LAGO_CLICKHOUSE_PASSWORD: "password"
       LAGO_KAFKA_EVENTS_CHARGED_IN_ADVANCE_TOPIC: events_charged_in_advance
-      KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
+      KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ''
       KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
       KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
       KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -52,7 +52,7 @@ jobs:
       LAGO_CLICKHOUSE_USERNAME: ""
       LAGO_CLICKHOUSE_PASSWORD: "password"
       LAGO_KAFKA_EVENTS_CHARGED_IN_ADVANCE_TOPIC: events_charged_in_advance
-      KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ''
+      KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
       KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
       KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
       KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -59,11 +59,6 @@ jobs:
       KNAPSACK_PRO_LOG_LEVEL: info
 
     steps:
-      - name: Fail if community PR
-        if: ${{ !env.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
-        run: |
-          echo '::error::This is a community PR. The `KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC` environment variable is not set and Knapsack Pro will not run the specs.'
-          exit 1
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Ruby and gems
@@ -82,7 +77,13 @@ jobs:
       - name: Set up Clickhouse database schema
         run: bin/rails db:migrate:clickhouse
       - name: Run tests
-        run: bundle exec rake knapsack_pro:queue:rspec
+        run: |
+          if [[ -z "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" ]]; then
+            echo "::warning::This is a community PR. We'll default to running the test using 'parallel_tests'."
+            bundle exec parallel_rspec --only-group "${KNAPSACK_PRO_CI_NODE_INDEX}" -n "${KNAPSACK_PRO_CI_NODE_TOTAL}" --exclude-pattern "spec/integration/.*_integration_spec.rb"
+          else
+            bundle exec rake knapsack_pro:queue:rspec
+          fi
         continue-on-error: true
       - name: retry failed tests
         run: bundle exec rspec --only-failures

--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,7 @@ group :development, :test do
   gem "awesome_print"
   gem "pry"
   gem "knapsack_pro", "~> 8.1"
+  gem "parallel_tests", "~> 5.3"
 
   gem "database_cleaner-active_record"
   gem "rspec-graphql_matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -653,6 +653,8 @@ GEM
       activerecord (>= 6.1)
       request_store (~> 1.4)
     parallel (1.27.0)
+    parallel_tests (5.3.0)
+      parallel
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
@@ -1012,6 +1014,7 @@ DEPENDENCIES
   ostruct
   paper_trail
   parallel
+  parallel_tests (~> 5.3)
   pg
   pry
   puma (~> 6.5)


### PR DESCRIPTION
## Context

Currently, if a community PR is opened, the`KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC` secret will not be set. This will cause the specs to fail with an error as we are not able to run Knapsack Pro in this case.

This is not an ideal situation as it will complexify the contribution process.

## Description

The specs will now run using `parallel_tests` (with the `parallel_rspec` CLI) in the CI workflow as a fallback if the `KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC` secret is not set.

Note that we don't use `parallel_rspec` to actually run the tests in parallel. By combining `--only-group` with `-n`, we tell `parallel_rspec` to:

1. Split the tests into `KNAPSACK_PRO_CI_NODE_INDEX` (8) groups
2. Run only the `KNAPSACK_PRO_CI_NODE_INDEX` group

So we have the same behavior as Knapsack but without a proper distribution based on timing.
