### PR TITLE
misc(organization): Not null constraint on remaining models

### DIFF
--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -42,7 +42,7 @@ end
 #  fee_id                    :uuid
 #  group_id                  :uuid
 #  invoice_id                :uuid             not null
-#  organization_id           :uuid
+#  organization_id           :uuid             not null
 #  subscription_id           :uuid
 #
 # Indexes

--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -59,7 +59,7 @@ end
 #  updated_at                   :datetime         not null
 #  coupon_id                    :uuid             not null
 #  customer_id                  :uuid             not null
-#  organization_id              :uuid
+#  organization_id              :uuid             not null
 #
 # Indexes
 #

--- a/app/models/applied_invoice_custom_section.rb
+++ b/app/models/applied_invoice_custom_section.rb
@@ -17,7 +17,7 @@ end
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  invoice_id      :uuid             not null
-#  organization_id :uuid
+#  organization_id :uuid             not null
 #
 # Indexes
 #

--- a/app/models/payment_provider_customers/adyen_customer.rb
+++ b/app/models/payment_provider_customers/adyen_customer.rb
@@ -17,7 +17,7 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  customer_id          :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #  payment_provider_id  :uuid
 #  provider_customer_id :string
 #

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -48,7 +48,7 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  customer_id          :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #  payment_provider_id  :uuid
 #  provider_customer_id :string
 #

--- a/app/models/payment_provider_customers/cashfree_customer.rb
+++ b/app/models/payment_provider_customers/cashfree_customer.rb
@@ -19,7 +19,7 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  customer_id          :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #  payment_provider_id  :uuid
 #  provider_customer_id :string
 #

--- a/app/models/payment_provider_customers/gocardless_customer.rb
+++ b/app/models/payment_provider_customers/gocardless_customer.rb
@@ -16,7 +16,7 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  customer_id          :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #  payment_provider_id  :uuid
 #  provider_customer_id :string
 #

--- a/app/models/payment_provider_customers/moneyhash_customer.rb
+++ b/app/models/payment_provider_customers/moneyhash_customer.rb
@@ -54,7 +54,7 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  customer_id          :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #  payment_provider_id  :uuid
 #  provider_customer_id :string
 #

--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -59,7 +59,7 @@ end
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #  customer_id          :uuid             not null
-#  organization_id      :uuid
+#  organization_id      :uuid             not null
 #  payment_provider_id  :uuid
 #  provider_customer_id :string
 #

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -244,7 +244,7 @@ end
 #  updated_at               :datetime         not null
 #  customer_id              :uuid             not null
 #  external_id              :string           not null
-#  organization_id          :uuid
+#  organization_id          :uuid             not null
 #  plan_id                  :uuid             not null
 #  previous_subscription_id :uuid
 #

--- a/db/migrate/20250707095955_organization_id_check_constaint_on_subscriptions.rb
+++ b/db/migrate/20250707095955_organization_id_check_constaint_on_subscriptions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnSubscriptions < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :subscriptions,
+      "organization_id IS NOT NULL",
+      name: "subscriptions_organization_id_not_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707095956_not_null_organization_id_on_subscriptions.rb
+++ b/db/migrate/20250707095956_not_null_organization_id_on_subscriptions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnSubscriptions < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :subscriptions, name: "subscriptions_organization_id_not_null"
+    change_column_null :subscriptions, :organization_id, false
+    remove_check_constraint :subscriptions, name: "subscriptions_organization_id_not_null"
+  end
+
+  def down
+    add_check_constraint :subscriptions, "organization_id IS NOT NULL", name: "subscriptions_organization_id_not_null", validate: false
+    change_column_null :subscriptions, :organization_id, true
+  end
+end

--- a/db/migrate/20250707100012_organization_id_check_constaint_on_adjusted_fees.rb
+++ b/db/migrate/20250707100012_organization_id_check_constaint_on_adjusted_fees.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnAdjustedFees < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :adjusted_fees,
+      "organization_id IS NOT NULL",
+      name: "adjusted_fees_organization_id_not_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707100013_not_null_organization_id_on_adjusted_fees.rb
+++ b/db/migrate/20250707100013_not_null_organization_id_on_adjusted_fees.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnAdjustedFees < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :adjusted_fees, name: "adjusted_fees_organization_id_not_null"
+    change_column_null :adjusted_fees, :organization_id, false
+    remove_check_constraint :adjusted_fees, name: "adjusted_fees_organization_id_not_null"
+  end
+
+  def down
+    add_check_constraint :adjusted_fees, "organization_id IS NOT NULL", name: "adjusted_fees_organization_id_not_null", validate: false
+    change_column_null :adjusted_fees, :organization_id, true
+  end
+end

