### PR TITLE
fix(dunning-campaign): send webhook when dunning campaign ends and is not paid

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -15,6 +15,7 @@ class SendWebhookJob < ApplicationJob
 
   WEBHOOK_SERVICES = {
     "alert.triggered" => Webhooks::UsageMonitoring::AlertTriggeredService,
+    "dunning_campaign.finished" => Webhooks::DunningCampaigns::FinishedService,
     "invoice.created" => Webhooks::Invoices::CreatedService,
     "invoice.one_off_created" => Webhooks::Invoices::OneOffCreatedService,
     "invoice.add_on_added" => Webhooks::Invoices::AddOnCreatedService,

--- a/app/serializers/v1/dunning_campaign_finished_serializer.rb
+++ b/app/serializers/v1/dunning_campaign_finished_serializer.rb
@@ -5,7 +5,7 @@ module V1
     def serialize
       {
         customer_external_id: model.external_id,
-        dunning_campaign_id:  options[:dunning_campaign_id],
+        dunning_campaign_id: options[:dunning_campaign_id],
         overdue_balance_cents: model.overdue_balance_cents,
         overdue_balance_currency: model.currency
       }

--- a/app/serializers/v1/dunning_campaign_finished_serializer.rb
+++ b/app/serializers/v1/dunning_campaign_finished_serializer.rb
@@ -5,7 +5,7 @@ module V1
     def serialize
       {
         customer_external_id: model.external_id,
-        dunning_campaign_id: options[:dunning_campaign_id],
+        dunning_campaign_code: options[:dunning_campaign_code],
         overdue_balance_cents: model.overdue_balance_cents,
         overdue_balance_currency: model.currency
       }

--- a/app/serializers/v1/dunning_campaign_finished_serializer.rb
+++ b/app/serializers/v1/dunning_campaign_finished_serializer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module V1
+  class DunningCampaignFinishedSerializer < ModelSerializer
+    def serialize
+      {
+        customer_external_id: model.external_id,
+        dunning_campaign_id:  options[:dunning_campaign_id],
+        overdue_balance_cents: model.overdue_balance_cents,
+        overdue_balance_currency: model.currency
+      }
+    end
+  end
+end

--- a/app/services/dunning_campaigns/bulk_process_service.rb
+++ b/app/services/dunning_campaigns/bulk_process_service.rb
@@ -31,7 +31,7 @@ module DunningCampaigns
 
       def call
         return result unless threshold
-        return result if max_attempts_reached?
+        return send_campaign_finished_webhook if max_attempts_reached?
         return result unless days_between_attempts_satisfied?
 
         DunningCampaigns::ProcessAttemptJob.perform_later(customer:, dunning_campaign_threshold: threshold)
@@ -66,6 +66,18 @@ module DunningCampaigns
         next_attempt_date = customer.last_dunning_campaign_attempt_at + dunning_campaign.days_between_attempts.days
 
         Time.zone.now >= next_attempt_date
+      end
+
+      def send_campaign_finished_webhook
+        return result unless customer.overdue_balance_cents.positive?
+
+        SendWebhookJob.perform_later(
+          "dunning_campaign.finished",
+          customer,
+          dunning_campaign_id: dunning_campaign.id
+        )
+
+        result
       end
     end
   end

--- a/app/services/dunning_campaigns/bulk_process_service.rb
+++ b/app/services/dunning_campaigns/bulk_process_service.rb
@@ -74,7 +74,7 @@ module DunningCampaigns
         SendWebhookJob.perform_later(
           "dunning_campaign.finished",
           customer,
-          dunning_campaign_id: dunning_campaign.id
+          dunning_campaign_code: dunning_campaign.code
         )
 
         result

--- a/app/services/webhooks/dunning_campaigns/finished_service.rb
+++ b/app/services/webhooks/dunning_campaigns/finished_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module DunningCampaigns
+    class FinishedService < Webhooks::BaseService
+      private
+
+      def object_serializer
+        ::V1::DunningCampaignFinishedSerializer.new(
+          object,
+          root_name: object_type,
+          dunning_campaign_id: options[:dunning_campaign_id]
+        )
+      end
+
+      def webhook_type
+        "dunning_campaign.finished"
+      end
+
+      def object_type
+        "dunning_campaign"
+      end
+    end
+  end
+end

--- a/app/services/webhooks/dunning_campaigns/finished_service.rb
+++ b/app/services/webhooks/dunning_campaigns/finished_service.rb
@@ -9,7 +9,7 @@ module Webhooks
         ::V1::DunningCampaignFinishedSerializer.new(
           object,
           root_name: object_type,
-          dunning_campaign_id: options[:dunning_campaign_id]
+          dunning_campaign_code: options[:dunning_campaign_code]
         )
       end
 

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -671,4 +671,29 @@ RSpec.describe SendWebhookJob, type: :job do
       expect(webhook_service).to have_received(:call)
     end
   end
+
+  context "when webhook_type is dunning_campaign.finished" do
+    let(:webhook_service) { instance_double(Webhooks::DunningCampaigns::FinishedService) }
+    let(:customer) { create(:customer) }
+    let(:webhook_options) do
+      {
+        dunning_campaign_id: "campaign_id"
+      }
+    end
+
+    before do
+      allow(Webhooks::DunningCampaigns::FinishedService)
+        .to receive(:new)
+        .with(object: customer, options: webhook_options)
+        .and_return(webhook_service)
+      allow(webhook_service).to receive(:call)
+    end
+
+    it "calls the webhook dunning_campaign.finished" do
+      send_webhook_job.perform_now("dunning_campaign.finished", customer, webhook_options)
+
+      expect(Webhooks::DunningCampaigns::FinishedService).to have_received(:new)
+      expect(webhook_service).to have_received(:call)
+    end
+  end
 end

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -677,7 +677,7 @@ RSpec.describe SendWebhookJob, type: :job do
     let(:customer) { create(:customer) }
     let(:webhook_options) do
       {
-        dunning_campaign_id: "campaign_id"
+        dunning_campaign_code: "campaign_code"
       }
     end
 

--- a/spec/serializers/v1/dunning_campaign_finished_serializer_spec.rb
+++ b/spec/serializers/v1/dunning_campaign_finished_serializer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::V1::DunningCampaignFinishedSerializer do
+  subject(:serializer) { described_class.new(customer, params) }
+
+  let(:customer) { create(:customer) }
+  let(:params) do
+    {
+      root_name: "dunning_campaign",
+      dunning_campaign_id: "campaign_id"
+    }
+  end
+
+  it "serializes the object" do
+    result = JSON.parse(serializer.to_json)
+
+    expect(result["dunning_campaign"]["customer_external_id"]).to eq(customer.external_id)
+    expect(result["dunning_campaign"]["dunning_campaign_id"]).to eq("campaign_id")
+    expect(result["dunning_campaign"]["overdue_balance_cents"]).to eq(customer.overdue_balance_cents)
+    expect(result["dunning_campaign"]["overdue_balance_currency"]).to eq(customer.currency)
+  end
+end

--- a/spec/serializers/v1/dunning_campaign_finished_serializer_spec.rb
+++ b/spec/serializers/v1/dunning_campaign_finished_serializer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ::V1::DunningCampaignFinishedSerializer do
   let(:params) do
     {
       root_name: "dunning_campaign",
-      dunning_campaign_id: "campaign_id"
+      dunning_campaign_code: "campaign_code"
     }
   end
 
@@ -17,7 +17,7 @@ RSpec.describe ::V1::DunningCampaignFinishedSerializer do
     result = JSON.parse(serializer.to_json)
 
     expect(result["dunning_campaign"]["customer_external_id"]).to eq(customer.external_id)
-    expect(result["dunning_campaign"]["dunning_campaign_id"]).to eq("campaign_id")
+    expect(result["dunning_campaign"]["dunning_campaign_code"]).to eq("campaign_code")
     expect(result["dunning_campaign"]["overdue_balance_cents"]).to eq(customer.overdue_balance_cents)
     expect(result["dunning_campaign"]["overdue_balance_currency"]).to eq(customer.currency)
   end

--- a/spec/services/dunning_campaigns/bulk_process_service_spec.rb
+++ b/spec/services/dunning_campaigns/bulk_process_service_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
 
           context "with overdue balance greater than zero" do
             it "sends valid webhook" do
-              expect { result }.to have_enqueued_job(SendWebhookJob).with("dunning_campaign.finished", customer, { dunning_campaign_id: dunning_campaign.id })
+              expect { result }.to have_enqueued_job(SendWebhookJob).with("dunning_campaign.finished", customer, {dunning_campaign_id: dunning_campaign.id})
             end
           end
         end

--- a/spec/services/dunning_campaigns/bulk_process_service_spec.rb
+++ b/spec/services/dunning_campaigns/bulk_process_service_spec.rb
@@ -93,6 +93,12 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
             result
             expect(DunningCampaigns::ProcessAttemptJob).not_to have_been_enqueued
           end
+
+          context "with overdue balance greater than zero" do
+            it "sends valid webhook" do
+              expect { result }.to have_enqueued_job(SendWebhookJob).with("dunning_campaign.finished", customer, { dunning_campaign_id: dunning_campaign.id })
+            end
+          end
         end
 
         context "when not enough days have passed since last attempt" do

--- a/spec/services/dunning_campaigns/bulk_process_service_spec.rb
+++ b/spec/services/dunning_campaigns/bulk_process_service_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_f
 
           context "with overdue balance greater than zero" do
             it "sends valid webhook" do
-              expect { result }.to have_enqueued_job(SendWebhookJob).with("dunning_campaign.finished", customer, {dunning_campaign_id: dunning_campaign.id})
+              expect { result }.to have_enqueued_job(SendWebhookJob).with("dunning_campaign.finished", customer, {dunning_campaign_code: dunning_campaign.code})
             end
           end
         end

--- a/spec/services/webhooks/dunning_campaigns/finished_service_spec.rb
+++ b/spec/services/webhooks/dunning_campaigns/finished_service_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::DunningCampaigns::FinishedService do
+  subject(:webhook_service) { described_class.new(object: customer, options: webhook_options) }
+
+  let(:customer) { create(:customer) }
+  let(:webhook_options) { {dunning_campaign_id: "campaign_id"} }
+
+  it_behaves_like "creates webhook", "dunning_campaign.finished", "dunning_campaign"
+end

--- a/spec/services/webhooks/dunning_campaigns/finished_service_spec.rb
+++ b/spec/services/webhooks/dunning_campaigns/finished_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Webhooks::DunningCampaigns::FinishedService do
   subject(:webhook_service) { described_class.new(object: customer, options: webhook_options) }
 
   let(:customer) { create(:customer) }
-  let(:webhook_options) { {dunning_campaign_id: "campaign_id"} }
+  let(:webhook_options) { {dunning_campaign_code: "campaign_code"} }
 
   it_behaves_like "creates webhook", "dunning_campaign.finished", "dunning_campaign"
 end


### PR DESCRIPTION
## Context

Request from users:

> We need webhook message when a dunning campaign ends and isn't paid so we can auto-block users who don't pay at the end of their dunning campaign. 
> 
> If possible - it would be great to include the customer's overdue balance in the message

## Description

This PR adds `dunning_campaign.finished` webhook to match described use-case