### PR TITLE
fix(mrrs-plan): Fix GraphQL DataApiMrrPlan mrr_share nullable

### DIFF
--- a/app/graphql/types/data_api/mrrs/plans/object.rb
+++ b/app/graphql/types/data_api/mrrs/plans/object.rb
@@ -20,7 +20,7 @@ module Types
           field :active_customers_share, Float, null: false
 
           field :mrr, Float, null: false
-          field :mrr_share, Float, null: false
+          field :mrr_share, Float, null: true
         end
       end
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4204,7 +4204,7 @@ type DataApiMrrPlan {
   amountCurrency: CurrencyEnum!
   dt: ISO8601Date!
   mrr: Float!
-  mrrShare: Float!
+  mrrShare: Float
   planCode: String!
   planDeletedAt: ISO8601DateTime
   planId: ID!

--- a/schema.json
+++ b/schema.json
@@ -18831,13 +18831,9 @@
               "name": "mrrShare",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/types/data_api/mrrs/plans/object_spec.rb
+++ b/spec/graphql/types/data_api/mrrs/plans/object_spec.rb
@@ -17,6 +17,6 @@ RSpec.describe Types::DataApi::Mrrs::Plans::Object do
     expect(subject).to have_field(:active_customers_count).of_type("BigInt!")
     expect(subject).to have_field(:active_customers_share).of_type("Float!")
     expect(subject).to have_field(:mrr).of_type("Float!")
-    expect(subject).to have_field(:mrr_share).of_type("Float!")
+    expect(subject).to have_field(:mrr_share).of_type("Float")
   end
 end


### PR DESCRIPTION
## Context

`mrr_share` contains `NULL` values but was defined as nullable.

## Description

Change `null: false` to `null: true` of `mrr_share` field in `DataApiMrrPlan` GraphQL type