### PR TITLE
Feat(fixed_charges): Plans::CreateService creates fixed charges

### DIFF
--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -24,7 +24,8 @@ module Plans
         amount_cents: args[:amount_cents],
         amount_currency: args[:amount_currency],
         trial_period: args[:trial_period],
-        bill_charges_monthly: (args[:interval]&.to_sym == :yearly) ? args[:bill_charges_monthly] || false : nil
+        bill_charges_monthly: (args[:interval]&.to_sym == :yearly) ? args[:bill_charges_monthly] || false : nil,
+        bill_fixed_charges_monthly: (args[:interval]&.to_sym == :yearly) ? args[:bill_fixed_charges_monthly] || false : nil
       )
 
       chargeables_validation_result = Plans::ChargeablesValidationService.call(
@@ -58,6 +59,12 @@ module Plans
               taxes_result = Charges::ApplyTaxesService.call(charge: new_charge, tax_codes: charge[:tax_codes])
               taxes_result.raise_if_error!
             end
+          end
+        end
+
+        if args[:fixed_charges].present?
+          args[:fixed_charges].each do |fixed_charge_args|
+            FixedCharges::CreateService.call!(plan:, params: fixed_charge_args)
           end
         end
 
@@ -148,6 +155,7 @@ module Plans
 
     def track_plan_created(plan)
       count_by_charge_model = plan.charges.group(:charge_model).count
+      count_by_fixed_charge_model = plan.fixed_charges.group(:charge_model).count
 
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
@@ -166,6 +174,10 @@ module Plans
           nb_percentage_charges: count_by_charge_model["percentage"] || 0,
           nb_graduated_charges: count_by_charge_model["graduated"] || 0,
           nb_package_charges: count_by_charge_model["package"] || 0,
+          nb_fixed_charges: plan.fixed_charges.count,
+          nb_standard_fixed_charges: count_by_fixed_charge_model["standard"] || 0,
+          nb_graduated_fixed_charges: count_by_fixed_charge_model["graduated"] || 0,
+          nb_volume_fixed_charges: count_by_fixed_charge_model["volume"] || 0,
           organization_id: plan.organization_id,
           parent_id: plan.parent_id
         }

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Plans::CreateService, type: :service do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
-  describe "create" do
+  describe "#call" do
     subject(:result) { plans_service.call }
 
     let(:plan_name) { "Some plan name" }
@@ -264,6 +264,22 @@ RSpec.describe Plans::CreateService, type: :service do
       )
     end
 
+    it "creates fixed charges" do
+      plan = result.plan
+      expect(plan.fixed_charges.count).to eq(1)
+
+      fixed_charge = plan.fixed_charges.first
+      expect(fixed_charge).to have_attributes(
+        organization_id: organization.id,
+        add_on_id: add_on.id,
+        charge_model: "standard",
+        pay_in_advance: false,
+        prorated: false,
+        units: 0,
+        properties: {"amount" => "0"}
+      )
+    end
+
     it "calls SegmentTrackJob" do
       plan = plans_service.call.plan
 
@@ -284,10 +300,49 @@ RSpec.describe Plans::CreateService, type: :service do
           nb_percentage_charges: 0,
           nb_graduated_charges: 1,
           nb_package_charges: 0,
+          nb_fixed_charges: 1,
+          nb_standard_fixed_charges: 1,
+          nb_graduated_fixed_charges: 0,
+          nb_volume_fixed_charges: 0,
           organization_id: plan.organization_id,
           parent_id: nil
         }
       )
+    end
+
+    describe "bill_fixed_charges_monthly" do
+      context "when plan is yearly" do
+        let(:create_args) do
+          super().merge(interval: "yearly", bill_fixed_charges_monthly: true)
+        end
+
+        it "persists bill_fixed_charges_monthly" do
+          plan = result.plan
+          expect(plan.bill_fixed_charges_monthly).to eq(true)
+        end
+
+        context "when not provided" do
+          let(:create_args) do
+            super().merge(interval: "yearly").except(:bill_fixed_charges_monthly)
+          end
+
+          it "defaults to false" do
+            plan = result.plan
+            expect(plan.bill_fixed_charges_monthly).to eq(false)
+          end
+        end
+      end
+
+      context "when plan is monthly" do
+        let(:create_args) do
+          super().merge(interval: "monthly", bill_fixed_charges_monthly: true)
+        end
+
+        it "ignores the flag and sets it to nil" do
+          plan = result.plan
+          expect(plan.bill_fixed_charges_monthly).to be_nil
+        end
+      end
     end
 
     it "produces an activity log" do


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

 ## Context

 What is the current situation?

 **Option 1:** User has to create a one off invoice alongside the
 subscription, it will create 2 different invoices.

 **Option 2:** User can add a recurring billable metric and use event to
 have this fee invoice on subscription renewal, but it won’t appear on
 the first billing subscription.

 What problem are we trying to solve?

 At subscription creation or afterward, there is no clear way to invoice
 a fixed fee that is not tied to events, aside from the subscription fee
 itself. This fee could be either a one-time charge or a recurring one.

 ## Description

 Updates `Plans::CreateService` to:
   - persist `bill_fixed_charges_monthly`
   - create fixed charges records with `FixedCharges::CreateService`
   - add fixed charge counts in track plan created for Segment tracking