### PR TITLE
Feat Allow multiple subscription_starting invoice_subscriptions when regenerating invoice 

### DIFF
--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -127,7 +127,7 @@ end
 #  index_invoice_subscriptions_on_organization_id                 (organization_id)
 #  index_invoice_subscriptions_on_regenerated_invoice_id          (regenerated_invoice_id)
 #  index_invoice_subscriptions_on_subscription_id                 (subscription_id)
-#  index_unique_starting_subscription_invoice                     (subscription_id,invoicing_reason) UNIQUE WHERE (invoicing_reason = 'subscription_starting'::subscription_invoicing_reason)
+#  index_unique_starting_invoice_subscription                     (subscription_id,invoicing_reason) UNIQUE WHERE ((invoicing_reason = 'subscription_starting'::subscription_invoicing_reason) AND (regenerated_invoice_id IS NULL))
 #  index_unique_terminating_invoice_subscription                  (subscription_id,invoicing_reason) UNIQUE WHERE ((invoicing_reason = 'subscription_terminating'::subscription_invoicing_reason) AND (regenerated_invoice_id IS NULL))
 #
 # Foreign Keys

--- a/db/migrate/20250731144632_add_scoped_index_to_starting_invoice_subscription.rb
+++ b/db/migrate/20250731144632_add_scoped_index_to_starting_invoice_subscription.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddScopedIndexToStartingInvoiceSubscription < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :invoice_subscriptions,
+      [:subscription_id, :invoicing_reason],
+      unique: true,
+      name: :index_unique_starting_invoice_subscription,
+      where: "invoicing_reason = 'subscription_starting' AND regenerated_invoice_id IS NULL",
+      algorithm: :concurrently
+  end
+end

--- a/db/migrate/20250731145640_remove_old_starting_invoice_subscription_index.rb
+++ b/db/migrate/20250731145640_remove_old_starting_invoice_subscription_index.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class RemoveOldStartingInvoiceSubscriptionIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :invoice_subscriptions, name: :index_unique_starting_subscription_invoice
+  end
+
+  def down
+    add_index :invoice_subscriptions,
+      [:subscription_id, :invoicing_reason],
+      unique: true,
+      name: :index_unique_starting_subscription_invoice,
+      where: "invoicing_reason = 'subscription_starting'",
+      algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -271,7 +271,7 @@ DROP INDEX IF EXISTS public.index_usage_monitoring_alerts_on_billable_metric_id;
 DROP INDEX IF EXISTS public.index_usage_monitoring_alert_thresholds_on_organization_id;
 DROP INDEX IF EXISTS public.index_unique_transaction_id;
 DROP INDEX IF EXISTS public.index_unique_terminating_invoice_subscription;
-DROP INDEX IF EXISTS public.index_unique_starting_subscription_invoice;
+DROP INDEX IF EXISTS public.index_unique_starting_invoice_subscription;
 DROP INDEX IF EXISTS public.index_unique_applied_to_organization_per_organization;
 DROP INDEX IF EXISTS public.index_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_taxes_on_code_and_organization_id;
@@ -7434,10 +7434,10 @@ CREATE UNIQUE INDEX index_unique_applied_to_organization_per_organization ON pub
 
 
 --
--- Name: index_unique_starting_subscription_invoice; Type: INDEX; Schema: public; Owner: -
+-- Name: index_unique_starting_invoice_subscription; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_unique_starting_subscription_invoice ON public.invoice_subscriptions USING btree (subscription_id, invoicing_reason) WHERE (invoicing_reason = 'subscription_starting'::public.subscription_invoicing_reason);
+CREATE UNIQUE INDEX index_unique_starting_invoice_subscription ON public.invoice_subscriptions USING btree (subscription_id, invoicing_reason) WHERE ((invoicing_reason = 'subscription_starting'::public.subscription_invoicing_reason) AND (regenerated_invoice_id IS NULL));
 
 
 --
@@ -9443,6 +9443,8 @@ ALTER TABLE ONLY public.dunning_campaign_thresholds
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250731145640'),
+('20250731144632'),
 ('20250724104251'),
 ('20250722094047'),
 ('20250721220908'),


### PR DESCRIPTION
## Context

To support regenerating invoices for starting subscriptions, we need to allow multiple `invoice_subscriptions` records with the same `subscription_id` and `invoicing_reason = 'subscription_starting'`, as long as the invoice has been regenerated.

Currently, the uniqueness constraint (`index_unique_starting_subscription_invoice`) prevents this scenario, blocking valid regeneration flows for subscription starts.

## Description

These changes allow invoice regeneration logic to function properly for starting subscriptions, while preserving database integrity for non-regenerated records.