### PR TITLE
feat(subscriptions): Allow to skip credit note on subscription termination

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -90,7 +90,9 @@ module Api
           query.active
         end.first
 
-        result = ::Subscriptions::TerminateService.call(subscription:)
+        kwargs = params.permit(:on_termination_credit_note).to_h.symbolize_keys
+
+        result = ::Subscriptions::TerminateService.call(subscription:, **kwargs)
 
         if result.success?
           render_subscription(result.subscription)
@@ -184,6 +186,7 @@ module Api
           :subscription_date,
           :subscription_at,
           :ending_at,
+          :on_termination_credit_note,
           plan_overrides:
         )
       end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -43,8 +43,13 @@ class Subscription < ApplicationRecord
     anniversary
   ].freeze
 
+  ON_TERMINATION_CREDIT_NOTES = {credit: "credit", skip: "skip"}.freeze
+
   enum :status, STATUSES
   enum :billing_time, BILLING_TIME
+  enum :on_termination_credit_note, ON_TERMINATION_CREDIT_NOTES
+
+  validates :on_termination_credit_note, absence: true, if: -> { plan&.pay_in_arrears? }
 
   scope :starting_in_the_future, -> { pending.where(previous_subscription: nil) }
 
@@ -239,23 +244,24 @@ end
 #
 # Table name: subscriptions
 #
-#  id                       :uuid             not null, primary key
-#  billing_time             :integer          default("calendar"), not null
-#  canceled_at              :datetime
-#  ending_at                :datetime
-#  name                     :string
-#  started_at               :datetime
-#  status                   :integer          not null
-#  subscription_at          :datetime
-#  terminated_at            :datetime
-#  trial_ended_at           :datetime
-#  created_at               :datetime         not null
-#  updated_at               :datetime         not null
-#  customer_id              :uuid             not null
-#  external_id              :string           not null
-#  organization_id          :uuid             not null
-#  plan_id                  :uuid             not null
-#  previous_subscription_id :uuid
+#  id                         :uuid             not null, primary key
+#  billing_time               :integer          default("calendar"), not null
+#  canceled_at                :datetime
+#  ending_at                  :datetime
+#  name                       :string
+#  on_termination_credit_note :enum
+#  started_at                 :datetime
+#  status                     :integer          not null
+#  subscription_at            :datetime
+#  terminated_at              :datetime
+#  trial_ended_at             :datetime
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  customer_id                :uuid             not null
+#  external_id                :string           not null
+#  organization_id            :uuid             not null
+#  plan_id                    :uuid             not null
+#  previous_subscription_id   :uuid
 #
 # Indexes
 #

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -23,7 +23,8 @@ module V1
         next_plan_code: model.next_subscription&.plan&.code,
         downgrade_plan_date: model.downgrade_plan_date&.iso8601,
         current_billing_period_started_at: dates_service.charges_from_datetime&.iso8601,
-        current_billing_period_ending_at: dates_service.charges_to_datetime&.iso8601
+        current_billing_period_ending_at: dates_service.charges_to_datetime&.iso8601,
+        on_termination_credit_note: model.on_termination_credit_note
       }
 
       payload = payload.merge(customer:) if include?(:customer)

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -8,6 +8,7 @@ module Subscriptions
 
       valid_subscription_at?
       valid_ending_at?
+      valid_on_termination_credit_note?
 
       if errors?
         result.validation_failure!(errors:)
@@ -55,6 +56,15 @@ module Subscriptions
 
       add_error(field: :ending_at, error_code: "invalid_date")
 
+      false
+    end
+
+    def valid_on_termination_credit_note?
+      return true if args[:on_termination_credit_note].blank?
+
+      return true if Subscription::ON_TERMINATION_CREDIT_NOTES.include?(args[:on_termination_credit_note].to_sym)
+
+      add_error(field: :on_termination_credit_note, error_code: "invalid_value")
       false
     end
 

--- a/db/migrate/20250709171329_add_on_termination_credit_note_to_subscriptions.rb
+++ b/db/migrate/20250709171329_add_on_termination_credit_note_to_subscriptions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddOnTerminationCreditNoteToSubscriptions < ActiveRecord::Migration[7.1]
+  def change
+    create_enum :subscription_on_termination_credit_note, %w[credit skip]
+    add_column :subscriptions, :on_termination_credit_note, :enum, enum_type: "subscription_on_termination_credit_note", default: nil
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -838,6 +838,7 @@ DROP TABLE IF EXISTS public.active_storage_attachments;
 DROP FUNCTION IF EXISTS public.set_payment_receipt_number();
 DROP TYPE IF EXISTS public.usage_monitoring_alert_types;
 DROP TYPE IF EXISTS public.tax_status;
