### PR TITLE
test(factory): Add `subscription_at` to `subscription` factory

### DIFF
--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     status { :active }
     external_id { SecureRandom.uuid }
     started_at { 1.day.ago }
+    subscription_at { 1.day.ago }
 
     trait :pending do
       status { :pending }

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
   subject(:update_service) { described_class.new(subscription:, params:) }
 
   let(:membership) { create(:membership) }
-  let(:subscription) { create(:subscription, subscription_at: Time.current - 1.year) }
+  let(:subscription) { create(:subscription) }
 
   describe "#call" do
     let(:subscription_at) { "2022-07-07T00:00:00Z" }
@@ -141,7 +141,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
 
     context "when plan_overrides" do
       let(:plan) { create(:plan, organization: membership.organization) }
-      let(:subscription) { create(:subscription, plan:, subscription_at: Time.current - 1.year) }
+      let(:subscription) { create(:subscription, plan:) }
       let(:params) do
         {
           plan_overrides: {


### PR DESCRIPTION
## Context

While working on the `Subscriptions::UpdateService`, I noticed some test cases missing so I decided to add them. Adding the following spec failed:

```ruby
      context "when specifying only name" do
        let(:subscription) { create(:subscription, customer:) }
        let(:params) { {name: "new name"} }

        it "updates the subscription" do
          result = update_service.call

          expect(result).to be_success

          expect(result.subscription.name).to eq("new name")
          expect(result.subscription.subscription_at.to_s).not_to include("2022-07-07")
        end
      end
```

This is due to the fact that `subscription_at` is `nil` in the factory but:

1. It is expected to be set in the `Subscriptions::UpdateService`
2. It is always set when creating a subscription https://github.com/getlago/lago-api/blob/9eebd429260041b822b1bf46abf51a2b200a54b9/app/services/subscriptions/create_service.rb#L13

## Description

This PR add a default `subscription_at` to the `subscription` factory.
