### PR TITLE
fix(invoice-collection): Add is_customer_tin_empty filter

### DIFF
--- a/app/models/analytics/invoice_collection.rb
+++ b/app/models/analytics/invoice_collection.rb
@@ -22,6 +22,15 @@ module Analytics
           )
         end
 
+        unless args[:is_customer_tin_empty].nil?
+          and_is_customer_tin_empty_sql =
+            if args[:is_customer_tin_empty] == true
+              sanitize_sql(["AND (c.tax_identification_number IS NULL OR trim(c.tax_identification_number) = '')"])
+            else
+              sanitize_sql(["AND (c.tax_identification_number IS NOT NULL AND trim(c.tax_identification_number) <> '')"])
+            end
+        end
+
         if args[:months].present?
           months_interval = (args[:months].to_i <= 1) ? 0 : args[:months].to_i - 1
 
@@ -71,6 +80,7 @@ module Analytics
             AND i.status = 1
             AND i.payment_dispute_lost_at IS NULL
             #{and_external_customer_id_sql}
+            #{and_is_customer_tin_empty_sql}
             #{and_billing_entity_id_sql}
             #{and_billing_entity_code_sql}
             GROUP BY payment_status, month, i.currency

--- a/spec/models/analytics/invoice_collection_spec.rb
+++ b/spec/models/analytics/invoice_collection_spec.rb
@@ -84,12 +84,15 @@ RSpec.describe Analytics::InvoiceCollection, type: :model do
     let(:billing_entity2) { create(:billing_entity, organization: organization) }
     let(:invoices) {
       [
-        create(:invoice, organization:, billing_entity: billing_entity1, issuing_date: 2.months.ago, total_amount_cents: 100, status: :pending),
-        create(:invoice, organization:, billing_entity: billing_entity1, issuing_date: 2.months.ago, total_amount_cents: 200, status: :finalized),
-        create(:invoice, organization:, billing_entity: billing_entity2, issuing_date: 1.month.ago, total_amount_cents: 300, status: :pending),
-        create(:invoice, organization:, billing_entity: billing_entity2, issuing_date: 1.month.ago, total_amount_cents: 400, status: :finalized)
+        create(:invoice, organization:, customer: customer1, billing_entity: billing_entity1, issuing_date: 2.months.ago, total_amount_cents: 100, status: :pending),
+        create(:invoice, organization:, customer: customer1, billing_entity: billing_entity1, issuing_date: 2.months.ago, total_amount_cents: 200, status: :finalized),
+        create(:invoice, organization:, customer: customer2, billing_entity: billing_entity2, issuing_date: 1.month.ago, total_amount_cents: 300, status: :pending),
+        create(:invoice, organization:, customer: customer2, billing_entity: billing_entity2, issuing_date: 1.month.ago, total_amount_cents: 400, status: :finalized)
       ]
     }
+
+    let(:customer1) { create(:customer, organization:, tax_identification_number: nil) }
+    let(:customer2) { create(:customer, organization:, tax_identification_number: "123456789") }
 
     before { invoices }
 
@@ -140,6 +143,40 @@ RSpec.describe Analytics::InvoiceCollection, type: :model do
                          "payment_status" => "pending", "currency" => "EUR", "invoices_count" => 1, "amount_cents" => 400.0}),
           hash_including({"month" => Time.current.beginning_of_month,
                          "payment_status" => nil, "currency" => nil, "invoices_count" => 0, "amount_cents" => 0.0})
+        ])
+      end
+    end
+
+    context "when is_customer_tin_empty is true" do
+      let(:args) { {is_customer_tin_empty: true} }
+
+      it "invoices collections for customer with no tax_identification_number" do
+        expect(invoice_collections).to match_array([
+          hash_including({"month" => Time.current.beginning_of_month - 3.months,
+            "payment_status" => nil, "currency" => nil, "invoices_count" => 0, "amount_cents" => 0.0}),
+          hash_including({"month" => Time.current.beginning_of_month - 2.months,
+            "payment_status" => "pending", "currency" => "EUR", "invoices_count" => 1, "amount_cents" => 200.0}),
+          hash_including({"month" => Time.current.beginning_of_month - 1.month,
+            "payment_status" => nil, "currency" => nil, "invoices_count" => 0, "amount_cents" => 0.0}),
+          hash_including({"month" => Time.current.beginning_of_month,
+            "payment_status" => nil, "currency" => nil, "invoices_count" => 0, "amount_cents" => 0.0})
+        ])
+      end
+    end
+
+    context "when is_customer_tin_empty is false" do
+      let(:args) { {is_customer_tin_empty: false} }
+
+      it "invoices collections for customer with tax_identification_number" do
+        expect(invoice_collections).to match_array([
+          hash_including({"month" => Time.current.beginning_of_month - 3.months,
+            "payment_status" => nil, "currency" => nil, "invoices_count" => 0, "amount_cents" => 0.0}),
+          hash_including({"month" => Time.current.beginning_of_month - 2.months,
+            "payment_status" => nil, "currency" => nil, "invoices_count" => 0, "amount_cents" => 0.0}),
+          hash_including({"month" => Time.current.beginning_of_month - 1.month,
+            "payment_status" => "pending", "currency" => "EUR", "invoices_count" => 1, "amount_cents" => 400.0}),
+          hash_including({"month" => Time.current.beginning_of_month,
+            "payment_status" => nil, "currency" => nil, "invoices_count" => 0, "amount_cents" => 0.0})
         ])
       end
     end


### PR DESCRIPTION
## Context

Filtering by `is_customer_tin_empty` which filters by existent or non-existent customer `tax_identification_number` was missing.

## Description

This PR adds the missing filter to invoice collection.