### PR TITLE
feat(logs): produce activity logs after commit by default

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -229,7 +229,7 @@ class BaseService
 
   Result = LegacyResult
 
-  def self.activity_loggable(action:, record:, condition: -> { true }, after_commit: nil)
+  def self.activity_loggable(action:, record:, condition: -> { true }, after_commit: true)
     self.activity_log_config = {action:, record:, condition:, after_commit:}
   end
 

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
   let(:create_subscription) { customer.present? }
 
   before do
-    allow(Utils::ActivityLog).to receive(:produce)
-
     create(:subscription, customer:) if create_subscription
   end
 
@@ -48,7 +46,7 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
     it "produces an activity log" do
       applied_coupon = described_class.call(customer:, coupon:, params:).applied_coupon
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(applied_coupon, "applied_coupon.created")
+      expect(Utils::ActivityLog).to have_produced("applied_coupon.created").after_commit.with(applied_coupon)
     end
 
     context "when coupon type is percentage" do

--- a/spec/services/applied_coupons/terminate_service_spec.rb
+++ b/spec/services/applied_coupons/terminate_service_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe AppliedCoupons::TerminateService, type: :service do
   let(:applied_coupon) { create(:applied_coupon, coupon:) }
 
   describe "#call" do
-    before do
-      allow(Utils::ActivityLog).to receive(:produce)
-    end
-
     it "terminates the applied coupon" do
       result = terminate_service.call
 
@@ -25,7 +21,7 @@ RSpec.describe AppliedCoupons::TerminateService, type: :service do
     it "produces an activity log" do
       described_class.call(applied_coupon:)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(applied_coupon, "applied_coupon.deleted")
+      expect(Utils::ActivityLog).to have_produced("applied_coupon.deleted").with(applied_coupon)
     end
 
     context "when applied coupon is already terminated" do

--- a/spec/services/billable_metrics/create_service_spec.rb
+++ b/spec/services/billable_metrics/create_service_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe BillableMetrics::CreateService, type: :service do
   describe "create" do
     before do
       allow(SegmentTrackJob).to receive(:perform_later)
-      allow(Utils::ActivityLog).to receive(:produce)
     end
 
     let(:create_args) do
@@ -106,7 +105,7 @@ RSpec.describe BillableMetrics::CreateService, type: :service do
     it "produces an activity log" do
       metric = described_class.call(create_args).billable_metric
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(metric, "billable_metric.created")
+      expect(Utils::ActivityLog).to have_produced("billable_metric.created").after_commit.with(metric)
     end
 
     context "with validation error" do

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
 
     allow(BillableMetrics::DeleteEventsJob).to receive(:perform_later).and_call_original
     allow(Invoices::RefreshDraftService).to receive(:call)
-    allow(Utils::ActivityLog).to receive(:produce).and_call_original
   end
 
   describe "#call" do
@@ -65,7 +64,7 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
     it "produces an activity log" do
       described_class.call(metric: billable_metric)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(billable_metric, "billable_metric.deleted")
+      expect(Utils::ActivityLog).to have_produced("billable_metric.deleted").after_commit.with(billable_metric)
     end
   end
 end

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -24,10 +24,6 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
   let(:filters) { nil }
 
   describe ".call" do
-    before do
-      allow(Utils::ActivityLog).to receive(:produce).and_call_original
-    end
-
     it "updates the billable metric" do
       result = described_class.call(billable_metric:, params:)
       expect(result).to be_success
@@ -47,7 +43,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
     it "produces an activity log" do
       described_class.call(billable_metric:, params:)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(billable_metric, "billable_metric.updated")
+      expect(Utils::ActivityLog).to have_produced("billable_metric.updated").after_commit.with(billable_metric)
     end
 
     context "with filters arguments" do

--- a/spec/services/billing_entities/create_service_spec.rb
+++ b/spec/services/billing_entities/create_service_spec.rb
@@ -13,14 +13,10 @@ RSpec.describe BillingEntities::CreateService, type: :service do
     }
   end
 
-  before do
-    allow(Utils::ActivityLog).to receive(:produce)
-  end
-
   it "produces an activity log" do
     billing_entity = result.billing_entity
 
-    expect(Utils::ActivityLog).to have_received(:produce).with(billing_entity, "billing_entities.created")
+    expect(Utils::ActivityLog).to have_produced("billing_entities.created").after_commit.with(billing_entity)
   end
 
   context "when lago freemium" do

--- a/spec/services/billing_entities/update_service_spec.rb
+++ b/spec/services/billing_entities/update_service_spec.rb
@@ -39,10 +39,6 @@ RSpec.describe BillingEntities::UpdateService do
     }
   end
 
-  before do
-    allow(Utils::ActivityLog).to receive(:produce)
-  end
-
   describe "#call" do
     it "updates the billing_entity" do
       result = update_service.call
@@ -68,7 +64,7 @@ RSpec.describe BillingEntities::UpdateService do
     it "produces an activity log" do
       described_class.call(billing_entity:, params:)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(billing_entity, "billing_entities.updated")
+      expect(Utils::ActivityLog).to have_produced("billing_entities.updated").after_commit.with(billing_entity)
     end
 
     context "when document_number_prefix is sent" do

--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe Coupons::CreateService, type: :service do
   let(:coupon_code) { "free-beer" }
 
   describe "create" do
