### PR TITLE
feat(subscription): Allow to skip invoice generation on subscription termination

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -90,7 +90,7 @@ module Api
           query.active
         end.first
 
-        kwargs = params.permit(:on_termination_credit_note).to_h.symbolize_keys
+        kwargs = params.permit(:on_termination_credit_note, :on_termination_invoice).to_h.symbolize_keys
 
         result = ::Subscriptions::TerminateService.call(subscription:, **kwargs)
 
@@ -187,6 +187,7 @@ module Api
           :subscription_at,
           :ending_at,
           :on_termination_credit_note,
+          :on_termination_invoice,
           plan_overrides:
         )
       end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -45,10 +45,12 @@ class Subscription < ApplicationRecord
   ].freeze
 
   ON_TERMINATION_CREDIT_NOTES = {credit: "credit", skip: "skip"}.freeze
+  ON_TERMINATION_INVOICES = {generate: "generate", skip: "skip"}.freeze
 
   enum :status, STATUSES
   enum :billing_time, BILLING_TIME
-  enum :on_termination_credit_note, ON_TERMINATION_CREDIT_NOTES
+  enum :on_termination_credit_note, ON_TERMINATION_CREDIT_NOTES, prefix: true
+  enum :on_termination_invoice, ON_TERMINATION_INVOICES, prefix: true
 
   validates :on_termination_credit_note, absence: true, if: -> { plan&.pay_in_arrears? }
 
@@ -251,6 +253,7 @@ end
 #  ending_at                  :datetime
 #  name                       :string
 #  on_termination_credit_note :enum
+#  on_termination_invoice     :enum             default("generate"), not null
 #  started_at                 :datetime
 #  status                     :integer          not null
 #  subscription_at            :datetime

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -24,7 +24,8 @@ module V1
         downgrade_plan_date: model.downgrade_plan_date&.iso8601,
         current_billing_period_started_at: dates_service.charges_from_datetime&.iso8601,
         current_billing_period_ending_at: dates_service.charges_to_datetime&.iso8601,
-        on_termination_credit_note: model.on_termination_credit_note
+        on_termination_credit_note: model.on_termination_credit_note,
+        on_termination_invoice: model.on_termination_invoice
       }
 
       payload = payload.merge(customer:) if include?(:customer)

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -4,11 +4,12 @@ module Subscriptions
   class TerminateService < BaseService
     Result = BaseResult[:subscription]
 
-    def initialize(subscription:, async: true, upgrade: false, on_termination_credit_note: subscription&.on_termination_credit_note)
+    def initialize(subscription:, async: true, upgrade: false, on_termination_credit_note: subscription&.on_termination_credit_note, on_termination_invoice: subscription&.on_termination_invoice)
       @subscription = subscription
       @async = async
       @upgrade = upgrade
-      @on_termination_credit_note = on_termination_credit_note
+      @on_termination_credit_note = on_termination_credit_note.blank? ? :credit : on_termination_credit_note.to_sym
+      @on_termination_invoice = on_termination_invoice.blank? ? :generate : on_termination_invoice.to_sym
 
       super
     end
@@ -21,7 +22,7 @@ module Subscriptions
           subscription.mark_as_canceled!
         elsif !subscription.terminated?
           subscription.mark_as_terminated!
-          update_on_termination_credit_note! if pay_in_advance?
+          update_on_termination_actions!
 
           if subscription.should_sync_hubspot_subscription?
             Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob.perform_after_commit(subscription:)
@@ -102,7 +103,7 @@ module Subscriptions
 
     private
 
-    attr_reader :subscription, :async, :upgrade
+    attr_reader :subscription, :async, :upgrade, :on_termination_credit_note, :on_termination_invoice
 
     def cancel_next_subscription
       next_subscription = subscription.next_subscription
@@ -116,23 +117,27 @@ module Subscriptions
     end
 
     def bill_subscription
