### PR TITLE
feat(one-off-invoice): Add billing period to one-off invoices

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -276,6 +276,8 @@ module Api
                 :unit_amount_cents,
                 :units,
                 :description,
+                :from_datetime,
+                :to_datetime,
                 {tax_codes: []}
               ]
             ).to_h.deep_symbolize_keys

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -37,6 +37,7 @@ module Types
 
       field :charge_filter, Types::ChargeFilters::Object, null: true
       field :pricing_unit_usage, Types::PricingUnitUsages::Object, null: true
+      field :properties, GraphQL::Types::JSON
 
       def item_type
         object.fee_type

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -37,7 +37,7 @@ module Types
 
       field :charge_filter, Types::ChargeFilters::Object, null: true
       field :pricing_unit_usage, Types::PricingUnitUsages::Object, null: true
-      field :properties, GraphQL::Types::JSON
+      field :properties, Types::Fees::Properties, null: true, method: :itself
 
       def item_type
         object.fee_type

--- a/app/graphql/types/fees/properties.rb
+++ b/app/graphql/types/fees/properties.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Types
+  module Fees
+    class Properties < Types::BaseObject
+      graphql_name "FeeProperties"
+
+      field :from_datetime, GraphQL::Types::ISO8601DateTime, null: true
+      field :to_datetime, GraphQL::Types::ISO8601DateTime, null: true
+
+      def from_datetime
+        object.properties["from_datetime"]
+      end
+
+      def to_datetime
+        object.properties["to_datetime"]
+      end
+    end
+  end
+end

--- a/app/graphql/types/invoices/fee_input.rb
+++ b/app/graphql/types/invoices/fee_input.rb
@@ -11,6 +11,8 @@ module Types
       argument :name, String, required: false
       argument :tax_codes, [String], required: false
       argument :unit_amount_cents, GraphQL::Types::BigInt, required: false
+      argument :from_datetime, GraphQL::Types::ISO8601DateTime, required: false
+      argument :to_datetime, GraphQL::Types::ISO8601DateTime, required: false
       argument :units, GraphQL::Types::Float, required: false
     end
   end

--- a/app/graphql/types/invoices/fee_input.rb
+++ b/app/graphql/types/invoices/fee_input.rb
@@ -7,12 +7,12 @@ module Types
 
       argument :add_on_id, ID, required: false
       argument :description, String, required: false
+      argument :from_datetime, GraphQL::Types::ISO8601DateTime, required: false
       argument :invoice_display_name, String, required: false
       argument :name, String, required: false
       argument :tax_codes, [String], required: false
-      argument :unit_amount_cents, GraphQL::Types::BigInt, required: false
-      argument :from_datetime, GraphQL::Types::ISO8601DateTime, required: false
       argument :to_datetime, GraphQL::Types::ISO8601DateTime, required: false
+      argument :unit_amount_cents, GraphQL::Types::BigInt, required: false
       argument :units, GraphQL::Types::Float, required: false
     end
   end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -77,6 +77,12 @@ class Fee < ApplicationRecord
   scope :from_customer_pay_in_advance, ->(org, external_customer_id) do
     from_organization_pay_in_advance(org).joins(subscription: :customer).where("customers.external_id = ?", external_customer_id)
   end
+  scope :ordered_by_period, -> do
+    from = Arel.sql("(properties->>'from_datetime')::timestamptz NULLS LAST")
+    to = Arel.sql("(properties->>'to_datetime')::timestamptz NULLS LAST")
+
+    order(from, to)
+  end
 
   def item_key
     id || object_id

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -54,7 +54,7 @@ module V1
         pricing_unit_details:
       }
 
-      payload.merge!(date_boundaries) if model.charge? || model.subscription?
+      payload.merge!(date_boundaries) if model.charge? || model.subscription? || model.add_on?
       payload.merge!(pay_in_advance_charge_attributes) if model.pay_in_advance?
       payload.merge!(applied_taxes) if include?(:applied_taxes)
 

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -155,7 +155,7 @@ module Fees
           DateTime.strptime(fee[:from_datetime], "%Y-%m-%dT%H:%M:%S.%LZ") :
           DateTime.strptime(fee[:from_datetime])
       else
