### PR TITLE
feat(subscription): Allow to skip credit note creation on subscription termination via GraphQL

### DIFF
--- a/app/graphql/mutations/subscriptions/terminate.rb
+++ b/app/graphql/mutations/subscriptions/terminate.rb
@@ -12,12 +12,13 @@ module Mutations
       description "Terminate a Subscription"
 
       argument :id, ID, required: true
+      argument :on_termination_credit_note, Types::Subscriptions::OnTerminationCreditNoteEnum, required: false
 
       type Types::Subscriptions::Object
 
-      def resolve(**args)
-        subscription = current_organization.subscriptions.find_by(id: args[:id])
-        result = ::Subscriptions::TerminateService.call(subscription:)
+      def resolve(id:, **args)
+        subscription = current_organization.subscriptions.find_by(id:)
+        result = ::Subscriptions::TerminateService.call(subscription:, **args.compact)
 
         result.success? ? result.subscription : result_error(result)
       end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -17,6 +17,7 @@ module Types
       field :billing_time, Types::Subscriptions::BillingTimeEnum
       field :canceled_at, GraphQL::Types::ISO8601DateTime
       field :ending_at, GraphQL::Types::ISO8601DateTime
+      field :on_termination_credit_note, Types::Subscriptions::OnTerminationCreditNoteEnum, null: true
       field :started_at, GraphQL::Types::ISO8601DateTime
       field :subscription_at, GraphQL::Types::ISO8601DateTime
       field :terminated_at, GraphQL::Types::ISO8601DateTime

--- a/app/graphql/types/subscriptions/on_termination_credit_note_enum.rb
+++ b/app/graphql/types/subscriptions/on_termination_credit_note_enum.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module Subscriptions
+    class OnTerminationCreditNoteEnum < Types::BaseEnum
+      Subscription::ON_TERMINATION_CREDIT_NOTES.each_key do |reason|
+        value reason
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -7425,6 +7425,11 @@ input OktaLoginInput {
   state: String!
 }
 
+enum OnTerminationCreditNoteEnum {
+  credit
+  skip
+}
+
 enum OrderByEnum {
   gross_revenue_amount_cents
   net_revenue_amount_cents
@@ -9062,6 +9067,7 @@ type Subscription {
   nextSubscription: Subscription
   nextSubscriptionAt: ISO8601DateTime
   nextSubscriptionType: NextSubscriptionTypeEnum
+  onTerminationCreditNote: OnTerminationCreditNoteEnum
   periodEndDate: ISO8601Date
   plan: Plan!
   startedAt: ISO8601DateTime
@@ -9354,6 +9360,7 @@ input TerminateSubscriptionInput {
   """
   clientMutationId: String
   id: ID!
+  onTerminationCreditNote: OnTerminationCreditNoteEnum
 }
 
 input ThresholdInput {

--- a/schema.json
+++ b/schema.json
@@ -34939,6 +34939,29 @@
         },
         {
           "kind": "ENUM",
+          "name": "OnTerminationCreditNoteEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "credit",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "skip",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
           "name": "OrderByEnum",
           "description": null,
           "interfaces": null,
@@ -47813,6 +47836,18 @@
               "args": []
             },
             {
+              "name": "onTerminationCreditNote",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "OnTerminationCreditNoteEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "periodEndDate",
               "description": null,
               "type": {
@@ -49249,6 +49284,18 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onTerminationCreditNote",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "OnTerminationCreditNoteEnum",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Types::Subscriptions::Object do
     expect(subject).to have_field(:started_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:subscription_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:terminated_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:on_termination_credit_note).of_type("OnTerminationCreditNoteEnum")
 
     expect(subject).to have_field(:current_billing_period_started_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:current_billing_period_ending_at).of_type("ISO8601DateTime")

--- a/spec/graphql/types/subscriptions/on_termination_credit_note_enum_spec.rb
+++ b/spec/graphql/types/subscriptions/on_termination_credit_note_enum_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Subscriptions::OnTerminationCreditNoteEnum do
+  it "enumerates the correct values" do
+    expect(described_class.values.keys).to match_array(%w[skip credit])
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/flexible-credit-note-management

## Context

When subscriptions are terminated before their billing period ends, the system previously always created credit notes for unused time on pay-in-advance plans. This inflexible behavior didn't accommodate different business needs where organizations might want to skip credit note generation for certain termination scenarios.

The API already accepts the termination behavior as a parameter during subscription termination but the GraphQL API did not.

## Description

This update the `terminateSubscription` mutation to handle the `on_termination_credit_note` behavior.
