### PR TITLE
chore(specs): Fix `DatabaseCleaner` for `clickhouse` database

### DIFF
--- a/spec/support/monkey_patches/database_cleaner.rb
+++ b/spec/support/monkey_patches/database_cleaner.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Monkey patch database cleaner to be compatible with Clickhouse.
+module DatabaseCleaner
+  module ActiveRecord
+    class Deletion
+      def delete_table(connection, table_name)
+        arel = Arel::DeleteManager.new.from(Arel::Table.new(table_name)).where(Arel.sql("1=1"))
+        connection.delete(arel)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This is a follow-up to https://github.com/getlago/lago-api/pull/3914.

Clickhouse database currently doesn't get cleaned up by `DatabaseCleaner`. This can result in tests failing because it expects a clean state. For example, the following test fails:

```ruby
require "rails_helper"

RSpec.describe DatabaseCleaner do
  context "with clickhouse: true", clickhouse: true do
    it "has zero events" do
      expect(Clickhouse::EventsRaw.count).to eq(0)

      create(:clickhouse_events_raw)

      expect(Clickhouse::EventsRaw.count).to eq(1)
    end

    it "also has zero events" do
      # This should work
      expect(Clickhouse::EventsRaw.count).to eq(0)
    end
  end
end
```

We get the following error:

```shell
⋊> lago exec api bundle exec rspec --color --format documentation spec/database_cleaner_spec.rb
Run options: include {locations: {"./spec/database_cleaner_spec.rb" => [5]}}

DatabaseCleaner
  with clickhouse: true
    has zero events
    also has zero events (FAILED - 1)

Failures:

  1) DatabaseCleaner with clickhouse: true also has zero events
     Failure/Error: expect(Clickhouse::EventsRaw.count).to eq(0)

       expected: 0
            got: 1

       (compared using ==)
     # ./spec/database_cleaner_spec.rb:16:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:180:in 'block (3 levels) in <top (required)>'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in 'DatabaseCleaner::Cleaners#cleaning'
     # ./spec/spec_helper.rb:179:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'

Finished in 0.6799 seconds (files took 2.94 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/database_cleaner_spec.rb:15 # DatabaseCleaner with clickhouse: true also has zero events
```

Note that none of the available strategies were working with `Clickhouse`:

* `transaction` - Clickhouse doesn't support transaction so `transaction` strategy is a no-op.
* `deletion` - `DatabaseCleaner` current implementation is not compatible with Clickhouse:

  ```shell
  ActiveRecord::ActiveRecordError: Response code: 400: Code: 62. DB::Exception: Syntax error: failed at position 37 (FORMAT): FORMAT JSONCompactEachRowWithNamesAndTypes. Expected one of: token, DoubleColon, OR, AND, IS NOT DISTINCT FROM, IS NULL, IS NOT NULL, BETWEEN, NOT BETWEEN, LIKE, ILIKE, NOT LIKE, NOT ILIKE, REGEXP, IN, NOT IN, GLOBAL IN, GLOBAL NOT IN, MOD, DIV, SETTINGS, ParallelWithClause, PARALLEL WITH, end of query. (SYNTAX_ERROR) (version 25.5.1.2782 (official build))
  ```

  This is due to `DatabaseCleaner` relying on `ActiveRecord::ConnectionAdapters::ClickhouseAdapter#execute` which will run the delete query with `FORMAT JSONCompactEachRowWithNamesAndTypes` which is invalid:

  ```sql
  DELETE FROM events_raw WHERE 1=1 FORMAT JSONCompactEachRowWithNamesAndTypes
  ```
* `truncation` - Clickhouse Kafka engine doesn't support `TRUNCATE`:

  ```shell
  ActiveRecord::ActiveRecordError: Response code: 501: [] [] ["Code: 48. DB::Exception: Truncate is not supported by storage Kafka. (NOT_IMPLEMENTED) (version 25.5.1.2782 (official build))"]
  ```

## Description

**Fix**

The correct way to execute a delete query with Clickhouse is to rely on `ActiveRecord::ConnectionAdapters::ClickhouseAdapter#delete` which will run the delete query without `FORMAT JSONCompactEachRowWithNamesAndTypes`:

```shell
lago-api(dev)> Clickhouse::BaseRecord.connection.execute("DELETE FROM events_raw")
D, [2025-07-03T21:05:23.876222 #24097] DEBUG -- :   Clickhouse  (3.0ms)  DELETE FROM events_raw
(lago-api):1:in '<main>': Response code: 400: (ActiveRecord::ActiveRecordError)
Code: 62. DB::Exception: Syntax error: failed at position 24 (FORMAT): FORMAT JSONCompactEachRowWithNamesAndTypes. Expected one of: ON, IN PARTITION, WHERE. (SYNTAX_ERROR) (version 25.5.1.2782 (official build))

lago-api(dev)> Clickhouse::BaseRecord.connection.delete(Arel::DeleteManager.new.from(Arel::Table.new('events_raw')).where(Arel.sql("1=1")))
D, [2025-07-03T21:06:07.921555 #24097] DEBUG -- :   Clickhouse  (10.8ms)  DELETE FROM events_raw WHERE 1=1
=> 0
```

To make it work, a Monkey patch was added to `DatabaseCleaner` to use `Clickhouse::BaseRecord.connection.delete` instead of `Clickhouse::BaseRecord.connection.execute`. We may want to submit a fix upstream instead but it is not clear to me whether this should be a `database_cleaner-active_record` or a `clickhouse-activerecord` fix.

**Performance impact**


Note that enabling cleanup for all Clickhouse tests does have a performance impact:

* On this branch:

  ```shell
  ⋊> ~/c/l/api on fix/db-cleaner-clickhouse ◦ lago exec api bundle exec rspec -t clickhouse
  Run options: include {clickhouse: true}

  Finished in 20.23 seconds (files took 13.86 seconds to load)
  196 examples, 0 failures
  ```

* On `main`:

  ```shell
  ⋊> ~/c/l/api on main ◦ lago exec api bundle exec rspec -t clickhouse
  Run options: include {clickhouse: true}

  Finished in 11.49 seconds (files took 16.1 seconds to load)
  196 examples, 0 failures
  ```

So for now, we only clean up Clickhouse before test suite and before each test that is annotated with `clickhouse: {clean_before: true}`.