+      if bill_in_arrears_fees?
+        if async
+          BillSubscriptionJob.perform_after_commit(
+            [subscription],
+            subscription.terminated_at,
+            invoicing_reason: :subscription_terminating
+          )
+        else
+          BillSubscriptionJob.perform_now(
+            [subscription],
+            subscription.terminated_at,
+            invoicing_reason: :subscription_terminating
+          )
+        end
+      end
+
+      # We always bill pay-in-advance non-invoiceable charges unless it's an upgrade.
       if async
-        BillSubscriptionJob.perform_after_commit(
-          [subscription],
-          subscription.terminated_at,
-          invoicing_reason: :subscription_terminating
-        )
         BillNonInvoiceableFeesJob.perform_after_commit([subscription], subscription.terminated_at)
       else
-        BillSubscriptionJob.perform_now(
-          [subscription],
-          subscription.terminated_at,
-          invoicing_reason: :subscription_terminating
-        )
-        BillNonInvoiceableFeesJob.perform_now(
-          [subscription],
-          subscription.terminated_at
-        )
+        BillNonInvoiceableFeesJob.perform_now([subscription], subscription.terminated_at)
       end
     end
 
@@ -187,18 +192,17 @@ module Subscriptions
       !pay_in_advance?
     end
 
-    def on_termination_credit_note
-      return nil if pay_in_arrears?
-
-      return :credit if @on_termination_credit_note.blank? || @on_termination_credit_note.to_sym == :credit
-      return :skip if @on_termination_credit_note.to_sym == :skip
-
-      # This will cause a validation error on update
-      @on_termination_credit_note
+    def bill_in_arrears_fees?
+      on_termination_invoice == :generate
     end
 
-    def update_on_termination_credit_note!
-      Subscriptions::UpdateService.call!(subscription:, params: {on_termination_credit_note:})
+    def update_on_termination_actions!
+      params = {}
+      params[:on_termination_credit_note] = on_termination_credit_note if pay_in_advance? && subscription.on_termination_credit_note != on_termination_credit_note
+      params[:on_termination_invoice] = on_termination_invoice if subscription.on_termination_invoice != on_termination_invoice
+      return if params.empty?
+
+      Subscriptions::UpdateService.call!(subscription:, params:)
     end
   end
 end

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -24,7 +24,8 @@ module Subscriptions
         plan: subscription.plan,
         subscription_at: params.key?(:subscription_at) ? params[:subscription_at] : subscription.subscription_at,
         ending_at: params[:ending_at],
-        on_termination_credit_note: params[:on_termination_credit_note]
+        on_termination_credit_note: params[:on_termination_credit_note],
+        on_termination_invoice: params[:on_termination_invoice]
       )
         return result
       end
@@ -35,6 +36,10 @@ module Subscriptions
 
       if pay_in_advance? && params.key?(:on_termination_credit_note)
         subscription.on_termination_credit_note = params[:on_termination_credit_note]
+      end
+
+      if params.key?(:on_termination_invoice)
+        subscription.on_termination_invoice = params[:on_termination_invoice]
       end
 
       if params.key?(:plan_overrides)

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -9,6 +9,7 @@ module Subscriptions
       valid_subscription_at?
       valid_ending_at?
       valid_on_termination_credit_note?
+      valid_on_termination_invoice?
 
       if errors?
         result.validation_failure!(errors:)
@@ -65,6 +66,15 @@ module Subscriptions
       return true if Subscription::ON_TERMINATION_CREDIT_NOTES.include?(args[:on_termination_credit_note].to_sym)
 
       add_error(field: :on_termination_credit_note, error_code: "invalid_value")
+      false
+    end
+
+    def valid_on_termination_invoice?
+      return true if args[:on_termination_invoice].blank?
+
+      return true if Subscription::ON_TERMINATION_INVOICES.include?(args[:on_termination_invoice].to_sym)
+
+      add_error(field: :on_termination_invoice, error_code: "invalid_value")
       false
     end
 

