### PR TITLE
Feat(fixed_charges): add bill_fixed_charges_monthly to plan

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -122,7 +122,7 @@ end
 #  amount_cents               :bigint           not null
 #  amount_currency            :string           not null
 #  bill_charges_monthly       :boolean
-#  bill_fixed_charges_monthly :boolean          default(FALSE), not null
+#  bill_fixed_charges_monthly :boolean          default(FALSE)
 #  code                       :string           not null
 #  deleted_at                 :datetime
 #  description                :string
@@ -139,7 +139,7 @@ end
 #
 # Indexes
 #
-#  index_plans_on_bill_fixed_charges_monthly  (bill_fixed_charges_monthly)
+#  index_plans_on_bill_fixed_charges_monthly  (bill_fixed_charges_monthly) WHERE ((deleted_at IS NULL) AND (bill_fixed_charges_monthly IS TRUE))
 #  index_plans_on_created_at                  (created_at)
 #  index_plans_on_deleted_at                  (deleted_at)
 #  index_plans_on_organization_id             (organization_id)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -118,31 +118,33 @@ end
 #
 # Table name: plans
 #
-#  id                   :uuid             not null, primary key
-#  amount_cents         :bigint           not null
-#  amount_currency      :string           not null
-#  bill_charges_monthly :boolean
-#  code                 :string           not null
-#  deleted_at           :datetime
-#  description          :string
-#  interval             :integer          not null
-#  invoice_display_name :string
-#  name                 :string           not null
-#  pay_in_advance       :boolean          default(FALSE), not null
-#  pending_deletion     :boolean          default(FALSE), not null
-#  trial_period         :float
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  organization_id      :uuid             not null
-#  parent_id            :uuid
+#  id                         :uuid             not null, primary key
+#  amount_cents               :bigint           not null
+#  amount_currency            :string           not null
+#  bill_charges_monthly       :boolean
+#  bill_fixed_charges_monthly :boolean          default(FALSE), not null
+#  code                       :string           not null
+#  deleted_at                 :datetime
+#  description                :string
+#  interval                   :integer          not null
+#  invoice_display_name       :string
+#  name                       :string           not null
+#  pay_in_advance             :boolean          default(FALSE), not null
+#  pending_deletion           :boolean          default(FALSE), not null
+#  trial_period               :float
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  organization_id            :uuid             not null
+#  parent_id                  :uuid
 #
 # Indexes
 #
-#  index_plans_on_created_at                (created_at)
-#  index_plans_on_deleted_at                (deleted_at)
-#  index_plans_on_organization_id           (organization_id)
-#  index_plans_on_organization_id_and_code  (organization_id,code) UNIQUE WHERE ((deleted_at IS NULL) AND (parent_id IS NULL))
-#  index_plans_on_parent_id                 (parent_id)
+#  index_plans_on_bill_fixed_charges_monthly  (bill_fixed_charges_monthly)
+#  index_plans_on_created_at                  (created_at)
+#  index_plans_on_deleted_at                  (deleted_at)
+#  index_plans_on_organization_id             (organization_id)
+#  index_plans_on_organization_id_and_code    (organization_id,code) UNIQUE WHERE ((deleted_at IS NULL) AND (parent_id IS NULL))
+#  index_plans_on_parent_id                   (parent_id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20250716123425_add_bill_fixed_charges_monthly_to_plan.rb
+++ b/db/migrate/20250716123425_add_bill_fixed_charges_monthly_to_plan.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddBillFixedChargesMonthlyToPlan < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :plans, :bill_fixed_charges_monthly, :boolean, default: false, null: false
+    add_index :plans, :bill_fixed_charges_monthly, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20250716123425_add_bill_fixed_charges_monthly_to_plan.rb
+++ b/db/migrate/20250716123425_add_bill_fixed_charges_monthly_to_plan.rb
@@ -4,7 +4,7 @@ class AddBillFixedChargesMonthlyToPlan < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
   def change
-    add_column :plans, :bill_fixed_charges_monthly, :boolean, default: false, null: false
-    add_index :plans, :bill_fixed_charges_monthly, algorithm: :concurrently
+    add_column :plans, :bill_fixed_charges_monthly, :boolean, default: false
+    add_index :plans, :bill_fixed_charges_monthly, algorithm: :concurrently, where: "deleted_at IS NULL AND bill_fixed_charges_monthly IS true"
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2442,7 +2442,7 @@ CREATE TABLE public.plans (
     deleted_at timestamp(6) without time zone,
     pending_deletion boolean DEFAULT false NOT NULL,
     invoice_display_name character varying,
-    bill_fixed_charges_monthly boolean DEFAULT false NOT NULL
+    bill_fixed_charges_monthly boolean DEFAULT false
 );
 
 
@@ -6813,7 +6813,7 @@ CREATE UNIQUE INDEX index_payments_on_provider_payment_id_and_payment_provider_i
 -- Name: index_plans_on_bill_fixed_charges_monthly; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_plans_on_bill_fixed_charges_monthly ON public.plans USING btree (bill_fixed_charges_monthly);
+CREATE INDEX index_plans_on_bill_fixed_charges_monthly ON public.plans USING btree (bill_fixed_charges_monthly) WHERE ((deleted_at IS NULL) AND (bill_fixed_charges_monthly IS TRUE));
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -306,6 +306,7 @@ DROP INDEX IF EXISTS public.index_plans_on_organization_id_and_code;
 DROP INDEX IF EXISTS public.index_plans_on_organization_id;
 DROP INDEX IF EXISTS public.index_plans_on_deleted_at;
 DROP INDEX IF EXISTS public.index_plans_on_created_at;
+DROP INDEX IF EXISTS public.index_plans_on_bill_fixed_charges_monthly;
 DROP INDEX IF EXISTS public.index_payments_on_provider_payment_id_and_payment_provider_id;
 DROP INDEX IF EXISTS public.index_payments_on_payment_type;
 DROP INDEX IF EXISTS public.index_payments_on_payment_provider_id;
@@ -2440,7 +2441,8 @@ CREATE TABLE public.plans (
     parent_id uuid,
     deleted_at timestamp(6) without time zone,
     pending_deletion boolean DEFAULT false NOT NULL,
-    invoice_display_name character varying
+    invoice_display_name character varying,
+    bill_fixed_charges_monthly boolean DEFAULT false NOT NULL
 );
 
 
@@ -6808,6 +6810,13 @@ CREATE UNIQUE INDEX index_payments_on_provider_payment_id_and_payment_provider_i
 
 
 --
+-- Name: index_plans_on_bill_fixed_charges_monthly; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_plans_on_bill_fixed_charges_monthly ON public.plans USING btree (bill_fixed_charges_monthly);
+
+
+--
 -- Name: index_plans_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9052,6 +9061,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250716142613'),
 ('20250716132759'),
 ('20250716132649'),
+('20250716123425'),
 ('20250715124108'),
 ('20250714131519'),
 ('20250710102337'),


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

## Context

in order to support yearly plan with monthly fixed charges, we need to add a new column that will be responsible for storing this data

## Description

Added a migration to add `bill_fixed_charges_monthly` field on plan