### PR TITLE
fix(activity-logs): Fix `Utils::ActivityLog.produce_after_commit` when passing block

### DIFF
--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -22,17 +22,16 @@ module Utils
     #
     # It is meant to avoid race-conditions where a asynchronous post-processing run before changes are commited to the DB.
     def self.produce_after_commit(object, activity_type, activity_id: nil, &)
-      AfterCommitEverywhere.after_commit do
-        kwargs = {activity_id:}.compact
-        produce(object, activity_type, **kwargs, &)
-      end
+      kwargs = {after_commit: true, activity_id:}.compact
+      produce(object, activity_type, **kwargs, &)
     end
 
-    def initialize(object, activity_type, activity_id: SecureRandom.uuid, &block)
+    def initialize(object, activity_type, activity_id: SecureRandom.uuid, after_commit: false, &block)
       @object = object
       @activity_type = activity_type
       @activity_id = activity_id
       @block = block
+      @after_commit = after_commit
     end
 
     def produce
@@ -53,13 +52,22 @@ module Utils
         end
       end
 
-      produce_with_diff(changes)
+      run_maybe_after_commit { produce_with_diff(changes) }
+
       block ? result : nil
     end
 
     private
 
-    attr_reader :object, :activity_type, :activity_id, :block
+    attr_reader :object, :activity_type, :activity_id, :block, :after_commit
+
+    def run_maybe_after_commit(&block)
+      if after_commit
+        AfterCommitEverywhere.after_commit(&block)
+      else
+        yield
+      end
+    end
 
     def produce_with_diff(changes)
       return if ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"].blank?

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -11,24 +11,31 @@ RSpec.describe Utils::ActivityLog, type: :service do
   let(:karafka_producer) { instance_double(WaterDrop::Producer) }
 
   let(:serialized_coupon) do
-    {topic: "activity_logs",
-     key: "#{organization.id}--activity-id",
-     payload: {
-       activity_source: "api",
-       api_key_id: api_key.id,
-       user_id: nil,
-       activity_type: "coupon.created",
-       activity_id: "activity-id",
-       logged_at: Time.current.iso8601[...-1],
-       created_at: Time.current.iso8601[...-1],
-       resource_id: coupon.id,
-       resource_type: "Coupon",
-       organization_id: organization.id,
-       activity_object: V1::CouponSerializer.new(coupon).serialize,
-       activity_object_changes: {},
-       external_customer_id: nil,
-       external_subscription_id: nil
-     }.to_json}
+    {
+      topic: "activity_logs",
+      key: "#{organization.id}--activity-id",
+      payload: payload.to_json
+    }
+  end
+  let(:activity_type) { "coupon.created" }
+  let(:activity_object_changes) { {} }
+  let(:payload) do
+    {
+      activity_source: "api",
+      api_key_id: api_key.id,
+      user_id: nil,
+      activity_type:,
+      activity_id: "activity-id",
+      logged_at: Time.current.iso8601[...-1],
+      created_at: Time.current.iso8601[...-1],
+      resource_id: coupon.id,
+      resource_type: "Coupon",
+      organization_id: organization.id,
+      activity_object: V1::CouponSerializer.new(coupon).serialize,
+      activity_object_changes:,
+      external_customer_id: nil,
+      external_subscription_id: nil
+    }
   end
 
   before do
@@ -53,17 +60,46 @@ RSpec.describe Utils::ActivityLog, type: :service do
   end
 
   describe ".produce_after_commit" do
+    def test_produce_after_commit(&block)
+      produce_result = ApplicationRecord.transaction do
+        produce_result = activity_log.produce_after_commit(coupon, activity_type, activity_id: "activity-id", &block)
+
+        expect(karafka_producer).not_to have_received(:produce_async)
+        produce_result
+      end
+
+      expect(karafka_producer).to have_received(:produce_async).with(
+        **serialized_coupon
+      )
+
+      produce_result
+    end
+
     context "when kafka is configured", :kafka_configured do
-      it "produces the event on kafka after the commit" do
-        ApplicationRecord.transaction do
-          activity_log.produce_after_commit(coupon, "coupon.created", activity_id: "activity-id") { BaseService::Result.new }
+      let(:result) { BaseService::Result.new }
 
