### PR TITLE
chore(webhook): Update webhook endpoint created in seeds to a working one

### DIFF
--- a/db/seeds/webhooks.rb
+++ b/db/seeds/webhooks.rb
@@ -6,7 +6,7 @@ require "factory_bot_rails"
 organization = Organization.find_or_create_by!(name: "Hooli")
 ApiKey.find_or_create_by!(organization:)
 
-webhook_endpoint = WebhookEndpoint.find_or_create_by!(organization:, webhook_url: "http://test.lago.dev/webhook")
+webhook_endpoint = WebhookEndpoint.find_or_create_by!(organization:, webhook_url: "http://webhook/11111111-2222-3333-4444-555555555555")
 
 3.times do
   FactoryBot.create(:webhook, :succeeded, organization:, webhook_endpoint:)


### PR DESCRIPTION
## Context

https://github.com/getlago/lago/pull/554 added a [`webhook-tester`](https://github.com/tarampampam/webhook-tester) container to the dev environment.

## Description

This PR updates the URL of webhook endpoint created in seeds to match the URL of the new container.
