### PR TITLE
fix/third party failure for generate payment link

### DIFF
--- a/app/graphql/concerns/execution_error_responder.rb
+++ b/app/graphql/concerns/execution_error_responder.rb
@@ -57,6 +57,15 @@ module ExecutionErrorResponder
     )
   end
 
+  def third_party_failure(messages:)
+    execution_error(
+      error: "Unprocessable Entity",
+      status: 422,
+      code: "third_party_error",
+      details: {error: messages}
+    )
+  end
+
   def result_error(service_result)
     case service_result.error
     when BaseService::NotFoundFailure
@@ -67,6 +76,8 @@ module ExecutionErrorResponder
       validation_error(messages: service_result.error.messages)
     when BaseService::ForbiddenFailure
       forbidden_error(code: service_result.error.code)
+    when BaseService::ThirdPartyFailure
+      third_party_failure(messages: service_result.error.message)
     else
       execution_error(
         error: "Internal error",

--- a/spec/graphql/concerns/execution_error_responder_spec.rb
+++ b/spec/graphql/concerns/execution_error_responder_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+RSpec.describe ExecutionErrorResponder do
+  let(:responder) { klass.new }
+
+  let(:klass) do
+    Class.new do
+      include ExecutionErrorResponder
+
+      public :execution_error, :not_found_error, :not_allowed_error, :forbidden_error, :validation_error,
+        :third_party_failure, :result_error
+    end
+  end
+
+  describe "execution_error" do
+    subject(:error) do
+      responder.execution_error(error: "Custom error", status: 400, code: "custom_code", details: {foo_bar: "baz"})
+    end
+
+    let(:extensions) do
+      {status: 400, code: "custom_code", details: {"fooBar" => "baz"}}
+    end
+
+    it "returns a GraphQL::ExecutionError with correct message and extensions" do
+      expect(subject).to be_a(GraphQL::ExecutionError)
+      expect(subject.message).to eq("Custom error")
+      expect(subject.extensions).to eq(extensions)
+    end
+
+    it "omits details if not a Hash" do
+      error = responder.execution_error(details: "not a hash")
+      expect(error.extensions).not_to have_key(:details)
+    end
+  end
+
+  describe "not_found_error" do
+    subject(:error) { responder.not_found_error(resource: :alert) }
+
+    let(:extensions) do
+      {status: 404, code: "not_found", details: {"alert" => ["not_found"]}}
+    end
+
+    it "returns a 404 not found error with resource details" do
+      expect(subject.extensions).to eq(extensions)
+    end
+  end
+
+  describe "not_allowed_error" do
+    subject(:error) { responder.not_allowed_error(code: "method_not_allowed") }
+
+    let(:extensions) do
+      {status: 405, code: "method_not_allowed"}
+    end
+
+    it "returns a 405 not allowed error with code" do
+      expect(subject.extensions).to eq(extensions)
+    end
+  end
+
+  describe "forbidden_error" do
+    subject(:error) { responder.forbidden_error(code: "access_denied") }
+
+    let(:extensions) do
+      {status: 403, code: "access_denied"}
+    end
+
+    it "returns a 403 forbidden error with code" do
+      expect(subject.extensions).to eq(extensions)
+    end
+  end
+
+  describe "validation_error" do
+    subject(:error) { responder.validation_error(messages: {name: ["can't be blank"]}) }
+
+    let(:extensions) do
+      {status: 422, code: "unprocessable_entity", details: {"name" => ["can't be blank"]}}
+    end
+
+    it "returns a 422 validation error with messages" do
+      expect(subject.extensions).to eq(extensions)
+    end
+  end
+
+  describe "#third_party_failure" do
+    subject(:error) { responder.third_party_failure(messages: "External service failed") }
+
+    let(:extensions) do
+      {status: 422, code: "third_party_error", details: {"error" => "External service failed"}}
+    end
+
+    it "returns a 422 third party error with messages" do
+      expect(subject.extensions).to eq(extensions)
+    end
+  end
+
+  describe "#result_error" do
+    subject(:result_error) { responder.result_error(result) }
+
+    let(:result) { BaseResult.new }
+
+    before { result.fail_with_error!(error) }
+
+    context "when the service result is a NotFoundFailure" do
+      let(:error) { BaseService::NotFoundFailure.new(result, resource: :alert) }
+
+      it "returns a not found error" do
+        expect(subject).to be_a(GraphQL::ExecutionError)
+        expect(subject.extensions).to include(status: 404, code: "not_found")
+      end
+    end
+
+    context "when the service result is a MethodNotAllowedFailure" do
+      let(:error) { BaseService::MethodNotAllowedFailure.new(result, code: "method_not_allowed") }
+
+      it "returns a not allowed error" do
+        expect(subject).to be_a(GraphQL::ExecutionError)
+        expect(subject.extensions).to include(status: 405, code: "method_not_allowed")
+      end
+    end
+
+    context "when the service result is a ValidationFailure" do
+      let(:error) { BaseService::ValidationFailure.new(result, messages: {name: ["can't be blank"]}) }
+
+      it "returns a validation error" do
+        expect(subject).to be_a(GraphQL::ExecutionError)
+        expect(subject.extensions).to include(status: 422, code: "unprocessable_entity")
+      end
+    end
+
+    context "when the service result is a ForbiddenFailure" do
+      let(:error) { BaseService::ForbiddenFailure.new(result, code: "access_denied") }
+
+      it "returns a forbidden error" do
+        expect(subject).to be_a(GraphQL::ExecutionError)
+        expect(subject.extensions).to include(status: 403, code: "access_denied")
+      end
+    end
+
+    context "when the service result is a ThirdPartyFailure" do
+      let(:error) do
+        BaseService::ThirdPartyFailure.new(
+          result,
+          third_party: "3rd party service",
+          error_code: "external_error",
+          error_message: "External service failed"
+        )
+      end
+
+      it "returns a third party failure error" do
+        expect(subject).to be_a(GraphQL::ExecutionError)
+        expect(subject.extensions).to include(status: 422, code: "third_party_error")
+      end
+    end
+
+    context "when the service result is an unknown failure" do
+      let(:error) { BaseService::UnknownTaxFailure.new(result, code: "unknown_tax", error_message: "error") }
+
+      it "returns an execution error" do
+        expect(subject).to be_a(GraphQL::ExecutionError)
+        expect(subject.extensions).to include({status: 500, code: "unknown_tax"})
+      end
+    end
+  end
+end

--- a/spec/graphql/mutations/invoices/generate_payment_url_spec.rb
+++ b/spec/graphql/mutations/invoices/generate_payment_url_spec.rb
@@ -95,5 +95,32 @@ RSpec.describe Mutations::Invoices::GeneratePaymentUrl, type: :graphql do
         message: "Unprocessable Entity"
       )
     end
