### PR TITLE
fix(pricing-units): Fix calculations for pay in advance fees

### DIFF
--- a/app/models/pricing_unit_usage.rb
+++ b/app/models/pricing_unit_usage.rb
@@ -8,13 +8,13 @@ class PricingUnitUsage < ApplicationRecord
   validates :short_name, :conversion_rate, presence: true
   validates :conversion_rate, numericality: {greater_than: 0}
 
-  def self.build_from_aggregation(aggregation, applied_pricing_unit)
+  def self.build_from_fiat_amounts(amount:, unit_amount:, applied_pricing_unit:)
     pricing_unit = applied_pricing_unit.pricing_unit
 
-    rounded_amount = aggregation.amount.round(pricing_unit.exponent)
+    rounded_amount = amount.round(pricing_unit.exponent)
     amount_cents = rounded_amount * pricing_unit.subunit_to_unit
-    precise_amount_cents = aggregation.amount * pricing_unit.subunit_to_unit.to_d
-    unit_amount_cents = aggregation.unit_amount * pricing_unit.subunit_to_unit
+    precise_amount_cents = amount * pricing_unit.subunit_to_unit.to_d
+    unit_amount_cents = unit_amount * pricing_unit.subunit_to_unit
 
     new(
       organization: pricing_unit.organization,
@@ -24,7 +24,7 @@ class PricingUnitUsage < ApplicationRecord
       amount_cents:,
       precise_amount_cents:,
       unit_amount_cents:,
-      precise_unit_amount: aggregation.unit_amount
+      precise_unit_amount: unit_amount
     )
   end
 

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -118,7 +118,12 @@ module Fees
       # NOTE: amount_result should be a BigDecimal, we need to round it
       # to the currency decimals and transform it into currency cents
       if charge.applied_pricing_unit
-        pricing_unit_usage = PricingUnitUsage.build_from_aggregation(amount_result, charge.applied_pricing_unit)
+        pricing_unit_usage = PricingUnitUsage.build_from_fiat_amounts(
+          amount: amount_result.amount,
+          unit_amount: amount_result.unit_amount,
+          applied_pricing_unit: charge.applied_pricing_unit
+        )
+
         amount_cents, precise_amount_cents, unit_amount_cents, precise_unit_amount = pricing_unit_usage
           .to_fiat_currency_cents(currency)
           .values_at(:amount_cents, :precise_amount_cents, :unit_amount_cents, :precise_unit_amount)

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -63,7 +63,12 @@ module Fees
       charge_model_result = apply_charge_model(aggregation_result:, properties:)
 
       if charge.applied_pricing_unit
-        pricing_unit_usage = PricingUnitUsage.build_from_aggregation(charge_model_result, charge.applied_pricing_unit)
+        pricing_unit_usage = PricingUnitUsage.build_from_fiat_amounts(
+          amount: charge_model_result.amount / charge.pricing_unit.subunit_to_unit.to_d,
+          unit_amount: charge_model_result.unit_amount,
+          applied_pricing_unit: charge.applied_pricing_unit
+        )
+
         amount_cents, precise_amount_cents, unit_amount_cents, precise_unit_amount = pricing_unit_usage
           .to_fiat_currency_cents(subscription.plan.amount.currency)
           .values_at(:amount_cents, :precise_amount_cents, :unit_amount_cents, :precise_unit_amount)

--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -77,18 +77,13 @@ module Fees
         return
       end
 
-      amount_cents = (prorated_min_amount_cents - used_amount_cents).round
+      amount_cents = prorated_min_amount_cents - used_amount_cents
       precise_amount_cents = prorated_min_amount_cents - used_precise_amount_cents
 
