### PR TITLE
Feat(Fixed_charges): add subscription_fixed_charge_units_override

### DIFF
--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class FixedCharge < ApplicationRecord
+  include Discard::Model
+  self.discard_column = :deleted_at
+
   belongs_to :organization
   belongs_to :plan
   belongs_to :add_on
   belongs_to :parent, optional: true
+  has_many :children, class_name: "FixedCharge", foreign_key: :parent_id, dependent: :nullify
 
   CHARGE_MODELS = {
     standard: "standard",

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -7,7 +7,7 @@ class FixedCharge < ApplicationRecord
   belongs_to :organization
   belongs_to :plan
   belongs_to :add_on
-  belongs_to :parent, optional: true
+  belongs_to :parent, class_name: "FixedCharge", optional: true
   has_many :children, class_name: "FixedCharge", foreign_key: :parent_id, dependent: :nullify
 
   CHARGE_MODELS = {

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -1,19 +1,10 @@
 # frozen_string_literal: true
 
 class FixedCharge < ApplicationRecord
-  include PaperTrailTraceable
-  include Discard::Model
-
-  self.discard_column = :deleted_at
-  default_scope -> { kept }
-
   belongs_to :organization
-  belongs_to :plan, -> { with_discarded }, touch: true
-  belongs_to :add_on, -> { with_discarded }, touch: true
-  belongs_to :parent, class_name: "FixedCharge", optional: true
-  has_many :children, class_name: "FixedCharge", foreign_key: :parent_id, dependent: :nullify
-
-  scope :pay_in_advance, -> { where(pay_in_advance: true) }
+  belongs_to :plan
+  belongs_to :add_on
+  belongs_to :parent, optional: true
 
   CHARGE_MODELS = {
     standard: "standard",

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 class FixedCharge < ApplicationRecord
+  include PaperTrailTraceable
   include Discard::Model
+
   self.discard_column = :deleted_at
 
   belongs_to :organization
-  belongs_to :plan
-  belongs_to :add_on
+  belongs_to :plan, -> { with_discarded }, touch: true
+  belongs_to :add_on, -> { with_discarded }, touch: true
   belongs_to :parent, class_name: "FixedCharge", optional: true
   has_many :children, class_name: "FixedCharge", foreign_key: :parent_id, dependent: :nullify
 

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -5,6 +5,7 @@ class FixedCharge < ApplicationRecord
   include Discard::Model
 
   self.discard_column = :deleted_at
+  default_scope -> { kept }
 
   belongs_to :organization
   belongs_to :plan, -> { with_discarded }, touch: true
@@ -12,6 +13,8 @@ class FixedCharge < ApplicationRecord
   belongs_to :parent, class_name: "FixedCharge", optional: true
   has_many :children, class_name: "FixedCharge", foreign_key: :parent_id, dependent: :nullify
   has_many :subscription_fixed_charge_units_overrides, dependent: :destroy
+
+  scope :pay_in_advance, -> { where(pay_in_advance: true) }
 
   CHARGE_MODELS = {
     standard: "standard",

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -11,6 +11,7 @@ class FixedCharge < ApplicationRecord
   belongs_to :add_on, -> { with_discarded }, touch: true
   belongs_to :parent, class_name: "FixedCharge", optional: true
   has_many :children, class_name: "FixedCharge", foreign_key: :parent_id, dependent: :nullify
+  has_many :subscription_fixed_charge_units_overrides, dependent: :destroy
 
   CHARGE_MODELS = {
     standard: "standard",

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -20,6 +20,7 @@ class Subscription < ApplicationRecord
   has_many :usage_thresholds, through: :plan
   has_many :entitlements, class_name: "Entitlement::Entitlement"
   has_many :entitlement_removals, class_name: "Entitlement::SubscriptionFeatureRemoval"
+  has_many :subscription_fixed_charge_units_overrides, dependent: :destroy
 
   has_many :activity_logs,
     -> { order(logged_at: :desc) },

--- a/app/models/subscription_fixed_charge_units_override.rb
+++ b/app/models/subscription_fixed_charge_units_override.rb
@@ -11,7 +11,7 @@ class SubscriptionFixedChargeUnitsOverride < ApplicationRecord
   belongs_to :subscription
   belongs_to :fixed_charge
 
-  validates :units, numericality: {greater_than_or_equal_to: 0}
+  validates :units, presence: true, numericality: {greater_than_or_equal_to: 0}
 end
 
 # == Schema Information

--- a/app/models/subscription_fixed_charge_units_override.rb
+++ b/app/models/subscription_fixed_charge_units_override.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class SubscriptionFixedChargeUnitsOverride < ApplicationRecord
+  include Discard::Model
+  include PaperTrailTraceable
+  self.discard_column = :deleted_at
+  default_scope -> { kept }
+
+  belongs_to :organization
+  belongs_to :billing_entity
+  belongs_to :subscription
+  belongs_to :fixed_charge
+
+  validates :units, numericality: {greater_than_or_equal_to: 0}
+end
+
+# == Schema Information
+#
+# Table name: subscription_fixed_charge_units_overrides
+#
+#  id                :uuid             not null, primary key
+#  deleted_at        :datetime
+#  units             :decimal(30, 10)  default(0.0), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  billing_entity_id :uuid             not null
+#  fixed_charge_id   :uuid             not null
+#  organization_id   :uuid             not null
+#  subscription_id   :uuid             not null
+#
+# Indexes
+#
+#  idx_on_billing_entity_id_ba78f5f5a5                            (billing_entity_id)
+#  idx_on_fixed_charge_id_06503ae1a5                              (fixed_charge_id)
+#  idx_on_organization_id_e742f77454                              (organization_id)
+#  idx_on_subscription_id_bd763c5aa3                              (subscription_id)
+#  index_subscription_fixed_charge_units_overrides_on_deleted_at  (deleted_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (billing_entity_id => billing_entities.id)
+#  fk_rails_...  (fixed_charge_id => fixed_charges.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#  fk_rails_...  (subscription_id => subscriptions.id)
+#

--- a/app/models/subscription_fixed_charge_units_override.rb
+++ b/app/models/subscription_fixed_charge_units_override.rb
@@ -34,6 +34,7 @@ end
 #  idx_on_fixed_charge_id_06503ae1a5                              (fixed_charge_id)
 #  idx_on_organization_id_e742f77454                              (organization_id)
 #  idx_on_subscription_id_bd763c5aa3                              (subscription_id)
+#  idx_on_subscription_id_fixed_charge_id_d85b30a9bf              (subscription_id,fixed_charge_id) UNIQUE WHERE (deleted_at IS NULL)
 #  index_subscription_fixed_charge_units_overrides_on_deleted_at  (deleted_at)
 #
 # Foreign Keys

--- a/db/migrate/20250717071548_create_subscription_fixed_charge_units_overrides.rb
+++ b/db/migrate/20250717071548_create_subscription_fixed_charge_units_overrides.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateSubscriptionFixedChargeUnitsOverrides < ActiveRecord::Migration[8.0]
+  def change
+    create_table :subscription_fixed_charge_units_overrides, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid
+      t.references :billing_entity, null: false, foreign_key: true, type: :uuid
+      t.references :subscription, null: false, foreign_key: true, type: :uuid
+      t.references :fixed_charge, null: false, foreign_key: true, type: :uuid
+
+      t.decimal :units, precision: 30, scale: 10, null: false, default: 0.0
+      t.datetime :deleted_at, index: true
+
+      t.index [:subscription_id, :fixed_charge_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250717071548_create_subscription_fixed_charge_units_overrides.rb
+++ b/db/migrate/20250717071548_create_subscription_fixed_charge_units_overrides.rb
@@ -11,7 +11,9 @@ class CreateSubscriptionFixedChargeUnitsOverrides < ActiveRecord::Migration[8.0]
       t.decimal :units, precision: 30, scale: 10, null: false, default: 0.0
       t.datetime :deleted_at, index: true
 
-      t.index [:subscription_id, :fixed_charge_id], unique: true
+      t.index [:subscription_id, :fixed_charge_id],
+        unique: true,
+        where: "deleted_at IS NULL"
 
       t.timestamps
     end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -39,11 +39,13 @@ ALTER TABLE IF EXISTS ONLY public.customers_invoice_custom_sections DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_d9ffb8b4a1;
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXISTS fk_rails_d9ea200904;
 ALTER TABLE IF EXISTS ONLY public.integration_resources DROP CONSTRAINT IF EXISTS fk_rails_d9448a540b;
+ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_d72a9877be;
 ALTER TABLE IF EXISTS ONLY public.entitlement_privileges DROP CONSTRAINT IF EXISTS fk_rails_d648e28d9f;
 ALTER TABLE IF EXISTS ONLY public.entitlement_entitlements DROP CONSTRAINT IF EXISTS fk_rails_d53f825a88;
 ALTER TABLE IF EXISTS ONLY public.idempotency_records DROP CONSTRAINT IF EXISTS fk_rails_d4f02c82b2;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_d07bc24ce3;
 ALTER TABLE IF EXISTS ONLY public.integration_customers DROP CONSTRAINT IF EXISTS fk_rails_ce2c63d69f;
+ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_cdaf36dc89;
 ALTER TABLE IF EXISTS ONLY public.pricing_units DROP CONSTRAINT IF EXISTS fk_rails_cd99351ee3;
 ALTER TABLE IF EXISTS ONLY public.integration_mappings DROP CONSTRAINT IF EXISTS fk_rails_cc318ad1ff;
 ALTER TABLE IF EXISTS ONLY public.plans DROP CONSTRAINT IF EXISTS fk_rails_cbf700aeb8;
@@ -85,6 +87,7 @@ ALTER TABLE IF EXISTS ONLY public.memberships DROP CONSTRAINT IF EXISTS fk_rails
 ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_98980b326b;
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_94cc21031f;
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_9298b8fdad;
+ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_90fd72ac8f;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_90d93bd016;
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_909197908c;
 ALTER TABLE IF EXISTS ONLY public.commitments_taxes DROP CONSTRAINT IF EXISTS fk_rails_8fa6f0d920;
@@ -230,6 +233,7 @@ ALTER TABLE IF EXISTS ONLY public.add_ons_taxes DROP CONSTRAINT IF EXISTS fk_rai
 ALTER TABLE IF EXISTS ONLY public.fees DROP CONSTRAINT IF EXISTS fk_rails_085d1cc97b;
 ALTER TABLE IF EXISTS ONLY public.billing_entities_taxes DROP CONSTRAINT IF EXISTS fk_rails_07b21049f2;
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_06b7046ec3;
+ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_0480ef4ad3;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_01a4c0c7db;
 DROP TRIGGER IF EXISTS before_payment_receipt_insert ON public.payment_receipts;
 CREATE OR REPLACE VIEW public.billable_metrics_grouped_charges AS
@@ -283,6 +287,7 @@ DROP INDEX IF EXISTS public.index_subscriptions_on_plan_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_organization_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_external_id;
 DROP INDEX IF EXISTS public.index_subscriptions_on_customer_id;
+DROP INDEX IF EXISTS public.index_subscription_fixed_charge_units_overrides_on_deleted_at;
 DROP INDEX IF EXISTS public.index_search_quantified_events;
 DROP INDEX IF EXISTS public.index_refunds_on_payment_provider_id;
 DROP INDEX IF EXISTS public.index_refunds_on_payment_provider_customer_id;
@@ -607,10 +612,12 @@ DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_4290c95dec;
 DROP INDEX IF EXISTS public.idx_on_timestamp_charge_id_external_subscription_id;
 DROP INDEX IF EXISTS public.idx_on_subscription_id_entitlement_feature_id_02bee9883b;
 DROP INDEX IF EXISTS public.idx_on_subscription_id_295edd8bb3;
+DROP INDEX IF EXISTS public.idx_on_subscription_id_bd763c5aa3;
 DROP INDEX IF EXISTS public.idx_on_plan_id_billable_metric_id_pay_in_advance_4a205974cb;
 DROP INDEX IF EXISTS public.idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167;
 DROP INDEX IF EXISTS public.idx_on_organization_id_organization_sequential_id_2387146f54;
 DROP INDEX IF EXISTS public.idx_on_organization_id_external_subscription_id_df3a30d96d;
+DROP INDEX IF EXISTS public.idx_on_organization_id_e742f77454;
 DROP INDEX IF EXISTS public.idx_on_organization_id_deleted_at_225e3f789d;
 DROP INDEX IF EXISTS public.idx_on_organization_id_83703a45f4;
 DROP INDEX IF EXISTS public.idx_on_organization_id_7020c3c43a;
@@ -619,6 +626,7 @@ DROP INDEX IF EXISTS public.idx_on_invoice_id_payment_request_id_aa550779a4;
 DROP INDEX IF EXISTS public.idx_on_invoice_custom_section_id_ccb39e9622;
 DROP INDEX IF EXISTS public.idx_on_invoice_custom_section_id_7edbcef7b5;
 DROP INDEX IF EXISTS public.idx_on_invoice_custom_section_id_5f37496c8c;
+DROP INDEX IF EXISTS public.idx_on_fixed_charge_id_06503ae1a5;
 DROP INDEX IF EXISTS public.idx_on_entitlement_privilege_id_entitlement_entitle_9d0542eb1a;
 DROP INDEX IF EXISTS public.idx_on_entitlement_privilege_id_6a228dc433;
 DROP INDEX IF EXISTS public.idx_on_entitlement_feature_id_821ae72311;
@@ -627,6 +635,7 @@ DROP INDEX IF EXISTS public.idx_on_dunning_campaign_id_currency_fbf233b2ae;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_invoice_custom_section_id_bd78c547d3;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_customer_id_invoice_custom_e7aada65cb;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655;
+DROP INDEX IF EXISTS public.idx_on_billing_entity_id_ba78f5f5a5;
 DROP INDEX IF EXISTS public.idx_on_billing_entity_id_724373e5ae;
 DROP INDEX IF EXISTS public.idx_on_amount_cents_plan_id_recurring_888044d66b;
 DROP INDEX IF EXISTS public.idx_features_code_unique_per_organization;
@@ -650,6 +659,7 @@ ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alerts DROP CONSTRAINT IF EXI
 ALTER TABLE IF EXISTS ONLY public.usage_monitoring_alert_thresholds DROP CONSTRAINT IF EXISTS usage_monitoring_alert_thresholds_pkey;
 ALTER TABLE IF EXISTS ONLY public.taxes DROP CONSTRAINT IF EXISTS taxes_pkey;
 ALTER TABLE IF EXISTS ONLY public.subscriptions DROP CONSTRAINT IF EXISTS subscriptions_pkey;
+ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS subscription_fixed_charge_units_overrides_pkey;
 ALTER TABLE IF EXISTS ONLY public.schema_migrations DROP CONSTRAINT IF EXISTS schema_migrations_pkey;
 ALTER TABLE IF EXISTS ONLY public.refunds DROP CONSTRAINT IF EXISTS refunds_pkey;
 ALTER TABLE IF EXISTS ONLY public.recurring_transaction_rules DROP CONSTRAINT IF EXISTS recurring_transaction_rules_pkey;
@@ -751,6 +761,7 @@ DROP SEQUENCE IF EXISTS public.usage_monitoring_subscription_activities_id_seq;
 DROP TABLE IF EXISTS public.usage_monitoring_subscription_activities;
 DROP TABLE IF EXISTS public.usage_monitoring_alerts;
 DROP TABLE IF EXISTS public.usage_monitoring_alert_thresholds;
+DROP TABLE IF EXISTS public.subscription_fixed_charge_units_overrides;
 DROP TABLE IF EXISTS public.schema_migrations;
 DROP TABLE IF EXISTS public.refunds;
 DROP TABLE IF EXISTS public.recurring_transaction_rules;
@@ -3860,6 +3871,23 @@ CREATE TABLE public.schema_migrations (
 
 
 --
+-- Name: subscription_fixed_charge_units_overrides; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.subscription_fixed_charge_units_overrides (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    billing_entity_id uuid NOT NULL,
+    subscription_id uuid NOT NULL,
+    fixed_charge_id uuid NOT NULL,
+    units numeric(30,10) DEFAULT 0.0 NOT NULL,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: usage_monitoring_alert_thresholds; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4774,6 +4802,14 @@ ALTER TABLE ONLY public.schema_migrations
 
 
 --
+-- Name: subscription_fixed_charge_units_overrides subscription_fixed_charge_units_overrides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
+    ADD CONSTRAINT subscription_fixed_charge_units_overrides_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: subscriptions subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4949,6 +4985,13 @@ CREATE INDEX idx_on_billing_entity_id_724373e5ae ON public.billing_entities_invo
 
 
 --
+-- Name: idx_on_billing_entity_id_ba78f5f5a5; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_billing_entity_id_ba78f5f5a5 ON public.subscription_fixed_charge_units_overrides USING btree (billing_entity_id);
+
+
+--
 -- Name: idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5002,6 +5045,13 @@ CREATE INDEX idx_on_entitlement_privilege_id_6a228dc433 ON public.entitlement_en
 --
 
 CREATE UNIQUE INDEX idx_on_entitlement_privilege_id_entitlement_entitle_9d0542eb1a ON public.entitlement_entitlement_values USING btree (entitlement_privilege_id, entitlement_entitlement_id) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: idx_on_fixed_charge_id_06503ae1a5; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_fixed_charge_id_06503ae1a5 ON public.subscription_fixed_charge_units_overrides USING btree (fixed_charge_id);
 
 
 --
@@ -5061,6 +5111,13 @@ CREATE INDEX idx_on_organization_id_deleted_at_225e3f789d ON public.invoice_cust
 
 
 --
+-- Name: idx_on_organization_id_e742f77454; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_organization_id_e742f77454 ON public.subscription_fixed_charge_units_overrides USING btree (organization_id);
+
+
+--
 -- Name: idx_on_organization_id_external_subscription_id_df3a30d96d; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5100,6 +5157,10 @@ CREATE INDEX idx_on_subscription_id_295edd8bb3 ON public.entitlement_subscriptio
 --
 
 CREATE UNIQUE INDEX idx_on_subscription_id_entitlement_feature_id_02bee9883b ON public.entitlement_subscription_feature_removals USING btree (subscription_id, entitlement_feature_id) WHERE (deleted_at IS NULL);
+-- Name: idx_on_subscription_id_bd763c5aa3; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_on_subscription_id_bd763c5aa3 ON public.subscription_fixed_charge_units_overrides USING btree (subscription_id);
 
 
 --
@@ -7357,6 +7418,13 @@ CREATE INDEX index_search_quantified_events ON public.quantified_events USING bt
 
 
 --
+-- Name: index_subscription_fixed_charge_units_overrides_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_subscription_fixed_charge_units_overrides_on_deleted_at ON public.subscription_fixed_charge_units_overrides USING btree (deleted_at);
+
+
+--
 -- Name: index_subscriptions_on_customer_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7666,6 +7734,14 @@ CREATE TRIGGER before_payment_receipt_insert BEFORE INSERT ON public.payment_rec
 
 ALTER TABLE ONLY public.wallet_transactions
     ADD CONSTRAINT fk_rails_01a4c0c7db FOREIGN KEY (invoice_id) REFERENCES public.invoices(id);
+
+
+--
+-- Name: subscription_fixed_charge_units_overrides fk_rails_0480ef4ad3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
+    ADD CONSTRAINT fk_rails_0480ef4ad3 FOREIGN KEY (fixed_charge_id) REFERENCES public.fixed_charges(id);
 
 
 --
@@ -8829,6 +8905,14 @@ ALTER TABLE ONLY public.invoice_subscriptions
 
 
 --
+-- Name: subscription_fixed_charge_units_overrides fk_rails_90fd72ac8f; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
+    ADD CONSTRAINT fk_rails_90fd72ac8f FOREIGN KEY (billing_entity_id) REFERENCES public.billing_entities(id);
+
+
+--
 -- Name: data_export_parts fk_rails_9298b8fdad; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9157,6 +9241,14 @@ ALTER TABLE ONLY public.pricing_units
 
 
 --
+-- Name: subscription_fixed_charge_units_overrides fk_rails_cdaf36dc89; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
+    ADD CONSTRAINT fk_rails_cdaf36dc89 FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: integration_customers fk_rails_ce2c63d69f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9194,6 +9286,14 @@ ALTER TABLE ONLY public.entitlement_entitlements
 
 ALTER TABLE ONLY public.entitlement_privileges
     ADD CONSTRAINT fk_rails_d648e28d9f FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: subscription_fixed_charge_units_overrides fk_rails_d72a9877be; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
+    ADD CONSTRAINT fk_rails_d72a9877be FOREIGN KEY (subscription_id) REFERENCES public.subscriptions(id);
 
 
 --
@@ -9456,6 +9556,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250718174008'),
 ('20250718140450'),
 ('20250717092012'),
+('20250717071548'),
 ('20250716150049'),
 ('20250716143358'),
 ('20250716142613'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -610,10 +610,10 @@ DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_recurring_756a2a370
 DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_78eb24d06c;
 DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_4290c95dec;
 DROP INDEX IF EXISTS public.idx_on_timestamp_charge_id_external_subscription_id;
-DROP INDEX IF EXISTS public.idx_on_subscription_id_entitlement_feature_id_02bee9883b;
-DROP INDEX IF EXISTS public.idx_on_subscription_id_295edd8bb3;
 DROP INDEX IF EXISTS public.idx_on_subscription_id_fixed_charge_id_d85b30a9bf;
+DROP INDEX IF EXISTS public.idx_on_subscription_id_entitlement_feature_id_02bee9883b;
 DROP INDEX IF EXISTS public.idx_on_subscription_id_bd763c5aa3;
+DROP INDEX IF EXISTS public.idx_on_subscription_id_295edd8bb3;
 DROP INDEX IF EXISTS public.idx_on_plan_id_billable_metric_id_pay_in_advance_4a205974cb;
 DROP INDEX IF EXISTS public.idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167;
 DROP INDEX IF EXISTS public.idx_on_organization_id_organization_sequential_id_2387146f54;
@@ -5154,14 +5154,17 @@ CREATE INDEX idx_on_subscription_id_295edd8bb3 ON public.entitlement_subscriptio
 
 
 --
--- Name: idx_on_subscription_id_entitlement_feature_id_02bee9883b; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX idx_on_subscription_id_entitlement_feature_id_02bee9883b ON public.entitlement_subscription_feature_removals USING btree (subscription_id, entitlement_feature_id) WHERE (deleted_at IS NULL);
 -- Name: idx_on_subscription_id_bd763c5aa3; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_on_subscription_id_bd763c5aa3 ON public.subscription_fixed_charge_units_overrides USING btree (subscription_id);
+
+
+--
+-- Name: idx_on_subscription_id_entitlement_feature_id_02bee9883b; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_on_subscription_id_entitlement_feature_id_02bee9883b ON public.entitlement_subscription_feature_removals USING btree (subscription_id, entitlement_feature_id) WHERE (deleted_at IS NULL);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -612,6 +612,7 @@ DROP INDEX IF EXISTS public.idx_on_usage_monitoring_alert_id_4290c95dec;
 DROP INDEX IF EXISTS public.idx_on_timestamp_charge_id_external_subscription_id;
 DROP INDEX IF EXISTS public.idx_on_subscription_id_entitlement_feature_id_02bee9883b;
 DROP INDEX IF EXISTS public.idx_on_subscription_id_295edd8bb3;
+DROP INDEX IF EXISTS public.idx_on_subscription_id_fixed_charge_id_d85b30a9bf;
 DROP INDEX IF EXISTS public.idx_on_subscription_id_bd763c5aa3;
 DROP INDEX IF EXISTS public.idx_on_plan_id_billable_metric_id_pay_in_advance_4a205974cb;
 DROP INDEX IF EXISTS public.idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167;
@@ -5161,6 +5162,13 @@ CREATE UNIQUE INDEX idx_on_subscription_id_entitlement_feature_id_02bee9883b ON 
 --
 
 CREATE INDEX idx_on_subscription_id_bd763c5aa3 ON public.subscription_fixed_charge_units_overrides USING btree (subscription_id);
+
+
+--
+-- Name: idx_on_subscription_id_fixed_charge_id_d85b30a9bf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_on_subscription_id_fixed_charge_id_d85b30a9bf ON public.subscription_fixed_charge_units_overrides USING btree (subscription_id, fixed_charge_id) WHERE (deleted_at IS NULL);
 
 
 --

--- a/spec/factories/subscription_fixed_charge_units_overrides.rb
+++ b/spec/factories/subscription_fixed_charge_units_overrides.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :subscription_fixed_charge_units_override do
+    organization { subscription&.organization || association(:organization) }
+    billing_entity { subscription&.billing_entity || association(:billing_entity) }
+    subscription
+    fixed_charge
+    units { Faker::Number.between(from: 0, to: 100) }
+  end
+end

--- a/spec/models/fixed_charge_spec.rb
+++ b/spec/models/fixed_charge_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe FixedCharge, type: :model do
   it { is_expected.to belong_to(:add_on) }
   it { is_expected.to belong_to(:parent).class_name("FixedCharge").optional }
   it { is_expected.to have_many(:children).class_name("FixedCharge").dependent(:nullify) }
+  it { is_expected.to have_many(:subscription_fixed_charge_units_overrides).dependent(:destroy) }
 
   it { is_expected.to validate_numericality_of(:units).is_greater_than_or_equal_to(0) }
   it { is_expected.to validate_presence_of(:charge_model) }

--- a/spec/models/subscription_fixed_charge_units_override_spec.rb
+++ b/spec/models/subscription_fixed_charge_units_override_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubscriptionFixedChargeUnitsOverride, type: :model do
+  subject { build(:subscription_fixed_charge_units_override) }
+
+  it { expect(described_class).to be_soft_deletable }
+  it_behaves_like "paper_trail traceable"
+
+  it { is_expected.to belong_to(:organization) }
+  it { is_expected.to belong_to(:billing_entity) }
+  it { is_expected.to belong_to(:subscription) }
+  it { is_expected.to belong_to(:fixed_charge) }
+
+  it { is_expected.to validate_numericality_of(:units).is_greater_than_or_equal_to(0) }
+end

--- a/spec/models/subscription_fixed_charge_units_override_spec.rb
+++ b/spec/models/subscription_fixed_charge_units_override_spec.rb
@@ -4,10 +4,10 @@ require "rails_helper"
 
 RSpec.describe SubscriptionFixedChargeUnitsOverride, type: :model do
   subject { build(:subscription_fixed_charge_units_override) }
+
   it_behaves_like "paper_trail traceable"
 
   it { expect(described_class).to be_soft_deletable }
-
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:billing_entity) }
   it { is_expected.to belong_to(:subscription) }

--- a/spec/models/subscription_fixed_charge_units_override_spec.rb
+++ b/spec/models/subscription_fixed_charge_units_override_spec.rb
@@ -13,5 +13,8 @@ RSpec.describe SubscriptionFixedChargeUnitsOverride, type: :model do
   it { is_expected.to belong_to(:subscription) }
   it { is_expected.to belong_to(:fixed_charge) }
 
-  it { is_expected.to validate_numericality_of(:units).is_greater_than_or_equal_to(0) }
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:units) }
+    it { is_expected.to validate_numericality_of(:units).is_greater_than_or_equal_to(0) }
+  end
 end

--- a/spec/models/subscription_fixed_charge_units_override_spec.rb
+++ b/spec/models/subscription_fixed_charge_units_override_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe SubscriptionFixedChargeUnitsOverride, type: :model do
   subject { build(:subscription_fixed_charge_units_override) }
+  it_behaves_like "paper_trail traceable"
 
   it { expect(described_class).to be_soft_deletable }
-  it_behaves_like "paper_trail traceable"
 
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:billing_entity) }

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Subscription, type: :model do
       expect(subject).to have_many(:fees)
       expect(subject).to have_many(:daily_usages)
       expect(subject).to have_many(:usage_thresholds).through(:plan)
+      expect(subject).to have_many(:subscription_fixed_charge_units_overrides).dependent(:destroy)
       expect(subject).to have_one(:lifetime_usage).autosave(true)
       expect(subject).to have_one(:subscription_activity).class_name("UsageMonitoring::SubscriptionActivity")
       expect(subject).to have_many(:entitlements).class_name("Entitlement::Entitlement")


### PR DESCRIPTION
## Context

For fixed charges on subscription level we can override number of units, but this should not create a plan override, so we need a new model that would only keep the overridden units

## Description

- added migration and model of subscrition_fixed_charges_units_override
