### PR TITLE
test(matcher): Improve `have_enqueued_job_after_commit` matcher

### DIFF
--- a/spec/support/matchers/job_matcher.rb
+++ b/spec/support/matchers/job_matcher.rb
@@ -14,7 +14,7 @@ RSpec::Matchers.define :have_enqueued_job_after_commit do |job|
     args = @args || []
     kwargs = @kwargs || {}
 
-    expect(job).to have_been_enqueued.with(*args, **kwargs, &@block)
+    expect(job).to have_been_enqueued.with(*args, **kwargs, &@block).send(expectation_type, expected_number)
   end
 
   match_when_negated do |block|
@@ -25,5 +25,48 @@ RSpec::Matchers.define :have_enqueued_job_after_commit do |job|
     @args = args
     @kwargs = kwargs
     @block = block
+  end
+
+  chain :twice do
+    set_expected_number(:exactly, 2)
+  end
+
+  chain :thrice do
+    set_expected_number(:exactly, 3)
+  end
+
+  chain :exactly do |count|
+    set_expected_number(:exactly, count)
+  end
+
+  chain :at_least do |count|
+    set_expected_number(:at_least, count)
+  end
+
+  chain :at_most do |count|
+    set_expected_number(:at_most, count)
+  end
+
+  chain :times do
+  end
+
+  private
+
+  def set_expected_number(relativity, count)
+    @expectation_type = relativity
+    @expected_number = case count
+    when :once then 1
+    when :twice then 2
+    when :thrice then 3
+    else Integer(count)
+    end
+  end
+
+  def expected_number
+    @expected_number || 1
+  end
+
+  def expectation_type
+    @expectation_type || :exactly
   end
 end


### PR DESCRIPTION
## Context

The current `have_enqueued_job_after_commit` matcher doesn't allow to expect multiple time the same job.

## Description

This PR adds this capability. It was tested using the following spec:

```ruby
# frozen_string_literal: true

require "rails_helper"

describe "Job matcher" do
  let(:customer) { create(:customer) }

  describe "#twice" do
    it "enqueues the job twice" do
      expect do
        SendWebhookJob.perform_after_commit("customer.created", customer)
        SendWebhookJob.perform_after_commit("customer.created", customer)
      end.to have_enqueued_job_after_commit(SendWebhookJob).twice
    end
  end

  describe "#thrice" do
    it "enqueues the job thrice" do
      expect do
        SendWebhookJob.perform_after_commit("customer.created", customer)
        SendWebhookJob.perform_after_commit("customer.created", customer)
        SendWebhookJob.perform_after_commit("customer.created", customer)
      end.to have_enqueued_job_after_commit(SendWebhookJob).thrice
    end
  end

  describe "#exactly" do
    it "enqueues the job exactly once" do
      expect do
        SendWebhookJob.perform_after_commit("customer.created", customer)
        SendWebhookJob.perform_after_commit("customer.created", customer)
      end.to have_enqueued_job_after_commit(SendWebhookJob).exactly(2)
    end
  end

  describe "#at_least" do
    it "enqueues the job at least once" do
      expect do
        SendWebhookJob.perform_after_commit("customer.created", customer)
        SendWebhookJob.perform_after_commit("customer.created", customer)
        SendWebhookJob.perform_after_commit("customer.created", customer)
      end.to have_enqueued_job_after_commit(SendWebhookJob).at_least(2)
    end
  end

  describe "#at_most" do
    it "enqueues the job at most once" do
      expect do
        SendWebhookJob.perform_after_commit("customer.created", customer)
        SendWebhookJob.perform_after_commit("customer.created", customer)
      end.to have_enqueued_job_after_commit(SendWebhookJob).at_most(2)
    end
  end

  describe "#times" do
    it "enqueues the job exactly once" do
      expect do
        SendWebhookJob.perform_after_commit("customer.created", customer)
      end.to have_enqueued_job_after_commit(SendWebhookJob).exactly(1).times
    end
  end
end
```
