### PR TITLE
Feat(fixed_charges): Add GraphQL types, update Plan resolver and create mutation

### DIFF
--- a/app/graphql/mutations/plans/create.rb
+++ b/app/graphql/mutations/plans/create.rb
@@ -16,6 +16,7 @@ module Mutations
 
       def resolve(entitlements: nil, **args)
         args[:charges].map!(&:to_h)
+        args[:fixed_charges]&.map!(&:to_h)
 
         result = ::Plans::CreateService.call(args.merge(organization_id: current_organization.id))
 

--- a/app/graphql/types/charge_models/graduated_percentage_range.rb
+++ b/app/graphql/types/charge_models/graduated_percentage_range.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module Types
-  module Charges
-    class GraduatedRange < Types::BaseObject
+  module ChargeModels
+    class GraduatedPercentageRange < Types::BaseObject
       field :from_value, GraphQL::Types::BigInt, null: false
       field :to_value, GraphQL::Types::BigInt, null: true
 
       field :flat_amount, String, null: false
-      field :per_unit_amount, String, null: false
+      field :rate, String, null: false
     end
   end
 end

--- a/app/graphql/types/charge_models/graduated_percentage_range_input.rb
+++ b/app/graphql/types/charge_models/graduated_percentage_range_input.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Types
-  module Charges
+  module ChargeModels
     class GraduatedPercentageRangeInput < Types::BaseInputObject
       argument :from_value, GraphQL::Types::BigInt, required: true
       argument :to_value, GraphQL::Types::BigInt, required: false
@@ -11,3 +11,4 @@ module Types
     end
   end
 end
+

--- a/app/graphql/types/charge_models/graduated_percentage_range_input.rb
+++ b/app/graphql/types/charge_models/graduated_percentage_range_input.rb
@@ -11,4 +11,3 @@ module Types
     end
   end
 end
-

--- a/app/graphql/types/charge_models/graduated_range.rb
+++ b/app/graphql/types/charge_models/graduated_range.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module Types
-  module Charges
-    class GraduatedPercentageRange < Types::BaseObject
+  module ChargeModels
+    class GraduatedRange < Types::BaseObject
       field :from_value, GraphQL::Types::BigInt, null: false
       field :to_value, GraphQL::Types::BigInt, null: true
 
       field :flat_amount, String, null: false
-      field :rate, String, null: false
+      field :per_unit_amount, String, null: false
     end
   end
 end

--- a/app/graphql/types/charge_models/graduated_range_input.rb
+++ b/app/graphql/types/charge_models/graduated_range_input.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Types
-  module Charges
+  module ChargeModels
     class GraduatedRangeInput < Types::BaseInputObject
       argument :from_value, GraphQL::Types::BigInt, required: true
       argument :to_value, GraphQL::Types::BigInt, required: false
@@ -11,3 +11,4 @@ module Types
     end
   end
 end
+

--- a/app/graphql/types/charge_models/graduated_range_input.rb
+++ b/app/graphql/types/charge_models/graduated_range_input.rb
@@ -11,4 +11,3 @@ module Types
     end
   end
 end
-

--- a/app/graphql/types/charge_models/volume_range.rb
+++ b/app/graphql/types/charge_models/volume_range.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Types
-  module Charges
+  module ChargeModels
     class VolumeRange < Types::BaseObject
       field :from_value, GraphQL::Types::BigInt, null: false
       field :to_value, GraphQL::Types::BigInt, null: true
@@ -11,3 +11,5 @@ module Types
     end
   end
 end
+
+

--- a/app/graphql/types/charge_models/volume_range.rb
+++ b/app/graphql/types/charge_models/volume_range.rb
@@ -11,5 +11,3 @@ module Types
     end
   end
 end
-
-

--- a/app/graphql/types/charge_models/volume_range_input.rb
+++ b/app/graphql/types/charge_models/volume_range_input.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Types
-  module Charges
+  module ChargeModels
     class VolumeRangeInput < Types::BaseInputObject
       argument :from_value, GraphQL::Types::BigInt, required: true
       argument :to_value, GraphQL::Types::BigInt, required: false
@@ -11,3 +11,5 @@ module Types
     end
   end
 end
+
+

--- a/app/graphql/types/charge_models/volume_range_input.rb
+++ b/app/graphql/types/charge_models/volume_range_input.rb
@@ -11,5 +11,3 @@ module Types
     end
   end
 end
-
-

--- a/app/graphql/types/charges/properties.rb
+++ b/app/graphql/types/charges/properties.rb
@@ -26,7 +26,7 @@ module Types
       field :rate, String, null: true
 
       # NOTE: Volume charge model
-      field :volume_ranges, [Types::Charges::VolumeRange], null: true
+      field :volume_ranges, [Types::ChargeModels::VolumeRange], null: true
 
       # NOTE: properties for the custom aggregation
       field :custom_properties, GraphQL::Types::JSON, null: true

--- a/app/graphql/types/charges/properties.rb
+++ b/app/graphql/types/charges/properties.rb
@@ -8,10 +8,10 @@ module Types
       field :pricing_group_keys, [String], null: true
 
       # NOTE: Graduated charge model
-      field :graduated_ranges, [Types::Charges::GraduatedRange], null: true
+      field :graduated_ranges, [Types::ChargeModels::GraduatedRange], null: true
 
       # NOTE: Graduated percentage modle
-      field :graduated_percentage_ranges, [Types::Charges::GraduatedPercentageRange], null: true
+      field :graduated_percentage_ranges, [Types::ChargeModels::GraduatedPercentageRange], null: true
 
       # NOTE: Package charge model
       field :free_units, GraphQL::Types::BigInt, null: true

--- a/app/graphql/types/charges/properties_input.rb
+++ b/app/graphql/types/charges/properties_input.rb
@@ -8,10 +8,10 @@ module Types
       argument :pricing_group_keys, [String], required: false
 
       # NOTE: Graduated charge model
-      argument :graduated_ranges, [Types::Charges::GraduatedRangeInput], required: false
+      argument :graduated_ranges, [Types::ChargeModels::GraduatedRangeInput], required: false
 
       # NOTE: Graduated percentage charge model
-      argument :graduated_percentage_ranges, [Types::Charges::GraduatedPercentageRangeInput], required: false
+      argument :graduated_percentage_ranges, [Types::ChargeModels::GraduatedPercentageRangeInput], required: false
 
       # NOTE: Package charge model
       argument :free_units, GraphQL::Types::BigInt, required: false

