### PR TITLE
misc: Add BillingPerdiodBoundaries

### DIFF
--- a/app/models/billing_period_boundaries.rb
+++ b/app/models/billing_period_boundaries.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class BillingPeriodBoundaries
+  attr_reader :from_datetime, :to_datetime, :charges_from_datetime, :charges_duration, :timestamp, :issuing_date
+  attr_accessor :charges_to_datetime
+
+  def self.from_fee(fee)
+    props = fee&.properties || {}
+
+    new(
+      from_datetime: props["from_datetime"],
+      to_datetime: props["to_datetime"],
+      charges_from_datetime: props["charges_from_datetime"],
+      charges_to_datetime: props["charges_to_datetime"],
+      charges_duration: props["charges_duration"],
+      timestamp: props["timestamp"],
+      issuing_date: props["issuing_date"]
+    )
+  end
+
+  def initialize(from_datetime:, to_datetime:, charges_from_datetime:, charges_to_datetime:, charges_duration:, timestamp:, issuing_date: nil)
+    @from_datetime = from_datetime
+    @to_datetime = to_datetime
+    @charges_from_datetime = charges_from_datetime
+    @charges_to_datetime = charges_to_datetime
+    @charges_duration = charges_duration
+    @timestamp = timestamp
+    @issuing_date = issuing_date
+  end
+
+  def to_h
+    h = {
+      "from_datetime" => from_datetime,
+      "to_datetime" => to_datetime,
+      "charges_from_datetime" => charges_from_datetime,
+      "charges_to_datetime" => charges_to_datetime,
+      "charges_duration" => charges_duration,
+      "timestamp" => timestamp
+    }.with_indifferent_access
+    h["issuing_date"] = issuing_date if issuing_date.present?
+    h
+  end
+end

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -41,15 +41,15 @@ class InvoiceSubscription < ApplicationRecord
   def self.matching?(subscription, boundaries, recurring: true)
     base_query = InvoiceSubscription
       .where(subscription_id: subscription.id)
-      .where(from_datetime: boundaries[:from_datetime])
-      .where(to_datetime: boundaries[:to_datetime])
+      .where(from_datetime: boundaries.from_datetime)
+      .where(to_datetime: boundaries.to_datetime)
 
     base_query = base_query.recurring if recurring
 
     if subscription.plan.yearly? && subscription.plan.bill_charges_monthly?
       base_query = base_query
-        .where(charges_from_datetime: boundaries[:charges_from_datetime])
-        .where(charges_to_datetime: boundaries[:charges_to_datetime])
+        .where(charges_from_datetime: boundaries.charges_from_datetime)
+        .where(charges_to_datetime: boundaries.charges_to_datetime)
     end
 
     base_query.exists?

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -233,14 +233,14 @@ class Subscription < ApplicationRecord
     # We should calculate boundaries as if subscription was not terminated
     dates_service = Subscriptions::DatesService.new_instance(duplicate, datetime, current_usage: false)
 
-    previous_period_boundaries = {
+    previous_period_boundaries = BillingPeriodBoundaries.new(
       from_datetime: dates_service.from_datetime,
       to_datetime: dates_service.to_datetime,
       charges_from_datetime: dates_service.charges_from_datetime,
       charges_to_datetime: dates_service.charges_to_datetime,
       timestamp: datetime,
       charges_duration: dates_service.charges_duration_in_days
-    }
+    )
 
     InvoiceSubscription.matching?(self, previous_period_boundaries) ? boundaries : previous_period_boundaries
   end

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -17,9 +17,9 @@ module Charges
         charge:,
         subscription:,
         boundaries: {
-          from_datetime: boundaries[:charges_from_datetime],
-          to_datetime: boundaries[:charges_to_datetime],
-          charges_duration: boundaries[:charges_duration]
+          from_datetime: boundaries.charges_from_datetime,
+          to_datetime: boundaries.charges_to_datetime,
+          charges_duration: boundaries.charges_duration
         },
         filters: aggregation_filters
       )

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -6,14 +6,14 @@ module Fees
       @invoice = invoice
       @charge = charge
       @subscription = subscription
