### PR TITLE
feat(pre-aggregation): Expose charge pay_in_advance in flat filters

### DIFF
--- a/db/migrate/20250812082721_update_flat_filters_to_version_3.rb
+++ b/db/migrate/20250812082721_update_flat_filters_to_version_3.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateFlatFiltersToVersion3 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :flat_filters, version: 3, revert_to_version: 2
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -251,7 +251,8 @@ SELECT
     NULL::timestamp(6) without time zone AS charge_filter_updated_at,
     NULL::jsonb AS filters,
     NULL::jsonb AS properties,
-    NULL::jsonb AS pricing_group_keys;
+    NULL::jsonb AS pricing_group_keys,
+    NULL::boolean AS pay_in_advance;
 CREATE OR REPLACE VIEW public.billable_metrics_grouped_charges AS
 SELECT
     NULL::uuid AS organization_id,
@@ -3431,7 +3432,8 @@ SELECT
     NULL::timestamp(6) without time zone AS charge_filter_updated_at,
     NULL::jsonb AS filters,
     NULL::jsonb AS properties,
-    NULL::jsonb AS pricing_group_keys;
+    NULL::jsonb AS pricing_group_keys,
+    NULL::boolean AS pay_in_advance;
 
 
 --
@@ -7824,7 +7826,8 @@ CREATE OR REPLACE VIEW public.flat_filters AS
             ELSE NULL::jsonb
         END AS filters,
     COALESCE(charge_filters.properties, charges.properties) AS properties,
-    (COALESCE(charge_filters.properties, charges.properties) -> 'pricing_group_keys'::text) AS pricing_group_keys
+    (COALESCE(charge_filters.properties, charges.properties) -> 'pricing_group_keys'::text) AS pricing_group_keys,
+    charges.pay_in_advance
    FROM ((((public.billable_metrics
      JOIN public.charges ON ((charges.billable_metric_id = billable_metrics.id)))
      LEFT JOIN public.charge_filters ON ((charge_filters.charge_id = charges.id)))
@@ -9689,6 +9692,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250812132802'),
+('20250812082721'),
 ('20250806174150'),
 ('20250806173900'),
 ('20250801072722'),

--- a/db/views/flat_filters_v03.sql
+++ b/db/views/flat_filters_v03.sql
@@ -1,0 +1,44 @@
+-- This view is used on events_processor side to check filters matching on events received for organization using the Clickhouse store
+-- It then allows us to expire the usage chage directly within the events events_processor service
+SELECT
+  billable_metrics.organization_id AS organization_id,
+  billable_metrics.code AS billable_metric_code,
+  charges.plan_id AS plan_id,
+  charges.id AS charge_id,
+  charges.updated_at AS charge_updated_at,
+  charge_filters.id AS charge_filter_id,
+  charge_filters.updated_at AS charge_filter_updated_at,
+  CASE WHEN charge_filters.id IS NOT NULL
+  THEN
+	  jsonb_object_agg(
+	    COALESCE(billable_metric_filters.key, ''),
+	    CASE
+	      WHEN charge_filter_values.values::text[] && ARRAY['__ALL_FILTER_VALUES__']
+	      THEN billable_metric_filters.values
+	      ELSE charge_filter_values.values
+	    end
+	  )
+	  ELSE NULL
+  END AS filters,
+  COALESCE(charge_filters.properties, charges.properties) AS properties,
+  COALESCE(charge_filters.properties, charges.properties)->'pricing_group_keys' AS pricing_group_keys,
+  charges.pay_in_advance AS pay_in_advance
+FROM billable_metrics
+  INNER JOIN charges ON charges.billable_metric_id = billable_metrics.id
+  LEFT JOIN charge_filters ON charge_filters.charge_id = charges.id
+  LEFT JOIN charge_filter_values ON charge_filter_values.charge_filter_id = charge_filters.id
+  LEFT JOIN billable_metric_filters ON billable_metric_filters.id = charge_filter_values.billable_metric_filter_id
+WHERE
+  billable_metrics.deleted_at IS NULL
+  AND charges.deleted_at IS NULL
+  AND charge_filters.deleted_at IS NULL
+  AND charge_filter_values.deleted_at IS NULL
+  AND billable_metric_filters.deleted_at IS NULL
+GROUP BY
+  billable_metrics.organization_id,
+  billable_metrics.code,
+  charges.plan_id,
+  charges.id,
+  charges.updated_at,
+  charge_filters.id,
+  charge_filters.updated_at


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This pull request is exposing the `pay_in_advance` field in the flat_filters view, to allow the events_processor use them when enriching the events.