+
+    context "when error is ThirdPartyFailure" do
+      let(:service_result) do
+        result = BaseService::Result.new
+        result.third_party_failure!(third_party: "stripe", error_code: 500, error_message: "Hummm, there's an error!")
+        result
+      end
+
+      it "returns a GraphQL error" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query: mutation,
+          variables: {
+            input: {
+              invoiceId: invoice.id
+            }
+          }
+        )
+
+        expect_graphql_error(
+          result:,
+          message: "Unprocessable Entity"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
### Problem
```            
"message": "undefined method 'code' for an instance of BaseService::ThirdPartyFailure",
 "backtrace": [
       "/app/app/graphql/concerns/execution_error_responder.rb:85:in 'ExecutionErrorResponder#result_error'",
       "/app/app/graphql/mutations/invoices/generate_payment_url.rb:23:in 'Mutations::Invoices::GeneratePaymentUrl#resolve'",
```

`::Invoices::Payments::GeneratePaymentUrlService.call(invoice:)` can result in a `result.third_party_failure!`.

https://github.com/getlago/lago-api/blob/main/app/services/invoices/payments/stripe_service.rb#L68

### Stacktrace
https://github.com/getlago/lago-api/blob/main/app/graphql/mutations/invoices/generate_payment_url.rb
https://github.com/getlago/lago-api/blob/main/app/services/invoices/payments/generate_payment_url_service.rb#L35
https://github.com/getlago/lago-api/blob/main/app/services/payment_intents/fetch_service.rb#L19-L21
https://github.com/getlago/lago-api/blob/main/app/services/invoices/payments/stripe_service.rb#L55-L69

### Fix
Respond `BaseService::ThirdPartyFailure` correctly at `ExecutionErrorResponder` 
https://github.com/getlago/lago-api/blob/0b0500f7fa85ab6e1fe6a204274e13d3c3a2ff4f/app/graphql/concerns/execution_error_responder.rb#L79-L80