### PR TITLE
Fix: forever-lasting coupon applied on progressive billing and subscription invoice

### DIFF
--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -42,6 +42,42 @@ class AppliedCoupon < ApplicationRecord
     already_applied_amount = credits.active.sum(&:amount_cents)
     @remaining_amount = amount_cents - already_applied_amount
   end
+
+  def credits_sum_for_invoice_subscription(invoice_subscription, invoice)
+    # The most correct boundaries are defined on a fee and not on an invoice_subscription
+    boundaries = invoice.fees.where(subscription_id: invoice_subscription.subscription_id).first&.properties ||
+      {"charges_from_datetime" => invoice_subscription.charges_from_datetime, "charges_to_datetime" => invoice_subscription.charges_to_datetime}
+
+    # invoices issued within this invoice_subscription's boundaries
+    invoice_ids = Fee.where(organization_id: invoice.organization_id,
+      billing_entity_id: invoice.billing_entity_id,
+      subscription_id: invoice_subscription.subscription_id)
+      .where("(properties->>'charges_from_datetime')::timestamptz >= ?::timestamptz", boundaries["charges_from_datetime"])
+      .where("(properties->>'charges_to_datetime')::timestamptz <= ?::timestamptz", boundaries["charges_to_datetime"])
+      .pluck(:invoice_id).uniq
+
+    credits.active.where(invoice_id: invoice_ids).joins(:invoice).where.not(invoices: {status: :voided}).sum(&:amount_cents)
+  end
+
+  def credits_applied_in_billing_period_present?(invoice)
+    invoice.invoice_subscriptions.map do |invoice_subscription|
+      credits_sum_for_invoice_subscription(invoice_subscription, invoice)
+    end.sum > 0
+  end
+
+  # coupon defines the amount that can be deducted during a billing_period. So if a coupon lasts n billing periods with m discount,
+  # during each billing period the maximum discount is m
+  def remaining_amount_for_this_subscription_billing_period(invoice:)
+    @remaining_amount_for_this_subscription_billing_period ||= {}
+    return @remaining_amount_for_this_subscription_billing_period[invoice.id] if @remaining_amount_for_this_subscription_billing_period[invoice.id].present?
+
+    min_used_amount = invoice.invoice_subscriptions.map do |invoice_subscription|
+      credits_sum_for_invoice_subscription(invoice_subscription, invoice)
+    end.min
+
+    remaining_amount = amount_cents - min_used_amount
+    @remaining_amount_for_this_subscription_billing_period[invoice.id] = remaining_amount.negative? ? 0 : remaining_amount
+  end
 end
 
 # == Schema Information

--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -44,39 +44,49 @@ class AppliedCoupon < ApplicationRecord
   end
 
   def credits_sum_for_invoice_subscription(invoice_subscription, invoice)
-    # The most correct boundaries are defined on a fee and not on an invoice_subscription
-    boundaries = invoice.fees.where(subscription_id: invoice_subscription.subscription_id).first&.properties ||
-      {"charges_from_datetime" => invoice_subscription.charges_from_datetime, "charges_to_datetime" => invoice_subscription.charges_to_datetime}
-
-    # invoices issued within this invoice_subscription's boundaries
-    invoice_ids = Fee.where(organization_id: invoice.organization_id,
-      billing_entity_id: invoice.billing_entity_id,
-      subscription_id: invoice_subscription.subscription_id)
-      .where("(properties->>'charges_from_datetime')::timestamptz >= ?::timestamptz", boundaries["charges_from_datetime"])
-      .where("(properties->>'charges_to_datetime')::timestamptz <= ?::timestamptz", boundaries["charges_to_datetime"])
-      .pluck(:invoice_id).uniq
-
-    credits.active.where(invoice_id: invoice_ids).joins(:invoice).where.not(invoices: {status: :voided}).sum(&:amount_cents)
+    credits.active.where(invoice_id: invoice_ids_for_invoice_subscription(invoice_subscription, invoice))
+      .joins(:invoice).where.not(invoices: {status: :voided}).sum(&:amount_cents)
   end
 
   def credits_applied_in_billing_period_present?(invoice)
-    invoice.invoice_subscriptions.map do |invoice_subscription|
-      credits_sum_for_invoice_subscription(invoice_subscription, invoice)
-    end.sum > 0
+    invoice.invoice_subscriptions.any? do |invoice_subscription|
+      credits_sum_for_invoice_subscription(invoice_subscription, invoice).positive?
+    end
   end
 
   # coupon defines the amount that can be deducted during a billing_period. So if a coupon lasts n billing periods with m discount,
   # during each billing period the maximum discount is m
   def remaining_amount_for_this_subscription_billing_period(invoice:)
     @remaining_amount_for_this_subscription_billing_period ||= {}
-    return @remaining_amount_for_this_subscription_billing_period[invoice.id] if @remaining_amount_for_this_subscription_billing_period[invoice.id].present?
+    cached = @remaining_amount_for_this_subscription_billing_period[invoice.id]
+    return cached unless cached.nil?
 
-    min_used_amount = invoice.invoice_subscriptions.map do |invoice_subscription|
+    used_amount = invoice.invoice_subscriptions.map do |invoice_subscription|
       credits_sum_for_invoice_subscription(invoice_subscription, invoice)
-    end.min
+    end.sum
 
-    remaining_amount = amount_cents - min_used_amount
+    remaining_amount = amount_cents - used_amount
     @remaining_amount_for_this_subscription_billing_period[invoice.id] = remaining_amount.negative? ? 0 : remaining_amount
+  end
+
+  private
+
+  # Returns invoice ids whose fees for this invoice_subscription's subscription fall within
+  # the billing period boundaries. Boundaries are read from a fee on the invoice rather than
+  # from the invoice_subscription itself, because pay-in-advance fees carry their own
+  # boundaries that may differ from the invoice_subscription record.
+  def invoice_ids_for_invoice_subscription(invoice_subscription, invoice)
+    boundaries = invoice.fees.where(subscription_id: invoice_subscription.subscription_id).first&.properties ||
+      {"charges_from_datetime" => invoice_subscription.charges_from_datetime,
+       "charges_to_datetime" => invoice_subscription.charges_to_datetime}
+
+    Fee.where(organization_id: invoice.organization_id,
+      billing_entity_id: invoice.billing_entity_id,
+      subscription_id: invoice_subscription.subscription_id)
+      .where("(properties->>'charges_from_datetime')::timestamptz >= ?::timestamptz", boundaries["charges_from_datetime"])
+      .where("(properties->>'charges_to_datetime')::timestamptz <= ?::timestamptz", boundaries["charges_to_datetime"])
+      .distinct
+      .pluck(:invoice_id)
   end
 end
 

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -23,6 +23,7 @@ class InvoiceSubscription < ApplicationRecord
     in_advance_charge_periodic: "in_advance_charge_periodic",
     progressive_billing: "progressive_billing"
   }.freeze
+  SUBSCRIPTION_INVOICING_REASONS = %w[subscription_starting subscription_periodic subscription_terminating].freeze
 
   enum :invoicing_reason, INVOICING_REASONS
 

--- a/app/services/applied_coupons/amount_service.rb
+++ b/app/services/applied_coupons/amount_service.rb
@@ -4,9 +4,10 @@ module AppliedCoupons
   class AmountService < BaseService
     Result = BaseResult[:amount]
 
-    def initialize(applied_coupon:, base_amount_cents:)
+    def initialize(applied_coupon:, base_amount_cents:, invoice:)
       @applied_coupon = applied_coupon
       @base_amount_cents = base_amount_cents
+      @invoice = invoice
 
       super
     end
@@ -20,7 +21,7 @@ module AppliedCoupons
 
     private
 
-    attr_reader :applied_coupon, :base_amount_cents
+    attr_reader :applied_coupon, :base_amount_cents, :invoice
 
     def compute_amount
       if applied_coupon.coupon.percentage?
@@ -30,9 +31,9 @@ module AppliedCoupons
       end
 
       if applied_coupon.recurring? || applied_coupon.forever?
-        return base_amount_cents if applied_coupon.amount_cents > base_amount_cents
+        return base_amount_cents if applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:) > base_amount_cents
 
-        applied_coupon.amount_cents
+        applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)
       else
         return base_amount_cents if applied_coupon.remaining_amount > base_amount_cents
 

--- a/app/services/applied_coupons/amount_service.rb
+++ b/app/services/applied_coupons/amount_service.rb
@@ -30,15 +30,14 @@ module AppliedCoupons
         return (discounted_value >= base_amount_cents) ? base_amount_cents : discounted_value.round
       end
 
-      if applied_coupon.recurring? || applied_coupon.forever?
-        return base_amount_cents if applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:) > base_amount_cents
-
+      remaining_amount = if applied_coupon.recurring? || applied_coupon.forever?
         applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)
       else
-        return base_amount_cents if applied_coupon.remaining_amount > base_amount_cents
-
         applied_coupon.remaining_amount
       end
+      return base_amount_cents if remaining_amount > base_amount_cents
+
+      remaining_amount
     end
   end
 end

--- a/app/services/coupons/preview_service.rb
+++ b/app/services/coupons/preview_service.rb
@@ -39,7 +39,7 @@ module Coupons
     attr_reader :applied_coupons, :invoice
 
     def add_credit(applied_coupon, fees, base_amount_cents)
-      credit_amount = AppliedCoupons::AmountService.call(applied_coupon:, base_amount_cents:).amount
+      credit_amount = AppliedCoupons::AmountService.call(applied_coupon:, base_amount_cents:, invoice:).amount
       new_credit = Credit.new(
         invoice:,
         organization_id: invoice.organization_id,

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -18,7 +18,7 @@ module Credits
       return result if already_applied?
       return result unless fees.any?
 
-      credit_amount = AppliedCoupons::AmountService.call(applied_coupon:, base_amount_cents:).amount
+      credit_amount = AppliedCoupons::AmountService.call(applied_coupon:, base_amount_cents:, invoice:).amount
 
       new_credit = Credit.create!(
         organization_id: invoice.organization_id,
@@ -83,7 +83,13 @@ module Credits
       end
     end
 
+    def is_for_subscription_invoice?
+      invoice.invoice_subscriptions.any? { |invoice_subscription| invoice_subscription.invoicing_reason.include?("subscription") }
+    end
+
     def decrement_frequency_duration_remaining
+      return unless is_for_subscription_invoice?
+
       applied_coupon.frequency_duration_remaining = [applied_coupon.frequency_duration_remaining.to_i - 1, 0].max
     end
 

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -84,7 +84,9 @@ module Credits
     end
 
     def is_for_subscription_invoice?
-      invoice.invoice_subscriptions.any? { |invoice_subscription| invoice_subscription.invoicing_reason.include?("subscription") }
+      invoice.invoice_subscriptions.any? do |invoice_subscription|
+        InvoiceSubscription::SUBSCRIPTION_INVOICING_REASONS.include?(invoice_subscription.invoicing_reason.to_s)
+      end
     end
 
     def decrement_frequency_duration_remaining

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -49,7 +49,13 @@ module Invoices
           invoice.coupons_amount_cents
 
         Credits::ProgressiveBillingService.call(invoice:)
-        Credits::AppliedCouponsService.call(invoice:) if should_create_coupon_credit?
+        if should_create_coupon_credit?
+          Credits::AppliedCouponsService.call(invoice:)
+        else
+          # we should reduce duration of recurring coupons if they were not used on this invoice,
+          # but when it's a subscription invoice, as subscription invoice defines billing period
+          reduce_coupon_usage
+        end
 
         totals_result = Invoices::ComputeTaxesAndTotalsService.call(invoice:, finalizing: finalizing_invoice?)
         return totals_result if !totals_result.success? && totals_result.error.is_a?(BaseService::UnknownTaxFailure) # rubocop:disable Rails/TransactionExitStatement
@@ -415,6 +421,19 @@ module Invoices
       Events::BillingPeriodFilterService.call!(
         subscription:, boundaries:
       )
+    end
+
+    def reduce_coupon_usage
+      return unless invoice.invoice_subscriptions.any? { |inv_sub| inv_sub.invoicing_reason.include?("subscription") }
+
+      customer.applied_coupons.active.recurring.each do |applied_coupon|
+        # if a customer has an applied coupon, but it has not been used in this billing period, we shouldn't deduct usage of the coupon
+        next unless applied_coupon.credits_applied_in_billing_period_present?(invoice)
+
+        applied_coupon.frequency_duration_remaining -= 1
+        applied_coupon.save!
+        applied_coupon.mark_as_terminated! if applied_coupon.frequency_duration_remaining.zero?
+      end
     end
   end
 end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -424,7 +424,7 @@ module Invoices
     end
 
     def reduce_coupon_usage
-      return unless invoice.invoice_subscriptions.any? { |inv_sub| inv_sub.invoicing_reason.include?("subscription") }
+      return unless subscription_invoice?
 
       customer.applied_coupons.active.recurring.each do |applied_coupon|
         # if a customer has an applied coupon, but it has not been used in this billing period, we shouldn't deduct usage of the coupon
@@ -433,6 +433,12 @@ module Invoices
         applied_coupon.frequency_duration_remaining -= 1
         applied_coupon.save!
         applied_coupon.mark_as_terminated! if applied_coupon.frequency_duration_remaining.zero?
+      end
+    end
+
+    def subscription_invoice?
+      invoice.invoice_subscriptions.any? do |inv_sub|
+        InvoiceSubscription::SUBSCRIPTION_INVOICING_REASONS.include?(inv_sub.invoicing_reason.to_s)
       end
     end
   end

--- a/app/services/subscriptions/progressive_billed_amount.rb
+++ b/app/services/subscriptions/progressive_billed_amount.rb
@@ -58,7 +58,7 @@ module Subscriptions
       result.progressive_billed_amount = result.progressive_billing_invoice.fees_amount_cents
 
       result.to_credit_amount = invoice.fees_amount_cents
-      # TODO: confirm with product. It was added to avoid crediting back the coupons,
+      # TODO: confirm with product. It was added to avoid crediting back the coupons, because they were not paid
       # but we should be able to apply these "credits" from PB invoice to normal invoice.
       # The question is: do we want to keep the old behaviour or does it make more sense?
       # result.to_credit_amount -= invoice.coupons_amount_cents

--- a/app/services/subscriptions/progressive_billed_amount.rb
+++ b/app/services/subscriptions/progressive_billed_amount.rb
@@ -58,7 +58,10 @@ module Subscriptions
       result.progressive_billed_amount = result.progressive_billing_invoice.fees_amount_cents
 
       result.to_credit_amount = invoice.fees_amount_cents
-      result.to_credit_amount -= invoice.coupons_amount_cents
+      # TODO: confirm with product. It was added to avoid crediting back the coupons,
+      # but we should be able to apply these "credits" from PB invoice to normal invoice.
+      # The question is: do we want to keep the old behaviour or does it make more sense?
+      # result.to_credit_amount -= invoice.coupons_amount_cents
       result.to_credit_amount -= invoice.progressive_billing_credits.active.sum(:amount_cents)
       result.to_credit_amount -= invoice.credit_notes.where(credit_status: ["available", "consumed"]).sum(:credit_amount_cents)
 

--- a/spec/factories/invoice_subscriptions.rb
+++ b/spec/factories/invoice_subscriptions.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :invoice_subscription do
     subscription
+    invoicing_reason { "subscription_periodic" }
     invoice
     organization { subscription&.organization || invoice&.organization || association(:organization) }
 

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe AppliedCoupon do
     let(:period_end) { Time.current.end_of_month }
     let(:invoice) do
       create(:invoice, :subscription, customer:, organization:, billing_entity:, subscriptions: [subscription]).tap do |inv|
-        inv.invoice_subscriptions.update_all(timestamp: Time.current, charges_from_datetime: period_start, charges_to_datetime: period_end)
+        inv.invoice_subscriptions.update_all(timestamp: Time.current, charges_from_datetime: period_start, charges_to_datetime: period_end) # rubocop:disable Rails/SkipsModelValidations
       end
     end
     let(:invoice_subscription) { invoice.invoice_subscriptions.first }
@@ -120,7 +120,7 @@ RSpec.describe AppliedCoupon do
     def add_period_invoice(offset: 0.months, voided: false, subs: [subscription])
       traits = voided ? [:voided] : []
       create(:invoice, :subscription, *traits, customer:, organization:, billing_entity:, subscriptions: subs).tap do |inv|
-        inv.invoice_subscriptions.update_all(timestamp: Time.current + offset, charges_from_datetime: period_start + offset, charges_to_datetime: period_end + offset)
+        inv.invoice_subscriptions.update_all(timestamp: Time.current + offset, charges_from_datetime: period_start + offset, charges_to_datetime: period_end + offset) # rubocop:disable Rails/SkipsModelValidations
       end
     end
 
@@ -181,7 +181,7 @@ RSpec.describe AppliedCoupon do
       end
     end
 
-    context "memoization" do
+    context "when called multiple times for the same invoice" do
       it "caches per invoice id" do
         first_call = applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)
         second_call = applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -86,211 +86,6 @@ RSpec.describe AppliedCoupon do
     end
   end
 
-  describe "#remaining_amount_for_this_subscription_billing_period" do
-    let(:applied_coupon) { create(:applied_coupon, amount_cents: 100) }
-    let(:organization) { applied_coupon.organization }
-    let(:customer) { applied_coupon.customer }
-    let(:subscription) { create(:subscription, customer:, organization:) }
-    let(:current_time) { Time.current }
-    let(:invoice) { create(:invoice, :subscription, customer:, organization:, subscriptions: [subscription]) }
-    let(:invoice_fee) do
-      create(:fee, invoice:, subscription:, amount_cents: 20, organization:,
-        properties: {charges_from_datetime: current_time.beginning_of_month,
-                     charges_to_datetime: current_time.end_of_month})
-    end
-
-    before do
-      invoice.invoice_subscriptions.update(timestamp: current_time, charges_from_datetime: current_time.beginning_of_month, charges_to_datetime: current_time.end_of_month)
-      invoice_fee
-    end
-
-    context "when no credits exist for the billing period" do
-      it "returns the full amount" do
-        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(100)
-      end
-    end
-
-    context "when credits exist for another invoice in the same billing period" do
-      let(:other_invoice) { create(:invoice, :subscription, customer:, organization:, subscriptions: [subscription]) }
-      let(:credit) do
-        create(:credit,
-          applied_coupon: applied_coupon,
-          invoice: other_invoice,
-          amount_cents: 30,
-          organization:)
-      end
-      let(:other_invoice_fee) do
-        create(:fee, invoice: other_invoice, subscription:, amount_cents: 20,
-          properties: {charges_from_datetime: current_time.beginning_of_month,
-                       charges_to_datetime: current_time.end_of_month})
-      end
-
-      before do
-        other_invoice.invoice_subscriptions.update(timestamp: current_time, charges_from_datetime: current_time.beginning_of_month,
-          charges_to_datetime: current_time.end_of_month)
-        other_invoice_fee
-        credit
-      end
-
-      it "returns the amount minus the credit" do
-        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(70)
-      end
-    end
-
-    context "when credits exist in non-overlapping billing periods" do
-      let(:other_invoice) { create(:invoice, :subscription, customer:, organization:, subscriptions: [subscription]) }
-      let(:other_invoice_fee) do
-        create(:fee, invoice: other_invoice, subscription:, amount_cents: 20, organization:,
-          properties: {charges_from_datetime: current_time.beginning_of_month - 1.month,
-                       charges_to_datetime: current_time.end_of_month - 1.month})
-      end
-
-      before do
-        other_invoice.invoice_subscriptions.update(timestamp: current_time, charges_from_datetime: current_time.beginning_of_month - 1.month, charges_to_datetime: current_time.end_of_month - 1.month)
-        other_invoice_fee
-        create(:credit,
-          applied_coupon: applied_coupon,
-          invoice: other_invoice,
-          amount_cents: 40,
-          organization:)
-      end
-
-      it "excludes credits from invoices with non-overlapping billing periods" do
-        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(100)
-      end
-    end
-
-    context "when credits exceed the original amount" do
-      let(:credit) do
-        create(:credit,
-          applied_coupon:,
-          invoice:,
-          amount_cents: 150,
-          organization:)
-      end
-
-      before do
-        credit
-      end
-
-      it "returns 0 (never negative)" do
-        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(0)
-      end
-    end
-
-    context "when invoice has voided credits" do
-      let(:voided_invoice) { create(:invoice, :subscription, :voided, customer:, organization:, subscriptions: [subscription]) }
-      let(:voided_invoice_fee) do
-        create(:fee, invoice: voided_invoice, subscription:, amount_cents: 20,
-          properties: {charges_from_datetime: current_time.beginning_of_month,
-                       charges_to_datetime: current_time.end_of_month})
-      end
-
-      before do
-        voided_invoice.invoice_subscriptions.update(timestamp: current_time, charges_from_datetime: current_time.beginning_of_month, charges_to_datetime: current_time.end_of_month)
-        voided_invoice_fee
-        create(:credit,
-          applied_coupon: applied_coupon,
-          invoice: voided_invoice,
-          amount_cents: 50,
-          organization: organization)
-      end
-
-      it "ignores voided invoice credits" do
-        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(100)
-      end
-    end
-
-    context "when called multiple times with the same invoice" do
-      it "caches the result" do
-        first_call = applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)
-        second_call = applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)
-
-        expect(first_call).to eq(second_call)
-        expect(first_call).to eq(100)
-      end
-    end
-
-    context "when invoice has multiple subscriptions with same billing period" do
-      let(:subscription_2) { create(:subscription, customer: customer, organization: organization) }
-      let(:invoice_subscription_2) do
-        create(:invoice_subscription,
-          invoice: invoice,
-          subscription: subscription_2,
-          organization: organization,
-          timestamp: current_time,
-          charges_from_datetime: current_time.beginning_of_month,
-          charges_to_datetime: current_time.end_of_month)
-      end
-      let(:invoice_fee_2) do
-        create(:fee, invoice: invoice, subscription: subscription_2, amount_cents: 20, organization:,
-          properties: {charges_from_datetime: current_time.beginning_of_month,
-                       charges_to_datetime: current_time.end_of_month})
-      end
-
-      # this credit is associated to subscription 1 and subscription 2
-      before do
-        invoice_subscription_2
-        create(:credit,
-          applied_coupon: applied_coupon,
-          invoice: invoice,
-          amount_cents: 20,
-          organization: organization)
-        invoice_fee_2
-      end
-
-      it "calculates based on the minimum used amount across all subscriptions" do
-        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(80)
-      end
-
-      context "when each subscription has different remaining amount of the coupon" do
-        let(:invoice_2) { create(:invoice, :subscription, customer:, organization:, subscriptions: [subscription_2]) }
-        let(:invoice_2_fee) do
-          create(:fee, invoice: invoice_2, subscription: subscription_2, amount_cents: 20, organization:,
-            properties: {charges_from_datetime: current_time.beginning_of_month,
-                         charges_to_datetime: current_time.end_of_month})
-        end
-
-        # this credit is associated only to subscription 2
-        let(:credit_2) { create(:credit, applied_coupon:, invoice: invoice_2, amount_cents: 30, organization:) }
-
-        before do
-          invoice_2.invoice_subscriptions.update(timestamp: current_time, charges_from_datetime: current_time.beginning_of_month, charges_to_datetime: current_time.end_of_month)
-          credit_2
-          invoice_2_fee
-        end
-
-        # Sum semantics: subscription has $20 in this period (on `invoice`), subscription_2 has
-        # $20 (on `invoice`) + $30 (on `invoice_2`) = $50. Total used = $70. Remaining = $30.
-        it "sums credits across all subscriptions on the invoice" do
-          invoice.reload
-          expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(30)
-        end
-      end
-
-      context "when one of subscription has no usage" do
-        let(:subscription_3) { create(:subscription, customer:, organization:) }
-        let(:invoice_3) { create(:invoice, :subscription, customer:, organization:, subscriptions: [subscription_3, subscription_2]) }
-        let(:invoice_3_fee) do
-          create(:fee, invoice: invoice_3, subscription: subscription_3, amount_cents: 20, organization:,
-            properties: {charges_from_datetime: current_time.beginning_of_month,
-                         charges_to_datetime: current_time.end_of_month})
-        end
-
-        before do
-          invoice_3.invoice_subscriptions.update(timestamp: current_time, charges_from_datetime: current_time.beginning_of_month, charges_to_datetime: current_time.end_of_month)
-          invoice_3_fee
-        end
-
-        # Sum semantics: subscription_3 used $0 in its period, subscription_2 used $20 (on `invoice`).
-        # Total = $20. Remaining = $80.
-        it "sums across subscriptions even when one has no usage" do
-          expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice_3)).to eq(80)
-        end
-      end
-    end
-  end
-
   describe "#mark_as_terminated!" do
     it "marks the applied coupon as terminated" do
       expect { applied_coupon.mark_as_terminated! }.to change(applied_coupon, :status).to("terminated").and \
