### PR TITLE
test(credit-note): Update job assertions for `CreditNotes::CreateService` tests

### DIFF
--- a/spec/support/matchers/job_matcher.rb
+++ b/spec/support/matchers/job_matcher.rb
@@ -14,15 +14,16 @@ RSpec::Matchers.define :have_enqueued_job_after_commit do |job|
     args = @args || []
     kwargs = @kwargs || {}
 
-    expect(job).to have_been_enqueued.with(*args, **kwargs), "Expected #{job} to have been enqueued with #{args} and #{kwargs}, but it was not."
+    expect(job).to have_been_enqueued.with(*args, **kwargs, &@block)
   end
 
   match_when_negated do |block|
     raise "The `have_enqueued_job_after_commit` matcher does not support negation. Use `expect { ... }.not_to have_enqueued_job` instead."
   end
 
-  chain :with do |*args, **kwargs|
+  chain :with do |*args, **kwargs, &block|
     @args = args
     @kwargs = kwargs
+    @block = block
   end
 end


### PR DESCRIPTION
## Description

https://github.com/getlago/lago-api/pull/3965 ensured that `Subscriptions::TerminateService` wraps its logic in a transaction. Since `Subscriptions::TerminateService` implicitly calls `CreditNotes::CreateService`, the tests for `CreditNotes::CreateService` were also updated to confirm that jobs are properly enqueued after the transaction is committed.

Note that I needed to update the `have_enqueued_job_after_commit` matcher so that the `with` chain accepts a block. This is because the job expect to receive the newly created credit note as argument. If we try to pass arguments to `with`, it will be evaluated before the credit note is actually created. So using a block is the only way to verify those arguments.