### PR TITLE
feat(fixed_charges): Add migration for FixedCharge ChargeModel enum

### DIFF
--- a/db/migrate/20250715124108_fixed_charge_charge_model.rb
+++ b/db/migrate/20250715124108_fixed_charge_charge_model.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class FixedChargeChargeModel < ActiveRecord::Migration[8.0]
+  def change
+    create_enum :fixed_charge_charge_model, %w[standard graduated volume]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -845,6 +845,7 @@ DROP TYPE IF EXISTS public.payment_type;
 DROP TYPE IF EXISTS public.payment_payable_payment_status;
 DROP TYPE IF EXISTS public.invoice_custom_section_type;
 DROP TYPE IF EXISTS public.inbound_webhook_status;
+DROP TYPE IF EXISTS public.fixed_charge_charge_model;
 DROP TYPE IF EXISTS public.entity_document_numbering;
 DROP TYPE IF EXISTS public.entitlement_privilege_value_types;
 DROP TYPE IF EXISTS public.customer_type;
@@ -926,6 +927,17 @@ CREATE TYPE public.entitlement_privilege_value_types AS ENUM (
 CREATE TYPE public.entity_document_numbering AS ENUM (
     'per_customer',
     'per_billing_entity'
+);
+
+
+--
+-- Name: fixed_charge_charge_model; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.fixed_charge_charge_model AS ENUM (
+    'standard',
+    'graduated',
+    'volume'
 );
 
 
@@ -9040,6 +9052,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250716142613'),
 ('20250716132759'),
 ('20250716132649'),
+('20250715124108'),
 ('20250714131519'),
 ('20250710102337'),
 ('20250709085218'),


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices
👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

## Context

What is the current situation?

**Option https://github.com/getlago/lago-api/pull/1** - User has to create a one off invoice alongside the subscription, it will create 2 different invoices.

**Option https://github.com/getlago/lago-api/pull/2** - User can add a recurring billable metric and use event to have this fee invoice on subscription renewal, but it won’t appear on the first billing subscription.

What problem are we trying to solve?

At subscription creation or afterward, there is no clear way to invoice a fixed fee that is not tied to events, aside from the subscription fee itself. This fee could be either a one-time charge or a recurring one.

## Description

DB migration to add a charge model enum for the fixed charge model