### PR TITLE
feat(event_store): Aggregate to_datetime when an specific event is passed in filters

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -33,7 +33,11 @@ module Events
         query = query.order(arel_table[:timestamp].desc) if ordered
 
         query = query.where(arel_table[:timestamp].gteq(from_datetime)) if force_from || use_from_boundary
-        query = query.where(arel_table[:timestamp].lteq(to_datetime)) if to_datetime
+        if filters[:event]
+          query = query.where(arel_table[:timestamp].lteq(filters[:event].timestamp))
+        elsif to_datetime
+          query = query.where(arel_table[:timestamp].lteq(to_datetime)) if to_datetime
+        end
         query = query.limit_by(1, "events_enriched.transaction_id")
 
         query = apply_arel_grouped_by_values(query) if grouped_by_values?

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -11,7 +11,12 @@ module Events
         scope = scope.order(timestamp: :asc) if ordered
 
         scope = scope.from_datetime(from_datetime) if force_from || use_from_boundary
-        scope = scope.to_datetime(to_datetime) if to_datetime
+
+        if filters[:event]
+          scope = scope.to_datetime(filters[:event].timestamp)
+        elsif to_datetime
+          scope = scope.to_datetime(to_datetime)
+        end
 
         if numeric_property
           scope = scope.where(presence_condition)

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -158,6 +158,29 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     it "returns the number of unique events" do
       expect(event_store.count).to eq(5)
     end
+
+    context "when event is provided" do
+      subject(:event_store) do
+        described_class.new(
+          code:,
+          subscription:,
+          boundaries:,
+          filters: {
+            grouped_by:,
+            grouped_by_values:,
+            matching_filters:,
+            ignored_filters:,
+            event:
+          }
+        )
+      end
+
+      let(:event) { events.sort_by(&:timestamp).third }
+
+      it "returns the number of unique events until the provided event.timestamp" do
+        expect(event_store.count).to eq(3)
+      end
+    end
   end
 
   describe ".grouped_count" do

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -148,6 +148,29 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     it "returns the number of unique events" do
       expect(event_store.count).to eq(5)
     end
+
+    context "when event is provided" do
+      subject(:event_store) do
+        described_class.new(
+          code:,
+          subscription:,
+          boundaries:,
+          filters: {
+            grouped_by:,
+            grouped_by_values:,
+            matching_filters:,
+            ignored_filters:,
+            event:
+          }
+        )
+      end
+
+      let(:event) { events.sort_by(&:timestamp).third }
+
+      it "returns the number of unique events until the provided event.timestamp" do
+        expect(event_store.count).to eq(3)
+      end
+    end
   end
 
   describe "#grouped_count" do


### PR DESCRIPTION
With Pay in advance events, we count all events in the period to determine the price. We should only count events stored PRIOR to this specific event.

This change might have other side effect that we need to evaluate.

- [x] PG
- [x] CH