### PR TITLE
misc(organization): Not null constraint on i|u_* models

### DIFF
--- a/app/models/metadata/invoice_metadata.rb
+++ b/app/models/metadata/invoice_metadata.rb
@@ -22,7 +22,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  invoice_id      :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/payment_request/applied_invoice.rb
+++ b/app/models/payment_request/applied_invoice.rb
@@ -18,7 +18,7 @@ end
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  invoice_id         :uuid             not null
-#  organization_id    :uuid
+#  organization_id    :uuid             not null
 #  payment_request_id :uuid             not null
 #
 # Indexes

--- a/app/models/usage_threshold.rb
+++ b/app/models/usage_threshold.rb
@@ -39,7 +39,7 @@ end
 #  threshold_display_name :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  organization_id        :uuid
+#  organization_id        :uuid             not null
 #  plan_id                :uuid             not null
 #
 # Indexes

--- a/db/migrate/20250707094900_organization_id_check_constaint_on_invoice_metadata.rb
+++ b/db/migrate/20250707094900_organization_id_check_constaint_on_invoice_metadata.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnInvoiceMetadata < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :invoice_metadata,
+      "organization_id IS NOT NULL",
+      name: "invoice_metadata_organization_id_not_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707094901_not_null_organization_id_on_invoice_metadata.rb
+++ b/db/migrate/20250707094901_not_null_organization_id_on_invoice_metadata.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnInvoiceMetadata < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :invoice_metadata, name: "invoice_metadata_organization_id_not_null"
+    change_column_null :invoice_metadata, :organization_id, false
+    remove_check_constraint :invoice_metadata, name: "invoice_metadata_organization_id_not_null"
+  end
+
+  def down
+    add_check_constraint :invoice_metadata, "organization_id IS NOT NULL", name: "invoice_metadata_organization_id_not_null", validate: false
+    change_column_null :invoice_metadata, :organization_id, true
+  end
+end

--- a/db/migrate/20250707094931_organization_id_check_constaint_on_invoices_payment_requests.rb
+++ b/db/migrate/20250707094931_organization_id_check_constaint_on_invoices_payment_requests.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnInvoicesPaymentRequests < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :invoices_payment_requests,
+      "organization_id IS NOT NULL",
+      name: "invoices_payment_requests_organization_id_not_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707094932_not_null_organization_id_on_invoices_payment_requests.rb
+++ b/db/migrate/20250707094932_not_null_organization_id_on_invoices_payment_requests.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnInvoicesPaymentRequests < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :invoices_payment_requests, name: "invoices_payment_requests_organization_id_not_null"
+    change_column_null :invoices_payment_requests, :organization_id, false
+    remove_check_constraint :invoices_payment_requests, name: "invoices_payment_requests_organization_id_not_null"
+  end
+
+  def down
+    add_check_constraint :invoices_payment_requests, "organization_id IS NOT NULL", name: "invoices_payment_requests_organization_id_not_null", validate: false
+    change_column_null :invoices_payment_requests, :organization_id, true
+  end
+end

--- a/db/migrate/20250707095223_organization_id_check_constaint_on_usage_thresholds.rb
+++ b/db/migrate/20250707095223_organization_id_check_constaint_on_usage_thresholds.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnUsageThresholds < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :usage_thresholds,
+      "organization_id IS NOT NULL",
+      name: "usage_thresholds_organization_id_not_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707095224_not_null_organization_id_on_usage_thresholds.rb
+++ b/db/migrate/20250707095224_not_null_organization_id_on_usage_thresholds.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnUsageThresholds < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :usage_thresholds, name: "usage_thresholds_organization_id_not_null"
+    change_column_null :usage_thresholds, :organization_id, false
+    remove_check_constraint :usage_thresholds, name: "usage_thresholds_organization_id_not_null"
+  end
+
+  def down
+    add_check_constraint :usage_thresholds, "organization_id IS NOT NULL", name: "usage_thresholds_organization_id_not_null", validate: false
+    change_column_null :usage_thresholds, :organization_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2600,7 +2600,7 @@ CREATE TABLE public.invoice_metadata (
     value character varying NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -3304,7 +3304,7 @@ CREATE TABLE public.invoices_payment_requests (
     payment_request_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -3699,7 +3699,7 @@ CREATE TABLE public.usage_thresholds (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -8916,6 +8916,12 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250707095224'),
+('20250707095223'),
+('20250707094932'),
+('20250707094931'),
+('20250707094901'),
+('20250707094900'),
 ('20250707090348'),
 ('20250707090347'),
 ('20250707090329'),


### PR DESCRIPTION
## Context

Let's continue with not null constraint on organization_id column after https://github.com/getlago/lago-api/pull/3879

## Description

This PR adds the not null constraint on new tables:
- `invoice_metadata`
- `invoices_payment_requests`
- `usage_threshold`