### PR TITLE
fix: prevent cascading when overridden plan is not linked to active sub

### DIFF
--- a/app/jobs/charges/create_children_job.rb
+++ b/app/jobs/charges/create_children_job.rb
@@ -8,7 +8,7 @@ module Charges
       plan = charge.plan
       return unless plan&.children&.any?
 
-      plan.children.order(created_at: :asc).pluck(:id).each_slice(20) do |child_ids|
+      plan.children.joins(:subscriptions).where(subscriptions: { status: 'active' }).distinct.pluck(:id).each_slice(20) do |child_ids|
         Charges::CreateChildrenBatchJob.perform_later(
           child_ids:,
           charge:,

--- a/app/jobs/charges/create_children_job.rb
+++ b/app/jobs/charges/create_children_job.rb
@@ -8,7 +8,7 @@ module Charges
       plan = charge.plan
       return unless plan&.children&.any?
 
-      plan.children.joins(:subscriptions).where(subscriptions: {status: "active"}).distinct.pluck(:id).each_slice(20) do |child_ids|
+      plan.children.joins(:subscriptions).where(subscriptions: {status: %w[active pending]}).distinct.pluck(:id).each_slice(20) do |child_ids|
         Charges::CreateChildrenBatchJob.perform_later(
           child_ids:,
           charge:,

--- a/app/jobs/charges/create_children_job.rb
+++ b/app/jobs/charges/create_children_job.rb
@@ -8,7 +8,7 @@ module Charges
       plan = charge.plan
       return unless plan&.children&.any?
 
-      plan.children.joins(:subscriptions).where(subscriptions: { status: 'active' }).distinct.pluck(:id).each_slice(20) do |child_ids|
+      plan.children.joins(:subscriptions).where(subscriptions: {status: "active"}).distinct.pluck(:id).each_slice(20) do |child_ids|
         Charges::CreateChildrenBatchJob.perform_later(
           child_ids:,
           charge:,

--- a/app/jobs/charges/update_children_job.rb
+++ b/app/jobs/charges/update_children_job.rb
@@ -8,7 +8,7 @@ module Charges
       charge = Charge.find_by(id: old_parent_attrs["id"])
       return unless charge
 
-      charge.children.order(created_at: :asc).pluck(:id).each_slice(20) do |child_ids|
+      charge.children.joins(plan: :subscriptions).where(subscriptions: { status: "active" }).distinct.pluck(:id).each_slice(20) do |child_ids|
         Charges::UpdateChildrenBatchJob.perform_later(
           child_ids:,
           params:,

--- a/app/jobs/charges/update_children_job.rb
+++ b/app/jobs/charges/update_children_job.rb
@@ -8,7 +8,7 @@ module Charges
       charge = Charge.find_by(id: old_parent_attrs["id"])
       return unless charge
 
-      charge.children.joins(plan: :subscriptions).where(subscriptions: {status: "active"}).distinct.pluck(:id).each_slice(20) do |child_ids|
+      charge.children.joins(plan: :subscriptions).where(subscriptions: {status: %w[active pending]}).distinct.pluck(:id).each_slice(20) do |child_ids|
         Charges::UpdateChildrenBatchJob.perform_later(
           child_ids:,
           params:,

--- a/app/jobs/charges/update_children_job.rb
+++ b/app/jobs/charges/update_children_job.rb
@@ -8,7 +8,7 @@ module Charges
       charge = Charge.find_by(id: old_parent_attrs["id"])
       return unless charge
 
-      charge.children.joins(plan: :subscriptions).where(subscriptions: { status: "active" }).distinct.pluck(:id).each_slice(20) do |child_ids|
+      charge.children.joins(plan: :subscriptions).where(subscriptions: {status: "active"}).distinct.pluck(:id).each_slice(20) do |child_ids|
         Charges::UpdateChildrenBatchJob.perform_later(
           child_ids:,
           params:,

--- a/app/services/charges/destroy_children_service.rb
+++ b/app/services/charges/destroy_children_service.rb
@@ -14,7 +14,7 @@ module Charges
       return result unless charge.discarded?
 
       ActiveRecord::Base.transaction do
-        charge.children.joins(plan: :subscriptions).where(subscriptions: {status: "active"}).distinct.find_each do |charge|
+        charge.children.joins(plan: :subscriptions).where(subscriptions: {status: %w[active pending]}).distinct.find_each do |charge|
           Charges::DestroyService.call!(charge:)
         end
       end

--- a/app/services/charges/destroy_children_service.rb
+++ b/app/services/charges/destroy_children_service.rb
@@ -14,7 +14,9 @@ module Charges
       return result unless charge.discarded?
 
       ActiveRecord::Base.transaction do
-        charge.children.find_each { Charges::DestroyService.call!(charge: it) }
+        charge.children.joins(plan: :subscriptions).where(subscriptions: { status: "active" }).distinct.find_each do |charge|
+          Charges::DestroyService.call!(charge:)
+        end
       end
 
       result.charge = charge

--- a/app/services/charges/destroy_children_service.rb
+++ b/app/services/charges/destroy_children_service.rb
@@ -14,7 +14,7 @@ module Charges
       return result unless charge.discarded?
 
       ActiveRecord::Base.transaction do
-        charge.children.joins(plan: :subscriptions).where(subscriptions: { status: "active" }).distinct.find_each do |charge|
+        charge.children.joins(plan: :subscriptions).where(subscriptions: {status: "active"}).distinct.find_each do |charge|
           Charges::DestroyService.call!(charge:)
         end
       end

--- a/spec/jobs/charges/create_children_job_spec.rb
+++ b/spec/jobs/charges/create_children_job_spec.rb
@@ -5,7 +5,10 @@ require "rails_helper"
 RSpec.describe Charges::CreateChildrenJob, type: :job do
   let(:billable_metric) { create(:billable_metric) }
   let(:plan) { create(:plan, organization: billable_metric.organization) }
+  let(:subscription) { create(:subscription, plan: child_plan) }
+  let(:subscription2) { create(:subscription, plan: child_plan2, status: :terminated) }
   let(:child_plan) { create(:plan, organization: billable_metric.organization, parent_id: plan.id) }
+  let(:child_plan2) { create(:plan, organization: billable_metric.organization, parent_id: plan.id) }
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
   let(:child_ids) { [child_plan.id] }
 
@@ -19,6 +22,9 @@ RSpec.describe Charges::CreateChildrenJob, type: :job do
   end
 
   before do
+    subscription
+    subscription2
+    child_plan2
     allow(Charges::CreateChildrenBatchJob).to receive(:perform_later)
       .with(child_ids:, charge:, payload: params)
       .and_call_original

--- a/spec/jobs/charges/update_children_job_spec.rb
+++ b/spec/jobs/charges/update_children_job_spec.rb
@@ -4,8 +4,12 @@ require "rails_helper"
 
 RSpec.describe Charges::UpdateChildrenJob, type: :job do
   let(:charge) { create(:standard_charge) }
-  let(:child_charge) { create(:standard_charge, parent_id: charge.id) }
-  let(:child_charge2) { create(:standard_charge, parent_id: charge.id) }
+  let(:child_plan1) { create(:plan, parent_id: charge.plan.id) }
+  let(:child_plan2) { create(:plan, parent_id: charge.plan.id) }
+  let(:child_charge) { create(:standard_charge, parent_id: charge.id, plan: child_plan1) }
+  let(:child_charge2) { create(:standard_charge, parent_id: charge.id, plan: child_plan2) }
+  let(:subscription) { create(:subscription, plan: child_plan1) }
+  let(:subscription2) { create(:subscription, plan: child_plan2, status: :terminated) }
   let(:old_parent_attrs) { charge.attributes }
   let(:old_parent_filters_attrs) { charge.filters.map(&:attributes) }
   let(:old_parent_applied_pricing_unit_attrs) { charge.filters.map(&:attributes) }
@@ -16,9 +20,13 @@ RSpec.describe Charges::UpdateChildrenJob, type: :job do
   end
 
   before do
+    child_plan1
+    child_plan2
+    subscription
+    subscription2
     allow(Charges::UpdateChildrenBatchJob)
       .to receive(:perform_later)
-      .with(child_ids: [child_charge.id, child_charge2.id], params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
+      .with(child_ids: [child_charge.id], params:, old_parent_attrs:, old_parent_filters_attrs:, old_parent_applied_pricing_unit_attrs:)
       .and_call_original
   end
 

--- a/spec/services/charges/destroy_children_service_spec.rb
+++ b/spec/services/charges/destroy_children_service_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Charges::DestroyChildrenService, type: :service do
   let(:child_plan) { create(:plan, organization:, parent_id:) }
   let(:parent_id) { plan.id }
   let(:charge_parent_id) { charge.id }
+  let(:subscription) { create(:subscription, plan: child_plan) }
   let(:child_charge) do
     create(
       :standard_charge,
@@ -23,7 +24,10 @@ RSpec.describe Charges::DestroyChildrenService, type: :service do
     )
   end
 
-  before { child_charge }
+  before do
+    child_charge
+    subscription
+  end
 
   describe "#call" do
     it "soft deletes the charge" do


### PR DESCRIPTION
## Context

Currently cascade feature targets all overridden plans even if linked subscription is terminated

## Description

Described scenario can lead to performing unnecessary cascading and this PR fixes it
