### PR TITLE
misc: Preload associations when applying taxes on current usage

### DIFF
--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -2,7 +2,7 @@
 
 module Fees
   class ApplyTaxesService < BaseService
-    def initialize(fee:, tax_codes: nil)
+    def initialize(fee:, tax_codes: nil, preloaded_customer_taxes: nil)
       @fee = fee
       @tax_codes = tax_codes
 
@@ -55,7 +55,7 @@ module Fees
 
     private
 
-    attr_reader :fee, :tax_codes
+    attr_reader :fee, :tax_codes, :preloaded_customer_taxes
 
     def customer
       @customer ||= fee.invoice&.customer || fee.subscription.customer
@@ -70,6 +70,7 @@ module Fees
       if (fee.charge? || fee.subscription? || fee.commitment?) && fee.subscription.plan.taxes.any?
         return fee.subscription.plan.taxes
       end
+      return preloaded_customer_taxes if preloaded_customer_taxes.present?
       return customer.taxes if customer.taxes.any?
 
       # billing_entity.taxes - are the default taxes applied on the billing entity


### PR DESCRIPTION
## Description

The goal of this PR is to improve performance when calling customer usage by preloading associations on taxes and avoiding doing N+1 queries.

And use Parallel to run tasks in threads to speed up batch operations and track the performance of each fee’s tax computation on OpenTelemetry.

```
require 'benchmark'

service = Invoices::CustomerUsageService.new(
  customer: subscription.customer,
  subscription: subscription,
  timestamp: Time.current,
  apply_taxes: true,
  with_cache: true
)

elapsed = Benchmark.realtime do
  result = service.call
end

Rails.logger.info "[BENCHMARK] CustomerUsageService#call took #{elapsed.round(3)} seconds"
```

On a usage with 250 fees:
Before: `[BENCHMARK] CustomerUsageService#call took 2.058 seconds`
After: `[BENCHMARK] CustomerUsageService#call took 0.299 seconds`