### PR TITLE
feat(entitlements): Add `entitlements` to Subscription Graphql object

### DIFF
--- a/app/graphql/mutations/entitlement/update_plan_entitlements.rb
+++ b/app/graphql/mutations/entitlement/update_plan_entitlements.rb
@@ -12,7 +12,7 @@ module Mutations
 
       argument :plan_id, ID, required: true
 
-      argument :entitlements, [Types::Entitlement::PlanEntitlementInput], required: true
+      argument :entitlements, [Types::Entitlement::EntitlementInput], required: true
 
       type Types::Entitlement::PlanEntitlementObject.collection_type
 

--- a/app/graphql/types/entitlement/entitlement_input.rb
+++ b/app/graphql/types/entitlement/entitlement_input.rb
@@ -2,11 +2,11 @@
 
 module Types
   module Entitlement
-    class PlanEntitlementInput < Types::BaseInputObject
+    class EntitlementInput < Types::BaseInputObject
       description "Input for updating a plan entitlement"
 
       argument :feature_code, String, required: true
-      argument :privileges, [PlanEntitlementPrivilegeInput], required: false, description: "The privileges configuration"
+      argument :privileges, [EntitlementPrivilegeInput], required: false, description: "The privileges configuration"
     end
   end
 end

--- a/app/graphql/types/entitlement/entitlement_privilege_input.rb
+++ b/app/graphql/types/entitlement/entitlement_privilege_input.rb
@@ -2,7 +2,7 @@
 
 module Types
   module Entitlement
-    class PlanEntitlementPrivilegeInput < Types::BaseInputObject
+    class EntitlementPrivilegeInput < Types::BaseInputObject
       description "Input for updating a plan entitlement privilege value"
 
       argument :privilege_code, String, required: true

--- a/app/graphql/types/entitlement/subscription_entitlement_object.rb
+++ b/app/graphql/types/entitlement/subscription_entitlement_object.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  module Entitlement
+    class SubscriptionEntitlementObject < Types::BaseObject
+      graphql_name "SubscriptionEntitlement"
+
+      field :code, String, null: false
+      field :description, String, null: true
+      field :name, String, null: false
+      field :privileges, [SubscriptionEntitlementPrivilegeObject], null: false
+    end
+  end
+end

--- a/app/graphql/types/entitlement/subscription_entitlement_privilege_object.rb
+++ b/app/graphql/types/entitlement/subscription_entitlement_privilege_object.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module Entitlement
+    class SubscriptionEntitlementPrivilegeObject < Types::BaseObject
+      field :code, String, null: false
+      field :config, GraphQL::Types::JSON, null: false
+      field :name, String, null: true
+      field :override_value, String, null: true
+      field :plan_value, String, null: true
+      field :value, String, null: true
+      field :value_type, Types::Entitlement::PrivilegeValueTypeEnum, null: false
+    end
+  end
+end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -40,6 +40,8 @@ module Types
 
       field :lifetime_usage, Types::Subscriptions::LifetimeUsageObject, null: true
 
+      field :entitlements, [Types::Entitlement::SubscriptionEntitlementObject], null: false
+
       def next_plan
         object.next_subscription&.plan
       end
@@ -81,6 +83,12 @@ module Types
 
       def dates_service
         @dates_service ||= ::Subscriptions::DatesService.new_instance(object, Time.current, current_usage: true)
+      end
+
+      def entitlements
+        entitlements = ::Entitlement::SubscriptionEntitlement.for_subscription(object)
+
+        ::V1::Entitlement::SubscriptionEntitlementsCollectionSerializer.new(entitlements).serialize_models
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4948,6 +4948,26 @@ enum EmailSettingsEnum {
   payment_receipt_created
 }
 