-          expect(karafka_producer).not_to have_received(:produce_async)
+      context "when providing a block" do
+        let(:activity_type) { "coupon.updated" }
+        let!(:coupon_name_before_update) { coupon.name }
+        let(:activity_object_changes) { {"name" => [coupon_name_before_update, "new name"]} }
+
+        it "produces the event on kafka after the commit" do
+          produce_result = test_produce_after_commit {
+            coupon.update!(name: "new name")
+            result.coupon = coupon
+            result
+          }
+
+          expect(produce_result).to eq(result)
         end
+      end
 
-        expect(karafka_producer).to have_received(:produce_async).with(
-          **serialized_coupon
-        )
+      context "when not providing a block" do
+        it "prouce the event after the commit" do
+          produce_result = test_produce_after_commit
+
+          expect(produce_result).to be_nil
+        end
       end
     end
   end
@@ -172,6 +208,23 @@ RSpec.describe Utils::ActivityLog, type: :service do
               external_customer_id: nil,
               external_subscription_id: nil
             }.to_json
+          )
+        end
+      end
+
+      context "when after_commit is true" do
+        let(:result) { BaseService::Result.new }
+
+        it "produces the event on kafka after the commit" do
+          ApplicationRecord.transaction do
+            produce_result = activity_log.produce(coupon, "coupon.created", activity_id: "activity-id", after_commit: true) { result }
+
+            expect(produce_result).to eq(result)
+            expect(karafka_producer).not_to have_received(:produce_async)
+          end
+
+          expect(karafka_producer).to have_received(:produce_async).with(
+            **serialized_coupon
           )
         end
       end


### PR DESCRIPTION
## Context

We expect `Utils::ActivityLog.produce_after_commit`:

1. to return the value returned by the block
2. to run the block before the commit but produce the event on Kafka after the commit

The current implementation is not matching those behaviors:

```shell
⋊> lago exec api bundle exec rspec --color --format documentation spec/services/utils/activity_log_spec.rb
Utils::ActivityLog
  .produce_after_commit
    when kafka is configured
      produces the event on kafka after the commit (FAILED - 1)
Failures:

  1) Utils::ActivityLog.produce_after_commit when kafka is configured when providing a block produces the event on kafka after the commit
     Failure/Error: expect(produce_result).to eq(result)
     
       expected: #<BaseService::LegacyResult coupon=#<Coupon id: "61398514-d441-4440-a96c-e586ad240a29", organization_..._plans: false, deleted_at: nil, limited_billable_metrics: false, description: "Coupon Description">>
            got: [#<AfterCommitEverywhere::Wrap:0x0000ffff604a0fc8 @connection=#<ActiveRecord::ConnectionAdapters::Pos...>, @handlers={after_commit: #<Proc:0x0000ffff604a11f8 /app/app/services/utils/activity_log.rb:25>}>]
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -#<BaseService::LegacyResult coupon=#<Coupon id: "61398514-d441-4440-a96c-e586ad240a29", organization_id: "9ccf4cec-b0a2-449c-bddf-cffecb000256", name: "new name", code: "m507v7gtmn", status: "active", terminated_at: nil, amount_cents: 200, amount_currency: "EUR", expiration: "no_expiration", created_at: "2023-03-22 12:00:00.000000000 +0000", updated_at: "2023-03-22 12:00:00.000000000 +0000", coupon_type: "fixed_amount", percentage_rate: nil, frequency: "once", frequency_duration: nil, expiration_at: nil, reusable: true, limited_plans: false, deleted_at: nil, limited_billable_metrics: false, description: "Coupon Description">>
       +[#<AfterCommitEverywhere::Wrap:0x0000ffff604a0fc8 @connection=#<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter:0x00000000005360 env_name="test" role=:writing>, @handlers={after_commit: #<Proc:0x0000ffff604a11f8 /app/app/services/utils/activity_log.rb:25>}>]
       
     # ./spec/services/utils/activity_log_spec.rb:93:in 'block (5 levels) in <top (required)>'
     # ...
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'

1 example, 1 failure

Failed examples:

rspec ./spec/services/utils/activity_log_spec.rb:86 # Utils::ActivityLog.produce_after_commit when kafka is configured when providing a block produces the event on kafka after the commit
```

## Description



The fix is to handle the `after_commit` behavior in the `Utils::ActivityLog#produce` instance method after the block is executed.