### PR TITLE
fix(entitlements): Use Array of privileges instead of hash indexed by code

### DIFF
--- a/app/controllers/api/v1/features_controller.rb
+++ b/app/controllers/api/v1/features_controller.rb
@@ -101,11 +101,15 @@ module Api
       private
 
       def feature_create_params
-        params.require(:feature).permit(:code, :name, :description, privileges: {})
+        params.require(:feature).permit(:code, :name, :description, privileges: [
+          :code, :name, :value_type, :config
+        ])
       end
 
       def feature_update_params
-        params.require(:feature).permit(:name, :description, privileges: {})
+        params.require(:feature).permit(:name, :description, privileges: [
+          :code, :name, :value_type, :config
+        ])
       end
 
       def root_name

--- a/app/graphql/mutations/entitlement/create_feature.rb
+++ b/app/graphql/mutations/entitlement/create_feature.rb
@@ -21,7 +21,7 @@ module Mutations
             code: args[:code],
             name: args[:name],
             description: args[:description],
-            privileges: args[:privileges].map(&:to_h).index_by { it[:code] }
+            privileges: args[:privileges].map(&:to_h)
           }
         )
 

--- a/app/graphql/mutations/entitlement/update_feature.rb
+++ b/app/graphql/mutations/entitlement/update_feature.rb
@@ -22,7 +22,7 @@ module Mutations
           params: {
             name: args[:name],
             description: args[:description],
-            privileges: args[:privileges].map(&:to_h).index_by { |it| it[:code] }
+            privileges: args[:privileges].map(&:to_h)
           },
           partial: false
         )

--- a/app/serializers/v1/entitlement/feature_serializer.rb
+++ b/app/serializers/v1/entitlement/feature_serializer.rb
@@ -22,7 +22,7 @@ module V1
             name: privilege.name,
             value_type: privilege.value_type
           }
-        end.index_by { it[:code] }
+        end
       end
     end
   end

--- a/app/serializers/v1/entitlement/plan_entitlement_serializer.rb
+++ b/app/serializers/v1/entitlement/plan_entitlement_serializer.rb
@@ -23,7 +23,7 @@ module V1
             value: Utils::Entitlement.cast_value(ev.value, ev.privilege.value_type),
             config: ev.privilege.config
           }
-        end.index_by { it[:code] }
+        end
       end
     end
   end

--- a/app/serializers/v1/entitlement/subscription_entitlements_collection_serializer.rb
+++ b/app/serializers/v1/entitlement/subscription_entitlements_collection_serializer.rb
@@ -21,7 +21,7 @@ module V1
                 plan_value: Utils::Entitlement.cast_value(e.privilege_plan_value, e.privilege_value_type),
                 override_value: Utils::Entitlement.cast_value(e.privilege_override_value, e.privilege_value_type)
               }
-            end.index_by { it[:code] },
+            end,
             overrides: feature_entitlements.filter_map do |e|
               [e.privilege_code, Utils::Entitlement.cast_value(e.privilege_override_value, e.privilege_value_type)] unless e.privilege_override_value.nil?
             end.to_h

--- a/app/services/entitlement/feature_create_service.rb
+++ b/app/services/entitlement/feature_create_service.rb
@@ -19,6 +19,10 @@ module Entitlement
       return result.forbidden_failure! unless License.premium?
       return result.not_found_failure!(resource: "organization") unless organization
 
