### PR TITLE
feat(wallet-limitations): add api support for billable metric limitation

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -108,7 +108,8 @@ module Api
             ]
           ],
           applies_to: [
-            fee_types: []
+            fee_types: [],
+            billable_metric_codes: []
           ]
         )
       end
@@ -140,7 +141,8 @@ module Api
             ]
           ],
           applies_to: [
-            fee_types: []
+            fee_types: [],
+            billable_metric_codes: []
           ]
         )
       end

--- a/app/serializers/v1/wallet_serializer.rb
+++ b/app/serializers/v1/wallet_serializer.rb
@@ -45,7 +45,8 @@ module V1
     def limitations
       {
         applies_to: {
-          fee_types: model.allowed_fee_types
+          fee_types: model.allowed_fee_types,
+          billable_metric_codes: model.billable_metrics.pluck(:code)
         }
       }
     end

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -290,6 +290,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
     end
 
     context "with limitations" do
+      let(:bm) { create(:billable_metric, organization:) }
       let(:create_params) do
         {
           external_customer_id: customer.external_id,
@@ -300,7 +301,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           granted_credits: "10",
           expiration_at:,
           applies_to: {
-            fee_types: %w[charge]
+            fee_types: %w[charge],
+            billable_metric_codes: [bm.code]
           }
         }
       end
@@ -313,6 +315,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
         expect(response).to have_http_status(:success)
         expect(limitations).to be_present
         expect(limitations[:fee_types]).to eq(%w[charge])
+        expect(limitations[:billable_metric_codes]).to eq([bm.code])
       end
     end
   end
@@ -367,11 +370,13 @@ RSpec.describe Api::V1::WalletsController, type: :request do
     end
 
     context "with limitations" do
+      let(:bm) { create(:billable_metric, organization:) }
       let(:update_params) do
         {
           name: "wallet1",
           applies_to: {
-            fee_types: %w[charge]
+            fee_types: %w[charge],
+            billable_metric_codes: [bm.code]
           }
         }
       end
@@ -383,6 +388,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
         expect(json[:wallet][:lago_id]).to eq(wallet.id)
         expect(json[:wallet][:name]).to eq(update_params[:name])
         expect(json[:wallet][:applies_to][:fee_types]).to eq(%w[charge])
+        expect(json[:wallet][:applies_to][:billable_metric_codes]).to eq([bm.code])
 
         expect(SendWebhookJob).to have_been_enqueued.with("wallet.updated", Wallet)
       end

--- a/spec/serializers/v1/wallet_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_serializer_spec.rb
@@ -7,8 +7,12 @@ RSpec.describe ::V1::WalletSerializer do
 
   let(:wallet) { create(:wallet, allowed_fee_types: %w[charge]) }
   let(:recurring_transaction_rule) { create(:recurring_transaction_rule, wallet:) }
+  let(:wallet_target) { create(:wallet_target, wallet:) }
 
-  before { recurring_transaction_rule }
+  before do
+    recurring_transaction_rule
+    wallet_target
+  end
 
   it "serializes the object" do
     result = JSON.parse(serializer.to_json)
@@ -37,6 +41,7 @@ RSpec.describe ::V1::WalletSerializer do
         "invoice_requires_successful_payment" => wallet.invoice_requires_successful_payment
       )
       expect(result["wallet"]["applies_to"]["fee_types"]).to eq(%w[charge])
+      expect(result["wallet"]["applies_to"]["billable_metric_codes"]).to eq([wallet_target.billable_metric.code])
       expect(result["wallet"]["recurring_transaction_rules"].first["lago_id"]).to eq(recurring_transaction_rule.id)
     end
   end


### PR DESCRIPTION
## Context

With this feature it will be possible to limit wallet consumption on specific billable metric fees

## Description

This PR adds api support for billable metrics that should be targeted by wallet credits
