### PR TITLE
feat(subscriptions): Add refund option for subscription termination

### DIFF
--- a/.cursor/rules/rails-general.mdc
+++ b/.cursor/rules/rails-general.mdc
@@ -54,9 +54,7 @@ Where:
 - The body should
   - Explain the context and rationale for the change
   - Explain the "why" and "what" at a conceptual level, not the "how" at a code level
-  - Be simple and direct
-  - Avoid verbose explanations
-  - Keep as many meaningful information as possible
+  - Be simple and direct using complete sentences without being verbose while keeping as much information as possible
 - Check the whole diff at once using `PAGER=cat git diff ...` to see all changes together
 - Generate the commit message based on the actual changes, not assumptions
 - Do not check previous commits or commit history

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -44,7 +44,7 @@ class Subscription < ApplicationRecord
     anniversary
   ].freeze
 
-  ON_TERMINATION_CREDIT_NOTES = {credit: "credit", skip: "skip"}.freeze
+  ON_TERMINATION_CREDIT_NOTES = {credit: "credit", skip: "skip", refund: "refund"}.freeze
   ON_TERMINATION_INVOICES = {generate: "generate", skip: "skip"}.freeze
 
   enum :status, STATUSES

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -30,11 +30,15 @@ module Subscriptions
 
           if generate_credit_note_for_unconsumed_subscription?
             # NOTE: As subscription was payed in advance and terminated before the end of the period,
-            #       we have to create a credit note for the days that were not consumed
+            #       we have to create a credit note for the days that were not consumed.
+            #       Depending on the termination behaviour, we will optionally refund the portion of the unconsumed
+            #       subscription that was already paid.
+
             CreditNotes::CreateFromTermination.call!(
               subscription:,
               reason: "order_cancellation",
-              upgrade:
+              upgrade: upgrade,
+              refund: !upgrade && on_termination_credit_note == :refund
             )
           end
 
@@ -181,7 +185,9 @@ module Subscriptions
     end
 
     def generate_credit_note_for_unconsumed_subscription?
-      pay_in_advance? && pay_in_advance_invoice_issued? && on_termination_credit_note == :credit
+      pay_in_advance? &&
+        pay_in_advance_invoice_issued? &&
+        (on_termination_credit_note == :credit || on_termination_credit_note == :refund)
     end
 
     def pay_in_advance?

