### PR TITLE
fix(entitlements): trim code on feature creation

### DIFF
--- a/app/services/entitlement/feature_create_service.rb
+++ b/app/services/entitlement/feature_create_service.rb
@@ -26,7 +26,7 @@ module Entitlement
       ActiveRecord::Base.transaction do
         feature = Feature.create!(
           organization:,
-          code: params[:code],
+          code: params[:code]&.strip,
           name: params[:name],
           description: params[:description]
         )
@@ -61,7 +61,7 @@ module Entitlement
       privileges_params.each do |privilege_params|
         privilege = feature.privileges.new(
           organization:,
-          code: privilege_params[:code],
+          code: privilege_params[:code]&.strip,
           name: privilege_params[:name]
         )
         privilege.value_type = privilege_params[:value_type] if privilege_params.has_key? :value_type

--- a/app/services/entitlement/feature_update_service.rb
+++ b/app/services/entitlement/feature_update_service.rb
@@ -88,7 +88,7 @@ module Entitlement
     def create_privilege(privilege_params)
       privilege = feature.privileges.new(
         organization: feature.organization,
-        code: privilege_params[:code],
+        code: privilege_params[:code]&.strip,
         name: privilege_params[:name]
       )
       privilege.value_type = privilege_params[:value_type] if privilege_params.has_key? :value_type

--- a/spec/services/entitlement/feature_create_service_spec.rb
+++ b/spec/services/entitlement/feature_create_service_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe Entitlement::FeatureCreateService, type: :service do
       expect(result.feature.organization).to eq(organization)
     end
 
+    it "trims code" do
+      params[:code] = "  seats  "
+      params[:privileges] = [{code: "  test "}]
+      result = subject
+      expect(result.feature.code).to eq "seats"
+      expect(result.feature.privileges.sole.code).to eq "test"
+    end
+
     it "produces an activity log" do
       result = subject
       expect(Utils::ActivityLog).to have_produced("feature.created").after_commit.with(result.feature)

--- a/spec/services/entitlement/feature_update_service_spec.rb
+++ b/spec/services/entitlement/feature_update_service_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
       end
 
       context "when new privileges is provided" do
-        let(:new_privilege_code) { "new_privilege" }
+        let(:new_privilege_code) { "     new_privilege     " }
         let(:params) do
           {
             privileges: [
@@ -219,7 +219,7 @@ RSpec.describe Entitlement::FeatureUpdateService, type: :service do
 
           expect(result).to be_success
           expect(feature.privileges.reload.count).to eq(1)
-          expect(feature.privileges.sole.code).to eq(new_privilege_code)
+          expect(feature.privileges.sole.code).to eq("new_privilege")
           expect(feature.privileges.sole.name).to eq("New Privilege")
           expect(feature.privileges.sole.value_type).to eq("string")
         end


### PR DESCRIPTION
The frontend will trim code so the backend should do it too. I think it makes sense to trim the code because it's used as "identifier". 
Today, you can create `seats`, ` seats` and `seats ` as 3 separate features. I believe it will create too much confusion for zero benefits.