### PR TITLE
fix: Abilitiy to filter subscriptions by plan code

### DIFF
--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -61,7 +61,7 @@ class SubscriptionsQuery < BaseQuery
   end
 
   def with_plan_code(scope)
-    scope.joins(:plan).where(plans: {code: filters.plan_code})
+    scope.joins(:plan).where(plan: {code: filters.plan_code})
   end
 
   def with_overriden(scope)


### PR DESCRIPTION
This pull request includes a minor fix in the `with_plan_code` method of the `SubscriptionsQuery` class. The change corrects a typo in the table name used in the query.

* [`app/queries/subscriptions_query.rb`](diffhunk://#diff-ee305bb9151bb4336edd6b087887276e3ef0fef59030c9a774a295f8190ade16L64-R64): Fixed a typo in the `with_plan_code` method by changing `plans` to `plan` in the `.where` clause to ensure the query functions correctly.