### PR TITLE
misc(organization): Not null constraint on *_taxes models

### DIFF
--- a/app/models/add_on/applied_tax.rb
+++ b/app/models/add_on/applied_tax.rb
@@ -18,7 +18,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  add_on_id       :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #  tax_id          :uuid             not null
 #
 # Indexes

--- a/app/models/fee/applied_tax.rb
+++ b/app/models/fee/applied_tax.rb
@@ -27,7 +27,7 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  fee_id               :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #  tax_id               :uuid
 #
 # Indexes

--- a/app/models/invoice/applied_tax.rb
+++ b/app/models/invoice/applied_tax.rb
@@ -50,7 +50,7 @@ end
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  invoice_id                :uuid             not null
-#  organization_id           :uuid
+#  organization_id           :uuid             not null
 #  tax_id                    :uuid
 #
 # Indexes

--- a/app/models/plan/applied_tax.rb
+++ b/app/models/plan/applied_tax.rb
@@ -19,7 +19,7 @@ end
 #  id              :uuid             not null, primary key
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #  plan_id         :uuid             not null
 #  tax_id          :uuid             not null
 #

--- a/db/migrate/20250707085614_organization_id_check_constaint_on_fees_taxes.rb
+++ b/db/migrate/20250707085614_organization_id_check_constaint_on_fees_taxes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnFeesTaxes < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :fees_taxes,
+      "organization_id IS NOT NULL",
+      name: "fees_taxes_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707085615_not_null_organization_id_on_fees_taxes.rb
+++ b/db/migrate/20250707085615_not_null_organization_id_on_fees_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnFeesTaxes < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :fees_taxes, name: "fees_taxes_organization_id_null"
+    change_column_null :fees_taxes, :organization_id, false
+    remove_check_constraint :fees_taxes, name: "fees_taxes_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :fees_taxes, "organization_id IS NOT NULL", name: "fees_taxes_organization_id_null", validate: false
+    change_column_null :fees_taxes, :organization_id, true
+  end
+end

--- a/db/migrate/20250707085633_organization_id_check_constaint_on_plans_taxes.rb
+++ b/db/migrate/20250707085633_organization_id_check_constaint_on_plans_taxes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnPlansTaxes < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :plans_taxes,
+      "organization_id IS NOT NULL",
+      name: "plans_taxes_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707085634_not_null_organization_id_on_plans_taxes.rb
+++ b/db/migrate/20250707085634_not_null_organization_id_on_plans_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnPlansTaxes < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :plans_taxes, name: "plans_taxes_organization_id_null"
+    change_column_null :plans_taxes, :organization_id, false
+    remove_check_constraint :plans_taxes, name: "plans_taxes_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :plans_taxes, "organization_id IS NOT NULL", name: "plans_taxes_organization_id_null", validate: false
+    change_column_null :plans_taxes, :organization_id, true
+  end
+end

--- a/db/migrate/20250707085650_organization_id_check_constaint_on_add_ons_taxes.rb
+++ b/db/migrate/20250707085650_organization_id_check_constaint_on_add_ons_taxes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnAddOnsTaxes < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :add_ons_taxes,
+      "organization_id IS NOT NULL",
+      name: "add_ons_taxes_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707085651_not_null_organization_id_on_add_ons_taxes.rb
+++ b/db/migrate/20250707085651_not_null_organization_id_on_add_ons_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnAddOnsTaxes < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :add_ons_taxes, name: "add_ons_taxes_organization_id_null"
+    change_column_null :add_ons_taxes, :organization_id, false
+    remove_check_constraint :add_ons_taxes, name: "add_ons_taxes_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :add_ons_taxes, "organization_id IS NOT NULL", name: "add_ons_taxes_organization_id_null", validate: false
+    change_column_null :add_ons_taxes, :organization_id, true
+  end
+end

--- a/db/migrate/20250707085724_organization_id_check_constaint_on_invoices_taxes.rb
+++ b/db/migrate/20250707085724_organization_id_check_constaint_on_invoices_taxes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnInvoicesTaxes < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :invoices_taxes,
+      "organization_id IS NOT NULL",
+      name: "invoices_taxes_organization_id_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707085725_not_null_organization_id_on_invoices_taxes.rb
+++ b/db/migrate/20250707085725_not_null_organization_id_on_invoices_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnInvoicesTaxes < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :invoices_taxes, name: "invoices_taxes_organization_id_null"
+    change_column_null :invoices_taxes, :organization_id, false
+    remove_check_constraint :invoices_taxes, name: "invoices_taxes_organization_id_null"
+  end
+
+  def down
+    add_check_constraint :invoices_taxes, "organization_id IS NOT NULL", name: "invoices_taxes_organization_id_null", validate: false
+    change_column_null :invoices_taxes, :organization_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1115,7 +1115,7 @@ CREATE TABLE public.add_ons_taxes (
     tax_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -2565,7 +2565,7 @@ CREATE TABLE public.fees_taxes (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     precise_amount_cents numeric(40,15) DEFAULT 0.0 NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -2742,7 +2742,7 @@ CREATE TABLE public.invoices_taxes (
     updated_at timestamp(6) without time zone NOT NULL,
     fees_amount_cents bigint DEFAULT 0 NOT NULL,
     taxable_base_amount_cents bigint DEFAULT 0 NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -2777,7 +2777,7 @@ CREATE TABLE public.plans_taxes (
     tax_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -8916,6 +8916,14 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250707085725'),
+('20250707085724'),
+('20250707085651'),
+('20250707085650'),
+('20250707085634'),
+('20250707085633'),
+('20250707085615'),
+('20250707085614'),
 ('20250707083222'),
 ('20250707083221'),
 ('20250707083211'),


### PR DESCRIPTION
## Context

Let's continue with not null constraint on organization_id column after https://github.com/getlago/lago-api/pull/3879

## Description

This PR adds the not null constraint on new tables:
- `add_ons_taxes`
- `fees_taxes`
- `invoices_taxes`
- `plans_taxes`