--- a/db/migrate/20250721192051_add_on_termination_invoice_to_subscriptions.rb
+++ b/db/migrate/20250721192051_add_on_termination_invoice_to_subscriptions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddOnTerminationInvoiceToSubscriptions < ActiveRecord::Migration[8.0]
+  def change
+    create_enum(
+      :subscription_on_termination_invoice,
+      %w[generate skip]
+    )
+    add_column(
+      :subscriptions,
+      :on_termination_invoice,
+      :enum,
+      enum_type: "subscription_on_termination_invoice",
+      default: "generate",
+      null: false
+    )
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -868,6 +868,7 @@ DROP TABLE IF EXISTS public.active_storage_attachments;
 DROP FUNCTION IF EXISTS public.set_payment_receipt_number();
 DROP TYPE IF EXISTS public.usage_monitoring_alert_types;
 DROP TYPE IF EXISTS public.tax_status;
+DROP TYPE IF EXISTS public.subscription_on_termination_invoice;
 DROP TYPE IF EXISTS public.subscription_on_termination_credit_note;
 DROP TYPE IF EXISTS public.subscription_invoicing_reason;
 DROP TYPE IF EXISTS public.payment_type;
@@ -1034,6 +1035,16 @@ CREATE TYPE public.subscription_invoicing_reason AS ENUM (
 
 CREATE TYPE public.subscription_on_termination_credit_note AS ENUM (
     'credit',
+    'skip'
+);
+
+
+--
+-- Name: subscription_on_termination_invoice; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.subscription_on_termination_invoice AS ENUM (
+    'generate',
     'skip'
 );
 
@@ -2582,7 +2593,8 @@ CREATE TABLE public.subscriptions (
     ending_at timestamp(6) without time zone,
     trial_ended_at timestamp(6) without time zone,
     organization_id uuid NOT NULL,
-    on_termination_credit_note public.subscription_on_termination_credit_note
+    on_termination_credit_note public.subscription_on_termination_credit_note,
+    on_termination_invoice public.subscription_on_termination_invoice DEFAULT 'generate'::public.subscription_on_termination_invoice NOT NULL
 );
 
 
@@ -9434,6 +9446,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250721220908'),
 ('20250721212307'),
 ('20250721211820'),
+('20250721192051'),
 ('20250721150002'),
 ('20250721150001'),
 ('20250721150000'),

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe Subscription, type: :model do
       expect(subject).to define_enum_for(:on_termination_credit_note)
         .backed_by_column_of_type(:enum)
         .with_values(credit: "credit", skip: "skip")
+        .with_prefix(:on_termination_credit_note)
+      expect(subject).to define_enum_for(:on_termination_invoice)
+        .backed_by_column_of_type(:enum)
+        .with_values(generate: "generate", skip: "skip")
+        .with_prefix(:on_termination_invoice)
     end
   end
 

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
 
     include_examples "requires API permission", "subscription", "write"
 
-    def test_termination(expected_on_termination_credit_note: nil)
+    def test_termination(expected_on_termination_credit_note: nil, expected_on_termination_invoice: "generate")
       subject
 
       expect(response).to have_http_status(:success)
@@ -392,6 +392,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       expect(json[:subscription][:status]).to eq("terminated")
       expect(json[:subscription][:terminated_at]).to be_present
       expect(json[:subscription][:on_termination_credit_note]).to eq(expected_on_termination_credit_note)
+      expect(json[:subscription][:on_termination_invoice]).to eq(expected_on_termination_invoice)
     end
 
     it "terminates a subscription" do
@@ -446,6 +447,47 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
               on_termination_credit_note: ["invalid_value"]
             )
           end