-      @boundaries = OpenStruct.new(boundaries)
+      @boundaries = boundaries
       @currency = subscription.plan.amount.currency
       @apply_taxes = apply_taxes
 
       @context = context
       @current_usage = context == :current_usage
       @cache_middleware = cache_middleware || Subscriptions::ChargeCacheMiddleware.new(
-        subscription:, charge:, to_datetime: boundaries[:charges_to_datetime], cache: false
+        subscription:, charge:, to_datetime: boundaries.charges_to_datetime, cache: false
       )
 
       # Allow the service to ignore events aggregation

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -92,7 +92,7 @@ module Fees
         invoiceable: charge,
         units: charge_model_result.units,
         total_aggregated_units: charge_model_result.units,
-        properties: boundaries,
+        properties: boundaries.to_h,
         events_count: charge_model_result.count,
         charge_filter_id: charge_filter&.id,
         pay_in_advance_event_id: event.id,
@@ -143,14 +143,14 @@ module Fees
     end
 
     def boundaries
-      @boundaries ||= {
+      @boundaries ||= BillingPeriodBoundaries.new(
         from_datetime: date_service.from_datetime,
         to_datetime: date_service.to_datetime,
         charges_from_datetime: date_service.charges_from_datetime,
         charges_to_datetime: date_service.charges_to_datetime,
         charges_duration: date_service.charges_duration_in_days,
         timestamp: billing_at
-      }
+      )
     end
 
     def aggregate(properties:, charge_filter: nil)

--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -6,7 +6,7 @@ module Fees
       @fee = fee
       @used_amount_cents = used_amount_cents
       @used_precise_amount_cents = used_precise_amount_cents
-      @boundaries = OpenStruct.new(fee&.properties)
+      @boundaries = BillingPeriodBoundaries.from_fee(fee)
 
       super
     end

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -5,7 +5,7 @@ module Fees
     def initialize(invoice:, subscription:, boundaries:, context: nil)
       @invoice = invoice
       @subscription = subscription
-      @boundaries = OpenStruct.new(boundaries)
+      @boundaries = boundaries
       @context = context
 
       super(nil)

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -25,14 +25,14 @@ module Invoices
             date_service: date_service(subscription)
           ).call
 
-          boundaries = {
+          boundaries = BillingPeriodBoundaries.new(
             from_datetime: invoice_subscription.from_datetime,
             to_datetime: invoice_subscription.to_datetime,
             charges_from_datetime: invoice_subscription.charges_from_datetime,
             charges_to_datetime: invoice_subscription.charges_to_datetime,
             timestamp: invoice_subscription.timestamp,
             charges_duration: date_service.charges_duration_in_days
-          }
+          )
 
           create_subscription_fee(subscription, boundaries) if should_create_subscription_fee?(subscription, boundaries)
           create_charges_fees(subscription, boundaries) if should_create_charge_fees?(subscription)
@@ -97,7 +97,7 @@ module Invoices
 
     def charge_boundaries_valid?(boundaries)
       # TODO: Investigate why invalid boundaries are even possible
-      boundaries[:charges_from_datetime] < boundaries[:charges_to_datetime]
+      boundaries.charges_from_datetime < boundaries.charges_to_datetime
     end
 
     def create_charges_fees(subscription, boundaries)
@@ -220,7 +220,7 @@ module Invoices
 
       return false if subscription.plan.pay_in_advance? && fee_exists
       return false unless should_create_yearly_subscription_fee?(subscription)
-      return false if in_trial_period_not_ending_today?(subscription, boundaries[:timestamp])
+      return false if in_trial_period_not_ending_today?(subscription, boundaries.timestamp)
 
       # NOTE: When a subscription is terminated we still need to charge the subscription
       #       fee if the plan is in pay in arrears, otherwise this fee will never
