### PR TITLE
misc(organization): Not null constraint on w* models

### DIFF
--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -82,7 +82,7 @@ end
 #  created_at                          :datetime         not null
 #  updated_at                          :datetime         not null
 #  customer_id                         :uuid             not null
-#  organization_id                     :uuid
+#  organization_id                     :uuid             not null
 #
 # Indexes
 #

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -78,7 +78,7 @@ end
 #  updated_at                          :datetime         not null
 #  credit_note_id                      :uuid
 #  invoice_id                          :uuid
-#  organization_id                     :uuid
+#  organization_id                     :uuid             not null
 #  wallet_id                           :uuid             not null
 #
 # Indexes

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -81,7 +81,7 @@ end
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  object_id           :uuid
-#  organization_id     :uuid
+#  organization_id     :uuid             not null
 #  webhook_endpoint_id :uuid
 #
 # Indexes

--- a/db/migrate/20250707083159_organization_id_check_constaint_on_wallets.rb
+++ b/db/migrate/20250707083159_organization_id_check_constaint_on_wallets.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnWallets < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :wallets,
+      "organization_id IS NOT NULL",
+      name: "wallets_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707083160_not_null_organization_id_on_wallets.rb
+++ b/db/migrate/20250707083160_not_null_organization_id_on_wallets.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnWallets < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :wallets, name: "wallets_organization_id_null"
+    change_column_null :wallets, :organization_id, false
+    remove_check_constraint :wallets, name: "wallets_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :wallets, "organization_id IS NOT NULL", name: "wallets_organization_id_null", validate: false
+    change_column_null :wallets, :organization_id, true
+  end
+end

--- a/db/migrate/20250707083210_organization_id_check_constaint_on_wallet_transactions.rb
+++ b/db/migrate/20250707083210_organization_id_check_constaint_on_wallet_transactions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnWalletTransactions < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :wallet_transactions,
+      "organization_id IS NOT NULL",
+      name: "wallet_transactions_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707083211_not_null_organization_id_on_wallet_transactions.rb
+++ b/db/migrate/20250707083211_not_null_organization_id_on_wallet_transactions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnWalletTransactions < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :wallet_transactions, name: "wallet_transactions_organization_id_null"
+    change_column_null :wallet_transactions, :organization_id, false
+    remove_check_constraint :wallet_transactions, name: "wallet_transactions_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :wallet_transactions, "organization_id IS NOT NULL", name: "wallet_transactions_organization_id_null", validate: false
+    change_column_null :wallet_transactions, :organization_id, true
+  end
+end

--- a/db/migrate/20250707083221_organization_id_check_constaint_on_webhooks.rb
+++ b/db/migrate/20250707083221_organization_id_check_constaint_on_webhooks.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnWebhooks < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :webhooks,
+      "organization_id IS NOT NULL",
+      name: "webhooks_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707083222_not_null_organization_id_on_webhooks.rb
+++ b/db/migrate/20250707083222_not_null_organization_id_on_webhooks.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnWebhooks < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :webhooks, name: "webhooks_organization_id_null"
+    change_column_null :webhooks, :organization_id, false
+    remove_check_constraint :webhooks, name: "webhooks_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :webhooks, "organization_id IS NOT NULL", name: "webhooks_organization_id_null", validate: false
+    change_column_null :webhooks, :organization_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2908,7 +2908,7 @@ CREATE TABLE public.wallet_transactions (
     metadata jsonb DEFAULT '[]'::jsonb,
     credit_note_id uuid,
     failed_at timestamp(6) without time zone,
-    organization_id uuid,
+    organization_id uuid NOT NULL,
     lock_version integer DEFAULT 0 NOT NULL
 );
 
@@ -2986,7 +2986,7 @@ CREATE TABLE public.wallets (
     invoice_requires_successful_payment boolean DEFAULT false NOT NULL,
     lock_version integer DEFAULT 0 NOT NULL,
     ready_to_be_refreshed boolean DEFAULT false NOT NULL,
-    organization_id uuid,
+    organization_id uuid NOT NULL,
     allowed_fee_types character varying[] DEFAULT '{}'::character varying[] NOT NULL,
     last_ongoing_balance_sync_at timestamp without time zone
 );
@@ -3785,7 +3785,7 @@ CREATE TABLE public.webhooks (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     webhook_endpoint_id uuid,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -8916,6 +8916,12 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250707083222'),
+('20250707083221'),
+('20250707083211'),
+('20250707083210'),
+('20250707083160'),
+('20250707083159'),
 ('20250707082521'),
 ('20250707082520'),
 ('20250707082510'),


### PR DESCRIPTION
## Context

Let's continue with not null constraint on organization_id column after https://github.com/getlago/lago-api/pull/3879

## Description

This PR adds the not null constraint on new tables:
- `wallets`
- `wallet_transactions`
- `webhooks`