+        end
+      end
+    end
+
+    context "with on_termination_invoice parameter" do
+      context "when on_termination_invoice is generate" do
+        let(:params) { {on_termination_invoice: "generate"} }
+
+        it "terminates subscription with generate invoice behavior" do
+          test_termination(expected_on_termination_invoice: "generate")
+        end
+      end
+
+      context "when on_termination_invoice is skip" do
+        let(:params) { {on_termination_invoice: "skip"} }
+
+        it "terminates subscription with skip invoice behavior" do
+          test_termination(expected_on_termination_invoice: "skip")
+        end
+      end
+
+      context "with invalid on_termination_invoice value" do
+        let(:params) { {on_termination_invoice: "invalid"} }
+
+        it "returns validation error" do
+          subject
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(json[:error_details]).to include(
+            on_termination_invoice: ["invalid_value"]
+          )
+        end
+      end
+
+      context "with both on_termination_credit_note and on_termination_invoice parameters" do
+        let(:plan) { create(:plan, :pay_in_advance, organization:) }
+        let(:subscription) { create(:subscription, customer:, plan:) }
+        let(:params) { {on_termination_credit_note: "skip", on_termination_invoice: "skip"} }
+
+        it "terminates subscription with both behaviors" do
+          test_termination(expected_on_termination_credit_note: "skip", expected_on_termination_invoice: "skip")
         end
       end
     end

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -114,6 +114,19 @@ RSpec.describe ::V1::SubscriptionSerializer do
       result = JSON.parse(serializer.to_json)
 
       expect(result["subscription"]["on_termination_credit_note"]).to eq("credit")
+      expect(result["subscription"]["on_termination_invoice"]).to eq("generate")
+      expect(result["subscription"]["terminated_at"]).to be_present
+      expect(result["subscription"]["status"]).to eq("terminated")
+    end
+  end
+
+  context "when terminated with skip invoice" do
+    let(:subscription) { create(:subscription, :terminated, on_termination_invoice: :skip) }
+
+    it "serializes the object with skip invoice behavior" do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result["subscription"]["on_termination_invoice"]).to eq("skip")
       expect(result["subscription"]["terminated_at"]).to be_present
       expect(result["subscription"]["status"]).to eq("terminated")
     end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -461,7 +461,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
           it "enqueues the Hubspot update job", :aggregate_failures do
             create_service.call
-            expect(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob).to have_been_enqueued.with(subscription:)
+            expect(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob).to have_been_enqueued.twice.with(subscription:)
           end
 
           it "creates a new subscription" do

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Subscriptions::PlanUpgradeService, type: :service do
       # is not meet by the test setup...
       # The subscription does not start in the future
       result
-      expect(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob).to have_been_enqueued.with(subscription:)
+      expect(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob).to have_been_enqueued.twice.with(subscription:)
     end
 
     it "creates a new subscription" do

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Subscriptions::TerminateService do
       let(:subscription) { create(:subscription, customer:) }
 
       it "calls the hubspot update job after commit" do
-        expect { subject }.to have_enqueued_job_after_commit(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob).with(subscription:)
+        expect { subject }.to have_enqueued_job_after_commit(Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob).with(subscription:).twice
       end
     end
 
@@ -256,6 +256,56 @@ RSpec.describe Subscriptions::TerminateService do
       it "updates the subscription termination behavior" do
         subject
         expect(subscription.reload.on_termination_credit_note).to eq(nil)
+      end
+    end
+
+    context "with on_termination_invoice parameter" do
+      subject(:result) { described_class.call(subscription:, on_termination_invoice:) }
+
+      context "when on_termination_invoice is generate" do
+        let(:on_termination_invoice) { "generate" }
+
+        it "enqueues a BillSubscriptionJob" do
+          freeze_time do
+            expect { subject }.to have_enqueued_job_after_commit(BillSubscriptionJob).with([subscription], Time.current, invoicing_reason: :subscription_terminating)
+          end
+        end
+
+        it "updates the subscription on_termination_invoice" do
+          subject
+          expect(subscription.reload.on_termination_invoice).to eq("generate")
+        end
+      end
+
+      context "when on_termination_invoice is skip" do
+        let(:on_termination_invoice) { "skip" }
+
+        it "does not enqueue a BillSubscriptionJob" do
+          expect { subject }.not_to have_enqueued_job(BillSubscriptionJob)
+        end
+
+        it "still enqueues a BillNonInvoiceableFeesJob" do
+          freeze_time do
+            expect { subject }.to have_enqueued_job_after_commit(BillNonInvoiceableFeesJob)
+              .with([subscription], Time.current)
+          end
+        end
+
+        it "updates the subscription on_termination_invoice" do
+          subject
+          expect(subscription.reload.on_termination_invoice).to eq("skip")
+        end
+      end
+
+      context "when on_termination_invoice is invalid" do
+        let(:on_termination_invoice) { "invalid" }
+
+        it "raises an error" do
+          subject
+
+          expect(result).to be_failure
+          expect(result.error.messages).to include({on_termination_invoice: ["invalid_value"]})
+        end
       end
     end
   end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -107,6 +107,23 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
           end
         end
       end
