### PR TITLE
misc: allow to remove a logo when passing nil

### DIFF
--- a/app/services/billing_entities/update_service.rb
+++ b/app/services/billing_entities/update_service.rb
@@ -103,7 +103,10 @@ module BillingEntities
     end
 
     def handle_base64_logo
-      return if params[:logo].blank?
+      if params[:logo].blank?
+        billing_entity.logo&.purge
+        return
+      end
 
       base64_data = params[:logo].split(",")
       data = base64_data.second

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -174,6 +174,21 @@ RSpec.describe BillingEntities::UpdateService do
       end
     end
 
+    context "when logo is set but then removed" do
+      let(:logo) do
+        logo_file = File.read(Rails.root.join("spec/factories/images/logo.png"))
+        base64_logo = Base64.encode64(logo_file)
+
+        "data:image/png;base64,#{base64_logo}"
+      end
+
+      it "removes the logo" do
+        update_service.call
+        result = described_class.new(billing_entity:, params: {logo: nil}).call
+        expect(result.billing_entity.logo.blob).to be_nil
+      end
+    end
+
     context "with validation errors" do
       let(:country) { "---" }
 


### PR DESCRIPTION
## Context

We want to allow users to remove a billing entity logo.

## Description

This PR removed the billing entity (blob) if the logo param passed is `nil`