### PR TITLE
allow frontend to read x-lago-token header

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -22,6 +22,7 @@ Rails.application.config.middleware.insert_before(0, Rack::Cors) do
 
     resource "*",
       headers: :any,
-      methods: %i[get post put patch delete options head]
+      methods: %i[get post put patch delete options head],
+      expose: ["x-lago-token"]
   end
 end


### PR DESCRIPTION
Necessary for [ISSUE-978](https://linear.app/getlago/issue/ISSUE-978/use-renewed-token-on-new-calls)

To make the response header available on front, we need to expose him on CORS configuration.

https://github.com/getlago/lago-api/blob/51d309a81861aa93fba9288ce97aa43ea8105c0d/config/initializers/cors.rb#L5-L28

This should not expose the header to any other page besides the ones listed on `origins` calls. 

```
ENV["LAGO_FRONT_URL"],
ENV["LAGO_DOMAIN"],
"app.lago.dev",
"api",
"lago.ngrok.dev"
```  