-    before do
-      allow(Utils::ActivityLog).to receive(:produce)
-    end
-
     let(:expiration_at) { (Time.current + 3.days).end_of_day }
     let(:create_args) do
       {
@@ -39,7 +35,7 @@ RSpec.describe Coupons::CreateService, type: :service do
     it "produces an activity log" do
       coupon = described_class.call(create_args).coupon
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(coupon, "coupon.created")
+      expect(Utils::ActivityLog).to have_produced("coupon.created").after_commit.with(coupon)
     end
 
     context "with code already used by a deleted coupon" do

--- a/spec/services/coupons/destroy_service_spec.rb
+++ b/spec/services/coupons/destroy_service_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe Coupons::DestroyService, type: :service do
 
   describe "#call" do
     before do
-      allow(Utils::ActivityLog).to receive(:produce)
-
       coupon
     end
 
@@ -34,7 +32,7 @@ RSpec.describe Coupons::DestroyService, type: :service do
     it "produces an activity log" do
       described_class.call(coupon:)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(coupon, "coupon.deleted")
+      expect(Utils::ActivityLog).to have_produced("coupon.deleted").after_commit.with(coupon)
     end
 
     context "with applied coupons" do

--- a/spec/services/coupons/update_service_spec.rb
+++ b/spec/services/coupons/update_service_spec.rb
@@ -29,10 +29,6 @@ RSpec.describe Coupons::UpdateService, type: :service do
   let(:applies_to) { nil }
 
   describe "#call" do
-    before do
-      allow(Utils::ActivityLog).to receive(:produce)
-    end
-
     it "updates the coupon" do
       result = update_service.call
 
@@ -51,7 +47,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
     it "produces an activity log" do
       described_class.call(coupon:, params:)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(coupon, "coupon.updated")
+      expect(Utils::ActivityLog).to have_produced("coupon.updated").after_commit.with(coupon)
     end
 
     context "with validation error" do

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe CreditNotes::CreateService, type: :service do
     create(:fee_applied_tax, tax:, fee: fee1)
     create(:fee_applied_tax, tax:, fee: fee2)
     create(:invoice_applied_tax, tax:, invoice:) if invoice
-    allow(Utils::ActivityLog).to receive(:produce)
   end
 
   describe "#call" do
@@ -144,7 +143,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
     it "produces an activity log" do
       result = create_service.call
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(result.credit_note, "credit_note.created")
+      expect(Utils::ActivityLog).to have_produced("credit_note.created").with(result.credit_note)
     end
 
     it_behaves_like "syncs credit note" do

--- a/spec/services/credit_notes/generate_service_spec.rb
+++ b/spec/services/credit_notes/generate_service_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe CreditNotes::GenerateService, type: :service do
 
     stub_pdf_generation
     allow(Utils::PdfGenerator).to receive(:call).and_call_original
-    allow(Utils::ActivityLog).to receive(:produce)
   end
 
   describe ".call" do
@@ -37,7 +36,7 @@ RSpec.describe CreditNotes::GenerateService, type: :service do
     it "produces an activity log" do
       result = credit_note_generate_service.call
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(result.credit_note, "credit_note.generated")
+      expect(Utils::ActivityLog).to have_produced("credit_note.generated").with(result.credit_note)
     end
 
     context "when credit note is for self billed invoice" do

--- a/spec/services/credit_notes/refunds/adyen_service_spec.rb
+++ b/spec/services/credit_notes/refunds/adyen_service_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
       before do
         allow(modifications_api).to receive(:refund_captured_payment)
           .and_raise(Adyen::AdyenError.new(nil, nil, "error"))
-        allow(Utils::ActivityLog).to receive(:produce)
       end
 
       it "delivers an error webhook" do
@@ -115,7 +114,7 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
         expect { adyen_service.create }
           .to raise_error(Adyen::AdyenError)
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failure")
+        expect(Utils::ActivityLog).to have_produced("credit_note.refund_failure").with(credit_note)
       end
     end
 
@@ -314,7 +313,6 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
     context "when status is failed" do
       before do
         adyen_customer
-        allow(Utils::ActivityLog).to receive(:produce)
       end
 
       it "delivers an error webhook" do
@@ -349,7 +347,7 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
           status: "failed"
         )
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failure")
+        expect(Utils::ActivityLog).to have_produced("credit_note.refund_failure").with(credit_note)
       end
     end
   end

--- a/spec/services/credit_notes/refunds/gocardless_service_spec.rb
+++ b/spec/services/credit_notes/refunds/gocardless_service_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe CreditNotes::Refunds::GocardlessService, type: :service do
       before do
         allow(gocardless_refunds_service).to receive(:create)
           .and_raise(GoCardlessPro::Error.new("code" => "code", "message" => "error"))
-        allow(Utils::ActivityLog).to receive(:produce)
       end
 
       it "delivers an error webhook" do
@@ -115,7 +114,7 @@ RSpec.describe CreditNotes::Refunds::GocardlessService, type: :service do
         expect { gocardless_service.create }
           .to raise_error(GoCardlessPro::Error)
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failure")
+        expect(Utils::ActivityLog).to have_produced("credit_note.refund_failure").with(credit_note)
       end
     end
 
