### PR TITLE
fix(vies): Fail invoice if customer's VIES check is in progress

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -263,6 +263,14 @@ class Customer < ApplicationRecord
     anrok_customer || avalara_customer
   end
 
+  def vies_check_in_progress?
+    if billing_entity.eu_tax_management?
+      taxes.where("code ILIKE ?", "lago_eu%").none?
+    else
+      false
+    end
+  end
+
   private
 
   def ensure_slug

--- a/app/services/customer_portal/customer_update_service.rb
+++ b/app/services/customer_portal/customer_update_service.rb
@@ -44,7 +44,6 @@ module CustomerPortal
         customer.reload
 
         tax_codes = []
-        # This service does not return a 'result' object but a string
         eu_tax_code_result = Customers::EuAutoTaxesService.call(
           customer:,
           new_record: false,

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -997,4 +997,41 @@ RSpec.describe Customer, type: :model do
       end
     end
   end
+
+  describe "#vies_check_in_progress?" do
+    subject { customer.vies_check_in_progress? }
+
+    let(:organization) { create(:organization) }
+    let(:billing_entity) { create(:billing_entity, organization:, eu_tax_management:) }
+    let(:customer) { create(:customer, organization:, billing_entity:) }
+
+    context "when billing_entity has no EU tax management" do
+      let(:eu_tax_management) { false }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "when billing_entity has EU tax management" do
+      let(:eu_tax_management) { true }
+
+      context "when VIES tax exist" do
+        before do
+          tax = create(:tax, organization:, code: "lago_eu_vat")
+          create(:customer_applied_tax, customer:, tax:)
+        end
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+
+      context "when VIES tax do not exist" do
+        it "returns true" do
+          expect(subject).to be true
+        end
+      end
+    end
+  end
 end

--- a/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
+++ b/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
@@ -196,5 +196,48 @@ RSpec.describe Invoices::ComputeTaxesAndTotalsService, type: :service do
         expect(Invoices::ComputeAmountsFromFees).to have_received(:call)
       end
     end
+
+    context "when a VIES check is in progress" do
+      subject(:result) { described_class.call(invoice:, finalizing:) }
+
+      let(:billing_entity) { create(:billing_entity, eu_tax_management: true) }
+      let(:customer) { create(:customer, organization:, billing_entity:) }
+
+      context "when finalizing" do
+        let(:finalizing) { true }
+
+        it "sets the invoice status to pending and tax_status to failed" do
+          subject
+
+          expect(invoice.reload.status).to eq("pending")
+          expect(invoice.reload.tax_status).to eq("failed")
+        end
+
+        it "returns an unknown_tax_failure with the appropriate message" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::UnknownTaxFailure)
+          expect(result.error.message).to eq("tax_error: vies check in progress")
+        end
+      end
+
+      context "when not finalizing" do
+        let(:finalizing) { false }
+
+        before { invoice.update!(status: :draft) }
+
+        it "sets the only tax_status to failed" do
+          subject
+
+          expect(invoice.reload.status).to eq("draft")
+          expect(invoice.reload.tax_status).to eq("failed")
+        end
+
+        it "returns an unknown_tax_failure with the appropriate message" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::UnknownTaxFailure)
+          expect(result.error.message).to eq("tax_error: vies check in progress")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Currently failed VIES check does not prevent invoice finalization which lead to situations when EU customers gets wrong tax amounts.

## Description

These changes will fail invoice if VIES check is not finished on a customer.
