### PR TITLE
feat(pricing-units): Support pricing units in current usage

### DIFF
--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -9,6 +9,7 @@ module Types
         field :amount_cents, GraphQL::Types::BigInt, null: false
         field :events_count, Integer, null: false
         field :id, ID, null: false
+        field :pricing_unit_amount_cents, GraphQL::Types::BigInt, null: true
         field :units, GraphQL::Types::Float, null: false
 
         field :billable_metric, Types::BillableMetrics::Object, null: false
@@ -30,6 +31,12 @@ module Types
 
         def amount_cents
           object.sum(&:amount_cents)
+        end
+
+        def pricing_unit_amount_cents
+          return if charge.applied_pricing_unit.nil?
+
+          object.map(&:pricing_unit_usage).sum(&:amount_cents)
         end
 
         def charge

--- a/schema.graphql
+++ b/schema.graphql
@@ -914,6 +914,7 @@ type ChargeUsage {
   filters: [ChargeFilterUsage!]
   groupedUsage: [GroupedChargeUsage!]!
   id: ID!
+  pricingUnitAmountCents: BigInt
   units: Float!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -5891,6 +5891,18 @@
               "args": []
             },
             {
+              "name": "pricingUnitAmountCents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "units",
               "description": null,
               "type": {

--- a/spec/graphql/types/customers/usage/charge_spec.rb
+++ b/spec/graphql/types/customers/usage/charge_spec.rb
@@ -14,5 +14,6 @@ RSpec.describe Types::Customers::Usage::Charge do
     expect(subject).to have_field(:charge).of_type("Charge!")
     expect(subject).to have_field(:grouped_usage).of_type("[GroupedChargeUsage!]!")
     expect(subject).to have_field(:filters).of_type("[ChargeFilterUsage!]")
+    expect(subject).to have_field(:pricing_unit_amount_cents).of_type("BigInt")
   end
 end


### PR DESCRIPTION
## Context

Add displaying amounts in pricing units for current usage.

## Description

Adjust GQL type.
Make changes in `ChargeCacheMiddleware` to support caching of `pricing_unit_usage` association for Fee.