### PR TITLE
misc(organization): Not null constraint on i* models

### DIFF
--- a/app/models/integration_item.rb
+++ b/app/models/integration_item.rb
@@ -33,7 +33,7 @@ end
 #  updated_at            :datetime         not null
 #  external_id           :string           not null
 #  integration_id        :uuid             not null
-#  organization_id       :uuid
+#  organization_id       :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_resource.rb
+++ b/app/models/integration_resource.rb
@@ -23,7 +23,7 @@ end
 #  updated_at      :datetime         not null
 #  external_id     :string
 #  integration_id  :uuid
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #  syncable_id     :uuid             not null
 #
 # Indexes

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -114,7 +114,7 @@ end
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  invoice_id            :uuid             not null
-#  organization_id       :uuid
+#  organization_id       :uuid             not null
 #  subscription_id       :uuid             not null
 #
 # Indexes

--- a/db/migrate/20250707081825_organization_id_check_constaint_on_integration_items.rb
+++ b/db/migrate/20250707081825_organization_id_check_constaint_on_integration_items.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnIntegrationItems < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :integration_items,
+      "organization_id IS NOT NULL",
+      name: "integration_items_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707081826_not_null_organization_id_on_integration_items.rb
+++ b/db/migrate/20250707081826_not_null_organization_id_on_integration_items.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnIntegrationItems < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :integration_items, name: "integration_items_organization_id_null"
+    change_column_null :integration_items, :organization_id, false
+    remove_check_constraint :integration_items, name: "integration_items_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :integration_items, "organization_id IS NOT NULL", name: "integration_items_organization_id_null", validate: false
+    change_column_null :integration_items, :organization_id, true
+  end
+end

--- a/db/migrate/20250707081836_organization_id_check_constaint_on_integration_resources.rb
+++ b/db/migrate/20250707081836_organization_id_check_constaint_on_integration_resources.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnIntegrationResources < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :integration_resources,
+      "organization_id IS NOT NULL",
+      name: "integration_resources_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707081837_not_null_organization_id_on_integration_resources.rb
+++ b/db/migrate/20250707081837_not_null_organization_id_on_integration_resources.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnIntegrationResources < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :integration_resources, name: "integration_resources_organization_id_null"
+    change_column_null :integration_resources, :organization_id, false
+    remove_check_constraint :integration_resources, name: "integration_resources_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :integration_resources, "organization_id IS NOT NULL", name: "integration_resources_organization_id_null", validate: false
+    change_column_null :integration_resources, :organization_id, true
+  end
+end

--- a/db/migrate/20250707081910_organization_id_check_constaint_on_invoice_subscriptions.rb
+++ b/db/migrate/20250707081910_organization_id_check_constaint_on_invoice_subscriptions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnInvoiceSubscriptions < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :invoice_subscriptions,
+      "organization_id IS NOT NULL",
+      name: "invoice_subscriptions_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707081911_not_null_organization_id_on_invoice_subscriptions.rb
+++ b/db/migrate/20250707081911_not_null_organization_id_on_invoice_subscriptions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnInvoiceSubscriptions < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :invoice_subscriptions, name: "invoice_subscriptions_organization_id_null"
+    change_column_null :invoice_subscriptions, :organization_id, false
+    remove_check_constraint :invoice_subscriptions, name: "invoice_subscriptions_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :invoice_subscriptions, "organization_id IS NOT NULL", name: "invoice_subscriptions_organization_id_null", validate: false
+    change_column_null :invoice_subscriptions, :organization_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3165,7 +3165,7 @@ CREATE TABLE public.integration_items (
     external_name character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -3199,7 +3199,7 @@ CREATE TABLE public.integration_resources (
     updated_at timestamp(6) without time zone NOT NULL,
     integration_id uuid,
     resource_type integer DEFAULT 0 NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -3290,7 +3290,7 @@ CREATE TABLE public.invoice_subscriptions (
     charges_from_datetime timestamp(6) without time zone,
     charges_to_datetime timestamp(6) without time zone,
     invoicing_reason public.subscription_invoicing_reason,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -8916,6 +8916,12 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250707081911'),
+('20250707081910'),
+('20250707081837'),
+('20250707081836'),
+('20250707081826'),
+('20250707081825'),
 ('20250704800001'),
 ('20250703133126'),
 ('20250630180000'),


### PR DESCRIPTION
## Context

Let's continue with not null constraint on organization_id column after https://github.com/getlago/lago-api/pull/3879

## Description

This PR adds the not null constraint on new tables:
- `integration_items`
- `integration_resources`
- `invoice_subscriptions`