### PR TITLE
fix/allow query subscriptions with plan attributes

### DIFF
--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -61,14 +61,14 @@ class SubscriptionsQuery < BaseQuery
   end
 
   def with_plan_code(scope)
-    scope.joins(:plan).where(plan: {code: filters.plan_code})
+    scope.joins(:plan).where(plans: {code: filters.plan_code})
   end
 
   def with_overriden(scope)
     if filters.overriden
-      scope.joins(:plan).where.not(plan: {parent_id: nil})
+      scope.joins(:plan).where.not(plans: {parent_id: nil})
     else
-      scope.joins(:plan).where(plan: {parent_id: nil})
+      scope.joins(:plan).where(plans: {parent_id: nil})
     end
   end
 

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -130,6 +130,21 @@ RSpec.describe SubscriptionsQuery, type: :query do
         expect(result.subscriptions).to match_array([subscription, subscription_2])
       end
     end
+
+    context "when has search_time and plan searchs" do
+      let(:search_term) { customer.firstname }
+      let(:filters) { {overriden: true} }
+      let(:plan2) { create(:plan, organization:, parent: plan) }
+      let(:subscription_3) { create(:subscription, customer:, plan: plan2, name: "Test Subscription 3") }
+
+      before { subscription_3 }
+
+      it "returns only subscriptions for the specified customer external_id" do
+        expect(result).to be_success
+        expect(result.subscriptions.count).to eq(1)
+        expect(result.subscriptions).to match_array([subscription_3])
+      end
+    end
   end
 
   context "with customer filter" do


### PR DESCRIPTION
## Problem
You can't filter by any plan attribute and have a search term. 

## Steps to reproduce
Add a filter to plan/subscription and a search term. 
```SubscriptionsQuery.call(organization:, filters: {overriden: true}, search_term: "Mario")```

This would produce this query
```
Subscription Count (0.5ms)  SELECT COUNT(*) FROM (SELECT 1 AS one FROM "subscriptions" INNER JOIN "customers" ON "customers"."id" = "subscriptions"."customer_id" INNER JOIN "plans" "plan" ON "plan"."id" = "subscriptions"."plan_id" WHERE "subscriptions"."organization_id" = $1 AND ((((((((("subscriptions"."id"::varchar ILIKE '%Mario%' OR "subscriptions"."name" ILIKE '%Mario%') OR "subscriptions"."external_id" ILIKE '%Mario%') OR "plans"."name" ILIKE '%Mario%') OR "plans"."code" ILIKE '%Mario%') OR "customers"."name" ILIKE '%Mario%') OR "customers"."firstname" ILIKE '%Mario%') OR "customers"."lastname" ILIKE '%Mario%') OR "customers"."external_id" ILIKE '%Mario%') OR "customers"."email" ILIKE '%Mario%') AND "plan"."parent_id" IS NULL LIMIT $2 OFFSET $3) subquery_for_count  [["organization_id", "034de852-b25c-41c5-9f58-a8f07bdcd2bd"], ["LIMIT", 25], ["OFFSET", 0]]
```

but fails with 
```
(lago-api):8:in '<main>': PG::UndefinedTable: ERROR:  invalid reference to FROM-clause entry for table "plans" (ActiveRecord::StatementInvalid)
LINE 1: ..."subscriptions"."external_id" ILIKE '%Mario%') OR "plans"."n...
                                                             ^
HINT:  Perhaps you meant to reference the table alias "plan".
```

Ramsack calls the table `plans` as `plans` and in our query, we are calling `plan`. 

## Fix
Call the `plans` table as `plans` just like Ramsack, without an alias.
```
SELECT COUNT(*) FROM (SELECT 1 AS one FROM "subscriptions" INNER JOIN "customers" ON "customers"."id" = "subscriptions"."customer_id" INNER JOIN "plans" ON "plans"."id" = "subscriptions"."plan_id" WHERE "subscriptions"."organization_id" = $1 AND ((((((((("subscriptions"."id"::varchar ILIKE '%Mario%' OR "subscriptions"."name" ILIKE '%Mario%') OR "subscriptions"."external_id" ILIKE '%Mario%') OR "plans"."name" ILIKE '%Mario%') OR "plans"."code" ILIKE '%Mario%') OR "customers"."name" ILIKE '%Mario%') OR "customers"."firstname" ILIKE '%Mario%') OR "customers"."lastname" ILIKE '%Mario%') OR "customers"."external_id" ILIKE '%Mario%') OR "customers"."email" ILIKE '%Mario%') AND "plans"."parent_id" IS NULL LIMIT $2 OFFSET $3) subquery_for_count  [["organization_id", "034de852-b25c-41c5-9f58-a8f07bdcd2bd"], ["LIMIT", 25], ["OFFSET", 0]]
```