### PR TITLE
chore(api): Improve subscription APIs after OpenAPI review

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -6,7 +6,8 @@ module Api
       def create
         response = {}
         billing_entity_result = BillingEntities::ResolveService.call(
-          organization: current_organization, billing_entity_code: params.dig(:subscription, :billing_entity_code)
+          organization: current_organization,
+          billing_entity_code: params.dig(:subscription, :billing_entity_code)
         )
         return render_error_response(billing_entity_result) unless billing_entity_result.success?
         billing_entity = billing_entity_result.billing_entity
@@ -173,7 +174,6 @@ module Api
             :name,
             :external_id,
             :billing_time,
-            :subscription_date,
             :subscription_at,
             :ending_at,
             plan_overrides:
@@ -183,7 +183,6 @@ module Api
       def update_params
         params.require(:subscription).permit(
           :name,
-          :subscription_date,
           :subscription_at,
           :ending_at,
           :on_termination_credit_note,
@@ -200,45 +199,34 @@ module Api
           :name,
           :invoice_display_name,
           :trial_period,
-          {tax_codes: []},
-          {
-            minimum_commitment: [
-              :id,
+          tax_codes: [],
+          minimum_commitment: [
+            :invoice_display_name,
+            :amount_cents,
+            tax_codes: []
+          ],
+          charges: [
+            :id,
+            :billable_metric_id,
+            :min_amount_cents,
+            :invoice_display_name,
+            :charge_model,
+            properties: {},
+            filters: [
               :invoice_display_name,
-              :amount_cents,
-              {tax_codes: []}
+              properties: {},
+              values: {}
             ],
-            charges: [
-              :id,
-              :billable_metric_id,
-              :min_amount_cents,
-              :invoice_display_name,
-              :charge_model,
-              {properties: {}},
-              {
-                filters: [
-                  :invoice_display_name,
-                  {
-                    properties: {},
-                    values: {}
-                  }
-                ]
-              },
-              {tax_codes: []},
-              {
-                applied_pricing_unit: [
-                  :code,
-                  :conversion_rate
-                ]
-              }
-            ],
-            usage_thresholds: [
-              :id,
-              :threshold_display_name,
-              :amount_cents,
-              :recurring
+            tax_codes: [],
+            applied_pricing_unit: [
+              :conversion_rate
             ]
-          }
+          ],
+          usage_thresholds: [
+            :threshold_display_name,
+            :amount_cents,
+            :recurring
+          ]
         ]
       end
 

--- a/app/services/webhooks/subscriptions/base_service.rb
+++ b/app/services/webhooks/subscriptions/base_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Subscriptions
+    class BaseService < Webhooks::BaseService
+      private
+
+      def object_serializer
+        ::V1::SubscriptionSerializer.new(
+          object,
+          root_name: "subscription",
+          includes: includes,
+          **serialization_options
+        )
+      end
+
+      def includes
+        %i[plan customer]
+      end
+
+      def serialization_options
+        {}
+      end
+
+      def object_type
+        "subscription"
+      end
+    end
+  end
+end

--- a/app/services/webhooks/subscriptions/started_service.rb
+++ b/app/services/webhooks/subscriptions/started_service.rb
@@ -2,23 +2,9 @@
 
 module Webhooks
   module Subscriptions
-    class StartedService < Webhooks::BaseService
-      private
-
-      def object_serializer
-        ::V1::SubscriptionSerializer.new(
-          object,
-          root_name: "subscription",
-          includes: %i[plan customer]
-        )
-      end
-
+    class StartedService < BaseService
       def webhook_type
         "subscription.started"
-      end
-
-      def object_type
-        "subscription"
       end
     end
   end

--- a/app/services/webhooks/subscriptions/terminated_service.rb
+++ b/app/services/webhooks/subscriptions/terminated_service.rb
@@ -2,23 +2,11 @@
 
 module Webhooks
   module Subscriptions
-    class TerminatedService < Webhooks::BaseService
+    class TerminatedService < BaseService
       private
-
-      def object_serializer
-        ::V1::SubscriptionSerializer.new(
-          object,
-          root_name: "subscription",
-          includes: %i[plan customer]
-        )
-      end
 
       def webhook_type
         "subscription.terminated"
-      end
-
-      def object_type
-        "subscription"
       end
     end
   end

--- a/app/services/webhooks/subscriptions/termination_alert_service.rb
+++ b/app/services/webhooks/subscriptions/termination_alert_service.rb
@@ -2,23 +2,11 @@
 
 module Webhooks
   module Subscriptions
-    class TerminationAlertService < Webhooks::BaseService
+    class TerminationAlertService < BaseService
       private
-
-      def object_serializer
-        ::V1::SubscriptionSerializer.new(
-          object,
-          root_name: "subscription",
-          includes: %i[plan customer]
-        )
-      end
 
       def webhook_type
         "subscription.termination_alert"
-      end
-
-      def object_type
-        "subscription"
       end
     end
   end

--- a/app/services/webhooks/subscriptions/trial_ended_service.rb
+++ b/app/services/webhooks/subscriptions/trial_ended_service.rb
@@ -2,23 +2,11 @@
 
 module Webhooks
   module Subscriptions
-    class TrialEndedService < Webhooks::BaseService
+    class TrialEndedService < BaseService
       private
-
-      def object_serializer
-        ::V1::SubscriptionSerializer.new(
-          object,
-          root_name: "subscription",
-          includes: %i[plan customer]
-        )
-      end
 
       def webhook_type
         "subscription.trial_ended"
-      end
-
-      def object_type
-        "subscription"
       end
     end
   end

--- a/app/services/webhooks/subscriptions/updated_service.rb
+++ b/app/services/webhooks/subscriptions/updated_service.rb
@@ -2,23 +2,11 @@
 
 module Webhooks
   module Subscriptions
-    class UpdatedService < Webhooks::BaseService
+    class UpdatedService < BaseService
       private
-
-      def object_serializer
-        ::V1::SubscriptionSerializer.new(
-          object,
-          root_name: "subscription",
-          includes: %i[plan customer]
-        )
-      end
 
       def webhook_type
         "subscription.updated"
-      end
-
-      def object_type
-        "subscription"
       end
     end
   end

--- a/app/services/webhooks/subscriptions/usage_thresholds_reached_service.rb
+++ b/app/services/webhooks/subscriptions/usage_thresholds_reached_service.rb
@@ -2,24 +2,19 @@
 
 module Webhooks
   module Subscriptions
-    class UsageThresholdsReachedService < Webhooks::BaseService
+    class UsageThresholdsReachedService < BaseService
       private
 
-      def object_serializer
-        ::V1::SubscriptionSerializer.new(
-          object,
-          root_name: "subscription",
-          includes: %i[plan customer usage_threshold],
-          usage_threshold: options[:usage_threshold]
-        )
+      def includes
+        %i[plan customer usage_threshold]
+      end
+
+      def serialization_options
+        {usage_threshold: options[:usage_threshold]}
       end
 
       def webhook_type
         "subscription.usage_threshold_reached"
-      end
-
-      def object_type
-        "subscription"
       end
     end
   end


### PR DESCRIPTION
## Context

After review the OpenAPI spec, I realized the following issues:

- `subscription_date` is allowed in params but unused
- `plan_overrides.minimum_commitment.id` is allowed in params but unused
- `plan_overrides.charges.applied_pricing_unit.code` is allowed in params but unused
- `plan_overrides.usage_thresholds.id` is allowed in params but unused
- The subscription webhooks had duplicated codes

## Description

This fixes those issues.