### PR TITLE
test(subscription): Add missing tests subscription GraphQL types

### DIFF
--- a/spec/graphql/types/subscriptions/billing_time_enum_spec.rb
+++ b/spec/graphql/types/subscriptions/billing_time_enum_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Subscriptions::BillingTimeEnum, type: :graphql do
+  it "exposes all enum values" do
+    expect(described_class.values.keys).to match_array(%w[calendar anniversary])
+  end
+end

--- a/spec/graphql/types/subscriptions/create_subscription_input_spec.rb
+++ b/spec/graphql/types/subscriptions/create_subscription_input_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Subscriptions::CreateSubscriptionInput do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:ending_at).of_type("ISO8601DateTime")
+    expect(subject).to accept_argument(:external_id).of_type("String")
+    expect(subject).to accept_argument(:customer_id).of_type("ID!")
+    expect(subject).to accept_argument(:plan_id).of_type("ID!")
+    expect(subject).to accept_argument(:plan_overrides).of_type("PlanOverridesInput")
+    expect(subject).to accept_argument(:subscription_at).of_type("ISO8601DateTime")
+    expect(subject).to accept_argument(:subscription_id).of_type("ID")
+    expect(subject).to accept_argument(:name).of_type("String")
+    expect(subject).to accept_argument(:billing_time).of_type("BillingTimeEnum!")
+  end
+end

--- a/spec/graphql/types/subscriptions/next_subscription_type_enum_spec.rb
+++ b/spec/graphql/types/subscriptions/next_subscription_type_enum_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Subscriptions::NextSubscriptionTypeEnum, type: :graphql do
+  it "exposes all enum values" do
+    expect(described_class.values.keys).to match_array(%w[upgrade downgrade])
+  end
+end

--- a/spec/graphql/types/subscriptions/status_type_enum_spec.rb
+++ b/spec/graphql/types/subscriptions/status_type_enum_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Subscriptions::StatusTypeEnum, type: :graphql do
+  it "exposes all enum values" do
+    expect(described_class.values.keys).to match_array(%w[pending active terminated canceled])
+  end
+end

--- a/spec/graphql/types/subscriptions/update_subscription_input_spec.rb
+++ b/spec/graphql/types/subscriptions/update_subscription_input_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Subscriptions::UpdateSubscriptionInput do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:id).of_type("ID!")
+    expect(subject).to accept_argument(:ending_at).of_type("ISO8601DateTime")
+    expect(subject).to accept_argument(:name).of_type("String")
+    expect(subject).to accept_argument(:plan_overrides).of_type("PlanOverridesInput")
+    expect(subject).to accept_argument(:subscription_at).of_type("ISO8601DateTime")
+  end
+end


### PR DESCRIPTION
## Context

Some tests were missing for subscriptions GraphQL types.

## Description

This PR adds those missing tests.