--- a/db/migrate/20250707100025_organization_id_check_constaint_on_applied_coupons.rb
+++ b/db/migrate/20250707100025_organization_id_check_constaint_on_applied_coupons.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnAppliedCoupons < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :applied_coupons,
+      "organization_id IS NOT NULL",
+      name: "applied_coupons_organization_id_not_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707100026_not_null_organization_id_on_applied_coupons.rb
+++ b/db/migrate/20250707100026_not_null_organization_id_on_applied_coupons.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnAppliedCoupons < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :applied_coupons, name: "applied_coupons_organization_id_not_null"
+    change_column_null :applied_coupons, :organization_id, false
+    remove_check_constraint :applied_coupons, name: "applied_coupons_organization_id_not_null"
+  end
+
+  def down
+    add_check_constraint :applied_coupons, "organization_id IS NOT NULL", name: "applied_coupons_organization_id_not_null", validate: false
+    change_column_null :applied_coupons, :organization_id, true
+  end
+end

--- a/db/migrate/20250707100101_organization_id_check_constaint_on_payment_provider_customers.rb
+++ b/db/migrate/20250707100101_organization_id_check_constaint_on_payment_provider_customers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnPaymentProviderCustomers < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :payment_provider_customers,
+      "organization_id IS NOT NULL",
+      name: "payment_provider_customers_organization_id_not_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707100102_not_null_organization_id_on_payment_provider_customers.rb
+++ b/db/migrate/20250707100102_not_null_organization_id_on_payment_provider_customers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnPaymentProviderCustomers < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :payment_provider_customers, name: "payment_provider_customers_organization_id_not_null"
+    change_column_null :payment_provider_customers, :organization_id, false
+    remove_check_constraint :payment_provider_customers, name: "payment_provider_customers_organization_id_not_null"
+  end
+
+  def down
+    add_check_constraint :payment_provider_customers, "organization_id IS NOT NULL", name: "payment_provider_customers_organization_id_not_null", validate: false
+    change_column_null :payment_provider_customers, :organization_id, true
+  end
+end

--- a/db/migrate/20250707113717_organization_id_check_constaint_on_applied_invoice_custom_sections.rb
+++ b/db/migrate/20250707113717_organization_id_check_constaint_on_applied_invoice_custom_sections.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OrganizationIdCheckConstaintOnAppliedInvoiceCustomSections < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :applied_invoice_custom_sections,
+      "organization_id IS NOT NULL",
+      name: "applied_invoice_custom_sections_organization_id_not_null",
+      validate: false
+  end
+end

--- a/db/migrate/20250707113718_not_null_organization_id_on_applied_invoice_custom_sections.rb
+++ b/db/migrate/20250707113718_not_null_organization_id_on_applied_invoice_custom_sections.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class NotNullOrganizationIdOnAppliedInvoiceCustomSections < ActiveRecord::Migration[8.0]
+  def up
+    validate_check_constraint :applied_invoice_custom_sections, name: "applied_invoice_custom_sections_organization_id_not_null"
+    change_column_null :applied_invoice_custom_sections, :organization_id, false
+    remove_check_constraint :applied_invoice_custom_sections, name: "applied_invoice_custom_sections_organization_id_not_null"
+  end
+
+  def down
+    add_check_constraint :applied_invoice_custom_sections, "organization_id IS NOT NULL", name: "applied_invoice_custom_sections_organization_id_not_null", validate: false
+    change_column_null :applied_invoice_custom_sections, :organization_id, true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1142,7 +1142,7 @@ CREATE TABLE public.adjusted_fees (
     grouped_by jsonb DEFAULT '{}'::jsonb NOT NULL,
     charge_filter_id uuid,
     unit_precise_amount_cents numeric(40,15) DEFAULT 0.0 NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1196,7 +1196,7 @@ CREATE TABLE public.applied_coupons (
     frequency integer DEFAULT 0 NOT NULL,
     frequency_duration integer,
     frequency_duration_remaining integer,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -1213,7 +1213,7 @@ CREATE TABLE public.applied_invoice_custom_sections (
     invoice_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -2256,7 +2256,7 @@ CREATE TABLE public.payment_provider_customers (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp(6) without time zone,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -2440,7 +2440,7 @@ CREATE TABLE public.subscriptions (
     subscription_at timestamp(6) without time zone,
     ending_at timestamp(6) without time zone,
     trial_ended_at timestamp(6) without time zone,
-    organization_id uuid
+    organization_id uuid NOT NULL
 );
 
 
@@ -8916,6 +8916,16 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250707113718'),
+('20250707113717'),
+('20250707100102'),
+('20250707100101'),
+('20250707100026'),
+('20250707100025'),
+('20250707100013'),
+('20250707100012'),
+('20250707095956'),
+('20250707095955'),
 ('20250707095224'),
 ('20250707095223'),
 ('20250707094932'),


### PR DESCRIPTION
## Context

Let's continue with not null constraint on organization_id column after https://github.com/getlago/lago-api/pull/3879

## Description

This PR adds the not null constraint on new tables:
- `adjusted_fees`
- `applied_coupons`
- `payment_provider_customers`
- `applied_invoice_custom_sections`