### PR TITLE
feat(entitlements): Restore privilege ids in gql

### DIFF
--- a/app/graphql/types/entitlement/privilege_object.rb
+++ b/app/graphql/types/entitlement/privilege_object.rb
@@ -3,6 +3,8 @@
 module Types
   module Entitlement
     class PrivilegeObject < Types::BaseObject
+      field :id, ID, null: false
+
       field :code, String, null: false
       field :config, Types::Entitlement::PrivilegeConfigObject, null: false
       field :name, String, null: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -7918,6 +7918,7 @@ type PrivilegeConfigObject {
 type PrivilegeObject {
   code: String!
   config: PrivilegeConfigObject!
+  id: ID!
   name: String
   valueType: PrivilegeValueTypeEnum!
 }

--- a/schema.json
+++ b/schema.json
@@ -39407,6 +39407,22 @@
               "args": []
             },
             {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "name",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/entitlement/feature_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/feature_resolver_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Resolvers::Entitlement::FeatureResolver, type: :graphql do
           name
           description
           privileges {
+            id
             code
             name
             valueType
@@ -53,6 +54,7 @@ RSpec.describe Resolvers::Entitlement::FeatureResolver, type: :graphql do
     expect(feature_response["description"]).to eq(feature.description)
     expect(feature_response["createdAt"]).to be_present
     expect(feature_response["privileges"].count).to eq(1)
+    expect(feature_response["privileges"].first["id"]).to eq(privilege.id)
     expect(feature_response["privileges"].first["code"]).to eq(privilege.code)
     expect(feature_response["privileges"].first["valueType"]).to eq(privilege.value_type)
     expect(feature_response["privileges"].first["config"]).to eq({"selectOptions" => nil})

--- a/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Resolvers::Entitlement::FeaturesResolver, type: :graphql do
             name
             description
             privileges {
+              id
               code
               name
               valueType
@@ -95,6 +96,7 @@ RSpec.describe Resolvers::Entitlement::FeaturesResolver, type: :graphql do
               name
               description
               privileges {
+                id
                 code
                 name
                 valueType

--- a/spec/graphql/types/entitlement/privilege_object_spec.rb
+++ b/spec/graphql/types/entitlement/privilege_object_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Types::Entitlement::PrivilegeObject do
   subject { described_class }
 
   it do
+    expect(subject).to have_field(:id).of_type("ID!")
+
     expect(subject).to have_field(:code).of_type("String!")
     expect(subject).to have_field(:config).of_type("PrivilegeConfigObject!")
     expect(subject).to have_field(:name).of_type("String")


### PR DESCRIPTION
ID is used to know if the privilege exists and is being edited or if it's new.