-        fee[:from_datetime] || Time.current.beginning_of_day
+        fee[:from_datetime] || Time.current
       end
     end
 
@@ -165,7 +165,7 @@ module Fees
           DateTime.strptime(fee[:to_datetime], "%Y-%m-%dT%H:%M:%S.%LZ") :
           DateTime.strptime(fee[:to_datetime])
       else
-        fee[:to_datetime] || Time.current.end_of_day
+        fee[:to_datetime] || Time.current
       end
     end
   end

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -140,8 +140,12 @@ module Fees
     end
 
     def valid_boundaries?(fee)
-      (fee[:from_datetime].nil? || Utils::Datetime.valid_format?(fee[:from_datetime])) &&
-        (fee[:to_datetime].nil? || Utils::Datetime.valid_format?(fee[:to_datetime])) &&
+      return true if fee[:from_datetime].nil? && fee[:to_datetime].nil?
+
+      fee[:from_datetime] &&
+        fee[:to_datetime] &&
+        Utils::Datetime.valid_format?(fee[:from_datetime]) &&
+        Utils::Datetime.valid_format?(fee[:to_datetime]) &&
         from_datetime(fee) < to_datetime(fee)
     end
 

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -90,7 +90,7 @@ module Invoices
     end
 
     def create_one_off_fees(invoice)
-      fees_result = Fees::OneOffService.new(invoice:, fees:).create
+      fees_result = Fees::OneOffService.new(invoice:, fees:).call
       fees_result.raise_if_error! unless tax_error?(fees_result)
 
       result.fees_taxes = fees_result.fees_taxes

--- a/app/views/templates/invoices/v4/_one_off.slim
+++ b/app/views/templates/invoices/v4/_one_off.slim
@@ -6,12 +6,13 @@ table.invoice-resume-table width="100%"
     td.body-2 = I18n.t('invoice.tax_rate')
     td.body-2 = I18n.t('invoice.amount')
   - if one_off?
-    - fees.each do |fee|
+    - fees.ordered_by_period.each do |fee|
       tr
         td
           .body-1 = fee.invoice_name
           .body-3 = fee.description
-        td.body-2 = RoundingHelper.round_decimal_part(fee.units)
+          - if fee.properties["from_datetime"] && fee.properties["to_datetime"]
+            .body-3 #{I18n.t('invoice.from_to_date', from_date: I18n.l(fee.properties["from_datetime"]&.to_date, format: :default), to_date: I18n.l(fee.properties["to_datetime"]&.to_date, format: :default))}
         td.body-2 = MoneyHelper.format(fee.unit_amount)
         td.body-2 == TaxHelper.applied_taxes(fee)
         td.body-2 = FeeDisplayHelper.format_amount(fee)

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -34,6 +34,7 @@ de:
     due_date: Fälligkeit %{date}
     fee_prorated: Die Gebühr wird anteilig nach Nutzungstagen berechnet, der angezeigte Stückpreis ist ein Durchschnitt
     fees_from_to_date: Gebühren vom %{from_date} bis %{to_date}
+    from_to_date: Vom %{from_date} bis %{to_date}
     graduated:
       fee_per_unit_for_the_first: Gebühr pro Einheit für die ersten %{to}
       fee_per_unit_for_the_last: Gebühr pro Einheit für %{from} und höher

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -35,6 +35,7 @@ en:
     due_date: Due %{date}
     fee_prorated: The fee is prorated on days of usage, the displayed unit price is an average
     fees_from_to_date: Fees from %{from_date} to %{to_date}
+    from_to_date: From %{from_date} to %{to_date}
     graduated:
       fee_per_unit_for_the_first: Fee per unit for the first %{to}
       fee_per_unit_for_the_last: Fee per unit for %{from} and above

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -33,6 +33,7 @@ es:
     due_date: Vence el %{date}
     fee_prorated: La tarifa se prorratea según los días de uso, el precio unitario mostrado es un promedio
     fees_from_to_date: Cargos desde %{from_date} hasta %{to_date}
+    from_to_date: Desde %{from_date} hasta %{to_date}
     graduated:
       fee_per_unit_for_the_first: Tarifa por unidad para las %{to} primeras
       fee_per_unit_for_the_last: Tarifa por unidad para %{from} y superiores

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -34,6 +34,7 @@ fr:
     due_date: Date d'échéance le %{date}
     fee_prorated: Les frais sont calculés au prorata des jours d'utilisation, le prix unitaire affiché est une moyenne
     fees_from_to_date: Frais de conso. du %{from_date} au %{to_date}