@@ -304,7 +303,6 @@ RSpec.describe CreditNotes::Refunds::GocardlessService, type: :service do
     context "when status is failed" do
       before do
         gocardless_service
-        allow(Utils::ActivityLog).to receive(:produce)
       end
 
       it "delivers an error webhook" do
@@ -339,7 +337,7 @@ RSpec.describe CreditNotes::Refunds::GocardlessService, type: :service do
           status: "failed"
         )
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failure")
+        expect(Utils::ActivityLog).to have_produced("credit_note.refund_failure").with(credit_note)
       end
     end
   end

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -132,7 +132,6 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
       before do
         allow(Stripe::Refund).to receive(:create)
           .and_raise(::Stripe::InvalidRequestError.new(error_message, {}, code: error_message))
-        allow(Utils::ActivityLog).to receive(:produce)
       end
 
       it "delivers an error webhook" do
@@ -157,7 +156,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
       it "produces an activity log" do
         stripe_service.create
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failure")
+        expect(Utils::ActivityLog).to have_produced("credit_note.refund_failure").with(credit_note)
       end
 
       context "when error is about non refundable payment method" do
@@ -380,7 +379,6 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
     context "when status is failed" do
       before do
         stripe_customer
-        allow(Utils::ActivityLog).to receive(:produce)
       end
 
       it "delivers an error webhook" do
@@ -415,7 +413,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
           status: "failed"
         )
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(credit_note, "credit_note.refund_failure")
+        expect(Utils::ActivityLog).to have_produced("credit_note.refund_failure").with(credit_note)
       end
     end
   end

--- a/spec/services/credits/applied_prepaid_credit_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credit_service_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
   let(:subscription) { create(:subscription, customer:) }
 
   before do
-    allow(Utils::ActivityLog).to receive(:produce)
-
     subscription
   end
 
@@ -58,7 +56,7 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
     it "produces an activity log" do
       wallet_transaction = described_class.call(invoice:, wallet:).wallet_transaction
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(wallet_transaction, "wallet_transaction.created")
+      expect(Utils::ActivityLog).to have_produced("wallet_transaction.created").after_commit.with(wallet_transaction)
     end
 
     context "when wallet credits are less than invoice amount" do

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Customers::CreateService, type: :service do
   before do
     allow(SendWebhookJob).to receive(:perform_later)
     allow(CurrentContext).to receive(:source).and_return("graphql")
-    allow(Utils::ActivityLog).to receive(:produce)
   end
 
   it "creates a new customer" do
@@ -67,7 +66,7 @@ RSpec.describe Customers::CreateService, type: :service do
   it "produces an activity log" do
     result
 
-    expect(Utils::ActivityLog).to have_received(:produce).with(result.customer, "customer.created")
+    expect(Utils::ActivityLog).to have_produced("customer.created").after_commit.with(result.customer)
   end
 
   context "when organization has multiple billing entities" do

--- a/spec/services/customers/destroy_service_spec.rb
+++ b/spec/services/customers/destroy_service_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Customers::DestroyService, type: :service do
 
   before do
     customer
-    allow(Utils::ActivityLog).to receive(:produce)
   end
 
   describe "#call" do
@@ -32,7 +31,7 @@ RSpec.describe Customers::DestroyService, type: :service do
     it "produces an activity log" do
       described_class.call(customer:)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(customer, "customer.deleted")
+      expect(Utils::ActivityLog).to have_produced("customer.deleted").after_commit.with(customer)
     end
 
     context "when customer is not found" do

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe Customers::UpdateService, type: :service do
   let(:payment_provider_code) { "stripe_1" }
 
   describe "update" do
-    before do
-      allow(Utils::ActivityLog).to receive(:produce)
-    end
-
     let(:customer) do
       create(
         :customer,
@@ -66,7 +62,7 @@ RSpec.describe Customers::UpdateService, type: :service do
     it "produces an activity log" do
       described_class.call(customer:, args: update_args)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(customer, "customer.updated")
+      expect(Utils::ActivityLog).to have_produced("customer.updated").after_commit.with(customer)
     end
 
     context "when updating the billing entity reference" do

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Customers::UpsertFromApiService, type: :service do
   before do
     allow(SendWebhookJob).to receive(:perform_later)
     allow(CurrentContext).to receive(:source).and_return("api")
-    allow(Utils::ActivityLog).to receive(:produce)
   end
 
   it "creates a new customer" do
@@ -100,7 +99,7 @@ RSpec.describe Customers::UpsertFromApiService, type: :service do
   it "produces an activity log" do
     result = described_class.call(organization:, params: create_args)
 
-    expect(Utils::ActivityLog).to have_received(:produce).with(result.customer, "customer.created")
+    expect(Utils::ActivityLog).to have_produced("customer.created").after_commit.with(result.customer)
   end
 
   context "when organization has multiple billing entities" do

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
         )
 
         succeeded_fees.each { |fee| Fees::ApplyTaxesService.call(fee:) }
-        allow(Utils::ActivityLog).to receive(:produce)
       end
 
       it "creates invoices" do
@@ -109,7 +108,7 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
         expect(sub.invoicing_reason).to eq "in_advance_charge_periodic"
 
         expect(SendWebhookJob).to have_been_enqueued.with("invoice.created", result.invoice)
