### PR TITLE
fix: rename post-upgrade task

### DIFF
--- a/lib/tasks/upgrade_verification.rake
+++ b/lib/tasks/upgrade_verification.rake
@@ -6,8 +6,8 @@ require "yaml"
 namespace :upgrade do
   # Note: this task is to be filled with jobs needed to be run before the upgrade
   #       and is to be changed depending on what is required for the next version.
-  desc "Checks data and performs required jobs to fix the data before the upgrade"
-  task check_readiness: :environment do
+  desc "Performs required jobs that need to be run after the upgrade"
+  task perform_required_jobs: :environment do
     Rails.logger.level = Logger::Severity::ERROR
 
     resources_to_fill = [


### PR DESCRIPTION
## Context

The newly added task is supposed to be run after the upgrade, not before the upgrade,
so if we're going 1.1 -> 1.2 -> 1.3, and the task fixes data before 1.3, it is better to run it as soon as v1.2 is installed, not when users decided to switch to 1.3
