### PR TITLE
fix(organization#admins): Return the correct set of admins

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -25,7 +25,10 @@ class Organization < ApplicationRecord
   has_many :billing_entities, -> { active }
   has_many :all_billing_entities, class_name: "BillingEntity"
   has_many :memberships
+  has_many :active_memberships, -> { active }, class_name: "Membership"
+  has_many :admins_memberships, -> { active.admin }, class_name: "Membership"
   has_many :users, through: :memberships
+  has_many :admins, through: :admins_memberships, source: :user
   has_many :billable_metrics
   has_many :plans
   has_many :pricing_units
@@ -151,10 +154,6 @@ class Organization < ApplicationRecord
 
   def using_lifetime_usage?
     lifetime_usage_enabled? || progressive_billing_enabled?
-  end
-
-  def admins
-    users.joins(:memberships).merge!(memberships.admin)
   end
 
   def logo_url

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -346,8 +346,10 @@ RSpec.describe Organization, type: :model do
     let(:scoped) { create(:membership, organization:).user }
 
     before do
+      scoped
       create(:membership)
       create(:membership, organization:, role: [:manager, :finance].sample)
+      create(:membership, organization:, role: :admin, status: :revoked)
     end
 
     it "returns admins of the organization" do


### PR DESCRIPTION
This PR fixes the method `Organization#admins` that is returning all admins, regardless their statuses on Membership class.

## Problem
```
(ruby) organization.memberships.admin.revoked.map(&:user).map(&:email)
> ["sandy@hills.example", "francesco.simonis@moen.test"]
(ruby) organization.memberships.admin.active.map(&:user).map(&:email)
> ["antoinette.pacocha@barton.example"]

(ruby) organization.admins.pluck(:email)
> ["antoinette.pacocha@barton.example", "sandy@hills.example", "francesco.simonis@moen.test"]
```

## Fix
```
(ruby) organization.memberships.admin.revoked.map(&:user).map(&:email)
> ["ellis@larkin-denesik.example", "simon.blick@okeefe.test"]
(ruby) organization.memberships.admin.active.map(&:user).map(&:email)
> ["gus.nikolaus@jacobs.test"]

(ruby) organization.admins.pluck(:email)
> ["gus.nikolaus@jacobs.test"]
```