@@ -330,7 +330,7 @@ module Invoices
         .store_class(organization: invoice.organization)
         .new(
           subscription:,
-          boundaries: {from_datetime: boundaries[:charges_from_datetime], to_datetime: boundaries[:charges_to_datetime]}
+          boundaries: {from_datetime: boundaries.charges_from_datetime, to_datetime: boundaries.charges_to_datetime}
         )
         .distinct_codes
     end

--- a/app/services/invoices/create_invoice_subscription_service.rb
+++ b/app/services/invoices/create_invoice_subscription_service.rb
@@ -31,11 +31,11 @@ module Invoices
           organization: subscription.organization,
           invoice:,
           subscription:,
-          timestamp: boundaries[:timestamp],
-          from_datetime: boundaries[:from_datetime],
-          to_datetime: boundaries[:to_datetime],
-          charges_from_datetime: boundaries[:charges_from_datetime],
-          charges_to_datetime: boundaries[:charges_to_datetime],
+          timestamp: boundaries.timestamp,
+          from_datetime: boundaries.from_datetime,
+          to_datetime: boundaries.to_datetime,
+          charges_from_datetime: boundaries.charges_from_datetime,
+          charges_to_datetime: boundaries.charges_to_datetime,
           recurring: invoicing_reason.to_sym == :subscription_periodic,
           invoicing_reason: invoicing_reason_for_subscription(subscription)
         )
@@ -81,13 +81,14 @@ module Invoices
     def calculate_boundaries(subscription)
       date_service = date_service(subscription)
 
-      {
+      BillingPeriodBoundaries.new(
         from_datetime: date_service.from_datetime,
         to_datetime: date_service.to_datetime,
         charges_from_datetime: date_service.charges_from_datetime,
         charges_to_datetime: date_service.charges_to_datetime,
+        charges_duration: date_service.charges_duration_in_days,
         timestamp: datetime
-      }
+      )
     end
 
     def date_service(subscription)
@@ -120,14 +121,14 @@ module Invoices
       # We should calculate boundaries as if subscription was not terminated
       dates_service = Subscriptions::DatesService.new_instance(duplicate, datetime, current_usage: false)
 
-      previous_period_boundaries = {
+      previous_period_boundaries = BillingPeriodBoundaries.new(
         from_datetime: dates_service.from_datetime,
         to_datetime: dates_service.to_datetime,
         charges_from_datetime: dates_service.charges_from_datetime,
         charges_to_datetime: dates_service.charges_to_datetime,
         timestamp: datetime,
         charges_duration: dates_service.charges_duration_in_days
-      }
+      )
 
       InvoiceSubscription.matching?(subscription, previous_period_boundaries) ? boundaries : previous_period_boundaries
     end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -59,7 +59,7 @@ module Invoices
         organization:,
         billing_entity:,
         customer:,
-        issuing_date: boundaries[:issuing_date],
+        issuing_date: boundaries.issuing_date,
         currency: plan.amount_currency
       )
 
@@ -97,12 +97,12 @@ module Invoices
       cache_middleware = Subscriptions::ChargeCacheMiddleware.new(
         subscription:,
         charge:,
-        to_datetime: boundaries[:charges_to_datetime],
+        to_datetime: boundaries.charges_to_datetime,
         cache: with_cache
       )
 
       applied_boundaries = boundaries
-      applied_boundaries = applied_boundaries.merge(charges_to_datetime: max_to_datetime) if max_to_datetime
+      applied_boundaries = boundaries.dup.tap { it.charges_to_datetime = max_to_datetime } if max_to_datetime
 
       Fees::ChargeService
         .call(invoice:, charge:, subscription:, boundaries: applied_boundaries, context: :current_usage, cache_middleware:)
@@ -119,14 +119,15 @@ module Invoices
         current_usage: true
       )
 
