### PR TITLE
Fix(invoice-deletion): when destroying invoices, also destroy it's payments

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -65,6 +65,7 @@ Rails.application.console do
       invoice.taxes.destroy_all
       invoice.credits.destroy_all
       invoice.applied_invoice_custom_sections.destroy_all
+      invoice.payments.destroy_all
       invoice.destroy!
     end
 


### PR DESCRIPTION
## Context

We have some payments that are related to not existing invoices. Since when organizations are setting up, sometimes we have to delete their existing invoices, this should be done together with their payments

## Description

Added a step of deleting payments when deleting invocies