-        expect(Utils::ActivityLog).to have_received(:produce).with(result.invoice, "invoice.created")
+        expect(Utils::ActivityLog).to have_produced("invoice.created").with(result.invoice)
         expect(Invoices::GeneratePdfAndNotifyJob).to have_been_enqueued.with(invoice: result.invoice, email: false)
         expect(SegmentTrackJob).to have_been_enqueued.once
         expect(Invoices::TransitionToFinalStatusService).to have_received(:call).with(invoice: result.invoice)

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -26,10 +26,6 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
     ]
   end
 
-  before do
-    allow(Utils::ActivityLog).to receive(:produce)
-  end
-
   describe "call" do
     before do
       tax
@@ -169,7 +165,7 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
       it "produces an activity log" do
         invoice = described_class.call(**args).invoice
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.one_off_created")
+        expect(Utils::ActivityLog).to have_produced("invoice.one_off_created").after_commit.with(invoice)
       end
 
       it "creates an invoice" do
@@ -214,10 +210,6 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
           File.read(p)
         end
 
-        before do
-          allow(Utils::ActivityLog).to receive(:produce)
-        end
-
         it "returns tax error" do
           result = described_class.call(**args)
 
@@ -226,7 +218,7 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
             expect(result.invoice.status).to eq("failed")
             expect(result.invoice.error_details.count).to eq(1)
             expect(result.invoice.error_details.first.details["tax_error"]).to eq("taxDateTooFarInFuture")
-            expect(Utils::ActivityLog).to have_received(:produce).with(result.invoice, "invoice.failed")
+            expect(Utils::ActivityLog).to have_produced("invoice.failed").with(result.invoice)
           end
         end
       end

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
 
       allow(SegmentTrackJob).to receive(:perform_later)
       allow(Invoices::TransitionToFinalStatusService).to receive(:call).and_call_original
-      allow(Utils::ActivityLog).to receive(:produce)
     end
 
     it "creates an invoice" do
@@ -160,7 +159,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
     it "produces an activity log" do
       invoice = described_class.call(charge:, event:, timestamp: timestamp.to_i).invoice
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.created")
+      expect(Utils::ActivityLog).to have_produced("invoice.created").with(invoice)
     end
 
     it "enqueues GeneratePdfAndNotifyJob with email false" do
@@ -254,10 +253,6 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
           File.read(p)
         end
 
-        before do
-          allow(Utils::ActivityLog).to receive(:produce)
-        end
-
         it "returns tax error" do
           result = described_class.call(charge:, event:, timestamp: timestamp.to_i)
 
@@ -271,7 +266,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
             expect(invoice.status).to eq("failed")
             expect(invoice.error_details.count).to eq(1)
             expect(invoice.error_details.first.details["tax_error"]).to eq("taxDateTooFarInFuture")
-            expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.failed")
+            expect(Utils::ActivityLog).to have_produced("invoice.failed").with(invoice)
           end
         end
       end

--- a/spec/services/invoices/finalize_open_credit_service_spec.rb
+++ b/spec/services/invoices/finalize_open_credit_service_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Invoices::FinalizeOpenCreditService, type: :service do
     if invoice
       allow(invoice).to receive(:should_sync_invoice?).and_return(true)
     end
-    allow(Utils::ActivityLog).to receive(:produce)
   end
 
   describe ".call" do
@@ -31,7 +30,7 @@ RSpec.describe Invoices::FinalizeOpenCreditService, type: :service do
         invoice_id: result.invoice.id,
         invoice_type: result.invoice.invoice_type
       })
-      expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.paid_credit_added")
+      expect(Utils::ActivityLog).to have_produced("invoice.paid_credit_added").with(invoice)
     end
 
     context "when invoice is already finalized" do

--- a/spec/services/invoices/generate_pdf_service_spec.rb
+++ b/spec/services/invoices/generate_pdf_service_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Invoices::GeneratePdfService, type: :service do
   before do
     invoice_subscription
     stub_pdf_generation
-    allow(Utils::ActivityLog).to receive(:produce)
   end
 
   describe "#call" do
@@ -32,7 +31,7 @@ RSpec.describe Invoices::GeneratePdfService, type: :service do
     it "produces an activity log" do
       result = described_class.call(invoice:, context:)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(result.invoice, "invoice.generated")
+      expect(Utils::ActivityLog).to have_produced("invoice.generated").with(result.invoice)
     end
 
     context "with not found invoice" do

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
     before do
       wallet_transaction
       subscription
-      allow(Utils::ActivityLog).to receive(:produce)
     end
 
     it "creates an invoice" do
@@ -68,7 +67,7 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
     it "produces an activity log" do
       invoice = invoice_service.call.invoice
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.paid_credit_added")
+      expect(Utils::ActivityLog).to have_produced("invoice.paid_credit_added").with(invoice)
     end
 
     it_behaves_like "syncs invoice" do

--- a/spec/services/invoices/payments/deliver_error_webhook_service_spec.rb
+++ b/spec/services/invoices/payments/deliver_error_webhook_service_spec.rb
@@ -19,10 +19,6 @@ RSpec.describe Invoices::Payments::DeliverErrorWebhookService, type: :service do
     context "when invoice is visible?" do
       let(:invoice) { create(:invoice, invoice_type: :subscription, status: :finalized) }
 