+    from_to_date: Du %{from_date} au %{to_date}
     graduated:
       fee_per_unit_for_the_first: Frais par unité pour les %{to} premières
       fee_per_unit_for_the_last: Frais par unité pour %{from} et plus

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -34,6 +34,7 @@ it:
     due_date: Scadenza %{date}
     fee_prorated: La tariffa è calcolata in base ai giorni di utilizzo, il prezzo unitario visualizzato è una media
     fees_from_to_date: Tariffe dal %{from_date} al %{to_date}
+    from_to_date: Dal %{from_date} al %{to_date}
     graduated:
       fee_per_unit_for_the_first: Tariffa per unità per le prime %{to}
       fee_per_unit_for_the_last: Tariffa per unità per %{from} e oltre

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -34,6 +34,7 @@ nb:
     due_date: Forfallsdato %{date}
     fee_prorated: Avgiften beregnes forholdsmessig etter brukerdager, den viste enhetsprisen er et gjennomsnitt
     fees_from_to_date: Gebyrer fra %{from_date} til %{to_date}
+    from_to_date: Fra %{from_date} til %{to_date}
     graduated:
       fee_per_unit_for_the_first: Avgift per enhet for de første %{to}
       fee_per_unit_for_the_last: Avgift per enhet for %{from} og mer

--- a/config/locales/pt_BR/invoice.yml
+++ b/config/locales/pt_BR/invoice.yml
@@ -34,6 +34,7 @@ pt_BR:
     due_date: Vencimento %{date}
     fee_prorated: A taxa é proporcional aos dias de uso, o preço unitário exibido é uma média
     fees_from_to_date: Taxas de %{from_date} até %{to_date}
+    from_to_date: De %{from_date} até %{to_date}
     graduated:
       fee_per_unit_for_the_first: Taxa por unidade para os primeiros %{to}
       fee_per_unit_for_the_last: Taxa por unidade para %{from} e acima

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -33,6 +33,7 @@ sv:
     due_date: Förfaller %{date}
     fee_prorated: Avgiften är proraterad för användningsdagar, det visade enhetspriset är ett genomsnitt
     fees_from_to_date: Avgifter från %{from_date} till %{to_date}
+    from_to_date: Från %{from_date} till %{to_date}
     graduated:
       fee_per_unit_for_the_first: Avgift per enhet för de första %{to}
       fee_per_unit_for_the_last: Avgift per enhet för %{from} och högre

