### PR TITLE
feat(entitlement): Send `plan.updated` webhooks

### DIFF
--- a/app/controllers/api/v1/plans/entitlements/privileges_controller.rb
+++ b/app/controllers/api/v1/plans/entitlements/privileges_controller.rb
@@ -11,7 +11,7 @@ module Api
           before_action :find_entitlement
 
           def destroy
-            result = ::Entitlement::EntitlementPrivilegeDestroyService.call(
+            result = ::Entitlement::PlanEntitlementPrivilegeDestroyService.call(
               entitlement: entitlement,
               privilege_code: params[:code]
             )

--- a/app/controllers/api/v1/plans/entitlements_controller.rb
+++ b/app/controllers/api/v1/plans/entitlements_controller.rb
@@ -73,7 +73,7 @@ module Api
         end
 
         def destroy
-          result = ::Entitlement::EntitlementDestroyService.call(entitlement: entitlement)
+          result = ::Entitlement::PlanEntitlementDestroyService.call(entitlement: entitlement)
 
           if result.success?
             render(

--- a/app/models/entitlement/feature.rb
+++ b/app/models/entitlement/feature.rb
@@ -9,6 +9,8 @@ module Entitlement
 
     belongs_to :organization
     has_many :privileges, class_name: "Entitlement::Privilege", foreign_key: "entitlement_feature_id", dependent: :destroy
+    has_many :entitlements, class_name: "Entitlement::Entitlement", foreign_key: "entitlement_feature_id", dependent: :destroy
+    has_many :entitlement_values, through: :entitlements, source: :values, class_name: "Entitlement::EntitlementValue", dependent: :destroy
 
     validates :code, presence: true, length: {maximum: 255}
     validates :name, length: {maximum: 255}

--- a/app/models/entitlement/privilege.rb
+++ b/app/models/entitlement/privilege.rb
@@ -12,6 +12,7 @@ module Entitlement
     belongs_to :organization
     belongs_to :feature, class_name: "Entitlement::Feature", foreign_key: :entitlement_feature_id
     has_many :values, class_name: "Entitlement::EntitlementValue", foreign_key: :entitlement_privilege_id, dependent: :destroy
+    has_many :entitlements, through: :values, class_name: "Entitlement::Entitlement"
 
     validates :code, presence: true, length: {maximum: 255}
     validates :name, length: {maximum: 255}

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -25,6 +25,7 @@ class Plan < ApplicationRecord
   has_many :applied_taxes, class_name: "Plan::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes
   has_many :entitlements, class_name: "Entitlement::Entitlement", dependent: :destroy
+  has_many :entitlement_values, through: :entitlements, source: :values, class_name: "Entitlement::EntitlementValue", dependent: :destroy
 
   has_many :activity_logs,
     -> { order(logged_at: :desc) },

--- a/app/services/entitlement/feature_destroy_service.rb
+++ b/app/services/entitlement/feature_destroy_service.rb
@@ -12,10 +12,18 @@ module Entitlement
     def call
       return result.not_found_failure!(resource: "feature") unless feature
 
+      jobs = feature.entitlements.select(:plan_id).distinct.pluck(:plan_id).map do |plan_id|
+        SendWebhookJob.new("plan.updated", Plan.new(id: plan_id))
+      end
+
       ActiveRecord::Base.transaction do
+        feature.entitlement_values.discard_all!
+        feature.entitlements.discard_all!
         feature.privileges.discard_all!
         feature.discard!
       end
+
+      after_commit { ActiveJob.perform_all_later(jobs) }
 
       result.feature = feature
       result

--- a/app/services/entitlement/feature_update_service.rb
+++ b/app/services/entitlement/feature_update_service.rb
@@ -13,12 +13,19 @@ module Entitlement
     def call
       return result.not_found_failure!(resource: "feature") unless feature
 
+      jobs = feature.entitlements.select(:plan_id).distinct.pluck(:plan_id).map do |plan_id|
+        SendWebhookJob.new("plan.updated", Plan.new(id: plan_id))
+      end
+
       ActiveRecord::Base.transaction do
         update_feature_attributes
         update_privileges if params[:privileges].present?
 
         feature.save!
       end
+
+      # NOTE: The webhook is sent even if there was no actual change
+      after_commit { ActiveJob.perform_all_later(jobs) }
 
       result.feature = feature
       result

--- a/app/services/entitlement/plan_entitlement_destroy_service.rb
+++ b/app/services/entitlement/plan_entitlement_destroy_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Entitlement
-  class EntitlementDestroyService < BaseService
+  class PlanEntitlementDestroyService < BaseService
     Result = BaseResult[:entitlement]
 
     def initialize(entitlement:)
@@ -16,6 +16,8 @@ module Entitlement
         entitlement.values.discard_all!
         entitlement.discard!
       end
+
+      SendWebhookJob.perform_after_commit("plan.updated", entitlement.plan)
 
       result.entitlement = entitlement
       result

--- a/app/services/entitlement/plan_entitlements_create_service.rb
+++ b/app/services/entitlement/plan_entitlements_create_service.rb
@@ -16,6 +16,8 @@ module Entitlement
           create_entitlements
         end
 
+        SendWebhookJob.perform_after_commit("plan.updated", plan)
+
         result.entitlements = plan.entitlements.includes(:feature, values: :privilege)
         result
       end

--- a/app/services/entitlement/plan_entitlements_update_service.rb
+++ b/app/services/entitlement/plan_entitlements_update_service.rb
@@ -12,6 +12,9 @@ module Entitlement
           update_entitlements
         end
 
+        # NOTE: The webhooks is sent even if no changes were made to the plan
+        SendWebhookJob.perform_after_commit("plan.updated", plan)
+
         result.entitlements = plan.entitlements.reload.includes(:feature, values: :privilege)
         result
       end

--- a/app/services/entitlement/privilege_destroy_service.rb
+++ b/app/services/entitlement/privilege_destroy_service.rb
@@ -12,10 +12,16 @@ module Entitlement
     def call
       return result.not_found_failure!(resource: "privilege") unless privilege
 
+      jobs = privilege.entitlements.select(:plan_id).distinct.pluck(:plan_id).map do |plan_id|
+        SendWebhookJob.new("plan.updated", Plan.new(id: plan_id))
+      end
+
       ActiveRecord::Base.transaction do
         privilege.values.discard_all!
         privilege.discard!
       end
+
+      after_commit { ActiveJob.perform_all_later(jobs) }
 
       result.privilege = privilege
       result

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -27,6 +27,9 @@ module Plans
       invoices = Invoice.draft.joins(:plans).where(plans: {id: plan.id}).distinct
       invoices.find_each { |invoice| Invoices::RefreshDraftAndFinalizeService.call(invoice:) }
 
+      plan.entitlement_values.discard_all!
+      plan.entitlements.discard_all!
+
       plan.pending_deletion = false
       plan.discard!
 

--- a/spec/models/entitlement/feature_spec.rb
+++ b/spec/models/entitlement/feature_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Entitlement::Feature, type: :model do
     it do
       expect(subject).to belong_to(:organization)
       expect(subject).to have_many(:privileges).class_name("Entitlement::Privilege").dependent(:destroy)
+      expect(subject).to have_many(:entitlements).class_name("Entitlement::Entitlement").dependent(:destroy)
+      expect(subject).to have_many(:entitlement_values).through(:entitlements).source(:values).class_name("Entitlement::EntitlementValue").dependent(:destroy)
     end
   end
 

--- a/spec/models/entitlement/privilege_spec.rb
+++ b/spec/models/entitlement/privilege_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Entitlement::Privilege, type: :model do
       expect(subject).to belong_to(:organization)
       expect(subject).to belong_to(:feature).class_name("Entitlement::Feature")
       expect(subject).to have_many(:values).class_name("Entitlement::EntitlementValue").dependent(:destroy)
+      expect(subject).to have_many(:entitlements).class_name("Entitlement::Entitlement").through(:values)
     end
   end
 

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Plan, type: :model do
     expect(subject).to have_many(:applied_taxes).class_name("Plan::AppliedTax").dependent(:destroy)
     expect(subject).to have_many(:taxes).through(:applied_taxes)
     expect(subject).to have_many(:entitlements).class_name("Entitlement::Entitlement").dependent(:destroy)
+    expect(subject).to have_many(:entitlement_values).through(:entitlements).source(:values).class_name("Entitlement::EntitlementValue").dependent(:destroy)
 
     expect(subject).to validate_presence_of(:interval)
     expect(subject).to define_enum_for(:interval).with_values(Plan::INTERVALS)

--- a/spec/requests/api/v1/plans/entitlements/privileges_controller_spec.rb
+++ b/spec/requests/api/v1/plans/entitlements/privileges_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::Plans::Entitlements::PrivilegesController, type: :reques
     it "deletes the specific privilege value from the entitlement" do
       expect {
         delete_with_token organization, "/api/v1/plans/#{plan.code}/entitlements/#{feature.code}/privileges/#{privilege.code}"
-      }.to change { Entitlement::EntitlementValue.kept.count }.by(-1)
+      }.to change(privilege.values, :count).by(-1)
 
       expect(response).to have_http_status(:success)
 

--- a/spec/requests/api/v1/plans/entitlements_controller_spec.rb
+++ b/spec/requests/api/v1/plans/entitlements_controller_spec.rb
@@ -403,8 +403,8 @@ RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
     it "deletes the entitlement and its values" do
       expect {
         delete_with_token organization, "/api/v1/plans/#{plan.code}/entitlements/#{feature.code}"
-      }.to change { Entitlement::Entitlement.kept.count }.by(-1)
-        .and change { Entitlement::EntitlementValue.kept.count }.by(-1)
+      }.to change(feature.entitlements, :count).by(-1)
+        .and change(feature.entitlement_values, :count).by(-1)
 
       expect(response).to have_http_status(:success)
     end

