### PR TITLE
feat(entitlements): Graphl resolver for subscription entitlements

### DIFF
--- a/app/graphql/resolvers/entitlement/subscription_entitlements_resolver.rb
+++ b/app/graphql/resolvers/entitlement/subscription_entitlements_resolver.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module Entitlement
+    class SubscriptionEntitlementsResolver < Resolvers::BaseResolver
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      REQUIRED_PERMISSION = "subscriptions:view"
+
+      description "Query subscription entitlements"
+
+      argument :subscription_external_id, String, required: true
+
+      type [Types::Entitlement::SubscriptionEntitlementObject], null: false
+
+      def resolve(subscription_external_id:)
+        raise forbidden_error(code: "feature_unavailable") unless License.premium?
+
+        # Get entitlements for the subscription
+        entitlements = current_organization.entitlements
+          .where(subscription_external_id: subscription_external_id)
+          .includes(:feature, :values)
+
+        # Get removed features for the subscription
+        removed_features = current_organization.subscription_feature_removals
+          .where(subscription_external_id: subscription_external_id)
+          .includes(:feature)
+
+        # Convert entitlements to objects with removed: false
+        entitlement_objects = entitlements.map do |entitlement|
+          entitlement.define_singleton_method(:removed) { false }
+          entitlement
+        end
+
+        # Convert removed features to entitlement-like objects with removed: true
+        removed_objects = removed_features.map do |removal|
+          # Create a pseudo-entitlement object that looks like an entitlement
+          pseudo_entitlement = Object.new
+          pseudo_entitlement.define_singleton_method(:feature) { removal.feature }
+          pseudo_entitlement.define_singleton_method(:values) { [] }
+          pseudo_entitlement.define_singleton_method(:removed) { true }
+          pseudo_entitlement
+        end
+
+        # Merge both lists
+        entitlement_objects + removed_objects
+      end
+    end
+  end
+end

--- a/app/graphql/types/entitlement/subscription_entitlement_object.rb
+++ b/app/graphql/types/entitlement/subscription_entitlement_object.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  module Entitlement
+    class SubscriptionEntitlementObject < Types::BaseObject
+      graphql_name "SubscriptionEntitlement"
+
+      field :code, String, null: false
+      field :privileges, [SubscriptionEntitlementPrivilegeObject], null: false, method: :values
+      field :removed, Boolean, null: false, description: "Whether this feature is removed from the subscription"
+
+      def code
+        object.feature.code
+      end
+
+      def removed
+        object.respond_to?(:removed) ? object.removed : false
+      end
+    end
+  end
+end

--- a/app/graphql/types/entitlement/subscription_entitlement_privilege_object.rb
+++ b/app/graphql/types/entitlement/subscription_entitlement_privilege_object.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  module Entitlement
+    class SubscriptionEntitlementPrivilegeObject < Types::BaseObject
+      field :code, String, null: false
+      field :value, String, null: false
+
+      def code
+        object.privilege.code
+      end
+    end
+  end
+end

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -50,6 +50,14 @@ module Types
         object.usage_thresholds.order(amount_cents: :asc)
       end
 
+      def entitlements
+        if object.parent_id.present?
+          object.parent.entitlements
+        else
+          object.entitlements
+        end
+      end
+
       def charges
         object.charges.includes(filters: {values: :billable_metric_filter}).order(created_at: :asc)
       end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -83,6 +83,7 @@ module Types
     field :pricing_unit, resolver: Resolvers::PricingUnitResolver
     field :pricing_units, resolver: Resolvers::PricingUnitsResolver
     field :subscription, resolver: Resolvers::SubscriptionResolver
+    field :subscription_entitlements, resolver: Resolvers::Entitlement::SubscriptionEntitlementsResolver
     field :subscriptions, resolver: Resolvers::SubscriptionsResolver
     field :tax, resolver: Resolvers::TaxResolver
     field :taxes, resolver: Resolvers::TaxesResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -8604,6 +8604,11 @@ type Query {
   ): Subscription
 
   """
+  Query subscription entitlements
+  """
+  subscriptionEntitlements(subscriptionExternalId: String!): [SubscriptionEntitlement!]!
+
+  """
   Query subscriptions of an organization
   """
   subscriptions(externalCustomerId: String, limit: Int, overriden: Boolean, page: Int, planCode: String, searchTerm: String, status: [StatusTypeEnum!]): SubscriptionCollection!
