### PR TITLE
misc(seeds): Update seeds to include tax, add-on and pay-in-advance plan

### DIFF
--- a/db/seeds/01_base.rb
+++ b/db/seeds/01_base.rb
@@ -42,6 +42,46 @@ plan = Plan.create_with(
   code: "standard_plan"
 )
 
+# Tax
+if !Tax.exists?(organization:, code: "lago_eu_fr_standard")
+  Taxes::CreateService.call!(
+    organization:,
+    params: {
+      name: "Lago EU FR Standard",
+      code: "lago_eu_fr_standard",
+      description: "Lago EU FR Standard",
+      rate: 20
+    }
+  )
+end
+
+# Pay-in-advance plan
+if !Plan.exists?(organization:, code: "pay_in_advance_plan")
+  Plans::CreateService.call!(
+    organization_id: organization.id,
+    name: "Pay-in-advance Plan",
+    code: "pay_in_advance_plan",
+    interval: "monthly",
+    pay_in_advance: true,
+    amount_cents: 10000,
+    amount_currency: "EUR",
+    tax_codes: ["lago_eu_fr_standard"]
+  )
+end
+
+# Add-on
+if !AddOn.exists?(organization:, code: "setup_fee")
+  AddOns::CreateService.call!(
+    organization_id: organization.id,
+    name: "Setup Fee",
+    code: "setup_fee",
+    description: "Fee for setting up the subscription",
+    amount_cents: 10000,
+    amount_currency: "EUR",
+    tax_codes: ["lago_eu_fr_standard"]
+  )
+end
+
 Charge.create_with(
   organization:,
   charge_model: "standard",


### PR DESCRIPTION
## Context

Current seeds do not include tax, add-on and pay-in-advance plan which makes it cumbersome to test certain cases with freshly seeded DBs.

