### PR TITLE
fix: do not return unauthorized when ActivityLogs are not available

### DIFF
--- a/app/graphql/resolvers/activity_log_resolver.rb
+++ b/app/graphql/resolvers/activity_log_resolver.rb
@@ -14,7 +14,8 @@ module Resolvers
     type Types::ActivityLogs::Object, null: true
 
     def resolve(activity_id: nil)
-      raise unauthorized_error unless License.premium? && Utils::ActivityLog.available?
+      raise unauthorized_error unless License.premium?
+      raise forbidden_error(code: "feature_unavailable") unless Utils::ActivityLog.available?
 
       current_organization.activity_logs.find_by!(activity_id: activity_id)
     rescue ActiveRecord::RecordNotFound

--- a/app/graphql/resolvers/activity_logs_resolver.rb
+++ b/app/graphql/resolvers/activity_logs_resolver.rb
@@ -27,7 +27,8 @@ module Resolvers
     type Types::ActivityLogs::Object.collection_type, null: true
 
     def resolve(**args)
-      raise unauthorized_error unless License.premium? && Utils::ActivityLog.available?
+      raise unauthorized_error unless License.premium?
+      raise forbidden_error(code: "feature_unavailable") unless Utils::ActivityLog.available?
 
       result = ActivityLogsQuery.call(
         organization: current_organization,

--- a/spec/graphql/resolvers/activity_log_resolver_spec.rb
+++ b/spec/graphql/resolvers/activity_log_resolver_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Resolvers::ActivityLogResolver, type: :graphql, clickhouse: true 
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "audit_logs:view"
 
-  shared_examples "unauthorized error" do
+  shared_examples "blocked feature" do |message|
     it "returns an error" do
       result = execute_graphql(
         current_user: membership.user,
@@ -32,12 +32,12 @@ RSpec.describe Resolvers::ActivityLogResolver, type: :graphql, clickhouse: true 
         variables: {activityLogId: clickhouse_activity_log.activity_id}
       )
 
-      expect_graphql_error(result:, message: "unauthorized")
+      expect_graphql_error(result:, message:)
     end
   end
 
   context "without premium feature" do
-    it_behaves_like "unauthorized error"
+    it_behaves_like "blocked feature", "unauthorized"
   end
 
   context "without database configuration" do
@@ -49,7 +49,7 @@ RSpec.describe Resolvers::ActivityLogResolver, type: :graphql, clickhouse: true 
       ENV["LAGO_CLICKHOUSE_ENABLED"] = nil
     end
 
-    it_behaves_like "unauthorized error"
+    it_behaves_like "blocked feature", "feature_unavailable"
   end
 
   context "with premium feature" do

--- a/spec/graphql/resolvers/activity_logs_resolver_spec.rb
+++ b/spec/graphql/resolvers/activity_logs_resolver_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Resolvers::ActivityLogsResolver, type: :graphql, clickhouse: true
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "audit_logs:view"
 
-  shared_examples "unauthorized error" do
+  shared_examples "blocked feature" do |message|
     it "returns an error" do
       result = execute_graphql(
         current_user: membership.user,
@@ -36,12 +36,12 @@ RSpec.describe Resolvers::ActivityLogsResolver, type: :graphql, clickhouse: true
         query:
       )
 
-      expect_graphql_error(result:, message: "unauthorized")
+      expect_graphql_error(result:, message:)
     end
   end
 
   context "without premium feature" do
-    it_behaves_like "unauthorized error"
+    it_behaves_like "blocked feature", "unauthorized"
   end
 
   context "without database configuration" do
@@ -53,7 +53,7 @@ RSpec.describe Resolvers::ActivityLogsResolver, type: :graphql, clickhouse: true
       ENV["LAGO_CLICKHOUSE_ENABLED"] = nil
     end
 
-    it_behaves_like "unauthorized error"
+    it_behaves_like "blocked feature", "feature_unavailable"
   end
 
   context "with premium feature" do


### PR DESCRIPTION
When the Activity Logs are not configured, it does not return `unauthorized_error`.

This was causing the front to log out the user and when clicking in ActivityLog pages. 
Returning `forbidden_error` will just have an error on a toast and keep the user logged in.