### PR TITLE
misc: better typing for PrivilegeObject config attribute

### DIFF
--- a/app/graphql/types/entitlement/plan_entitlement_privilege_object.rb
+++ b/app/graphql/types/entitlement/plan_entitlement_privilege_object.rb
@@ -4,7 +4,7 @@ module Types
   module Entitlement
     class PlanEntitlementPrivilegeObject < Types::BaseObject
       field :code, String, null: false
-      field :config, GraphQL::Types::JSON, null: false
+      field :config, Types::Entitlement::PrivilegeConfigObject, null: false
       field :name, String, null: true
       field :value_type, Types::Entitlement::PrivilegeValueTypeEnum, null: false
 

--- a/app/graphql/types/entitlement/privilege_config_input.rb
+++ b/app/graphql/types/entitlement/privilege_config_input.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module Entitlement
+    class PrivilegeConfigInput < Types::BaseInputObject
+      description "Input for privilege configuration"
+
+      argument :select_options, [String], required: false, description: "Available options for select type privileges"
+    end
+  end
+end 

--- a/app/graphql/types/entitlement/privilege_config_object.rb
+++ b/app/graphql/types/entitlement/privilege_config_object.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module Entitlement
+    class PrivilegeConfigObject < Types::BaseObject
+      description "Configuration object for privileges"
+
+      field :select_options, [String], null: true, description: "Available options for select type privileges"
+    end
+  end
+end 

--- a/app/graphql/types/entitlement/privilege_object.rb
+++ b/app/graphql/types/entitlement/privilege_object.rb
@@ -6,7 +6,7 @@ module Types
       field :id, ID, null: false
 
       field :code, String, null: false
-      field :config, GraphQL::Types::JSON, null: false
+      field :config, Types::Entitlement::PrivilegeConfigObject, null: false
       field :name, String, null: true
       field :value_type, Types::Entitlement::PrivilegeValueTypeEnum, null: false
     end

--- a/app/graphql/types/entitlement/update_privilege_input.rb
+++ b/app/graphql/types/entitlement/update_privilege_input.rb
@@ -6,7 +6,7 @@ module Types
       description "Input for updating a privilege"
 
       argument :code, String, required: true
-      argument :config, GraphQL::Types::JSON, required: false
+      argument :config, Types::Entitlement::PrivilegeConfigInput, required: false
       argument :name, String, required: false
       argument :value_type, PrivilegeValueTypeEnum, required: false
     end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4780,7 +4780,7 @@ CREATE INDEX idx_on_billing_entity_id_724373e5ae ON public.billing_entities_invo
 -- Name: idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655 ON public.invoices USING btree (billing_entity_id, billing_entity_sequential_id DESC) INCLUDE (self_billed);
+CREATE UNIQUE INDEX idx_on_billing_entity_id_billing_entity_sequential__bd26b2e655 ON public.invoices USING btree (billing_entity_id, billing_entity_sequential_id DESC) INCLUDE (self_billed);
 
 
 --

--- a/schema.graphql
+++ b/schema.graphql
@@ -7806,7 +7806,7 @@ input PlanEntitlementPrivilegeInput {
 
 type PlanEntitlementPrivilegeObject {
   code: String!
-  config: JSON!
+  config: PrivilegeConfigObject!
   name: String
   value: String!
   valueType: PrivilegeValueTypeEnum!
@@ -7895,9 +7895,29 @@ type PricingUnitUsage {
   updatedAt: ISO8601DateTime!
 }
 
+"""
+Input for privilege configuration
+"""
+input PrivilegeConfigInput {
+  """
+  Available options for select type privileges
+  """
+  selectOptions: [String!]
+}
+
+"""
+Configuration object for privileges
+"""
+type PrivilegeConfigObject {
+  """
+  Available options for select type privileges
+  """
+  selectOptions: [String!]
+}
+
 type PrivilegeObject {
   code: String!
-  config: JSON!
+  config: PrivilegeConfigObject!
   id: ID!
   name: String
   valueType: PrivilegeValueTypeEnum!
@@ -10688,7 +10708,7 @@ Input for updating a privilege
 """
 input UpdatePrivilegeInput {
   code: String!
-  config: JSON
+  config: PrivilegeConfigInput
   name: String
   valueType: PrivilegeValueTypeEnum
 }

--- a/schema.json
+++ b/schema.json
@@ -38582,8 +38582,8 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "JSON",
+                  "kind": "OBJECT",
+                  "name": "PrivilegeConfigObject",
                   "ofType": null
                 }
               },
@@ -39314,6 +39314,68 @@
           "enumValues": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "PrivilegeConfigInput",
+          "description": "Input for privilege configuration",
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "selectOptions",
+              "description": "Available options for select type privileges",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PrivilegeConfigObject",
+          "description": "Configuration object for privileges",
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "selectOptions",
+              "description": "Available options for select type privileges",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
           "kind": "OBJECT",
           "name": "PrivilegeObject",
           "description": null,
@@ -39343,8 +39405,8 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "JSON",
+                  "kind": "OBJECT",
+                  "name": "PrivilegeConfigObject",
                   "ofType": null
                 }
               },
@@ -54622,8 +54684,8 @@
               "name": "config",
               "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "JSON",
+                "kind": "INPUT_OBJECT",
+                "name": "PrivilegeConfigInput",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/types/entitlement/privilege_config_object_spec.rb
+++ b/spec/graphql/types/entitlement/privilege_config_object_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Entitlement::PrivilegeConfigObject do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:select_options).of_type("[String]")
+  end
+end 

--- a/spec/graphql/types/entitlement/privilege_object_spec.rb
+++ b/spec/graphql/types/entitlement/privilege_object_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Types::Entitlement::PrivilegeObject do
     expect(subject).to have_field(:id).of_type("ID!")
 
     expect(subject).to have_field(:code).of_type("String!")
-    expect(subject).to have_field(:config).of_type("JSON!")
+    expect(subject).to have_field(:config).of_type("PrivilegeConfigObject!")
     expect(subject).to have_field(:name).of_type("String")
     expect(subject).to have_field(:value_type).of_type("PrivilegeValueTypeEnum!")
   end


### PR DESCRIPTION
## Context

We've added the ability to create "feature" object containing an array of privileges. Those privilege holds a `JSON` type under the config attribute. This config attribute receive a typing as `JSON` without details about the keys it can contain.

## Description

This pull request makes the config attribute more explicit to only include values that it can contain. 