### PR TITLE
fix(db): Add `where deleted_at is null` condition on privileges

### DIFF
--- a/app/models/entitlement/privilege.rb
+++ b/app/models/entitlement/privilege.rb
@@ -58,7 +58,7 @@ end
 #
 # Indexes
 #
-#  idx_privileges_code_unique_per_feature                  (code,entitlement_feature_id) UNIQUE
+#  idx_privileges_code_unique_per_feature                  (code,entitlement_feature_id) UNIQUE WHERE (deleted_at IS NULL)
 #  index_entitlement_privileges_on_entitlement_feature_id  (entitlement_feature_id)
 #  index_entitlement_privileges_on_organization_id         (organization_id)
 #

--- a/db/migrate/20250630180000_create_entitlement_features_and_privileges.rb
+++ b/db/migrate/20250630180000_create_entitlement_features_and_privileges.rb
@@ -12,7 +12,10 @@ class CreateEntitlementFeaturesAndPrivileges < ActiveRecord::Migration[8.0]
       t.datetime :deleted_at
       t.timestamps
 
-      t.index %w[code organization_id], unique: true, name: "idx_features_code_unique_per_organization", where: "(deleted_at IS NULL)"
+      t.index %w[code organization_id],
+        name: "idx_features_code_unique_per_organization",
+        unique: true,
+        where: "deleted_at IS NULL"
     end
 
     create_table :entitlement_privileges, id: :uuid do |t|
@@ -25,7 +28,9 @@ class CreateEntitlementFeaturesAndPrivileges < ActiveRecord::Migration[8.0]
       t.datetime :deleted_at
       t.timestamps
 
-      t.index %w[code entitlement_feature_id], unique: true, name: "idx_privileges_code_unique_per_feature"
+      t.index %w[code entitlement_feature_id],
+        name: "idx_privileges_code_unique_per_feature",
+        unique: true
     end
   end
 end

--- a/db/migrate/20250704800001_create_plan_entitlement.rb
+++ b/db/migrate/20250704800001_create_plan_entitlement.rb
@@ -9,7 +9,9 @@ class CreatePlanEntitlement < ActiveRecord::Migration[8.0]
       t.datetime :deleted_at
       t.timestamps
 
-      t.index %w[entitlement_feature_id plan_id], unique: true, where: "(deleted_at IS NULL)"
+      t.index %w[entitlement_feature_id plan_id],
+        unique: true,
+        where: "deleted_at IS NULL"
     end
 
     create_table :entitlement_entitlement_values, id: :uuid do |t|
@@ -20,7 +22,9 @@ class CreatePlanEntitlement < ActiveRecord::Migration[8.0]
       t.datetime :deleted_at
       t.timestamps
 
-      t.index %w[entitlement_privilege_id entitlement_entitlement_id], unique: true, where: "(deleted_at IS NULL)"
+      t.index %w[entitlement_privilege_id entitlement_entitlement_id],
+        unique: true,
+        where: "deleted_at IS NULL"
     end
   end
 end

--- a/db/migrate/20250717092012_fix_privilege_index.rb
+++ b/db/migrate/20250717092012_fix_privilege_index.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class FixPrivilegeIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :entitlement_privileges, %w[code entitlement_feature_id],
+      name: :idx_privileges_code_unique_per_feature,
+      unique: true,
+      algorithm: :concurrently,
+      if_exists: true
+
+    add_index :entitlement_privileges, %w[code entitlement_feature_id],
+      name: "idx_privileges_code_unique_per_feature",
+      unique: true,
+      where: "deleted_at IS NULL",
+      algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4860,7 +4860,7 @@ CREATE UNIQUE INDEX idx_on_usage_threshold_id_invoice_id_cb82cdf163 ON public.ap
 -- Name: idx_privileges_code_unique_per_feature; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_privileges_code_unique_per_feature ON public.entitlement_privileges USING btree (code, entitlement_feature_id);
+CREATE UNIQUE INDEX idx_privileges_code_unique_per_feature ON public.entitlement_privileges USING btree (code, entitlement_feature_id) WHERE (deleted_at IS NULL);
 
 
 --
@@ -9036,6 +9036,7 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250717092012'),
 ('20250716143358'),
 ('20250716142613'),
 ('20250716132759'),

--- a/spec/models/entitlement/privilege_spec.rb
+++ b/spec/models/entitlement/privilege_spec.rb
@@ -132,4 +132,14 @@ RSpec.describe Entitlement::Privilege, type: :model do
       expect(privilege.config).to include("select_options" => ["option1", "option2", "option3"])
     end
   end
+
+  describe "unique code per feature" do
+    it "fails if code already exist for the feature, unless it's soft deleted" do
+      feature = create(:feature)
+      privilege = create(:privilege, feature:, code: "test")
+      expect { create(:privilege, feature:, code: "test") }.to raise_error(ActiveRecord::RecordNotUnique)
+      privilege.update! deleted_at: Time.current
+      expect { create(:privilege, feature:, code: "test") }.not_to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
 end


### PR DESCRIPTION
As I'm adding Feature entitlements, I created 4 tables so far. 
One table had the wrong index because it didn't have the `where deleted_at is null` condition on the unique index 😭 😭 😭 

I'm deleting the index and creating the new one (in that order) because **the feature is NOT released**.