### PR TITLE
avoid papertrail when touching ChargeFilterValue

### DIFF
--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -47,8 +47,10 @@ module ChargeFilters
               cascade_pricing_group_keys(filter, filter_param)
               filter.save!
 
-              # NOTE: Make sure update_at is touched even if not changed to keep the order
-              filter.touch # rubocop:disable Rails/SkipsModelValidations
+              PaperTrail.request.disable_model(filter.class) do
+                # NOTE: Make sure update_at is touched even if not changed to keep the order
+                filter.touch # rubocop:disable Rails/SkipsModelValidations
+              end
               result.filters << filter
 
               next
@@ -64,7 +66,10 @@ module ChargeFilters
           ).properties
           if filter.save! && touch && !filter.changed?
             # NOTE: Make sure update_at is touched even if not changed to keep the right order
-            filter.touch # rubocop:disable Rails/SkipsModelValidations
+            PaperTrail.request.disable_model(filter.class) do
+              # Keep this touch inside PaperTrail disable model to not overload db operations
+              filter.touch # rubocop:disable Rails/SkipsModelValidations
+            end
           end
 
           # NOTE: Create or update the filter values
@@ -78,7 +83,10 @@ module ChargeFilters
             filter_value.values = values
             if filter_value.save! && touch && !filter_value.changed?
               # NOTE: Make sure update_at is touched even if not changed to keep the right order
-              filter_value.touch # rubocop:disable Rails/SkipsModelValidations
+              PaperTrail.request.disable_model(filter_value.class) do
+                # Keep this touch inside PaperTrail disable model to not overload db operations
+                filter_value.touch # rubocop:disable Rails/SkipsModelValidations
+              end
             end
           end
 


### PR DESCRIPTION
This PR ignores PaperTrail gem when `touch` a  `ChargeFilterValue` and `ChargeFilter` classes in `ChargeFilters::CreateOrUpdateBatchService`. 

The expected behaviour here is to speed up the `Charge` processing. 
Here are some benchmarks.
The column is the execution time.

