### PR TITLE
feat(usages): Add is_customer_tin_empty argument to resolvers

### DIFF
--- a/app/graphql/resolvers/analytics/invoice_collections_resolver.rb
+++ b/app/graphql/resolvers/analytics/invoice_collections_resolver.rb
@@ -13,6 +13,7 @@ module Resolvers
       argument :billing_entity_code, String, required: false
       argument :billing_entity_id, ID, required: false
       argument :currency, Types::CurrencyEnum, required: false
+      argument :is_customer_tin_empty, Boolean, required: false
 
       type Types::Analytics::InvoiceCollections::Object.collection_type, null: false
 

--- a/app/graphql/resolvers/analytics/overdue_balances_resolver.rb
+++ b/app/graphql/resolvers/analytics/overdue_balances_resolver.rb
@@ -14,6 +14,7 @@ module Resolvers
       argument :billing_entity_id, ID, required: false
       argument :currency, Types::CurrencyEnum, required: false
       argument :external_customer_id, String, required: false
+      argument :is_customer_tin_empty, Boolean, required: false
       argument :months, Integer, required: false
 
       argument :expire_cache, Boolean, required: false

--- a/app/graphql/resolvers/data_api/mrrs_resolver.rb
+++ b/app/graphql/resolvers/data_api/mrrs_resolver.rb
@@ -27,6 +27,8 @@ module Resolvers
       argument :billing_entity_code, String, required: false
       argument :plan_code, String, required: false
 
+      argument :is_customer_tin_empty, Boolean, required: false
+
       type Types::DataApi::Mrrs::Object.collection_type, null: false
 
       def resolve(**args)

--- a/app/graphql/resolvers/data_api/prepaid_credits_resolver.rb
+++ b/app/graphql/resolvers/data_api/prepaid_credits_resolver.rb
@@ -27,6 +27,8 @@ module Resolvers
       argument :billing_entity_code, String, required: false
       argument :plan_code, String, required: false
 
+      argument :is_customer_tin_empty, Boolean, required: false
+
       type Types::DataApi::PrepaidCredits::Object.collection_type, null: false
 
       def resolve(**args)

--- a/app/graphql/resolvers/data_api/revenue_streams_resolver.rb
+++ b/app/graphql/resolvers/data_api/revenue_streams_resolver.rb
@@ -27,6 +27,8 @@ module Resolvers
       argument :billing_entity_code, String, required: false
       argument :plan_code, String, required: false
 
+      argument :is_customer_tin_empty, Boolean, required: false
+
       type Types::DataApi::RevenueStreams::Object.collection_type, null: false
 
       def resolve(**args)

--- a/app/graphql/resolvers/data_api/usages/aggregated_amounts_resolver.rb
+++ b/app/graphql/resolvers/data_api/usages/aggregated_amounts_resolver.rb
@@ -9,7 +9,7 @@ module Resolvers
 
         REQUIRED_PERMISSION = "data_api:view"
 
-        graphql_name "DataApiUsages"
+        graphql_name "DataApiUsagesAggregatedAmounts"
         description "Query usages of an organization"
 
         argument :currency, Types::CurrencyEnum, required: false
@@ -28,6 +28,8 @@ module Resolvers
 
         argument :billing_entity_code, String, required: false
         argument :plan_code, String, required: false
+
+        argument :is_customer_tin_empty, Boolean, required: false
 
         type Types::DataApi::Usages::AggregatedAmounts::Object.collection_type, null: false
 

--- a/app/graphql/resolvers/data_api/usages/invoiced_resolver.rb
+++ b/app/graphql/resolvers/data_api/usages/invoiced_resolver.rb
@@ -32,6 +32,8 @@ module Resolvers
         argument :filter_values, String, required: false
         argument :grouped_by, String, required: false
 
+        argument :is_customer_tin_empty, Boolean, required: false
+
         type Types::DataApi::Usages::Invoiced::Object.collection_type, null: false
 
         def resolve(**args)

--- a/app/graphql/resolvers/data_api/usages_resolver.rb
+++ b/app/graphql/resolvers/data_api/usages_resolver.rb
@@ -29,6 +29,8 @@ module Resolvers
       argument :billing_entity_code, String, required: false
       argument :plan_code, String, required: false
 
+      argument :is_customer_tin_empty, Boolean, required: false
+
       type Types::DataApi::Usages::Object.collection_type, null: false
 
       def resolve(**args)