@@ -9084,6 +9089,21 @@ type SubscriptionCollection {
   Pagination Metadata for navigating the Pagination
   """
   metadata: CollectionMetadata!
+}
+
+type SubscriptionEntitlement {
+  code: String!
+  privileges: [SubscriptionEntitlementPrivilegeObject!]!
+
+  """
+  Whether this feature is removed from the subscription
+  """
+  removed: Boolean!
+}
+
+type SubscriptionEntitlementPrivilegeObject {
+  code: String!
+  value: String!
 }
 
 type SubscriptionLifetimeUsage {

--- a/schema.json
+++ b/schema.json
@@ -45247,6 +45247,47 @@
               ]
             },
             {
+              "name": "subscriptionEntitlements",
+              "description": "Query subscription entitlements",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SubscriptionEntitlement",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "subscriptionExternalId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "subscriptions",
               "description": "Query subscriptions of an organization",
               "type": {
@@ -47948,6 +47989,116 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SubscriptionEntitlement",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "privileges",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SubscriptionEntitlementPrivilegeObject",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "removed",
+              "description": "Whether this feature is removed from the subscription",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SubscriptionEntitlementPrivilegeObject",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "value",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },

--- a/spec/graphql/mutations/entitlement/update_plan_entitlements_spec.rb
+++ b/spec/graphql/mutations/entitlement/update_plan_entitlements_spec.rb
@@ -161,7 +161,6 @@ RSpec.describe Mutations::Entitlement::UpdatePlanEntitlements, type: :graphql do
     end
 
     it "returns not found error" do
-      pps subject
       expect_graphql_error(result: subject, message: "not_found")
     end
   end

--- a/spec/graphql/resolvers/entitlement/subscription_entitlements_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/subscription_entitlements_resolver_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::Entitlement::SubscriptionEntitlementsResolver, type: :graphql do
+  subject { execute_query(query:) }
+
+  let(:organization) { create(:organization) }
+  let(:subscription_external_id) { "sub_123" }
+  let(:required_permission) { "subscriptions:view" }
+  let(:query) do
+    <<~GQL
+      query {
+        subscriptionEntitlements(subscriptionExternalId: "#{subscription_external_id}") {
+          code
+          removed
+          privileges {
+            code
+            value
+          }
+        }
+      }
+    GQL
+  end
+
+  around { |test| lago_premium!(&test) }
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "subscriptions:view"
+  it_behaves_like "requires Premium license"
+
+  it do
+    expect(described_class).to accept_argument(:subscription_external_id).of_type("String!")
+  end
+
+  it "returns subscription entitlements and removed features" do
+    feature1 = create(:feature, organization:)
+    feature2 = create(:feature, organization:)
+    _feature3 = create(:feature, organization:)
+
+    # Create an entitlement for the subscription
+    entitlement = create(:entitlement, organization:, feature: feature1, subscription_external_id:)
+    entitlement_value = create(:entitlement_value, entitlement:, privilege: create(:privilege, feature: feature1))
+
+    # Create a removed feature for the subscription
+    create(:subscription_feature_removal, organization:, feature: feature2, subscription_external_id:)
+
+    result = subject
+
+    subscription_entitlements = result["data"]["subscriptionEntitlements"]
+    expect(subscription_entitlements.count).to eq(2)
+
+    # Check regular entitlement
+    regular_entitlement = subscription_entitlements.find { |e| e["code"] == feature1.code }
+    expect(regular_entitlement["removed"]).to be(false)
+    expect(regular_entitlement["privileges"]).to eq([
+      {"code" => entitlement_value.privilege.code, "value" => entitlement_value.value}
+    ])
+
+    # Check removed feature
+    removed_entitlement = subscription_entitlements.find { |e| e["code"] == feature2.code }
+    expect(removed_entitlement["removed"]).to be(true)
+    expect(removed_entitlement["privileges"]).to be_empty
+  end
+
+  it "returns only entitlements for the specified subscription" do
+    feature1 = create(:feature, organization:)
+    feature2 = create(:feature, organization:)
+    other_subscription_id = "sub_456"
+
+    # Create entitlements for different subscriptions
+    create(:entitlement, organization:, feature: feature1, subscription_external_id:)
+    create(:entitlement, organization:, feature: feature2, subscription_external_id: other_subscription_id)
+
+    result = subject
+
+    subscription_entitlements = result["data"]["subscriptionEntitlements"]
+    expect(subscription_entitlements.count).to eq(1)
+    expect(subscription_entitlements.first["code"]).to eq(feature1.code)
+  end
+
+  it "returns only removed features for the specified subscription" do
+    feature1 = create(:feature, organization:)
+    feature2 = create(:feature, organization:)
+    other_subscription_id = "sub_456"
+
+    # Create removed features for different subscriptions
+    create(:subscription_feature_removal, organization:, feature: feature1, subscription_external_id:)
+    create(:subscription_feature_removal, organization:, feature: feature2, subscription_external_id: other_subscription_id)
+
+    result = subject
+
+    subscription_entitlements = result["data"]["subscriptionEntitlements"]
+    expect(subscription_entitlements.count).to eq(1)
+    expect(subscription_entitlements.first["code"]).to eq(feature1.code)
+    expect(subscription_entitlements.first["removed"]).to be(true)
+  end
+
+  it "returns empty array when no entitlements or removed features exist" do
+    result = subject
+
+    subscription_entitlements = result["data"]["subscriptionEntitlements"]
+    expect(subscription_entitlements).to be_empty
+  end
+end

--- a/spec/graphql/types/entitlement/subscription_entitlement_object_spec.rb
+++ b/spec/graphql/types/entitlement/subscription_entitlement_object_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Entitlement::SubscriptionEntitlementObject do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:code).of_type("String!")
+    expect(subject).to have_field(:privileges).of_type("[SubscriptionEntitlementPrivilegeObject!]!")
+    expect(subject).to have_field(:removed).of_type("Boolean!")
+  end
+end

--- a/spec/graphql/types/entitlement/subscription_entitlement_privilege_object_spec.rb
+++ b/spec/graphql/types/entitlement/subscription_entitlement_privilege_object_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Entitlement::SubscriptionEntitlementPrivilegeObject do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:code).of_type("String!")
+    expect(subject).to have_field(:value).of_type("String!")
+  end
+end


### PR DESCRIPTION
## How to use

This is a little different from the API endpoints because I think our apps has different need.

I expect the subscription view to do a few thing:

1. get all entitlements from the subscription plan
2. get the subscription entitlements (to be discussed if this should be part of the SubscriptionObject)
3. merge the two list by:
  1. removing features of the subscription entitlements has `removed: true`
  2. adding features from subscription of not in plan entitlements
  3. override values if feature is in both

I believe the frontend needs a way to:
- show the default plan value 
- highlight that a feature is supposed to be available but was removed specifically for this sub
  - and a way to undo the removal
- highlight that a feature  was added specifically for this sub


**This complexity is exactly why the db view exists in #4022 so we can easily retrieve the complete data.**

## Payload Examples

### Plan entitlements

```
[
    {
        "code": "seats",
        "name": "Feature Name",
        "description": "Feature Description",
        "privileges":
        [
            {
                "code": "max",
                "value": "10",
                "name": null,
                "valueType": "integer",
                "config":
                {}
            }
        ]
    },
    {
        "code": "support",
        "name": "Premium Support",
        "description": null,
        "privileges": []
    },
    {
        "code": "salesforce",
        "name": "Salesforce Integration",
        "description": null,
        "privileges": []
    }
]
```

### Subscription entitlements

```
[
    {
        "code": "seats",
        "name": "Feature Name",
        "description": "Feature Description",
        "removed": false,
        "privileges":
        [
            {
                "code": "max",
                "value": "25",
                "name": null,
                "valueType": "integer",
                "config": {}
            },
            {
                "code": "max_admin",
                "value": "2",
                "name": null,
                "valueType": "integer",
                "config": {}
            }
        ]
    },
    {
        "code": "mcp",
        "name": "MCP Server",
        "description": null,
        "privileges": []
    },
    {
        "code": "salesforce",
        "name": "Salesforce Integration",
        "description": null,
        "removed": true,
        "privileges": []
    }
]
```

### Expected merged list to display

* `seats.max` value is added overridden
* `seats.max_admin` is added
* `salesforce` is removed
* `mcp` is added

```
[
    {
        "code": "seats",
        "name": "Feature Name",
        "description": "Feature Description",
        "privileges":
        [
            {
                "code": "max",
                "value": "25",
                "name": null,
                "valueType": "integer",
                "config": {}
            },
            {
                "code": "max_admin",
                "value": "2",
                "name": null,
                "valueType": "integer",
                "config": {}
            }
        ]
    },
    {
        "code": "support",
        "name": "Premium Support",
        "description": null,
        "privileges": []
    },
    {
        "code": "mcp",
        "name": "MCP Server",
        "description": null,
        "removed": false,
        "privileges": []
    }
]
```