### PR TITLE
fix(gql-customer): Fix customer type

### DIFF
--- a/app/graphql/types/payments/object.rb
+++ b/app/graphql/types/payments/object.rb
@@ -10,7 +10,7 @@ module Types
       field :amount_cents, GraphQL::Types::BigInt, null: false
       field :amount_currency, Types::CurrencyEnum, null: false
 
-      field :customer, Types::Customers::Object, null: false
+      field :customer, Types::Customers::Object, null: true
       field :payable, Types::Payables::Object, null: false
       field :payable_payment_status, Types::Payments::PayablePaymentStatusEnum, null: true
       field :payment_provider_type, Types::PaymentProviders::ProviderTypeEnum, null: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -7435,7 +7435,7 @@ type Payment {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   createdAt: ISO8601DateTime!
-  customer: Customer!
+  customer: Customer
   id: ID!
   payable: Payable!
   payablePaymentStatus: PayablePaymentStatusEnum

--- a/schema.json
+++ b/schema.json
@@ -35133,13 +35133,9 @@
               "name": "customer",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Customer",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Customer",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/types/payments/object_spec.rb
+++ b/spec/graphql/types/payments/object_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Types::Payments::Object do
   it { is_expected.to have_field(:amount_cents).of_type("BigInt!") }
   it { is_expected.to have_field(:amount_currency).of_type("CurrencyEnum!") }
 
-  it { is_expected.to have_field(:customer).of_type("Customer!") }
+  it { is_expected.to have_field(:customer).of_type("Customer") }
   it { is_expected.to have_field(:payable).of_type("Payable!") }
   it { is_expected.to have_field(:payable_payment_status).of_type("PayablePaymentStatusEnum") }
   it { is_expected.to have_field(:payment_provider_type).of_type("ProviderTypeEnum") }


### PR DESCRIPTION
## Context

Some payments have no customers and the FE returns and error because customer field was as `null: false`

## Description

Change the `customer` field to be `null: true`