--- a/schema.graphql
+++ b/schema.graphql
@@ -8016,7 +8016,7 @@ type Query {
   """
   Query monthly recurring revenues of an organization
   """
-  dataApiMrrs(billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiMrrCollection!
+  dataApiMrrs(billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, isCustomerTinEmpty: Boolean, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiMrrCollection!
 
   """
   Query monthly recurring revenues plans of an organization
@@ -8026,12 +8026,12 @@ type Query {
   """
   Query prepaid credits of an organization
   """
-  dataApiPrepaidCredits(billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiPrepaidCreditCollection!
+  dataApiPrepaidCredits(billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, isCustomerTinEmpty: Boolean, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiPrepaidCreditCollection!
 
   """
   Query revenue streams of an organization
   """
-  dataApiRevenueStreams(billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiRevenueStreamCollection!
+  dataApiRevenueStreams(billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, isCustomerTinEmpty: Boolean, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiRevenueStreamCollection!
 
   """
   Query revenue streams customers of an organization
@@ -8046,17 +8046,17 @@ type Query {
   """
   Query usages of an organization
   """
-  dataApiUsages(billableMetricCode: String, billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, isBillableMetricRecurring: Boolean, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiUsageCollection!
+  dataApiUsages(billableMetricCode: String, billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, isBillableMetricRecurring: Boolean, isCustomerTinEmpty: Boolean, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiUsageCollection!
 
   """
   Query usages of an organization
   """
-  dataApiUsagesAggregatedAmounts(billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, isBillableMetricRecurring: Boolean, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiUsageAggregatedAmountCollection!
+  dataApiUsagesAggregatedAmounts(billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, fromDate: ISO8601Date, isBillableMetricRecurring: Boolean, isCustomerTinEmpty: Boolean, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiUsageAggregatedAmountCollection!
 
   """
   Query invoiced usages of an organization
   """
-  dataApiUsagesInvoiced(billableMetricCode: String, billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, filterValues: String, fromDate: ISO8601Date, groupedBy: String, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiUsageInvoicedCollection!
+  dataApiUsagesInvoiced(billableMetricCode: String, billingEntityCode: String, currency: CurrencyEnum, customerCountry: CountryCode, customerType: CustomerTypeEnum, externalCustomerId: String, externalSubscriptionId: String, filterValues: String, fromDate: ISO8601Date, groupedBy: String, isCustomerTinEmpty: Boolean, planCode: String, timeGranularity: TimeGranularityEnum, toDate: ISO8601Date): DataApiUsageInvoicedCollection!
 
   """
   Query a single dunning campaign of an organization
@@ -8181,7 +8181,7 @@ type Query {
   """
   Query invoice collections of an organization
   """
-  invoiceCollections(billingEntityCode: String, billingEntityId: ID, currency: CurrencyEnum): FinalizedInvoiceCollectionCollection!
+  invoiceCollections(billingEntityCode: String, billingEntityId: ID, currency: CurrencyEnum, isCustomerTinEmpty: Boolean): FinalizedInvoiceCollectionCollection!
 
   """
   Query invoice's credit note
@@ -8262,7 +8262,7 @@ type Query {
   """
   Query overdue balances of an organization
   """
-  overdueBalances(billingEntityCode: String, billingEntityId: ID, currency: CurrencyEnum, expireCache: Boolean, externalCustomerId: String, months: Int): OverdueBalanceCollection!
+  overdueBalances(billingEntityCode: String, billingEntityId: ID, currency: CurrencyEnum, expireCache: Boolean, externalCustomerId: String, isCustomerTinEmpty: Boolean, months: Int): OverdueBalanceCollection!
 
   """
   Query a password reset by token

--- a/schema.json
+++ b/schema.json
@@ -40933,6 +40933,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "isCustomerTinEmpty",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },
@@ -41123,6 +41135,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "isCustomerTinEmpty",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },
@@ -41255,6 +41279,18 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "isCustomerTinEmpty",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -41551,6 +41587,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "isCustomerTinEmpty",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },
@@ -41695,6 +41743,18 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "isCustomerTinEmpty",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -41868,6 +41928,18 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "isCustomerTinEmpty",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null,
@@ -42682,6 +42754,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "isCustomerTinEmpty",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },
@@ -43277,6 +43361,18 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "isCustomerTinEmpty",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null,


### PR DESCRIPTION
## Description

Add `is_customer_tin_empty` argument to GraphQL resolvers so that is can be passed to Data API.

