### PR TITLE
fit(entitlements): Better serializer constructor

### DIFF
--- a/app/controllers/api/v1/subscriptions/entitlements/privileges_controller.rb
+++ b/app/controllers/api/v1/subscriptions/entitlements/privileges_controller.rb
@@ -20,7 +20,6 @@ module Api
               render(
                 json: ::V1::Entitlement::SubscriptionEntitlementsCollectionSerializer.new(
                   Entitlement::SubscriptionEntitlement.for_subscription(subscription),
-                  nil,
                   collection_name: "entitlements"
                 ).serialize
               )

--- a/app/controllers/api/v1/subscriptions/entitlements_controller.rb
+++ b/app/controllers/api/v1/subscriptions/entitlements_controller.rb
@@ -13,7 +13,6 @@ module Api
           render(
             json: ::V1::Entitlement::SubscriptionEntitlementsCollectionSerializer.new(
               Entitlement::SubscriptionEntitlement.for_subscription(subscription),
-              nil,
               collection_name: "entitlements"
             ).serialize
           )
@@ -31,7 +30,6 @@ module Api
             render(
               json: ::V1::Entitlement::SubscriptionEntitlementsCollectionSerializer.new(
                 Entitlement::SubscriptionEntitlement.for_subscription(subscription),
-                nil,
                 collection_name: "entitlements"
               ).serialize
             )
@@ -47,7 +45,6 @@ module Api
             render(
               json: ::V1::Entitlement::SubscriptionEntitlementsCollectionSerializer.new(
                 Entitlement::SubscriptionEntitlement.for_subscription(subscription),
-                nil,
                 collection_name: "entitlements"
               ).serialize
             )
@@ -65,7 +62,6 @@ module Api
             render(
               json: ::V1::Entitlement::SubscriptionEntitlementsCollectionSerializer.new(
                 Entitlement::SubscriptionEntitlement.for_subscription(subscription),
-                nil,
                 collection_name: "entitlements"
               ).serialize
             )
@@ -84,7 +80,6 @@ module Api
             render(
               json: ::V1::Entitlement::SubscriptionEntitlementsCollectionSerializer.new(
                 Entitlement::SubscriptionEntitlement.for_subscription(subscription),
-                nil,
                 collection_name: "entitlements"
               ).serialize
             )

--- a/app/serializers/v1/entitlement/subscription_entitlements_collection_serializer.rb
+++ b/app/serializers/v1/entitlement/subscription_entitlements_collection_serializer.rb
@@ -3,6 +3,10 @@
 module V1
   module Entitlement
     class SubscriptionEntitlementsCollectionSerializer < CollectionSerializer
+      def initialize(collection, options = nil)
+        super(collection, nil, options)
+      end
+
       def serialize_models
         collection.group_by(&:feature_code).map do |feature_code, feature_entitlements|
           first_entitlement = feature_entitlements.first

--- a/spec/serializers/v1/entitlement/subscription_entitlements_collection_serializer_spec.rb
+++ b/spec/serializers/v1/entitlement/subscription_entitlements_collection_serializer_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe V1::Entitlement::SubscriptionEntitlementsCollectionSerializer, type: :serializer do
-  subject(:serializer) { described_class.new(collection, nil, collection_name: "entitlements") }
+  subject(:serializer) { described_class.new(collection, collection_name: "entitlements") }
 
   let(:organization) { create(:organization) }
   let(:collection) { Entitlement::SubscriptionEntitlement.for_subscription(subscription).where(removed: false) }


### PR DESCRIPTION
For this collection serializer, we don't need a serializer. I added an initialize method instead of passing `nil` everywhere.