### PR TITLE
Fix(payments with customer_id): update query that populates payments with customer id

### DIFF
--- a/app/jobs/database_migrations/populate_payments_with_customer_id.rb
+++ b/app/jobs/database_migrations/populate_payments_with_customer_id.rb
@@ -10,16 +10,23 @@ module DatabaseMigrations
     def perform(batch_number = 1)
       # rubocop:disable Rails/SkipsModelValidations
       Payment.where(payable_type: "Invoice", customer_id: nil)
+        .joins("LEFT JOIN invoices ON invoices.id = payments.payable_id AND payments.payable_type = 'Invoice'")
+        .where("payments.customer_id IS NULL AND invoices.customer_id IS NOT NULL")
         .limit(BATCH_SIZE)
-        .update_all("customer_id = (SELECT customer_id FROM invoices WHERE invoices.id = payments.payable_id)")
+        .update_all("customer_id = invoices.customer_id")
 
       Payment.where(payable_type: "PaymentRequest", customer_id: nil)
+        .joins("LEFT JOIN payment_requests ON payment_requests.id = payments.payable_id AND payments.payable_type = 'PaymentRequest'")
+        .where("payments.customer_id IS NULL AND payment_requests.customer_id IS NOT NULL")
         .limit(BATCH_SIZE)
-        .update_all("customer_id = (SELECT customer_id FROM payment_requests WHERE payment_requests.id = payments.payable_id)")
+        .update_all("customer_id = payment_requests.customer_id")
       # rubocop:enable Rails/SkipsModelValidations
 
       # Queue the next batch
-      self.class.perform_later(batch_number + 1) if Payment.where(customer_id: nil).exists?
+      self.class.perform_later(batch_number + 1) if Payment.joins("LEFT JOIN invoices ON invoices.id = payments.payable_id AND payments.payable_type = 'Invoice'")
+        .joins("LEFT JOIN payment_requests ON payment_requests.id = payments.payable_id AND payments.payable_type = 'PaymentRequest'")
+        .where("payments.customer_id IS NULL AND (invoices.customer_id IS NOT NULL OR payment_requests.customer_id IS NOT NULL)")
+        .exists?
     end
 
     def lock_key_arguments


### PR DESCRIPTION
## Context

Earlier we introduced a job that updates payments with customer_id, pulling them from payable object. Apparently we have some Payments for Invoices and PaymentRequests (all of them are for "developer" organizations), where related Invoices or PaymentRequests do not exist in the database. 

## Description

Modified requests:
- Only search for payments that, when joined with invoices or payment_requests have invoices.customer_id or payment_request.customer_id
