### PR TITLE
feat(entitlement): Add `Feature.subscriptions_count`

### DIFF
--- a/app/graphql/types/entitlement/feature_object.rb
+++ b/app/graphql/types/entitlement/feature_object.rb
@@ -11,6 +11,8 @@ module Types
 
       field :privileges, [Types::Entitlement::PrivilegeObject], null: false
 
+      field :subscriptions_count, Integer, null: false
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     end
   end

--- a/app/models/entitlement/feature.rb
+++ b/app/models/entitlement/feature.rb
@@ -11,6 +11,7 @@ module Entitlement
     has_many :privileges, class_name: "Entitlement::Privilege", foreign_key: "entitlement_feature_id", dependent: :destroy
     has_many :entitlements, class_name: "Entitlement::Entitlement", foreign_key: "entitlement_feature_id", dependent: :destroy
     has_many :entitlement_values, through: :entitlements, source: :values, class_name: "Entitlement::EntitlementValue", dependent: :destroy
+    has_many :plans, through: :entitlements
 
     validates :code, presence: true, length: {maximum: 255}
     validates :name, length: {maximum: 255}
@@ -18,6 +19,12 @@ module Entitlement
 
     def self.ransackable_attributes(_auth_object = nil)
       %w[code name description]
+    end
+
+    def subscriptions_count
+      Subscription.joins(:plan).where(plan: plans, status: [:active, :pending]).or(
+        Subscription.joins(:plan).where(plan: {parent: plans}, status: [:active, :pending])
+      ).count
     end
   end
 end

--- a/app/models/entitlement/feature.rb
+++ b/app/models/entitlement/feature.rb
@@ -22,9 +22,8 @@ module Entitlement
     end
 
     def subscriptions_count
-      Subscription.joins(:plan).where(plan: plans, status: [:active, :pending]).or(
-        Subscription.joins(:plan).where(plan: {parent: plans}, status: [:active, :pending])
-      ).count
+      base_scope = Subscription.joins(:plan).where(status: [:active, :pending])
+      base_scope.where(plan: plans).or(base_scope.where(plan: {parent: plans})).count
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4976,6 +4976,7 @@ type FeatureObject {
   id: ID!
   name: String
   privileges: [PrivilegeObject!]!
+  subscriptionsCount: Int!
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -23114,6 +23114,22 @@
               "isDeprecated": false,
               "deprecationReason": null,
               "args": []
+            },
+            {
+              "name": "subscriptionsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
             }
           ],
           "inputFields": null,

--- a/spec/graphql/types/entitlement/feature_object_spec.rb
+++ b/spec/graphql/types/entitlement/feature_object_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Types::Entitlement::FeatureObject do
 
     expect(subject).to have_field(:privileges).of_type("[PrivilegeObject!]!")
 
+    expect(subject).to have_field(:subscriptions_count).of_type("Int!")
+
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
   end
 end

--- a/spec/models/entitlement/feature_spec.rb
+++ b/spec/models/entitlement/feature_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Entitlement::Feature, type: :model do
       expect(subject).to have_many(:privileges).class_name("Entitlement::Privilege").dependent(:destroy)
       expect(subject).to have_many(:entitlements).class_name("Entitlement::Entitlement").dependent(:destroy)
       expect(subject).to have_many(:entitlement_values).through(:entitlements).source(:values).class_name("Entitlement::EntitlementValue").dependent(:destroy)
+      expect(subject).to have_many(:plans).through(:entitlements)
     end
   end
 
@@ -22,6 +23,23 @@ RSpec.describe Entitlement::Feature, type: :model do
       expect(subject).to validate_length_of(:code).is_at_most(255)
       expect(subject).to validate_length_of(:name).is_at_most(255)
       expect(subject).to validate_length_of(:description).is_at_most(600)
+    end
+  end
+
+  describe "#subscriptions_count" do
+    it "returns the number of subscriptions" do
+      expect(subject.subscriptions_count).to eq(0)
+      entitlement = create(:entitlement, feature: subject)
+      create(:subscription, plan: entitlement.plan)
+      create(:subscription, :pending, plan: entitlement.plan)
+      create(:subscription, :terminated, plan: entitlement.plan)
+      create(:subscription, :canceled, plan: entitlement.plan)
+      expect(subject.subscriptions_count).to eq(2)
+      create(:subscription, plan: create(:plan, parent: entitlement.plan))
+      create(:subscription, :pending, plan: create(:plan, parent: entitlement.plan))
+      create(:subscription, :terminated, plan: create(:plan, parent: entitlement.plan))
+      create(:subscription, :canceled, plan: create(:plan, parent: entitlement.plan))
+      expect(subject.subscriptions_count).to eq(4)
     end
   end
 end


### PR DESCRIPTION
Used to display the number of subscription in the frontend. Not returned in the API.
Notice that this is a very nice N+1 😬 but it's acceptable since it's only used in the Frontend, on the Freature list page (this is the same for plans list for instance).

Notice that this return only the active and pending subscription, unlike the plans list that shows also terminated subscriptions.

<img width="2934" height="1104" alt="CleanShot 2025-07-16 at 15 55 49@2x" src="https://github.com/user-attachments/assets/f2496ab5-7d1e-4cab-b432-3a1e407dcb44" />


### The final query

```sql
SELECT
  COUNT(*)
FROM
  "subscriptions"
  INNER JOIN "plans" "plan" ON "plan"."id" = "subscriptions"."plan_id"
WHERE
  "subscriptions"."status" IN (1, 0)
  AND (
    "subscriptions"."plan_id" IN (
      SELECT
        "plans"."id"
      FROM
        "plans"
        INNER JOIN "entitlement_entitlements" ON "plans"."id" = "entitlement_entitlements"."plan_id"
      WHERE
        "plans"."deleted_at" IS NULL
        AND "entitlement_entitlements"."deleted_at" IS NULL
        AND "entitlement_entitlements"."entitlement_feature_id" = '753b7132-e26e-41da-9e83-b2bf49b4b0af'
    )
    OR "plan"."parent_id" IN (
      SELECT
        "plans"."id"
      FROM
        "plans"
        INNER JOIN "entitlement_entitlements" ON "plans"."id" = "entitlement_entitlements"."plan_id"
      WHERE
        "plans"."deleted_at" IS NULL
        AND "entitlement_entitlements"."deleted_at" IS NULL
        AND "entitlement_entitlements"."entitlement_feature_id" = '753b7132-e26e-41da-9e83-b2bf49b4b0af'
    )
  );
```