### PR TITLE
Feat(fixed_charges): Extract chargeable validation service 

### DIFF
--- a/app/services/plans/chargeables_validation_service.rb
+++ b/app/services/plans/chargeables_validation_service.rb
@@ -51,7 +51,7 @@ module Plans
       return if add_on_ids.blank?
 
       if organization.add_ons.where(id: add_on_ids).count != add_on_ids.count
-        result.not_found_failure!(resource: "fixed_charges")
+        result.not_found_failure!(resource: "add_ons")
       end
     end
 
@@ -60,7 +60,7 @@ module Plans
       return if add_on_codes.blank?
 
       if organization.add_ons.where(code: add_on_codes).count != add_on_codes.count
-        result.not_found_failure!(resource: "fixed_charges")
+        result.not_found_failure!(resource: "add_ons")
       end
     end
   end

--- a/app/services/plans/chargeables_validation_service.rb
+++ b/app/services/plans/chargeables_validation_service.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Plans
+  class ChargeablesValidationService < BaseService
+    Result = BaseResult
+
+    def initialize(organization:, charges: nil, fixed_charges: nil)
+      @organization = organization
+      @charges = charges
+      @fixed_charges = fixed_charges
+      super
+    end
+
+    def call
+      return result unless should_validate?
+
+      validate_billable_metrics
+      validate_add_ons
+
+      result
+    end
+
+    private
+
+    attr_reader :organization, :charges, :fixed_charges
+
+    def should_validate?
+      charges.present? || fixed_charges.present?
+    end
+
+    def validate_billable_metrics
+      return if charges.blank?
+
+      metric_ids = charges.map { |c| c[:billable_metric_id] }.uniq
+      return if metric_ids.blank?
+
+      if organization.billable_metrics.where(id: metric_ids).count != metric_ids.count
+        result.not_found_failure!(resource: "billable_metrics")
+      end
+    end
+
+    def validate_add_ons
+      return if fixed_charges.blank?
+
+      validate_add_on_ids
+      validate_add_on_codes
+    end
+
+    def validate_add_on_ids
+      add_on_ids = fixed_charges.map { |c| c[:add_on_id] }.uniq.compact
+      return if add_on_ids.blank?
+
+      if organization.add_ons.where(id: add_on_ids).count != add_on_ids.count
+        result.not_found_failure!(resource: "fixed_charges")
+      end
+    end
+
+    def validate_add_on_codes
+      add_on_codes = fixed_charges.map { |c| c[:add_on_code] }.uniq.compact
+      return if add_on_codes.blank?
+
+      if organization.add_ons.where(code: add_on_codes).count != add_on_codes.count
+        result.not_found_failure!(resource: "fixed_charges")
+      end
+    end
+  end
+end

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -35,6 +35,20 @@ module Plans
         end
       end
 
+      # Validates fixed charges
+      if args[:fixed_charges].present?
+
+        addon_ids = args[:fixed_charges].map { |c| c[:addon_id] }.uniq.compact
+        if addon_ids.present? && plan.organization.addons.where(id: addon_ids).count != addon_ids.count
+          return result.not_found_failure!(resource: "fixed_charges")
+        end
+
+        addon_codes = args[:fixed_charges].map { |c| c[:addon_code] }.uniq.compact
+        if addon_codes.present? && plan.organization.addons.where(code: addon_codes).count != addon_codes.count
+          return result.not_found_failure!(resource: "fixed_charges")
+        end
+      end
+
       ActiveRecord::Base.transaction do
         plan.save!
 

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -27,12 +27,12 @@ module Plans
         bill_charges_monthly: (args[:interval]&.to_sym == :yearly) ? args[:bill_charges_monthly] || false : nil
       )
 
