### PR TITLE
misc(event): Add missing results on events services

### DIFF
--- a/app/services/events/calculate_expression_service.rb
+++ b/app/services/events/calculate_expression_service.rb
@@ -2,6 +2,8 @@
 
 module Events
   class CalculateExpressionService < BaseService
+    Result = BaseResult[:event]
+
     def initialize(organization:, event:)
       @organization = organization
       @event = event

--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -4,6 +4,8 @@ module Events
   class CreateBatchService < BaseService
     MAX_LENGTH = ENV.fetch("LAGO_EVENTS_BATCH_MAX_LENGTH", 100).to_i
 
+    Result = BaseResult[:events, :errors]
+
     def initialize(organization:, events_params:, timestamp:, metadata:)
       @organization = organization
       @events_params = events_params[:events]

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -2,6 +2,8 @@
 
 module Events
   class CreateService < BaseService
+    Result = BaseResult[:event]
+
     def initialize(organization:, params:, timestamp:, metadata:)
       @organization = organization
       @params = params

--- a/app/services/events/pay_in_advance_service.rb
+++ b/app/services/events/pay_in_advance_service.rb
@@ -2,6 +2,8 @@
 
 module Events
   class PayInAdvanceService < BaseService
+    Result = BaseResult[:event]
+
     def initialize(event:)
       @event = Events::CommonFactory.new_instance(source: event)
       super

--- a/app/services/events/post_process_service.rb
+++ b/app/services/events/post_process_service.rb
@@ -2,6 +2,8 @@
 
 module Events
   class PostProcessService < BaseService
+    Result = BaseResult[:event]
+
     def initialize(event:)
       @organization = event.organization
       @event = event

--- a/app/services/events/post_validation_service.rb
+++ b/app/services/events/post_validation_service.rb
@@ -2,6 +2,8 @@
 
 module Events
   class PostValidationService < BaseService
+    Result = BaseResult[:errors]
+
     def initialize(organization:)
       @organization = organization
 


### PR DESCRIPTION
## Description

This PR defines the `Result` object for all Events services, the goal is to avoid relying on the Legacy base result as it uses `OpenStruct` internally and is knows to cause memory issues