--- a/spec/services/entitlement/feature_update_service_spec.rb
+++ b/spec/services/entitlement/feature_update_service_spec.rb
@@ -145,5 +145,21 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
         expect(result.feature.name).to eq("")
       end
     end
+
+    context "when feature is attached to a plan" do
+      let(:params) { {} }
+      let(:entitlement) { create(:entitlement, feature:) }
+      let(:privilege1_value) { create(:entitlement_value, entitlement:, privilege: privilege1, value: 10) }
+      let(:privilege2_value) { create(:entitlement_value, entitlement:, privilege: privilege2, value: true) }
+
+      before do
+        privilege1_value
+        privilege2_value
+      end
+
+      it "discard all values and entitlement" do
+        expect { subject }.to have_enqueued_job_after_commit(SendWebhookJob).with("plan.updated", entitlement.plan)
+      end
+    end
   end
 end

--- a/spec/services/entitlement/plan_entitlements_create_service_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_create_service_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe Entitlement::PlanEntitlementsCreateService, type: :service do
       expect(result.entitlements.count).to eq(1)
     end
 
+    it "sends `plan.updated` webhook" do
+      expect { subject }.to have_enqueued_job_after_commit(SendWebhookJob).with("plan.updated", plan)
+    end
+
     it "creates the entitlement with correct values" do
       result
       entitlement = plan.entitlements.first