+
+      context "when updating on_termination_invoice" do
+        let(:params) { {on_termination_invoice: "generate"} }
+
+        %w[generate skip].each do |value|
+          context "when on_termination_invoice is #{value}" do
+            let(:params) { {on_termination_invoice: value} }
+
+            it "accepts the value" do
+              result = update_service.call
+
+              expect(result).to be_success
+              expect(result.subscription.on_termination_invoice).to eq(value)
+            end
+          end
+        end
+      end
     end
 
     context "when subscription is starting in the future" do
@@ -269,6 +286,17 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
 
           expect(result).not_to be_success
           expect(result.error.messages).to eq({on_termination_credit_note: ["invalid_value"]})
+        end
+      end
+
+      context "with invalid on_termination_invoice" do
+        let(:params) { {on_termination_invoice: "invalid_value"} }
+
+        it "returns validation failure" do
+          result = update_service.call
+
+          expect(result).not_to be_success
+          expect(result.error.messages).to eq({on_termination_invoice: ["invalid_value"]})
         end
       end
     end

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -19,11 +19,13 @@ RSpec.describe Subscriptions::ValidateService, type: :service do
       plan:,
       subscription_at:,
       ending_at:,
-      on_termination_credit_note:
+      on_termination_credit_note:,
+      on_termination_invoice:
     }
   end
 
   let(:on_termination_credit_note) { nil }
+  let(:on_termination_invoice) { nil }
 
   describe "#ending_at" do
     subject(:method_call) { validate_service.__send__(:ending_at) }
@@ -156,6 +158,31 @@ RSpec.describe Subscriptions::ValidateService, type: :service do
 
     context "with valid on_termination_credit_note" do
       let(:on_termination_credit_note) { "credit" }
+
+      it "returns true" do
+        expect(validate_service).to be_valid
+      end
+    end
+
+    context "with invalid on_termination_invoice" do
+      let(:on_termination_invoice) { "invalid" }
+
+      it "returns false and result has errors" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:on_termination_invoice]).to eq(["invalid_value"])
+      end
+    end
+
+    context "with valid on_termination_invoice" do
+      let(:on_termination_invoice) { "generate" }
+
+      it "returns true" do
+        expect(validate_service).to be_valid
+      end
+    end
+
+    context "with valid on_termination_invoice skip" do
+      let(:on_termination_invoice) { "skip" }
 
       it "returns true" do
         expect(validate_service).to be_valid


### PR DESCRIPTION
## Context

When a subscription is terminated,whether due to an error or otherwise,Lago automatically generates a closing invoice for pay-in-arrears fees. This inflexible behavior didn't accommodate different business needs where organizations might want to skip the invoice generation.

## Description

This introduces an `on_termination_invoice` enum field to subscriptions that controls whether an invoice is generated for pay-in-arrears fees. The field supports "generate" (default) and "skip" values, allowing organizations to choose their preferred termination behavior.

The termination service now respects this setting and only generates an invoice when explicitly configured to do so. The API accepts the termination behavior as a parameter during subscription termination.

The implementation includes database schema changes, API parameter handling, service logic updates, and comprehensive test coverage for all termination scenarios. Scenario specs for termination behaviors will come later on.