@@ -298,407 +93,151 @@ RSpec.describe AppliedCoupon do
     end
   end
 
-  describe "#credits_sum_for_invoice_subscription" do
-    let(:applied_coupon) { create(:applied_coupon) }
+  # Covers the trio of methods used to track per-billing-period coupon usage:
+  #   #remaining_amount_for_this_subscription_billing_period (public, used by AmountService)
+  #   #credits_applied_in_billing_period_present?           (public, used by reduce_coupon_usage)
+  #   #credits_sum_for_invoice_subscription                 (helper for both)
+  describe "billing-period coupon tracking" do
+    let(:applied_coupon) { create(:applied_coupon, amount_cents: 100) }
     let(:organization) { applied_coupon.organization }
+    let(:billing_entity) { organization.default_billing_entity }
     let(:customer) { applied_coupon.customer }
     let(:subscription) { create(:subscription, customer:, organization:) }
-    let(:billing_entity) { organization.default_billing_entity }
-    let(:current_time) { Time.current }
-    let(:charges_from) { current_time.beginning_of_month }
-    let(:charges_to) { current_time.end_of_month }
-    let(:invoice) { create(:invoice, customer:, organization:, billing_entity:) }
-    let(:invoice_subscription) do
-      create(:invoice_subscription,
-        invoice:,
-        subscription:,
-        organization:,
-        charges_from_datetime: charges_from,
-        charges_to_datetime: charges_to)
+    let(:period_start) { Time.current.beginning_of_month }
+    let(:period_end) { Time.current.end_of_month }
+    let(:invoice) do
+      create(:invoice, :subscription, customer:, organization:, billing_entity:, subscriptions: [subscription]).tap do |inv|
+        inv.invoice_subscriptions.update_all(timestamp: Time.current, charges_from_datetime: period_start, charges_to_datetime: period_end)
+      end
+    end
+    let(:invoice_subscription) { invoice.invoice_subscriptions.first }
+
+    def add_fee(inv, sub, amount, offset: 0.months)
+      create(:fee, invoice: inv, subscription: sub, amount_cents: amount, organization:, billing_entity:,
+        properties: {charges_from_datetime: period_start + offset, charges_to_datetime: period_end + offset})
     end
 
-    before do
-      invoice_subscription
+    def add_period_invoice(offset: 0.months, voided: false, subs: [subscription])
+      traits = voided ? [:voided] : []
+      create(:invoice, :subscription, *traits, customer:, organization:, billing_entity:, subscriptions: subs).tap do |inv|
+        inv.invoice_subscriptions.update_all(timestamp: Time.current + offset, charges_from_datetime: period_start + offset, charges_to_datetime: period_end + offset)
+      end
     end
 
-    context "when fees exist with matching billing period boundaries and credits exist" do
-      let(:fee) do
-        create(:fee,
-          invoice:,
-          subscription:,
-          organization:,
-          billing_entity:,
-          properties: {
-            "charges_from_datetime" => charges_from.iso8601,
-            "charges_to_datetime" => charges_to.iso8601
-          })
-      end
-      let(:credit) do
-        create(:credit,
-          applied_coupon: applied_coupon,
-          invoice:,
-          amount_cents: 50,
-          organization:)
-      end
+    before { add_fee(invoice, subscription, 20) }
 
+    context "without any prior credits" do
+      it "remaining is the full amount, no credits present, sum is 0" do
+        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)).to eq(100)
+        expect(applied_coupon.credits_applied_in_billing_period_present?(invoice)).to be(false)
+        expect(applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)).to eq(0)
+      end
+    end
+
+    context "with a credit on another invoice in the same period" do
       before do
-        fee
-        credit
+        other = add_period_invoice
+        add_fee(other, subscription, 20)
+        create(:credit, applied_coupon:, invoice: other, amount_cents: 30, organization:)
       end
 
-      it "returns the sum of credits for matching invoice IDs" do
-        result = applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)
-        expect(result).to eq(50)
+      it "remaining decreases by the credit, present? is true" do
+        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)).to eq(70)
+        expect(applied_coupon.credits_applied_in_billing_period_present?(invoice)).to be(true)
       end
     end
 
-    context "when fees exist but outside billing period boundaries" do
-      let(:other_invoice) { create(:invoice, customer:, organization:, billing_entity:) }
-      let(:fee) do
-        create(:fee,
-          invoice: other_invoice,
-          subscription:,
-          organization:,
-          billing_entity:,
-          properties: {
-            "charges_from_datetime" => (charges_from - 1.month).iso8601,
-            "charges_to_datetime" => (charges_to - 1.month).iso8601
-          })
-      end
-      let(:credit) do
-        create(:credit,
-          applied_coupon:,
-          invoice: other_invoice,
-          amount_cents: 50,
-          organization:)
-      end
-
+    context "with a credit on a voided invoice" do
       before do
-        fee
-        credit
+        other = add_period_invoice(voided: true)
+        add_fee(other, subscription, 20)
+        create(:credit, applied_coupon:, invoice: other, amount_cents: 50, organization:)
       end
 
-      it "returns 0 as no fees match the billing period" do
-        result = applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)
-        expect(result).to eq(0)
+      it "ignores voided-invoice credits" do
+        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)).to eq(100)
+        expect(applied_coupon.credits_applied_in_billing_period_present?(invoice)).to be(false)
       end
     end
 
-    context "when no fees exist for the subscription" do
-      it "returns 0" do
-        result = applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)
-        expect(result).to eq(0)
-      end
-    end
-
-    context "when credits exist but for voided invoices" do
-      let(:voided_invoice) { create(:invoice, customer:, organization:, billing_entity:, status: :voided) }
-      let(:fee) do
-        create(:fee,
-          invoice: voided_invoice,
-          subscription:,
-          organization:,
-          billing_entity:,
-          properties: {
-            "charges_from_datetime" => charges_from.iso8601,
-            "charges_to_datetime" => charges_to.iso8601
-          })
-      end
-      let(:credit) do
-        create(:credit,
-          applied_coupon:,
-          invoice: voided_invoice,
-          amount_cents: 50,
-          organization:)
-      end
-
+    context "with credits in non-overlapping billing periods" do
       before do
-        fee
-        credit
+        other = add_period_invoice(offset: -1.month)
+        add_fee(other, subscription, 20, offset: -1.month)
+        create(:credit, applied_coupon:, invoice: other, amount_cents: 40, organization:)
       end
 
-      it "excludes credits from voided invoices" do
-        result = applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)
-        expect(result).to eq(0)
+      it "excludes credits outside the billing period" do
+        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)).to eq(100)
+        expect(applied_coupon.credits_applied_in_billing_period_present?(invoice)).to be(false)
       end
     end
 
-    context "when no credits exist" do
-      let(:fee) do
-        create(:fee,
-          invoice:,
-          subscription:,
-          organization:,
-          billing_entity:,
-          properties: {
-            "charges_from_datetime" => charges_from.iso8601,
-            "charges_to_datetime" => charges_to.iso8601
-          })
-      end
+    context "with credits exceeding amount_cents" do
+      before { create(:credit, applied_coupon:, invoice:, amount_cents: 150, organization:) }
 
-      before do
-        fee
-      end
-
-      it "returns 0" do
-        result = applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)
-        expect(result).to eq(0)
+      it "clamps remaining to 0" do
+        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)).to eq(0)
       end
     end
 
-    context "when multiple fees exist for the same subscription in different invoices" do
-      let(:fee_1) do
-        create(:fee,
-          invoice:,
-          subscription:,
-          organization:,
-          billing_entity:,
-          properties: {
-            "charges_from_datetime" => charges_from.iso8601,
-            "charges_to_datetime" => charges_to.iso8601
-          })
-      end
-      let(:invoice_2) { create(:invoice, customer:, organization:, billing_entity:) }
-      let(:fee_2) do
-        create(:fee,
-          invoice: invoice_2,
-          subscription:,
-          organization:,
-          billing_entity:,
-          properties: {
-            "charges_from_datetime" => charges_from.iso8601,
-            "charges_to_datetime" => charges_to.iso8601
-          })
-      end
-      let(:credit_1) do
-        create(:credit,
-          applied_coupon:,
-          invoice:,
-          amount_cents: 25,
-          organization:)
-      end
-      let(:credit_2) do
-        create(:credit,
-          applied_coupon:,
-          invoice: invoice_2,
-          amount_cents: 35,
-          organization:)
-      end
-
-      before do
-        fee_1
-        fee_2
-        credit_1
-        credit_2
-      end
-
-      it "sums credits from all matching invoices" do
-        result = applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)
-        expect(result).to eq(60)
-      end
-    end
-  end
-
-  describe "#credits_applied_in_billing_period_present?" do
-    let(:applied_coupon) { create(:applied_coupon) }
-    let(:organization) { applied_coupon.organization }
-    let(:customer) { applied_coupon.customer }
-    let(:subscription) { create(:subscription, customer:, organization:) }
-    let(:billing_entity) { organization.default_billing_entity }
-    let(:current_time) { Time.current }
-    let(:charges_from) { current_time.beginning_of_month }
-    let(:charges_to) { current_time.end_of_month }
-    let(:invoice) { create(:invoice, customer:, organization:, billing_entity:) }
-    let(:invoice_subscription) do
-      create(:invoice_subscription,
-        invoice:,
-        subscription:,
-        organization: organization,
-        charges_from_datetime: charges_from,
-        charges_to_datetime: charges_to)
-    end
-
-    before do
-      invoice_subscription
-    end
-
-    context "when credits are applied in the billing period" do
-      let(:fee) do
-        create(:fee,
-          invoice:,
-          subscription:,
-          organization:,
-          billing_entity:,
-          properties: {
-            "charges_from_datetime" => charges_from.iso8601,
-            "charges_to_datetime" => charges_to.iso8601
-          })
-      end
-      let(:credit) do
-        create(:credit,
-          applied_coupon:,
-          invoice:,
-          amount_cents: 50,
-          organization:)
-      end
-
-      before do
-        fee
-        credit
-      end
-
-      it "returns true" do
-        result = applied_coupon.credits_applied_in_billing_period_present?(invoice)
-        expect(result).to be true
+    context "memoization" do
+      it "caches per invoice id" do
+        first_call = applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)
+        second_call = applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)
+        expect(first_call).to eq(second_call).and eq(100)
       end
     end
 
-    context "when no credits are applied in the billing period" do
-      let(:fee) do
-        create(:fee,
-          invoice:,
-          subscription:,
-          organization:,
-          billing_entity:,
-          properties: {
-            "charges_from_datetime" => charges_from.iso8601,
-            "charges_to_datetime" => charges_to.iso8601
-          })
-      end
-
-      before do
-        fee
-      end
-
-      it "returns false" do
-        result = applied_coupon.credits_applied_in_billing_period_present?(invoice)
-        expect(result).to be false
-      end
-    end
-
-    context "when credits exist but for voided invoices" do
-      let(:voided_invoice) { create(:invoice, customer:, organization:, billing_entity:, status: :voided) }
-      let(:voided_invoice_subscription) do
-        create(:invoice_subscription,
-          invoice: voided_invoice,
-          subscription:,
-          organization:,
-          charges_from_datetime: charges_from,
-          charges_to_datetime: charges_to)
-      end
-      let(:fee) do
-        create(:fee,
-          invoice: voided_invoice,
-          subscription:,
-          organization:,
-          billing_entity:,
-          properties: {
-            "charges_from_datetime" => charges_from.iso8601,
-            "charges_to_datetime" => charges_to.iso8601
-          })
-      end
-      let(:credit) do
-        create(:credit,
-          applied_coupon:,
-          invoice: voided_invoice,
-          amount_cents: 50,
-          organization:)
-      end
-
-      before do
-        voided_invoice_subscription
-        fee
-        credit
-      end
-
-      it "returns false as voided invoice credits are excluded" do
-        result = applied_coupon.credits_applied_in_billing_period_present?(invoice)
-        expect(result).to be false
-      end
-    end
-
-    context "when invoice has multiple subscriptions with mixed credit scenarios" do
+    # Multi-subscription semantics: credits are summed across subs without de-duplicating
+    # invoice IDs. A credit on an invoice that has fees for both subs is therefore counted
+    # once per subscription. Conservative — never undercounts usage; may overcount slightly
+    # for the rare shared-invoice case. Per-sub semantics, sub-billed independently.
+    context "with multiple subscriptions on the invoice" do
       let(:subscription_2) { create(:subscription, customer:, organization:) }
-      let(:invoice_subscription_2) do
-        create(:invoice_subscription,
-          invoice:,
-          subscription: subscription_2,
-          organization:,
-          charges_from_datetime: charges_from,
-          charges_to_datetime: charges_to)
-      end
-      let(:fee_1) do
-        create(:fee,
-          invoice:,
-          subscription:,
-          organization:,
-          billing_entity:,
-          properties: {
-            "charges_from_datetime" => charges_from.iso8601,
-            "charges_to_datetime" => charges_to.iso8601
-          })
-      end
-      let(:fee_2) do
-        create(:fee,
-          invoice:,
-          subscription: subscription_2,
-          organization:,
-          billing_entity:,
-          properties: {
-            "charges_from_datetime" => charges_from.iso8601,
-            "charges_to_datetime" => charges_to.iso8601
-          })
-      end
-      let(:credit) do
-        create(:credit,
-          applied_coupon:,
-          invoice:,
-          amount_cents: 30,
-          organization:)
-      end
 
       before do
-        invoice_subscription_2
-        fee_1
-        fee_2
-        credit
+        create(:invoice_subscription, invoice:, subscription: subscription_2, organization:,
+          timestamp: Time.current, charges_from_datetime: period_start, charges_to_datetime: period_end)
+        add_fee(invoice, subscription_2, 20)
       end
 
-      it "returns true when at least one subscription has credits" do
-        result = applied_coupon.credits_applied_in_billing_period_present?(invoice)
-        expect(result).to be true
-      end
-    end
+      context "with a credit on the shared invoice" do
+        before { create(:credit, applied_coupon:, invoice:, amount_cents: 20, organization:) }
 
-    context "when credits exist but for invoice with fees outside billing period boundaries" do
-      let(:other_invoice) { create(:invoice, customer:, organization:, billing_entity:) }
-      let(:fee) do
-        create(:fee,
-          invoice: other_invoice,
-          subscription:,
-          organization:,
-          billing_entity:,
-          properties: {
-            "charges_from_datetime" => (charges_from - 1.month).iso8601,
-            "charges_to_datetime" => (charges_to - 1.month).iso8601
-          })
-      end
-      let(:credit) do
-        create(:credit,
-          applied_coupon:,
-          invoice: other_invoice,
-          amount_cents: 50,
-          organization:)
+        it "counts the credit once per subscription on that invoice" do
+          # Sub uses $20, sub_2 uses $20 (same credit, counted twice). Sum=$40, remaining=$60.
+          expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)).to eq(60)
+        end
       end
 
-      before do
-        fee
-        credit
+      context "with credits split between subscriptions" do
+        before do
+          create(:credit, applied_coupon:, invoice:, amount_cents: 20, organization:)
+          other = add_period_invoice(subs: [subscription_2])
+          add_fee(other, subscription_2, 20)
+          create(:credit, applied_coupon:, invoice: other, amount_cents: 30, organization:)
+        end
+
+        it "sums credits per-subscription across all in-period invoices" do
+          # sub: $20. sub_2: $20 (shared) + $30 (other) = $50. Sum=$70, remaining=$30.
+          expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)).to eq(30)
+        end
       end
 
-      it "returns false as credits are outside the billing period" do
-        result = applied_coupon.credits_applied_in_billing_period_present?(invoice)
-        expect(result).to be false
+      context "with one subscription that has no usage in this period" do
+        let(:subscription_3) { create(:subscription, customer:, organization:) }
+        let(:invoice_3) { add_period_invoice(subs: [subscription_3, subscription_2]) }
+
+        before do
+          add_fee(invoice_3, subscription_3, 20)
+          create(:credit, applied_coupon:, invoice:, amount_cents: 20, organization:)
+        end
+
+        it "sums credits found via any subscription's billing period" do
+          # sub_3: $0. sub_2: $20 (on invoice). Sum=$20, remaining=$80.
+          expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice_3)).to eq(80)
+        end
       end
     end
   end

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe AppliedCoupon do
       it "remaining decreases by the credit, present? is true" do
         expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)).to eq(70)
         expect(applied_coupon.credits_applied_in_billing_period_present?(invoice)).to be(true)
+        expect(applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)).to eq(30)
       end
     end
 
@@ -157,6 +158,7 @@ RSpec.describe AppliedCoupon do
       it "ignores voided-invoice credits" do
         expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)).to eq(100)
         expect(applied_coupon.credits_applied_in_billing_period_present?(invoice)).to be(false)
+        expect(applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)).to eq(0)
       end
     end
 
@@ -170,6 +172,7 @@ RSpec.describe AppliedCoupon do
       it "excludes credits outside the billing period" do
         expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)).to eq(100)
         expect(applied_coupon.credits_applied_in_billing_period_present?(invoice)).to be(false)
+        expect(applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)).to eq(0)
       end
     end
 
@@ -208,6 +211,9 @@ RSpec.describe AppliedCoupon do
         it "counts the credit once per subscription on that invoice" do
           # Sub uses $20, sub_2 uses $20 (same credit, counted twice). Sum=$40, remaining=$60.
           expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)).to eq(60)
+          # this is only for the first subscription
+          expect(applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)).to eq(20)
+          expect(applied_coupon.credits_applied_in_billing_period_present?(invoice)).to be(true)
         end
       end
 
@@ -222,6 +228,7 @@ RSpec.describe AppliedCoupon do
         it "sums credits per-subscription across all in-period invoices" do
           # sub: $20. sub_2: $20 (shared) + $30 (other) = $50. Sum=$70, remaining=$30.
           expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice:)).to eq(30)
+          expect(applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)).to eq(20)
         end
       end
 

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -86,10 +86,618 @@ RSpec.describe AppliedCoupon do
     end
   end
 
