### PR TITLE
fix(refunds): Fix refunds when payment provider customer is discarded

### DIFF
--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -22,7 +22,7 @@ module CreditNotes
           credit_note:,
           payment:,
           payment_provider: payment.payment_provider,
-          payment_provider_customer: payment.payment_provider_customer,
+          payment_provider_customer: payment_provider_customer(customer),
           amount_cents: adyen_result.response.dig("amount", "value"),
           amount_currency: adyen_result.response.dig("amount", "currency"),
           status: "pending",
@@ -116,7 +116,7 @@ module CreditNotes
         SendWebhookJob.perform_later(
           "credit_note.provider_refund_failure",
           credit_note,
-          provider_customer_id: customer.adyen_customer.provider_customer_id,
+          provider_customer_id: payment_provider_customer(customer)&.provider_customer_id,
           provider_error: {
             message:,
             error_code: code

--- a/app/services/credit_notes/refunds/gocardless_service.rb
+++ b/app/services/credit_notes/refunds/gocardless_service.rb
@@ -26,7 +26,7 @@ module CreditNotes
           credit_note:,
           payment:,
           payment_provider: payment.payment_provider,
-          payment_provider_customer: payment.payment_provider_customer,
+          payment_provider_customer: payment_provider_customer(customer),
           amount_cents: gocardless_result.amount,
           amount_currency: gocardless_result.currency&.upcase,
           status: gocardless_result.status,
@@ -126,7 +126,7 @@ module CreditNotes
         SendWebhookJob.perform_later(
           "credit_note.provider_refund_failure",
           credit_note,
-          provider_customer_id: customer.gocardless_customer.provider_customer_id,
+          provider_customer_id: payment_provider_customer(customer)&.provider_customer_id,
           provider_error: {
             message:,
             error_code: code

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -24,7 +24,7 @@ module CreditNotes
           credit_note:,
           payment:,
           payment_provider: payment.payment_provider,
-          payment_provider_customer: payment.payment_provider_customer,
+          payment_provider_customer: payment_provider_customer(customer),
           amount_cents: stripe_result.amount,
           amount_currency: stripe_result.currency&.upcase,
           status: stripe_result.status,
@@ -141,7 +141,7 @@ module CreditNotes
         SendWebhookJob.perform_later(
           "credit_note.provider_refund_failure",
           credit_note,
-          provider_customer_id: customer.stripe_customer.provider_customer_id,
+          provider_customer_id: payment_provider_customer(customer)&.provider_customer_id,
           provider_error: {
             message:,
             error_code: code

--- a/app/services/customers/payment_provider_finder.rb
+++ b/app/services/customers/payment_provider_finder.rb
@@ -17,6 +17,12 @@ module Customers
         payment_provider_result.raise_if_error!
         payment_provider_result.payment_provider
       end
+
+      def payment_provider_customer(customer)
+        return nil unless customer
+
+        PaymentProviderCustomers::BaseCustomer.with_discarded.find_by(customer_id: customer.id)
+      end
     end
   end
 end

--- a/spec/services/credit_notes/refunds/adyen_service_spec.rb
+++ b/spec/services/credit_notes/refunds/adyen_service_spec.rb
@@ -176,6 +176,32 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
         end
       end
     end
+
+    context "when payment provider customer was discarded" do
+      before { adyen_customer.discard }
+
+      it "creates a adyen refund and a refund" do
+        result = adyen_service.create
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.refund.id).to be_present
+
+          expect(result.refund.credit_note).to eq(credit_note)
+          expect(result.refund.payment).to eq(payment)
+          expect(result.refund.payment_provider).to eq(adyen_payment_provider)
+          expect(result.refund.payment_provider_customer).to eq(adyen_customer)
+          expect(result.refund.amount_cents).to eq(134)
+          expect(result.refund.amount_currency).to eq("CHF")
+          expect(result.refund.status).to eq("pending")
+          expect(result.refund.provider_refund_id).to eq(refunds_response.response["pspReference"])
+
+          expect(result.credit_note).not_to be_succeeded
+          expect(result.credit_note.refunded_at).not_to be_present
+        end
+      end
+    end
   end
 
   describe "#update_status" do

--- a/spec/services/credit_notes/refunds/gocardless_service_spec.rb
+++ b/spec/services/credit_notes/refunds/gocardless_service_spec.rb
@@ -198,6 +198,31 @@ RSpec.describe CreditNotes::Refunds::GocardlessService, type: :service do
         end
       end
     end
+
+    context "when payment provider customer was discarded" do
+      before { gocardless_customer.discard }
+
+      it "creates a gocardless refund" do
+        result = gocardless_service.create
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.refund.id).to be_present
+
+          expect(result.refund.credit_note).to eq(credit_note)
+          expect(result.refund.payment).to eq(payment)
+          expect(result.refund.payment_provider).to eq(gocardless_payment_provider)
+          expect(result.refund.payment_provider_customer).to eq(gocardless_customer)
+          expect(result.refund.amount_cents).to eq(134)
+          expect(result.refund.amount_currency).to eq("CHF")
+          expect(result.refund.status).to eq("paid")
+          expect(result.refund.provider_refund_id).to eq("re_123456")
+
+          expect(result.credit_note).to be_succeeded
+        end
+      end
+    end
   end
 
   describe "#update_status" do


### PR DESCRIPTION
## Context

Performing a refund fails when payment provider customer is discarded.
A refund is performed only on the PSP - the API is called and it succeeds, but it fails to create the refund record in Lago DB.

## Description

This PR fixes the issue by adding a method that fetches the payment provider customer even if it's discarded.

`Customers::PaymentProviderFinder#payment_provider_customer`