--- a/db/migrate/20250712000000_add_refund_to_subscription_on_termination_credit_note.rb
+++ b/db/migrate/20250712000000_add_refund_to_subscription_on_termination_credit_note.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddRefundToSubscriptionOnTerminationCreditNote < ActiveRecord::Migration[7.1]
+  def up
+    add_enum_value :subscription_on_termination_credit_note, "refund", if_not_exists: true
+  end
+
+  def down
+    # No rollback needed as removing enum values is not supported
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1035,7 +1035,8 @@ CREATE TYPE public.subscription_invoicing_reason AS ENUM (
 
 CREATE TYPE public.subscription_on_termination_credit_note AS ENUM (
     'credit',
-    'skip'
+    'skip',
+    'refund'
 );
 
 
@@ -9464,6 +9465,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250716123425'),
 ('20250715124108'),
 ('20250714131519'),
+('20250712000000'),
 ('20250710102337'),
 ('20250709171329'),
 ('20250709085218'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -7439,6 +7439,7 @@ input OktaLoginInput {
 
 enum OnTerminationCreditNoteEnum {
   credit
+  refund
   skip
 }
 

--- a/schema.json
+++ b/schema.json
@@ -35034,6 +35034,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "refund",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/graphql/types/subscriptions/on_termination_credit_note_enum_spec.rb
+++ b/spec/graphql/types/subscriptions/on_termination_credit_note_enum_spec.rb
@@ -4,6 +4,6 @@ require "rails_helper"
 
 RSpec.describe Types::Subscriptions::OnTerminationCreditNoteEnum do
   it "enumerates the correct values" do
-    expect(described_class.values.keys).to match_array(%w[skip credit])
+    expect(described_class.values.keys).to match_array(%w[skip credit refund])
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Subscription, type: :model do
       )
       expect(subject).to define_enum_for(:on_termination_credit_note)
         .backed_by_column_of_type(:enum)
-        .with_values(credit: "credit", skip: "skip")
+        .with_values(credit: "credit", skip: "skip", refund: "refund")
         .with_prefix(:on_termination_credit_note)
       expect(subject).to define_enum_for(:on_termination_invoice)
         .backed_by_column_of_type(:enum)

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -436,6 +436,14 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
           end
         end
 
+        context "when on_termination_credit_note is refund" do
+          let(:params) { {on_termination_credit_note: "refund"} }
+
+          it "terminates subscription with refund behavior" do
+            test_termination(expected_on_termination_credit_note: "refund")
+          end
+        end
+
         context "with invalid on_termination_credit_note value" do
           let(:params) { {on_termination_credit_note: "invalid"} }
 

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -210,6 +210,23 @@ RSpec.describe Subscriptions::TerminateService do
         end
       end
 
+      context "when on_termination_credit_note is refund" do
+        let(:on_termination_credit_note) { "refund" }
+
+        it "creates a credit note for the remaining days with refund" do
+          travel_to(Time.current.end_of_month - 4.days) do
+            expect { subject }.to change(CreditNote, :count).by(1)
+          end
+        end
+
+        it "updates the subscription termination behavior" do
+          travel_to(Time.current.end_of_month - 4.days) do
+            subject
+            expect(subscription.reload.on_termination_credit_note).to eq("refund")
+          end
+        end
+      end
+
       context "when on_termination_credit_note is not set" do
         subject(:result) { described_class.call(subscription:) }
 


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/flexible-credit-note-management

## Context

When subscriptions are terminated before their billing period ends, the system previously allowed to create credit notes for unused time on pay-in-advance plans. It was also possible to skip the creation of credit note. In cases where the customer already paid, it was not possible to issue a refund as part of the credit note.

## Description

This adds support for refunding customers via the `on_termination_credit_note` when terminating pay-in-advance subscriptions early.

This implementation extends the subscription termination process with a new `refund` option alongside the existing `credit` and `omit` behaviors. When a pay-in-advance subscription is terminated early, the system now calculates the unused subscription amount and determines how much should be refunded versus credited based on what was actually paid by the customer.

The refund calculation considers existing credit notes or coupons, prorated paid amount against the subscription usage, handling edge cases for trial periods and partial payments.

Here's an example of calculation:

```
== Context ==

BILLING PERIOD DETAILS
Start of period                 October 1st
End of period                   October 31st  
Termination                     October 15th (15 days usage / 16 days unused)

INVOICE 1 (BEGINNING OF PERIOD)
Subscription 1 (pay-in-advance)
Amount per day                  €1.00
Total amount used               €31.00
Tax (20%)                       €6.20
                                ------
Total after tax                 €37.20

Subscription 2 (pay-in-advance) 
Amount per day                  €1.00
Total amount used               €31.00
Tax (20%)                       €6.20
                                ------
Total after tax                 €37.20

INVOICE TOTALS
Total amount                    €74.40  (€37.20 × 2)
Credit note already generated   -€2.00  (subscription 1 fee)

CUSTOMER PAYMENTS (partially paid)
Total paid                      €55.80
Subscription 1 portion (50%)    €27.90
Subscription 2 portion (50%)    €27.90

== Calculation ==

CREDITABLE AMOUNT CALCULATION
Unused subscription (16 days)    €16.00
Previous credit notes            -€2.00
                                ------
Subtotal                         €14.00
Coupons (14€/31€ * 5€)           -€2.26
Tax (20%)                        €2.35
                                ------
Total creditable                 €14.09

REFUND CALCULATION
Invoice total paid               €55.80
Subscription portion (45.61%)    €25.45

Used subscription (15 days)      €15.00
                                ------
Used subtotal                    €15.00
Coupons (15€/31€ * 5€)           -€2.42
Tax (20%)                        €2.52
                                ------
Total used                       €15.10

Available for refund             €10.35  (€25.45 - €15.10)

FINAL AMOUNTS
Refund amount                    €10.35
Credit amount                    €3.74   (€14.09 - €10.35)
                                ------
Total credit note                €14.09
```
