### PR TITLE
feat(entitlement): append new select_options + not null db column

### DIFF
--- a/app/models/entitlement/privilege.rb
+++ b/app/models/entitlement/privilege.rb
@@ -47,7 +47,7 @@ end
 #
 #  id                     :uuid             not null, primary key
 #  code                   :string           not null
-#  config                 :jsonb
+#  config                 :jsonb            not null
 #  deleted_at             :datetime
 #  name                   :string
 #  value_type             :enum             default("string"), not null

--- a/app/services/entitlement/feature_update_service.rb
+++ b/app/services/entitlement/feature_update_service.rb
@@ -70,6 +70,13 @@ module Entitlement
           create_privilege(code, privilege_params)
         else
           privilege.name = privilege_params[:name] if privilege_params.key?(:name)
+
+          if privilege_params.dig(:config, :select_options)
+            privilege.config ||= {}
+            privilege.config["select_options"] ||= []
+            privilege.config["select_options"] |= privilege_params[:config][:select_options]
+          end
+
           privilege.save!
         end
       end

--- a/app/services/entitlement/feature_update_service.rb
+++ b/app/services/entitlement/feature_update_service.rb
@@ -72,7 +72,6 @@ module Entitlement
           privilege.name = privilege_params[:name] if privilege_params.key?(:name)
 
           if privilege_params.dig(:config, :select_options)
-            privilege.config ||= {}
             privilege.config["select_options"] ||= []
             privilege.config["select_options"] |= privilege_params[:config][:select_options]
           end

--- a/db/migrate/20250630180000_create_entitlement_features_and_privileges.rb
+++ b/db/migrate/20250630180000_create_entitlement_features_and_privileges.rb
@@ -24,6 +24,7 @@ class CreateEntitlementFeaturesAndPrivileges < ActiveRecord::Migration[8.0]
       t.string :code, null: false
       t.string :name
       t.enum :value_type, enum_type: "entitlement_privilege_value_types", null: false
+      # NOTE: NOT NULL see: db/migrate/20250722094047_change_privilege_config_to_not_null.rb
       t.jsonb :config, default: {}
       t.datetime :deleted_at
       t.timestamps

--- a/db/migrate/20250722094047_change_privilege_config_to_not_null.rb
+++ b/db/migrate/20250722094047_change_privilege_config_to_not_null.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ChangePrivilegeConfigToNotNull < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      change_column_null :entitlement_privileges, :config, false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1975,7 +1975,7 @@ CREATE TABLE public.entitlement_privileges (
     code character varying NOT NULL,
     name character varying,
     value_type public.entitlement_privilege_value_types DEFAULT 'string'::public.entitlement_privilege_value_types NOT NULL,
-    config jsonb DEFAULT '{}'::jsonb,
+    config jsonb DEFAULT '{}'::jsonb NOT NULL,
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
@@ -9429,6 +9429,7 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250722094047'),
 ('20250721220908'),
 ('20250721212307'),
 ('20250721211820'),

--- a/spec/services/entitlement/feature_update_service_spec.rb
+++ b/spec/services/entitlement/feature_update_service_spec.rb
@@ -119,6 +119,25 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
         end
       end
 
+      context "when updating select_options of a privilege" do
+        let(:privilege3) { create(:privilege, feature:, code: "opt", value_type: "select", config: {select_options: %w[zero one]}) }
+
+        let(:params) do
+          {
+            privileges: {
+              "opt" => {config: {select_options: %w[one two three]}}
+            }
+          }
+        end
+
+        it "appends the new options" do
+          result = subject
+
+          expect(result).to be_success
+          expect(privilege3.reload.config["select_options"]).to eq %w[zero one two three]
+        end
+      end
+
       context "when deleting privileges with associated entitlement values" do
         let(:entitlement) { create(:entitlement, feature:) }
         let(:privilege1_value) { create(:entitlement_value, entitlement:, privilege: privilege1, value: "10") }
@@ -367,6 +386,25 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
           expect(result).to be_success
           expect(privilege1.reload.name).to eq(original_name)
           expect(privilege2.reload.name).to eq("Min.")
+        end
+      end
+
+      context "when updating select_options of a privilege" do
+        let(:privilege3) { create(:privilege, feature:, code: "opt", value_type: "select", config: {select_options: %w[zero one]}) }
+
+        let(:params) do
+          {
+            privileges: {
+              "opt" => {config: {select_options: %w[one two three]}}
+            }
+          }
+        end
+
+        it "appends the new options" do
+          result = subject
+
+          expect(result).to be_success
+          expect(privilege3.reload.config["select_options"]).to eq %w[zero one two three]
         end
       end
 


### PR DESCRIPTION
Allow `config.select_options` to be updated for `select` privilege.

I don't know why the config column is nullable in the DB, this is a mistake.
Notice that I can simply change the column with "safety_assured" because **the feature is not released and there was no tagged version [since I added this model](https://github.com/getlago/lago-api/pull/3873).**