--- a/app/graphql/types/charges/properties_input.rb
+++ b/app/graphql/types/charges/properties_input.rb
@@ -26,7 +26,7 @@ module Types
       argument :rate, String, required: false
 
       # NOTE: Volume charge model
-      argument :volume_ranges, [Types::Charges::VolumeRangeInput], required: false
+      argument :volume_ranges, [Types::ChargeModels::VolumeRangeInput], required: false
 
       # NOTE: properties for the custom aggregation
       argument :custom_properties, GraphQL::Types::JSON, required: false

--- a/app/graphql/types/fixed_charges/charge_model_enum.rb
+++ b/app/graphql/types/fixed_charges/charge_model_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module FixedCharges
+    class ChargeModelEnum < Types::BaseEnum
+      graphql_name "FixedChargeChargeModelEnum"
+
+      FixedCharge::CHARGE_MODELS.keys.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/fixed_charges/input.rb
+++ b/app/graphql/types/fixed_charges/input.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Types
+  module FixedCharges
+    class Input < Types::BaseInputObject
+      graphql_name "FixedChargeInput"
+
+      argument :add_on_id, ID, required: true
+      argument :charge_model, Types::FixedCharges::ChargeModelEnum, required: true
+      argument :invoice_display_name, String, required: false
+      argument :pay_in_advance, Boolean, required: false
+      argument :prorated, Boolean, required: false
+      argument :units, String, required: false
+
+      argument :properties, Types::FixedCharges::PropertiesInput, required: false
+
+      argument :tax_codes, [String], required: false
+    end
+  end
+end

--- a/app/graphql/types/fixed_charges/object.rb
+++ b/app/graphql/types/fixed_charges/object.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Types
+  module FixedCharges
+    class Object < Types::BaseObject
+      graphql_name "FixedCharge"
+
+      field :id, ID, null: false
+      field :invoice_display_name, String, null: true
+
+      field :add_on, Types::AddOns::Object, null: false
+      field :charge_model, Types::FixedCharges::ChargeModelEnum, null: false
+      field :pay_in_advance, Boolean, null: false
+      field :properties, Types::FixedCharges::Properties, null: true
+      field :prorated, Boolean, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      field :taxes, [Types::Taxes::Object]
+
+      def properties
+        return object.properties unless object.properties == "{}"
+
+        JSON.parse(object.properties)
+      end
+
+      def add_on
+        AddOn.with_discarded.find_by(id: object.add_on_id)
+      end
+    end
+  end
+end

--- a/app/graphql/types/fixed_charges/properties.rb
+++ b/app/graphql/types/fixed_charges/properties.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Types
+  module FixedCharges
+    class Properties < Types::BaseObject
+      graphql_name "FixedChargeProperties"
+
+      # NOTE: Standard and Package charge model
+      field :amount, String, null: true
+
+      # NOTE: Graduated charge model
+      field :graduated_ranges, [Types::ChargeModels::GraduatedRange], null: true
+
+      # NOTE: Volume charge model
+      field :volume_ranges, [Types::ChargeModels::VolumeRange], null: true
+    end
+  end
+end

--- a/app/graphql/types/fixed_charges/properties_input.rb
+++ b/app/graphql/types/fixed_charges/properties_input.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Types
+  module FixedCharges
+    class PropertiesInput < Types::BaseInputObject
+      graphql_name "FixedChargePropertiesInput"
+
+      # NOTE: Standard and Package charge model
+      argument :amount, String, required: false
+
+      # NOTE: Graduated charge model
+      argument :graduated_ranges, [Types::ChargeModels::GraduatedRangeInput], required: false
+
+      # NOTE: Volume charge model
+      argument :volume_ranges, [Types::ChargeModels::VolumeRangeInput], required: false
+    end
+  end
+end

--- a/app/graphql/types/plans/create_input.rb
+++ b/app/graphql/types/plans/create_input.rb
@@ -8,6 +8,7 @@ module Types
       argument :amount_cents, GraphQL::Types::BigInt, required: true
       argument :amount_currency, Types::CurrencyEnum
       argument :bill_charges_monthly, Boolean, required: false
+      argument :bill_fixed_charges_monthly, Boolean, required: false
       argument :code, String, required: true
       argument :description, String, required: false
       argument :interval, Types::Plans::IntervalEnum, required: true

--- a/app/graphql/types/plans/create_input.rb
+++ b/app/graphql/types/plans/create_input.rb
@@ -18,6 +18,7 @@ module Types
       argument :trial_period, Float, required: false
 
       argument :charges, [Types::Charges::Input]
+      argument :fixed_charges, [Types::FixedCharges::Input]
       argument :minimum_commitment, Types::Commitments::Input, required: false
       argument :usage_thresholds, [Types::UsageThresholds::Input], required: false
 

--- a/app/graphql/types/plans/create_input.rb
+++ b/app/graphql/types/plans/create_input.rb
@@ -19,7 +19,7 @@ module Types
       argument :trial_period, Float, required: false
 
       argument :charges, [Types::Charges::Input]
-      argument :fixed_charges, [Types::FixedCharges::Input]
+      argument :fixed_charges, [Types::FixedCharges::Input], required: false
       argument :minimum_commitment, Types::Commitments::Input, required: false
       argument :usage_thresholds, [Types::UsageThresholds::Input], required: false
 

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -11,6 +11,7 @@ module Types
       field :amount_cents, GraphQL::Types::BigInt, null: false
       field :amount_currency, Types::CurrencyEnum, null: false
       field :bill_charges_monthly, Boolean
+      field :bill_fixed_charges_monthly, Boolean
       field :code, String, null: false
       field :description, String
       field :interval, Types::Plans::IntervalEnum, null: false
@@ -26,12 +27,14 @@ module Types
 
       field :activity_logs, [Types::ActivityLogs::Object], null: true
       field :charges, [Types::Charges::Object]
+      field :fixed_charges, [Types::FixedCharges::Object]
       field :taxes, [Types::Taxes::Object]
 
       field :has_active_subscriptions, Boolean, null: false
       field :has_charges, Boolean, null: false
       field :has_customers, Boolean, null: false
       field :has_draft_invoices, Boolean, null: false
+      field :has_fixed_charges, Boolean, null: false
       field :has_overridden_plans, Boolean
       field :has_subscriptions, Boolean, null: false
 
@@ -80,6 +83,10 @@ module Types
       # NOTE: should this one include children charges?
       def has_charges
         object.charges.exists?