-      @pricing_unit_usage = PricingUnitUsage.new(
-        organization: fee.organization,
-        pricing_unit: charge.pricing_unit,
-        short_name: charge.pricing_unit.short_name,
-        conversion_rate: charge.applied_pricing_unit.conversion_rate,
-        amount_cents:,
-        precise_amount_cents:,
-        unit_amount_cents: amount_cents,
-        precise_unit_amount: precise_amount_cents / charge.pricing_unit.subunit_to_unit
+      @pricing_unit_usage = PricingUnitUsage.build_from_fiat_amounts(
+        amount: amount_cents / charge.pricing_unit.subunit_to_unit.to_d,
+        unit_amount: precise_amount_cents / charge.pricing_unit.subunit_to_unit.to_d,
+        applied_pricing_unit: charge.applied_pricing_unit
       )
     end
   end

--- a/app/services/fees/init_from_adjusted_charge_fee_service.rb
+++ b/app/services/fees/init_from_adjusted_charge_fee_service.rb
@@ -105,22 +105,20 @@ module Fees
         return
       end
 
-      @pricing_unit_usage = if adjusted_fee.adjusted_units?
-        PricingUnitUsage.build_from_aggregation(amount_result, charge.applied_pricing_unit)
+      if adjusted_fee.adjusted_units?
+        amount = amount_result.amount
+        unit_amount = amount_result.unit_amount
       else
-        unit_precise_amount_cents = adjusted_fee.unit_precise_amount_cents
-        precise_amount_cents = adjusted_fee.units * unit_precise_amount_cents
-
-        PricingUnitUsage.new(
-          pricing_unit: charge.pricing_unit,
-          short_name: charge.pricing_unit.short_name,
-          conversion_rate: charge.applied_pricing_unit.conversion_rate,
-          amount_cents: precise_amount_cents.round,
-          precise_amount_cents:,
-          unit_amount_cents: unit_precise_amount_cents.round,
-          precise_unit_amount: unit_precise_amount_cents / charge.pricing_unit.subunit_to_unit
-        )
+        precise_amount_cents = adjusted_fee.units * adjusted_fee.unit_precise_amount_cents
+        amount = precise_amount_cents / charge.pricing_unit.subunit_to_unit.to_d
+        unit_amount = adjusted_fee.unit_precise_amount_cents / charge.pricing_unit.subunit_to_unit.to_d
       end
+
+      @pricing_unit_usage = PricingUnitUsage.build_from_fiat_amounts(
+        amount:,
+        unit_amount:,
+        applied_pricing_unit: charge.applied_pricing_unit
+      )
     end
   end
 end

--- a/spec/models/pricing_unit_usage_spec.rb
+++ b/spec/models/pricing_unit_usage_spec.rb
@@ -13,12 +13,13 @@ RSpec.describe PricingUnitUsage, type: :model do
   it { is_expected.to validate_presence_of(:conversion_rate) }
   it { is_expected.to validate_numericality_of(:conversion_rate).is_greater_than(0) }
 
-  describe ".build_from_aggregation" do
-    subject { described_class.build_from_aggregation(aggregation, applied_pricing_unit) }
+  describe ".build_from_fiat_amounts" do
+    subject { described_class.build_from_fiat_amounts(amount:, unit_amount:, applied_pricing_unit:) }
 
     let(:pricing_unit) { create(:pricing_unit) }
     let(:applied_pricing_unit) { create(:applied_pricing_unit, pricing_unit:, conversion_rate: 3.0150695) }
-    let(:aggregation) { Struct.new(:amount, :unit_amount).new(10655.243249, 5.5423123) }
+    let(:amount) { 10655.243249 }
+    let(:unit_amount) { 5.5423123 }
 
     let(:expected_attributes) do
       {

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -502,7 +502,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
         create(
           :applied_pricing_unit,
           organization: subscription.organization,
-          conversion_rate: 0.25,
+          conversion_rate: 0.5,
           pricing_unitable: charge
         )
       end
@@ -519,7 +519,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
           organization_id: organization.id,
           billing_entity_id: billing_entity.id,
           charge:,
-          amount_cents: 250,
+          amount_cents: 5,
           amount_currency: "EUR",
           fee_type: "charge",
           pay_in_advance: true,
@@ -532,11 +532,11 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
           payment_status: "pending",
           unit_amount_cents: 0,
           taxes_rate: 20.0,
-          taxes_amount_cents: 50
+          taxes_amount_cents: 1
         )
-        expect(fee.precise_amount_cents.to_f).to eq(250.0)
-        expect(fee.precise_unit_amount.to_f).to eq(0.0025)
-        expect(fee.taxes_precise_amount_cents.to_f).to eq(50.0)
+        expect(fee.precise_amount_cents.to_f).to eq(5.0)
+        expect(fee.precise_unit_amount.to_f).to eq(0.005)
+        expect(fee.taxes_precise_amount_cents.to_f).to eq(1.0)
         expect(result.fees.first.applied_taxes.count).to eq(1)
       end
 
@@ -546,8 +546,8 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
         expect(result).to be_success
         pricing_unit_usage = result.fees.first.pricing_unit_usage
         expect(pricing_unit_usage).to be_persisted
-        expect(pricing_unit_usage.amount_cents).to eq(1000)
-        expect(pricing_unit_usage.precise_amount_cents.to_f).to eq(1000.0)
+        expect(pricing_unit_usage.amount_cents).to eq(10)
+        expect(pricing_unit_usage.precise_amount_cents.to_f).to eq(10.0)
         expect(pricing_unit_usage.unit_amount_cents).to eq(1)
       end
     end


### PR DESCRIPTION
## Context

Adjusting calculations of fee amounts defined in pricing units. Currently fees created as part of pay in advance events has amount multiplied by 100 but shouldn't.

## Description

Moved from `.build_from_aggregation` to `.build_from_fiat_amounts` for more transparency how and what values are used.
I've discovered that in `Fees::CreatePayInAdvanceService` aggregation amount contains amount cents.
`Fees::ChargeService` aggregation amount contains amount.
In such condition it's dangerous to have method that accepts aggregation.
