### PR TITLE
chore(dependency): Add `pry-byebug` as dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,6 @@ end
 
 group :development, :test do
   gem "bullet"
-  gem "byebug"
   gem "clockwork-test"
   gem "debug", platforms: %i[mri mingw x64_mingw], require: false
   gem "dotenv"
@@ -114,7 +113,7 @@ group :development, :test do
   gem "simplecov", require: false
   gem "webmock"
   gem "awesome_print"
-  gem "pry"
+  gem "pry-byebug"
   gem "knapsack_pro", "~> 8.1"
   gem "parallel_tests", "~> 5.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
     bullet (8.0.7)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    byebug (11.1.3)
+    byebug (12.0.0)
     clickhouse-activerecord (1.3.1)
       activerecord (>= 7.1, < 9.0)
       bundler (>= 1.13.4)
@@ -666,6 +666,9 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.11.0)
+      byebug (~> 12.0)
+      pry (>= 0.13, < 0.16)
     psych (5.2.6)
       date
       stringio
@@ -971,7 +974,6 @@ DEPENDENCIES
   bigdecimal
   bootsnap
   bullet
-  byebug
   clickhouse-activerecord (~> 1.3.0)
   clockwork
   clockwork-test
@@ -1016,7 +1018,7 @@ DEPENDENCIES
   parallel
   parallel_tests (~> 5.3)
   pg
-  pry
+  pry-byebug
   puma (~> 6.5)
   rack-cors
   rails (~> 8.0)


### PR DESCRIPTION
## Context

`byebug` will not work properly within factory attribute or association definition:

```ruby
FactoryBot.define do
   factory :subscription do
    customer do
      byebug # DOESN'T WORK
      create(:customer)
    end
  end

  factory :customer do
    after :create do |customer|
      byebug # WORKS
      create(:hubspot_customer, customer:)
    end
  end
end
```

The `byebug` call in the `customer` block will fail with the following error:

```shell
Failure/Error: byebug
     
     LoadError:
       cannot load such file -- /usr/local/bundle/gems/factory_bot-6.5.0/lib/factory_bot/core
     # /usr/local/bundle/gems/factory_bot-6.5.0/lib/factory_bot/evaluator.rb:43:in 'Kernel#require_relative'
     # /usr/local/bundle/gems/factory_bot-6.5.0/lib/factory_bot/evaluator.rb:43:in 'FactoryBot::Evaluator#method_missing'
     # /usr/local/bundle/gems/byebug-12.0.0/lib/byebug/attacher.rb:36:in 'Kernel#byebug'
     # ...
     # ./spec/spec_helper.rb:172:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'
```

Using `binding.pry` instead will properly stop execution but it will not stop at the right stack level:

```shell
⋊> lago exec api bundle exec rspec --color --format documentation spec/services/subscriptions/update_service_spec.rb
Subscriptions::UpdateService
  #call

From: /usr/local/bundle/gems/factory_bot-6.5.0/lib/factory_bot/evaluator.rb:42 FactoryBot::Evaluator#method_missing:

    38: def method_missing(method_name, ...)
    39:   if @instance.respond_to?(method_name)
    40:     @instance.send(method_name, ...)
    41:   else
  => 42:     SyntaxRunner.new.send(method_name, ...)
    43:   end
    44: end
```

## Description

Using `pry-byebug` will solve the issue:

```shell
⋊> lago exec api bundle exec rspec --color --format documentation spec/services/subscriptions/update_service_spec.rb
Subscriptions::UpdateService
  #call

From: /app/spec/factories/subscriptions.rb:13 :

    8: 
    9:     customer do
    10:       traits = []
    11:       traits << :with_hubspot_integration if with_hubspot_integration
    12:       binding.pry
 => 13:       create(:customer, *traits)
    14:     end
    15:     plan
    16:     organization { customer&.organization || plan&.organization || association(:organization) }
    17:     status { :active }
    18:     external_id { SecureRandom.uuid }
```

It also allows us to rely on features of both `pry` (`show-source`, `cd`, etc.) and  `byebug` (`continue`, `up`, etc.) at the same time.
