### PR TITLE
chore(sec): Add GraphQL max query length validation

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class GraphqlController < ApplicationController
+  MAX_QUERY_LENGTH = 15_000
+
   include AuthenticableUser
   include CustomerPortalUser
   include OrganizationHeader
@@ -30,6 +32,14 @@ class GraphqlController < ApplicationController
         current_user&.memberships&.find_by(organization: current_organization)&.permissions_hash ||
           Permission::EMPTY_PERMISSIONS_HASH
     }
+
+    if query.present? && query.length > MAX_QUERY_LENGTH
+      return render_graphql_error(
+        code: "query_is_too_large",
+        status: 413, 
+        message: "Max query length is #{MAX_QUERY_LENGTH}, your query is #{query.length}"
+      )
+    end
 
     OpenTelemetry::Trace.current_span.add_attributes({"query" => query, "operation_name" => operation_name})
     result = LagoTracer.in_span("LagoApiSchema.execute") do

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -85,8 +85,6 @@ class GraphqlController < ApplicationController
   end
 
   def render_graphql_error(code:, status:, message: nil)
-    # TODO: we currently return a 200 even if we have an error
-    # We should refactor this and return the right http status
     render(
       json: {
         data: {},

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -36,7 +36,7 @@ class GraphqlController < ApplicationController
     if query.present? && query.length > MAX_QUERY_LENGTH
       return render_graphql_error(
         code: "query_is_too_large",
-        status: 413, 
+        status: 413,
         message: "Max query length is #{MAX_QUERY_LENGTH}, your query is #{query.length}"
       )
     end
@@ -85,6 +85,8 @@ class GraphqlController < ApplicationController
   end
 
   def render_graphql_error(code:, status:, message: nil)
+    # TODO: we currently return a 200 even if we have an error
+    # We should refactor this and return the right http status
     render(
       json: {
         data: {},

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -883,14 +883,6 @@ DROP TYPE IF EXISTS public.billable_metric_weighted_interval;
 DROP TYPE IF EXISTS public.billable_metric_rounding_function;
 DROP EXTENSION IF EXISTS unaccent;
 DROP EXTENSION IF EXISTS pgcrypto;
--- *not* dropping schema, since initdb creates it
---
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
-
-
 --
 -- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -883,6 +883,14 @@ DROP TYPE IF EXISTS public.billable_metric_weighted_interval;
 DROP TYPE IF EXISTS public.billable_metric_rounding_function;
 DROP EXTENSION IF EXISTS unaccent;
 DROP EXTENSION IF EXISTS pgcrypto;
+-- *not* dropping schema, since initdb creates it
+--
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+-- *not* creating schema, since initdb creates it
+
+
 --
 -- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
 --

--- a/spec/requests/graphql_controller_spec.rb
+++ b/spec/requests/graphql_controller_spec.rb
@@ -199,7 +199,5 @@ RSpec.describe GraphqlController, type: :request do
         expect(json["errors"]).not_to be_present
       end
     end
-
-    
   end
 end

--- a/spec/requests/graphql_controller_spec.rb
+++ b/spec/requests/graphql_controller_spec.rb
@@ -151,5 +151,55 @@ RSpec.describe GraphqlController, type: :request do
         expect(response.status).to be(200)
       end
     end
+
+    context "with query length validation" do
+      let(:token) do
+        UsersService.new.new_token(user).token
+      end
+
+      it "rejects queries that exceed maximum length" do
+        long_query = "query { " + "a" * (GraphqlController::MAX_QUERY_LENGTH + 1) + " }"
+
+        post "/graphql",
+          headers: {
+            "Authorization" => "Bearer #{token}"
+          },
+          params: {
+            query: long_query
+          }
+
+        expect(response.status).to be(200)
+        
+        json = JSON.parse(response.body)
+        expect(json["errors"]).to be_present
+        expect(json["errors"].first["message"]).to include("Max query length is 15000")
+        expect(json["errors"].first["extensions"]["code"]).to eq("query_is_too_large")
+        expect(json["errors"].first["extensions"]["status"]).to eq(413)
+      end
+
+      it "accepts queries within maximum length" do
+        normal_query = mutation
+
+        post "/graphql",
+          headers: {
+            "Authorization" => "Bearer #{token}"
+          },
+          params: {
+            query: normal_query,
+            variables: {
+              input: {
+                email: user.email,
+                password: "ILoveLago"
+              }
+            }
+          }
+
+        expect(response.status).to be(200)
+
+        expect(json["errors"]).not_to be_present
+      end
+    end
+
+    
   end
 end

--- a/spec/requests/graphql_controller_spec.rb
+++ b/spec/requests/graphql_controller_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe GraphqlController, type: :request do
           }
 
         expect(response.status).to be(200)
-        
+
         json = JSON.parse(response.body)
         expect(json["errors"]).to be_present
         expect(json["errors"].first["message"]).to include("Max query length is 15000")


### PR DESCRIPTION
- Add `MAX_QUERY_LENGTH` on GraphQL queries
- If we hit the max length, it will returns an error with 413 status