--- a/schema.graphql
+++ b/schema.graphql
@@ -5081,6 +5081,7 @@ type Fee implements InvoiceItem {
   itemType: String!
   preciseUnitAmount: Float!
   pricingUnitUsage: PricingUnitUsage
+  properties: JSON
   subscription: Subscription
   succeededAt: ISO8601DateTime
   taxesAmountCents: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -5149,9 +5149,11 @@ Fee input for creating invoice
 input FeeInput {
   addOnId: ID
   description: String
+  fromDatetime: ISO8601DateTime
   invoiceDisplayName: String
   name: String
   taxCodes: [String!]
+  toDatetime: ISO8601DateTime
   unitAmountCents: BigInt
   units: Float
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -5081,7 +5081,7 @@ type Fee implements InvoiceItem {
   itemType: String!
   preciseUnitAmount: Float!
   pricingUnitUsage: PricingUnitUsage
-  properties: JSON
+  properties: FeeProperties
   subscription: Subscription
   succeededAt: ISO8601DateTime
   taxesAmountCents: BigInt!
@@ -5157,6 +5157,11 @@ input FeeInput {
   toDatetime: ISO8601DateTime
   unitAmountCents: BigInt
   units: Float
+}
+
+type FeeProperties {
+  fromDatetime: ISO8601DateTime
+  toDatetime: ISO8601DateTime
 }
 
 enum FeeTypesEnum {

--- a/schema.json
+++ b/schema.json
@@ -24678,6 +24678,18 @@
               "deprecationReason": null
             },
             {
+              "name": "fromDatetime",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "invoiceDisplayName",
               "description": null,
               "type": {
@@ -24722,35 +24734,23 @@
               "deprecationReason": null
             },
             {
-              "name": "unitAmountCents",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "BigInt",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "fromDatetime",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601DateTime",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "toDatetime",
               "description": null,
               "type": {
                 "kind": "SCALAR",
                 "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "unitAmountCents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
                 "ofType": null
               },
               "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -24734,6 +24734,30 @@
               "deprecationReason": null
             },
             {
+              "name": "fromDatetime",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "toDatetime",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "units",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -23956,6 +23956,18 @@
               "args": []
             },
             {
+              "name": "properties",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "subscription",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -23959,8 +23959,8 @@
               "name": "properties",
               "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "JSON",
+                "kind": "OBJECT",
+                "name": "FeeProperties",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -24782,6 +24782,41 @@
               "deprecationReason": null
             }
           ],
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FeeProperties",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "fromDatetime",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "toDatetime",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
           "enumValues": null
         },
         {

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -40,7 +40,14 @@ RSpec.describe Mutations::Invoices::Create, type: :graphql do
           invoiceType,
           issuingDate,
           appliedTaxes { id taxCode taxRate },
-          fees { units preciseUnitAmount properties },
+          fees {
+            units
+            preciseUnitAmount
+            properties {
+              fromDatetime
+              toDatetime
+            }
+          },
         }
       }
     GQL
@@ -87,18 +94,16 @@ RSpec.describe Mutations::Invoices::Create, type: :graphql do
             "units" => 2.0,
             "preciseUnitAmount" => 12.0,
             "properties" => {
-              "from_datetime" => current_time.beginning_of_day.to_time.utc.iso8601(3),
-              "to_datetime" => current_time.end_of_day.to_time.utc.iso8601(3),
-              "timestamp" => current_time
+              "fromDatetime" => current_time.beginning_of_day.to_time.utc.iso8601,
+              "toDatetime" => current_time.end_of_day.to_time.utc.iso8601
             }
           },
           {
             "units" => 1.0,
             "preciseUnitAmount" => 4.0,
             "properties" => {
-              "from_datetime" => current_time.beginning_of_day.to_time.utc.iso8601(3),
-              "to_datetime" => current_time.end_of_day.to_time.utc.iso8601(3),
-              "timestamp" => current_time
+              "fromDatetime" => current_time.beginning_of_day.to_time.utc.iso8601,
+              "toDatetime" => current_time.end_of_day.to_time.utc.iso8601
             }
           }
         )

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -94,16 +94,16 @@ RSpec.describe Mutations::Invoices::Create, type: :graphql do
             "units" => 2.0,
             "preciseUnitAmount" => 12.0,
             "properties" => {
-              "fromDatetime" => current_time.beginning_of_day.to_time.utc.iso8601,
-              "toDatetime" => current_time.end_of_day.to_time.utc.iso8601
+              "fromDatetime" => current_time.to_time.utc.iso8601,
+              "toDatetime" => current_time.to_time.utc.iso8601
             }
           },
           {
             "units" => 1.0,
             "preciseUnitAmount" => 4.0,
             "properties" => {
-              "fromDatetime" => current_time.beginning_of_day.to_time.utc.iso8601,
-              "toDatetime" => current_time.end_of_day.to_time.utc.iso8601
+              "fromDatetime" => current_time.to_time.utc.iso8601,
+              "toDatetime" => current_time.to_time.utc.iso8601
             }
           }
         )

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Mutations::Invoices::Create, type: :graphql do
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
   let(:add_on_first) { create(:add_on, organization:) }
   let(:add_on_second) { create(:add_on, amount_cents: 400, organization:) }
+  let(:current_time) { DateTime.new(2023, 7, 19, 12, 12) }
   let(:fees) do
     [
       {
@@ -39,7 +40,7 @@ RSpec.describe Mutations::Invoices::Create, type: :graphql do
           invoiceType,
           issuingDate,
           appliedTaxes { id taxCode taxRate },
-          fees { units preciseUnitAmount },
+          fees { units preciseUnitAmount properties },
         }
       }
     GQL
