### PR TITLE
fix(charge-model-factory): Boolean param to only calculate the projected values when being called by the projection service

### DIFF
--- a/app/services/charge_models/base_service.rb
+++ b/app/services/charge_models/base_service.rb
@@ -21,12 +21,13 @@ module ChargeModels
       new(...).apply
     end
 
-    def initialize(charge:, aggregation_result:, properties:, period_ratio: nil)
+    def initialize(charge:, aggregation_result:, properties:, period_ratio: nil, calculate_projected_usage: false)
       super(nil)
       @charge = charge
       @aggregation_result = aggregation_result
       @properties = properties
       @period_ratio = period_ratio
+      @calculate_projected_usage = calculate_projected_usage
     end
 
     def apply
@@ -42,8 +43,13 @@ module ChargeModels
         result.total_aggregated_units = aggregation_result.total_aggregated_units
       end
 
-      result.projected_units = projected_units
-      result.projected_amount = compute_projected_amount
+      if calculate_projected_usage
+        result.projected_units = projected_units
+        result.projected_amount = compute_projected_amount
+      else
+        result.projected_units = BigDecimal("0.0")
+        result.projected_amount = 0
+      end
 
       result.grouped_results = [result]
       result
@@ -51,7 +57,7 @@ module ChargeModels
 
     protected
 
-    attr_accessor :charge, :aggregation_result, :properties, :period_ratio
+    attr_accessor :charge, :aggregation_result, :properties, :period_ratio, :calculate_projected_usage
 
     delegate :units, to: :result
     delegate :grouped_by, to: :aggregation_result

--- a/app/services/charge_models/grouped_service.rb
+++ b/app/services/charge_models/grouped_service.rb
@@ -10,8 +10,8 @@ module ChargeModels
       :projected_units
     ]
 
-    def initialize(charge_model:, charge:, aggregation_result:, properties:, period_ratio:)
-      super(charge:, aggregation_result:, properties:, period_ratio:)
+    def initialize(charge_model:, charge:, aggregation_result:, properties:, period_ratio:, calculate_projected_usage: false)
+      super(charge:, aggregation_result:, properties:, period_ratio:, calculate_projected_usage:)
       @charge_model = charge_model
     end
 
@@ -22,7 +22,8 @@ module ChargeModels
           charge:,
           aggregation_result: aggregation,
           properties:,
-          period_ratio:
+          period_ratio:,
+          calculate_projected_usage:
         )
         group_result.grouped_by = aggregation.grouped_by
         group_result

--- a/app/services/charges/charge_model_factory.rb
+++ b/app/services/charges/charge_model_factory.rb
@@ -2,13 +2,14 @@
 
 module Charges
   class ChargeModelFactory
-    def self.new_instance(charge:, aggregation_result:, properties:, period_ratio: nil)
+    def self.new_instance(charge:, aggregation_result:, properties:, period_ratio: nil, calculate_projected_usage: false)
       charge_model_class = charge_model_class(charge:)
       common_args = {
         charge:,
         aggregation_result:,
         properties:,
-        period_ratio:
+        period_ratio:,
+        calculate_projected_usage:
       }
 
       # TODO(pricing_group_keys): remove after deprecation of grouped_by

--- a/app/services/fees/projection_service.rb
+++ b/app/services/fees/projection_service.rb
@@ -49,7 +49,8 @@ module Fees
         charge: charge,
         aggregation_result: aggregation_result,
         properties: properties_for_charge_model,
-        period_ratio: period_ratio
+        period_ratio: period_ratio,
+        calculate_projected_usage: true
       ).apply
 
       return result.fail_with_error!(charge_model_result.error) unless charge_model_result.success?

--- a/spec/services/fees/projection_service_spec.rb
+++ b/spec/services/fees/projection_service_spec.rb
@@ -195,7 +195,8 @@ RSpec.describe Fees::ProjectionService do
           charge: charge,
           aggregation_result: aggregation_result,
           properties: charge_properties,
-          period_ratio: expected_period_ratio
+          period_ratio: expected_period_ratio,
+          calculate_projected_usage: true
         )
       end
     end
@@ -223,6 +224,7 @@ RSpec.describe Fees::ProjectionService do
       end
 
       it "uses charge filter properties and filters" do
+        allow(service).to receive(:period_ratio).and_return(0.5)
         aggregator = instance_double("Aggregator", aggregate: aggregation_result)
         allow(BillableMetrics::AggregationFactory).to receive(:new_instance).and_return(aggregator)
         service.call
@@ -246,7 +248,8 @@ RSpec.describe Fees::ProjectionService do
           charge: charge,
           aggregation_result: aggregation_result,
           properties: {"key" => "value"},
-          period_ratio: anything
+          period_ratio: 0.5,
+          calculate_projected_usage: true
         )
 
         service.call

--- a/spec/services/fees/projection_service_spec.rb
+++ b/spec/services/fees/projection_service_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Fees::ProjectionService do
       end
 
       it "uses charge filter properties and filters" do
-        allow(service).to receive(:period_ratio).and_return(0.5)
+        allow(service).to receive(:period_ratio).and_return(0.5) # rubocop:disable RSpec/SubjectStub
         aggregator = instance_double("Aggregator", aggregate: aggregation_result)
         allow(BillableMetrics::AggregationFactory).to receive(:new_instance).and_return(aggregator)
         service.call


### PR DESCRIPTION
## Context

Related to the RAM increase after the projected usage feature was merged. This one complements the previous that added a boolean flag to only calculate the projected values from the right parts of the application.

## Description

In the `ChargeModelFactory`, added a boolean attribute that is only `true` when coming from the `ProjectionService`.