### PR TITLE
fix(invoice): Voided invoice is disputable as well

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -329,7 +329,7 @@ class Invoice < ApplicationRecord
   end
 
   def payment_dispute_losable?
-    finalized?
+    finalized? || voided?
   end
 
   def voidable?

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -48,6 +48,10 @@ FactoryBot.define do
       status { :pending }
     end
 
+    trait :voided do
+      status { :voided }
+    end
+
     trait :with_subscriptions do
       transient do
         subscriptions { [create(:subscription)] }

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Invoice, type: :model do
 
   describe "validation" do
     describe "of payment dispute lost absence" do
-      context "when invoice is not voided" do
+      context "when invoice is finalized" do
         let(:invoice) { create(:invoice) }
 
         specify do
@@ -46,7 +46,39 @@ RSpec.describe Invoice, type: :model do
       end
 
       context "when invoice is voided" do
-        let(:invoice) { create(:invoice, status: :voided) }
+        let(:invoice) { create(:invoice, :voided) }
+
+        specify do
+          expect(invoice).not_to validate_absence_of(:payment_dispute_lost_at)
+        end
+      end
+
+      context "when invoice is pending" do
+        let(:invoice) { create(:invoice, :pending) }
+
+        specify do
+          expect(invoice).to validate_absence_of(:payment_dispute_lost_at)
+        end
+      end
+
+      context "when invoice is draft" do
+        let(:invoice) { create(:invoice, :draft) }
+
+        specify do
+          expect(invoice).to validate_absence_of(:payment_dispute_lost_at)
+        end
+      end
+
+      context "when invoice is failed" do
+        let(:invoice) { create(:invoice, :failed) }
+
+        specify do
+          expect(invoice).to validate_absence_of(:payment_dispute_lost_at)
+        end
+      end
+
+      context "when invoice is invisible" do
+        let(:invoice) { create(:invoice, :invisible) }
 
         specify do
           expect(invoice).to validate_absence_of(:payment_dispute_lost_at)

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -895,9 +895,15 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       context "when invoice is voided" do
         let(:status) { :voided }
 
-        it "returns method not allowed error" do
+        it "marks the dispute as lost" do
+          expect { subject }.to change { invoice.reload.payment_dispute_lost_at }.from(nil)
+        end
+
+        it "returns the invoice" do
           subject
-          expect(response).to have_http_status(:method_not_allowed)
+
+          expect(response).to have_http_status(:success)
+          expect(json[:invoice][:lago_id]).to eq(invoice.id)
         end
       end
 

--- a/spec/services/invoices/lose_dispute_service_spec.rb
+++ b/spec/services/invoices/lose_dispute_service_spec.rb
@@ -31,18 +31,25 @@ RSpec.describe Invoices::LoseDisputeService, type: :service do
       context "when the invoice is voided" do
         let(:status) { :voided }
 
-        it "returns a failure" do
+        it "marks the dispute as lost" do
           result = lose_dispute_service.call
 
           aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-            expect(result.error.code).to eq("not_disputable")
+            expect(result).to be_success
+            expect(result.invoice.payment_dispute_lost_at).to be_present
           end
         end
 
-        it "does not enqueue a send webhook job for the invoice" do
-          expect { lose_dispute_service.call }.not_to have_enqueued_job(SendWebhookJob)
+        it "enqueues a send webhook job for the invoice" do
+          expect do
+            lose_dispute_service.call
+          end.to have_enqueued_job(SendWebhookJob).with("invoice.payment_dispute_lost", invoice, provider_error: nil)
+        end
+
+        it "enqueues a sync void invoice job" do
+          expect do
+            lose_dispute_service.call
+          end.to have_enqueued_job(Invoices::ProviderTaxes::VoidJob).with(invoice:)
         end
       end
 

--- a/spec/services/payments/lose_dispute_service_spec.rb
+++ b/spec/services/payments/lose_dispute_service_spec.rb
@@ -47,16 +47,23 @@ RSpec.describe Payments::LoseDisputeService, type: :service do
       context "when the invoice is voided" do
         let(:status) { :voided }
 
-        it "returns a failure" do
+        it "marks the dispute as lost" do
           result = lose_dispute_service.call
 
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-          expect(result.error.code).to eq("not_disputable")
+          expect(result).to be_success
+          expect(result.invoices.sole.payment_dispute_lost_at).to be_present
         end
 
-        it "does not enqueue a send webhook job for the invoice" do
-          expect { lose_dispute_service.call }.not_to have_enqueued_job(SendWebhookJob)
+        it "enqueues a send webhook job for the invoice" do
+          expect do
+            lose_dispute_service.call
+          end.to have_enqueued_job(SendWebhookJob).with("invoice.payment_dispute_lost", payment.payable, provider_error: nil)
+        end
+
+        it "enqueues a sync void invoice job" do
+          expect do
+            lose_dispute_service.call
+          end.to have_enqueued_job(Invoices::ProviderTaxes::VoidJob).with(invoice: payment.payable)
         end
       end
 


### PR DESCRIPTION
## Context

Voided invoice should be disputable as well.

## Description

Change `Invoice#payment_dispute_losable?` method to return true even if invoice is voided.