@@ -52,38 +53,56 @@ RSpec.describe Mutations::Invoices::Create, type: :graphql do
   it_behaves_like "requires permission", "invoices:create"
 
   it "creates one-off invoice" do
-    result = execute_graphql(
-      current_user: membership.user,
-      current_organization: organization,
-      permissions: required_permission,
-      query: mutation,
-      variables: {
-        input: {
-          customerId: customer.id,
-          currency:,
-          fees:
+    travel_to(current_time) do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            customerId: customer.id,
+            currency:,
+            fees:
+          }
         }
-      }
-    )
-
-    result_data = result["data"]["createInvoice"]
-
-    aggregate_failures do
-      expect(result_data).to include(
-        "id" => String,
-        "issuingDate" => Time.current.to_date.to_s,
-        "invoiceType" => "one_off",
-        "feesAmountCents" => "2800",
-        "taxesAmountCents" => "560",
-        "totalAmountCents" => "3360",
-        "taxesRate" => 20,
-        "currency" => "EUR"
       )
-      expect(result_data["appliedTaxes"].map { |t| t["taxCode"] }).to contain_exactly(tax.code)
-      expect(result_data["fees"]).to contain_exactly(
-        {"units" => 2.0, "preciseUnitAmount" => 12.0},
-        {"units" => 1.0, "preciseUnitAmount" => 4.0}
-      )
+
+      result_data = result["data"]["createInvoice"]
+
+      aggregate_failures do
+        expect(result_data).to include(
+          "id" => String,
+          "issuingDate" => Time.current.to_date.to_s,
+          "invoiceType" => "one_off",
+          "feesAmountCents" => "2800",
+          "taxesAmountCents" => "560",
+          "totalAmountCents" => "3360",
+          "taxesRate" => 20,
+          "currency" => "EUR"
+        )
+        expect(result_data["appliedTaxes"].map { |t| t["taxCode"] }).to contain_exactly(tax.code)
+        expect(result_data["fees"]).to contain_exactly(
+          {
+            "units" => 2.0,
+            "preciseUnitAmount" => 12.0,
+            "properties" => {
+              "from_datetime" => current_time.beginning_of_day.to_time.utc.iso8601(3),
+              "to_datetime" => current_time.end_of_day.to_time.utc.iso8601(3),
+              "timestamp" => current_time
+            }
+          },
+          {
+            "units" => 1.0,
+            "preciseUnitAmount" => 4.0,
+            "properties" => {
+              "from_datetime" => current_time.beginning_of_day.to_time.utc.iso8601(3),
+              "to_datetime" => current_time.end_of_day.to_time.utc.iso8601(3),
+              "timestamp" => current_time
+            }
+          }
+        )
+      end
     end
   end
 end

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -26,6 +26,6 @@ RSpec.describe Types::Fees::Object do
 
     expect(subject).to have_field(:charge_filter).of_type("ChargeFilter")
     expect(subject).to have_field(:pricing_unit_usage).of_type("PricingUnitUsage")
-    expect(subject).to have_field(:properties).of_type("JSON")
+    expect(subject).to have_field(:properties).of_type("FeeProperties")
   end
 end

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -26,5 +26,6 @@ RSpec.describe Types::Fees::Object do
 
     expect(subject).to have_field(:charge_filter).of_type("ChargeFilter")
     expect(subject).to have_field(:pricing_unit_usage).of_type("PricingUnitUsage")
+    expect(subject).to have_field(:properties).of_type("JSON")
   end
 end

--- a/spec/graphql/types/invoices/fee_input_spec.rb
+++ b/spec/graphql/types/invoices/fee_input_spec.rb
@@ -13,5 +13,7 @@ RSpec.describe Types::Invoices::FeeInput do
     expect(subject).to accept_argument(:tax_codes).of_type("[String!]")
     expect(subject).to accept_argument(:unit_amount_cents).of_type("BigInt")
     expect(subject).to accept_argument(:units).of_type("Float")
+    expect(subject).to accept_argument(:from_datetime).of_type("ISO8601DateTime")
+    expect(subject).to accept_argument(:to_datetime).of_type("ISO8601DateTime")
   end
 end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -15,6 +15,45 @@ RSpec.describe Fee, type: :model do
   it { is_expected.to have_one(:pricing_unit_usage).dependent(:destroy) }
   it { is_expected.to have_one(:true_up_fee).with_foreign_key(:true_up_parent_fee_id).class_name("Fee").dependent(:destroy) }
 
