### PR TITLE
Feat(fixed_charges): Move `AmountDetails` to `ChargeModels` namespace

### DIFF
--- a/app/services/charge_models/amount_details/range_graduated_percentage_service.rb
+++ b/app/services/charge_models/amount_details/range_graduated_percentage_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Charges
+module ChargeModels
   module AmountDetails
     class RangeGraduatedPercentageService < ::BaseService
       def initialize(range:, total_units:)

--- a/app/services/charge_models/amount_details/range_graduated_service.rb
+++ b/app/services/charge_models/amount_details/range_graduated_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Charges
+module ChargeModels
   module AmountDetails
     class RangeGraduatedService < ::BaseService
       def initialize(range:, total_units:)

--- a/app/services/charge_models/graduated_percentage_service.rb
+++ b/app/services/charge_models/graduated_percentage_service.rb
@@ -11,7 +11,7 @@ module ChargeModels
     def amount_details
       {
         graduated_percentage_ranges: ranges.each_with_object([]) do |range, amounts|
-          amounts << Charges::AmountDetails::RangeGraduatedPercentageService.call(range:, total_units: units)
+          amounts << ChargeModels::AmountDetails::RangeGraduatedPercentageService.call(range:, total_units: units)
           break amounts if range[:to_value].nil? || range[:to_value] >= units
         end
       }

--- a/app/services/charge_models/graduated_service.rb
+++ b/app/services/charge_models/graduated_service.rb
@@ -11,7 +11,7 @@ module ChargeModels
     def amount_details
       {
         graduated_ranges: ranges.each_with_object([]) do |range, amounts|
-          amounts << Charges::AmountDetails::RangeGraduatedService.call(range:, total_units: units)
+          amounts << ChargeModels::AmountDetails::RangeGraduatedService.call(range:, total_units: units)
           break amounts if range[:to_value].nil? || range[:to_value] >= units
         end
       }

--- a/spec/services/charge_models/amount_details/range_graduated_percentage_service_spec.rb
+++ b/spec/services/charge_models/amount_details/range_graduated_percentage_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::AmountDetails::RangeGraduatedPercentageService, type: :service do
+RSpec.describe ChargeModels::AmountDetails::RangeGraduatedPercentageService, type: :service do
   subject(:service) { described_class.new(range:, total_units:) }
 
   let(:total_units) { 15 }

--- a/spec/services/charge_models/amount_details/range_graduated_service_spec.rb
+++ b/spec/services/charge_models/amount_details/range_graduated_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::AmountDetails::RangeGraduatedService, type: :service do
+RSpec.describe ChargeModels::AmountDetails::RangeGraduatedService, type: :service do
   subject(:service) { described_class.new(range:, total_units:) }
 
   let(:total_units) { 15 }


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

 ## Context

What is the current situation?

**Option 1:** User has to create a one off invoice alongside the subscription, it will create 2 different invoices.

**Option 2:** User can add a recurring billable metric and use event to have this fee invoice on subscription renewal, but it won’t appear on the first billing subscription.

What problem are we trying to solve?

At subscription creation or afterward, there is no clear way to invoice a fixed fee that is not tied to events, aside from the subscription fee itself. This fee could be either a one-time charge or a recurring one.

 ## Description

- Move `AmountDetails` services from `Charges` to `ChargeModels` namespace