+DROP TYPE IF EXISTS public.subscription_on_termination_credit_note;
 DROP TYPE IF EXISTS public.subscription_invoicing_reason;
 DROP TYPE IF EXISTS public.payment_type;
 DROP TYPE IF EXISTS public.payment_payable_payment_status;
@@ -982,6 +983,16 @@ CREATE TYPE public.subscription_invoicing_reason AS ENUM (
     'in_advance_charge',
     'in_advance_charge_periodic',
     'progressive_billing'
+);
+
+
+--
+-- Name: subscription_on_termination_credit_note; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.subscription_on_termination_credit_note AS ENUM (
+    'credit',
+    'skip'
 );
 
 
@@ -2451,7 +2462,8 @@ CREATE TABLE public.subscriptions (
     subscription_at timestamp(6) without time zone,
     ending_at timestamp(6) without time zone,
     trial_ended_at timestamp(6) without time zone,
-    organization_id uuid NOT NULL
+    organization_id uuid NOT NULL,
+    on_termination_credit_note public.subscription_on_termination_credit_note
 );
 
 
@@ -9020,6 +9032,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250714131519'),
 ('20250710102337'),
+('20250709171329'),
 ('20250709085218'),
 ('20250709082136'),
 ('20250708094414'),

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe Subscription, type: :model do
         calendar: 0,
         anniversary: 1
       )
+      expect(subject).to define_enum_for(:on_termination_credit_note)
+        .backed_by_column_of_type(:enum)
+        .with_values(credit: "credit", skip: "skip")
     end
   end
 
@@ -73,6 +76,20 @@ RSpec.describe Subscription, type: :model do
     it do
       expect(subject).to validate_presence_of(:external_id)
       expect(subject).to validate_presence_of(:billing_time)
+    end
+
+    describe "on_termination_credit_note validation" do
+      context "when plan is pay in arrears" do
+        subject(:subscription) { build(:subscription) }
+
+        it { is_expected.to validate_absence_of(:on_termination_credit_note) }
+      end
+
+      context "when plan is pay in advance" do
+        subject(:subscription) { build(:subscription, plan: create(:plan, :pay_in_advance)) }
+
+        it { is_expected.to be_valid }
+      end
     end
 
     describe "external_id validation" do

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -105,4 +105,17 @@ RSpec.describe ::V1::SubscriptionSerializer do
       expect(result["subscription"]["usage_threshold"]).to be_present
     end
   end
+
+  context "when terminated with credit note" do
+    let(:plan) { create(:plan, :pay_in_advance) }
+    let(:subscription) { create(:subscription, :terminated, plan:, on_termination_credit_note: :credit) }
+
+    it "serializes the object" do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result["subscription"]["on_termination_credit_note"]).to eq("credit")
+      expect(result["subscription"]["terminated_at"]).to be_present
+      expect(result["subscription"]["status"]).to eq("terminated")
+    end
+  end
 end

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -18,9 +18,12 @@ RSpec.describe Subscriptions::ValidateService, type: :service do
       customer:,
       plan:,
       subscription_at:,
-      ending_at:
+      ending_at:,
+      on_termination_credit_note:
     }
   end
+
+  let(:on_termination_credit_note) { nil }
 
   describe "#ending_at" do
     subject(:method_call) { validate_service.__send__(:ending_at) }
@@ -139,6 +142,23 @@ RSpec.describe Subscriptions::ValidateService, type: :service do
           expect(validate_service).not_to be_valid
           expect(result.error.messages[:ending_at]).to eq(["invalid_date"])
         end
+      end
+    end
+
+    context "with invalid on_termination_credit_note" do
+      let(:on_termination_credit_note) { "invalid" }
+
+      it "returns false and result has errors" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:on_termination_credit_note]).to eq(["invalid_value"])
+      end
+    end
+
+    context "with valid on_termination_credit_note" do
+      let(:on_termination_credit_note) { "credit" }
+
+      it "returns true" do
+        expect(validate_service).to be_valid
       end
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/flexible-credit-note-management

## Context

When subscriptions are terminated before their billing period ends, the system previously always created credit notes for unused time on pay-in-advance plans. This inflexible behavior didn't accommodate different business needs where organizations might want to skip credit note generation for certain termination scenarios.

## Description

This introduces an `on_termination_credit_note` enum field to subscriptions that controls whether credit notes are created when pay-in-advance subscriptions are terminated early. The field supports "credit" (default) and "skip" values, allowing organizations to choose their preferred termination behavior.

The termination service now respects this setting and only creates credit notes when explicitly configured to do so. The API accepts the termination behavior as a parameter during subscription termination, with validation ensuring only pay-in-advance plans can use this feature.

The implementation includes database schema changes, API parameter handling, service logic updates, and comprehensive test coverage for all termination scenarios. Scenario specs for termination behaviors will come later on. 
