### PR TITLE
feat (wallet-limitations): Apply billable metric limitation to ongoing balance

### DIFF
--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -53,7 +53,7 @@ class Wallet < ApplicationRecord
     allowed_fee_types.present?
   end
 
-  def limited_billable_metrics?
+  def limited_to_billable_metrics?
     billable_metrics.any?
   end
 end

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -52,6 +52,10 @@ class Wallet < ApplicationRecord
   def limited_fee_types?
     allowed_fee_types.present?
   end
+
+  def limited_billable_metrics?
+    billable_metrics.any?
+  end
 end
 
 # == Schema Information

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -49,4 +49,20 @@ RSpec.describe Wallet, type: :model do
       end
     end
   end
+
+  describe "limited_billable_metrics?" do
+    context "when wallet_targets are present" do
+      before { create(:wallet_target, wallet:) }
+
+      it "returns true" do
+        expect(wallet.limited_billable_metrics?).to be true
+      end
+    end
+
+    context "when wallet targets are not present" do
+      it "returns false" do
+        expect(wallet.limited_billable_metrics?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -50,18 +50,18 @@ RSpec.describe Wallet, type: :model do
     end
   end
 
-  describe "limited_billable_metrics?" do
+  describe "limited_to_billable_metrics?" do
     context "when wallet_targets are present" do
       before { create(:wallet_target, wallet:) }
 
       it "returns true" do
-        expect(wallet.limited_billable_metrics?).to be true
+        expect(wallet.limited_to_billable_metrics?).to be true
       end
     end
 
     context "when wallet targets are not present" do
       it "returns false" do
-        expect(wallet.limited_billable_metrics?).to be false
+        expect(wallet.limited_to_billable_metrics?).to be false
       end
     end
   end


### PR DESCRIPTION
## Context

Currently it is not possible to scope wallet consumption to target only specific BM fees

## Description

With this PR, ongoing balance calculation will take into account wallet limitations to specific billable metric

### Example
Fees: `charge_fee1` (bm1_code), `charge_fee2` (bm2_code)

BM limitation: [`bm1_code`]

=> Wallet credits will only target `charge_fee1`
