### PR TITLE
misc(organization): Not null constraint on p|r* models

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -119,7 +119,7 @@ end
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  invoice_id                   :uuid
-#  organization_id              :uuid
+#  organization_id              :uuid             not null
 #  payable_id                   :uuid
 #  payment_provider_customer_id :uuid
 #  payment_provider_id          :uuid

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -66,7 +66,7 @@ end
 #  trigger                             :integer          default("interval"), not null
 #  created_at                          :datetime         not null
 #  updated_at                          :datetime         not null
-#  organization_id                     :uuid
+#  organization_id                     :uuid             not null
 #  wallet_id                           :uuid             not null
 #
 # Indexes

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -21,7 +21,7 @@ end
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  credit_note_id               :uuid             not null
-#  organization_id              :uuid
+#  organization_id              :uuid             not null
 #  payment_id                   :uuid             not null
 #  payment_provider_customer_id :uuid             not null
 #  payment_provider_id          :uuid

--- a/db/migrate/20250707082435_organization_id_check_constaint_on_payments.rb
+++ b/db/migrate/20250707082435_organization_id_check_constaint_on_payments.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnPayments < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :payments,
+      "organization_id IS NOT NULL",
+      name: "payments_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707082436_not_null_organization_id_on_payments.rb
+++ b/db/migrate/20250707082436_not_null_organization_id_on_payments.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnPayments < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :payments, name: "payments_organization_id_null"
+    change_column_null :payments, :organization_id, false
+    remove_check_constraint :payments, name: "payments_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :payments, "organization_id IS NOT NULL", name: "payments_organization_id_null", validate: false
+    change_column_null :payments, :organization_id, true
+  end
+end

--- a/db/migrate/20250707082509_organization_id_check_constaint_on_recurring_transaction_rules.rb
+++ b/db/migrate/20250707082509_organization_id_check_constaint_on_recurring_transaction_rules.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnRecurringTransactionRules < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :recurring_transaction_rules,
+      "organization_id IS NOT NULL",
+      name: "recurring_transaction_rules_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707082510_not_null_organization_id_on_recurring_transaction_rules.rb
+++ b/db/migrate/20250707082510_not_null_organization_id_on_recurring_transaction_rules.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnRecurringTransactionRules < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :recurring_transaction_rules, name: "recurring_transaction_rules_organization_id_null"
+    change_column_null :recurring_transaction_rules, :organization_id, false
+    remove_check_constraint :recurring_transaction_rules, name: "recurring_transaction_rules_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :recurring_transaction_rules, "organization_id IS NOT NULL", name: "recurring_transaction_rules_organization_id_null", validate: false
+    change_column_null :recurring_transaction_rules, :organization_id, true
+  end
+end

--- a/db/migrate/20250707082520_organization_id_check_constaint_on_refunds.rb
+++ b/db/migrate/20250707082520_organization_id_check_constaint_on_refunds.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnRefunds < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :refunds,
+      "organization_id IS NOT NULL",
+      name: "refunds_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707082521_not_null_organization_id_on_refunds.rb
+++ b/db/migrate/20250707082521_not_null_organization_id_on_refunds.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnRefunds < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :refunds, name: "refunds_organization_id_null"
+    change_column_null :refunds, :organization_id, false
+    remove_check_constraint :refunds, name: "refunds_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :refunds, "organization_id IS NOT NULL", name: "refunds_organization_id_null", validate: false
+    change_column_null :refunds, :organization_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3483,7 +3483,7 @@ CREATE TABLE public.payments (
     reference character varying,
     provider_payment_method_data jsonb DEFAULT '{}'::jsonb NOT NULL,
     provider_payment_method_id character varying,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -3566,7 +3566,7 @@ CREATE TABLE public.recurring_transaction_rules (
     expiration_at timestamp(6) without time zone,
     terminated_at timestamp(6) without time zone,
     status integer DEFAULT 0,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -3586,7 +3586,7 @@ CREATE TABLE public.refunds (
     provider_refund_id character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -8916,6 +8916,12 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250707082521'),
+('20250707082520'),
+('20250707082510'),
+('20250707082509'),
+('20250707082436'),
+('20250707082435'),
 ('20250707081911'),
 ('20250707081910'),
 ('20250707081837'),


### PR DESCRIPTION
## Context

Let's continue with not null constraint on organization_id column after https://github.com/getlago/lago-api/pull/3879

## Description

This PR adds the not null constraint on new tables:
- `payments`
- `recurring_transaction_rules`
- `refunds`