### PR TITLE
misc(events-processor): Add new index to speed up in advance charge processing

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -173,12 +173,13 @@ end
 #
 # Indexes
 #
-#  index_charges_on_billable_metric_id  (billable_metric_id) WHERE (deleted_at IS NULL)
-#  index_charges_on_deleted_at          (deleted_at)
-#  index_charges_on_organization_id     (organization_id)
-#  index_charges_on_parent_id           (parent_id)
-#  index_charges_on_plan_id             (plan_id)
-#  index_charges_pay_in_advance         (billable_metric_id) WHERE ((deleted_at IS NULL) AND (pay_in_advance = true))
+#  idx_on_plan_id_billable_metric_id_pay_in_advance_4a205974cb  (plan_id,billable_metric_id,pay_in_advance) WHERE (deleted_at IS NULL)
+#  index_charges_on_billable_metric_id                          (billable_metric_id) WHERE (deleted_at IS NULL)
+#  index_charges_on_deleted_at                                  (deleted_at)
+#  index_charges_on_organization_id                             (organization_id)
+#  index_charges_on_parent_id                                   (parent_id)
+#  index_charges_on_plan_id                                     (plan_id)
+#  index_charges_pay_in_advance                                 (billable_metric_id) WHERE ((deleted_at IS NULL) AND (pay_in_advance = true))
 #
 # Foreign Keys
 #

--- a/db/migrate/20250708094414_add_in_advance_index_to_charge.rb
+++ b/db/migrate/20250708094414_add_in_advance_index_to_charge.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddInAdvanceIndexToCharge < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :charges,
+      [:plan_id, :billable_metric_id, :pay_in_advance],
+      algorithm: :concurrently,
+      using: :btree,
+      where: "deleted_at IS NULL",
+      if_not_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -579,6 +579,7 @@ DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_recurring_756a2a370
 DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_78eb24d06c;
 DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_4290c95dec;
 DROP INDEX IF EXISTS public.idx_on_timestamp_charge_id_external_subscription_id;
+DROP INDEX IF EXISTS public.idx_on_plan_id_billable_metric_id_pay_in_advance_4a205974cb;
 DROP INDEX IF EXISTS public.idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167;
 DROP INDEX IF EXISTS public.idx_on_organization_id_organization_sequential_id_2387146f54;
 DROP INDEX IF EXISTS public.idx_on_organization_id_external_subscription_id_df3a30d96d;
@@ -4769,6 +4770,13 @@ CREATE UNIQUE INDEX idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca1
 
 
 --
+-- Name: idx_on_plan_id_billable_metric_id_pay_in_advance_4a205974cb; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_plan_id_billable_metric_id_pay_in_advance_4a205974cb ON public.charges USING btree (plan_id, billable_metric_id, pay_in_advance) WHERE (deleted_at IS NULL);
+
+
+--
 -- Name: idx_on_timestamp_charge_id_external_subscription_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8916,6 +8924,7 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250708094414'),
 ('20250707113718'),
 ('20250707113717'),
 ('20250707100102'),


### PR DESCRIPTION
## Context

A slow query was identified on the charge table:
```
SELECT count(*) FROM "charges" WHERE (plan_id = $1 AND billable_metric_id = $2) AND pay_in_advance = true AND "charges"."deleted_at" IS NULL
```

This query is made by the events processor to identify if an event needs to be billed in advance. The problem was identified because a big burst of event was post-processed, leading to a pike in CPU usage on the database.

## Description

This PR only adds a new index to speed up the processing.