### PR TITLE
fix: skip touching during cascade to avoid deadlocks

### DIFF
--- a/app/services/charges/create_children_service.rb
+++ b/app/services/charges/create_children_service.rb
@@ -15,8 +15,11 @@ module Charges
       return result.not_found_failure!(resource: "charge") unless charge
 
       ActiveRecord::Base.transaction do
-        plan.children.where(id: child_ids).find_each do |child|
-          Charges::CreateService.call!(plan: child, params: payload.merge(parent_id: charge.id))
+        # skip touching to avoid deadlocks
+        Plan.no_touching do
+          plan.children.where(id: child_ids).find_each do |child|
+            Charges::CreateService.call!(plan: child, params: payload.merge(parent_id: charge.id))
+          end
         end
       end
 


### PR DESCRIPTION
## Context

If parent plan has 20 charges and 10 children plans, following scenario can happen:
- 5 charges got removed on parent plan
- 5 jobs are scheduled, one for removing each charge on all children
- 5 jobs potentially can touch related child plan and it can lead to deadlock dead jobs 

## Description

This PR skips touching plans during cascade