-      before do
-        allow(Utils::ActivityLog).to receive(:produce)
-      end
-
       it "enqueues a job to send an invoice payment failure webhook" do
         expect do
           webhook_service.call_async
@@ -34,7 +30,7 @@ RSpec.describe Invoices::Payments::DeliverErrorWebhookService, type: :service do
       it "produces an activity log" do
         webhook_service.call_async
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.payment_failure")
+        expect(Utils::ActivityLog).to have_produced("invoice.payment_failure").with(invoice)
       end
     end
 
@@ -53,8 +49,6 @@ RSpec.describe Invoices::Payments::DeliverErrorWebhookService, type: :service do
       let(:fee) { create(:fee, fee_type: :credit, invoice: invoice, invoiceable:) }
 
       before do
-        allow(Utils::ActivityLog).to receive(:produce)
-
         fee
       end
 
@@ -71,7 +65,7 @@ RSpec.describe Invoices::Payments::DeliverErrorWebhookService, type: :service do
         it "produces an activity log" do
           webhook_service.call_async
 
-          expect(Utils::ActivityLog).to have_received(:produce).with(invoiceable, "wallet_transaction.payment_failure")
+          expect(Utils::ActivityLog).to have_produced("wallet_transaction.payment_failure").with(invoiceable)
         end
       end
 
@@ -88,7 +82,7 @@ RSpec.describe Invoices::Payments::DeliverErrorWebhookService, type: :service do
         it "produces an activity log" do
           webhook_service.call_async
 
-          expect(Utils::ActivityLog).to have_received(:produce).with(invoiceable, "wallet_transaction.payment_failure")
+          expect(Utils::ActivityLog).to have_produced("wallet_transaction.payment_failure").with(invoiceable)
         end
       end
     end

--- a/spec/services/invoices/payments/mark_overdue_service_spec.rb
+++ b/spec/services/invoices/payments/mark_overdue_service_spec.rb
@@ -18,10 +18,6 @@ RSpec.describe Invoices::Payments::MarkOverdueService, type: :service do
   let(:invoice_dispute_lost_at) { nil }
 
   describe "#call" do
-    before do
-      allow(Utils::ActivityLog).to receive(:produce)
-    end
-
     it "mark the invoice as payment_overdue" do
       expect(result.invoice.payment_overdue).to be_truthy
     end
@@ -35,7 +31,7 @@ RSpec.describe Invoices::Payments::MarkOverdueService, type: :service do
     it "produces an activity log" do
       invoice = result.invoice
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.payment_overdue")
+      expect(Utils::ActivityLog).to have_produced("invoice.payment_overdue").after_commit.with(invoice)
     end
 
     context "when invoice is nil" do

--- a/spec/services/invoices/payments/retry_service_spec.rb
+++ b/spec/services/invoices/payments/retry_service_spec.rb
@@ -54,14 +54,10 @@ RSpec.describe Invoices::Payments::RetryService, type: :service do
           create(:invoice, customer:, organization: customer.organization, invoice_type: type)
         end
 
-        before do
-          allow(Utils::ActivityLog).to receive(:produce)
-        end
-
         it "produces an activity log" do
           described_class.call(invoice:)
 
-          expect(Utils::ActivityLog).to have_received(:produce).with(invoice, action)
+          expect(Utils::ActivityLog).to have_produced(action).with(invoice)
         end
       end
     end

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service, transaction:
 
   before do
     allow(SegmentTrackJob).to receive(:perform_later)
-    allow(Utils::ActivityLog).to receive(:produce)
 
     tax
     charge
@@ -199,7 +198,7 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service, transaction:
     it "produces an activity log" do
       invoice = described_class.call(sorted_usage_thresholds:, lifetime_usage:, timestamp:).invoice
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.created")
+      expect(Utils::ActivityLog).to have_produced("invoice.created").with(invoice)
     end
 
     context "with lago_premium" do

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -142,10 +142,6 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
     end
 
     context "when taxes are fetched successfully" do
-      before do
-        allow(Utils::ActivityLog).to receive(:produce)
-      end
-
       it "marks the invoice as finalized" do
         expect { pull_taxes_service.call }
           .to change(invoice, :status).from("pending").to("finalized")
@@ -208,7 +204,7 @@ RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service
       it "produces an activity log" do
         described_class.call(invoice:)
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.created")
+        expect(Utils::ActivityLog).to have_produced("invoice.created").with(invoice)
       end
 
       it "enqueues GeneratePdfAndNotifyJob with email false" do

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
       allow(SegmentTrackJob).to receive(:perform_later)
       allow(Invoices::Payments::CreateService).to receive(:call_async).and_call_original
       allow(Invoices::TransitionToFinalStatusService).to receive(:call).and_call_original
-      allow(Utils::ActivityLog).to receive(:produce)
     end
 
     it "marks the invoice as finalized" do
@@ -110,7 +109,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
     it "produces an activity log" do
       described_class.call(invoice:)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.created")
+      expect(Utils::ActivityLog).to have_produced("invoice.created").with(invoice)
     end
 
     it "enqueues GeneratePdfAndNotifyJob with email false" do
@@ -192,7 +191,6 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
     context "with credit notes" do
       before do
         create(:credit_note_item, credit_note:, fee:)
-        allow(Utils::ActivityLog).to receive(:produce)
       end
 
       it "marks the credit notes as finalized" do