+  describe "#ordered_by_period" do
+    let(:fee1) do
+      create(:fee, properties: {
+        "from_datetime" => "2021-02-01T00:00:00Z",
+        "to_datetime" => "2021-03-31T23:59:59Z"
+      })
+    end
+    let(:fee2) do
+      create(:fee, properties: {
+        "from_datetime" => "2021-03-01T00:00:00Z",
+        "to_datetime" => "2021-04-20T23:59:59Z"
+      })
+    end
+    let(:fee3) do
+      create(:fee, properties: {
+        "from_datetime" => "2021-01-01T00:00:00Z",
+        "to_datetime" => "2021-02-18T23:59:59Z"
+      })
+    end
+    let(:fee4) do
+      create(:fee, properties: {
+        "from_datetime" => "2021-01-01T00:00:00Z",
+        "to_datetime" => "2021-01-31T23:59:59Z"
+      })
+    end
+
+    before do
+      Fee.destroy_all
+      fee1
+      fee2
+      fee3
+      fee4
+    end
+
+    it "returns fees in right order" do
+      expect(Fee.ordered_by_period).to eq([fee4, fee3, fee1, fee2])
+    end
+  end
+
   describe "#item_code" do
     context "when it is a subscription fee" do
       let(:subscription) { create(:subscription) }

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Fees::OneOffService do
     before { CurrentContext.source = "api" }
 
     it "creates fees" do
-      result = one_off_service.create
+      result = one_off_service.call
 
       expect(result).to be_success
 
@@ -80,6 +80,56 @@ RSpec.describe Fees::OneOffService do
       expect(second_fee.taxes.map(&:code)).to contain_exactly(tax.code)
     end
 
+    context "with passed boundaries" do
+      let(:current_time) { DateTime.new(2023, 7, 19, 12, 12) }
+      let(:fees) do
+        [
+          {
+            add_on_code: add_on_first.code,
+            unit_amount_cents: 1200,
+            units: 2,
+            description: "desc-123",
+            from_datetime: "2022-01-01T00:00:00Z",
+            to_datetime: "2022-01-31T23:59:59Z",
+            tax_codes: [tax2.code]
+          }
+        ]
+      end
+
+      it "creates fees" do
+        travel_to(current_time) do
+          result = one_off_service.call
+
+          expect(result).to be_success
+
+          first_fee = result.fees[0]
+
+          expect(first_fee).to have_attributes(
+            id: String,
+            organization_id: organization.id,
+            billing_entity_id: billing_entity.id,
+            invoice_id: invoice.id,
+            add_on_id: add_on_first.id,
+            description: "desc-123",
+            unit_amount_cents: 1200,
+            precise_unit_amount: 12,
+            units: 2,
+            amount_cents: 2400,
+            precise_amount_cents: 2400.0,
+            amount_currency: "EUR",
+            fee_type: "add_on",
+            payment_status: "pending",
+            properties: {
+              "from_datetime" => DateTime.strptime("2022-01-01T00:00:00Z").iso8601(3),
+              "to_datetime" => DateTime.strptime("2022-01-31T23:59:59Z").iso8601(3),
+              "timestamp" => current_time
+            }
+          )
+          expect(first_fee.taxes.map(&:code)).to contain_exactly(tax2.code)
+        end
+      end
+    end
+
     context "when add_on_code is invalid" do
       let(:fees) do
         [
@@ -96,9 +146,69 @@ RSpec.describe Fees::OneOffService do
       end
 
       it "does not create an invalid fee" do
-        one_off_service.create
+        one_off_service.call
 
         expect(Fee.find_by(description: add_on_second.description)).to be_nil
+      end
+    end
+
+    context "when boundaries have invalid values" do
+      let(:fees) do
+        [
+          {
+            add_on_code: add_on_first.code,
+            unit_amount_cents: 1200,
+            units: 2,
+            description: "desc-123",
+            from_datetime: "2022-05-01T00:00:00Z",
+            to_datetime: "2022-01-31T23:59:59Z",
+            tax_codes: [tax2.code]
+          }
+        ]
+      end
+
+      it "does not create an invalid fee" do
+        one_off_service.call
+
+        expect(Fee.find_by(description: add_on_first.description)).to be_nil
+      end
+
+      it "returns validation failure" do
+        result = one_off_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:boundaries]).to include("values_are_invalid")
+      end
+    end
+
+    context "when one boundary has invalid format" do
+      let(:fees) do
+        [
+          {
+            add_on_code: add_on_first.code,
+            unit_amount_cents: 1200,
+            units: 2,
+            description: "desc-123",
+            from_datetime: "2022-01-01T00:00:00Z",
+            to_datetime: "invalid",
+            tax_codes: [tax2.code]
+          }
+        ]
+      end
+
+      it "does not create an invalid fee" do
+        one_off_service.call
+
+        expect(Fee.find_by(description: add_on_first.description)).to be_nil
+      end
+
+      it "returns validation failure" do
+        result = one_off_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:boundaries]).to include("values_are_invalid")
       end
     end
 