+"""
+Input for updating a plan entitlement
+"""
+input EntitlementInput {
+  featureCode: String!
+
+  """
+  The privileges configuration
+  """
+  privileges: [EntitlementPrivilegeInput!]
+}
+
+"""
+Input for updating a plan entitlement privilege value
+"""
+input EntitlementPrivilegeInput {
+  privilegeCode: String!
+  value: String!
+}
+
 enum ErrorCodesEnum {
   invoice_generation_error
   not_provided
@@ -7804,26 +7824,6 @@ type PlanEntitlementCollection {
   metadata: CollectionMetadata!
 }
 
-"""
-Input for updating a plan entitlement
-"""
-input PlanEntitlementInput {
-  featureCode: String!
-
-  """
-  The privileges configuration
-  """
-  privileges: [PlanEntitlementPrivilegeInput!]
-}
-
-"""
-Input for updating a plan entitlement privilege value
-"""
-input PlanEntitlementPrivilegeInput {
-  privilegeCode: String!
-  value: String!
-}
-
 type PlanEntitlementPrivilegeObject {
   code: String!
   config: PrivilegeConfigObject!
@@ -9097,6 +9097,7 @@ type Subscription {
   currentBillingPeriodStartedAt: ISO8601DateTime
   customer: Customer!
   endingAt: ISO8601DateTime
+  entitlements: [SubscriptionEntitlement!]!
   externalId: String!
   fees: [Fee!]
   id: ID!
@@ -9131,6 +9132,23 @@ type SubscriptionCollection {
   Pagination Metadata for navigating the Pagination
   """
   metadata: CollectionMetadata!
+}
+
+type SubscriptionEntitlement {
+  code: String!
+  description: String
+  name: String!
+  privileges: [SubscriptionEntitlementPrivilegeObject!]!
+}
+
+type SubscriptionEntitlementPrivilegeObject {
+  code: String!
+  config: JSON!
+  name: String
+  overrideValue: String
+  planValue: String
+  value: String
+  valueType: PrivilegeValueTypeEnum!
 }
 
 type SubscriptionLifetimeUsage {
@@ -10681,7 +10699,7 @@ input UpdatePlanEntitlementsInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  entitlements: [PlanEntitlementInput!]!
+  entitlements: [EntitlementInput!]!
   planId: ID!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -22809,6 +22809,96 @@
           ]
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "EntitlementInput",
+          "description": "Input for updating a plan entitlement",
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "featureCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "privileges",
+              "description": "The privileges configuration",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "EntitlementPrivilegeInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "EntitlementPrivilegeInput",
+          "description": "Input for updating a plan entitlement privilege value",
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "privilegeCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
           "kind": "ENUM",
           "name": "ErrorCodesEnum",
           "description": null,
@@ -38611,96 +38701,6 @@
           "enumValues": null
         },
         {
-          "kind": "INPUT_OBJECT",
-          "name": "PlanEntitlementInput",
-          "description": "Input for updating a plan entitlement",
-          "interfaces": null,
-          "possibleTypes": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "featureCode",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "privileges",
-              "description": "The privileges configuration",
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "PlanEntitlementPrivilegeInput",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "enumValues": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "PlanEntitlementPrivilegeInput",
-          "description": "Input for updating a plan entitlement privilege value",
-          "interfaces": null,
-          "possibleTypes": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "privilegeCode",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "value",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "enumValues": null
-        },
-        {
           "kind": "OBJECT",
           "name": "PlanEntitlementPrivilegeObject",
           "description": null,
@@ -47910,6 +47910,30 @@
               "args": []
             },
             {
+              "name": "entitlements",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SubscriptionEntitlement",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "externalId",
               "description": null,
               "type": {
@@ -48209,6 +48233,192 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SubscriptionEntitlement",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "description",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "privileges",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SubscriptionEntitlementPrivilegeObject",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SubscriptionEntitlementPrivilegeObject",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "config",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "overrideValue",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "planValue",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "value",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "valueType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "PrivilegeValueTypeEnum",
                   "ofType": null
                 }
               },
@@ -54485,7 +54695,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "PlanEntitlementInput",
+                      "name": "EntitlementInput",
                       "ofType": null
                     }
                   }

--- a/spec/graphql/mutations/entitlement/update_plan_entitlements_spec.rb
+++ b/spec/graphql/mutations/entitlement/update_plan_entitlements_spec.rb
@@ -159,7 +159,6 @@ RSpec.describe Mutations::Entitlement::UpdatePlanEntitlements, type: :graphql do
     end
 
     it "returns not found error" do
-      pps subject
       expect_graphql_error(result: subject, message: "not_found")
     end
   end

--- a/spec/graphql/resolvers/subscription_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscription_resolver_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Resolvers::SubscriptionResolver, type: :graphql do
           }
           nextSubscriptionType
           nextSubscriptionAt
+          entitlements { code }
         }
       }
     GQL
@@ -68,6 +69,7 @@ RSpec.describe Resolvers::SubscriptionResolver, type: :graphql do
       subscription_response = result["data"]["subscription"]
       expect(subscription_response["id"]).to eq(subscription.id)
       expect(subscription_response["externalId"]).to eq(subscription.external_id)
+      expect(subscription_response["entitlements"]).to eq []
     end
   end
 
@@ -108,7 +110,7 @@ RSpec.describe Resolvers::SubscriptionResolver, type: :graphql do
     end
   end
 
-  context "when subscription was ugpraded" do
+  context "when subscription was upgraded" do
     let(:subscription) { create(:subscription, :terminated, customer:, next_subscriptions: [next_subscription], terminated_at: 1.day.ago, external_id: next_subscription.external_id) }
     let(:next_subscription) { create(:subscription, customer: customer, plan: create(:plan, amount_cents: 33000_00)) }
 
@@ -124,6 +126,113 @@ RSpec.describe Resolvers::SubscriptionResolver, type: :graphql do
       subscription_response = result["data"]["subscription"]
       expect(subscription_response["nextSubscriptionType"]).to eq "upgrade"
       expect(subscription_response["nextSubscriptionAt"]).to be_present
+    end
+  end
+
+  context "when subscription has entitlements" do
+    let(:query) do
+      <<~GQL
+        query($subscriptionId: ID, $externalId: ID) {
+          subscription(id: $subscriptionId, externalId: $externalId) {
+            id
+            externalId
+            name
+            startedAt
+            endingAt
+            plan {
+              id
+              code
+            }
+            nextSubscriptionType
+            nextSubscriptionAt
+            entitlements {
+              code
+              name
+              description
+              privileges {
+                code
+                name
+                valueType
+                config
+                value
+                planValue
+                overrideValue
+              }
+            }
+          }
+        }
+      GQL
+    end
+
+    let(:feature1) { create(:feature, organization:, code: "feature1", name: "Feature 1", description: "First feature") }
+    let(:privilege1) { create(:privilege, feature: feature1, code: "privilege1", name: "Privilege 1", value_type: "boolean") }
+    let(:entitlement1) { create(:entitlement, feature: feature1, plan: subscription.plan) }
+    let(:entitlement_value1) { create(:entitlement_value, entitlement: entitlement1, privilege: privilege1, value: "true") }
+
+    let(:feature2) { create(:feature, organization:, code: "feature2", name: "Feature 2", description: "Second feature") }
+    let(:privilege2) { create(:privilege, feature: feature2, code: "privilege2", name: "Privilege 2", value_type: "string") }
+    let(:entitlement2) { create(:entitlement, feature: feature2, plan: subscription.plan) }
+    let(:entitlement_value2) { create(:entitlement_value, entitlement: entitlement2, privilege: privilege2, value: "test_value") }
+
+    # Subscription override
+    let(:entitlement3) { create(:entitlement, feature: feature2, plan: nil, subscription:) }
+    let(:entitlement_value3) { create(:entitlement_value, entitlement: entitlement3, privilege: privilege2, value: "override_value") }
+
+    before do
+      entitlement_value1
+      entitlement_value2
+      entitlement_value3
+    end
+
+    it "returns all non-removed entitlements" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {
+          subscriptionId: subscription.id
+        }
+      )
+
+      entitlements_response = result["data"]["subscription"]["entitlements"]
+
+      expect(entitlements_response).to be_an(Array)
+      expect(entitlements_response.size).to eq(2)
+
+      feature1_entitlement = entitlements_response.find { |e| e["code"] == "feature1" }
+      expect(feature1_entitlement).to include(
+        "code" => "feature1",
+        "name" => "Feature 1",
+        "description" => "First feature"
+      )
+      expect(feature1_entitlement["privileges"]).to be_an(Array)
+      expect(feature1_entitlement["privileges"].size).to eq(1)
+      expect(feature1_entitlement["privileges"].first).to include(
+        "code" => "privilege1",
+        "name" => "Privilege 1",
+        "valueType" => "boolean",
+        "value" => "true",
+        "planValue" => "true",
+        "overrideValue" => nil
+      )
+
+      feature2_entitlement = entitlements_response.find { |e| e["code"] == "feature2" }
+      expect(feature2_entitlement).to include(
+        "code" => "feature2",
+        "name" => "Feature 2",
+        "description" => "Second feature"
+      )
+      expect(feature2_entitlement["privileges"]).to be_an(Array)
+      expect(feature2_entitlement["privileges"].size).to eq(1)
+      expect(feature2_entitlement["privileges"].first).to include(
+        "code" => "privilege2",
+        "name" => "Privilege 2",
+        "valueType" => "string",
+        "value" => "override_value",
+        "planValue" => "test_value",
+        "overrideValue" => "override_value"
+      )
     end
   end
 end

--- a/spec/graphql/types/entitlement/entitlement_input_spec.rb
+++ b/spec/graphql/types/entitlement/entitlement_input_spec.rb
@@ -2,11 +2,11 @@
 
 require "rails_helper"
 
-RSpec.describe Types::Entitlement::PlanEntitlementInput do
+RSpec.describe Types::Entitlement::EntitlementInput do
   subject { described_class }
 
   it do
     expect(subject).to accept_argument(:feature_code).of_type("String!")
-    expect(subject).to accept_argument(:privileges).of_type("[PlanEntitlementPrivilegeInput!]")
+    expect(subject).to accept_argument(:privileges).of_type("[EntitlementPrivilegeInput!]")
   end
 end

--- a/spec/graphql/types/entitlement/entitlement_privilege_input_spec.rb
+++ b/spec/graphql/types/entitlement/entitlement_privilege_input_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Types::Entitlement::PlanEntitlementPrivilegeInput do
+RSpec.describe Types::Entitlement::EntitlementPrivilegeInput do
   subject { described_class }
 
   it do

--- a/spec/graphql/types/entitlement/subscription_entitlement_object_spec.rb
+++ b/spec/graphql/types/entitlement/subscription_entitlement_object_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Entitlement::SubscriptionEntitlementObject do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:code).of_type("String!")
+    expect(subject).to have_field(:description).of_type("String")
+    expect(subject).to have_field(:name).of_type("String!")
+    expect(subject).to have_field(:privileges).of_type("[SubscriptionEntitlementPrivilegeObject!]!")
+  end
+end

--- a/spec/graphql/types/entitlement/subscription_entitlement_privilege_object_spec.rb
+++ b/spec/graphql/types/entitlement/subscription_entitlement_privilege_object_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Entitlement::SubscriptionEntitlementPrivilegeObject do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:code).of_type("String!")
+    expect(subject).to have_field(:config).of_type("JSON!")
+    expect(subject).to have_field(:name).of_type("String")
+    expect(subject).to have_field(:override_value).of_type("String")
+    expect(subject).to have_field(:plan_value).of_type("String")
+    expect(subject).to have_field(:value).of_type("String")
+    expect(subject).to have_field(:value_type).of_type("PrivilegeValueTypeEnum!")
+  end
+end


### PR DESCRIPTION
Simplified version of #4024

Entitlements are a new field on subscriptions

### Payload

```json
[
    {
        "code": "seats",
        "name": "Feature Name",
        "description": "Feature Description",
        "privileges":
        [
            {
                "code": "max",
                "name": null,
                "valueType": "string",
                "value": "100",
                "planValue": "100",
                "overrideValue": null
            },
            {
                "code": "max_admins",
                "name": null,
                "valueType": "string",
                "value": "12",
                "planValue": "5",
                "overrideValue": "12"
            }
        ]
    },
    {
        "code": "api",
        "name": "Feature Name",
        "description": "Feature Description",
        "privileges": []
    },
    {
        "code": "storage",
        "name": "Feature Name",
        "description": "Feature Description",
        "privileges": []
    }
]
```