### PR TITLE
misc(subscription): Ensure `Subscriptions::UpdateService` uses `perform_after_commit`

### DIFF
--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -43,12 +43,10 @@ module Subscriptions
       else
         subscription.save!
 
-        after_commit do
-          SendWebhookJob.perform_later("subscription.updated", subscription)
-        end
+        SendWebhookJob.perform_after_commit("subscription.updated", subscription)
 
         if subscription.should_sync_hubspot_subscription?
-          Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_later(subscription:)
+          Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_after_commit(subscription:)
         end
       end
 
@@ -71,7 +69,7 @@ module Subscriptions
 
       return unless subscription.plan.pay_in_advance? && subscription.subscription_at.today?
 
-      BillSubscriptionJob.perform_later([subscription], Time.current.to_i, invoicing_reason: :subscription_starting)
+      BillSubscriptionJob.perform_after_commit([subscription], Time.current.to_i, invoicing_reason: :subscription_starting)
     end
 
     def handle_plan_override

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -38,8 +38,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
       end
 
       it "sends updated subscription webhook" do
-        update_service.call
-        expect(SendWebhookJob).to have_been_enqueued.with("subscription.updated", subscription)
+        expect { update_service.call }.to have_enqueued_job_after_commit(SendWebhookJob).with("subscription.updated", subscription)
       end
 
       it "does not sync to Hubspot" do
@@ -62,7 +61,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
             result = update_service.call
 
             expect(result).to be_success
-          }.to have_enqueued_job(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob).with(subscription:)
+          }.to have_enqueued_job_after_commit(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob).with(subscription:)
         end
       end
 
@@ -123,7 +122,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
           end
 
           it "enqueues a job to bill the subscription" do
-            expect { update_service.call }.to have_enqueued_job(BillSubscriptionJob)
+            expect { update_service.call }.to have_enqueued_job_after_commit(BillSubscriptionJob)
               .with([subscription], Time.now.to_i, invoicing_reason: :subscription_starting)
           end
         end


### PR DESCRIPTION
## Context

`Subscriptions::UpdateService` currently do not ensure that jobs are scheduled after commit. This has no impact right now as the service is not called in a transaction anywhere but it will be the case soon.

## Description

This PR ensures the jobs are scheduled after commit.
