### PR TITLE
chore(naming): Rename `pay_in_arrear` to `pay_in_arrears`

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -55,7 +55,7 @@ class Plan < ApplicationRecord
     %w[name code]
   end
 
-  def pay_in_arrear?
+  def pay_in_arrears?
     !pay_in_advance
   end
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -200,7 +200,7 @@ module Invoices
         (
           subscription.terminated? &&
           (
-            subscription.plan.pay_in_arrear? ||
+            subscription.plan.pay_in_arrears? ||
             subscription.terminated_at >= invoice.created_at ||
             calculate_true_up_fee_result.amount_cents.positive?
           )
@@ -224,7 +224,7 @@ module Invoices
       #       fee if the plan is in pay in arrears, otherwise this fee will never
       #       be created.
       subscription.active? ||
-        (subscription.terminated? && subscription.plan.pay_in_arrear?) ||
+        (subscription.terminated? && subscription.plan.pay_in_arrears?) ||
         (subscription.terminated? && subscription.terminated_at > invoice.created_at)
     end
 
@@ -245,7 +245,7 @@ module Invoices
         return !date_service(subscription).first_month_in_first_yearly_period? && date_service(subscription).first_month_in_yearly_period?
       end
 
-      if subscription.plan.pay_in_arrear?
+      if subscription.plan.pay_in_arrears?
         return subscription.terminated? || date_service(subscription).first_month_in_yearly_period?
       end
 

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -287,7 +287,7 @@ module Invoices
     def should_create_subscription_fee?(subscription)
       return true if subscription_context == :default
 
-      subscription.terminated? == subscription.plan.pay_in_arrear?
+      subscription.terminated? == subscription.plan.pay_in_arrears?
     end
 
     def should_not_create_charge_fee?(charge, subscription)

--- a/app/services/subscriptions/dates/monthly_service.rb
+++ b/app/services/subscriptions/dates/monthly_service.rb
@@ -4,7 +4,7 @@ module Subscriptions
   module Dates
     class MonthlyService < Subscriptions::DatesService
       def compute_from_date(date = base_date)
-        if plan.pay_in_advance? || terminated_pay_in_arrear?
+        if plan.pay_in_advance? || terminated_pay_in_arrears?
           return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_month
         end
 
@@ -16,7 +16,7 @@ module Subscriptions
           return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_month
         end
 
-        return compute_from_date if plan.pay_in_arrear?
+        return compute_from_date if plan.pay_in_arrears?
         return base_date.beginning_of_month if calendar?
 
         previous_anniversary_day(base_date)

--- a/app/services/subscriptions/dates/quarterly_service.rb
+++ b/app/services/subscriptions/dates/quarterly_service.rb
@@ -6,7 +6,7 @@ module Subscriptions
       private
 
       def compute_from_date(date = base_date)
-        if plan.pay_in_advance? || terminated_pay_in_arrear?
+        if plan.pay_in_advance? || terminated_pay_in_arrears?
           return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_quarter
         end
 
@@ -18,7 +18,7 @@ module Subscriptions
           return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_quarter
         end
 
-        return compute_from_date if plan.pay_in_arrear?
+        return compute_from_date if plan.pay_in_arrears?
         return base_date.beginning_of_quarter if calendar?
 
         previous_anniversary_day(base_date)
@@ -148,7 +148,7 @@ module Subscriptions
       def should_find_previous_billing_date?(date, billing_months, day)
         return false if last_day_of_month?(date) && last_day_of_month?(subscription_at)
 
-        return true if date.day < day && terminated_pay_in_arrear?
+        return true if date.day < day && terminated_pay_in_arrears?
         return true if (date.day + 1) < day && last_day_of_month?(subscription_at)
         return true if date.day < day && !last_day_of_month?(subscription_at)
         return true if billing_months.exclude?(date.month)

--- a/app/services/subscriptions/dates/weekly_service.rb
+++ b/app/services/subscriptions/dates/weekly_service.rb
@@ -12,7 +12,7 @@ module Subscriptions
       end
 
       def compute_from_date
-        if plan.pay_in_advance? || terminated_pay_in_arrear?
+        if plan.pay_in_advance? || terminated_pay_in_arrears?
           return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_week
         end
 
@@ -31,7 +31,7 @@ module Subscriptions
           return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_week
         end
 
-        return compute_from_date if plan.pay_in_arrear?
+        return compute_from_date if plan.pay_in_arrears?
         return base_date.beginning_of_week if calendar?
 
         previous_anniversary_day(base_date)

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -27,7 +27,7 @@ module Subscriptions
       end
 
       def compute_from_date
-        if plan.pay_in_advance? || terminated_pay_in_arrear?
+        if plan.pay_in_advance? || terminated_pay_in_arrears?
           return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_year
         end
 
@@ -51,7 +51,7 @@ module Subscriptions
           return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_year
         end
 
-        return compute_from_date if plan.pay_in_arrear?
+        return compute_from_date if plan.pay_in_arrears?
         return base_date.beginning_of_year if calendar?
 
         previous_anniversary_day(base_date)

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -185,10 +185,10 @@ module Subscriptions
       last_invoice_subscription.charges_to_datetime
     end
 
-    def terminated_pay_in_arrear?
+    def terminated_pay_in_arrears?
       # NOTE: In case of termination or upgrade when we are terminating old plan (paying in arrear),
       #       we should take to the beginning of the billing period
-      subscription.terminated_at?(billing_at) && plan.pay_in_arrear? && !subscription.downgraded?
+      subscription.terminated_at?(billing_at) && plan.pay_in_arrears? && !subscription.downgraded?
     end
 
     def terminated?

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
     pay_in_advance { false }
     amount_cents { 100 }
     amount_currency { "EUR" }
+
+    trait :pay_in_advance do
+      pay_in_advance { true }
+    end
   end
 end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Plan, type: :model do
     end
   end
 
-  describe ".has_trial?" do
+  describe "#has_trial?" do
     it "returns true when trial_period" do
       expect(plan).to have_trial
     end
@@ -59,7 +59,7 @@ RSpec.describe Plan, type: :model do
     end
   end
 
-  describe ".yearly_amount_cents" do
+  describe "#yearly_amount_cents" do
     let(:plan) do
       build(:plan, interval: :yearly, amount_cents: 100)
     end
@@ -145,6 +145,20 @@ RSpec.describe Plan, type: :model do
       create(:invoice_subscription, invoice: invoice2, subscription: subscription2)
 
       expect(plan.draft_invoices_count).to eq(2)
+    end
+  end
+
+  describe "#pay_in_arrears?" do
+    context "when pay_in_advance is true" do
+      let(:plan) { build(:plan, :pay_in_advance) }
+
+      it { expect(plan.pay_in_arrears?).to be(false) }
+    end
+
+    context "when pay_in_advance is false" do
+      let(:plan) { build(:plan) }
+
+      it { expect(plan.pay_in_arrears?).to be(true) }
     end
   end
 end


### PR DESCRIPTION
## Context

While working on a feature, Cursor generated code with the `pay_in_arrears` naming and failed to match the rest of the codebase which uses the incorrect `pay_in_arrear` naming.

## Description

This commit fixes the naming in the whole codebase and adds a test for `Plan#pay_in_arrears?`.