@@ -225,7 +223,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
       it "produces an activity log" do
         result = finalize_service.call
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(result.invoice.credit_notes.first, "credit_note.created")
+        expect(Utils::ActivityLog).to have_produced("credit_note.created").with(result.invoice.credit_notes.first)
       end
 
       it "enqueues CreditNotes::GeneratePdfJob" do

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
       allow(SegmentTrackJob).to receive(:perform_later)
       allow(Invoices::Payments::CreateService).to receive(:call_async).and_call_original
       allow(Invoices::TransitionToFinalStatusService).to receive(:call).and_call_original
-      allow(Utils::ActivityLog).to receive(:produce)
     end
 
     it "calls SegmentTrackJob" do
@@ -121,7 +120,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
     it "produces an activity log" do
       invoice = described_class.call(subscriptions:, timestamp: timestamp.to_i, invoicing_reason:).invoice
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.created")
+      expect(Utils::ActivityLog).to have_produced("invoice.created").with(invoice)
     end
 
     it "enqueues GeneratePdfAndNotifyJob with email false" do
@@ -241,7 +240,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
       it "produces an activity log" do
         invoice = described_class.call(subscriptions:, timestamp: timestamp.to_i, invoicing_reason:).invoice
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.drafted")
+        expect(Utils::ActivityLog).to have_produced("invoice.drafted").with(invoice)
       end
 
       it "does not flag lifetime usage for refresh" do

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -258,10 +258,6 @@ RSpec.describe Invoices::UpdateService do
       let(:webhook_notification) { true }
 
       context "when invoice is visible" do
-        before do
-          allow(Utils::ActivityLog).to receive(:produce)
-        end
-
         it "delivers a webhook" do
           expect { result }.to have_enqueued_job_after_commit(SendWebhookJob).with("invoice.payment_status_updated", invoice)
         end
@@ -269,7 +265,7 @@ RSpec.describe Invoices::UpdateService do
         it "produces an activity log" do
           result
 
-          expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.payment_status_updated", after_commit: true)
+          expect(Utils::ActivityLog).to have_produced("invoice.payment_status_updated").after_commit.with(invoice)
         end
       end
 

--- a/spec/services/invoices/void_service_spec.rb
+++ b/spec/services/invoices/void_service_spec.rb
@@ -72,10 +72,6 @@ RSpec.describe Invoices::VoidService, type: :service do
       context "when the payment status is not succeeded" do
         let(:payment_status) { [:pending, :failed].sample }
 
-        before do
-          allow(Utils::ActivityLog).to receive(:produce)
-        end
-
         it "voids the invoice" do
           result = void_service.call
 
@@ -108,7 +104,7 @@ RSpec.describe Invoices::VoidService, type: :service do
         it "produces an activity log" do
           invoice = described_class.call(invoice:).invoice
 
-          expect(Utils::ActivityLog).to have_received(:produce).with(invoice, "invoice.voided")
+          expect(Utils::ActivityLog).to have_produced("invoice.voided").after_commit.with(invoice)
         end
 
         context "when the invoice has applied credits from the wallet" do

--- a/spec/services/payment_receipts/create_service_spec.rb
+++ b/spec/services/payment_receipts/create_service_spec.rb
@@ -78,7 +78,6 @@ RSpec.describe PaymentReceipts::CreateService, type: :service do
 
               before do
                 allow(PaymentReceipt).to receive(:new).and_return(payment_receipt)
-                allow(Utils::ActivityLog).to receive(:produce)
               end
 
               it "creates the payment receipt" do
@@ -102,7 +101,7 @@ RSpec.describe PaymentReceipts::CreateService, type: :service do
               it "produces an activity log" do
                 payment_receipt = described_class.call(payment:).payment_receipt
 
-                expect(Utils::ActivityLog).to have_received(:produce).with(payment_receipt, "payment_receipt.created")
+                expect(Utils::ActivityLog).to have_produced("payment_receipt.created").with(payment_receipt)
               end
             end
           end

--- a/spec/services/payment_receipts/generate_pdf_service_spec.rb
+++ b/spec/services/payment_receipts/generate_pdf_service_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe PaymentReceipts::GeneratePdfService, type: :service do
       filename: "logo"
     )
     stub_pdf_generation
-    allow(Utils::ActivityLog).to receive(:produce)
   end
 
   describe "#call" do
@@ -38,7 +37,7 @@ RSpec.describe PaymentReceipts::GeneratePdfService, type: :service do
     it "produces an activity log" do
       receipt = described_class.call(payment_receipt:, context:).payment_receipt
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(receipt, "payment_receipt.generated")
+      expect(Utils::ActivityLog).to have_produced("payment_receipt.generated").with(receipt)
     end
 
     context "with not found payment receipt" do

--- a/spec/services/payments/manual_create_service_spec.rb
+++ b/spec/services/payments/manual_create_service_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe Payments::ManualCreateService, type: :service do
   let(:amount_cents) { 10000 }
 
   describe "#call" do
-    before do
-      allow(Utils::ActivityLog).to receive(:produce)
-    end
-
     context "when organization is not premium" do
       it "returns forbidden failure" do
         result = service.call
@@ -178,7 +174,7 @@ RSpec.describe Payments::ManualCreateService, type: :service do
         it "produces an activity log" do
           payment = described_class.call(organization:, params:).payment
 
