### PR TITLE
(fix): Use new TokenService

### DIFF
--- a/spec/requests/graphql_controller_spec.rb
+++ b/spec/requests/graphql_controller_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe GraphqlController, type: :request do
 
     context "with query length validation" do
       let(:token) do
-        UsersService.new.new_token(user).token
+        Auth::TokenService.encode(user:)
       end
 
       it "rejects queries that exceed maximum length" do


### PR DESCRIPTION
Use the `Auth::TokenService` to encode the token. 