### PR TITLE
fix(payments): allow load discarded customers

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -7,7 +7,7 @@ class Payment < ApplicationRecord
   PAYABLE_PAYMENT_STATUS = %w[pending processing succeeded failed].freeze
 
   belongs_to :organization
-  belongs_to :customer, optional: true
+  belongs_to :customer, -> { with_discarded }, optional: true
   belongs_to :payable, polymorphic: true
   belongs_to :payment_provider, optional: true, class_name: "PaymentProviders::BaseProvider"
   belongs_to :payment_provider_customer, optional: true, class_name: "PaymentProviderCustomers::BaseCustomer"

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -528,4 +528,18 @@ RSpec.describe Payment, type: :model do
       expect(payments).not_to include(other_org_payment_request_payment)
     end
   end
+
+  describe ".customer" do
+    context "with discarded customer" do
+      before do
+        payment.customer.discard
+        payment.save!
+      end
+
+      it "loads the discarded customer" do
+        payment.reload
+        expect(payment.customer).not_to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description
When an organization have a payment from a discarded customer, the page for listing payments and the payment page gets broken. 

## Fix
Allow payment to load discarded customers.