### PR TITLE
fix(anrok): issuing_date should be 30 days in the future at most

### DIFF
--- a/app/services/integrations/aggregator/taxes/invoices/payloads/anrok.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payloads/anrok.rb
@@ -18,7 +18,7 @@ module Integrations
             def body
               [
                 {
-                  "issuing_date" => invoice.issuing_date,
+                  "issuing_date" => issuing_date,
                   "currency" => invoice.currency,
                   "contact" => {
                     "external_id" => integration_customer&.external_customer_id || customer.external_id,
@@ -61,6 +61,11 @@ module Integrations
 
             def empty_struct
               @empty_struct ||= OpenStruct.new
+            end
+
+            def issuing_date
+              # NOTE: Anrok API requires issuing date to be 30 days in the future at  most.
+              [invoice.issuing_date, 30.days.from_now.to_date].min
             end
           end
         end

--- a/spec/services/integrations/aggregator/taxes/invoices/payloads/anrok_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/payloads/anrok_spec.rb
@@ -100,5 +100,12 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::Payloads::Anrok do
     it "returns the payload body" do
       expect(call).to eq payload_body
     end
+
+    context "when invoice.issuing_date is too far in the future" do
+      it "uses issuing date 30 days in the future at most" do
+        invoice.issuing_date = 61.days.from_now.to_date
+        expect(call.sole["issuing_date"]).to eq 30.days.from_now.to_date
+      end
+    end
   end
 end


### PR DESCRIPTION
Anrok will return a `taxDateTooFarInFuture` error if the issuing date is more than 30 days in the future, which can happen with Quarterly and Yearly subscription.