### PR TITLE
misc(migration): Update migration to version `8.0`

### DIFF
--- a/.cursor/rules/rails-general.mdc
+++ b/.cursor/rules/rails-general.mdc
@@ -162,6 +162,7 @@ To create a webhook:
 
 # Migrations
 
+- Make sure to specify the latest available `ActiveRecord::Migration` version. For example, if the latest version is `8.0`, use `ActiveRecord::Migration[8.0]`.
 - Prefer `add_column` over `change_table` when adding single columns
 - Use `safety_assured` wrapper when required for complex operations
 - Never use hardcoded or fake timestamps in migration filenames. Migration timestamps should be generated using `date +"%Y%m%d%H%M%S"` command to ensure proper chronological ordering.

--- a/db/migrate/20250709171329_add_on_termination_credit_note_to_subscriptions.rb
+++ b/db/migrate/20250709171329_add_on_termination_credit_note_to_subscriptions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddOnTerminationCreditNoteToSubscriptions < ActiveRecord::Migration[7.1]
+class AddOnTerminationCreditNoteToSubscriptions < ActiveRecord::Migration[8.0]
   def change
     create_enum :subscription_on_termination_credit_note, %w[credit skip]
     add_column :subscriptions, :on_termination_credit_note, :enum, enum_type: "subscription_on_termination_credit_note", default: nil


### PR DESCRIPTION
## Context

a64c544ef0af51d0a9bba60776e7402f6e22cc30 introduced the `db/migrate/20250709171329_add_on_termination_credit_note_to_subscriptions.rb` migration. This migration was generated by Cursor with `7.1` as the migration version. This has no impact on database schema but it's better to stick with the latest available version.

## Description

This PR updates the migration to version `8.0` and add a rule for AI agents.