@@ -116,7 +226,7 @@ RSpec.describe Fees::OneOffService do
       end
 
       it "creates fees" do
-        result = one_off_service.create
+        result = one_off_service.call
 
         expect(result).to be_success
 
@@ -190,7 +300,7 @@ RSpec.describe Fees::OneOffService do
       end
 
       it "creates fees" do
-        result = one_off_service.create
+        result = one_off_service.call
         first_fee = result.fees[0]
         second_fee = result.fees[1]
 
@@ -252,7 +362,7 @@ RSpec.describe Fees::OneOffService do
         end
 
         it "creates fees" do
-          result = one_off_service.create
+          result = one_off_service.call
           first_fee = result.fees[0]
           second_fee = result.fees[1]
 
@@ -306,7 +416,7 @@ RSpec.describe Fees::OneOffService do
         end
 
         it "returns tax error" do
-          result = one_off_service.create
+          result = one_off_service.call
 
           expect(result).not_to be_success
           expect(result.error.code).to eq("tax_error")
@@ -323,7 +433,7 @@ RSpec.describe Fees::OneOffService do
           end
 
           it "returns and store proper error details" do
-            result = one_off_service.create
+            result = one_off_service.call
 
             expect(result).not_to be_success
             expect(result.error.code).to eq("tax_error")

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Fees::OneOffService do
   let(:tax2) { create(:tax, organization:, applied_to_organization: false) }
   let(:add_on_first) { create(:add_on, organization:) }
   let(:add_on_second) { create(:add_on, amount_cents: 400, organization:) }
