### PR TITLE
feat(wallet-limitations): apply wallet credits with BM limitation

### DIFF
--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -52,6 +52,10 @@ class Wallet < ApplicationRecord
   def limited_fee_types?
     allowed_fee_types.present?
   end
+
+  def limited_billable_metrics?
+    billable_metrics.any?
+  end
 end
 
 # == Schema Information

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -49,4 +49,20 @@ RSpec.describe Wallet, type: :model do
       end
     end
   end
+
+  describe "limited_billable_metrics?" do
+    context "when wallet_targets are present" do
+      before { create(:wallet_target, wallet:) }
+
+      it "returns true" do
+        expect(wallet.limited_billable_metrics?).to be true
+      end
+    end
+
+    context "when wallet targets are not present" do
+      it "returns false" do
+        expect(wallet.limited_billable_metrics?).to be false
+      end
+    end
+  end
 end

--- a/spec/services/credits/applied_prepaid_credit_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credit_service_spec.rb
@@ -166,5 +166,115 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
         end
       end
     end
+
+    context "with billable metric limitations" do
+      let(:subscription_fees) { [fee1, fee2] }
+      let(:fee1) { create(:fee, invoice:, subscription:, amount_cents: 60, taxes_amount_cents: 6) }
+      let(:fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 40, taxes_amount_cents: 4, charge:) }
+      let(:charge) { create(:standard_charge, organization: wallet.organization, billable_metric:) }
+      let(:wallet) { create(:wallet, customer:, balance_cents: 1000, credits_balance: 10.0) }
+      let(:billable_metric) { create(:billable_metric, organization: wallet.organization) }
+      let(:wallet_target) { create(:wallet_target, wallet:, billable_metric:) }
+
+      before do
+        subscription_fees
+        wallet_target
+      end
+
+      it "calculates prepaid credit" do
+        result = credit_service.call
+
+        expect(result).to be_success
+        expect(result.prepaid_credit_amount_cents).to eq(44)
+        expect(invoice.prepaid_credit_amount_cents).to eq(44)
+      end
+
+      it "creates wallet transaction" do
+        result = credit_service.call
+
+        expect(result).to be_success
+        expect(result.wallet_transaction).to be_present
+        expect(result.wallet_transaction.amount).to eq(0.44)
+        expect(result.wallet_transaction).to be_invoiced
+      end
+
+      it "updates wallet balance" do
+        result = credit_service.call
+        wallet = result.wallet_transaction.wallet
+
+        expect(wallet.balance_cents).to eq(956)
+        expect(wallet.credits_balance).to eq(9.56)
+      end
+
+      context "when wallet credits are less than invoice amount" do
+        let(:amount_cents) { 10_000 }
+        let(:fee1) { create(:fee, invoice:, subscription:, amount_cents: 6_000, taxes_amount_cents: 600) }
+        let(:fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 4_000, taxes_amount_cents: 400, charge:) }
+
+        it "calculates prepaid credit" do
+          result = credit_service.call
+
+          expect(result).to be_success
+          expect(result.prepaid_credit_amount_cents).to eq(1000)
+        end
+
+        it "creates wallet transaction" do
+          result = credit_service.call
+
+          expect(result).to be_success
+          expect(result.wallet_transaction).to be_present
+          expect(result.wallet_transaction.amount).to eq(10.0)
+        end
+
+        it "updates wallet balance" do
+          result = credit_service.call
+          wallet = result.wallet_transaction.wallet
+
+          expect(wallet.balance).to eq(0.0)
+          expect(wallet.credits_balance).to eq(0.0)
+        end
+      end
+    end
+
+    context "with billable metric limitations and fee type limitation" do
+      let(:subscription_fees) { [fee1, fee2, fee3] }
+      let(:fee1) { create(:fee, invoice:, subscription:, amount_cents: 60, taxes_amount_cents: 6) }
+      let(:fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 20, taxes_amount_cents: 2, charge:) }
+      let(:fee3) { create(:charge_fee, invoice:, subscription:, amount_cents: 20, taxes_amount_cents: 2) }
+      let(:charge) { create(:standard_charge, organization: wallet.organization, billable_metric:) }
+      let(:wallet) { create(:wallet, customer:, balance_cents: 1000, credits_balance: 10.0, allowed_fee_types: %w[subscription]) }
+      let(:billable_metric) { create(:billable_metric, organization: wallet.organization) }
+      let(:wallet_target) { create(:wallet_target, wallet:, billable_metric:) }
+
+      before do
+        subscription_fees
+        wallet_target
+      end
+
+      it "calculates prepaid credit" do
+        result = credit_service.call
+
+        expect(result).to be_success
+        expect(result.prepaid_credit_amount_cents).to eq(88)
+        expect(invoice.prepaid_credit_amount_cents).to eq(88)
+      end
+
+      it "creates wallet transaction" do
+        result = credit_service.call
+
+        expect(result).to be_success
+        expect(result.wallet_transaction).to be_present
+        expect(result.wallet_transaction.amount).to eq(0.88)
+        expect(result.wallet_transaction).to be_invoiced
+      end
+
+      it "updates wallet balance" do
+        result = credit_service.call
+        wallet = result.wallet_transaction.wallet
+
+        expect(wallet.balance_cents).to eq(912)
+        expect(wallet.credits_balance).to eq(9.12)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Currently it is not possible to scope wallet consumption to target only specific BM fees

## Description

With this PR it is possible to apply wallet credits on specific charge fees. Also, it is possible to combine fee type limitation and billable metric limitation.

### Example
Fees: `subscription_fee`, `charge_fee1` (bm1_code), `charge_fee2` (bm2_code)

Type limitation: [charge, subscription]

BM limitation: [`bm1_code`]

=> Wallet credits will only target `subscription_fee` and `charge_fee1`
