### PR TITLE
integration(netsuite): add plan_code to netsuite payload

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -53,7 +53,8 @@ module Integrations
                 "duedate" => due_date,
                 "taxdetailsoverride" => true,
                 "custbody_lago_id" => invoice.id,
-                "entity" => integration_customer.external_customer_id
+                "entity" => integration_customer.external_customer_id,
+                "lago_plan_code" => invoice.plan.code
               }
             )
 


### PR DESCRIPTION
A customer wants to add the Lago plan_code of an invoice to a Netsuite payload. This should be part of the main result payload (not at the line item level).