### PR TITLE
feat(pricing-units): Support pricing units for true up fees

### DIFF
--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -221,8 +221,14 @@ module Fees
 
     def init_true_up_fee
       fee = result.fees.find { |f| f.charge_filter_id.nil? }
-      used_amount_cents = result.fees.sum(&:amount_cents)
-      used_precise_amount_cents = result.fees.sum(&:precise_amount_cents)
+
+      if charge.applied_pricing_unit
+        used_amount_cents = result.fees.map(&:pricing_unit_usage).sum(&:amount_cents)
+        used_precise_amount_cents = result.fees.map(&:pricing_unit_usage).sum(&:precise_amount_cents)
+      else
+        used_amount_cents = result.fees.sum(&:amount_cents)
+        used_precise_amount_cents = result.fees.sum(&:precise_amount_cents)
+      end
 
       true_up_fee = Fees::CreateTrueUpService.call(fee:, used_amount_cents:, used_precise_amount_cents:).true_up_fee
       result.fees << true_up_fee if true_up_fee


### PR DESCRIPTION
## Context

Add support pricing units for charge's min amount and as result true up fee.

## Description

Adjust `Fees::ChargeService` to sum current fee's amount in pricing units or fiat currency depending on charge's configuration.
Adjust `Fees:: CreateTrueUpService` to convert from pricing units to fiat currency when needed.
