### PR TITLE
feat(invoice): Allow to filter invoices by `subscription_id` via GraphQL

### DIFF
--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -28,6 +28,7 @@ module Resolvers
     argument :search_term, String, required: false
     argument :self_billed, Boolean, required: false
     argument :status, [Types::Invoices::StatusTypeEnum], required: false
+    argument :subscription_id, ID, required: false
 
     type Types::Invoices::Object.collection_type, null: false
 
@@ -50,7 +51,8 @@ module Resolvers
       payment_status: nil,
       search_term: nil,
       self_billed: nil,
-      status: nil
+      status: nil,
+      subscription_id: nil
     )
       result = InvoicesQuery.call(
         organization: current_organization,
@@ -72,7 +74,8 @@ module Resolvers
           payment_status:,
           positive_due_amount:,
           self_billed:,
-          status:
+          status:,
+          subscription_id:
         }
       )
 

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -19,7 +19,8 @@ class InvoicesQuery < BaseQuery
     :metadata,
     :partially_paid,
     :positive_due_amount,
-    :self_billed
+    :self_billed,
+    :subscription_id
   ]
 
   def call
@@ -45,6 +46,7 @@ class InvoicesQuery < BaseQuery
     invoices = with_partially_paid(invoices) unless filters.partially_paid.nil?
     invoices = with_positive_due_amount(invoices) unless filters.positive_due_amount.nil?
     invoices = with_self_billed(invoices) unless filters.self_billed.nil?
+    invoices = with_subscription_id(invoices) if filters.subscription_id.present?
 
     result.invoices = invoices
     result
@@ -91,6 +93,10 @@ class InvoicesQuery < BaseQuery
 
   def with_customer_id(scope)
     scope.where(customer_id: filters.customer_id)
+  end
+
+  def with_subscription_id(scope)
+    scope.joins(:invoice_subscriptions).where(invoice_subscriptions: {subscription_id: filters.subscription_id})
   end
 
   def with_invoice_type(scope)

--- a/schema.graphql
+++ b/schema.graphql
@@ -8750,6 +8750,7 @@ type Query {
     searchTerm: String
     selfBilled: Boolean
     status: [InvoiceStatusTypeEnum!]
+    subscriptionId: ID
   ): InvoiceCollection!
 
   """

--- a/schema.json
+++ b/schema.json
@@ -46624,6 +46624,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "subscriptionId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -803,4 +803,20 @@ RSpec.describe InvoicesQuery, type: :query do
       expect(returned_ids).not_to include(invoice_fourth.id, invoice_fifth.id, invoice_sixth.id)
     end
   end
+
+  context "when filtering by subscription_id" do
+    let(:invoice_with_subscription_1) { create(:invoice, :subscription, organization:) }
+    let(:invoice_with_subscription_2) { create(:invoice, :subscription, organization:) }
+
+    let(:filters) { {subscription_id: [invoice_with_subscription_1.subscriptions.first.id]} }
+
+    before do
+      invoice_with_subscription_1
+      invoice_with_subscription_2
+    end
+
+    it "returns invoices for the specified subscription" do
+      expect(returned_ids).to eq([invoice_with_subscription_1.id])
+    end
+  end
 end


### PR DESCRIPTION
## Context

Currently, it is not possible for the front to retrieve a list of invoices related to a subscription.

## Description

This adds a new filter on the `invoices` GraphQL query.