-          expect(Utils::ActivityLog).to have_received(:produce).with(payment, "payment.recorded")
+          expect(Utils::ActivityLog).to have_produced("payment.recorded").after_commit.with(payment)
         end
 
         context "when issue_receipts_enabled is true" do

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -120,7 +120,6 @@ RSpec.describe Plans::CreateService, type: :service do
 
     before do
       allow(SegmentTrackJob).to receive(:perform_later)
-      allow(Utils::ActivityLog).to receive(:produce)
     end
 
     it "creates a plan" do
@@ -283,7 +282,7 @@ RSpec.describe Plans::CreateService, type: :service do
     it "produces an activity log" do
       result = described_class.call(create_args)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(result.plan, "plan.created")
+      expect(Utils::ActivityLog).to have_produced("plan.created").after_commit.with(result.plan)
     end
 
     context "when premium" do

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Plans::DestroyService, type: :service do
 
   before do
     plan
-    allow(Utils::ActivityLog).to receive(:produce).and_call_original
   end
 
   describe "#call" do
@@ -29,7 +28,7 @@ RSpec.describe Plans::DestroyService, type: :service do
     it "produces an activity log" do
       described_class.call(plan:)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(plan, "plan.deleted")
+      expect(Utils::ActivityLog).to have_produced("plan.deleted").after_commit.with(plan)
     end
 
     context "when plan is not found" do

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe Plans::UpdateService, type: :service do
   describe "call" do
     before do
       applied_tax
-      allow(Utils::ActivityLog).to receive(:produce)
     end
 
     it "updates a plan" do
@@ -145,7 +144,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         it "produces" do
           described_class.call(plan:, params: update_args)
 
-          expect(Utils::ActivityLog).to have_received(:produce).with(plan, "plan.updated")
+          expect(Utils::ActivityLog).to have_produced("plan.updated").after_commit.with(plan)
         end
       end
 

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe Subscriptions::ActivateService, type: :service, clickhouse: true 
 
   let(:timestamp) { Time.current }
 
-  before do
-    allow(Utils::ActivityLog).to receive(:produce)
-  end
-
   describe ".activate_all_pending" do
     it "activates all pending subscriptions with subscription date set to today" do
       create(:subscription)

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -30,10 +30,6 @@ RSpec.describe Subscriptions::CreateService, type: :service do
   end
 
   describe "#call" do
-    before do
-      allow(Utils::ActivityLog).to receive(:produce)
-    end
-
     it "creates a subscription with subscription date set to current date" do
       result = create_service.call
 
@@ -71,7 +67,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
     it "produces an activity log" do
       subscription = create_service.call.subscription
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(subscription, "subscription.started")
+      expect(Utils::ActivityLog).to have_produced("subscription.started").with(subscription)
     end
 
     context "when ending_at is passed" do
@@ -663,7 +659,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
           it "produces an activity log" do
             create_service.call
-            expect(Utils::ActivityLog).to have_received(:produce).with(subscription, "subscription.updated")
+            expect(Utils::ActivityLog).to have_produced("subscription.updated").with(subscription)
           end
 
           it "keeps the current subscription" do

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe Subscriptions::PlanUpgradeService, type: :service do
 
   describe "#call", :aggregate_failures do
     before do
-      allow(Utils::ActivityLog).to receive(:produce)
-
       subscription.mark_as_active!
     end
 
@@ -53,7 +51,7 @@ RSpec.describe Subscriptions::PlanUpgradeService, type: :service do
 
     it "produces an activity log" do
       result
-      expect(Utils::ActivityLog).to have_received(:produce).with(result.subscription, "subscription.started")
+      expect(Utils::ActivityLog).to have_produced("subscription.started").with(result.subscription)
     end
 
     it "enqueues the Hubspot update job" do

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -190,7 +190,6 @@ RSpec.describe Subscriptions::TerminateService do
     let(:timestamp) { Time.zone.now.to_i }
 
     before do
-      allow(Utils::ActivityLog).to receive(:produce)
       next_subscription
     end
 
@@ -217,8 +216,8 @@ RSpec.describe Subscriptions::TerminateService do
 
     it "produces the activity logs" do
       terminate_service.terminate_and_start_next(timestamp:)
-      expect(Utils::ActivityLog).to have_received(:produce).with(subscription, "subscription.terminated")
-      expect(Utils::ActivityLog).to have_received(:produce).with(next_subscription, "subscription.started")
+      expect(Utils::ActivityLog).to have_produced("subscription.terminated").with(subscription)
+      expect(Utils::ActivityLog).to have_produced("subscription.started").with(next_subscription)
     end
 
     context "when terminated subscription is payed in arrear" do

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
     end
 
     before do
-      allow(Utils::ActivityLog).to receive(:produce).and_call_original
-
       subscription
     end
 
@@ -48,7 +46,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
       it "produces an activity log after commit" do
         described_class.call(subscription:, params:)
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(subscription, "subscription.updated", after_commit: true)
+        expect(Utils::ActivityLog).to have_produced("subscription.updated").after_commit.with(subscription)
       end
 
       context "when subscription should be synced with Hubspot" do

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -25,8 +25,6 @@ RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
   let(:rate_amount) { 1 }
 
   before do