-      validation_result = Plans::ChargeablesValidationService.call(
+      chargeables_validation_result = Plans::ChargeablesValidationService.call(
         organization: plan.organization,
         charges: args[:charges],
         fixed_charges: args[:fixed_charges]
       )
-      return validation_result if validation_result.failure?
+      return chargeables_validation_result if chargeables_validation_result.failure?
 
       ActiveRecord::Base.transaction do
         plan.save!

--- a/spec/services/plans/chargeables_validation_service_spec.rb
+++ b/spec/services/plans/chargeables_validation_service_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Plans::ChargeablesValidationService do
+  subject(:validation_service) { described_class.call(organization:, charges:, fixed_charges:) }
+
+  let(:organization) { create(:organization) }
+  let(:charges) { nil }
+  let(:fixed_charges) { nil }
+
+  describe "validations" do
+    context "when no charges or fixed_charges are provided" do
+      it "returns success" do
+        expect(validation_service).to be_success
+      end
+    end
+
+    context "when validating billable metrics" do
+      let(:billable_metric) { create(:billable_metric, organization:) }
+      let(:charges) do
+        [
+          {billable_metric_id: billable_metric.id}
+        ]
+      end
+
+      it "returns success when billable metric exists" do
+        expect(validation_service).to be_success
+      end
+
+      context "when billable metric does not exist" do
+        let(:charges) do
+          [
+            {billable_metric_id: "non-existent-id"}
+          ]
+        end
+
+        it "returns not found failure" do
+          expect(validation_service).to be_a_failure
+          expect(validation_service.error).to be_a(BaseService::NotFoundFailure)
+          expect(validation_service.error.message).to eq("billable_metrics_not_found")
+        end
+      end
+
+      context "when some billable metrics do not exist" do
+        let(:billable_metric2) { create(:billable_metric, organization:) }
+        let(:charges) do
+          [
+            {billable_metric_id: billable_metric.id},
+            {billable_metric_id: "non-existent-id"}
+          ]
+        end
+
+        it "returns not found failure" do
+          expect(validation_service).to be_a_failure
+          expect(validation_service.error).to be_a(BaseService::NotFoundFailure)
+          expect(validation_service.error.message).to eq("billable_metrics_not_found")
+        end
+      end
+    end
+
+    context "when validating add ons by id" do
+      let(:add_on) { create(:add_on, organization:) }
+      let(:fixed_charges) do
+        [
+          {add_on_id: add_on.id}
+        ]
+      end
+
+      it "returns success when add on exists" do
+        expect(validation_service).to be_success
+      end
+
+      context "when add on id does not exist" do
+        let(:fixed_charges) do
+          [
+            {add_on_id: "non-existent-id"}
+          ]
+        end
+
+        it "returns not found failure" do
+          expect(validation_service).to be_a_failure
+          expect(validation_service.error).to be_a(BaseService::NotFoundFailure)
+          expect(validation_service.error.message).to eq("fixed_charges_not_found")
+        end
+      end
+
+      context "when validating add ons by code" do
+        let(:fixed_charges) do
+          [
+            {add_on_code: add_on.code}
+          ]
+        end
+
+        it "returns success when add on exists" do
+          expect(validation_service).to be_success
+        end
+
+        context "when add on does not exist" do
+          let(:fixed_charges) do
+            [
+              {add_on_code: "non-existent-code"}
+            ]
+          end
+
+          it "returns not found failure" do
+            expect(validation_service).to be_a_failure
+            expect(validation_service.error).to be_a(BaseService::NotFoundFailure)
+            expect(validation_service.error.message).to eq("fixed_charges_not_found")
+          end
+        end
+      end
+
+      context "when validating both add_on_id and add_on_code" do
+        let(:add_on2) { create(:add_on, organization:) }
+        let(:fixed_charges) do
+          [
+            {add_on_id: add_on.id},
+            {add_on_code: add_on2.code}
+          ]
+        end
+
+        it "returns success when both exist" do
+          expect(validation_service).to be_success
+        end
+      end
+
+      context "when add_on_id is nil" do
+        let(:fixed_charges) do
+          [
+            {add_on_id: nil, add_on_code: add_on.code}
+          ]
+        end
+
+        it "ignores nil add_on_id and validates by code" do
+          expect(validation_service).to be_success
+        end
+      end
+
+      context "when add_on_code is nil" do
+        let(:fixed_charges) do
+          [
+            {add_on_id: add_on.id, add_on_code: nil}
+          ]
+        end
+
+        it "ignores nil add_on_code and validates by id" do
+          expect(validation_service).to be_success
+        end
+      end
+    end
+
+    context "when validating both charges and fixed_charges" do
+      let(:billable_metric) { create(:billable_metric, organization:) }
+      let(:add_on) { create(:add_on, organization:) }
+      let(:charges) do
+        [
+          {billable_metric_id: billable_metric.id}
+        ]
+      end
+      let(:fixed_charges) do
+        [
+          {add_on_id: add_on.id}
+        ]
+      end
+
+      it "returns success when both exist" do
+        expect(validation_service).to be_success
+      end
+
+      context "when billable metric does not exist" do
+        let(:charges) do
+          [
+            {billable_metric_id: "non-existent-id"}
+          ]
+        end
+
+        it "returns not found failure for billable metrics" do
+          expect(validation_service).to be_a_failure
+          expect(validation_service.error).to be_a(BaseService::NotFoundFailure)
+          expect(validation_service.error.message).to eq("billable_metrics_not_found")
+        end
+      end
+
+      context "when add-on does not exist" do
+        let(:fixed_charges) do
+          [
+            {add_on_id: "non-existent-id"}
+          ]
+        end
+
+        it "returns not found failure for fixed charges" do
+          expect(validation_service).to be_a_failure
+          expect(validation_service.error).to be_a(BaseService::NotFoundFailure)
+          expect(validation_service.error.message).to eq("fixed_charges_not_found")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/plans/chargeables_validation_service_spec.rb
+++ b/spec/services/plans/chargeables_validation_service_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Plans::ChargeablesValidationService do
         it "returns not found failure" do
           expect(validation_service).to be_a_failure
           expect(validation_service.error).to be_a(BaseService::NotFoundFailure)
-          expect(validation_service.error.message).to eq("fixed_charges_not_found")
+          expect(validation_service.error.message).to eq("add_ons_not_found")
         end
       end
 
@@ -106,7 +106,7 @@ RSpec.describe Plans::ChargeablesValidationService do
           it "returns not found failure" do
             expect(validation_service).to be_a_failure
             expect(validation_service.error).to be_a(BaseService::NotFoundFailure)
-            expect(validation_service.error.message).to eq("fixed_charges_not_found")
+            expect(validation_service.error.message).to eq("add_ons_not_found")
           end
         end
       end
@@ -192,7 +192,7 @@ RSpec.describe Plans::ChargeablesValidationService do
         it "returns not found failure for fixed charges" do
           expect(validation_service).to be_a_failure
           expect(validation_service.error).to be_a(BaseService::NotFoundFailure)
-          expect(validation_service.error.message).to eq("fixed_charges_not_found")
+          expect(validation_service.error.message).to eq("add_ons_not_found")
         end
       end
     end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -431,7 +431,6 @@ RSpec.describe Plans::CreateService, type: :service do
       end
     end
 
-
     context "with add ons from other organization" do
       let(:add_on) { create(:add_on) }
 
@@ -445,7 +444,7 @@ RSpec.describe Plans::CreateService, type: :service do
           pay_in_advance: false,
           amount_cents: 200,
           amount_currency: "EUR",
-          fixed_charges: fixed_charges_args,
+          fixed_charges: fixed_charges_args
         }
       end
 

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Plans::CreateService, type: :service do
     let(:plan_invoice_display_name) { "Some plan invoice name" }
     let(:billable_metric) { create(:billable_metric, organization:) }
     let(:sum_billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
+    let(:add_on) { create(:add_on, organization:) }
     let(:plan_tax) { create(:tax, organization:) }
     let(:charge_tax) { create(:tax, organization:) }
     let(:pricing_unit) { create(:pricing_unit, organization:) }
@@ -35,6 +36,7 @@ RSpec.describe Plans::CreateService, type: :service do
         amount_currency: "EUR",
         tax_codes: [plan_tax.code],
         charges: charges_args,
+        fixed_charges: fixed_charges_args,
         usage_thresholds: usage_thresholds_args,
         minimum_commitment: minimum_commitment_args
       }