-      @boundaries = {
+      @boundaries = BillingPeriodBoundaries.new(
         from_datetime: date_service.from_datetime,
         to_datetime: date_service.to_datetime,
         charges_from_datetime: date_service.charges_from_datetime,
         charges_to_datetime: date_service.charges_to_datetime,
         issuing_date: date_service.next_end_of_period,
-        charges_duration: date_service.charges_duration_in_days
-      }
+        charges_duration: date_service.charges_duration_in_days,
+        timestamp:
+      )
     end
 
     def compute_amounts
@@ -176,8 +177,8 @@ module Invoices
 
     def format_usage
       SubscriptionUsage.new(
-        from_datetime: boundaries[:charges_from_datetime].iso8601,
-        to_datetime: boundaries[:charges_to_datetime].iso8601,
+        from_datetime: boundaries.charges_from_datetime.iso8601,
+        to_datetime: boundaries.charges_to_datetime.iso8601,
         issuing_date: invoice.issuing_date.iso8601,
         currency: invoice.currency,
         amount_cents: invoice.fees_amount_cents,

--- a/app/services/invoices/preview_service.rb
+++ b/app/services/invoices/preview_service.rb
@@ -102,14 +102,14 @@ module Invoices
         current_usage: subscription.persisted? && subscription.terminated? && subscription.upgraded?
       )
 
-      boundaries = {
+      boundaries = BillingPeriodBoundaries.new(
         from_datetime: date_service.from_datetime,
         to_datetime: date_service.to_datetime,
         charges_from_datetime: date_service.charges_from_datetime,
         charges_to_datetime: date_service.charges_to_datetime,
         timestamp: billing_time,
         charges_duration: date_service.charges_duration_in_days
-      }
+      )
 
       subscription.adjusted_boundaries(billing_time, boundaries)
     end
@@ -175,7 +175,7 @@ module Invoices
               cache_middleware = Subscriptions::ChargeCacheMiddleware.new(
                 subscription:,
                 charge:,
-                to_datetime: boundaries[:charges_to_datetime]
+                to_datetime: boundaries.charges_to_datetime
               )
 
               Fees::ChargeService

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -114,14 +114,14 @@ module Invoices
         current_usage: true
       )
 
-      @boundaries = {
+      @boundaries = BillingPeriodBoundaries.new(
         from_datetime: invoice_subscription.from_datetime,
         to_datetime: invoice_subscription.to_datetime,
         charges_from_datetime: invoice_subscription.charges_from_datetime,
         charges_to_datetime: invoice_subscription.charges_to_datetime,
         timestamp: timestamp,
         charges_duration: date_service.charges_duration_in_days
-      }
+      )
     end
 
     def create_applied_usage_thresholds

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -159,13 +159,14 @@ module Subscriptions
         current_usage: false
       )
 
-      boundaries = {
+      boundaries = BillingPeriodBoundaries.new(
         from_datetime: dates_service.from_datetime,
         to_datetime: dates_service.to_datetime,
         charges_from_datetime: dates_service.charges_from_datetime,
         charges_to_datetime: dates_service.charges_to_datetime,
-        charges_duration: dates_service.charges_duration_in_days
-      }
+        charges_duration: dates_service.charges_duration_in_days,
+        timestamp: beginning_of_period
+      )
 
       InvoiceSubscription.matching?(subscription, boundaries, recurring: false)
     end