+      if Utils::Entitlement.privilege_code_is_duplicated?(params[:privileges])
+        return result.single_validation_failure!(field: :"privilege.code", error_code: "value_is_duplicated")
+      end
+
       ActiveRecord::Base.transaction do
         feature = Feature.create!(
           organization:,
@@ -54,10 +58,10 @@ module Entitlement
     attr_reader :organization, :params
 
     def create_privileges(feature, privileges_params)
-      privileges_params.each do |code, privilege_params|
+      privileges_params.each do |privilege_params|
         privilege = feature.privileges.new(
           organization:,
-          code:,
+          code: privilege_params[:code],
           name: privilege_params[:name]
         )
         privilege.value_type = privilege_params[:value_type] if privilege_params.has_key? :value_type

--- a/app/services/utils/entitlement.rb
+++ b/app/services/utils/entitlement.rb
@@ -2,6 +2,13 @@
 
 module Utils
   class Entitlement
+    def self.privilege_code_is_duplicated?(privileges_params)
+      return false if privileges_params.blank?
+
+      seen = Set.new
+      privileges_params.any? { !seen.add?(it[:code]) }
+    end
+
     def self.cast_value(value, type)
       return nil if value.blank?
 

--- a/spec/requests/api/v1/features/privileges_controller_spec.rb
+++ b/spec/requests/api/v1/features/privileges_controller_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Api::V1::Features::PrivilegesController, type: :request do
       expect(response).to have_http_status(:ok)
       expect(json[:feature][:code]).to eq("seats")
       expect(json[:feature][:privileges]).not_to include(:max_admins)
-      expect(json[:feature][:privileges]).to include(
-        max: {code: "max", name: "Maximum", value_type: "integer"}
+      expect(json[:feature][:privileges]).to contain_exactly(
+        {code: "max", name: "Maximum", value_type: "integer"}
       )
     end
 

--- a/spec/requests/api/v1/plans/entitlements/privileges_controller_spec.rb
+++ b/spec/requests/api/v1/plans/entitlements/privileges_controller_spec.rb
@@ -28,9 +28,7 @@ RSpec.describe Api::V1::Plans::Entitlements::PrivilegesController, type: :reques
       expect { subject }.to change(privilege.values, :count).by(-1)
 
       expect(response).to have_http_status(:success)
-
-      expect(json[:entitlement][:privileges]).to have_key(privilege2.code.to_sym)
-      expect(json[:entitlement][:privileges]).not_to have_key(privilege.code.to_sym)
+      expect(json[:entitlement][:privileges].pluck(:code)).to eq(["max_admins"])
     end
 
     it "returns not found error when plan does not exist" do
@@ -58,8 +56,10 @@ RSpec.describe Api::V1::Plans::Entitlements::PrivilegesController, type: :reques
 
       json = JSON.parse(response.body, symbolize_names: true)
       expect(json[:entitlement][:code]).to eq(feature.code)
-      expect(json[:entitlement][:privileges]).not_to have_key(privilege.code.to_sym)
-      expect(json[:entitlement][:privileges][privilege2.code.to_sym][:value]).to eq(entitlement_value2.value)
+      expect(json[:entitlement][:privileges].sole).to include({
+        code: "max_admins",
+        value: entitlement_value2.value
+      })
     end
   end
 end

--- a/spec/requests/api/v1/plans/entitlements_controller_spec.rb
+++ b/spec/requests/api/v1/plans/entitlements_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
       expect(response).to have_http_status(:success)
       expect(json[:entitlements]).to be_present
       expect(json[:entitlements].length).to eq(1)
-      expect(json[:entitlements].first[:privileges][:max][:value]).to eq(30)
+      expect(json[:entitlements].first[:privileges].sole[:value]).to eq(30)
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
 
       expect(response).to have_http_status(:success)
       expect(json[:entitlement][:code]).to eq("seats")
-      expect(json[:entitlement][:privileges][:max][:value]).to eq(30)
+      expect(json[:entitlement][:privileges].sole[:value]).to eq(30)
     end
 
     it "returns not found error when plan does not exist" do
@@ -94,7 +94,7 @@ RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
       expect(response).to have_http_status(:success)
       expect(json[:entitlements]).to be_present
       expect(json[:entitlements].length).to eq(1)
-      expect(json[:entitlements].first[:privileges][:max][:value]).to eq(25)
+      expect(json[:entitlements].first[:privileges].sole[:value]).to eq(25)
     end
 
     context "when plan has existing entitlements" do
@@ -110,7 +110,7 @@ RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
         subject
 
         expect(response).to have_http_status(:success)
-        expect(json[:entitlements].first[:privileges][:max][:value]).to eq(25)
+        expect(json[:entitlements].first[:privileges].sole[:value]).to eq(25)
       end
     end
 
@@ -239,9 +239,19 @@ RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
         expect { subject }.to change(Entitlement::EntitlementValue, :count).by(2)
 
         expect(response).to have_http_status(:success)
-        entitlements = json[:entitlements].first[:privileges]
-        expect(entitlements[:max][:value]).to eq(25)
-        expect(entitlements[:max_admins][:value]).to eq(5)
+        expect(json[:entitlements].first[:privileges]).to contain_exactly({
+          code: "max",
+          name: nil,
+          value_type: "integer",
+          value: 25,
+          config: {}
+        }, {
+          code: "max_admins",
+          name: nil,
+          value_type: "integer",
+          value: 5,
+          config: {}
+        })
       end
     end
   end
@@ -274,7 +284,7 @@ RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
       expect(response).to have_http_status(:success)
       expect(json[:entitlements]).to be_present
       expect(json[:entitlements].length).to eq(1)
-      expect(json[:entitlements].first[:privileges][:max][:value]).to eq(60)
+      expect(json[:entitlements].first[:privileges].sole[:value]).to eq(60)
     end
 
     it "does not create new entitlement" do
@@ -309,7 +319,7 @@ RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
         subject
 
         expect(response).to have_http_status(:success)
-        expect(json[:entitlements].first[:privileges][:max_admins][:value]).to eq(30)
+        expect(json[:entitlements].first[:privileges].find { it[:code] == "max_admins" }[:value]).to eq(30)
       end
     end
 
@@ -400,7 +410,7 @@ RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
 
         expect(response).to have_http_status(:success)
         expect(json[:entitlements]).to be_present
-        expect(json[:entitlements].first[:privileges][:max][:value]).to eq(10)
+        expect(json[:entitlements].first[:privileges].sole[:value]).to eq(10)
       end
     end
   end

--- a/spec/requests/api/v1/subscriptions/entitlements_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/entitlements_controller_spec.rb
@@ -36,9 +36,10 @@ RSpec.describe Api::V1::Subscriptions::EntitlementsController, type: :request do
       expect(se).to include({
         code: "seats",
         name: "Feature Name",
-        description: "Feature Description"
+        description: "Feature Description",
+        overrides: {root?: true}
       })
-      expect(se[:privileges][:root?]).to eq({
+      expect(se[:privileges]).to contain_exactly({
         code: "root?",
         name: nil,
         value_type: "boolean",
@@ -46,8 +47,7 @@ RSpec.describe Api::V1::Subscriptions::EntitlementsController, type: :request do
         value: true,
         plan_value: nil,
         override_value: true
-      })
-      expect(se[:privileges][:max]).to eq({
+      }, {
         code: "max",
         name: nil,
         value_type: "integer",
@@ -95,7 +95,7 @@ RSpec.describe Api::V1::Subscriptions::EntitlementsController, type: :request do
       expect(response).to have_http_status(:success)
       expect(json[:entitlements]).to be_present
       expect(json[:entitlements].length).to eq(1)
-      expect(json[:entitlements].first[:privileges][:max]).to include({
+      expect(json[:entitlements].first[:privileges].find { it[:code] == "max" }).to include({
         value: 60,
         plan_value: 10,
         override_value: 60
@@ -137,7 +137,7 @@ RSpec.describe Api::V1::Subscriptions::EntitlementsController, type: :request do
         subject
 
         expect(response).to have_http_status(:success)
-        expect(json[:entitlements].first[:privileges][:max_admins][:value]).to eq(30)
+        expect(json[:entitlements].first[:privileges].find { it[:code] == "max_admins" }[:value]).to eq(30)
       end
     end
 
@@ -228,7 +228,7 @@ RSpec.describe Api::V1::Subscriptions::EntitlementsController, type: :request do
 
         expect(response).to have_http_status(:success)
         expect(json[:entitlements]).to be_present
-        expect(json[:entitlements].first[:privileges][:max][:value]).to eq(10)
+        expect(json[:entitlements].first[:privileges].find { it[:code] == "max" }[:value]).to eq(10)
       end
     end
   end

--- a/spec/serializers/v1/entitlement/feature_serializer_spec.rb
+++ b/spec/serializers/v1/entitlement/feature_serializer_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe V1::Entitlement::FeatureSerializer, type: :serializer do
         created_at: feature.created_at.iso8601
       )
 
-      expect(result[:privileges]).to include(
-        "max_admins" => {
+      expect(result[:privileges]).to contain_exactly(
+        {
           code: "max_admins",
           name: nil,
           value_type: "integer"
         },
-        "max" => {
+        {
           code: "max",
           name: "Maximum",
           value_type: "integer"
@@ -72,7 +72,7 @@ RSpec.describe V1::Entitlement::FeatureSerializer, type: :serializer do
       it "returns empty privileges hash" do
         result = subject.serialize
 
-        expect(result[:privileges]).to eq({})
+        expect(result[:privileges]).to eq([])
       end
     end
   end

--- a/spec/serializers/v1/entitlement/plan_entitlement_serializer_spec.rb
+++ b/spec/serializers/v1/entitlement/plan_entitlement_serializer_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe V1::Entitlement::PlanEntitlementSerializer do
         name: feature.name,
         description: feature.description
       )
-      expect(result[:privileges]).to eq({
-        "int" => {code: "int", name: nil, value_type: "integer", value: 30, config: {}},
-        "bool" => {code: "bool", name: nil, value_type: "boolean", value: false, config: {}},
-        "str" => {code: "str", name: nil, value_type: "string", value: "str", config: {}},
-        "opt" => {code: "opt", name: nil, value_type: "select", value: "option1", config: {
+      expect(result[:privileges]).to contain_exactly(
+        {code: "int", name: nil, value_type: "integer", value: 30, config: {}},
+        {code: "bool", name: nil, value_type: "boolean", value: false, config: {}},
+        {code: "str", name: nil, value_type: "string", value: "str", config: {}},
+        {code: "opt", name: nil, value_type: "select", value: "option1", config: {
           "select_options" => ["option1", "option2", "option3"]
         }}
-      })
+      )
     end
   end
 end

--- a/spec/serializers/v1/entitlement/subscription_entitlements_collection_serializer_spec.rb
+++ b/spec/serializers/v1/entitlement/subscription_entitlements_collection_serializer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe V1::Entitlement::SubscriptionEntitlementsCollectionSerializer, ty
         name: "Feature Name",
         description: "Feature Description"
       })
-      expect(seats[:privileges][:root?]).to eq({
+      expect(seats[:privileges]).to contain_exactly({
         code: "root?",
         name: nil,
         value_type: "boolean",
@@ -63,8 +63,7 @@ RSpec.describe V1::Entitlement::SubscriptionEntitlementsCollectionSerializer, ty
         value: true,
         plan_value: nil,
         override_value: true
-      })
-      expect(seats[:privileges][:max]).to eq({
+      }, {
         code: "max",
         name: nil,
         value_type: "integer",
@@ -72,8 +71,7 @@ RSpec.describe V1::Entitlement::SubscriptionEntitlementsCollectionSerializer, ty
         value: 30,
         plan_value: 30,
         override_value: nil
-      })
-      expect(seats[:privileges][:reset]).to eq({
+      }, {
         code: "reset",
         name: nil,
         value_type: "string",
@@ -94,7 +92,7 @@ RSpec.describe V1::Entitlement::SubscriptionEntitlementsCollectionSerializer, ty
         name: nil,
         description: nil
       })
-      expect(storage[:privileges][:limit]).to eq({
+      expect(storage[:privileges]).to contain_exactly({
         code: "limit",
         name: "L",
         value_type: "integer",

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -147,15 +147,15 @@ RSpec.describe ::V1::PlanSerializer do
         "code" => "seats",
         "name" => "Seats",
         "description" => "Nb users",
-        "privileges" => {
-          "max" => {
+        "privileges" => [
+          {
             "code" => "max",
             "name" => nil,
             "value" => 100,
             "config" => {},
             "value_type" => "integer"
           }
-        }
+        ]
       })
     end
   end

--- a/spec/services/entitlement/feature_create_service_spec.rb
+++ b/spec/services/entitlement/feature_create_service_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Entitlement::FeatureCreateService, type: :service do
       code: "seats",
       name: "Number of seats",
       description: "Number of users of the account",
-      privileges: {
-        "max_admins" => {value_type: "integer"},
-        "max" => {name: "Maximum", value_type: "integer"}
-      }
+      privileges: [
+        {code: "max_admins", value_type: "integer"},
+        {code: "max", name: "Maximum", value_type: "integer"}
+      ]
     }
   end
 
@@ -111,9 +111,9 @@ RSpec.describe Entitlement::FeatureCreateService, type: :service do
           code: "seats",
           name: "Number of seats",
           description: "Number of users of the account",
-          privileges: {
-            "max_admins" => {}
-          }
+          privileges: [
+            {code: "max_admins"}
+          ]
         }
       end
 
@@ -125,15 +125,35 @@ RSpec.describe Entitlement::FeatureCreateService, type: :service do
       end
     end
 
+    context "when privilege code is duplicated" do
+      let(:params) do
+        {
+          code: "seats",
+          privileges: [
+            {code: "max_admins"},
+            {code: "max_admins"}
+          ]
+        }
+      end
+
+      it "returns a validation failure" do
+        result = subject
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:"privilege.code"]).to eq ["value_is_duplicated"]
+      end
+    end
+
     context "when privilege value_type is invalid" do
       let(:params) do
         {
           code: "seats",
           name: "Number of seats",
           description: "Number of users of the account",
-          privileges: {
-            "max_admins" => {value_type: "invalid_type"}
-          }
+          privileges: [
+            {code: "max_admins", value_type: "invalid_type"}
+          ]
         }
       end
 
@@ -152,9 +172,9 @@ RSpec.describe Entitlement::FeatureCreateService, type: :service do
           code: "seats",
           name: "Number of seats",
           description: "Number of users of the account",
-          privileges: {
-            "" => {value_type: "integer"} # Invalid empty code
-          }
+          privileges: [
+            {value_type: "integer"} # Invalid empty code
+          ]
         }
       end
 
@@ -190,9 +210,9 @@ RSpec.describe Entitlement::FeatureCreateService, type: :service do
       let(:params) do
         {
           code: "seats",
-          privileges: {
-            "max_admins" => {value_type: "integer"}
-          }
+          privileges: [
+            {code: "max_admins", value_type: "integer"}
+          ]
         }
       end
 
@@ -211,13 +231,14 @@ RSpec.describe Entitlement::FeatureCreateService, type: :service do
       let(:params) do
         {
           code: "sso",
-          privileges: {
-            "provider" => {
+          privileges: [
+            {
+              code: "provider",
               name: "Provider Name",
               value_type: "select",
               config: {select_options: %w[okta ad google custom]}
             }
-          }
+          ]
         }
       end
 

--- a/spec/services/entitlement/feature_update_service_spec.rb
+++ b/spec/services/entitlement/feature_update_service_spec.rb
@@ -27,6 +27,26 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
     context "when update is full" do
       let(:partial) { false }
 
+      context "when privilege code is duplicated" do
+        let(:params) do
+          {
+            code: "seats",
+            privileges: [
+              {code: "max_admins"},
+              {code: "max_admins"}
+            ]
+          }
+        end
+
+        it "returns a validation failure" do
+          result = subject
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:"privilege.code"]).to eq ["value_is_duplicated"]
+        end
+      end
+
       context "when updating feature attributes" do
         let(:params) do
           {
@@ -67,10 +87,10 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
       context "when updating privileges" do
         let(:params) do
           {
-            privileges: {
-              "max" => {name: "Max."},
-              "min" => {name: "Min."}
-            }
+            privileges: [
+              {code: "max", name: "Max."},
+              {code: "min", name: "Min."}
+            ]
           }
         end
 
@@ -86,7 +106,10 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
 
         it "only updates provided privilege attributes" do
           original_name = privilege1.name
-          params[:privileges]["max"].delete(:name)
+          params[:privileges] = [
+            {code: "max"},
+            {code: "min", name: "Min."}
+          ]
 
           result = subject
 
@@ -101,9 +124,9 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
           {
             name: "Updated Feature Name",
             description: "Updated feature description",
-            privileges: {
-              "max" => {name: "Max."}
-            }
+            privileges: [
+              {code: "max", name: "Max."}
+            ]
           }
         end
 
@@ -124,9 +147,9 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
 
         let(:params) do
           {
-            privileges: {
-              "opt" => {config: {select_options: %w[one two three]}}
-            }
+            privileges: [
+              {code: "opt", config: {select_options: %w[one two three]}}
+            ]
           }
         end
 
@@ -146,9 +169,9 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
 
         let(:params) do
           {
-            privileges: {
-              "max" => {name: "Max."}
-            }
+            privileges: [
+              {code: "max", name: "Max."}
+            ]
           }
         end
 
@@ -185,9 +208,9 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
         let(:new_privilege_code) { "new_privilege" }
         let(:params) do
           {
-            privileges: {
-              new_privilege_code => {name: "New Privilege"}
-            }
+            privileges: [
+              {code: new_privilege_code, name: "New Privilege"}
+            ]
           }
         end
 
@@ -204,9 +227,9 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
         context "when new privilege params are invalid" do
           let(:params) do
             {
-              privileges: {
-                new_privilege_code => {name: "New Privilege", value_type: "invalid_type"}
-              }
+              privileges: [
+                {code: new_privilege_code, name: "New Privilege", value_type: "invalid_type"}
+              ]
             }
           end
 
@@ -235,9 +258,9 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
       context "when privilege name is empty" do
         let(:params) do
           {
-            privileges: {
-              "max" => {name: ""} # Empty name is allowed
-            }
+            privileges: [
+              {code: "max", name: ""} # Empty name is allowed
+            ]
           }
         end
 
@@ -312,6 +335,26 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
     describe "when update is partial" do
       let(:partial) { true }
 
+      context "when privilege code is duplicated" do
+        let(:params) do
+          {
+            code: "seats",
+            privileges: [
+              {code: "max_admins"},
+              {code: "max_admins"}
+            ]
+          }
+        end
+
+        it "returns a validation failure" do
+          result = subject
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:"privilege.code"]).to eq ["value_is_duplicated"]
+        end
+      end
+
       context "when updating feature attributes" do
         let(:params) do
           {
@@ -352,10 +395,10 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
       context "when updating privilege names" do
         let(:params) do
           {
-            privileges: {
-              "max" => {name: "Max."},
-              "min" => {name: "Min."}
-            }
+            privileges: [
+              {code: "max", name: "Max."},
+              {code: "min", name: "Min."}
+            ]
           }
         end
 
@@ -368,7 +411,7 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
         end
 
         it "only updates privileges that exist" do
-          params[:privileges]["nonexistent"] = {name: "New Name"}
+          params[:privileges] << {code: "nonexistent", name: "New Name"}
 
           result = subject
 
@@ -379,7 +422,10 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
 
         it "only updates provided privilege attributes" do
           original_name = privilege1.name
-          params[:privileges]["max"].delete(:name)
+          params[:privileges] = [
+            {code: "max"},
+            {code: "min", name: "Min."}
+          ]
 
           result = subject
 
@@ -394,9 +440,9 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
 
         let(:params) do
           {
-            privileges: {
-              "opt" => {config: {select_options: %w[one two three]}}
-            }
+            privileges: [
+              {code: "opt", config: {select_options: %w[one two three]}}
+            ]
           }
         end
 
@@ -413,9 +459,9 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
           {
             name: "Updated Feature Name",
             description: "Updated feature description",
-            privileges: {
-              "max" => {name: "Max."}
-            }
+            privileges: [
+              {code: "max", name: "Max."}
+            ]
           }
         end
 
@@ -445,9 +491,9 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
       context "when privilege name is empty" do
         let(:params) do
           {
-            privileges: {
-              "max" => {name: ""} # Empty name is allowed
-            }
+            privileges: [
+              {code: "max", name: ""} # Empty name is allowed
+            ]
           }
         end
 
@@ -474,9 +520,9 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
         let(:new_privilege_code) { "new_privilege" }
         let(:params) do
           {
-            privileges: {
-              new_privilege_code => {name: "New Privilege"}
-            }
+            privileges: [
+              {code: new_privilege_code, name: "New Privilege"}
+            ]
           }
         end
 
@@ -493,9 +539,9 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
         context "when new privilege params are invalid" do
           let(:params) do
             {
-              privileges: {
-                new_privilege_code => {name: "New Privilege", value_type: "invalid_type"}
-              }
+              privileges: [
+                {code: new_privilege_code, name: "New Privilege", value_type: "invalid_type"}
+              ]
             }
           end
 

--- a/spec/services/webhooks/features/created_service_spec.rb
+++ b/spec/services/webhooks/features/created_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Webhooks::Features::CreatedService do
       "code" => String,
       "name" => String,
       "description" => String,
-      "privileges" => Hash,
+      "privileges" => Array,
       "created_at" => String
     }
   end

--- a/spec/services/webhooks/features/deleted_service_spec.rb
+++ b/spec/services/webhooks/features/deleted_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Webhooks::Features::DeletedService do
       "code" => String,
       "name" => String,
       "description" => String,
-      "privileges" => Hash,
+      "privileges" => Array,
       "created_at" => String
     }
   end

--- a/spec/services/webhooks/features/updated_service_spec.rb
+++ b/spec/services/webhooks/features/updated_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Webhooks::Features::UpdatedService do
       "code" => String,
       "name" => String,
       "description" => String,
-      "privileges" => Hash,
+      "privileges" => Array,
       "created_at" => String
     }
   end


### PR DESCRIPTION
This PR modifies the serializer for features and privileges, as well as the payload to manage features.
The payload to manage entitlements (attaching features to plans *with values* is still a hash.

The first thing that made me want to change this was GQL, which was not so easy to use with hash.
Then, I wrote the open API spec and it was even worse.

### serialized feature / Payload to manage features

```diff
      {
        feature: {
          code: "new_feature",
          name: "New Feature",
          description: "A new feature",
-          privileges: {
-            "priv1" => {value_type: "boolean"},
-            "priv2" => {name: "Maximum", value_type: "boolean"}
-          }
+          privileges: [
+            {code: "priv1", value_type: "boolean"},
+            {code: "priv2", name: "Maximum", value_type: "boolean"}
+          ]
        }
      }
```

### payload to manage entitlements

```rb
{
  "entitlements" => {
    "seats" => {
      "max" => 25
    }
  }
}
```

I think to EDIT entitlements, a hash is a lot nicer. When you receive it back, it's an array.