@@ -89,6 +91,15 @@ RSpec.describe Plans::CreateService, type: :service do
               }
             ]
           }
+        }
+      ]
+    end
+
+    let(:fixed_charges_args) do
+      [
+        {
+          add_on_id: add_on.id,
+          charge_model: "standard"
         }
       ]
     end
@@ -417,6 +428,39 @@ RSpec.describe Plans::CreateService, type: :service do
       it "returns an error" do
         expect(result).not_to be_success
         expect(result.error.error_code).to eq("billable_metrics_not_found")
+      end
+    end
+
+
+    context "with add ons from other organization" do
+      let(:add_on) { create(:add_on) }
+
+      let(:create_args) do
+        {
+          name: plan_name,
+          invoice_display_name: plan_invoice_display_name,
+          organization_id: organization.id,
+          code: "new_plan",
+          interval: "monthly",
+          pay_in_advance: false,
+          amount_cents: 200,
+          amount_currency: "EUR",
+          fixed_charges: fixed_charges_args,
+        }
+      end
+
+      let(:fixed_charges_args) do
+        [
+          {
+            add_on_id: add_on.id,
+            charge_model: "standard"
+          }
+        ]
+      end
+
+      it "returns an error" do
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq("add_ons_not_found")
       end
     end
   end


### PR DESCRIPTION
## Roadmap Task

 👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

 👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

## Context

 What is the current situation?

 **Option 1:** User has to create a one off invoice alongside the
 subscription, it will create 2 different invoices.

 **Option 2:** User can add a recurring billable metric and use event to
 have this fee invoice on subscription renewal, but it won’t appear on
 the first billing subscription.

 What problem are we trying to solve?

 At subscription creation or afterward, there is no clear way to invoice
 a fixed fee that is not tied to events, aside from the subscription fee
 itself. This fee could be either a one-time charge or a recurring one.

## Description

  Add `Plans::ChargeablesValidationService` to validate billable metrics
  and add ons for charges and fixed charges on plans creation params.