--- a/spec/models/billing_period_boundaries_spec.rb
+++ b/spec/models/billing_period_boundaries_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BillingPeriodBoundaries, type: :model do
+  subject(:boundaries) do
+    described_class.new(
+      from_datetime:,
+      to_datetime:,
+      charges_from_datetime:,
+      charges_to_datetime:,
+      timestamp:,
+      charges_duration:
+    )
+  end
+
+  let(:from_datetime) { timestamp.beginning_of_month }
+  let(:to_datetime) { timestamp.end_of_month }
+  let(:charges_from_datetime) { (timestamp - 1.month).beginning_of_month }
+  let(:charges_to_datetime) { (timestamp - 1.month).end_of_month }
+  let(:timestamp) { Time.current }
+  let(:charges_duration) { charges_to_datetime - charges_from_datetime }
+
+  describe "#to_h" do
+    it "returns a hash with the boundaries" do
+      expect(boundaries.to_h).to eq(
+        "from_datetime" => from_datetime,
+        "to_datetime" => to_datetime,
+        "charges_from_datetime" => charges_from_datetime,
+        "charges_to_datetime" => charges_to_datetime,
+        "timestamp" => timestamp,
+        "charges_duration" => charges_duration
+      )
+    end
+  end
+
+  describe ".from_fee" do
+    let(:fee) { build(:charge_fee) }
+
+    it "returns a BillingPeriodBoundaries instance" do
+      instance = described_class.from_fee(fee)
+
+      expect(instance).to be_a(described_class)
+      expect(instance.from_datetime).to eq(fee.properties["from_datetime"])
+      expect(instance.to_datetime).to eq(fee.properties["to_datetime"])
+      expect(instance.charges_from_datetime).to eq(fee.properties["charges_from_datetime"])
+      expect(instance.charges_to_datetime).to eq(fee.properties["charges_to_datetime"])
+      expect(instance.charges_duration).to eq(fee.properties["charges_duration"])
+      expect(instance.timestamp).to eq(fee.properties["timestamp"])
+    end
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -692,10 +692,10 @@ RSpec.describe Subscription, type: :model do
         new_boundaries = subscription.adjusted_boundaries(billing_date, default_boundaries)
 
         expect(new_boundaries).not_to eq(default_boundaries)
-        expect(new_boundaries[:from_datetime].iso8601).to eq("2024-05-01T00:00:00Z")
-        expect(new_boundaries[:to_datetime].iso8601).to eq("2024-05-31T23:59:59Z")
-        expect(new_boundaries[:charges_from_datetime].iso8601).to eq("2024-05-01T00:00:00Z")
-        expect(new_boundaries[:charges_to_datetime].iso8601).to eq("2024-05-31T23:59:59Z")
+        expect(new_boundaries.from_datetime.iso8601).to eq("2024-05-01T00:00:00Z")
+        expect(new_boundaries.to_datetime.iso8601).to eq("2024-05-31T23:59:59Z")
+        expect(new_boundaries.charges_from_datetime.iso8601).to eq("2024-05-01T00:00:00Z")
+        expect(new_boundaries.charges_to_datetime.iso8601).to eq("2024-05-31T23:59:59Z")
       end
     end
   end

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -22,10 +22,14 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
   end
 
   let(:boundaries) do
-    {
+    BillingPeriodBoundaries.new(
+      from_datetime: subscription.started_at.beginning_of_day,
+      to_datetime: subscription.started_at.end_of_month.end_of_day,
       charges_from_datetime: subscription.started_at.beginning_of_day,
-      charges_to_datetime: subscription.started_at.end_of_month.end_of_day
-    }
+      charges_to_datetime: subscription.started_at.end_of_month.end_of_day,
+      charges_duration: subscription.started_at.end_of_month.end_of_day - subscription.started_at.beginning_of_day,
+      timestamp: subscription.started_at.end_of_month.to_i
+    )
   end
 
   let(:agg_result) { BaseService::Result.new }
