### PR TITLE
Feat(fixed_charges-6): update plan with fixed-charge specific values

### DIFF
--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -36,7 +36,7 @@ module Plans
         plan.bill_fixed_charges_monthly = bill_fixed_charges_monthly?
       end
 
-       chargeables_validation_result = Plans::ChargeablesValidationService.call(
+      chargeables_validation_result = Plans::ChargeablesValidationService.call(
         organization: plan.organization,
         charges: params[:charges],
         fixed_charges: params[:fixed_charges]

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -1183,7 +1183,7 @@ RSpec.describe Plans::UpdateService, type: :service do
       end
     end
 
-    context "bill_fixed_charges_monthly functionality" do
+    context "with bill_fixed_charges_monthly functionality" do
       context "when interval is yearly and bill_fixed_charges_monthly is sent" do
         let(:update_args) do
           {
@@ -1232,7 +1232,7 @@ RSpec.describe Plans::UpdateService, type: :service do
       end
     end
 
-    context "fixed_charges validation" do
+    context "with fixed_charges validation" do
       context "when valid fixed_charges are provided" do
         let(:update_args) do
           {
@@ -1303,7 +1303,7 @@ RSpec.describe Plans::UpdateService, type: :service do
       end
     end
 
-    context "complete fixed_charges flow" do
+    context "with complete fixed_charges flow" do
       let(:update_args) do
         {
           name: plan_name,
@@ -1318,6 +1318,7 @@ RSpec.describe Plans::UpdateService, type: :service do
 
         expect(result).to be_success
         expect(result.plan.bill_fixed_charges_monthly).to eq(true)
+        # to be continued with fixed_charges management
       end
     end
   end


### PR DESCRIPTION
## Context

There are several steps we need to do to update plans:
- update plan itself
- handle fixed_charges update
- handle fixed_charges addition
- handle fixed_charges deletion

this PR handles first part: updating plan itself + validating params for fixed_charges

## Description
- Added plan update with fixed_charges_bill_monthly
- Validate params for fixed charges