### PR TITLE
feat(revenue-streams): add new data for the revenue streams reports

### DIFF
--- a/app/graphql/types/data_api/revenue_streams/object.rb
+++ b/app/graphql/types/data_api/revenue_streams/object.rb
@@ -17,6 +17,12 @@ module Types
         field :subscription_fee_amount_cents, GraphQL::Types::BigInt, null: false
         field :usage_based_fee_amount_cents, GraphQL::Types::BigInt, null: false
 
+        field :contra_revenue_amount_cents, GraphQL::Types::BigInt, null: false
+        field :credit_notes_credits_amount_cents, GraphQL::Types::BigInt, null: false
+        field :free_credits_amount_cents, GraphQL::Types::BigInt, null: false
+        field :prepaid_credits_amount_cents, GraphQL::Types::BigInt, null: false
+        field :progressive_billing_credit_amount_cents, GraphQL::Types::BigInt, null: false
+
         field :end_of_period_dt, GraphQL::Types::ISO8601Date, null: false
         field :start_of_period_dt, GraphQL::Types::ISO8601Date, null: false
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4285,11 +4285,16 @@ type DataApiPrepaidCreditCollection {
 type DataApiRevenueStream {
   amountCurrency: CurrencyEnum!
   commitmentFeeAmountCents: BigInt!
+  contraRevenueAmountCents: BigInt!
   couponsAmountCents: BigInt!
+  creditNotesCreditsAmountCents: BigInt!
   endOfPeriodDt: ISO8601Date!
+  freeCreditsAmountCents: BigInt!
   grossRevenueAmountCents: BigInt!
   netRevenueAmountCents: BigInt!
   oneOffFeeAmountCents: BigInt!
+  prepaidCreditsAmountCents: BigInt!
+  progressiveBillingCreditAmountCents: BigInt!
   startOfPeriodDt: ISO8601Date!
   subscriptionFeeAmountCents: BigInt!
   usageBasedFeeAmountCents: BigInt!

--- a/schema.json
+++ b/schema.json
@@ -19572,7 +19572,39 @@
               "args": []
             },
             {
+              "name": "contraRevenueAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "couponsAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "creditNotesCreditsAmountCents",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -19596,6 +19628,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "freeCreditsAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
                   "ofType": null
                 }
               },
@@ -19637,6 +19685,38 @@
             },
             {
               "name": "oneOffFeeAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "prepaidCreditsAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "progressiveBillingCreditAmountCents",
               "description": null,
               "type": {
                 "kind": "NON_NULL",


### PR DESCRIPTION
## Context

We need to display more information on the graph for the revenue streams. So the data pipeline created and populated new columns on the Analytical DB called:
```
contra_revenue_amount_cents
credit_notes_credits_amount_cents
free_credits_amount_cents
prepaid_credits_amount_cents
progressive_billing_credit_amount_cents
```
The backend should make the graphql query send these new columns to the FE.

## Description

Just created the fields on the main object type.