### PR TITLE
misc(organization): Not null constraint on integrations_* models

### DIFF
--- a/app/models/integration_collection_mappings/anrok_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/anrok_collection_mapping.rb
@@ -16,7 +16,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  integration_id  :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_collection_mappings/avalara_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/avalara_collection_mapping.rb
@@ -16,7 +16,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  integration_id  :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_collection_mappings/base_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/base_collection_mapping.rb
@@ -33,7 +33,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  integration_id  :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_collection_mappings/netsuite_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/netsuite_collection_mapping.rb
@@ -17,7 +17,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  integration_id  :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_collection_mappings/xero_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/xero_collection_mapping.rb
@@ -16,7 +16,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  integration_id  :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_customers/anrok_customer.rb
+++ b/app/models/integration_customers/anrok_customer.rb
@@ -17,7 +17,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_customers/avalara_customer.rb
+++ b/app/models/integration_customers/avalara_customer.rb
@@ -17,7 +17,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -87,7 +87,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_customers/hubspot_customer.rb
+++ b/app/models/integration_customers/hubspot_customer.rb
@@ -26,7 +26,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_customers/netsuite_customer.rb
+++ b/app/models/integration_customers/netsuite_customer.rb
@@ -18,7 +18,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_customers/salesforce_customer.rb
+++ b/app/models/integration_customers/salesforce_customer.rb
@@ -17,7 +17,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_customers/xero_customer.rb
+++ b/app/models/integration_customers/xero_customer.rb
@@ -17,7 +17,7 @@ end
 #  customer_id          :uuid             not null
 #  external_customer_id :string
 #  integration_id       :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_mappings/anrok_mapping.rb
+++ b/app/models/integration_mappings/anrok_mapping.rb
@@ -17,7 +17,7 @@ end
 #  updated_at      :datetime         not null
 #  integration_id  :uuid             not null
 #  mappable_id     :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_mappings/avalara_mapping.rb
+++ b/app/models/integration_mappings/avalara_mapping.rb
@@ -17,7 +17,7 @@ end
 #  updated_at      :datetime         not null
 #  integration_id  :uuid             not null
 #  mappable_id     :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_mappings/base_mapping.rb
+++ b/app/models/integration_mappings/base_mapping.rb
@@ -29,7 +29,7 @@ end
 #  updated_at      :datetime         not null
 #  integration_id  :uuid             not null
 #  mappable_id     :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_mappings/netsuite_mapping.rb
+++ b/app/models/integration_mappings/netsuite_mapping.rb
@@ -17,7 +17,7 @@ end
 #  updated_at      :datetime         not null
 #  integration_id  :uuid             not null
 #  mappable_id     :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/integration_mappings/xero_mapping.rb
+++ b/app/models/integration_mappings/xero_mapping.rb
@@ -17,7 +17,7 @@ end
 #  updated_at      :datetime         not null
 #  integration_id  :uuid             not null
 #  mappable_id     :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/db/migrate/20250707090313_organization_id_check_constaint_on_integration_mappings.rb
+++ b/db/migrate/20250707090313_organization_id_check_constaint_on_integration_mappings.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnIntegrationMappings < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :integration_mappings,
+      "organization_id IS NOT NULL",
+      name: "integration_mappings_organization_id_not_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707090314_not_null_organization_id_on_integration_mappings.rb
+++ b/db/migrate/20250707090314_not_null_organization_id_on_integration_mappings.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnIntegrationMappings < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :integration_mappings, name: "integration_mappings_organization_id_not_null"
+    change_column_null :integration_mappings, :organization_id, false
+    remove_check_constraint :integration_mappings, name: "integration_mappings_organization_id_not_null"
+  end
+
+  def down
+    add_check_constraint :integration_mappings, "organization_id IS NOT NULL", name: "integration_mappings_organization_id_not_null", validate: false
+    change_column_null :integration_mappings, :organization_id, true
+  end
+end