@@ -45,9 +49,9 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
             charge:,
             subscription:,
             boundaries: {
-              from_datetime: boundaries[:charges_from_datetime],
-              to_datetime: boundaries[:charges_to_datetime],
-              charges_duration: boundaries[:charges_duration]
+              from_datetime: boundaries.charges_from_datetime,
+              to_datetime: boundaries.charges_to_datetime,
+              charges_duration: boundaries.charges_duration
             },
             filters: {
               event:
@@ -90,9 +94,9 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
               charge:,
               subscription:,
               boundaries: {
-                from_datetime: boundaries[:charges_from_datetime],
-                to_datetime: boundaries[:charges_to_datetime],
-                charges_duration: boundaries[:charges_duration]
+                from_datetime: boundaries.charges_from_datetime,
+                to_datetime: boundaries.charges_to_datetime,
+                charges_duration: boundaries.charges_duration
               },
               filters: {
                 event:,
@@ -136,9 +140,9 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
               charge:,
               subscription:,
               boundaries: {
-                from_datetime: boundaries[:charges_from_datetime],
-                to_datetime: boundaries[:charges_to_datetime],
-                charges_duration: boundaries[:charges_duration]
+                from_datetime: boundaries.charges_from_datetime,
+                to_datetime: boundaries.charges_to_datetime,
+                charges_duration: boundaries.charges_duration
               },
               filters: {
                 event:,
@@ -178,9 +182,9 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
               charge:,
               subscription:,
               boundaries: {
-                from_datetime: boundaries[:charges_from_datetime],
-                to_datetime: boundaries[:charges_to_datetime],
-                charges_duration: boundaries[:charges_duration]
+                from_datetime: boundaries.charges_from_datetime,
+                to_datetime: boundaries.charges_to_datetime,
+                charges_duration: boundaries.charges_duration
               },
               filters: {
                 event:,
@@ -215,9 +219,9 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
             charge:,
             subscription:,
             boundaries: {
-              from_datetime: boundaries[:charges_from_datetime],
-              to_datetime: boundaries[:charges_to_datetime],
-              charges_duration: boundaries[:charges_duration]
+              from_datetime: boundaries.charges_from_datetime,
+              to_datetime: boundaries.charges_to_datetime,
+              charges_duration: boundaries.charges_duration
             },
             filters: {
               event:
@@ -247,9 +251,9 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
             charge:,
             subscription:,
             boundaries: {
-              from_datetime: boundaries[:charges_from_datetime],
-              to_datetime: boundaries[:charges_to_datetime],
-              charges_duration: boundaries[:charges_duration]
+              from_datetime: boundaries.charges_from_datetime,
+              to_datetime: boundaries.charges_to_datetime,
+              charges_duration: boundaries.charges_duration
             },
             filters: {
               event:

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Fees::ChargeService do
   end
 
   let(:boundaries) do
-    {
+    BillingPeriodBoundaries.new(
       from_datetime: subscription.started_at.to_date.beginning_of_day,
       to_datetime: subscription.started_at.end_of_month.end_of_day,
       charges_from_datetime: subscription.started_at.beginning_of_day,
@@ -34,7 +34,7 @@ RSpec.describe Fees::ChargeService do
       charges_duration: (
         subscription.started_at.end_of_month.end_of_day - subscription.started_at.beginning_of_month
       ).fdiv(1.day).ceil
-    }
+    )
   end
 
   let(:invoice) do
@@ -68,7 +68,7 @@ RSpec.describe Fees::ChargeService do
             organization: subscription.organization,
             subscription:,
             code: billable_metric.code,
-            timestamp: boundaries[:charges_to_datetime] - 2.days
+            timestamp: boundaries.charges_to_datetime - 2.days
           )
         end
 
@@ -230,8 +230,8 @@ RSpec.describe Fees::ChargeService do
 
             let(:properties) do
               {
-                charges_from_datetime: boundaries[:charges_from_datetime],
-                charges_to_datetime: boundaries[:charges_to_datetime]
+                charges_from_datetime: boundaries.charges_from_datetime,
+                charges_to_datetime: boundaries.charges_to_datetime
               }
             end
 
@@ -426,8 +426,8 @@ RSpec.describe Fees::ChargeService do
 
             let(:properties) do
               {
-                charges_from_datetime: boundaries[:charges_from_datetime],
-                charges_to_datetime: boundaries[:charges_to_datetime]
+                charges_from_datetime: boundaries.charges_from_datetime,
+                charges_to_datetime: boundaries.charges_to_datetime
               }
             end
 
@@ -578,14 +578,14 @@ RSpec.describe Fees::ChargeService do
         end
 
         let(:boundaries) do
-          {
+          BillingPeriodBoundaries.new(
             from_datetime: Time.zone.parse("15 Apr 2022 00:01:00"),
             to_datetime: Time.zone.parse("30 Apr 2022 00:01:00"),
             charges_from_datetime: subscription.started_at,
             charges_to_datetime: Time.zone.parse("30 Apr 2022 00:01:00"),
             charges_duration: 30,
             timestamp: Time.zone.parse("2022-05-01T00:01:00")
-          }
+          )
         end
 
         before do
@@ -616,7 +616,7 @@ RSpec.describe Fees::ChargeService do
             code: billable_metric.code,
             organization: organization,
             external_subscription_id: subscription.external_id,
-            timestamp: boundaries[:charges_to_datetime] - 2.days,
+            timestamp: boundaries.charges_to_datetime - 2.days,
             properties: {"foo_bar" => 1}
           )
         end
@@ -712,8 +712,8 @@ RSpec.describe Fees::ChargeService do
         end
         let(:properties) do
           {
-            charges_from_datetime: boundaries[:charges_from_datetime],
-            charges_to_datetime: boundaries[:charges_to_datetime]
+            charges_from_datetime: boundaries.charges_from_datetime,
+            charges_to_datetime: boundaries.charges_to_datetime
           }
         end
 
@@ -2286,7 +2286,7 @@ RSpec.describe Fees::ChargeService do
           expect(cached_aggregation.external_subscription_id).to eq(subscription.external_id)
           expect(cached_aggregation.charge_filter_id).to be_nil
           expect(cached_aggregation.charge_id).to eq(charge.id)
-          expect(cached_aggregation.timestamp).to eq(boundaries[:from_datetime])
+          expect(cached_aggregation.timestamp).to eq(boundaries.from_datetime)
           expect(cached_aggregation.current_aggregation).to eq(0.0)
         end
       end
@@ -2455,7 +2455,7 @@ RSpec.describe Fees::ChargeService do
           organization: invoice.organization,
           subscription:,
           code: billable_metric.code,
-          timestamp: boundaries[:charges_to_datetime] - 2.days
+          timestamp: boundaries.charges_to_datetime - 2.days
         )
       end
 

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
 
     before do
       allow(Charges::PayInAdvanceAggregationService).to receive(:call)
-        .with(charge:, boundaries: Hash, properties: Hash, event:, charge_filter:)
+        .with(charge:, boundaries: BillingPeriodBoundaries, properties: Hash, event:, charge_filter:)
         .and_return(aggregation_result)
 
       allow(Charges::ApplyPayInAdvanceChargeModelService).to receive(:call)

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
 
     before do
       allow(Charges::PayInAdvanceAggregationService).to receive(:call)
-        .with(charge:, boundaries: Hash, properties: Hash, event:, charge_filter:)
+        .with(charge:, boundaries: BillingPeriodBoundaries, properties: Hash, event:, charge_filter:)
         .and_return(aggregation_result)
 
       allow(Charges::ApplyPayInAdvanceChargeModelService).to receive(:call)


### PR DESCRIPTION
## Context

In many places of the application, we are defining a `boundaries` object, sometimes as an instance of a `Hash`, sometimes as an `OpenStruct`. The fields are not always the same and since the boundaries are injected in a lot of services, this causes some uncertainty when accessing the properties.

## Description

In an attempt to improve the readability and the reliability of this key part of the application, the goal of this PR is to introduce a new `BillingPeriodBoundaries` class and to use it everywhere in replacement of `Hash` and `OpenStruct`.

It should also improve the memory consumption as OpenStructs are known to cause memory issues in Ruby when YJIT is enabled