### PR TITLE
chore(plans): Use update_all to flag plan children for deletion

### DIFF
--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -19,7 +19,8 @@ module V1
         customers_count: 0,
         active_subscriptions_count: 0,
         draft_invoices_count: 0,
-        parent_id: model.parent_id
+        parent_id: model.parent_id,
+        pending_deletion: model.pending_deletion
       }
 
       payload.merge!(charges) if include?(:charges)

--- a/app/services/plans/prepare_destroy_service.rb
+++ b/app/services/plans/prepare_destroy_service.rb
@@ -12,7 +12,7 @@ module Plans
 
       ActiveRecord::Base.transaction do
         plan.update!(pending_deletion: true)
-        plan.children.each { |c| c.update!(pending_deletion: true) }
+        plan.children.update_all(pending_deletion: true) # rubocop:disable Rails/SkipsModelValidations
         Plans::DestroyJob.perform_later(plan)
       end
 

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe ::V1::PlanSerializer do
         "active_subscriptions_count" => 0,
         "draft_invoices_count" => 0,
         "parent_id" => nil,
+        "pending_deletion" => false,
         "taxes" => []
       )
 


### PR DESCRIPTION
### Expose `pending_deletion` 

When you delete a plan via the API, you get it in the response but nothing shows that it is deleted or about to be deleted.
Because deletion is async, getting this plan from the API will work as if nothing happened until the job is processed.

Need openapi and clients update.

### use `update_all` instead of `.each{ it.update! }`

A plan can have maaany children and since we're not calling a service or relying on any model callbacks, I believe it's best to flag them all at once.

Introduced here: https://github.com/getlago/lago-api/commit/69a84700632f760507eee028ede987184d332971