### PR TITLE
fix(weighted-sum): Clickhouse query

### DIFF
--- a/app/services/events/stores/clickhouse/weighted_sum_query.rb
+++ b/app/services/events/stores/clickhouse/weighted_sum_query.rb
@@ -147,8 +147,8 @@ module Events
 
             [
               groups,
-              "toDateTime64(:from_datetime, 5, 'UTC') AS timestamp",
-              "toDecimal128(#{initial_value[:value]}, :decimal_scale) AS difference"
+              "toDateTime64(:from_datetime, 5, 'UTC')",
+              "toDecimal128(#{initial_value[:value]}, :decimal_scale)"
             ].flatten.join(", ")
           end
 
@@ -169,8 +169,8 @@ module Events
 
             [
               groups,
-              "toDateTime64(:to_datetime, 5, 'UTC') AS timestamp",
-              "toDecimal128(0, :decimal_scale) AS difference"
+              "toDateTime64(:to_datetime, 5, 'UTC')",
+              "toDecimal128(0, :decimal_scale)"
             ].flatten.join(", ")
           end
 


### PR DESCRIPTION
Error: Different expressions with the same alias difference:\ntoDecimal128(25., 26) AS difference\nand\ntoDecimal128(15., 26) AS difference\n: While processing toDecimal128(25., 26) AS difference.
