### PR TITLE
Fix(daily-usages): Retry job fix (#3987) - use after_commit instead

### DIFF
--- a/app/jobs/daily_usages/fill_from_invoice_job.rb
+++ b/app/jobs/daily_usages/fill_from_invoice_job.rb
@@ -10,8 +10,6 @@ module DailyUsages
       end
     end
 
-    retry_on ActiveJob::DeserializationError, wait: :polynomially_longer, attempts: 10
-
     def perform(invoice:, subscriptions:)
       DailyUsages::FillFromInvoiceService.call(invoice:, subscriptions:).raise_if_error!
     end

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -167,7 +167,9 @@ module Invoices
         .map(&:subscription)
       return if subscriptions.blank?
 
-      DailyUsages::FillFromInvoiceJob.perform_later(invoice:, subscriptions: subscriptions)
+      after_commit do
+        DailyUsages::FillFromInvoiceJob.perform_later(invoice:, subscriptions:)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

This job was sometimes executed before the actual invoice existed.

## Description

Use `after_commit` to ensure the invoice was created before enqueuing a job