+  describe "#remaining_amount_for_this_subscription_billing_period" do
+    let(:applied_coupon) { create(:applied_coupon, amount_cents: 100) }
+    let(:organization) { applied_coupon.organization }
+    let(:customer) { applied_coupon.customer }
+    let(:subscription) { create(:subscription, customer:, organization:) }
+    let(:current_time) { Time.current }
+    let(:invoice) { create(:invoice, :subscription, customer:, organization:, subscriptions: [subscription]) }
+    let(:invoice_fee) do
+      create(:fee, invoice:, subscription:, amount_cents: 20, organization:,
+        properties: {charges_from_datetime: current_time.beginning_of_month,
+                     charges_to_datetime: current_time.end_of_month})
+    end
+
+    before do
+      invoice.invoice_subscriptions.update(timestamp: current_time, charges_from_datetime: current_time.beginning_of_month, charges_to_datetime: current_time.end_of_month)
+      invoice_fee
+    end
+
+    context "when no credits exist for the billing period" do
+      it "returns the full amount" do
+        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(100)
+      end
+    end
+
+    context "when credits exist for another invoice in the same billing period" do
+      let(:other_invoice) { create(:invoice, :subscription, customer:, organization:, subscriptions: [subscription]) }
+      let(:credit) do
+        create(:credit,
+          applied_coupon: applied_coupon,
+          invoice: other_invoice,
+          amount_cents: 30,
+          organization:)
+      end
+      let(:other_invoice_fee) do
+        create(:fee, invoice: other_invoice, subscription:, amount_cents: 20,
+          properties: {charges_from_datetime: current_time.beginning_of_month,
+                       charges_to_datetime: current_time.end_of_month})
+      end
+
+      before do
+        other_invoice.invoice_subscriptions.update(timestamp: current_time, charges_from_datetime: current_time.beginning_of_month,
+          charges_to_datetime: current_time.end_of_month)
+        other_invoice_fee
+        credit
+      end
+
+      it "returns the amount minus the credit" do
+        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(70)
+      end
+    end
+
+    context "when credits exist in non-overlapping billing periods" do
+      let(:other_invoice) { create(:invoice, :subscription, customer:, organization:, subscriptions: [subscription]) }
+      let(:other_invoice_fee) do
+        create(:fee, invoice: other_invoice, subscription:, amount_cents: 20, organization:,
+          properties: {charges_from_datetime: current_time.beginning_of_month - 1.month,
+                       charges_to_datetime: current_time.end_of_month - 1.month})
+      end
+
+      before do
+        other_invoice.invoice_subscriptions.update(timestamp: current_time, charges_from_datetime: current_time.beginning_of_month - 1.month, charges_to_datetime: current_time.end_of_month - 1.month)
+        other_invoice_fee
+        create(:credit,
+          applied_coupon: applied_coupon,
+          invoice: other_invoice,
+          amount_cents: 40,
+          organization:)
+      end
+
+      it "excludes credits from invoices with non-overlapping billing periods" do
+        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(100)
+      end
+    end
+
+    context "when credits exceed the original amount" do
+      let(:credit) do
+        create(:credit,
+          applied_coupon:,
+          invoice:,
+          amount_cents: 150,
+          organization:)
+      end
+
+      before do
+        credit
+      end
+
+      it "returns 0 (never negative)" do
+        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(0)
+      end
+    end
+
+    context "when invoice has voided credits" do
+      let(:voided_invoice) { create(:invoice, :subscription, :voided, customer:, organization:, subscriptions: [subscription]) }
+      let(:voided_invoice_fee) do
+        create(:fee, invoice: voided_invoice, subscription:, amount_cents: 20,
+          properties: {charges_from_datetime: current_time.beginning_of_month,
+                       charges_to_datetime: current_time.end_of_month})
+      end
+
+      before do
+        voided_invoice.invoice_subscriptions.update(timestamp: current_time, charges_from_datetime: current_time.beginning_of_month, charges_to_datetime: current_time.end_of_month)
+        voided_invoice_fee
+        create(:credit,
+          applied_coupon: applied_coupon,
+          invoice: voided_invoice,
+          amount_cents: 50,
+          organization: organization)
+      end
+
+      it "ignores voided invoice credits" do
+        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(100)
+      end
+    end
+
+    context "when called multiple times with the same invoice" do
+      it "caches the result" do
+        first_call = applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)
+        second_call = applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)
+
+        expect(first_call).to eq(second_call)
+        expect(first_call).to eq(100)
+      end
+    end
+
+    context "when invoice has multiple subscriptions with same billing period" do
+      let(:subscription_2) { create(:subscription, customer: customer, organization: organization) }
+      let(:invoice_subscription_2) do
+        create(:invoice_subscription,
+          invoice: invoice,
+          subscription: subscription_2,
+          organization: organization,
+          timestamp: current_time,
+          charges_from_datetime: current_time.beginning_of_month,
+          charges_to_datetime: current_time.end_of_month)
+      end
+      let(:invoice_fee_2) do
+        create(:fee, invoice: invoice, subscription: subscription_2, amount_cents: 20, organization:,
+          properties: {charges_from_datetime: current_time.beginning_of_month,
+                       charges_to_datetime: current_time.end_of_month})
+      end
+
+      # this credit is associated to subscription 1 and subscription 2
+      before do
+        invoice_subscription_2
+        create(:credit,
+          applied_coupon: applied_coupon,
+          invoice: invoice,
+          amount_cents: 20,
+          organization: organization)
+        invoice_fee_2
+      end
+
+      it "calculates based on the minimum used amount across all subscriptions" do
+        expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(80)
+      end
+
+      context "when each subscription has different remaining amount of the coupon" do
+        let(:invoice_2) { create(:invoice, :subscription, customer:, organization:, subscriptions: [subscription_2]) }
+        let(:invoice_2_fee) do
+          create(:fee, invoice: invoice_2, subscription: subscription_2, amount_cents: 20, organization:,
+            properties: {charges_from_datetime: current_time.beginning_of_month,
+                         charges_to_datetime: current_time.end_of_month})
+        end
+
+        # this credit is associated only to subscription 2
+        let(:credit_2) { create(:credit, applied_coupon:, invoice: invoice_2, amount_cents: 30, organization:) }
+
+        before do
+          invoice_2.invoice_subscriptions.update(timestamp: current_time, charges_from_datetime: current_time.beginning_of_month, charges_to_datetime: current_time.end_of_month)
+          credit_2
+          invoice_2_fee
+        end
+
+        # Note: subscription_2 has 50 credits, becasue it's associated to invoice and invoice_2,
+        # but subscription has 20 credits, so the remaining amount is 80
+        it "calculates based on the minimum used amount across all subscriptions" do
+          invoice.reload
+          expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(80)
+        end
+      end
+
+      context "when one of subscription has no usage" do
+        let(:subscription_3) { create(:subscription, customer:, organization:) }
+        let(:invoice_3) { create(:invoice, :subscription, customer:, organization:, subscriptions: [subscription_3, subscription_2]) }
+        let(:invoice_3_fee) do
+          create(:fee, invoice: invoice_3, subscription: subscription_3, amount_cents: 20, organization:,
+            properties: {charges_from_datetime: current_time.beginning_of_month,
+                         charges_to_datetime: current_time.end_of_month})
+        end
+
+        before do
+          invoice_3.invoice_subscriptions.update(timestamp: current_time, charges_from_datetime: current_time.beginning_of_month, charges_to_datetime: current_time.end_of_month)
+          invoice_3_fee
+        end
+
+        it "calculates based on the minimum used amount across all subscriptions" do
+          expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice_3)).to eq(100)
+        end
+      end
+    end
+  end
+
   describe "#mark_as_terminated!" do
     it "marks the applied coupon as terminated" do
       expect { applied_coupon.mark_as_terminated! }.to change(applied_coupon, :status).to("terminated").and \
         change(applied_coupon, :terminated_at).to be_present
+    end
+  end
+
+  describe "#credits_sum_for_invoice_subscription" do
+    let(:applied_coupon) { create(:applied_coupon) }
+    let(:organization) { applied_coupon.organization }
+    let(:customer) { applied_coupon.customer }
+    let(:subscription) { create(:subscription, customer:, organization:) }
+    let(:billing_entity) { organization.default_billing_entity }
+    let(:current_time) { Time.current }
+    let(:charges_from) { current_time.beginning_of_month }
+    let(:charges_to) { current_time.end_of_month }
+    let(:invoice) { create(:invoice, customer:, organization:, billing_entity:) }
+    let(:invoice_subscription) do
+      create(:invoice_subscription,
+        invoice:,
+        subscription:,
+        organization:,
+        charges_from_datetime: charges_from,
+        charges_to_datetime: charges_to)
+    end
+
+    before do
+      invoice_subscription
+    end
+
+    context "when fees exist with matching billing period boundaries and credits exist" do
+      let(:fee) do
+        create(:fee,
+          invoice:,
+          subscription:,
+          organization:,
+          billing_entity:,
+          properties: {
+            "charges_from_datetime" => charges_from.iso8601,
+            "charges_to_datetime" => charges_to.iso8601
+          })
+      end
+      let(:credit) do
+        create(:credit,
+          applied_coupon: applied_coupon,
+          invoice:,
+          amount_cents: 50,
+          organization:)
+      end
+
+      before do
+        fee
+        credit
+      end
+
+      it "returns the sum of credits for matching invoice IDs" do
+        result = applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)
+        expect(result).to eq(50)
+      end
+    end
+
+    context "when fees exist but outside billing period boundaries" do
+      let(:other_invoice) { create(:invoice, customer:, organization:, billing_entity:) }
+      let(:fee) do
+        create(:fee,
+          invoice: other_invoice,
+          subscription:,
+          organization:,
+          billing_entity:,
+          properties: {
+            "charges_from_datetime" => (charges_from - 1.month).iso8601,
+            "charges_to_datetime" => (charges_to - 1.month).iso8601
+          })
+      end
+      let(:credit) do
+        create(:credit,
+          applied_coupon:,
+          invoice: other_invoice,
+          amount_cents: 50,
+          organization:)
+      end
+
+      before do
+        fee
+        credit
+      end
+
+      it "returns 0 as no fees match the billing period" do
+        result = applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)
+        expect(result).to eq(0)
+      end
+    end
+
+    context "when no fees exist for the subscription" do
+      it "returns 0" do
+        result = applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)
+        expect(result).to eq(0)
+      end
+    end
+
+    context "when credits exist but for voided invoices" do
+      let(:voided_invoice) { create(:invoice, customer:, organization:, billing_entity:, status: :voided) }
+      let(:fee) do
+        create(:fee,
+          invoice: voided_invoice,
+          subscription:,
+          organization:,
+          billing_entity:,
+          properties: {
+            "charges_from_datetime" => charges_from.iso8601,
+            "charges_to_datetime" => charges_to.iso8601
+          })
+      end
+      let(:credit) do
+        create(:credit,
+          applied_coupon:,
+          invoice: voided_invoice,
+          amount_cents: 50,
+          organization:)
+      end
+
+      before do
+        fee
+        credit
+      end
+
+      it "excludes credits from voided invoices" do
+        result = applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)
+        expect(result).to eq(0)
+      end
+    end
+
+    context "when no credits exist" do
+      let(:fee) do
+        create(:fee,
+          invoice:,
+          subscription:,
+          organization:,
+          billing_entity:,
+          properties: {
+            "charges_from_datetime" => charges_from.iso8601,
+            "charges_to_datetime" => charges_to.iso8601
+          })
+      end
+
+      before do
+        fee
+      end
+
+      it "returns 0" do
+        result = applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)
+        expect(result).to eq(0)
+      end
+    end
+
+    context "when multiple fees exist for the same subscription in different invoices" do
+      let(:fee_1) do
+        create(:fee,
+          invoice:,
+          subscription:,
+          organization:,
+          billing_entity:,
+          properties: {
+            "charges_from_datetime" => charges_from.iso8601,
+            "charges_to_datetime" => charges_to.iso8601
+          })
+      end
+      let(:invoice_2) { create(:invoice, customer:, organization:, billing_entity:) }
+      let(:fee_2) do
+        create(:fee,
+          invoice: invoice_2,
+          subscription:,
+          organization:,
+          billing_entity:,
+          properties: {
+            "charges_from_datetime" => charges_from.iso8601,
+            "charges_to_datetime" => charges_to.iso8601
+          })
+      end
+      let(:credit_1) do
+        create(:credit,
+          applied_coupon:,
+          invoice:,
+          amount_cents: 25,
+          organization:)
+      end
+      let(:credit_2) do
+        create(:credit,
+          applied_coupon:,
+          invoice: invoice_2,
+          amount_cents: 35,
+          organization:)
+      end
+
+      before do
+        fee_1
+        fee_2
+        credit_1
+        credit_2
+      end
+
+      it "sums credits from all matching invoices" do
+        result = applied_coupon.credits_sum_for_invoice_subscription(invoice_subscription, invoice)
+        expect(result).to eq(60)
+      end
+    end
+  end
+
+  describe "#credits_applied_in_billing_period_present?" do
+    let(:applied_coupon) { create(:applied_coupon) }
+    let(:organization) { applied_coupon.organization }
+    let(:customer) { applied_coupon.customer }
+    let(:subscription) { create(:subscription, customer:, organization:) }
+    let(:billing_entity) { organization.default_billing_entity }
+    let(:current_time) { Time.current }
+    let(:charges_from) { current_time.beginning_of_month }
+    let(:charges_to) { current_time.end_of_month }
+    let(:invoice) { create(:invoice, customer:, organization:, billing_entity:) }
+    let(:invoice_subscription) do
+      create(:invoice_subscription,
+        invoice:,
+        subscription:,
+        organization: organization,
+        charges_from_datetime: charges_from,
+        charges_to_datetime: charges_to)
+    end
+
+    before do
+      invoice_subscription
+    end
+
+    context "when credits are applied in the billing period" do
+      let(:fee) do
+        create(:fee,
+          invoice:,
+          subscription:,
+          organization:,
+          billing_entity:,
+          properties: {
+            "charges_from_datetime" => charges_from.iso8601,
+            "charges_to_datetime" => charges_to.iso8601
+          })
+      end
+      let(:credit) do
+        create(:credit,
+          applied_coupon:,
+          invoice:,
+          amount_cents: 50,
+          organization:)
+      end
+
+      before do
+        fee
+        credit
+      end
+
+      it "returns true" do
+        result = applied_coupon.credits_applied_in_billing_period_present?(invoice)
+        expect(result).to be true
+      end
+    end
+
+    context "when no credits are applied in the billing period" do
+      let(:fee) do
+        create(:fee,
+          invoice:,
+          subscription:,
+          organization:,
+          billing_entity:,
+          properties: {
+            "charges_from_datetime" => charges_from.iso8601,
+            "charges_to_datetime" => charges_to.iso8601
+          })
+      end
+
+      before do
+        fee
+      end
+
+      it "returns false" do
+        result = applied_coupon.credits_applied_in_billing_period_present?(invoice)
+        expect(result).to be false
+      end
+    end
+
+    context "when credits exist but for voided invoices" do
+      let(:voided_invoice) { create(:invoice, customer:, organization:, billing_entity:, status: :voided) }
+      let(:voided_invoice_subscription) do
+        create(:invoice_subscription,
+          invoice: voided_invoice,
+          subscription:,
+          organization:,
+          charges_from_datetime: charges_from,
+          charges_to_datetime: charges_to)
+      end
+      let(:fee) do
+        create(:fee,
+          invoice: voided_invoice,
+          subscription:,
+          organization:,
+          billing_entity:,
+          properties: {
+            "charges_from_datetime" => charges_from.iso8601,
+            "charges_to_datetime" => charges_to.iso8601
+          })
+      end
+      let(:credit) do
+        create(:credit,
+          applied_coupon:,
+          invoice: voided_invoice,
+          amount_cents: 50,
+          organization:)
+      end
+
+      before do
+        voided_invoice_subscription
+        fee
+        credit
+      end
+
+      it "returns false as voided invoice credits are excluded" do
+        result = applied_coupon.credits_applied_in_billing_period_present?(invoice)
+        expect(result).to be false
+      end
+    end
+
+    context "when invoice has multiple subscriptions with mixed credit scenarios" do
+      let(:subscription_2) { create(:subscription, customer:, organization:) }
+      let(:invoice_subscription_2) do
+        create(:invoice_subscription,
+          invoice:,
+          subscription: subscription_2,
+          organization:,
+          charges_from_datetime: charges_from,
+          charges_to_datetime: charges_to)
+      end
+      let(:fee_1) do
+        create(:fee,
+          invoice:,
+          subscription:,
+          organization:,
+          billing_entity:,
+          properties: {
+            "charges_from_datetime" => charges_from.iso8601,
+            "charges_to_datetime" => charges_to.iso8601
+          })
+      end
+      let(:fee_2) do
+        create(:fee,
+          invoice:,
+          subscription: subscription_2,
+          organization:,
+          billing_entity:,
+          properties: {
+            "charges_from_datetime" => charges_from.iso8601,
+            "charges_to_datetime" => charges_to.iso8601
+          })
+      end
+      let(:credit) do
+        create(:credit,
+          applied_coupon:,
+          invoice:,
+          amount_cents: 30,
+          organization:)
+      end
+
+      before do
+        invoice_subscription_2
+        fee_1
+        fee_2
+        credit
+      end
+
+      it "returns true when at least one subscription has credits" do
+        result = applied_coupon.credits_applied_in_billing_period_present?(invoice)
+        expect(result).to be true
+      end
+    end
+
+    context "when credits exist but for invoice with fees outside billing period boundaries" do
+      let(:other_invoice) { create(:invoice, customer:, organization:, billing_entity:) }
+      let(:fee) do
+        create(:fee,
+          invoice: other_invoice,
+          subscription:,
+          organization:,
+          billing_entity:,
+          properties: {
+            "charges_from_datetime" => (charges_from - 1.month).iso8601,
+            "charges_to_datetime" => (charges_to - 1.month).iso8601
+          })
+      end
+      let(:credit) do
+        create(:credit,
+          applied_coupon:,
+          invoice: other_invoice,
+          amount_cents: 50,
+          organization:)
+      end
+
+      before do
+        fee
+        credit
+      end
+
+      it "returns false as credits are outside the billing period" do
+        result = applied_coupon.credits_applied_in_billing_period_present?(invoice)
+        expect(result).to be false
+      end
     end
   end
 end

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -260,11 +260,11 @@ RSpec.describe AppliedCoupon do
           invoice_2_fee
         end
 
-        # Note: subscription_2 has 50 credits, becasue it's associated to invoice and invoice_2,
-        # but subscription has 20 credits, so the remaining amount is 80
-        it "calculates based on the minimum used amount across all subscriptions" do
+        # Sum semantics: subscription has $20 in this period (on `invoice`), subscription_2 has
+        # $20 (on `invoice`) + $30 (on `invoice_2`) = $50. Total used = $70. Remaining = $30.
+        it "sums credits across all subscriptions on the invoice" do
           invoice.reload
-          expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(80)
+          expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice)).to eq(30)
         end
       end
 
@@ -282,8 +282,10 @@ RSpec.describe AppliedCoupon do
           invoice_3_fee
         end
 
-        it "calculates based on the minimum used amount across all subscriptions" do
-          expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice_3)).to eq(100)
+        # Sum semantics: subscription_3 used $0 in its period, subscription_2 used $20 (on `invoice`).
+        # Total = $20. Remaining = $80.
+        it "sums across subscriptions even when one has no usage" do
+          expect(applied_coupon.remaining_amount_for_this_subscription_billing_period(invoice: invoice_3)).to eq(80)
         end
       end
     end

--- a/spec/scenarios/coupons_breakdown_spec.rb
+++ b/spec/scenarios/coupons_breakdown_spec.rb
@@ -1387,8 +1387,11 @@ describe "Coupons breakdown Spec", :premium do
             subscription_invoice = progressive_subscription.invoices.order(:created_at).last
             expect(subscription_invoice.fees_amount_cents).to eq(50_00) # 30 units * $1 = $30 + subscription fee 20$
             expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(20_00)
-            expect(subscription_invoice.coupons_amount_cents).to eq(30_00)
-            expect(subscription_invoice.total_amount_cents).to eq(0)
+            # ISSUE-1007 sum semantics: coupon usage in this period across all invoices is
+            # 3 * $5 (pay_in_advance) + $20 (PB) = $35. Period budget = $50. Final invoice
+            # gets only the $15 remaining, not another $30.
+            expect(subscription_invoice.coupons_amount_cents).to eq(15_00)
+            expect(subscription_invoice.total_amount_cents).to eq(15_00) # $50 - $20 PB credit - $15 coupon
             expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(nil) # Forever
             expect(customer.applied_coupons.first.status).to eq("active")
           end

--- a/spec/scenarios/coupons_breakdown_spec.rb
+++ b/spec/scenarios/coupons_breakdown_spec.rb
@@ -327,106 +327,54 @@ describe "Coupons breakdown Spec", :premium do
   end
 
   context "when progressive billing and multiple subscriptions with multiple invoices" do