```
with paper trail: 1.330198 |          | without updated_at for some blocks: 0.594328 
with paper trail: 1.334182 |          | without updated_at for some blocks: 0.601362
with paper trail: 1.431661 |          | without updated_at for some blocks: 0.601495
with paper trail: 1.441464 |          | without updated_at for some blocks: 0.745986
with paper trail: 1.457205 |          | without updated_at for some blocks: 0.922767
with paper trail: 1.446475 |          | without updated_at for some blocks: 0.390570
with paper trail: 3.047239 |          | without updated_at for some blocks: 0.348014
with paper trail: 2.020926 |          | without updated_at for some blocks: 0.454543
with paper trail: 2.059722 |          | without updated_at for some blocks: 0.493386
with paper trail: 1.435968 |          | without updated_at for some blocks: 0.364133
with paper trail: 1.613248 |          | without updated_at for some blocks: 0.325380
with paper trail: 1.627282 |          | without updated_at for some blocks: 0.470174
with paper trail: 1.425840 |          | without updated_at for some blocks: 0.568249
with paper trail: 2.489701 |          | without updated_at for some blocks: 0.574546
with paper trail: 1.607393 |          | without updated_at for some blocks: 0.377249
with paper trail: 1.579659 |          | without updated_at for some blocks: 0.766737
with paper trail: 1.605848 |          | without updated_at for some blocks: 0.536228
with paper trail: 1.816462 |          | without updated_at for some blocks: 0.725419
with paper trail: 1.379300 |          | without updated_at for some blocks: 0.312837
with paper trail: 1.972439 |          | without updated_at for some blocks: 0.770305
with paper trail: 1.554785 |          | without updated_at for some blocks: 0.362360
with paper trail: 1.676870 |          | without updated_at for some blocks: 0.517356
with paper trail: 1.853867 |          | without updated_at for some blocks: 0.351933
with paper trail: 1.406766 |          | without updated_at for some blocks: 0.442250
with paper trail: 1.333707 |          | without updated_at for some blocks: 0.626961
with paper trail: 2.254768 |          | without updated_at for some blocks: 0.410133
with paper trail: 1.617074 |          | without updated_at for some blocks: 0.388117
with paper trail: 1.525648 |          | without updated_at for some blocks: 0.430591
with paper trail: 1.332170 |          | without updated_at for some blocks: 0.298124
with paper trail: 1.699629 |          | without updated_at for some blocks: 0.448570
with paper trail: 1.366738 |          | without updated_at for some blocks: 0.375580
with paper trail: 2.078655 |          | without updated_at for some blocks: 0.334107
with paper trail: 1.436798 |          | without updated_at for some blocks: 0.315864
with paper trail: 1.456177 |          | without updated_at for some blocks: 0.374689
with paper trail: 1.462480 |          | without updated_at for some blocks: 0.450574
with paper trail: 1.425200 |          | without updated_at for some blocks: 0.305071
with paper trail: 1.379966 |          | without updated_at for some blocks: 0.441018
with paper trail: 1.376614 |          | without updated_at for some blocks: 0.430980
with paper trail: 1.378886 |          | without updated_at for some blocks: 0.328736
with paper trail: 1.373058 |          | without updated_at for some blocks: 0.384520
with paper trail: 1.385375 |          | without updated_at for some blocks: 0.294447
with paper trail: 1.392433 |          | without updated_at for some blocks: 0.438179
with paper trail: 1.445116 |          | without updated_at for some blocks: 0.310957
with paper trail: 1.503114 |          | without updated_at for some blocks: 0.341993
with paper trail: 1.523240 |          | without updated_at for some blocks: 0.295318
with paper trail: 1.516659 |          | without updated_at for some blocks: 0.348288
with paper trail: 1.453048 |          | without updated_at for some blocks: 0.396281
with paper trail: 1.451868 |          | without updated_at for some blocks: 0.363915
with paper trail: 1.484317 |          | without updated_at for some blocks: 0.344391
with paper trail: 1.489028 |          | without updated_at for some blocks: 0.453008
with paper trail: 1.457538 |          | without updated_at for some blocks: 0.423612
with paper trail: 1.415402 |          | without updated_at for some blocks: 0.424893
with paper trail: 1.312427 |          | without updated_at for some blocks: 0.471143
with paper trail: 1.289789 |          | without updated_at for some blocks: 0.314261
with paper trail: 1.319216 |          | without updated_at for some blocks: 0.349288
with paper trail: 1.305880 |          | without updated_at for some blocks: 0.386506
with paper trail: 1.380430 |          | without updated_at for some blocks: 0.248609
with paper trail: 1.393700 |          | without updated_at for some blocks: 0.293551
with paper trail: 1.367154 |          | without updated_at for some blocks: 0.369854
with paper trail: 1.359034 |          | without updated_at for some blocks: 0.373322
with paper trail: 1.391205 |          | without updated_at for some blocks: 0.398348
with paper trail: 1.342277 |          | without updated_at for some blocks: 0.426885
with paper trail: 1.358889 |          | without updated_at for some blocks: 0.328775
with paper trail: 1.366493 |          | without updated_at for some blocks: 0.400891
with paper trail: 1.318671 |          | without updated_at for some blocks: 0.353039
with paper trail: 1.348235 |          | without updated_at for some blocks: 0.347935
with paper trail: 1.340710 |          | without updated_at for some blocks: 0.464833
with paper trail: 1.334500 |          | without updated_at for some blocks: 0.423088
with paper trail: 1.261572 |          | without updated_at for some blocks: 0.406778
with paper trail: 1.217464 |          | without updated_at for some blocks: 0.442549
with paper trail: 1.203725 |          | without updated_at for some blocks: 0.371885
with paper trail: 1.329336 |          | without updated_at for some blocks: 0.280831
with paper trail: 1.391845 |          | without updated_at for some blocks: 0.469446
with paper trail: 1.435728 |          | without updated_at for some blocks: 0.264899
with paper trail: 1.451278 |          | without updated_at for some blocks: 0.389971
with paper trail: 1.356684 |          | without updated_at for some blocks: 0.312929
with paper trail: 1.373211 |          | without updated_at for some blocks: 0.393406
with paper trail: 1.366159 |          | without updated_at for some blocks: 0.366458
with paper trail: 1.359568 |          | without updated_at for some blocks: 0.332525
with paper trail: 1.380263 |          | without updated_at for some blocks: 0.411630
with paper trail: 1.376157 |          | without updated_at for some blocks: 0.361578
with paper trail: 1.374809 |          | without updated_at for some blocks: 0.749983
with paper trail: 1.377746 |          | without updated_at for some blocks: 0.711857
with paper trail: 1.369452 |          | without updated_at for some blocks: 0.680676
with paper trail: 1.353476 |          | without updated_at for some blocks: 0.600250
with paper trail: 1.277399 |          | without updated_at for some blocks: 0.077537 
``` 