--- a/spec/services/entitlement/plan_entitlements_update_service_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe Entitlement::PlanEntitlementsUpdateService, type: :service do
       expect(result.entitlements).to include(entitlement)
     end
 
+    it "sends `plan.updated` webhook" do
+      expect { subject }.to have_enqueued_job_after_commit(SendWebhookJob).with("plan.updated", plan)
+    end
+
     context "when privilege value does not exist" do
       let(:entitlements_params) do
         {

--- a/spec/services/entitlement/privilege_destroy_service_spec.rb
+++ b/spec/services/entitlement/privilege_destroy_service_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe Entitlement::PrivilegeDestroyService, type: :service do
       it "discards all related entitlement values" do
         expect { subject }.to change(Entitlement::EntitlementValue, :count).by(-1)
       end
+
+      it "sends `plan.updated` webhook" do
+        expect { subject }.to have_enqueued_job_after_commit(SendWebhookJob).with("plan.updated", entitlement.plan)
+      end
     end
   end
 end

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -94,5 +94,21 @@ RSpec.describe Plans::DestroyService, type: :service do
         end
       end
     end
+
+    context "with entitlements" do
+      let(:entitlement) { create(:entitlement, plan:) }
+      let(:entitlement_value) { create(:entitlement_value, entitlement: entitlement, privilege: create(:privilege, feature: entitlement.feature)) }
+
+      before do
+        entitlement
+        entitlement_value
+      end
+
+      it "destroys the entitlements" do
+        destroy_service.call
+        expect(entitlement.reload).to be_discarded
+        expect(entitlement_value.reload).to be_discarded
+      end
+    end
   end
 end


### PR DESCRIPTION

When a feature is modified, we send a `plan.updated` webhook for all plan using this feature.

When a feature privilege is modified, we send a `plan.updated` webhook for all plan having a value for this privilege.