### PR TITLE
fix(webhook-endpoint): Add missing created_at

### DIFF
--- a/app/serializers/v1/webhook_endpoint_serializer.rb
+++ b/app/serializers/v1/webhook_endpoint_serializer.rb
@@ -7,7 +7,8 @@ module V1
         lago_id: model.id,
         lago_organization_id: model.organization_id,
         webhook_url: model.webhook_url,
-        signature_algo: model.signature_algo
+        signature_algo: model.signature_algo,
+        created_at: model.created_at.iso8601
       }
     end
   end

--- a/spec/serializers/v1/webhook_endpoint_serializer_spec.rb
+++ b/spec/serializers/v1/webhook_endpoint_serializer_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe ::V1::WebhookEndpointSerializer do
     aggregate_failures do
       expect(result["webhook_endpoint"]["lago_organization_id"]).to eq(webhook_endpoint.organization_id)
       expect(result["webhook_endpoint"]["webhook_url"]).to eq(webhook_endpoint.webhook_url)
+      expect(result["webhook_endpoint"]["created_at"]).to eq(webhook_endpoint.created_at.iso8601)
+      expect(result["webhook_endpoint"]["signature_algo"]).to eq(webhook_endpoint.signature_algo)
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

This PR fixes https://github.com/getlago/lago-python-client/issues/322

## Context

The [OpenAPI documentation](https://github.com/getlago/lago-openapi/blob/main/src/schemas/WebhookEndpointObject.yaml#L29) as well as the API SDKs are exposing a `webhook_enpoint.created_at` field, but the `WebhookEndpointSerializer` is not...

## Description

This PR adds the missing field