+  let(:current_time) { DateTime.new(2023, 7, 19, 12, 12) }
   let(:fees) do
     [
       {
@@ -36,52 +37,63 @@ RSpec.describe Fees::OneOffService do
     before { CurrentContext.source = "api" }
 
     it "creates fees" do
-      result = one_off_service.call
+      travel_to(current_time) do
+        result = one_off_service.call
 
-      expect(result).to be_success
+        expect(result).to be_success
 
-      first_fee = result.fees[0]
-      second_fee = result.fees[1]
+        first_fee = result.fees[0]
+        second_fee = result.fees[1]
 
-      expect(first_fee).to have_attributes(
-        id: String,
-        organization_id: organization.id,
-        billing_entity_id: billing_entity.id,
-        invoice_id: invoice.id,
-        add_on_id: add_on_first.id,
-        description: "desc-123",
-        unit_amount_cents: 1200,
-        precise_unit_amount: 12,
-        units: 2,
-        amount_cents: 2400,
-        precise_amount_cents: 2400.0,
-        amount_currency: "EUR",
-        fee_type: "add_on",
-        payment_status: "pending"
-      )
-      expect(first_fee.taxes.map(&:code)).to contain_exactly(tax2.code)
+        expect(first_fee).to have_attributes(
+          id: String,
+          organization_id: organization.id,
+          billing_entity_id: billing_entity.id,
+          invoice_id: invoice.id,
+          add_on_id: add_on_first.id,
+          description: "desc-123",
+          unit_amount_cents: 1200,
+          precise_unit_amount: 12,
+          units: 2,
+          amount_cents: 2400,
+          precise_amount_cents: 2400.0,
+          amount_currency: "EUR",
+          fee_type: "add_on",
+          payment_status: "pending",
+          properties: {
+            "from_datetime" => current_time.beginning_of_day.to_time.utc.iso8601(3),
+            "to_datetime" => current_time.end_of_day.to_time.utc.iso8601(3),
+            "timestamp" => current_time
+          }
+        )
+        expect(first_fee.taxes.map(&:code)).to contain_exactly(tax2.code)
 
-      expect(second_fee).to have_attributes(
-        id: String,
-        organization_id: organization.id,
-        billing_entity_id: billing_entity.id,
-        invoice_id: invoice.id,
-        add_on_id: add_on_second.id,
-        description: add_on_second.description,
-        unit_amount_cents: 400,
-        precise_unit_amount: 4,
-        units: 1,
-        amount_cents: 400,
-        precise_amount_cents: 400.0,
-        amount_currency: "EUR",
-        fee_type: "add_on",
-        payment_status: "pending"
-      )
-      expect(second_fee.taxes.map(&:code)).to contain_exactly(tax.code)
+        expect(second_fee).to have_attributes(
+          id: String,
+          organization_id: organization.id,
+          billing_entity_id: billing_entity.id,
+          invoice_id: invoice.id,
+          add_on_id: add_on_second.id,
+          description: add_on_second.description,
+          unit_amount_cents: 400,
+          precise_unit_amount: 4,
+          units: 1,
+          amount_cents: 400,
+          precise_amount_cents: 400.0,
+          amount_currency: "EUR",
+          fee_type: "add_on",
+          payment_status: "pending",
+          properties: {
+            "from_datetime" => current_time.beginning_of_day.to_time.utc.iso8601(3),
+            "to_datetime" => current_time.end_of_day.to_time.utc.iso8601(3),
+            "timestamp" => current_time
+          }
+        )
+        expect(second_fee.taxes.map(&:code)).to contain_exactly(tax.code)
+      end
     end
 
     context "with passed boundaries" do
-      let(:current_time) { DateTime.new(2023, 7, 19, 12, 12) }
       let(:fees) do
         [
           {
@@ -192,6 +204,35 @@ RSpec.describe Fees::OneOffService do
             description: "desc-123",
             from_datetime: "2022-01-01T00:00:00Z",
             to_datetime: "invalid",
+            tax_codes: [tax2.code]
+          }
+        ]
+      end
+
+      it "does not create an invalid fee" do
+        one_off_service.call
+
+        expect(Fee.find_by(description: add_on_first.description)).to be_nil
+      end
+
+      it "returns validation failure" do
+        result = one_off_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:boundaries]).to include("values_are_invalid")
+      end
+    end
+
+    context "when one boundary is missing" do
+      let(:fees) do
+        [
+          {
+            add_on_code: add_on_first.code,
+            unit_amount_cents: 1200,
+            units: 2,
+            description: "desc-123",
+            from_datetime: "2022-01-01T00:00:00Z",
             tax_codes: [tax2.code]
           }
         ]

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe Fees::OneOffService do
           fee_type: "add_on",
           payment_status: "pending",
           properties: {
-            "from_datetime" => current_time.beginning_of_day.to_time.utc.iso8601(3),
-            "to_datetime" => current_time.end_of_day.to_time.utc.iso8601(3),
+            "from_datetime" => current_time.to_time.utc.iso8601(3),
+            "to_datetime" => current_time.to_time.utc.iso8601(3),
             "timestamp" => current_time
           }
         )
@@ -84,8 +84,8 @@ RSpec.describe Fees::OneOffService do
           fee_type: "add_on",
           payment_status: "pending",
           properties: {
-            "from_datetime" => current_time.beginning_of_day.to_time.utc.iso8601(3),
-            "to_datetime" => current_time.end_of_day.to_time.utc.iso8601(3),
+            "from_datetime" => current_time.to_time.utc.iso8601(3),
+            "to_datetime" => current_time.to_time.utc.iso8601(3),
             "timestamp" => current_time
           }
         )


### PR DESCRIPTION
## Context

Currently fees on one-off invoices does not contain billing period

## Description

As part of the `quotes` feature, the decision is to add billing period on one-off invoice. This information would be consumed by analytics since it would allow splitting revenue across the billing interval
