### PR TITLE
feat(wallet-limitations): add gql support for billable metric limitations

### DIFF
--- a/app/graphql/types/wallets/applies_to.rb
+++ b/app/graphql/types/wallets/applies_to.rb
@@ -6,6 +6,7 @@ module Types
       graphql_name "WalletAppliesTo"
 
       field :fee_types, [Types::Fees::TypesEnum], null: true, method: :allowed_fee_types
+      field :billable_metrics, [Types::BillableMetrics::Object]
     end
   end
 end

--- a/app/graphql/types/wallets/applies_to_input.rb
+++ b/app/graphql/types/wallets/applies_to_input.rb
@@ -4,6 +4,7 @@ module Types
   module Wallets
     class AppliesToInput < BaseInputObject
       argument :fee_types, [Types::Fees::TypesEnum], required: false
+      argument :billable_metric_ids, [ID], required: false
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -578,6 +578,7 @@ interface AppliedTax {
 }
 
 input AppliesToInput {
+  billableMetricIds: [ID!]
   feeTypes: [FeeTypesEnum!]
 }
 
@@ -10745,6 +10746,7 @@ type Wallet {
 }
 
 type WalletAppliesTo {
+  billableMetrics: [BillableMetric!]
   feeTypes: [FeeTypesEnum!]
 }
 

--- a/schema.json
+++ b/schema.json
@@ -3140,6 +3140,26 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "billableMetricIds",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "enumValues": null
@@ -55349,6 +55369,26 @@
           "interfaces": [],
           "possibleTypes": null,
           "fields": [
+            {
+              "name": "billableMetrics",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "BillableMetric",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
             {
               "name": "feeTypes",
               "description": null,

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization: membership.organization) }
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:) }
   let(:expiration_at) { (Time.zone.now + 1.year) }
@@ -39,6 +40,9 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
           }
           appliesTo {
             feeTypes
+            billableMetrics {
+              id
+            }
           }
         }
       }
@@ -86,7 +90,8 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
             }
           ],
           appliesTo: {
-            feeTypes: %w[subscription]
+            feeTypes: %w[subscription],
+            billableMetricIds: [billable_metric.id]
           }
         }
       }
@@ -118,6 +123,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
       "invoiceRequiresSuccessfulPayment" => true
     )
     expect(result_data["appliesTo"]["feeTypes"]).to eq(["subscription"])
+    expect(result_data["appliesTo"]["billableMetrics"].first["id"]).to eq(billable_metric.id)
 
     expect(SendWebhookJob).to have_been_enqueued.with("wallet.updated", Wallet)
   end


### PR DESCRIPTION
## Context

With this feature it will be possible to limit wallet consumption on specific billable metric fees

## Description

This PR adds graphQL support for billable metrics that should be targeted by wallet credits