+    def setup_test_billable_metric
+      create_metric({name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1"})
+      organization.billable_metrics.find_by(code: "bm1")
+    end
+
+    def setup_pia_plan(bm)
+      create_plan({
+        name: "Pay in Advance Plan", code: "pay_in_advance_plan", interval: "monthly",
+        amount_cents: 0, amount_currency: "EUR", pay_in_advance: false,
+        charges: [{billable_metric_id: bm.id, charge_model: "standard", pay_in_advance: true, properties: {amount: "1"}}]
+      })
+      organization.plans.find_by(code: "pay_in_advance_plan")
+    end
+
+    def setup_pb_plan(bm, thresholds: [20_00, 50_00])
+      create_plan({
+        name: "Progressive Billing Plan", code: "progressive_plan", interval: "monthly",
+        amount_cents: 20_00, amount_currency: "EUR", pay_in_advance: false,
+        charges: [{billable_metric_id: bm.id, charge_model: "standard", pay_in_advance: false, properties: {amount: "1"}}],
+        usage_thresholds: thresholds.each_with_index.map { |c, i| {amount_cents: c, threshold_display_name: "Threshold #{i + 1}"} }
+      })
+      organization.plans.find_by(code: "progressive_plan")
+    end
+
+    def setup_pb_test_customer_and_subs(coupon_attrs, pia_plan, pb_plan, time0)
+      create_coupon(coupon_attrs)
+      create_or_update_customer({external_id: "customer-12345"})
+      apply_coupon({external_customer_id: "customer-12345", coupon_code: coupon_attrs[:code]})
+
+      travel_to(time0) do
+        create_subscription({external_customer_id: "customer-12345", external_id: "sub_pay_in_advance", plan_code: pia_plan.code}) if pia_plan
+        create_subscription({external_customer_id: "customer-12345", external_id: "sub_progressive", plan_code: pb_plan.code}) if pb_plan
+      end
+      organization.customers.find_by(external_id: "customer-12345")
+    end
+
     context "when coupon is single use" do
       it "applies the coupon, calculating the remaining amount", transaction: false do
-        # Create billable metric
-        create_metric({name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1"})
-        bm = organization.billable_metrics.find_by(code: "bm1")
-
-        # Create plan with pay_in_advance charge
-        create_plan(
-          {
-            name: "Pay in Advance Plan",
-            code: "pay_in_advance_plan",
-            interval: "monthly",
-            amount_cents: 0,
-            amount_currency: "EUR",
-            pay_in_advance: false,
-            charges: [
-              {
-                billable_metric_id: bm.id,
-                charge_model: "standard",
-                pay_in_advance: true,
-                properties: {amount: "1"}
-              }
-            ]
-          }
-        )
-        pay_in_advance_plan = organization.plans.find_by(code: "pay_in_advance_plan")
-
-        # Create plan with progressive billing
-        create_plan(
-          {
-            name: "Progressive Billing Plan",
-            code: "progressive_plan",
-            interval: "monthly",
-            amount_cents: 20_00, # $20
-            amount_currency: "EUR",
-            pay_in_advance: false,
-            charges: [
-              {
-                billable_metric_id: bm.id,
-                charge_model: "standard",
-                pay_in_advance: false,
-                properties: {amount: "1"} # $1 per unit
-              }
-            ],
-            usage_thresholds: [
-              {
-                amount_cents: 20_00, # $20 threshold
-                threshold_display_name: "First threshold"
-              },
-              {
-                amount_cents: 50_00, # $50 threshold
-                threshold_display_name: "Second threshold"
-              }
-            ]
-          }
-        )
-        progressive_plan = organization.plans.find_by(code: "progressive_plan")
-
-        # Create single use coupon
-        create_coupon(
-          {
-            name: "Single Use Coupon",
-            code: "single_use_coupon",
-            coupon_type: "fixed_amount",
-            frequency: "once",
-            amount_cents: 100_00, # $100
-            amount_currency: "EUR",
-            expiration: "no_expiration",
-            reusable: false
-          }
-        )
-
-        # Create customer and subscriptions
-        create_or_update_customer({external_id: "customer-12345"})
-        customer = organization.customers.find_by(external_id: "customer-12345")
-
-        # Apply coupon to customer
-        apply_coupon({external_customer_id: "customer-12345", coupon_code: "single_use_coupon"})
-
-        # Start subscriptions at time0
+        bm = setup_test_billable_metric
+        pay_in_advance_plan = setup_pia_plan(bm)
+        progressive_plan = setup_pb_plan(bm)
         time0 = DateTime.new(2025, 1, 1)
-        travel_to(time0) do
-          # Create pay in advance subscription
-          create_subscription(
-            {
-              external_customer_id: "customer-12345",
-              external_id: "sub_pay_in_advance",
-              plan_code: pay_in_advance_plan.code
-            }
-          )
-
-          # Create progressive billing subscription
-          create_subscription(
-            {
-              external_customer_id: "customer-12345",
-              external_id: "sub_progressive",
-              plan_code: progressive_plan.code
-            }
-          )
-        end
+        customer = setup_pb_test_customer_and_subs(
+          {name: "Single Use Coupon", code: "single_use_coupon", coupon_type: "fixed_amount",
+           frequency: "once", amount_cents: 100_00, amount_currency: "EUR",
+           expiration: "no_expiration", reusable: false},
+          pay_in_advance_plan, progressive_plan, time0
+        )
 
         # time0 + 5 days: send an event (5 units)
         travel_to(time0 + 5.days) do
@@ -580,105 +528,16 @@ describe "Coupons breakdown Spec", :premium do
     context "when coupon is recurring" do
       context "when recurring once" do
         it "applies the coupon only during one billing period, calculating the remaining amount", transaction: false do
-          # Create billable metric
-          create_metric({name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1"})
-          bm = organization.billable_metrics.find_by(code: "bm1")
-
-          # Create plan with pay_in_advance charge
-          create_plan(
-            {
-              name: "Pay in Advance Plan",
-              code: "pay_in_advance_plan",
-              interval: "monthly",
-              amount_cents: 0,
-              amount_currency: "EUR",
-              pay_in_advance: false,
-              charges: [
-                {
-                  billable_metric_id: bm.id,
-                  charge_model: "standard",
-                  pay_in_advance: true,
-                  properties: {amount: "1"}
-                }
-              ]
-            }
-          )
-          pay_in_advance_plan = organization.plans.find_by(code: "pay_in_advance_plan")
-
-          # Create plan with progressive billing
-          create_plan(
-            {
-              name: "Progressive Billing Plan",
-              code: "progressive_plan",
-              interval: "monthly",
-              amount_cents: 20_00, # $20
-              amount_currency: "EUR",
-              pay_in_advance: false,
-              charges: [
-                {
-                  billable_metric_id: bm.id,
-                  charge_model: "standard",
-                  pay_in_advance: false,
-                  properties: {amount: "1"} # $1 per unit
-                }
-              ],
-              usage_thresholds: [
-                {
-                  amount_cents: 20_00, # $20 threshold
-                  threshold_display_name: "First threshold"
-                },
-                {
-                  amount_cents: 50_00, # $50 threshold
-                  threshold_display_name: "Second threshold"
-                }
-              ]
-            }
-          )
-          progressive_plan = organization.plans.find_by(code: "progressive_plan")
-
-          # Create recurring coupon with frequency equal 1 month
-          create_coupon(
-            {
-              name: "Single Use Coupon",
-              code: "single_use_coupon",
-              coupon_type: "fixed_amount",
-              frequency: "recurring",
-              frequency_duration: 1,
-              amount_cents: 100_00, # $100
-              amount_currency: "EUR",
-              expiration: "no_expiration",
-              reusable: false
-            }
-          )
-
-          # Create customer and subscriptions
-          create_or_update_customer({external_id: "customer-12345"})
-          customer = organization.customers.find_by(external_id: "customer-12345")
-
-          # Apply coupon to customer
-          apply_coupon({external_customer_id: "customer-12345", coupon_code: "single_use_coupon"})
-
-          # Start subscriptions at time0
+          bm = setup_test_billable_metric
+          pay_in_advance_plan = setup_pia_plan(bm)
+          progressive_plan = setup_pb_plan(bm)
           time0 = DateTime.new(2025, 1, 1)
-          travel_to(time0) do
-            # Create pay in advance subscription
-            create_subscription(
-              {
-                external_customer_id: "customer-12345",
-                external_id: "sub_pay_in_advance",
-                plan_code: pay_in_advance_plan.code
-              }
-            )
-
-            # Create progressive billing subscription
-            create_subscription(
-              {
-                external_customer_id: "customer-12345",
-                external_id: "sub_progressive",
-                plan_code: progressive_plan.code
-              }
-            )
-          end
+          customer = setup_pb_test_customer_and_subs(
+            {name: "Single Use Coupon", code: "single_use_coupon", coupon_type: "fixed_amount",
+             frequency: "recurring", frequency_duration: 1, amount_cents: 100_00, amount_currency: "EUR",
+             expiration: "no_expiration", reusable: false},
+            pay_in_advance_plan, progressive_plan, time0
+          )
 
           # time0 + 5 days: send an event (5 units)
           travel_to(time0 + 5.days) do
@@ -830,63 +689,15 @@ describe "Coupons breakdown Spec", :premium do
         end
 
         it "does not terminate if nothing was billed" do
-          # Create billable metric
-          create_metric({name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1"})
-          bm = organization.billable_metrics.find_by(code: "bm1")
-
-          # Create plan with pay_in_advance charge
-          create_plan(
-            {
-              name: "Pay in Advance Plan",
-              code: "pay_in_advance_plan",
-              interval: "monthly",
-              amount_cents: 0,
-              amount_currency: "EUR",
-              pay_in_advance: false,
-              charges: [
-                {
-                  billable_metric_id: bm.id,
-                  charge_model: "standard",
-                  pay_in_advance: true,
-                  properties: {amount: "1"}
-                }
-              ]
-            }
-          )
-          pay_in_advance_plan = organization.plans.find_by(code: "pay_in_advance_plan")
-
-          create_coupon(
-            {
-              name: "Recurring Coupon",
-              code: "recurring_coupon",
-              coupon_type: "fixed_amount",
-              frequency: "recurring",
-              frequency_duration: 1,
-              amount_cents: 100_00, # $100
-              amount_currency: "EUR",
-              expiration: "no_expiration",
-              reusable: false
-            }
-          )
-
-          create_or_update_customer({external_id: "customer-12345"})
-          customer = organization.customers.find_by(external_id: "customer-12345")
-
-          # Apply coupon to customer
-          apply_coupon({external_customer_id: "customer-12345", coupon_code: "recurring_coupon"})
-
-          # Start subscription at time0
+          bm = setup_test_billable_metric
+          pay_in_advance_plan = setup_pia_plan(bm)
           time0 = DateTime.new(2025, 1, 1)
-          travel_to(time0) do
-            # Create subscription
-            create_subscription(
-              {
-                external_customer_id: "customer-12345",
-                external_id: "sub_pay_in_advance",
-                plan_code: pay_in_advance_plan.code
-              }
-            )
-          end
+          customer = setup_pb_test_customer_and_subs(
+            {name: "Recurring Coupon", code: "recurring_coupon", coupon_type: "fixed_amount",
+             frequency: "recurring", frequency_duration: 1, amount_cents: 100_00, amount_currency: "EUR",
+             expiration: "no_expiration", reusable: false},
+            pay_in_advance_plan, nil, time0
+          )
 
           travel_to(time0 + 1.month) do
             perform_billing
@@ -903,105 +714,16 @@ describe "Coupons breakdown Spec", :premium do
 
       context "when recurring multiple times" do
         it "applies the coupon multiple times, calculating the remaining amount", transaction: false do
-          # Create billable metric
-          create_metric({name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1"})
-          bm = organization.billable_metrics.find_by(code: "bm1")
-
-          # Create plan with pay_in_advance charge
-          create_plan(
-            {
-              name: "Pay in Advance Plan",
-              code: "pay_in_advance_plan",
-              interval: "monthly",
-              amount_cents: 0,
-              amount_currency: "EUR",
-              pay_in_advance: false,
-              charges: [
-                {
-                  billable_metric_id: bm.id,
-                  charge_model: "standard",
-                  pay_in_advance: true,
-                  properties: {amount: "1"}
-                }
-              ]
-            }
-          )
-          pay_in_advance_plan = organization.plans.find_by(code: "pay_in_advance_plan")
-
-          # Create plan with progressive billing
-          create_plan(
-            {
-              name: "Progressive Billing Plan",
-              code: "progressive_plan",
-              interval: "monthly",
-              amount_cents: 20_00, # $20
-              amount_currency: "EUR",
-              pay_in_advance: false,
-              charges: [
-                {
-                  billable_metric_id: bm.id,
-                  charge_model: "standard",
-                  pay_in_advance: false,
-                  properties: {amount: "1"} # $1 per unit
-                }
-              ],
-              usage_thresholds: [
-                {
-                  amount_cents: 20_00, # $20 threshold
-                  threshold_display_name: "First threshold"
-                },
-                {
-                  amount_cents: 50_00, # $50 threshold
-                  threshold_display_name: "Second threshold"
-                }
-              ]
-            }
-          )
-          progressive_plan = organization.plans.find_by(code: "progressive_plan")
-
-          # Create recurring coupon with frequency equal 3 months
-          create_coupon(
-            {
-              name: "Recurring Coupon",
-              code: "recurring_coupon",
-              coupon_type: "fixed_amount",
-              frequency: "recurring",
-              frequency_duration: 3,
-              amount_cents: 100_00, # $100
-              amount_currency: "EUR",
-              expiration: "no_expiration",
-              reusable: false
-            }
-          )
-
-          # Create customer and subscriptions
-          create_or_update_customer({external_id: "customer-12345"})
-          customer = organization.customers.find_by(external_id: "customer-12345")
-
-          # Apply coupon to customer
-          apply_coupon({external_customer_id: "customer-12345", coupon_code: "recurring_coupon"})
-
-          # Start subscriptions at time0
+          bm = setup_test_billable_metric
+          pay_in_advance_plan = setup_pia_plan(bm)
+          progressive_plan = setup_pb_plan(bm)
           time0 = DateTime.new(2025, 1, 1)
-          travel_to(time0) do
-            # Create pay in advance subscription
-            create_subscription(
-              {
-                external_customer_id: "customer-12345",
-                external_id: "sub_pay_in_advance",
-                plan_code: pay_in_advance_plan.code
-              }
-            )
-
-            # Create progressive billing subscription
-            create_subscription(
-              {
-                external_customer_id: "customer-12345",
-                external_id: "sub_progressive",
-                plan_code: progressive_plan.code
-              }
-            )
-          end
+          customer = setup_pb_test_customer_and_subs(
+            {name: "Recurring Coupon", code: "recurring_coupon", coupon_type: "fixed_amount",
+             frequency: "recurring", frequency_duration: 3, amount_cents: 100_00, amount_currency: "EUR",
+             expiration: "no_expiration", reusable: false},
+            pay_in_advance_plan, progressive_plan, time0
+          )
 
           # time0 + 5 days: send events (5 units for pay in advance, 10 units for progressive billing)
           travel_to(time0 + 5.days) do
@@ -1208,109 +930,16 @@ describe "Coupons breakdown Spec", :premium do
 
       context "when recurring forever" do
         it "applies the coupon multiple times, calculating the remaining amount", transaction: false do
-          # Create billable metric
-          create_metric({name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1"})
-          bm = organization.billable_metrics.find_by(code: "bm1")
-
-          # Create plan with pay_in_advance charge
-          create_plan(
-            {
-              name: "Pay in Advance Plan",
-              code: "pay_in_advance_plan",
-              interval: "monthly",
-              amount_cents: 0,
-              amount_currency: "EUR",
-              pay_in_advance: false,
-              charges: [
-                {
-                  billable_metric_id: bm.id,
-                  charge_model: "standard",
-                  pay_in_advance: true,
-                  properties: {amount: "1"}
-                }
-              ]
-            }
-          )
-          pay_in_advance_plan = organization.plans.find_by(code: "pay_in_advance_plan")
-
-          # Create plan with progressive billing
-          create_plan(
-            {
-              name: "Progressive Billing Plan",
-              code: "progressive_plan",
-              interval: "monthly",
-              amount_cents: 20_00, # $20
-              amount_currency: "EUR",
-              pay_in_advance: false,
-              charges: [
-                {
-                  billable_metric_id: bm.id,
-                  charge_model: "standard",
-                  pay_in_advance: false,
-                  properties: {amount: "1"} # $1 per unit
-                }
-              ],
-              usage_thresholds: [
-                {
-                  amount_cents: 20_00, # $20 threshold
-                  threshold_display_name: "First threshold"
-                },
-                {
-                  amount_cents: 50_00, # $50 threshold
-                  threshold_display_name: "Second threshold"
-                },
-                {
-                  amount_cents: 80_00, # $80 threshold
-                  threshold_display_name: "Second threshold"
-                }
-              ]
-            }
-          )
-          progressive_plan = organization.plans.find_by(code: "progressive_plan")
-
-          # Create recurring coupon with frequency forever (nil frequency_duration)
-          create_coupon(
-            {
-              name: "Forever Recurring Coupon",
-              code: "forever_recurring_coupon",
-              coupon_type: "fixed_amount",
-              frequency: "forever",
-              frequency_duration: nil, # Forever
-              amount_cents: 50_00,
-              amount_currency: "EUR",
-              expiration: "no_expiration",
-              reusable: false
-            }
-          )
-
-          # Create customer and subscriptions
-          create_or_update_customer({external_id: "customer-12345"})
-          customer = organization.customers.find_by(external_id: "customer-12345")
-
-          # Apply coupon to customer
-          apply_coupon({external_customer_id: "customer-12345", coupon_code: "forever_recurring_coupon"})
-
-          # Start subscriptions at time0
+          bm = setup_test_billable_metric
+          pay_in_advance_plan = setup_pia_plan(bm)
+          progressive_plan = setup_pb_plan(bm, thresholds: [20_00, 50_00, 80_00])
           time0 = DateTime.new(2025, 1, 1)
-          travel_to(time0) do
-            # Create pay in advance subscription
-            create_subscription(
-              {
-                external_customer_id: "customer-12345",
-                external_id: "sub_pay_in_advance",
-                plan_code: pay_in_advance_plan.code
-              }
-            )
-
-            # Create progressive billing subscription
-            create_subscription(
-              {
-                external_customer_id: "customer-12345",
-                external_id: "sub_progressive",
-                plan_code: progressive_plan.code
-              }
-            )
-          end
+          customer = setup_pb_test_customer_and_subs(
+            {name: "Forever Recurring Coupon", code: "forever_recurring_coupon", coupon_type: "fixed_amount",
+             frequency: "forever", frequency_duration: nil, amount_cents: 50_00, amount_currency: "EUR",
+             expiration: "no_expiration", reusable: false},
+            pay_in_advance_plan, progressive_plan, time0
+          )
 
           # time0 + 5 days: send events (5 units for pay in advance, 10 units for progressive billing)
           travel_to(time0 + 5.days) do
@@ -1554,7 +1183,7 @@ describe "Coupons breakdown Spec", :premium do
   #
   # Customer's "paid" = sum of invoice totals; "refund" = sum of credit notes issued.
   # Net cash-out = paid - refund.
-  context "PB invoice + $20 coupon matrix (ISSUE-1007)", transaction: false do
+  context "with PB invoice and $20 coupon matrix (ISSUE-1007)", transaction: false do
     let(:start_time) { DateTime.new(2025, 1, 1) }
     let(:bm) do
       create_metric({name: "U", code: "u", aggregation_type: "sum_agg", field_name: "n"})
@@ -1575,7 +1204,7 @@ describe "Coupons breakdown Spec", :premium do
       create_coupon({
         name: "C", code: "c", coupon_type: "fixed_amount",
         frequency: frequency, amount_cents: 20_00, amount_currency: "EUR",
-        frequency_duration: (frequency == "recurring" ? 1 : nil),
+        frequency_duration: ((frequency == "recurring") ? 1 : nil),
         expiration: "no_expiration", reusable: false
       })
       create_or_update_customer({external_id: "cust"})
@@ -1611,7 +1240,7 @@ describe "Coupons breakdown Spec", :premium do
       end
     end
 
-    context "Sc1: 1 PB at $5, period total $35" do
+    context "with Sc1: 1 PB at $5, period total $35" do
       let(:thresholds) { [5_00] }
 
       def trigger_usage(sub)
@@ -1623,7 +1252,7 @@ describe "Coupons breakdown Spec", :premium do
       include_examples "matrix case", coupon: "forever", paid: 15_00, refund: 0
     end
 
-    context "Sc2: 1 PB at $30, period total $35" do
+    context "with Sc2: 1 PB at $30, period total $35" do
       let(:thresholds) { [30_00] }
 
       def trigger_usage(sub)
@@ -1635,7 +1264,7 @@ describe "Coupons breakdown Spec", :premium do
       include_examples "matrix case", coupon: "forever", paid: 15_00, refund: 0
     end
 
-    context "Sc3: 2 PBs at $5 and $30, period total $50" do
+    context "with Sc3: 2 PBs at $5 and $30, period total $50" do
       let(:thresholds) { [5_00, 30_00] }
 
       def trigger_usage(sub)
@@ -1648,7 +1277,7 @@ describe "Coupons breakdown Spec", :premium do
       include_examples "matrix case", coupon: "forever", paid: 30_00, refund: 0
     end
 
-    context "Sc4: PB at $40, usage clawed back to $0" do
+    context "with Sc4: PB at $40, usage clawed back to $0" do
       let(:thresholds) { [40_00] }
 
       def trigger_usage(sub)
@@ -1661,7 +1290,7 @@ describe "Coupons breakdown Spec", :premium do
       include_examples "matrix case", coupon: "forever", paid: 20_00, refund: 20_00
     end
 
-    context "Sc5: PB at $40, usage clawed back to $20" do
+    context "with Sc5: PB at $40, usage clawed back to $20" do
       let(:thresholds) { [40_00] }
 
       def trigger_usage(sub)

--- a/spec/scenarios/coupons_breakdown_spec.rb
+++ b/spec/scenarios/coupons_breakdown_spec.rb
@@ -1548,4 +1548,133 @@ describe "Coupons breakdown Spec", :premium do
       end
     end
   end
+
+  # ISSUE-1007: documents how a $20 fixed-amount coupon interacts with progressive billing
+  # for a single-subscription, single-billing-period across the matrix of PB amounts.
+  #
+  # Customer's "paid" = sum of invoice totals; "refund" = sum of credit notes issued.
+  # Net cash-out = paid - refund.
+  context "PB invoice + $20 coupon matrix (ISSUE-1007)", transaction: false do
+    let(:start_time) { DateTime.new(2025, 1, 1) }
+    let(:bm) do
+      create_metric({name: "U", code: "u", aggregation_type: "sum_agg", field_name: "n"})
+      organization.billable_metrics.find_by(code: "u")
+    end
+
+    def setup_pb_plan(thresholds_cents)
+      create_plan({
+        name: "P", code: "pb", interval: "monthly",
+        amount_cents: 0, amount_currency: "EUR", pay_in_advance: false,
+        charges: [{billable_metric_id: bm.id, charge_model: "standard", pay_in_advance: false, properties: {amount: "1"}}],
+        usage_thresholds: thresholds_cents.map { |c| {amount_cents: c} }
+      })
+      organization.plans.find_by(code: "pb")
+    end
+
+    def apply_fixed_coupon(frequency)
+      create_coupon({
+        name: "C", code: "c", coupon_type: "fixed_amount",
+        frequency: frequency, amount_cents: 20_00, amount_currency: "EUR",
+        frequency_duration: (frequency == "recurring" ? 1 : nil),
+        expiration: "no_expiration", reusable: false
+      })
+      create_or_update_customer({external_id: "cust"})
+      apply_coupon({external_customer_id: "cust", coupon_code: "c"})
+    end
+
+    def create_sub(plan)
+      travel_to(start_time) { create_subscription({external_customer_id: "cust", external_id: "s", plan_code: plan.code}) }
+      Subscription.find_by(external_id: "s")
+    end
+
+    def end_of_month_billing
+      travel_to(start_time + 1.month) { perform_billing }
+    end
+
+    def customer_totals
+      customer = organization.customers.find_by(external_id: "cust")
+      {
+        paid: customer.invoices.sum(:total_amount_cents),
+        refund: CreditNote.where(invoice_id: customer.invoices.pluck(:id)).sum(:credit_amount_cents)
+      }
+    end
+
+    shared_examples "matrix case" do |coupon:, paid:, refund:|
+      it "with #{coupon} coupon: customer pays $#{paid / 100.0}, refund $#{refund / 100.0}" do
+        plan = setup_pb_plan(thresholds)
+        apply_fixed_coupon(coupon)
+        sub = create_sub(plan)
+        trigger_usage(sub)
+        end_of_month_billing
+
+        expect(customer_totals).to eq(paid: paid, refund: refund)
+      end
+    end
+
+    context "Sc1: 1 PB at $5, period total $35" do
+      let(:thresholds) { [5_00] }
+
+      def trigger_usage(sub)
+        travel_to(start_time + 5.days) { ingest_event(sub, bm, 5) }
+        travel_to(start_time + 15.days) { ingest_event(sub, bm, 30) }
+      end
+
+      include_examples "matrix case", coupon: "once", paid: 15_00, refund: 0
+      include_examples "matrix case", coupon: "forever", paid: 15_00, refund: 0
+    end
+
+    context "Sc2: 1 PB at $30, period total $35" do
+      let(:thresholds) { [30_00] }
+
+      def trigger_usage(sub)
+        travel_to(start_time + 5.days) { ingest_event(sub, bm, 30) }
+        travel_to(start_time + 15.days) { ingest_event(sub, bm, 5) }
+      end
+
+      include_examples "matrix case", coupon: "once", paid: 15_00, refund: 0
+      include_examples "matrix case", coupon: "forever", paid: 15_00, refund: 0
+    end
+
+    context "Sc3: 2 PBs at $5 and $30, period total $50" do
+      let(:thresholds) { [5_00, 30_00] }
+
+      def trigger_usage(sub)
+        travel_to(start_time + 5.days) { ingest_event(sub, bm, 5) }
+        travel_to(start_time + 10.days) { ingest_event(sub, bm, 25) }
+        travel_to(start_time + 15.days) { ingest_event(sub, bm, 20) }
+      end
+
+      include_examples "matrix case", coupon: "once", paid: 30_00, refund: 0
+      include_examples "matrix case", coupon: "forever", paid: 30_00, refund: 0
+    end
+
+    context "Sc4: PB at $40, usage clawed back to $0" do
+      let(:thresholds) { [40_00] }
+
+      def trigger_usage(sub)
+        travel_to(start_time + 5.days) { ingest_event(sub, bm, 40) }
+        Event.where(external_subscription_id: sub.external_id).destroy_all
+        perform_usage_update
+      end
+
+      include_examples "matrix case", coupon: "once", paid: 20_00, refund: 20_00
+      include_examples "matrix case", coupon: "forever", paid: 20_00, refund: 20_00
+    end
+
+    context "Sc5: PB at $40, usage clawed back to $20" do
+      let(:thresholds) { [40_00] }
+
+      def trigger_usage(sub)
+        travel_to(start_time + 5.days) { ingest_event(sub, bm, 40) }
+        Event.where(external_subscription_id: sub.external_id).destroy_all
+        travel_to(start_time + 10.days) { ingest_event(sub, bm, 20) }
+      end
+
+      # Known limitation: $10 of coupon stays stranded on the PB for usage that was
+      # clawed back. Refund is the proportional cash portion only ($10), not the full
+      # $20 needed for the customer to come out at $0 owed.
+      include_examples "matrix case", coupon: "once", paid: 20_00, refund: 10_00
+      include_examples "matrix case", coupon: "forever", paid: 20_00, refund: 10_00
+    end
+  end
 end

--- a/spec/scenarios/coupons_breakdown_spec.rb
+++ b/spec/scenarios/coupons_breakdown_spec.rb
@@ -40,7 +40,7 @@ describe "Coupons breakdown Spec", :premium do
         create_tax({name: "Banking rates 1", code: "banking_rates1", rate: 10.0})
         create_tax({name: "Banking rates 2", code: "banking_rates2", rate: 20.0})
 
-        create_or_update_customer({ external_id: "customer-12345" })
+        create_or_update_customer({external_id: "customer-12345"})
 
         create_plan(
           {
@@ -400,7 +400,7 @@ describe "Coupons breakdown Spec", :premium do
         )
 
         # Create customer and subscriptions
-        create_or_update_customer({ external_id: "customer-12345" })
+        create_or_update_customer({external_id: "customer-12345"})
         customer = organization.customers.find_by(external_id: "customer-12345")
 
         # Apply coupon to customer
@@ -581,7 +581,7 @@ describe "Coupons breakdown Spec", :premium do
       context "when recurring once" do
         it "applies the coupon only during one billing period, calculating the remaining amount", transaction: false do
           # Create billable metric
-          create_metric({ name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1" })
+          create_metric({name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1"})
           bm = organization.billable_metrics.find_by(code: "bm1")
 
           # Create plan with pay_in_advance charge
@@ -652,7 +652,7 @@ describe "Coupons breakdown Spec", :premium do
           )
 
           # Create customer and subscriptions
-          create_or_update_customer({ external_id: "customer-12345" })
+          create_or_update_customer({external_id: "customer-12345"})
           customer = organization.customers.find_by(external_id: "customer-12345")
 
           # Apply coupon to customer
@@ -831,7 +831,7 @@ describe "Coupons breakdown Spec", :premium do
 
         it "does not terminate if nothing was billed" do
           # Create billable metric
-          create_metric({ name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1" })
+          create_metric({name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1"})
           bm = organization.billable_metrics.find_by(code: "bm1")
 
           # Create plan with pay_in_advance charge
@@ -869,7 +869,7 @@ describe "Coupons breakdown Spec", :premium do
             }
           )
 
-          create_or_update_customer({ external_id: "customer-12345" })
+          create_or_update_customer({external_id: "customer-12345"})
           customer = organization.customers.find_by(external_id: "customer-12345")
 
           # Apply coupon to customer
@@ -904,7 +904,7 @@ describe "Coupons breakdown Spec", :premium do
       context "when recurring multiple times" do
         it "applies the coupon multiple times, calculating the remaining amount", transaction: false do
           # Create billable metric
-          create_metric({ name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1" })
+          create_metric({name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1"})
           bm = organization.billable_metrics.find_by(code: "bm1")
 
           # Create plan with pay_in_advance charge
@@ -975,7 +975,7 @@ describe "Coupons breakdown Spec", :premium do
           )
 
           # Create customer and subscriptions
-          create_or_update_customer({ external_id: "customer-12345" })
+          create_or_update_customer({external_id: "customer-12345"})
           customer = organization.customers.find_by(external_id: "customer-12345")
 
           # Apply coupon to customer
@@ -1209,7 +1209,7 @@ describe "Coupons breakdown Spec", :premium do
       context "when recurring forever" do
         it "applies the coupon multiple times, calculating the remaining amount", transaction: false do
           # Create billable metric
-          create_metric({ name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1" })
+          create_metric({name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1"})
           bm = organization.billable_metrics.find_by(code: "bm1")
 
           # Create plan with pay_in_advance charge
@@ -1284,7 +1284,7 @@ describe "Coupons breakdown Spec", :premium do
           )
 
           # Create customer and subscriptions
-          create_or_update_customer({ external_id: "customer-12345" })
+          create_or_update_customer({external_id: "customer-12345"})
           customer = organization.customers.find_by(external_id: "customer-12345")
 
           # Apply coupon to customer

--- a/spec/scenarios/coupons_breakdown_spec.rb
+++ b/spec/scenarios/coupons_breakdown_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe "Coupons breakdown Spec", :premium do
-  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:organization) { create(:organization, webhook_url: nil, premium_integrations: ["progressive_billing"]) }
 
   before do
     organization
@@ -40,7 +40,7 @@ describe "Coupons breakdown Spec", :premium do
         create_tax({name: "Banking rates 1", code: "banking_rates1", rate: 10.0})
         create_tax({name: "Banking rates 2", code: "banking_rates2", rate: 20.0})
 
-        create_or_update_customer({external_id: "customer-12345"})
+        create_or_update_customer({ external_id: "customer-12345" })
 
         create_plan(
           {
@@ -323,6 +323,1226 @@ describe "Coupons breakdown Spec", :premium do
       expect(invoice.sub_total_excluding_taxes_amount_cents).to eq(16_500)
       expect(invoice.taxes_amount_cents).to eq(1_889)
       expect(invoice.total_amount_cents).to eq(18_389)
+    end
+  end
+
+  context "when progressive billing and multiple subscriptions with multiple invoices" do
+    context "when coupon is single use" do
+      it "applies the coupon, calculating the remaining amount", transaction: false do
+        # Create billable metric
+        create_metric({name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1"})
+        bm = organization.billable_metrics.find_by(code: "bm1")
+
+        # Create plan with pay_in_advance charge
+        create_plan(
+          {
+            name: "Pay in Advance Plan",
+            code: "pay_in_advance_plan",
+            interval: "monthly",
+            amount_cents: 0,
+            amount_currency: "EUR",
+            pay_in_advance: false,
+            charges: [
+              {
+                billable_metric_id: bm.id,
+                charge_model: "standard",
+                pay_in_advance: true,
+                properties: {amount: "1"}
+              }
+            ]
+          }
+        )
+        pay_in_advance_plan = organization.plans.find_by(code: "pay_in_advance_plan")
+
+        # Create plan with progressive billing
+        create_plan(
+          {
+            name: "Progressive Billing Plan",
+            code: "progressive_plan",
+            interval: "monthly",
+            amount_cents: 20_00, # $20
+            amount_currency: "EUR",
+            pay_in_advance: false,
+            charges: [
+              {
+                billable_metric_id: bm.id,
+                charge_model: "standard",
+                pay_in_advance: false,
+                properties: {amount: "1"} # $1 per unit
+              }
+            ],
+            usage_thresholds: [
+              {
+                amount_cents: 20_00, # $20 threshold
+                threshold_display_name: "First threshold"
+              },
+              {
+                amount_cents: 50_00, # $50 threshold
+                threshold_display_name: "Second threshold"
+              }
+            ]
+          }
+        )
+        progressive_plan = organization.plans.find_by(code: "progressive_plan")
+
+        # Create single use coupon
+        create_coupon(
+          {
+            name: "Single Use Coupon",
+            code: "single_use_coupon",
+            coupon_type: "fixed_amount",
+            frequency: "once",
+            amount_cents: 100_00, # $100
+            amount_currency: "EUR",
+            expiration: "no_expiration",
+            reusable: false
+          }
+        )
+
+        # Create customer and subscriptions
+        create_or_update_customer({ external_id: "customer-12345" })
+        customer = organization.customers.find_by(external_id: "customer-12345")
+
+        # Apply coupon to customer
+        apply_coupon({external_customer_id: "customer-12345", coupon_code: "single_use_coupon"})
+
+        # Start subscriptions at time0
+        time0 = DateTime.new(2025, 1, 1)
+        travel_to(time0) do
+          # Create pay in advance subscription
+          create_subscription(
+            {
+              external_customer_id: "customer-12345",
+              external_id: "sub_pay_in_advance",
+              plan_code: pay_in_advance_plan.code
+            }
+          )
+
+          # Create progressive billing subscription
+          create_subscription(
+            {
+              external_customer_id: "customer-12345",
+              external_id: "sub_progressive",
+              plan_code: progressive_plan.code
+            }
+          )
+        end
+
+        # time0 + 5 days: send an event (5 units)
+        travel_to(time0 + 5.days) do
+          pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+          progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+          ingest_event(pay_in_advance_subscription, bm, 5)
+          ingest_event(progressive_subscription, bm, 10)
+
+          # Check that invoice is generated for pay_in_advance
+          expect(pay_in_advance_subscription.invoices.count).to eq(1)
+
+          fee = pay_in_advance_subscription.fees.first
+          expect(fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+          expect(fee.pay_in_advance).to eq(true)
+
+          # Check that coupon was applied to the pay in advance invoice (coupons are applied to pay-in-advance)
+          invoice = pay_in_advance_subscription.invoices.first
+          expect(invoice).to be_present
+          expect(invoice.coupons_amount_cents).to eq(5_00) # Coupons are applied on pay in advance invoices
+          expect(invoice.fees_amount_cents).to eq(5_00)
+          expect(invoice.total_amount_cents).to eq(0)
+          expect(progressive_subscription.invoices.count).to eq(0)
+          perform_all_enqueued_jobs
+        end
+
+        # time0 + 10 days: send event (5 units) and perform lifetime calculation
+        travel_to(time0 + 10.days) do
+          pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+          progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+          ingest_event(pay_in_advance_subscription, bm, 5)
+          ingest_event(progressive_subscription, bm, 10)
+
+          # Check that progressive billing invoice is generated
+          # At time0 + 5 days: 10 units = $10 (does NOT exceed $20 threshold)
+          # At time0 + 10 days: 10 more units = $20 total (exceeds $20 threshold)
+          progressive_invoices = progressive_subscription.invoices
+          expect(progressive_invoices.count).to eq(1) # 1 progressive billing invoice
+
+          # Invoice should be for $20 (total usage at threshold)
+          progressive_invoice = progressive_invoices.first
+          expect(progressive_invoice.fees_amount_cents).to eq(20_00)
+          expect(progressive_invoice.coupons_amount_cents).to eq(20_00) # 20 units - 20$ coupon = 0
+          expect(progressive_invoice.total_amount_cents).to eq(0) # 20 units - 20$ coupon = 0
+
+          # Pay in advance should have another invoice
+          pay_in_advance_invoices = pay_in_advance_subscription.invoices
+          expect(pay_in_advance_invoices.count).to eq(2) # Original + new one
+        end
+
+        # time0 + 15 days: send an event (5 units)
+        travel_to(time0 + 15.days) do
+          pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+          progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+          ingest_event(pay_in_advance_subscription, bm, 5)
+          ingest_event(progressive_subscription, bm, 10)
+
+          # Check that invoice is generated for pay_in_advance
+          expect(pay_in_advance_subscription.fees.count).to eq(3) # 2 previous + 1 new
+          expect(progressive_subscription.fees.count).to eq(1) # 1 progressive billing fee
+
+          latest_fee = pay_in_advance_subscription.fees.order(:created_at).last
+          expect(latest_fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+          expect(latest_fee.pay_in_advance).to eq(true) # Pay in advance
+        end
+
+        # Travel to time0 + 1 month, run subscription billing
+        # coupon usage: 20$ progressive usage + 30$ subscription invoice + 3 * 5$ pay in advance invoice = 65$
+        travel_to(time0 + 1.month) do
+          perform_billing
+
+          # Check that invoices are generated
+          customer = organization.customers.find_by(external_id: "customer-12345")
+          expect(customer.invoices.count).to eq(5) # 3 pay in advance + 1 progressive_billing + 1 subscription
+          progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+          subscription_invoice = progressive_subscription.invoices.order(:created_at).last
+          expect(subscription_invoice.fees_amount_cents).to eq(50_00) # 30 units * $1 = $30 + subscription fee 20$
+          expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(20_00)
+          expect(subscription_invoice.coupons_amount_cents).to eq(30_00)
+          expect(subscription_invoice.total_amount_cents).to eq(0)
+        end
+        # coupon remaining: 35$
+
+        # Repeat for next month
+        time1 = time0 + 1.month
+        travel_to(time1 + 5.days) do
+          pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+          progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+          ingest_event(pay_in_advance_subscription, bm, 5)
+          ingest_event(progressive_subscription, bm, 10)
+
+          # Check that invoice is generated for pay_in_advance
+          expect(pay_in_advance_subscription.invoices.count).to eq(5) # 4 previous (3 pay in advance + 1 subscription) + 1 new (5 units)
+
+          fee = pay_in_advance_subscription.fees.order(:created_at).last
+          expect(fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+          expect(fee.pay_in_advance).to eq(true)
+
+          # Check that no coupon is applied since it's single use
+          invoice = pay_in_advance_subscription.invoices.order(:created_at).last
+          expect(invoice).to be_present
+          expect(invoice.fees_amount_cents).to eq(5_00)
+          expect(invoice.coupons_amount_cents).to eq(5_00) # 5$ coupon applied
+          expect(invoice.total_amount_cents).to eq(0)
+          expect(progressive_subscription.invoices.count).to eq(2) # 2 previous + 0 new (no threshold exceeded)
+          perform_all_enqueued_jobs
+        end
+
+        travel_to(time1 + 10.days) do
+          pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+          progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+          ingest_event(pay_in_advance_subscription, bm, 5)
+          ingest_event(progressive_subscription, bm, 10)
+
+          # Check that progressive billing invoice is generated
+          # At time1 + 5 days: 10 units = $10 (does NOT exceed $20 threshold)
+          # At time1 + 10 days: 10 more units = $20 total (exceeds $20 threshold)
+          progressive_invoices = progressive_subscription.invoices
+          expect(progressive_invoices.count).to eq(3) # 2 previous + 1 new
+
+          # Invoice should be for $20 (total usage at threshold)
+          progressive_invoice = progressive_invoices.order(:created_at).last
+          expect(progressive_invoice.fees_amount_cents).to eq(20_00)
+          expect(progressive_invoice.coupons_amount_cents).to eq(20_00) # 20 units - 20$ coupon = 0
+          expect(progressive_invoice.total_amount_cents).to eq(0) # 20 units - 20$ coupon = 0
+
+          # Pay in advance should have another invoice
+          pay_in_advance_invoices = pay_in_advance_subscription.invoices
+          expect(pay_in_advance_invoices.count).to eq(6) # 5 previous (4 pay in advance + 1 subscription) + 1 new (5 units)
+        end
+
+        # coupon remaining: 5$
+        travel_to(time1 + 1.month) do
+          perform_billing
+
+          # Check that invoices are generated
+          customer = organization.customers.find_by(external_id: "customer-12345")
+          # Pay in advance: 3 prev month + 2 this month
+          # Progressive billing: 1 prev month + 1 this month
+          # Subscription: 1 prev month + 1 this month (combines both subscriptions through invoice_subscriptions)
+          expect(customer.invoices.count).to eq(9) # 5 previous + 3 pay in advance + 1 progressive_billing + 1 subscription
+          progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+          subscription_invoice = progressive_subscription.invoices.order(:created_at).last
+          expect(subscription_invoice.fees_amount_cents).to eq(40_00) # 20 units * $1 = $20 + subscription fee 20$
+          expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(20_00)
+          expect(subscription_invoice.coupons_amount_cents).to eq(5_00) # 5$ coupon applied
+          expect(subscription_invoice.total_amount_cents).to eq(15_00) # 40$ - 20$ credit - 5$ coupon = 15$
+        end
+      end
+    end
+
+    context "when coupon is recurring" do
+      context "when recurring once" do
+        it "applies the coupon only during one billing period, calculating the remaining amount", transaction: false do
+          # Create billable metric
+          create_metric({ name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1" })
+          bm = organization.billable_metrics.find_by(code: "bm1")
+
+          # Create plan with pay_in_advance charge
+          create_plan(
+            {
+              name: "Pay in Advance Plan",
+              code: "pay_in_advance_plan",
+              interval: "monthly",
+              amount_cents: 0,
+              amount_currency: "EUR",
+              pay_in_advance: false,
+              charges: [
+                {
+                  billable_metric_id: bm.id,
+                  charge_model: "standard",
+                  pay_in_advance: true,
+                  properties: {amount: "1"}
+                }
+              ]
+            }
+          )
+          pay_in_advance_plan = organization.plans.find_by(code: "pay_in_advance_plan")
+
+          # Create plan with progressive billing
+          create_plan(
+            {
+              name: "Progressive Billing Plan",
+              code: "progressive_plan",
+              interval: "monthly",
+              amount_cents: 20_00, # $20
+              amount_currency: "EUR",
+              pay_in_advance: false,
+              charges: [
+                {
+                  billable_metric_id: bm.id,
+                  charge_model: "standard",
+                  pay_in_advance: false,
+                  properties: {amount: "1"} # $1 per unit
+                }
+              ],
+              usage_thresholds: [
+                {
+                  amount_cents: 20_00, # $20 threshold
+                  threshold_display_name: "First threshold"
+                },
+                {
+                  amount_cents: 50_00, # $50 threshold
+                  threshold_display_name: "Second threshold"
+                }
+              ]
+            }
+          )
+          progressive_plan = organization.plans.find_by(code: "progressive_plan")
+
+          # Create recurring coupon with frequency equal 1 month
+          create_coupon(
+            {
+              name: "Single Use Coupon",
+              code: "single_use_coupon",
+              coupon_type: "fixed_amount",
+              frequency: "recurring",
+              frequency_duration: 1,
+              amount_cents: 100_00, # $100
+              amount_currency: "EUR",
+              expiration: "no_expiration",
+              reusable: false
+            }
+          )
+
+          # Create customer and subscriptions
+          create_or_update_customer({ external_id: "customer-12345" })
+          customer = organization.customers.find_by(external_id: "customer-12345")
+
+          # Apply coupon to customer
+          apply_coupon({external_customer_id: "customer-12345", coupon_code: "single_use_coupon"})
+
+          # Start subscriptions at time0
+          time0 = DateTime.new(2025, 1, 1)
+          travel_to(time0) do
+            # Create pay in advance subscription
+            create_subscription(
+              {
+                external_customer_id: "customer-12345",
+                external_id: "sub_pay_in_advance",
+                plan_code: pay_in_advance_plan.code
+              }
+            )
+
+            # Create progressive billing subscription
+            create_subscription(
+              {
+                external_customer_id: "customer-12345",
+                external_id: "sub_progressive",
+                plan_code: progressive_plan.code
+              }
+            )
+          end
+
+          # time0 + 5 days: send an event (5 units)
+          travel_to(time0 + 5.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that invoice is generated for pay_in_advance
+            expect(pay_in_advance_subscription.invoices.count).to eq(1)
+
+            fee = pay_in_advance_subscription.fees.first
+            expect(fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+            expect(fee.pay_in_advance).to eq(true)
+
+            # Check that coupon was applied to the pay in advance invoice (coupons are applied to pay-in-advance)
+            invoice = pay_in_advance_subscription.invoices.first
+            expect(invoice).to be_present
+            expect(invoice.coupons_amount_cents).to eq(5_00) # Coupons are applied on pay in advance invoices
+            expect(invoice.fees_amount_cents).to eq(5_00)
+            expect(invoice.total_amount_cents).to eq(0)
+            expect(progressive_subscription.invoices.count).to eq(0)
+            perform_all_enqueued_jobs
+          end
+
+          # time0 + 10 days: send event (5 units) and perform lifetime calculation
+          travel_to(time0 + 10.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that progressive billing invoice is generated
+            # At time0 + 5 days: 10 units = $10 (does NOT exceed $20 threshold)
+            # At time0 + 10 days: 10 more units = $20 total (exceeds $20 threshold)
+            progressive_invoices = progressive_subscription.invoices
+            expect(progressive_invoices.count).to eq(1) # 1 progressive billing invoice
+
+            # Invoice should be for $20 (total usage at threshold)
+            progressive_invoice = progressive_invoices.first
+            expect(progressive_invoice.fees_amount_cents).to eq(20_00)
+            expect(progressive_invoice.coupons_amount_cents).to eq(20_00) # 20 units - 20$ coupon = 0
+            expect(progressive_invoice.total_amount_cents).to eq(0) # 20 units - 20$ coupon = 0
+
+            # Pay in advance should have another invoice
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices
+            expect(pay_in_advance_invoices.count).to eq(2) # Original + new one
+          end
+
+          # time0 + 15 days: send an event (5 units)
+          travel_to(time0 + 15.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that invoice is generated for pay_in_advance
+            expect(pay_in_advance_subscription.fees.count).to eq(3) # 2 previous + 1 new
+            expect(progressive_subscription.fees.count).to eq(1) # 1 progressive billing fee
+
+            latest_fee = pay_in_advance_subscription.fees.order(:created_at).last
+            expect(latest_fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+            expect(latest_fee.pay_in_advance).to eq(true) # Pay in advance
+          end
+
+          # Travel to time0 + 1 month, run subscription billing
+          # coupon usage: 20$ progressive usage + 30$ subscription invoice + 3 * 5$ pay in advance invoice = 65$
+          travel_to(time0 + 1.month) do
+            perform_billing
+
+            # Check that invoices are generated
+            customer = organization.customers.find_by(external_id: "customer-12345")
+            expect(customer.invoices.count).to eq(5) # 3 pay in advance + 1 progressive_billing + 1 subscription
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            subscription_invoice = progressive_subscription.invoices.order(:created_at).last
+            expect(subscription_invoice.fees_amount_cents).to eq(50_00) # 30 units * $1 = $30 + subscription fee 20$
+            expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(20_00)
+            expect(subscription_invoice.coupons_amount_cents).to eq(30_00)
+            expect(subscription_invoice.total_amount_cents).to eq(0)
+          end
+          # coupon remaining: 35$
+          # coupon is terminated
+
+          # Repeat for next month
+          time1 = time0 + 1.month
+          travel_to(time1 + 5.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that invoice is generated for pay_in_advance
+            expect(pay_in_advance_subscription.invoices.count).to eq(5) # 4 previous (3 pay in advance + 1 subscription) + 1 new (5 units)
+
+            fee = pay_in_advance_subscription.fees.order(:created_at).last
+            expect(fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+            expect(fee.pay_in_advance).to eq(true)
+
+            # Check that no coupon is applied since it's single use
+            invoice = pay_in_advance_subscription.invoices.order(:created_at).last
+            expect(invoice).to be_present
+            expect(invoice.fees_amount_cents).to eq(5_00)
+            expect(invoice.coupons_amount_cents).to eq(0)
+            expect(invoice.total_amount_cents).to eq(5_00)
+            expect(progressive_subscription.invoices.count).to eq(2) # 2 previous + 0 new (no threshold exceeded)
+            perform_all_enqueued_jobs
+          end
+
+          travel_to(time1 + 10.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that progressive billing invoice is generated
+            # At time1 + 5 days: 10 units = $10 (does NOT exceed $20 threshold)
+            # At time1 + 10 days: 10 more units = $20 total (exceeds $20 threshold)
+            progressive_invoices = progressive_subscription.invoices
+            expect(progressive_invoices.count).to eq(3) # 2 previous + 1 new
+
+            # Invoice should be for $20 (total usage at threshold)
+            progressive_invoice = progressive_invoices.order(:created_at).last
+            expect(progressive_invoice.fees_amount_cents).to eq(20_00)
+            expect(progressive_invoice.coupons_amount_cents).to eq(0)
+            expect(progressive_invoice.total_amount_cents).to eq(20_00) # 20 units - 20$ coupon = 0
+
+            # Pay in advance should have another invoice
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices
+            expect(pay_in_advance_invoices.count).to eq(6) # 5 previous (4 pay in advance + 1 subscription) + 1 new (5 units)
+          end
+
+          # coupon remaining: 5$
+          travel_to(time1 + 1.month) do
+            perform_billing
+
+            # Check that invoices are generated
+            customer = organization.customers.find_by(external_id: "customer-12345")
+            # Pay in advance: 3 prev month + 2 this month
+            # Progressive billing: 1 prev month + 1 this month
+            # Subscription: 1 prev month + 1 this month (combines both subscriptions through invoice_subscriptions)
+            expect(customer.invoices.count).to eq(9) # 5 previous + 3 pay in advance + 1 progressive_billing + 1 subscription
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            subscription_invoice = progressive_subscription.invoices.order(:created_at).last
+            expect(subscription_invoice.fees_amount_cents).to eq(40_00) # 20 units * $1 = $20 + subscription fee 20$
+            expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(20_00)
+            expect(subscription_invoice.coupons_amount_cents).to eq(0)
+            expect(subscription_invoice.total_amount_cents).to eq(20_00) # 20$ - 20$ credit = 20$
+          end
+        end
+
+        it "does not terminate if nothing was billed" do
+          # Create billable metric
+          create_metric({ name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1" })
+          bm = organization.billable_metrics.find_by(code: "bm1")
+
+          # Create plan with pay_in_advance charge
+          create_plan(
+            {
+              name: "Pay in Advance Plan",
+              code: "pay_in_advance_plan",
+              interval: "monthly",
+              amount_cents: 0,
+              amount_currency: "EUR",
+              pay_in_advance: false,
+              charges: [
+                {
+                  billable_metric_id: bm.id,
+                  charge_model: "standard",
+                  pay_in_advance: true,
+                  properties: {amount: "1"}
+                }
+              ]
+            }
+          )
+          pay_in_advance_plan = organization.plans.find_by(code: "pay_in_advance_plan")
+
+          create_coupon(
+            {
+              name: "Recurring Coupon",
+              code: "recurring_coupon",
+              coupon_type: "fixed_amount",
+              frequency: "recurring",
+              frequency_duration: 1,
+              amount_cents: 100_00, # $100
+              amount_currency: "EUR",
+              expiration: "no_expiration",
+              reusable: false
+            }
+          )
+
+          create_or_update_customer({ external_id: "customer-12345" })
+          customer = organization.customers.find_by(external_id: "customer-12345")
+
+          # Apply coupon to customer
+          apply_coupon({external_customer_id: "customer-12345", coupon_code: "recurring_coupon"})
+
+          # Start subscription at time0
+          time0 = DateTime.new(2025, 1, 1)
+          travel_to(time0) do
+            # Create subscription
+            create_subscription(
+              {
+                external_customer_id: "customer-12345",
+                external_id: "sub_pay_in_advance",
+                plan_code: pay_in_advance_plan.code
+              }
+            )
+          end
+
+          travel_to(time0 + 1.month) do
+            perform_billing
+
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+
+            # Check that invoice is generated for pay in advance
+            expect(pay_in_advance_subscription.invoices.count).to eq(1)
+            expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(1)
+            expect(customer.applied_coupons.first.status).to eq("active")
+          end
+        end
+      end
+
+      context "when recurring multiple times" do
+        it "applies the coupon multiple times, calculating the remaining amount", transaction: false do
+          # Create billable metric
+          create_metric({ name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1" })
+          bm = organization.billable_metrics.find_by(code: "bm1")
+
+          # Create plan with pay_in_advance charge
+          create_plan(
+            {
+              name: "Pay in Advance Plan",
+              code: "pay_in_advance_plan",
+              interval: "monthly",
+              amount_cents: 0,
+              amount_currency: "EUR",
+              pay_in_advance: false,
+              charges: [
+                {
+                  billable_metric_id: bm.id,
+                  charge_model: "standard",
+                  pay_in_advance: true,
+                  properties: {amount: "1"}
+                }
+              ]
+            }
+          )
+          pay_in_advance_plan = organization.plans.find_by(code: "pay_in_advance_plan")
+
+          # Create plan with progressive billing
+          create_plan(
+            {
+              name: "Progressive Billing Plan",
+              code: "progressive_plan",
+              interval: "monthly",
+              amount_cents: 20_00, # $20
+              amount_currency: "EUR",
+              pay_in_advance: false,
+              charges: [
+                {
+                  billable_metric_id: bm.id,
+                  charge_model: "standard",
+                  pay_in_advance: false,
+                  properties: {amount: "1"} # $1 per unit
+                }
+              ],
+              usage_thresholds: [
+                {
+                  amount_cents: 20_00, # $20 threshold
+                  threshold_display_name: "First threshold"
+                },
+                {
+                  amount_cents: 50_00, # $50 threshold
+                  threshold_display_name: "Second threshold"
+                }
+              ]
+            }
+          )
+          progressive_plan = organization.plans.find_by(code: "progressive_plan")
+
+          # Create recurring coupon with frequency equal 3 months
+          create_coupon(
+            {
+              name: "Recurring Coupon",
+              code: "recurring_coupon",
+              coupon_type: "fixed_amount",
+              frequency: "recurring",
+              frequency_duration: 3,
+              amount_cents: 100_00, # $100
+              amount_currency: "EUR",
+              expiration: "no_expiration",
+              reusable: false
+            }
+          )
+
+          # Create customer and subscriptions
+          create_or_update_customer({ external_id: "customer-12345" })
+          customer = organization.customers.find_by(external_id: "customer-12345")
+
+          # Apply coupon to customer
+          apply_coupon({external_customer_id: "customer-12345", coupon_code: "recurring_coupon"})
+
+          # Start subscriptions at time0
+          time0 = DateTime.new(2025, 1, 1)
+          travel_to(time0) do
+            # Create pay in advance subscription
+            create_subscription(
+              {
+                external_customer_id: "customer-12345",
+                external_id: "sub_pay_in_advance",
+                plan_code: pay_in_advance_plan.code
+              }
+            )
+
+            # Create progressive billing subscription
+            create_subscription(
+              {
+                external_customer_id: "customer-12345",
+                external_id: "sub_progressive",
+                plan_code: progressive_plan.code
+              }
+            )
+          end
+
+          # time0 + 5 days: send events (5 units for pay in advance, 10 units for progressive billing)
+          travel_to(time0 + 5.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that invoice is generated for pay_in_advance
+            expect(pay_in_advance_subscription.invoices.count).to eq(1)
+
+            fee = pay_in_advance_subscription.fees.first
+            expect(fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+            expect(fee.pay_in_advance).to eq(true)
+
+            # Check that coupon was applied to the pay in advance invoice
+            invoice = pay_in_advance_subscription.invoices.first
+            expect(invoice).to be_present
+            expect(invoice.coupons_amount_cents).to eq(5_00) # Coupons are applied on pay in advance invoices
+            expect(invoice.fees_amount_cents).to eq(5_00)
+            expect(invoice.total_amount_cents).to eq(0)
+            expect(progressive_subscription.invoices.count).to eq(0)
+            perform_all_enqueued_jobs
+          end
+
+          # time0 + 10 days: send events (5 units for pay in advance, 10 units for progressive billing)
+          travel_to(time0 + 10.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that progressive billing invoice is generated
+            progressive_invoices = progressive_subscription.invoices
+            expect(progressive_invoices.count).to eq(1) # 1 progressive billing invoice
+
+            # Invoice should be for $20 (total usage at threshold)
+            progressive_invoice = progressive_invoices.first
+            expect(progressive_invoice.fees_amount_cents).to eq(20_00)
+            expect(progressive_invoice.coupons_amount_cents).to eq(20_00) # 20 units - 20$ coupon = 0
+            expect(progressive_invoice.total_amount_cents).to eq(0) # 20 units - 20$ coupon = 0
+
+            # Pay in advance should have another invoice
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices
+            expect(pay_in_advance_invoices.count).to eq(2) # Original + new one
+          end
+
+          # time0 + 15 days: send an event (5 units)
+          travel_to(time0 + 15.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that invoice is generated for pay_in_advance
+            expect(pay_in_advance_subscription.fees.count).to eq(3) # 2 previous + 1 new
+            expect(progressive_subscription.fees.count).to eq(1) # 1 progressive billing fee
+
+            latest_fee = pay_in_advance_subscription.fees.order(:created_at).last
+            expect(latest_fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+            expect(latest_fee.pay_in_advance).to eq(true) # Pay in advance
+          end
+
+          # Travel to time0 + 1 month, run subscription billing
+          # coupon usage after billing: 20$ progressive usage + 30$ subscription invoice + 3 * 5$ pay in advance invoice = 65$
+          travel_to(time0 + 1.month) do
+            perform_billing
+
+            # Check that invoices are generated
+            customer = organization.customers.find_by(external_id: "customer-12345")
+            expect(customer.invoices.count).to eq(5) # 3 pay in advance + 1 progressive_billing + 1 subscription
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            subscription_invoice = progressive_subscription.invoices.order(:created_at).last
+            expect(subscription_invoice.fees_amount_cents).to eq(50_00) # 30 units * $1 = $30 + subscription fee 20$
+            expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(20_00)
+            expect(subscription_invoice.coupons_amount_cents).to eq(30_00)
+            expect(subscription_invoice.total_amount_cents).to eq(0)
+            expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(2)
+          end
+
+          # Second month
+          time1 = time0 + 1.month
+          travel_to(time1 + 5.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that invoice is generated for pay_in_advance
+            expect(pay_in_advance_subscription.invoices.count).to eq(5) # 4 previous (3 pay in advance + 1 subscription) + 1 new (5 units)
+
+            fee = pay_in_advance_subscription.fees.order(:created_at).last
+            expect(fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+            expect(fee.pay_in_advance).to eq(true)
+
+            # Check that coupon is still applied since it's recurring for 3 months
+            invoice = pay_in_advance_subscription.invoices.order(:created_at).last
+            expect(invoice).to be_present
+            expect(invoice.fees_amount_cents).to eq(5_00)
+            expect(invoice.coupons_amount_cents).to eq(5_00) # 5$ coupon applied
+            expect(invoice.total_amount_cents).to eq(0)
+            expect(progressive_subscription.invoices.count).to eq(2) # 2 previous + 0 new (no threshold exceeded)
+            perform_all_enqueued_jobs
+          end
+
+          travel_to(time1 + 10.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that progressive billing invoice is generated
+            progressive_invoices = progressive_subscription.invoices
+            expect(progressive_invoices.count).to eq(3) # 2 previous + 1 new
+
+            # Invoice should be for $20 (total usage at threshold)
+            progressive_invoice = progressive_invoices.order(:created_at).last
+            expect(progressive_invoice.fees_amount_cents).to eq(20_00)
+            expect(progressive_invoice.coupons_amount_cents).to eq(20_00) # 20$ coupon applied
+            expect(progressive_invoice.total_amount_cents).to eq(0) # 20 units - 20$ coupon = 0
+
+            # Pay in advance should have another invoice
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices
+            expect(pay_in_advance_invoices.count).to eq(6) # 5 previous (4 pay in advance + 1 subscription) + 1 new (5 units)
+          end
+
+          # coupon still active for 1 more billing period
+          travel_to(time1 + 1.month) do
+            perform_billing
+
+            # Check that invoices are generated
+            customer = organization.customers.find_by(external_id: "customer-12345")
+            expect(customer.invoices.count).to eq(9) # 5 previous + 3 pay in advance + 1 progressive_billing + 1 subscription
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            subscription_invoice = progressive_subscription.invoices.order(:created_at).last
+            expect(subscription_invoice.fees_amount_cents).to eq(40_00) # 20 units * $1 = $20 + subscription fee 20$
+            expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(20_00)
+            expect(subscription_invoice.coupons_amount_cents).to eq(20_00) # 20$ coupon applied
+            expect(subscription_invoice.total_amount_cents).to eq(0) # 40$ - 20$ credit - 20$ coupon = 0
+            expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(1)
+          end
+
+          # Third month, last coupon cycle
+          time2 = time0 + 2.months
+          travel_to(time2 + 5.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that invoice is generated for pay_in_advance
+            expect(pay_in_advance_subscription.invoices.count).to eq(8) # 7 previous + 1 new (5 units)
+
+            fee = pay_in_advance_subscription.fees.order(:created_at).last
+            expect(fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+            expect(fee.pay_in_advance).to eq(true)
+
+            # Check that coupon is still applied since it's recurring for 3 months
+            invoice = pay_in_advance_subscription.invoices.order(:created_at).last
+            expect(invoice).to be_present
+            expect(invoice.fees_amount_cents).to eq(5_00)
+            expect(invoice.coupons_amount_cents).to eq(5_00) # 5$ coupon applied
+            expect(invoice.total_amount_cents).to eq(0)
+            expect(progressive_subscription.invoices.count).to eq(4) # 3 previous + 0 new (no threshold exceeded)
+            perform_all_enqueued_jobs
+          end
+
+          travel_to(time2 + 10.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that progressive billing invoice is not generated
+            progressive_invoices = progressive_subscription.invoices
+            expect(progressive_invoices.count).to eq(4) # 4 previous
+
+            # Pay in advance should have another invoice
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices
+            expect(pay_in_advance_invoices.count).to eq(9) # 8 previous + 1 new (5 units)
+            expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(1)
+            expect(customer.applied_coupons.first.status).to eq("active")
+
+            terminate_subscription(progressive_subscription)
+            perform_all_enqueued_jobs
+            expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(0)
+            expect(customer.applied_coupons.first.status).to eq("terminated")
+          end
+
+          # check that coupon is no longer applied
+          travel_to(time2 + 15.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+
+            # Check that pay in advance invoice is generated
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices.order(:created_at)
+            expect(pay_in_advance_invoices.count).to eq(10) # 9 previous + 1 new (5 units)
+            expect(pay_in_advance_invoices.last.fees_amount_cents).to eq(5_00) # 5 units * $1 = $5
+            expect(pay_in_advance_invoices.last.coupons_amount_cents).to eq(0) # 0$ coupon applied
+            expect(pay_in_advance_invoices.last.total_amount_cents).to eq(5_00) # 5$ - 0$ coupon = 5$
+          end
+        end
+      end
+
+      context "when recurring forever" do
+        it "applies the coupon multiple times, calculating the remaining amount", transaction: false do
+          # Create billable metric
+          create_metric({ name: "Name", code: "bm1", aggregation_type: "sum_agg", field_name: "total1" })
+          bm = organization.billable_metrics.find_by(code: "bm1")
+
+          # Create plan with pay_in_advance charge
+          create_plan(
+            {
+              name: "Pay in Advance Plan",
+              code: "pay_in_advance_plan",
+              interval: "monthly",
+              amount_cents: 0,
+              amount_currency: "EUR",
+              pay_in_advance: false,
+              charges: [
+                {
+                  billable_metric_id: bm.id,
+                  charge_model: "standard",
+                  pay_in_advance: true,
+                  properties: {amount: "1"}
+                }
+              ]
+            }
+          )
+          pay_in_advance_plan = organization.plans.find_by(code: "pay_in_advance_plan")
+
+          # Create plan with progressive billing
+          create_plan(
+            {
+              name: "Progressive Billing Plan",
+              code: "progressive_plan",
+              interval: "monthly",
+              amount_cents: 20_00, # $20
+              amount_currency: "EUR",
+              pay_in_advance: false,
+              charges: [
+                {
+                  billable_metric_id: bm.id,
+                  charge_model: "standard",
+                  pay_in_advance: false,
+                  properties: {amount: "1"} # $1 per unit
+                }
+              ],
+              usage_thresholds: [
+                {
+                  amount_cents: 20_00, # $20 threshold
+                  threshold_display_name: "First threshold"
+                },
+                {
+                  amount_cents: 50_00, # $50 threshold
+                  threshold_display_name: "Second threshold"
+                },
+                {
+                  amount_cents: 80_00, # $80 threshold
+                  threshold_display_name: "Second threshold"
+                }
+              ]
+            }
+          )
+          progressive_plan = organization.plans.find_by(code: "progressive_plan")
+
+          # Create recurring coupon with frequency forever (nil frequency_duration)
+          create_coupon(
+            {
+              name: "Forever Recurring Coupon",
+              code: "forever_recurring_coupon",
+              coupon_type: "fixed_amount",
+              frequency: "forever",
+              frequency_duration: nil, # Forever
+              amount_cents: 50_00,
+              amount_currency: "EUR",
+              expiration: "no_expiration",
+              reusable: false
+            }
+          )
+
+          # Create customer and subscriptions
+          create_or_update_customer({ external_id: "customer-12345" })
+          customer = organization.customers.find_by(external_id: "customer-12345")
+
+          # Apply coupon to customer
+          apply_coupon({external_customer_id: "customer-12345", coupon_code: "forever_recurring_coupon"})
+
+          # Start subscriptions at time0
+          time0 = DateTime.new(2025, 1, 1)
+          travel_to(time0) do
+            # Create pay in advance subscription
+            create_subscription(
+              {
+                external_customer_id: "customer-12345",
+                external_id: "sub_pay_in_advance",
+                plan_code: pay_in_advance_plan.code
+              }
+            )
+
+            # Create progressive billing subscription
+            create_subscription(
+              {
+                external_customer_id: "customer-12345",
+                external_id: "sub_progressive",
+                plan_code: progressive_plan.code
+              }
+            )
+          end
+
+          # time0 + 5 days: send events (5 units for pay in advance, 10 units for progressive billing)
+          travel_to(time0 + 5.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that invoice is generated for pay_in_advance
+            expect(pay_in_advance_subscription.invoices.count).to eq(1)
+
+            fee = pay_in_advance_subscription.fees.first
+            expect(fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+            expect(fee.pay_in_advance).to eq(true)
+
+            # Check that coupon was applied to the pay in advance invoice
+            invoice = pay_in_advance_subscription.invoices.first
+            expect(invoice).to be_present
+            expect(invoice.coupons_amount_cents).to eq(5_00) # Coupons are applied on pay in advance invoices
+            expect(invoice.fees_amount_cents).to eq(5_00)
+            expect(invoice.total_amount_cents).to eq(0)
+            expect(progressive_subscription.invoices.count).to eq(0)
+            perform_all_enqueued_jobs
+          end
+
+          # time0 + 10 days: send events (5 units for pay in advance, 10 units for progressive billing)
+          travel_to(time0 + 10.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that progressive billing invoice is generated
+            progressive_invoices = progressive_subscription.invoices
+            expect(progressive_invoices.count).to eq(1) # 1 progressive billing invoice
+
+            # Invoice should be for $20 (total usage at threshold)
+            progressive_invoice = progressive_invoices.first
+            expect(progressive_invoice.fees_amount_cents).to eq(20_00)
+            expect(progressive_invoice.coupons_amount_cents).to eq(20_00) # 20 units - 20$ coupon = 0
+            expect(progressive_invoice.total_amount_cents).to eq(0) # 20 units - 20$ coupon = 0
+
+            # Pay in advance should have another invoice
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices
+            expect(pay_in_advance_invoices.count).to eq(2) # Original + new one
+          end
+
+          # time0 + 15 days: send an event (5 units)
+          travel_to(time0 + 15.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that invoice is generated for pay_in_advance
+            expect(pay_in_advance_subscription.fees.count).to eq(3) # 2 previous + 1 new
+            expect(progressive_subscription.fees.count).to eq(1) # 1 progressive billing fee
+
+            latest_fee = pay_in_advance_subscription.fees.order(:created_at).last
+            expect(latest_fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+            expect(latest_fee.pay_in_advance).to eq(true) # Pay in advance
+          end
+
+          # Travel to time0 + 1 month, run subscription billing
+          # when applied forever, coupons are applied by subscription
+          # coupon usage after billing: 20$ progressive usage + 30$ subscription invoice; 3 * 5$ pay in advance invoice
+          travel_to(time0 + 1.month) do
+            perform_billing
+
+            # Check that invoices are generated
+            customer = organization.customers.find_by(external_id: "customer-12345")
+            expect(customer.invoices.count).to eq(5) # 3 pay in advance + 1 progressive_billing + 1 subscription
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            subscription_invoice = progressive_subscription.invoices.order(:created_at).last
+            expect(subscription_invoice.fees_amount_cents).to eq(50_00) # 30 units * $1 = $30 + subscription fee 20$
+            expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(20_00)
+            expect(subscription_invoice.coupons_amount_cents).to eq(30_00)
+            expect(subscription_invoice.total_amount_cents).to eq(0)
+            expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(nil) # Forever
+            expect(customer.applied_coupons.first.status).to eq("active")
+          end
+
+          # Second month - coupon is fully available again
+          time1 = time0 + 1.month
+          travel_to(time1 + 5.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 30)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that invoice is generated for pay_in_advance
+            expect(pay_in_advance_subscription.invoices.count).to eq(5) # 4 previous (3 pay in advance + 1 subscription) + 1 new (5 units)
+
+            fee = pay_in_advance_subscription.fees.order(:created_at).last
+            expect(fee.amount_cents).to eq(30_00) # 30 units * $1 = $30
+            expect(fee.pay_in_advance).to eq(true)
+
+            # Check that coupon is still applied since it's recurring forever
+            invoice = pay_in_advance_subscription.invoices.order(:created_at).last
+            expect(invoice).to be_present
+            expect(invoice.fees_amount_cents).to eq(30_00)
+            expect(invoice.coupons_amount_cents).to eq(30_00) # 30$ coupon applied
+            expect(invoice.total_amount_cents).to eq(0)
+            expect(progressive_subscription.invoices.count).to eq(2) # 2 previous + 0 new (no threshold exceeded)
+            perform_all_enqueued_jobs
+          end
+
+          travel_to(time1 + 10.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 30)
+            ingest_event(progressive_subscription, bm, 20)
+
+            # Pay in advance should have another invoice
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices.order(:created_at)
+            expect(pay_in_advance_invoices.count).to eq(6) # 5 previous (4 pay in advance + 1 subscription) + 1 new (30 units)
+            expect(pay_in_advance_invoices.last.fees_amount_cents).to eq(30_00) # 30 units * $1 = $30
+            expect(pay_in_advance_invoices.last.coupons_amount_cents).to eq(20_00) # 20$ coupon remaining
+            expect(pay_in_advance_invoices.last.total_amount_cents).to eq(10_00) # 30$ - 20$ coupon = 10$
+
+            # Check that progressive billing invoice is generated
+            progressive_invoices = progressive_subscription.invoices
+            expect(progressive_invoices.count).to eq(3) # 2 previous + 1 new
+
+            # Invoice should be for $30 (total usage at threshold); this is 50$ threshold (total usage now is 60$)
+            progressive_invoice = progressive_invoices.order(:created_at).last
+            expect(progressive_invoice.fees_amount_cents).to eq(30_00)
+            expect(progressive_invoice.coupons_amount_cents).to eq(30_00) # 30$ coupon applied
+            expect(progressive_invoice.total_amount_cents).to eq(0) # 30 units - 30$ coupon = 0
+          end
+
+          # coupon usage so far: 30$ + 30$; 30$
+          travel_to(time1 + 15.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 20)
+            ingest_event(progressive_subscription, bm, 50)
+
+            # Check that progressive billing invoice is generated again
+            progressive_invoices = progressive_subscription.invoices
+            expect(progressive_invoices.count).to eq(4) # 3 previous + 1 new
+
+            # Invoice should be for $80 (total usage is 110, 20 is invoiced in previous billing period - is not used in calculation,
+            # 30 is progressively billed in this period, so it is calculated
+            # when applied forever, coupons are applied by subscription
+            progressive_invoice = progressive_invoices.order(:created_at).last
+            expect(progressive_invoice.fees_amount_cents).to eq(80_00)
+            expect(progressive_invoice.coupons_amount_cents).to eq(20_00) # only 20$ of coupon is remaining
+            expect(progressive_invoice.progressive_billing_credit_amount_cents).to eq(30_00)
+            expect(progressive_invoice.total_amount_cents).to eq(30_00) # 50 units - 20$ coupon = 30$
+
+            # Pay in advance should have another invoice
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices
+            expect(pay_in_advance_invoices.count).to eq(7) # 6 previous (5 pay in advance + 1 subscription) + 1 new (30 units)
+          end
+
+          # coupon still active forever
+          travel_to(time1 + 1.month) do
+            perform_billing
+
+            # Check that invoices are generated
+            customer = organization.customers.find_by(external_id: "customer-12345")
+            expect(customer.invoices.count).to eq(11) # 5 previous + 3 pay in advance + 2 progressive_billing + 1 subscription
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            subscription_invoice = progressive_subscription.invoices.order(:created_at).last
+            expect(subscription_invoice.fees_amount_cents).to eq(100_00) # 80 units * $1 = $80 + subscription fee 20$
+            expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(80_00)
+            expect(subscription_invoice.coupons_amount_cents).to eq(0) # current coupon is fully used
+            expect(subscription_invoice.total_amount_cents).to eq(20_00) # 100$ - 80$ credit = 20$
+            expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(nil) # Forever
+            expect(customer.applied_coupons.first.status).to eq("active")
+          end
+
+          # Third month - coupon should still be active forever
+          time2 = time0 + 2.months
+          travel_to(time2 + 5.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that invoice is generated for pay_in_advance
+            expect(pay_in_advance_subscription.invoices.count).to eq(9) # 8 previous + 1 new (5 units)
+
+            fee = pay_in_advance_subscription.fees.order(:created_at).last
+            expect(fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
+            expect(fee.pay_in_advance).to eq(true)
+
+            # Check that coupon is still applied since it's recurring forever
+            invoice = pay_in_advance_subscription.invoices.order(:created_at).last
+            expect(invoice).to be_present
+            expect(invoice.fees_amount_cents).to eq(5_00)
+            expect(invoice.coupons_amount_cents).to eq(5_00) # 5$ coupon applied
+            expect(invoice.total_amount_cents).to eq(0)
+            expect(progressive_subscription.invoices.count).to eq(5) # 5 previous + 0 new (no threshold exceeded)
+            perform_all_enqueued_jobs
+          end
+
+          travel_to(time2 + 10.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+            ingest_event(progressive_subscription, bm, 10)
+
+            # Check that progressive billing invoice is not generated, because all thresholds are exceeded
+            progressive_invoices = progressive_subscription.invoices
+            expect(progressive_invoices.count).to eq(5) # 5 previous
+
+            # Pay in advance should have another invoice
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices
+            expect(pay_in_advance_invoices.count).to eq(10) # 9 previous + 1 new (5 units)
+
+            terminate_subscription(progressive_subscription)
+            perform_all_enqueued_jobs
+            expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(nil) # Still forever
+            expect(customer.applied_coupons.first.status).to eq("active")
+          end
+
+          # check that coupon is still applied after subscription termination
+          travel_to(time2 + 15.days) do
+            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
+            ingest_event(pay_in_advance_subscription, bm, 5)
+
+            # Check that pay in advance invoice is generated
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices.order(:created_at)
+            expect(pay_in_advance_invoices.count).to eq(11) # 10 previous + 1 new (5 units)
+            expect(pay_in_advance_invoices.last.fees_amount_cents).to eq(5_00) # 5 units * $1 = $5
+            expect(pay_in_advance_invoices.last.coupons_amount_cents).to eq(5_00) # 5$ coupon applied
+            expect(pay_in_advance_invoices.last.total_amount_cents).to eq(0) # 5$ - 5$ coupon = 0
+          end
+        end
+      end
     end
   end
 end

--- a/spec/scenarios/coupons_breakdown_spec.rb
+++ b/spec/scenarios/coupons_breakdown_spec.rb
@@ -438,10 +438,12 @@ describe "Coupons breakdown Spec", :premium do
           latest_fee = pay_in_advance_subscription.fees.order(:created_at).last
           expect(latest_fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
           expect(latest_fee.pay_in_advance).to eq(true) # Pay in advance
+          expect(pay_in_advance_subscription.invoices.order(:created_at).last.total_amount_cents).to eq(0) # Invoice is covered with coupon
         end
 
         # Travel to time0 + 1 month, run subscription billing
-        # coupon usage: 20$ progressive usage + 30$ subscription invoice + 3 * 5$ pay in advance invoice = 65$
+        # coupon usage: 20$ subscription + 30$ usage (20$ were billed progressively) + 3 * 5$ pay in advance invoice = 65$
+        expect(customer.applied_coupons.last.remaining_amount).to eq(65_00)
         travel_to(time0 + 1.month) do
           perform_billing
 
@@ -456,6 +458,7 @@ describe "Coupons breakdown Spec", :premium do
           expect(subscription_invoice.total_amount_cents).to eq(0)
         end
         # coupon remaining: 35$
+        expect(customer.applied_coupons.last.remaining_amount).to eq(35_00)
 
         # Repeat for next month
         time1 = time0 + 1.month
@@ -490,7 +493,7 @@ describe "Coupons breakdown Spec", :premium do
 
           # Check that progressive billing invoice is generated
           # At time1 + 5 days: 10 units = $10 (does NOT exceed $20 threshold)
-          # At time1 + 10 days: 10 more units = $20 total (exceeds $20 threshold)
+          # At time1 + 10 days: 10 more units = $20 total (exceeds $20 threshold of current usage)
           progressive_invoices = progressive_subscription.invoices
           expect(progressive_invoices.count).to eq(3) # 2 previous + 1 new
 
@@ -506,6 +509,7 @@ describe "Coupons breakdown Spec", :premium do
         end
 
         # coupon remaining: 5$
+        expect(customer.applied_coupons.last.remaining_amount).to eq(5_00)
         travel_to(time1 + 1.month) do
           perform_billing
 
@@ -521,11 +525,13 @@ describe "Coupons breakdown Spec", :premium do
           expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(20_00)
           expect(subscription_invoice.coupons_amount_cents).to eq(5_00) # 5$ coupon applied
           expect(subscription_invoice.total_amount_cents).to eq(15_00) # 40$ - 20$ credit - 5$ coupon = 15$
+          expect(customer.applied_coupons.last.remaining_amount).to eq(0) # Coupon is now fully used
+          expect(customer.applied_coupons.last.terminated?).to eq(true) # Coupon is terminated
         end
       end
     end
 
-    context "when coupon is recurring" do
+    context "when coupon is recurring (same set up as for single use)" do
       context "when recurring once" do
         it "applies the coupon only during one billing period, calculating the remaining amount", transaction: false do
           bm = setup_test_billable_metric
@@ -562,6 +568,7 @@ describe "Coupons breakdown Spec", :premium do
             expect(progressive_subscription.invoices.count).to eq(0)
             perform_all_enqueued_jobs
           end
+          expect(customer.applied_coupons.last.active?).to eq(true)
 
           # time0 + 10 days: send event (5 units) and perform lifetime calculation
           travel_to(time0 + 10.days) do
@@ -583,9 +590,12 @@ describe "Coupons breakdown Spec", :premium do
             expect(progressive_invoice.total_amount_cents).to eq(0) # 20 units - 20$ coupon = 0
 
             # Pay in advance should have another invoice
-            pay_in_advance_invoices = pay_in_advance_subscription.invoices
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices.order(:created_at)
             expect(pay_in_advance_invoices.count).to eq(2) # Original + new one
+            expect(pay_in_advance_invoices.last.coupons_amount_cents).to eq(5_00)
+            expect(pay_in_advance_invoices.last.total_amount_cents).to eq(0)
           end
+          expect(customer.applied_coupons.last.active?).to eq(true)
 
           # time0 + 15 days: send an event (5 units)
           travel_to(time0 + 15.days) do
@@ -601,10 +611,14 @@ describe "Coupons breakdown Spec", :premium do
             latest_fee = pay_in_advance_subscription.fees.order(:created_at).last
             expect(latest_fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
             expect(latest_fee.pay_in_advance).to eq(true) # Pay in advance
+            pay_in_advance_invoices = pay_in_advance_subscription.invoices.order(:created_at)
+            expect(pay_in_advance_invoices.last.coupons_amount_cents).to eq(5_00) # 5$ coupon applied
+            expect(pay_in_advance_invoices.last.total_amount_cents).to eq(0)
           end
 
           # Travel to time0 + 1 month, run subscription billing
           # coupon usage: 20$ progressive usage + 30$ subscription invoice + 3 * 5$ pay in advance invoice = 65$
+          expect(customer.applied_coupons.last.active?).to eq(true)
           travel_to(time0 + 1.month) do
             perform_billing
 
@@ -619,7 +633,8 @@ describe "Coupons breakdown Spec", :premium do
             expect(subscription_invoice.total_amount_cents).to eq(0)
           end
           # coupon remaining: 35$
-          # coupon is terminated
+          # coupon is terminated after billing cycle since it's recurring once
+          expect(customer.applied_coupons.last.terminated?).to eq(true)
 
           # Repeat for next month
           time1 = time0 + 1.month
@@ -669,7 +684,6 @@ describe "Coupons breakdown Spec", :premium do
             expect(pay_in_advance_invoices.count).to eq(6) # 5 previous (4 pay in advance + 1 subscription) + 1 new (5 units)
           end
 
-          # coupon remaining: 5$
           travel_to(time1 + 1.month) do
             perform_billing
 
@@ -748,6 +762,7 @@ describe "Coupons breakdown Spec", :premium do
             expect(progressive_subscription.invoices.count).to eq(0)
             perform_all_enqueued_jobs
           end
+          expect(customer.applied_coupons.last.frequency_duration_remaining).to eq(3)
 
           # time0 + 10 days: send events (5 units for pay in advance, 10 units for progressive billing)
           travel_to(time0 + 10.days) do
@@ -770,6 +785,7 @@ describe "Coupons breakdown Spec", :premium do
             pay_in_advance_invoices = pay_in_advance_subscription.invoices
             expect(pay_in_advance_invoices.count).to eq(2) # Original + new one
           end
+          expect(customer.applied_coupons.last.frequency_duration_remaining).to eq(3)
 
           # time0 + 15 days: send an event (5 units)
           travel_to(time0 + 15.days) do
@@ -788,7 +804,6 @@ describe "Coupons breakdown Spec", :premium do
           end
 
           # Travel to time0 + 1 month, run subscription billing
-          # coupon usage after billing: 20$ progressive usage + 30$ subscription invoice + 3 * 5$ pay in advance invoice = 65$
           travel_to(time0 + 1.month) do
             perform_billing
 
@@ -801,8 +816,8 @@ describe "Coupons breakdown Spec", :premium do
             expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(20_00)
             expect(subscription_invoice.coupons_amount_cents).to eq(30_00)
             expect(subscription_invoice.total_amount_cents).to eq(0)
-            expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(2)
           end
+          expect(customer.applied_coupons.last.frequency_duration_remaining).to eq(2)
 
           # Second month
           time1 = time0 + 1.month
@@ -863,8 +878,8 @@ describe "Coupons breakdown Spec", :premium do
             expect(subscription_invoice.progressive_billing_credit_amount_cents).to eq(20_00)
             expect(subscription_invoice.coupons_amount_cents).to eq(20_00) # 20$ coupon applied
             expect(subscription_invoice.total_amount_cents).to eq(0) # 40$ - 20$ credit - 20$ coupon = 0
-            expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(1)
           end
+          expect(customer.applied_coupons.last.frequency_duration_remaining).to eq(1)
 
           # Third month, last coupon cycle
           time2 = time0 + 2.months
@@ -929,7 +944,7 @@ describe "Coupons breakdown Spec", :premium do
       end
 
       context "when recurring forever" do
-        it "applies the coupon multiple times, calculating the remaining amount", transaction: false do
+        it "applies the coupon multiple times, calculating the remaining amount (coupon total is 50$)", transaction: false do
           bm = setup_test_billable_metric
           pay_in_advance_plan = setup_pia_plan(bm)
           progressive_plan = setup_pb_plan(bm, thresholds: [20_00, 50_00, 80_00])
@@ -1005,7 +1020,6 @@ describe "Coupons breakdown Spec", :premium do
 
           # Travel to time0 + 1 month, run subscription billing
           # when applied forever, coupons are applied by subscription
-          # coupon usage after billing: 20$ progressive usage + 30$ subscription invoice; 3 * 5$ pay in advance invoice
           travel_to(time0 + 1.month) do
             perform_billing
 
@@ -1115,64 +1129,6 @@ describe "Coupons breakdown Spec", :premium do
             expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(nil) # Forever
             expect(customer.applied_coupons.first.status).to eq("active")
           end
-
-          # Third month - coupon should still be active forever
-          time2 = time0 + 2.months
-          travel_to(time2 + 5.days) do
-            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
-            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
-            ingest_event(pay_in_advance_subscription, bm, 5)
-            ingest_event(progressive_subscription, bm, 10)
-
-            # Check that invoice is generated for pay_in_advance
-            expect(pay_in_advance_subscription.invoices.count).to eq(9) # 8 previous + 1 new (5 units)
-
-            fee = pay_in_advance_subscription.fees.order(:created_at).last
-            expect(fee.amount_cents).to eq(5_00) # 5 units * $1 = $5
-            expect(fee.pay_in_advance).to eq(true)
-
-            # Check that coupon is still applied since it's recurring forever
-            invoice = pay_in_advance_subscription.invoices.order(:created_at).last
-            expect(invoice).to be_present
-            expect(invoice.fees_amount_cents).to eq(5_00)
-            expect(invoice.coupons_amount_cents).to eq(5_00) # 5$ coupon applied
-            expect(invoice.total_amount_cents).to eq(0)
-            expect(progressive_subscription.invoices.count).to eq(5) # 5 previous + 0 new (no threshold exceeded)
-            perform_all_enqueued_jobs
-          end
-
-          travel_to(time2 + 10.days) do
-            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
-            progressive_subscription = Subscription.find_by(external_id: "sub_progressive")
-            ingest_event(pay_in_advance_subscription, bm, 5)
-            ingest_event(progressive_subscription, bm, 10)
-
-            # Check that progressive billing invoice is not generated, because all thresholds are exceeded
-            progressive_invoices = progressive_subscription.invoices
-            expect(progressive_invoices.count).to eq(5) # 5 previous
-
-            # Pay in advance should have another invoice
-            pay_in_advance_invoices = pay_in_advance_subscription.invoices
-            expect(pay_in_advance_invoices.count).to eq(10) # 9 previous + 1 new (5 units)
-
-            terminate_subscription(progressive_subscription)
-            perform_all_enqueued_jobs
-            expect(customer.applied_coupons.first.frequency_duration_remaining).to eq(nil) # Still forever
-            expect(customer.applied_coupons.first.status).to eq("active")
-          end
-
-          # check that coupon is still applied after subscription termination
-          travel_to(time2 + 15.days) do
-            pay_in_advance_subscription = Subscription.find_by(external_id: "sub_pay_in_advance")
-            ingest_event(pay_in_advance_subscription, bm, 5)
-
-            # Check that pay in advance invoice is generated
-            pay_in_advance_invoices = pay_in_advance_subscription.invoices.order(:created_at)
-            expect(pay_in_advance_invoices.count).to eq(11) # 10 previous + 1 new (5 units)
-            expect(pay_in_advance_invoices.last.fees_amount_cents).to eq(5_00) # 5 units * $1 = $5
-            expect(pay_in_advance_invoices.last.coupons_amount_cents).to eq(5_00) # 5$ coupon applied
-            expect(pay_in_advance_invoices.last.total_amount_cents).to eq(0) # 5$ - 5$ coupon = 0
-          end
         end
       end
     end
@@ -1180,10 +1136,16 @@ describe "Coupons breakdown Spec", :premium do
 
   # ISSUE-1007: documents how a $20 fixed-amount coupon interacts with progressive billing
   # for a single-subscription, single-billing-period across the matrix of PB amounts.
+  # scenarios are (run against coupon 20$ applied once and coupon applied forever):
+  #   - Sc1: PB $5, final fees $35 (everything in charges or split, doesn't matter — math works the same)
+  #   - Sc2: PB $30, final fees $35
+  #   - Sc3: PB1 $5 + PB2 $30, final fees $50
+  #   - Sc4: PB $40, final fees $0 (no sub, no charges)
+  #   - Sc5: PB $40, final fees $20 (no sub, $20 charges)
   #
   # Customer's "paid" = sum of invoice totals; "refund" = sum of credit notes issued.
   # Net cash-out = paid - refund.
-  context "with PB invoice and $20 coupon matrix (ISSUE-1007)", transaction: false do
+  context "with PB invoice and $20 coupon matrix", transaction: false do
     let(:start_time) { DateTime.new(2025, 1, 1) }
     let(:bm) do
       create_metric({name: "U", code: "u", aggregation_type: "sum_agg", field_name: "n"})
@@ -1282,7 +1244,7 @@ describe "Coupons breakdown Spec", :premium do
 
       def trigger_usage(sub)
         travel_to(start_time + 5.days) { ingest_event(sub, bm, 40) }
-        Event.where(external_subscription_id: sub.external_id).destroy_all
+        travel_to(start_time + 5.days) { ingest_event(sub, bm, -40) }
         perform_usage_update
       end
 
@@ -1295,8 +1257,7 @@ describe "Coupons breakdown Spec", :premium do
 
       def trigger_usage(sub)
         travel_to(start_time + 5.days) { ingest_event(sub, bm, 40) }
-        Event.where(external_subscription_id: sub.external_id).destroy_all
-        travel_to(start_time + 10.days) { ingest_event(sub, bm, 20) }
+        travel_to(start_time + 10.days) { ingest_event(sub, bm, -20) }
       end
 
       # Known limitation: $10 of coupon stays stranded on the PB for usage that was

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe Credits::AppliedCouponService do
       sub_total_excluding_taxes_amount_cents: base_amount_cents
     )
   end
+  let(:invoice_subscription) do
+    create(
+      :invoice_subscription,
+      invoice:,
+      timestamp: invoice.issuing_date,
+      charges_to_datetime: invoice.issuing_date,
+      charges_from_datetime: invoice.issuing_date - 1.month
+    )
+  end
   let(:base_amount_cents) { 300 }
 
   let(:coupon) { create(:coupon, organization:) }
@@ -30,6 +39,7 @@ RSpec.describe Credits::AppliedCouponService do
   before do
     fee1
     fee2
+    invoice_subscription
   end
 
   context "without lock" do
@@ -82,23 +92,61 @@ RSpec.describe Credits::AppliedCouponService do
       end
 
       context "when coupon amount is higher than invoice amount" do
-        let(:base_amount_cents) { 6 }
+        context "when coupon is applied once" do
+          let(:base_amount_cents) { 6 }
 
-        it "limits the credit amount to the invoice amount" do
-          result = credit_service.call
+          it "limits the credit amount to the invoice amount" do
+            result = credit_service.call
 
-          expect(result).to be_success
-          expect(result.credit.amount_cents).to eq(6)
+            expect(result).to be_success
+            expect(result.credit.amount_cents).to eq(6)
 
-          expect(fee1.reload.precise_coupons_amount_cents).to eq(4)
-          expect(fee2.reload.precise_coupons_amount_cents).to eq(2)
+            expect(fee1.reload.precise_coupons_amount_cents).to eq(4)
+            expect(fee2.reload.precise_coupons_amount_cents).to eq(2)
+          end
+
+          it "does not terminate the applied coupon" do
+            result = credit_service.call
+
+            expect(result).to be_success
+            expect(applied_coupon.reload).not_to be_terminated
+          end
         end
 
-        it "does not terminate the applied coupon" do
-          result = credit_service.call
+        context "when applied coupon is recurring" do
+          let(:coupon) { create(:coupon, frequency: "recurring", frequency_duration: 3) }
+          let(:applied_coupon) { create(:applied_coupon, customer:, coupon:, frequency: "recurring", frequency_duration_remaining: 1) }
 
-          expect(result).to be_success
-          expect(applied_coupon.reload).not_to be_terminated
+          context "when invoice is for subscription" do
+            it "reduces frequency_duration" do
+              result = credit_service.call
+
+              expect(result).to be_success
+              expect(applied_coupon.reload.frequency_duration_remaining).to eq(0)
+              expect(applied_coupon.reload).to be_terminated
+            end
+          end
+
+          context "when invoice is for charge" do
+            let(:invoice_subscription) do
+              create(
+                :invoice_subscription,
+                invoicing_reason: "in_advance_charge",
+                invoice:,
+                timestamp: invoice.issuing_date,
+                charges_to_datetime: invoice.issuing_date,
+                charges_from_datetime: invoice.issuing_date - 1.month
+              )
+            end
+
+            it "does not reduce frequency_duration" do
+              result = credit_service.call
+
+              expect(result).to be_success
+              expect(applied_coupon.reload.frequency_duration_remaining).to eq(1)
+              expect(applied_coupon.reload).not_to be_terminated
+            end
+          end
         end
       end
 

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Credits::AppliedCouponService do
 
         context "when applied coupon is recurring" do
           let(:coupon) { create(:coupon, frequency: "recurring", frequency_duration: 3) }
-          let(:applied_coupon) { create(:applied_coupon, customer:, coupon:, frequency: "recurring", frequency_duration_remaining: 1) }
+          let(:applied_coupon) { create(:applied_coupon, customer:, coupon:, frequency: "recurring", frequency_duration: 3, frequency_duration_remaining: 1) }
 
           context "when invoice is for subscription" do
             it "reduces frequency_duration" do

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -2893,8 +2893,8 @@ RSpec.describe Invoices::CalculateFeesService do
     end
 
     context "when customer has applied recurring coupon" do
-      let(:coupon) { create(:coupon, organization:, coupon_type: "fixed_amount", amount_cents: 100, frequency: "recurring") }
-      let(:applied_coupon) { create(:applied_coupon, customer:, coupon:, frequency: "recurring", frequency_duration_remaining: 3) }
+      let(:coupon) { create(:coupon, organization:, coupon_type: "fixed_amount", amount_cents: 100, frequency: "recurring", frequency_duration: 3) }
+      let(:applied_coupon) { create(:applied_coupon, customer:, coupon:, frequency: "recurring", frequency_duration: 3, frequency_duration_remaining: 3) }
 
       before { applied_coupon }
 
@@ -2944,7 +2944,7 @@ RSpec.describe Invoices::CalculateFeesService do
       end
 
       context "when applied_coupon has frequency_duration_remaining of 1" do
-        let(:applied_coupon) { create(:applied_coupon, customer:, coupon:, frequency_duration_remaining: 1, frequency: "recurring") }
+        let(:applied_coupon) { create(:applied_coupon, customer:, coupon:, frequency: "recurring", frequency_duration: 1, frequency_duration_remaining: 1) }
 
         it "reduces frequency_duration and marks coupon as terminated" do
           expect { invoice_service.call }.to change { applied_coupon.reload.frequency_duration_remaining }.by(-1)

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -2891,5 +2891,66 @@ RSpec.describe Invoices::CalculateFeesService do
         end
       end
     end
+
+    context "when customer has applied recurring coupon" do
+      let(:coupon) { create(:coupon, organization:, coupon_type: "fixed_amount", amount_cents: 100, frequency: "recurring") }
+      let(:applied_coupon) { create(:applied_coupon, customer:, coupon:, frequency: "recurring", frequency_duration_remaining: 3) }
+
+      before { applied_coupon }
+
+      context "when invoice is for pay_in_advance charge" do
+        before { invoice.invoice_subscriptions.first.update!(invoicing_reason: "in_advance_charge") }
+
+        it "does not deduct coupon's frequency_duration" do
+          expect { invoice_service.call }.not_to change { applied_coupon.reload.frequency_duration_remaining }
+        end
+      end
+
+      context "when it's a subscription invoice with total 0" do
+        let(:event) { nil }
+        let(:fixed_charge_event) { nil }
+        let(:plan) { create(:plan, organization:, amount_cents: 0) }
+
+        context "when no credits were used in this billing period" do
+          it "does not reduce frequency_duration" do
+            expect { invoice_service.call }.not_to change { applied_coupon.reload.frequency_duration_remaining }
+          end
+        end
+
+        context "when credits were used in this billing period" do
+          let(:previous_invoice) { create(:invoice, :with_subscriptions, customer:, organization:, subscriptions: [subscription]) }
+          let(:previous_invoice_fee) do
+            create(:fee, invoice: previous_invoice, subscription:, amount_cents: 100,
+              properties: {charges_to_datetime: date_service.charges_to_datetime,
+                           charges_from_datetime: date_service.charges_from_datetime})
+          end
+          let(:previous_invoice_credit) { create(:credit, applied_coupon:, invoice: previous_invoice, amount_cents: 10) }
+
+          before do
+            previous_invoice_fee
+            previous_invoice_credit
+          end
+
+          it "reduces frequency_duration" do
+            expect { invoice_service.call }.to change { applied_coupon.reload.frequency_duration_remaining }.by(-1)
+          end
+        end
+      end
+
+      context "when it's a subscription invoice with total > 0" do
+        it "reduces frequency_duration" do
+          expect { invoice_service.call }.to change { applied_coupon.reload.frequency_duration_remaining }.by(-1)
+        end
+      end
+
+      context "when applied_coupon has frequency_duration_remaining of 1" do
+        let(:applied_coupon) { create(:applied_coupon, customer:, coupon:, frequency_duration_remaining: 1, frequency: "recurring") }
+
+        it "reduces frequency_duration and marks coupon as terminated" do
+          expect { invoice_service.call }.to change { applied_coupon.reload.frequency_duration_remaining }.by(-1)
+          expect(applied_coupon.reload.status).to eq("terminated")
+        end
+      end
+    end
   end
 end

--- a/spec/services/subscriptions/progressive_billed_amount_spec.rb
+++ b/spec/services/subscriptions/progressive_billed_amount_spec.rb
@@ -303,11 +303,14 @@ RSpec.describe Subscriptions::ProgressiveBilledAmount do
       invoice.update!(invoice_type:, fees_amount_cents: 100, coupons_amount_cents: 100, sub_total_excluding_taxes_amount_cents: 0, total_amount_cents: 0)
     end
 
-    it "returns to_credit_amount of 0 when fees are fully discounted" do
+    it "returns gross fees so the coupon discount survives the PB" do
+      # ISSUE-1007: to_credit_amount no longer subtracts coupons_amount_cents.
+      # The gross fee amount is credited on the next invoice so the coupon's
+      # discount is transferred forward instead of being silently dropped.
       result = service.call
       expect(result.progressive_billing_invoice).to eq(invoice)
       expect(result.progressive_billed_amount).to eq(100)
-      expect(result.to_credit_amount).to be_zero
+      expect(result.to_credit_amount).to eq(100)
       expect(result.total_billed_amount_cents).to be_zero
       expect(result.invoice_subscriptions).to contain_exactly(invoice_subscription)
     end
@@ -324,11 +327,12 @@ RSpec.describe Subscriptions::ProgressiveBilledAmount do
       invoice.update!(invoice_type:, fees_amount_cents: 100, coupons_amount_cents: 30, sub_total_excluding_taxes_amount_cents: 70, taxes_amount_cents: 14, total_amount_cents: 84)
     end
 
-    it "returns net amount after coupons" do
+    it "returns gross fees regardless of coupons" do
+      # ISSUE-1007: gross fees, not net of coupons.
       result = service.call
       expect(result.progressive_billing_invoice).to eq(invoice)
       expect(result.progressive_billed_amount).to eq(100)
-      expect(result.to_credit_amount).to eq(70)
+      expect(result.to_credit_amount).to eq(100)
       expect(result.total_billed_amount_cents).to eq(84)
       expect(result.invoice_subscriptions).to contain_exactly(invoice_subscription)
     end
@@ -350,11 +354,12 @@ RSpec.describe Subscriptions::ProgressiveBilledAmount do
       invoice2.update!(invoice_type:, issuing_date: timestamp - 1.day, fees_amount_cents: 100, coupons_amount_cents: 20, sub_total_excluding_taxes_amount_cents: 80)
     end
 
-    it "returns to_credit_amount from most recent invoice after coupons" do
+    it "returns gross fees from the most recent invoice" do
+      # ISSUE-1007: gross, not net of coupons.
       result = service.call
       expect(result.progressive_billing_invoice).to eq(invoice2)
       expect(result.progressive_billed_amount).to eq(100)
-      expect(result.to_credit_amount).to eq(80)
+      expect(result.to_credit_amount).to eq(100)
       expect(result.total_billed_amount_cents).to eq(120)
       expect(result.invoice_subscriptions).to contain_exactly(invoice_subscription1, invoice_subscription2)
     end
@@ -373,11 +378,12 @@ RSpec.describe Subscriptions::ProgressiveBilledAmount do
       existing_credit
     end
 
-    it "subtracts existing credits from net amount" do
+    it "subtracts existing PB credits from gross fees" do
+      # ISSUE-1007: 100 (gross) - 30 (existing PB credit) = 70. Coupons no longer subtracted.
       result = service.call
       expect(result.progressive_billing_invoice).to eq(invoice)
       expect(result.progressive_billed_amount).to eq(100)
-      expect(result.to_credit_amount).to eq(50)
+      expect(result.to_credit_amount).to eq(70)
       expect(result.total_billed_amount_cents).to eq(80)
       expect(result.invoice_subscriptions).to contain_exactly(invoice_subscription)
     end
@@ -396,35 +402,39 @@ RSpec.describe Subscriptions::ProgressiveBilledAmount do
       existing_credit_note
     end
 
-    it "subtracts existing credit notes from net amount" do
+    it "subtracts existing credit notes from gross fees" do
+      # ISSUE-1007: 100 (gross) - 20 (credit note) = 80. Coupons no longer subtracted.
       result = service.call
       expect(result.progressive_billing_invoice).to eq(invoice)
       expect(result.progressive_billed_amount).to eq(100)
-      expect(result.to_credit_amount).to eq(60)
+      expect(result.to_credit_amount).to eq(80)
       expect(result.total_billed_amount_cents).to eq(80)
       expect(result.invoice_subscriptions).to contain_exactly(invoice_subscription)
     end
   end
 
-  context "when coupons and existing credits would result in negative to_credit_amount" do
+  context "when existing credits and credit notes would result in negative to_credit_amount" do
     let(:invoice_subscription) { create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) }
     let(:invoice) { invoice_subscription.invoice }
     let(:charge) { create(:standard_charge, plan: subscription.plan) }
-    let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, amount_cents: 100, precise_coupons_amount_cents: 60, taxes_amount_cents: 0) }
-    let(:existing_credit) { create(:credit, invoice:, progressive_billing_invoice: invoice, amount_cents: 50) }
+    let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, amount_cents: 100, precise_coupons_amount_cents: 0, taxes_amount_cents: 0) }
+    let(:existing_credit) { create(:credit, invoice:, progressive_billing_invoice: invoice, amount_cents: 80) }
+    let(:existing_credit_note) { create(:credit_note, invoice:, credit_amount_cents: 50, total_amount_cents: 50, credit_status: :available) }
 
     before do
       fee
-      invoice.update!(invoice_type:, fees_amount_cents: 100, coupons_amount_cents: 60, sub_total_excluding_taxes_amount_cents: 40)
+      invoice.update!(invoice_type:, fees_amount_cents: 100, sub_total_excluding_taxes_amount_cents: 100)
       existing_credit
+      existing_credit_note
     end
 
-    it "returns 0 instead of negative value" do
+    it "returns 0 instead of a negative value" do
+      # 100 (gross) - 80 (PB credit) - 50 (CN) = -30 -> clamped to 0.
       result = service.call
       expect(result.progressive_billing_invoice).to eq(invoice)
       expect(result.progressive_billed_amount).to eq(100)
       expect(result.to_credit_amount).to be_zero
-      expect(result.total_billed_amount_cents).to eq(40)
+      expect(result.total_billed_amount_cents).to eq(100)
       expect(result.invoice_subscriptions).to contain_exactly(invoice_subscription)
     end
   end
@@ -496,10 +506,11 @@ RSpec.describe Subscriptions::ProgressiveBilledAmount do
     end
 
     it "correctly calculates total_billed_amount_cents from multiple fees with varying coupons" do
+      # ISSUE-1007: to_credit_amount = gross fees (180), not net of coupons (140).
       result = service.call
       expect(result.progressive_billing_invoice).to eq(invoice)
       expect(result.progressive_billed_amount).to eq(180)
-      expect(result.to_credit_amount).to eq(140)
+      expect(result.to_credit_amount).to eq(180)
       expect(result.total_billed_amount_cents).to eq(140)
       expect(result.invoice_subscriptions).to contain_exactly(invoice_subscription)
     end


### PR DESCRIPTION
## Context

This PR started with coupons (applied forever) being applied twice on an invoice with previous progressive billing invoice (because it was applied on progressive billing, and then once more on the final invoice, that includes progressively_billed_amount)
so we added a concept of billing period to applied forever coupons, so amount of coupon is spread on all invoices applied during the billing period

After this we have coupons applied once and coupons applied forever being spread in time
but recurring invoices, despite are created with specification on how many billing_periods are active, are being "completely used" with each invoice, the concept of billing_periods has been added to recurring coupons as well, so number of remaining usages is only deducted with subscription invoice

And finally, to find invoices with applied credits for "current billing period" initially we were using invoice_subscriptions, but right now paid_in_advance invoices has correct boundaries at fees, but invoice_subscription boundaries are taken one month before, so query through fees was used


## Description

- introduced `remaining_amount_for_this_subscription_billing_period` method, that calculates  how much of the coupon has already been used in this billing period, and returns actual remaining amount
- only reduce number of usages of recurring coupon with subscription invoice