-    allow(Utils::ActivityLog).to receive(:produce)
-
     subscription
   end
 

--- a/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
+++ b/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe WalletTransactions::MarkAsFailedService, type: :service do
   let(:wallet_transaction) { create(:wallet_transaction, status: "pending") }
 
   describe ".call" do
-    before do
-      allow(Utils::ActivityLog).to receive(:produce)
-    end
-
     context "when wallet_transaction is nil" do
       let(:wallet_transaction) { nil }
 
@@ -35,7 +31,7 @@ RSpec.describe WalletTransactions::MarkAsFailedService, type: :service do
       it "produces an activity log" do
         described_class.call(wallet_transaction:)
 
-        expect(Utils::ActivityLog).to have_received(:produce).with(wallet_transaction, "wallet_transaction.updated")
+        expect(Utils::ActivityLog).to have_produced("wallet_transaction.updated").after_commit.with(wallet_transaction)
       end
     end
 

--- a/spec/services/wallet_transactions/settle_service_spec.rb
+++ b/spec/services/wallet_transactions/settle_service_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe WalletTransactions::SettleService, type: :service do
   let(:wallet_transaction) { create(:wallet_transaction, status: "pending", settled_at: nil) }
 
   describe ".call" do
-    before do
-      allow(Utils::ActivityLog).to receive(:produce)
-    end
-
     it "updates wallet_transaction status" do
       expect {
         service.call
@@ -28,7 +24,7 @@ RSpec.describe WalletTransactions::SettleService, type: :service do
     it "produces an activity log" do
       described_class.call(wallet_transaction:)
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(wallet_transaction, "wallet_transaction.updated")
+      expect(Utils::ActivityLog).to have_produced("wallet_transaction.updated").after_commit.with(wallet_transaction)
     end
   end
 end

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe Wallets::CreateService, type: :service do
   let(:customer_currency) { "EUR" }
 
   describe "#call" do
-    before do
-      allow(Utils::ActivityLog).to receive(:produce)
-    end
-
     let(:paid_credits) { "1.00" }
     let(:granted_credits) { "0.00" }
     let(:expiration_at) { (Time.current + 1.year).iso8601 }
@@ -59,7 +55,7 @@ RSpec.describe Wallets::CreateService, type: :service do
     it "produces an activity log" do
       wallet = described_class.call(params:).wallet
 
-      expect(Utils::ActivityLog).to have_received(:produce).with(wallet, "wallet.created")
+      expect(Utils::ActivityLog).to have_produced("wallet.created").after_commit.with(wallet)
     end
 
     it "enqueues the WalletTransaction::CreateJob" do

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe Wallets::UpdateService, type: :service do
 
   describe "#call" do
     before do
-      allow(Utils::ActivityLog).to receive(:produce).and_call_original
-
       subscription
       wallet
     end
@@ -39,7 +37,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
         expect(result.wallet.invoice_requires_successful_payment).to eq(true)
 
         expect(SendWebhookJob).to have_been_enqueued.with("wallet.updated", Wallet)
-        expect(Utils::ActivityLog).to have_received(:produce).with(wallet, "wallet.updated")
+        expect(Utils::ActivityLog).to have_produced("wallet.updated").after_commit.with(wallet)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -129,6 +129,7 @@ RSpec.configure do |config|
 
   config.before do |example|
     ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    allow(Utils::ActivityLog).to receive(:produce).and_call_original
 
     if example.metadata[:scenarios]
       stub_pdf_generation

--- a/spec/support/matchers/activity_log_matcher.rb
+++ b/spec/support/matchers/activity_log_matcher.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :have_produced do |activity_type|
+  match do |actual|
+    @actual = actual
+    @activity_type = activity_type
+
+    expected_params = [@object, activity_type]
+    expected_params << {after_commit: @after_commit} unless @after_commit.nil?
+
+    expect(actual).to have_received(:produce).with(*expected_params)
+  end
+
+  chain :with do |object|
+    @object = object
+  end
+
+  chain :after_commit do
+    @after_commit = true
+  end
+
+  chain :not_after_commit do
+    @after_commit = false
+  end
+
+  failure_message do
+    base_message = "expected #{@actual} to have produced '#{@activity_type}'"
+    base_message += " with #{@object.inspect} and {after_commit: #{@after_commit}}"
+    base_message
+  end
+
+  failure_message_when_negated do
+    base_message = "expected #{@actual} not to have produced '#{@activity_type}'"
+    base_message += " with #{@object.inspect} and {after_commit: #{@after_commit}}"
+    base_message
+  end
+
+  description do
+    "produce '#{@activity_type}'"
+  end
+end


### PR DESCRIPTION
## Context

`after_commit` parameter was added yesterday #3970.

## Description



This PR uses `after_commit: true` by default when using activity_loggable.

All expectations `with` call had to be updated to add the new params `with(..., ..., after_commit: true`). I took this opportunity to add a new custom matcher.

You have to appreciate the search and replace with regex in IntelliJ

```
have_received\(:produce\)\.with\(([a-z_\.]+),\s+("[a-z_\.]+")\)
have_produced($2).after_commit.with($1)
```

<img width="6240" height="3460" alt="CleanShot 2025-07-16 at 13 55 55@2x" src="https://github.com/user-attachments/assets/12f8123e-af35-4765-9c21-182a628b13c9" />
