### PR TITLE
misc(activity-log): Add `after_commit` parameter to `BaseService.activity_loggable`

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -229,8 +229,8 @@ class BaseService
 
   Result = LegacyResult
 
-  def self.activity_loggable(action:, record:, condition: -> { true })
-    self.activity_log_config = {action:, record:, condition:}
+  def self.activity_loggable(action:, record:, condition: -> { true }, after_commit: nil)
+    self.activity_log_config = {action:, record:, condition:, after_commit:}
   end
 
   def self.call(*, **, &)
@@ -280,15 +280,17 @@ class BaseService
 
   def call_with_activity_log(&block)
     action = self.class.activity_log_config[:action]
+    after_commit = self.class.activity_log_config[:after_commit]
+    kwargs = {after_commit:}.compact
 
     case action
     when /updated/
       record = instance_exec(&self.class.activity_log_config[:record])
-      Utils::ActivityLog.produce(record, action) { call(&block) }
+      Utils::ActivityLog.produce(record, action, **kwargs) { call(&block) }
     else
       call(&block).tap do |result|
         record = instance_exec(&self.class.activity_log_config[:record])
-        Utils::ActivityLog.produce(record, action) { result }
+        Utils::ActivityLog.produce(record, action, **kwargs) { result }
       end
     end
   end

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -11,7 +11,8 @@ module Subscriptions
     activity_loggable(
       action: "subscription.updated",
       record: -> { subscription },
-      condition: -> { !subscription&.starting_in_the_future? }
+      condition: -> { !subscription&.starting_in_the_future? },
+      after_commit: true
     )
 
     def call

--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -49,6 +49,8 @@ module Utils
         result = block.call
         return result if result.failure?
 
+        # NOTE: This will cause any unsaved changes to be lost. So if `object` is used in `result`, the service `result`
+        #       will not contain the unsaved changes.
         object.reload
         after_attrs = object_serialized
 

--- a/spec/services/base_service_spec.rb
+++ b/spec/services/base_service_spec.rb
@@ -23,4 +23,104 @@ RSpec.describe ::BaseService, type: :service do
       expect(result.user).to be_nil
     end
   end
+
+  context "with activity_loggable" do
+    let(:service_class) do
+      action = activity_loggable_action
+      after_commit = activity_loggable_after_commit
+      Class.new(described_class) do
+        const_set(:Result, BaseResult[:subscription])
+
+        activity_loggable(action: action, record: -> { subscription }, after_commit:)
+
+        def initialize(subscription:)
+          @subscription = subscription
+          super()
+        end
+
+        def call
+          subscription.update!(name: "Updated Subscription")
+
+          result.subscription = subscription
+          result
+        end
+
+        private
+
+        attr_reader :subscription
+      end
+    end
+
+    let(:subscription) { create(:subscription, name: "My Subscription") }
+    let(:activity_loggable_after_commit) { false }
+
+    def test_service_with_activity_loggable(after_commit:, action_match_updated: false)
+      allow(Utils::ActivityLog).to receive(:produce).and_wrap_original do |m, *args, **kwargs, &block|
+        if action_match_updated
+          # For "updated" actions, `Utils::ActivityLog#produce` will execute `BaseService#call` method so subscription is not yet updated here
+          expect(subscription.name).to eq("My Subscription")
+        else
+          # For other actions, `Utils::ActivityLog#produce` is executed after `BaseService#call` method so subscription is already updated here
+          expect(subscription.name).to eq("Updated Subscription")
+        end
+
+        result = m.call(*args, **kwargs, &block)
+
+        # Test that `Utils::ActivityLog#produce` returns the result of the service call
+        expect(result).to be_success
+        expect(result.subscription).to eq(subscription)
+        expect(result.subscription.name).to eq("Updated Subscription")
+
+        result
+      end
+
+      result = service_class.call(subscription:)
+
+      expect(Utils::ActivityLog).to have_received(:produce).with(subscription, activity_loggable_action, after_commit:)
+
+      expect(result).to be_success
+      expect(result.subscription).to eq(subscription)
+      expect(result.subscription.name).to eq("Updated Subscription")
+    end
+
+    context "when action matches /updated/" do
+      let(:activity_loggable_action) { "subscription.updated" }
+
+      context "when after_commit is true" do
+        let(:activity_loggable_after_commit) { true }
+
+        it "produces the activity log after commit" do
+          test_service_with_activity_loggable(after_commit: true, action_match_updated: true)
+        end
+      end
+
+      context "when after_commit is false" do
+        let(:activity_loggable_after_commit) { false }
+
+        it "produces the activity log before commit" do
+          test_service_with_activity_loggable(after_commit: false, action_match_updated: true)
+        end
+      end
+    end
+
+    context "when action does not match /updated/" do
+      let(:activity_loggable_action) { "subscription.created" }
+
+      context "when after_commit is true" do
+        let(:activity_loggable_after_commit) { true }
+
+        it "produces the activity log" do
+          test_service_with_activity_loggable(after_commit: true, action_match_updated: false)
+        end
+      end
+
+      context "when after_commit is false" do
+        let(:activity_loggable_after_commit) { false }
+
+        it "produces the activity log" do
+          test_service_with_activity_loggable(after_commit: false, action_match_updated: false)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -45,10 +45,10 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
         expect { update_service.call }.not_to have_enqueued_job(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob)
       end
 
-      it "produces an activity log" do
+      it "produces an activity log after commit" do
         described_class.call(subscription:, params:)
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(subscription, "subscription.updated")
+        expect(Utils::ActivityLog).to have_received(:produce).with(subscription, "subscription.updated", after_commit: true)
       end
 
       context "when subscription should be synced with Hubspot" do


### PR DESCRIPTION
## Context

The `BaseService` activity logging system did not support controlling when activity logs are produced relative to database transactions. This could cause race conditions when activity logs were created before transactions committed. This is problematic if the transaction later failed as we would log an activity for changes that were rolled back.

## Description

This adds an `after_commit` parameter to the `BaseService.activity_loggable` method. Services can now control whether activity logs are produced immediately or after the current transaction commits.

Note that the parameter defaults to `false` for backward compatibility. Even though I believe we should log activities by default after commit, this default allows for incremental changes and tests.

The `Subscriptions::UpdateService` now uses `after_commit: true` to ensure activity logs are only created after successful subscription update.