+      end
+
+      def has_fixed_charges
+        object.fixed_charges.exists?
       end
 
       # NOTE: if it has active subscriptions, it has customers

--- a/schema.graphql
+++ b/schema.graphql
@@ -2892,7 +2892,7 @@ input CreatePlanInput {
   code: String!
   description: String
   entitlements: [EntitlementInput!]
-  fixedCharges: [FixedChargeInput!]!
+  fixedCharges: [FixedChargeInput!]
   interval: PlanInterval!
   invoiceDisplayName: String
   minimumCommitment: CommitmentInput

--- a/schema.graphql
+++ b/schema.graphql
@@ -2882,6 +2882,7 @@ input CreatePlanInput {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   billChargesMonthly: Boolean
+  billFixedChargesMonthly: Boolean
   charges: [ChargeInput!]!
 
   """

--- a/schema.graphql
+++ b/schema.graphql
@@ -2891,6 +2891,7 @@ input CreatePlanInput {
   code: String!
   description: String
   entitlements: [EntitlementInput!]
+  fixedCharges: [FixedChargeInput!]!
   interval: PlanInterval!
   invoiceDisplayName: String
   minimumCommitment: CommitmentInput
@@ -5249,6 +5250,29 @@ type FinalizedInvoiceCollectionCollection {
   Pagination Metadata for navigating the Pagination
   """
   metadata: CollectionMetadata!
+}
+
+enum FixedChargeChargeModelEnum {
+  graduated
+  standard
+  volume
+}
+
+input FixedChargeInput {
+  addOnId: ID!
+  chargeModel: FixedChargeChargeModelEnum!
+  invoiceDisplayName: String
+  payInAdvance: Boolean
+  properties: FixedChargePropertiesInput
+  prorated: Boolean
+  taxCodes: [String!]
+  units: String
+}
+
+input FixedChargePropertiesInput {
+  amount: String
+  graduatedRanges: [GraduatedRangeInput!]
+  volumeRanges: [VolumeRangeInput!]
 }
 
 type FlutterwaveProvider {

--- a/schema.graphql
+++ b/schema.graphql
@@ -5253,6 +5253,20 @@ type FinalizedInvoiceCollectionCollection {
   metadata: CollectionMetadata!
 }
 
+type FixedCharge {
+  addOn: AddOn!
+  chargeModel: FixedChargeChargeModelEnum!
+  createdAt: ISO8601DateTime!
+  deletedAt: ISO8601DateTime
+  id: ID!
+  invoiceDisplayName: String
+  payInAdvance: Boolean!
+  properties: FixedChargeProperties
+  prorated: Boolean!
+  taxes: [Tax!]
+  updatedAt: ISO8601DateTime!
+}
+
 enum FixedChargeChargeModelEnum {
   graduated
   standard
@@ -5268,6 +5282,12 @@ input FixedChargeInput {
   prorated: Boolean
   taxCodes: [String!]
   units: String
+}
+
+type FixedChargeProperties {
+  amount: String
+  graduatedRanges: [GraduatedRange!]
+  volumeRanges: [VolumeRange!]
 }
 
 input FixedChargePropertiesInput {
@@ -7851,6 +7871,7 @@ type Plan {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   billChargesMonthly: Boolean
+  billFixedChargesMonthly: Boolean
   charges: [Charge!]
 
   """
@@ -7868,10 +7889,12 @@ type Plan {
   description: String
   draftInvoicesCount: Int!
   entitlements: [PlanEntitlement!]
+  fixedCharges: [FixedCharge!]
   hasActiveSubscriptions: Boolean!
   hasCharges: Boolean!
   hasCustomers: Boolean!
   hasDraftInvoices: Boolean!
+  hasFixedCharges: Boolean!
   hasOverriddenPlans: Boolean
   hasSubscriptions: Boolean!
   id: ID!

--- a/schema.json
+++ b/schema.json
@@ -12549,6 +12549,30 @@
               "deprecationReason": null
             },
             {
+              "name": "fixedCharges",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "FixedChargeInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "minimumCommitment",
               "description": null,
               "type": {
@@ -25183,6 +25207,221 @@
             }
           ],
           "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "FixedChargeChargeModelEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "standard",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graduated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "volume",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "FixedChargeInput",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "addOnId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "chargeModel",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "FixedChargeChargeModelEnum",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "payInAdvance",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "prorated",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "units",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "properties",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "FixedChargePropertiesInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxCodes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "FixedChargePropertiesInput",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "amount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graduatedRanges",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "GraduatedRangeInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "volumeRanges",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "VolumeRangeInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "enumValues": null
         },
         {

--- a/schema.json
+++ b/schema.json
@@ -12564,19 +12564,15 @@
               "name": "fixedCharges",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
+                  "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "FixedChargeInput",
-                      "ofType": null
-                    }
+                    "kind": "INPUT_OBJECT",
+                    "name": "FixedChargeInput",
+                    "ofType": null
                   }
                 }
               },

--- a/schema.json
+++ b/schema.json
@@ -25222,6 +25222,185 @@
           "enumValues": null
         },
         {
+          "kind": "OBJECT",
+          "name": "FixedCharge",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "addOn",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AddOn",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "chargeModel",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "FixedChargeChargeModelEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "payInAdvance",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "properties",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "FixedChargeProperties",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "prorated",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "taxes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Tax",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
           "kind": "ENUM",
           "name": "FixedChargeChargeModelEnum",
           "description": null,
@@ -25371,6 +25550,69 @@
               "deprecationReason": null
             }
           ],
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FixedChargeProperties",
+          "description": null,
+          "interfaces": [],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "graduatedRanges",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GraduatedRange",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "volumeRanges",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "VolumeRange",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "inputFields": null,
           "enumValues": null
         },
         {
@@ -38764,6 +39006,18 @@
               "args": []
             },
             {
+              "name": "billFixedChargesMonthly",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "charges",
               "description": null,
               "type": {
@@ -38908,6 +39162,26 @@
               "args": []
             },
             {
+              "name": "fixedCharges",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "FixedCharge",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "hasActiveSubscriptions",
               "description": null,
               "type": {
@@ -38957,6 +39231,22 @@
             },
             {
               "name": "hasDraftInvoices",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "hasFixedCharges",
               "description": null,
               "type": {
                 "kind": "NON_NULL",

--- a/schema.json
+++ b/schema.json
@@ -12405,6 +12405,18 @@
               "deprecationReason": null
             },
             {
+              "name": "billFixedChargesMonthly",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "code",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -423,6 +423,34 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
     expect(volume_fixed_charge["properties"]["volumeRanges"].count).to eq(2)
   end
 
+  context "when fixed charges are not provided" do
+    it "creates a plan without fixed charges" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            name: "Plan Without Fixed Charges",
+            invoiceDisplayName: "No Fixed Charges Plan",
+            code: "no_fixed_charges_plan",
+            interval: "monthly",
+            payInAdvance: false,
+            amountCents: 100,
+            amountCurrency: "USD",
+            charges: []
+          }
+        }
+      )
+
+      result_data = result["data"]["createPlan"]
+
+      expect(result_data["id"]).to be_present
+      expect(result_data["fixedCharges"]).to be_empty
+    end
+  end
+
   context "when interval is yearly" do
     it "creates a plan with monthly billing for charges and fixed charges" do
       result = execute_graphql(

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
           payInAdvance,
           amountCents,
           amountCurrency,
+          billChargesMonthly,
+          billFixedChargesMonthly,
           taxes { id code rate }
           minimumCommitment {
             id,
@@ -68,6 +70,17 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
               properties { amount }
             }
           }
+          fixedCharges {
+            id,
+            chargeModel,
+            addOn { id name code }
+            taxes { id code rate }
+            properties {
+              amount,
+              graduatedRanges { fromValue, toValue }
+              volumeRanges { fromValue, toValue }
+            }
+          }
           usageThresholds {
             id,
             amountCents,
@@ -85,6 +98,10 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
 
   let(:billable_metrics) do
     create_list(:billable_metric, 6, organization:)
+  end
+
+  let(:add_ons) do
+    create_list(:add_on, 3, organization:)
   end
 
   let(:billable_metric_filter) do
@@ -228,6 +245,54 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
               }
             }
           ],
+          fixedCharges: [
+            {
+              addOnId: add_ons[0].id,
+              chargeModel: "standard",
+              properties: {amount: "100.00"},
+              taxCodes: [charge_tax.code]
+            },
+            {
+              addOnId: add_ons[1].id,
+              chargeModel: "graduated",
+              properties: {
+                graduatedRanges: [
+                  {
+                    fromValue: 0,
+                    toValue: 10,
+                    perUnitAmount: "2.00",
+                    flatAmount: "0"
+                  },
+                  {
+                    fromValue: 11,
+                    toValue: nil,
+                    perUnitAmount: "3.00",
+                    flatAmount: "3.00"
+                  }
+                ]
+              }
+            },
+            {
+              addOnId: add_ons[2].id,
+              chargeModel: "volume",
+              properties: {
+                volumeRanges: [
+                  {
+                    fromValue: 0,
+                    toValue: 10,
+                    perUnitAmount: "5.00",
+                    flatAmount: "0"
+                  },
+                  {
+                    fromValue: 11,
+                    toValue: nil,
+                    perUnitAmount: "1.00",
+                    flatAmount: "2.00"
+                  }
+                ]
+              }
+            }
+          ],
           usageThresholds: [
             {
               amountCents: 100,
@@ -260,8 +325,11 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
     expect(result_data["interval"]).to eq("monthly")
     expect(result_data["payInAdvance"]).to eq(false)
     expect(result_data["amountCents"]).to eq("200")
+    expect(result_data["billChargesMonthly"]).to be_nil
+    expect(result_data["billFixedChargesMonthly"]).to be_nil
     expect(result_data["taxes"][0]["code"]).to eq(plan_tax.code)
     expect(result_data["charges"].count).to eq(6)
+    expect(result_data["fixedCharges"].count).to eq(3)
     expect(result_data["usageThresholds"].count).to eq(3)
 
     standard_charge = result_data["charges"][0]
@@ -340,5 +408,49 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
         "privileges" => []
       }
     )
+    standard_fixed_charge = result_data["fixedCharges"][0]
+    expect(standard_fixed_charge["properties"]["amount"]).to eq("100.00")
+    expect(standard_fixed_charge["chargeModel"]).to eq("standard")
+    expect(standard_fixed_charge["taxes"].count).to eq(1)
+    expect(standard_fixed_charge["taxes"].first["code"]).to eq(charge_tax.code)
+
+    graduated_fixed_charge = result_data["fixedCharges"][1]
+    expect(graduated_fixed_charge["chargeModel"]).to eq("graduated")
+    expect(graduated_fixed_charge["properties"]["graduatedRanges"].count).to eq(2)
+
+    volume_fixed_charge = result_data["fixedCharges"][2]
+    expect(volume_fixed_charge["chargeModel"]).to eq("volume")
+    expect(volume_fixed_charge["properties"]["volumeRanges"].count).to eq(2)
+  end
+
+  context "when interval is yearly" do
+    it "creates a plan with monthly billing for charges and fixed charges" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            name: "New Plan",
+            invoiceDisplayName: "New Plan Invoice Name",
+            code: "new_plan",
+            interval: "yearly",
+            payInAdvance: true,
+            amountCents: 200,
+            amountCurrency: "EUR",
+            billChargesMonthly: true,
+            billFixedChargesMonthly: true,
+            charges: [],
+            fixedCharges: []
+          }
+        }
+      )
+
+      result_data = result["data"]["createPlan"]
+
+      expect(result_data["billChargesMonthly"]).to be true
+      expect(result_data["billFixedChargesMonthly"]).to be true
+    end
   end
 end

--- a/spec/graphql/resolvers/plan_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_resolver_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
           hasCharges
           hasCustomers
           hasDraftInvoices
+          hasFixedCharges
           hasOverriddenPlans
           hasSubscriptions
 
@@ -49,6 +50,11 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
               rate
             }
           }
+          fixedCharges {
+            id
+            taxes { id rate }
+            properties { amount }
+          }
           minimumCommitment {
             id
             amountCents
@@ -66,6 +72,7 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }
 
+  let(:add_on) { create(:add_on, organization:) }
   let(:billable_metric) { create(:billable_metric, organization:) }
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:) }
 
@@ -85,6 +92,7 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
     expect(plan_response["hasCharges"]).to eq(false)
     expect(plan_response["hasCustomers"]).to eq(false)
     expect(plan_response["hasDraftInvoices"]).to eq(false)
+    expect(plan_response["hasFixedCharges"]).to eq(false)
     expect(plan_response["hasActiveSubscriptions"]).to eq(false)
     expect(plan_response["hasSubscriptions"]).to eq(false)
 
@@ -176,6 +184,19 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
       plan_response = result["data"]["plan"]
 
       expect(plan_response["hasCharges"]).to eq(true)
+    end
+  end
+
+  context "when plan has fixed charges" do
+    let(:fixed_charge) { create(:fixed_charge, add_on:, plan:) }
+
+    before { fixed_charge }
+
+    it "returns true for has charges" do
+      plan_response = result["data"]["plan"]
+
+      expect(plan_response["hasFixedCharges"]).to eq(true)
+      expect(plan_response["fixedCharges"].pluck("id")).to match_array([fixed_charge.id])
     end
   end
 

--- a/spec/graphql/types/charge_models/graduated_percentage_range_input_spec.rb
+++ b/spec/graphql/types/charge_models/graduated_percentage_range_input_spec.rb
@@ -5,13 +5,10 @@ require "rails_helper"
 RSpec.describe Types::ChargeModels::GraduatedPercentageRangeInput do
   subject { described_class }
 
-  it do
-    expect(subject).to accept_argument(:from_value).of_type("BigInt!")
-    expect(subject).to accept_argument(:to_value).of_type("BigInt")
-
-    expect(subject).to accept_argument(:flat_amount).of_type("String!")
-    expect(subject).to accept_argument(:rate).of_type("String!")
-  end
+  it { is_expected.to accept_argument(:from_value).of_type("BigInt!") }
+  it { is_expected.to accept_argument(:to_value).of_type("BigInt") }
+  it { is_expected.to accept_argument(:flat_amount).of_type("String!") }
+  it { is_expected.to accept_argument(:rate).of_type("String!") }
 end
 
 

--- a/spec/graphql/types/charge_models/graduated_percentage_range_input_spec.rb
+++ b/spec/graphql/types/charge_models/graduated_percentage_range_input_spec.rb
@@ -10,5 +10,3 @@ RSpec.describe Types::ChargeModels::GraduatedPercentageRangeInput do
   it { is_expected.to accept_argument(:flat_amount).of_type("String!") }
   it { is_expected.to accept_argument(:rate).of_type("String!") }
 end
-
-

--- a/spec/graphql/types/charge_models/graduated_percentage_range_input_spec.rb
+++ b/spec/graphql/types/charge_models/graduated_percentage_range_input_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::ChargeModels::GraduatedPercentageRangeInput do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:from_value).of_type("BigInt!")
+    expect(subject).to accept_argument(:to_value).of_type("BigInt")
+
+    expect(subject).to accept_argument(:flat_amount).of_type("String!")
+    expect(subject).to accept_argument(:rate).of_type("String!")
+  end
+end
+
+

--- a/spec/graphql/types/charge_models/graduated_percentage_range_spec.rb
+++ b/spec/graphql/types/charge_models/graduated_percentage_range_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::ChargeModels::GraduatedPercentageRange, type: :graphql do
+  let(:object) { described_class }
+
+  it { expect(object).to have_field(:from_value).of_type("BigInt!") }
+  it { expect(object).to have_field(:to_value).of_type("BigInt") }
+  it { expect(object).to have_field(:flat_amount).of_type("String!") }
+  it { expect(object).to have_field(:rate).of_type("String!") }
+end

--- a/spec/graphql/types/charge_models/graduated_percentage_range_spec.rb
+++ b/spec/graphql/types/charge_models/graduated_percentage_range_spec.rb
@@ -2,11 +2,11 @@
 
 require "rails_helper"
 
-RSpec.describe Types::ChargeModels::GraduatedPercentageRange, type: :graphql do
-  let(:object) { described_class }
+RSpec.describe Types::ChargeModels::GraduatedPercentageRange do
+  subject { described_class }
 
-  it { expect(object).to have_field(:from_value).of_type("BigInt!") }
-  it { expect(object).to have_field(:to_value).of_type("BigInt") }
-  it { expect(object).to have_field(:flat_amount).of_type("String!") }
-  it { expect(object).to have_field(:rate).of_type("String!") }
+  it { is_expected.to have_field(:from_value).of_type("BigInt!") }
+  it { is_expected.to have_field(:to_value).of_type("BigInt") }
+  it { is_expected.to have_field(:flat_amount).of_type("String!") }
+  it { is_expected.to have_field(:rate).of_type("String!") }
 end

--- a/spec/graphql/types/charge_models/graduated_range_input_spec.rb
+++ b/spec/graphql/types/charge_models/graduated_range_input_spec.rb
@@ -10,5 +10,3 @@ RSpec.describe Types::ChargeModels::GraduatedRangeInput do
   it { is_expected.to accept_argument(:flat_amount).of_type("String!") }
   it { is_expected.to accept_argument(:per_unit_amount).of_type("String!") }
 end
-
-

--- a/spec/graphql/types/charge_models/graduated_range_input_spec.rb
+++ b/spec/graphql/types/charge_models/graduated_range_input_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::ChargeModels::GraduatedRangeInput do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:from_value).of_type("BigInt!")
+    expect(subject).to accept_argument(:to_value).of_type("BigInt")
+
+    expect(subject).to accept_argument(:flat_amount).of_type("String!")
+    expect(subject).to accept_argument(:per_unit_amount).of_type("String!")
+  end
+end
+
+

--- a/spec/graphql/types/charge_models/graduated_range_input_spec.rb
+++ b/spec/graphql/types/charge_models/graduated_range_input_spec.rb
@@ -5,13 +5,10 @@ require "rails_helper"
 RSpec.describe Types::ChargeModels::GraduatedRangeInput do
   subject { described_class }
 
-  it do
-    expect(subject).to accept_argument(:from_value).of_type("BigInt!")
-    expect(subject).to accept_argument(:to_value).of_type("BigInt")
-
-    expect(subject).to accept_argument(:flat_amount).of_type("String!")
-    expect(subject).to accept_argument(:per_unit_amount).of_type("String!")
-  end
+  it { is_expected.to accept_argument(:from_value).of_type("BigInt!") }
+  it { is_expected.to accept_argument(:to_value).of_type("BigInt") }
+  it { is_expected.to accept_argument(:flat_amount).of_type("String!") }
+  it { is_expected.to accept_argument(:per_unit_amount).of_type("String!") }
 end
 
 

--- a/spec/graphql/types/charge_models/graduated_range_spec.rb
+++ b/spec/graphql/types/charge_models/graduated_range_spec.rb
@@ -2,11 +2,11 @@
 
 require "rails_helper"
 
-RSpec.describe Types::ChargeModels::GraduatedRange, type: :graphql do
-  let(:object) { described_class }
+RSpec.describe Types::ChargeModels::GraduatedRange do
+  subject { described_class }
 
-  it { expect(object).to have_field(:from_value).of_type("BigInt!") }
-  it { expect(object).to have_field(:to_value).of_type("BigInt") }
-  it { expect(object).to have_field(:flat_amount).of_type("String!") }
-  it { expect(object).to have_field(:per_unit_amount).of_type("String!") }
+  it { is_expected.to have_field(:from_value).of_type("BigInt!") }
+  it { is_expected.to have_field(:to_value).of_type("BigInt") }
+  it { is_expected.to have_field(:flat_amount).of_type("String!") }
+  it { is_expected.to have_field(:per_unit_amount).of_type("String!") }
 end

--- a/spec/graphql/types/charge_models/graduated_range_spec.rb
+++ b/spec/graphql/types/charge_models/graduated_range_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::ChargeModels::GraduatedRange, type: :graphql do
+  let(:object) { described_class }
+
+  it { expect(object).to have_field(:from_value).of_type("BigInt!") }
+  it { expect(object).to have_field(:to_value).of_type("BigInt") }
+  it { expect(object).to have_field(:flat_amount).of_type("String!") }
+  it { expect(object).to have_field(:per_unit_amount).of_type("String!") }
+end

--- a/spec/graphql/types/charge_models/volume_range_input_spec.rb
+++ b/spec/graphql/types/charge_models/volume_range_input_spec.rb
@@ -10,5 +10,3 @@ RSpec.describe Types::ChargeModels::VolumeRangeInput do
   it { is_expected.to accept_argument(:flat_amount).of_type("String!") }
   it { is_expected.to accept_argument(:per_unit_amount).of_type("String!") }
 end
-
-

--- a/spec/graphql/types/charge_models/volume_range_input_spec.rb
+++ b/spec/graphql/types/charge_models/volume_range_input_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::ChargeModels::VolumeRangeInput do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:from_value).of_type("BigInt!") }
+  it { is_expected.to accept_argument(:to_value).of_type("BigInt") }
+  it { is_expected.to accept_argument(:flat_amount).of_type("String!") }
+  it { is_expected.to accept_argument(:per_unit_amount).of_type("String!") }
+end
+
+

--- a/spec/graphql/types/charge_models/volume_range_spec.rb
+++ b/spec/graphql/types/charge_models/volume_range_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::ChargeModels::VolumeRange do
+  subject { described_class }
+
+  it { is_expected.to have_field(:from_value).of_type("BigInt!") }
+  it { is_expected.to have_field(:to_value).of_type("BigInt") }
+  it { is_expected.to have_field(:flat_amount).of_type("String!") }
+  it { is_expected.to have_field(:per_unit_amount).of_type("String!") }
+end
+
+

--- a/spec/graphql/types/charge_models/volume_range_spec.rb
+++ b/spec/graphql/types/charge_models/volume_range_spec.rb
@@ -10,5 +10,3 @@ RSpec.describe Types::ChargeModels::VolumeRange do
   it { is_expected.to have_field(:flat_amount).of_type("String!") }
   it { is_expected.to have_field(:per_unit_amount).of_type("String!") }
 end
-
-

--- a/spec/graphql/types/charges/charge_model_enum_spec.rb
+++ b/spec/graphql/types/charges/charge_model_enum_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Charges::ChargeModelEnum do
+  subject { described_class }
+
+  it "enumerates the correct charge model values" do
+    expect(subject.values.keys)
+      .to match_array(
+        %w[
+          standard
+          graduated
+          package
+          percentage
+          volume
+          graduated_percentage
+          custom
+          dynamic
+        ]
+      )
+  end
+end

--- a/spec/graphql/types/fixed_charges/charge_model_enum_spec.rb
+++ b/spec/graphql/types/fixed_charges/charge_model_enum_spec.rb
@@ -10,4 +10,3 @@ RSpec.describe Types::FixedCharges::ChargeModelEnum do
       .to match_array(%w[standard graduated volume])
   end
 end
-

--- a/spec/graphql/types/fixed_charges/charge_model_enum_spec.rb
+++ b/spec/graphql/types/fixed_charges/charge_model_enum_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::FixedCharges::ChargeModelEnum do
+  subject { described_class }
+
+  it "enumerates the correct charge model values" do
+    expect(subject.values.keys)
+      .to match_array(%w[standard graduated volume])
+  end
+end
+

--- a/spec/graphql/types/fixed_charges/input_spec.rb
+++ b/spec/graphql/types/fixed_charges/input_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::FixedCharges::Input do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:add_on_id).of_type("ID!") }
+  it { is_expected.to accept_argument(:charge_model).of_type("FixedChargeChargeModelEnum!") }
+  it { is_expected.to accept_argument(:invoice_display_name).of_type("String") }
+  it { is_expected.to accept_argument(:pay_in_advance).of_type("Boolean") }
+  it { is_expected.to accept_argument(:prorated).of_type("Boolean") }
+  it { is_expected.to accept_argument(:properties).of_type("FixedChargePropertiesInput") }
+  it { is_expected.to accept_argument(:tax_codes).of_type("[String!]") }
+end

--- a/spec/graphql/types/fixed_charges/object_spec.rb
+++ b/spec/graphql/types/fixed_charges/object_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::FixedCharges::Object do
+  subject { described_class }
+
+  it { is_expected.to have_field(:id).of_type("ID!") }
+  it { is_expected.to have_field(:invoice_display_name).of_type("String") }
+
+  it { is_expected.to have_field(:add_on).of_type("AddOn!") }
+  it { is_expected.to have_field(:charge_model).of_type("FixedChargeChargeModelEnum!") }
+  it { is_expected.to have_field(:pay_in_advance).of_type("Boolean!") }
+  it { is_expected.to have_field(:properties).of_type("FixedChargeProperties") }
+  it { is_expected.to have_field(:prorated).of_type("Boolean!") }
+
+  it { is_expected.to have_field(:created_at).of_type("ISO8601DateTime!") }
+  it { is_expected.to have_field(:deleted_at).of_type("ISO8601DateTime") }
+  it { is_expected.to have_field(:updated_at).of_type("ISO8601DateTime!") }
+
+  it { is_expected.to have_field(:taxes).of_type("[Tax!]") }
+end

--- a/spec/graphql/types/fixed_charges/properties_input_spec.rb
+++ b/spec/graphql/types/fixed_charges/properties_input_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::FixedCharges::PropertiesInput do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:amount).of_type("String") }
+  it { is_expected.to accept_argument(:graduated_ranges).of_type("[GraduatedRangeInput!]") }
+  it { is_expected.to accept_argument(:volume_ranges).of_type("[VolumeRangeInput!]") }
+end

--- a/spec/graphql/types/fixed_charges/properties_spec.rb
+++ b/spec/graphql/types/fixed_charges/properties_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::FixedCharges::PropertiesInput do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:amount).of_type("String") }
+  it { is_expected.to accept_argument(:graduated_ranges).of_type("[GraduatedRangeInput!]") }
+  it { is_expected.to accept_argument(:volume_ranges).of_type("[VolumeRangeInput!]") }
+end

--- a/spec/graphql/types/fixed_charges/properties_spec.rb
+++ b/spec/graphql/types/fixed_charges/properties_spec.rb
@@ -2,10 +2,10 @@
 
 require "rails_helper"
 
-RSpec.describe Types::FixedCharges::PropertiesInput do
+RSpec.describe Types::FixedCharges::Properties do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:amount).of_type("String") }
-  it { is_expected.to accept_argument(:graduated_ranges).of_type("[GraduatedRangeInput!]") }
-  it { is_expected.to accept_argument(:volume_ranges).of_type("[VolumeRangeInput!]") }
+  it { is_expected.to have_field(:amount).of_type("String") }
+  it { is_expected.to have_field(:graduated_ranges).of_type("[GraduatedRangeInput!]") }
+  it { is_expected.to have_field(:volume_ranges).of_type("[VolumeRangeInput!]") }
 end

--- a/spec/graphql/types/fixed_charges/properties_spec.rb
+++ b/spec/graphql/types/fixed_charges/properties_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe Types::FixedCharges::Properties do
   subject { described_class }
 
   it { is_expected.to have_field(:amount).of_type("String") }
-  it { is_expected.to have_field(:graduated_ranges).of_type("[GraduatedRangeInput!]") }
-  it { is_expected.to have_field(:volume_ranges).of_type("[VolumeRangeInput!]") }
+  it { is_expected.to have_field(:graduated_ranges).of_type("[GraduatedRange!]") }
+  it { is_expected.to have_field(:volume_ranges).of_type("[VolumeRange!]") }
 end

--- a/spec/graphql/types/plans/create_input_spec.rb
+++ b/spec/graphql/types/plans/create_input_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Types::Plans::CreateInput do
   it { is_expected.to accept_argument(:trial_period).of_type("Float") }
 
   it { is_expected.to accept_argument(:charges).of_type("[ChargeInput!]!") }
-  it { is_expected.to accept_argument(:fixed_charges).of_type("[FixedChargeInput!]!") }
+  it { is_expected.to accept_argument(:fixed_charges).of_type("[FixedChargeInput!]") }
   it { is_expected.to accept_argument(:minimum_commitment).of_type("CommitmentInput") }
   it { is_expected.to accept_argument(:usage_thresholds).of_type("[UsageThresholdInput!]") }
 end

--- a/spec/graphql/types/plans/create_input_spec.rb
+++ b/spec/graphql/types/plans/create_input_spec.rb
@@ -5,21 +5,20 @@ require "rails_helper"
 RSpec.describe Types::Plans::CreateInput do
   subject { described_class }
 
-  it do
-    expect(subject).to accept_argument(:amount_cents).of_type("BigInt!")
-    expect(subject).to accept_argument(:amount_currency).of_type("CurrencyEnum!")
-    expect(subject).to accept_argument(:bill_charges_monthly).of_type("Boolean")
-    expect(subject).to accept_argument(:code).of_type("String!")
-    expect(subject).to accept_argument(:description).of_type("String")
-    expect(subject).to accept_argument(:interval).of_type("PlanInterval!")
-    expect(subject).to accept_argument(:invoice_display_name).of_type("String")
-    expect(subject).to accept_argument(:name).of_type("String!")
-    expect(subject).to accept_argument(:pay_in_advance).of_type("Boolean!")
-    expect(subject).to accept_argument(:tax_codes).of_type("[String!]")
-    expect(subject).to accept_argument(:trial_period).of_type("Float")
+  it { is_expected.to accept_argument(:amount_cents).of_type("BigInt!") }
+  it { is_expected.to accept_argument(:amount_currency).of_type("CurrencyEnum!") }
+  it { is_expected.to accept_argument(:bill_charges_monthly).of_type("Boolean") }
+  it { is_expected.to accept_argument(:code).of_type("String!") }
+  it { is_expected.to accept_argument(:description).of_type("String") }
+  it { is_expected.to accept_argument(:interval).of_type("PlanInterval!") }
+  it { is_expected.to accept_argument(:invoice_display_name).of_type("String") }
+  it { is_expected.to accept_argument(:name).of_type("String!") }
+  it { is_expected.to accept_argument(:pay_in_advance).of_type("Boolean!") }
+  it { is_expected.to accept_argument(:tax_codes).of_type("[String!]") }
+  it { is_expected.to accept_argument(:trial_period).of_type("Float") }
 
-    expect(subject).to accept_argument(:charges).of_type("[ChargeInput!]!")
-    expect(subject).to accept_argument(:minimum_commitment).of_type("CommitmentInput")
-    expect(subject).to accept_argument(:usage_thresholds).of_type("[UsageThresholdInput!]")
-  end
+  it { is_expected.to accept_argument(:charges).of_type("[ChargeInput!]!") }
+  it { is_expected.to accept_argument(:fixed_charges).of_type("[FixedChargeInput!]!") }
+  it { is_expected.to accept_argument(:minimum_commitment).of_type("CommitmentInput") }
+  it { is_expected.to accept_argument(:usage_thresholds).of_type("[UsageThresholdInput!]") }
 end

--- a/spec/graphql/types/plans/create_input_spec.rb
+++ b/spec/graphql/types/plans/create_input_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::Plans::CreateInput do
   it { is_expected.to accept_argument(:amount_cents).of_type("BigInt!") }
   it { is_expected.to accept_argument(:amount_currency).of_type("CurrencyEnum!") }
   it { is_expected.to accept_argument(:bill_charges_monthly).of_type("Boolean") }
+  it { is_expected.to accept_argument(:bill_fixed_charges_monthly).of_type("Boolean") }
   it { is_expected.to accept_argument(:code).of_type("String!") }
   it { is_expected.to accept_argument(:description).of_type("String") }
   it { is_expected.to accept_argument(:interval).of_type("PlanInterval!") }

--- a/spec/graphql/types/plans/object_spec.rb
+++ b/spec/graphql/types/plans/object_spec.rb
@@ -5,40 +5,41 @@ require "rails_helper"
 RSpec.describe Types::Plans::Object do
   subject { described_class }
 
-  it do
-    expect(subject).to have_field(:id).of_type("ID!")
-    expect(subject).to have_field(:organization).of_type("Organization")
-    expect(subject).to have_field(:amount_cents).of_type("BigInt!")
-    expect(subject).to have_field(:amount_currency).of_type("CurrencyEnum!")
-    expect(subject).to have_field(:bill_charges_monthly).of_type("Boolean")
-    expect(subject).to have_field(:code).of_type("String!")
-    expect(subject).to have_field(:description).of_type("String")
-    expect(subject).to have_field(:has_overridden_plans).of_type("Boolean")
-    expect(subject).to have_field(:interval).of_type("PlanInterval!")
-    expect(subject).to have_field(:invoice_display_name).of_type("String")
-    expect(subject).to have_field(:minimum_commitment).of_type("Commitment")
-    expect(subject).to have_field(:name).of_type("String!")
-    expect(subject).to have_field(:parent).of_type("Plan")
-    expect(subject).to have_field(:pay_in_advance).of_type("Boolean!")
-    expect(subject).to have_field(:trial_period).of_type("Float")
-    expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
-    expect(subject).to have_field(:charges).of_type("[Charge!]")
-    expect(subject).to have_field(:taxes).of_type("[Tax!]")
-    expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
-    expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
-    expect(subject).to have_field(:deleted_at).of_type("ISO8601DateTime")
-    expect(subject).to have_field(:usage_thresholds).of_type("[UsageThreshold!]")
+  it { is_expected.to have_field(:id).of_type("ID!") }
+  it { is_expected.to have_field(:organization).of_type("Organization") }
+  it { is_expected.to have_field(:amount_cents).of_type("BigInt!") }
+  it { is_expected.to have_field(:amount_currency).of_type("CurrencyEnum!") }
+  it { is_expected.to have_field(:bill_charges_monthly).of_type("Boolean") }
+  it { is_expected.to have_field(:bill_fixed_charges_monthly).of_type("Boolean") }
+  it { is_expected.to have_field(:code).of_type("String!") }
+  it { is_expected.to have_field(:description).of_type("String") }
+  it { is_expected.to have_field(:has_overridden_plans).of_type("Boolean") }
+  it { is_expected.to have_field(:interval).of_type("PlanInterval!") }
+  it { is_expected.to have_field(:invoice_display_name).of_type("String") }
+  it { is_expected.to have_field(:minimum_commitment).of_type("Commitment") }
+  it { is_expected.to have_field(:name).of_type("String!") }
+  it { is_expected.to have_field(:parent).of_type("Plan") }
+  it { is_expected.to have_field(:pay_in_advance).of_type("Boolean!") }
+  it { is_expected.to have_field(:trial_period).of_type("Float") }
+  it { is_expected.to have_field(:activity_logs).of_type("[ActivityLog!]") }
+  it { is_expected.to have_field(:charges).of_type("[Charge!]") }
+  it { is_expected.to have_field(:fixed_charges).of_type("[FixedCharge!]") }
+  it { is_expected.to have_field(:taxes).of_type("[Tax!]") }
+  it { is_expected.to have_field(:created_at).of_type("ISO8601DateTime!") }
+  it { is_expected.to have_field(:updated_at).of_type("ISO8601DateTime!") }
+  it { is_expected.to have_field(:deleted_at).of_type("ISO8601DateTime") }
+  it { is_expected.to have_field(:usage_thresholds).of_type("[UsageThreshold!]") }
 
-    expect(subject).to have_field(:has_active_subscriptions).of_type("Boolean!")
-    expect(subject).to have_field(:has_charges).of_type("Boolean!")
-    expect(subject).to have_field(:has_customers).of_type("Boolean!")
-    expect(subject).to have_field(:has_draft_invoices).of_type("Boolean!")
-    expect(subject).to have_field(:has_subscriptions).of_type("Boolean!")
+  it { is_expected.to have_field(:has_active_subscriptions).of_type("Boolean!") }
+  it { is_expected.to have_field(:has_charges).of_type("Boolean!") }
+  it { is_expected.to have_field(:has_customers).of_type("Boolean!") }
+  it { is_expected.to have_field(:has_draft_invoices).of_type("Boolean!") }
+  it { is_expected.to have_field(:has_fixed_charges).of_type("Boolean!") }
+  it { is_expected.to have_field(:has_subscriptions).of_type("Boolean!") }
 
-    expect(subject).to have_field(:active_subscriptions_count).of_type("Int!")
-    expect(subject).to have_field(:charges_count).of_type("Int!")
-    expect(subject).to have_field(:customers_count).of_type("Int!")
-    expect(subject).to have_field(:draft_invoices_count).of_type("Int!")
-    expect(subject).to have_field(:subscriptions_count).of_type("Int!")
-  end
+  it { is_expected.to have_field(:active_subscriptions_count).of_type("Int!") }
+  it { is_expected.to have_field(:charges_count).of_type("Int!") }
+  it { is_expected.to have_field(:customers_count).of_type("Int!") }
+  it { is_expected.to have_field(:draft_invoices_count).of_type("Int!") }
+  it { is_expected.to have_field(:subscriptions_count).of_type("Int!") }
 end


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

 ## Context

 What is the current situation?

 **Option 1:** User has to create a one off invoice alongside the
 subscription, it will create 2 different invoices.

 **Option 2:** User can add a recurring billable metric and use event to
 have this fee invoice on subscription renewal, but it won’t appear on
 the first billing subscription.

 What problem are we trying to solve?

 At subscription creation or afterward, there is no clear way to invoice
 a fixed fee that is not tied to events, aside from the subscription fee
 itself. This fee could be either a one-time charge or a recurring one.

 ## Description

  Update Plans::Create mutation and Plan resolver to include fixed charges data,
  also, adds all required graphql types.