### PR TITLE
fix(activity-log): Do not include fees when there are too many of them

### DIFF
--- a/app/services/utils/activity_log.rb
+++ b/app/services/utils/activity_log.rb
@@ -120,7 +120,17 @@ module Utils
       serializer = "V1::#{object.class.name}Serializer".constantize
       root_name = object.class.name.underscore.to_sym
 
-      serializer.new(object, root_name:, includes: SERIALIZED_INCLUDED_OBJECTS[root_name] || []).serialize
+      serializer.new(object, root_name:, includes: serializer_includes(root_name)).serialize
+    end
+
+    def serializer_includes(root_name)
+      return SERIALIZED_INCLUDED_OBJECTS[root_name] || [] if root_name != :invoice
+
+      if object.fees.count > 25
+        SERIALIZED_INCLUDED_OBJECTS[:invoice] - [:fees]
+      else
+        SERIALIZED_INCLUDED_OBJECTS[:invoice]
+      end
     end
 
     def object_changes(changes)


### PR DESCRIPTION
## Context

There is an issue when we're calling `ActivityLog` with a huge payload e.g. an invoice with a lot of fees.
In that case we're hitting the Kafka payload limit (1MB by default) and getting `WaterDrop::Errors::MessageInvalidError`

## Description

In order to fix this issue we skip fees to be serialized for invoices that have more than 25 fees.
So that `ActivityLog` would still log the invoice except the fees in this case.