--- a/db/migrate/20250707090328_organization_id_check_constaint_on_integration_customers.rb
+++ b/db/migrate/20250707090328_organization_id_check_constaint_on_integration_customers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnIntegrationCustomers < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :integration_customers,
+      "organization_id IS NOT NULL",
+      name: "integration_customers_organization_id_not_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707090329_not_null_organization_id_on_integration_customers.rb
+++ b/db/migrate/20250707090329_not_null_organization_id_on_integration_customers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnIntegrationCustomers < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :integration_customers, name: "integration_customers_organization_id_not_null"
+    change_column_null :integration_customers, :organization_id, false
+    remove_check_constraint :integration_customers, name: "integration_customers_organization_id_not_null"
+  end
+
+  def down
+    add_check_constraint :integration_customers, "organization_id IS NOT NULL", name: "integration_customers_organization_id_not_null", validate: false
+    change_column_null :integration_customers, :organization_id, true
+  end
+end

--- a/db/migrate/20250707090347_organization_id_check_constaint_on_integration_collection_mappings.rb
+++ b/db/migrate/20250707090347_organization_id_check_constaint_on_integration_collection_mappings.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnIntegrationCollectionMappings < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :integration_collection_mappings,
+      "organization_id IS NOT NULL",
+      name: "integration_collection_mappings_organization_id_not_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707090348_not_null_organization_id_on_integration_collection_mappings.rb
+++ b/db/migrate/20250707090348_not_null_organization_id_on_integration_collection_mappings.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnIntegrationCollectionMappings < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :integration_collection_mappings, name: "integration_collection_mappings_organization_id_not_null"
+    change_column_null :integration_collection_mappings, :organization_id, false
+    remove_check_constraint :integration_collection_mappings, name: "integration_collection_mappings_organization_id_not_null"
+  end
+
+  def down
+    add_check_constraint :integration_collection_mappings, "organization_id IS NOT NULL", name: "integration_collection_mappings_organization_id_not_null", validate: false
+    change_column_null :integration_collection_mappings, :organization_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3131,7 +3131,7 @@ CREATE TABLE public.integration_collection_mappings (
     settings jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -3148,7 +3148,7 @@ CREATE TABLE public.integration_customers (
     settings jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -3182,7 +3182,7 @@ CREATE TABLE public.integration_mappings (
     settings jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -8916,6 +8916,12 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250707090348'),
+('20250707090347'),
+('20250707090329'),
+('20250707090328'),
+('20250707090314'),
+('20250707090313'),
 ('20250707085725'),
 ('20250707085724'),
 ('20250707085651'),

--- a/lib/generators/not_null_organization_id/templates/not_null_organization_id.rb.erb
+++ b/lib/generators/not_null_organization_id/templates/not_null_organization_id.rb.erb
@@ -2,13 +2,13 @@
 
 class NotNullOrganizationIdOn<%= class_name %> < ActiveRecord::Migration[8.0]
   def up
-    validate_check_constraint :<%= file_name %>, name: "<%= file_name %>_organization_id_null"
+    validate_check_constraint :<%= file_name %>, name: "<%= file_name %>_organization_id_not_null"
     change_column_null :<%= file_name %>, :organization_id, false
-    remove_check_constraint :<%= file_name %>, name: "<%= file_name %>_organization_id_null"
+    remove_check_constraint :<%= file_name %>, name: "<%= file_name %>_organization_id_not_null"
   end
 
   def down
-    add_check_constraint :<%= file_name %>, "organization_id IS NOT NULL", name: "<%= file_name %>_organization_id_null", validate: false
+    add_check_constraint :<%= file_name %>, "organization_id IS NOT NULL", name: "<%= file_name %>_organization_id_not_null", validate: false
     change_column_null :<%= file_name %>, :organization_id, true
   end
 end

--- a/lib/generators/not_null_organization_id/templates/organization_id_check_constaint.rb.erb
+++ b/lib/generators/not_null_organization_id/templates/organization_id_check_constaint.rb.erb
@@ -4,7 +4,7 @@ class OrganizationIdCheckConstaintOn<%= class_name %> < ActiveRecord::Migration[
   def change
     add_check_constraint :<%= file_name %>,
       "organization_id IS NOT NULL",
-      name: "<%= file_name %>_organization_id_null",
+      name: "<%= file_name %>_organization_id_not_null",
       validate: false
   end
 end


### PR DESCRIPTION
## Context

Let's continue with not null constraint on organization_id column after https://github.com/getlago/lago-api/pull/3879

## Description

This PR adds the not null constraint on new tables:
- `integration_collection_mappings`
- `integration_customers`
- `integration_mappings`