### PR TITLE
fix(invoice): Fix units and unit_amount in invoice pdf template

### DIFF
--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -26,8 +26,8 @@
                 td.body-1 = subscription_fee&.invoice_display_name
               - else
                 td.body-1 = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.invoice_name)
-              td.body-2 = 1
-              td.body-2 = MoneyHelper.format(invoice_subscription.subscription_amount)
+              td.body-2 = subscription_fee&.units || 1
+              td.body-2 = MoneyHelper.format(subscription_fee&.unit_amount || 0)
               td.body-2 == TaxHelper.applied_taxes(subscription_fee)
               td.body-2 = MoneyHelper.format(invoice_subscription.subscription_amount)
 


### PR DESCRIPTION
## Context

After updating a draft invoice (e.g. changing the units amount), it is not reflected in the PDF just in tu UI.

## Description

This PR fixes the pdf template to reflect this change.