### PR TITLE
feat(infra): Process SubscriptionActivity every minute

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -30,7 +30,7 @@ module Clockwork
       .perform_later
   end
 
-  subscription_activity_processing_interval = ENV["LAGO_SUBSCRIPTION_ACTIVITY_PROCESSING_INTERVAL_SECONDS"].presence || 5.minutes
+  subscription_activity_processing_interval = ENV["LAGO_SUBSCRIPTION_ACTIVITY_PROCESSING_INTERVAL_SECONDS"].presence || 1.minute
   every(subscription_activity_processing_interval.to_i.seconds, "schedule:process_subscription_activity") do
     Clock::ProcessAllSubscriptionActivitiesJob
       .set(sentry: {"slug" => "lago_process_subscription_activity", "cron" => "#{subscription_activity_processing_interval} interval"})

--- a/spec/clockwork_spec.rb
+++ b/spec/clockwork_spec.rb
@@ -84,7 +84,7 @@ describe Clockwork do
       )
 
       expect(Clockwork::Test).to be_ran_job(job)
-      expect(Clockwork::Test.times_run(job)).to eq(6)
+      expect(Clockwork::Test.times_run(job)).to eq(30)
 
       Clockwork::Test.block_for(job).call
       expect(Clock::ProcessAllSubscriptionActivitiesJob).to have_been_enqueued.once


### PR DESCRIPTION
I considered updating `LAGO_SUBSCRIPTION_ACTIVITY_PROCESSING_INTERVAL_SECONDS` on our infra but I think it makes more sense to change the default.