### PR TITLE
feat(models): Introduce SoftDeletable concern

### DIFF
--- a/app/models/add_on.rb
+++ b/app/models/add_on.rb
@@ -4,8 +4,7 @@ class AddOn < ApplicationRecord
   include PaperTrailTraceable
   include Currencies
   include IntegrationMappable
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   belongs_to :organization
 
@@ -25,8 +24,6 @@ class AddOn < ApplicationRecord
 
   validates :amount_cents, numericality: {greater_than: 0}
   validates :amount_currency, inclusion: {in: currency_list}
-
-  default_scope -> { kept }
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[name code]

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -2,9 +2,7 @@
 
 class BillableMetric < ApplicationRecord
   include PaperTrailTraceable
-  include Discard::Model
   include IntegrationMappable
-  self.discard_column = :deleted_at
 
   belongs_to :organization
 
@@ -57,8 +55,6 @@ class BillableMetric < ApplicationRecord
     if: :weighted_sum_agg?
   validates :custom_aggregator, presence: true, if: :custom_agg?
   validates :rounding_function, inclusion: {in: ROUNDING_FUNCTIONS.values}, allow_nil: true
-
-  default_scope -> { kept }
 
   scope :with_expression, -> { where("expression IS NOT NULL AND expression <> ''") }
 

--- a/app/models/billable_metric_filter.rb
+++ b/app/models/billable_metric_filter.rb
@@ -2,8 +2,7 @@
 
 class BillableMetricFilter < ApplicationRecord
   include PaperTrailTraceable
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   belongs_to :billable_metric, -> { with_discarded }
   belongs_to :organization
@@ -13,8 +12,6 @@ class BillableMetricFilter < ApplicationRecord
 
   validates :key, presence: true
   validates :values, presence: true
-
-  default_scope -> { kept }
 end
 
 # == Schema Information

--- a/app/models/billing_entity.rb
+++ b/app/models/billing_entity.rb
@@ -4,9 +4,7 @@ class BillingEntity < ApplicationRecord
   include PaperTrailTraceable
   include OrganizationTimezone
   include Currencies
-  include Discard::Model
-
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   EMAIL_SETTINGS = [
     "invoice.finalized",
@@ -59,7 +57,6 @@ class BillingEntity < ApplicationRecord
 
   enum :document_numbering, DOCUMENT_NUMBERINGS
 
-  default_scope -> { kept }
   scope :active, -> { where(archived_at: nil).order(created_at: :asc) }
 
   validates :code,

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -4,8 +4,7 @@ class Charge < ApplicationRecord
   include PaperTrailTraceable
   include Currencies
   include ChargePropertiesValidation
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   belongs_to :organization
   belongs_to :plan, -> { with_discarded }, touch: true
@@ -52,8 +51,6 @@ class Charge < ApplicationRecord
   validate :validate_prorated
   validate :validate_min_amount_cents
   validate :validate_custom_model
-
-  default_scope -> { kept }
 
   scope :pay_in_advance, -> { where(pay_in_advance: true) }
 

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -2,9 +2,7 @@
 
 class ChargeFilter < ApplicationRecord
   include PaperTrailTraceable
-  include Discard::Model
   include ChargePropertiesValidation
-  self.discard_column = :deleted_at
 
   belongs_to :charge, -> { with_discarded }, touch: true
   belongs_to :organization

--- a/app/models/charge_filter_value.rb
+++ b/app/models/charge_filter_value.rb
@@ -2,8 +2,7 @@
 
 class ChargeFilterValue < ApplicationRecord
   include PaperTrailTraceable
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   ALL_FILTER_VALUES = "__ALL_FILTER_VALUES__"
 

--- a/app/models/concerns/soft_deletable.rb
+++ b/app/models/concerns/soft_deletable.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SoftDeletable
+  extend ActiveSupport::Concern
+
+  included do
+    include Discard::Model
+    self.discard_column = :deleted_at
+
+    default_scope -> { kept }
+  end
+end

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -3,8 +3,7 @@
 class Coupon < ApplicationRecord
   include PaperTrailTraceable
   include Currencies
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   belongs_to :organization
 
@@ -58,7 +57,6 @@ class Coupon < ApplicationRecord
 
   validates :percentage_rate, presence: true, if: :percentage?
 
-  default_scope -> { kept }
   scope :order_by_status_and_expiration,
     lambda {
       order(

--- a/app/models/coupon_target.rb
+++ b/app/models/coupon_target.rb
@@ -2,15 +2,12 @@
 
 class CouponTarget < ApplicationRecord
   include PaperTrailTraceable
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   belongs_to :coupon
   belongs_to :plan, optional: true
   belongs_to :billable_metric, optional: true
   belongs_to :organization
-
-  default_scope -> { kept }
 end
 
 # == Schema Information

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -7,8 +7,7 @@ class Customer < ApplicationRecord
   include CustomerTimezone
   include OrganizationTimezone
   include BillingEntityTimezone
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   FINALIZE_ZERO_AMOUNT_INVOICE_OPTIONS = [
     :inherit,
@@ -97,7 +96,6 @@ class Customer < ApplicationRecord
 
   PAYMENT_PROVIDERS = %w[stripe gocardless cashfree adyen flutterwave moneyhash].freeze
 
-  default_scope -> { kept }
   sequenced scope: ->(customer) { customer.organization.customers.with_discarded },
     lock_key: ->(customer) { customer.organization_id }
 

--- a/app/models/dunning_campaign.rb
+++ b/app/models/dunning_campaign.rb
@@ -2,8 +2,7 @@
 
 class DunningCampaign < ApplicationRecord
   include PaperTrailTraceable
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
   self.ignored_columns += %w[applied_to_organization]
 
   ORDERS = %w[name code].freeze
@@ -25,7 +24,6 @@ class DunningCampaign < ApplicationRecord
     uniqueness: {conditions: -> { where(deleted_at: nil) }, scope: :organization_id},
     unless: :deleted_at
 
-  default_scope -> { kept }
   scope :applied_to_organization, -> { where(applied_to_organization: true) }
   scope :with_currency_threshold, ->(currencies) {
     joins(:thresholds)

--- a/app/models/dunning_campaign_threshold.rb
+++ b/app/models/dunning_campaign_threshold.rb
@@ -3,8 +3,7 @@
 class DunningCampaignThreshold < ApplicationRecord
   include Currencies
   include PaperTrailTraceable
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   belongs_to :dunning_campaign
   belongs_to :organization
@@ -14,8 +13,6 @@ class DunningCampaignThreshold < ApplicationRecord
   validates :currency,
     uniqueness: {conditions: -> { where(deleted_at: nil) }, scope: :dunning_campaign_id},
     unless: :deleted_at
-
-  default_scope -> { kept }
 end
 
 # == Schema Information

--- a/app/models/entitlement/entitlement.rb
+++ b/app/models/entitlement/entitlement.rb
@@ -2,10 +2,7 @@
 
 module Entitlement
   class Entitlement < ApplicationRecord
-    include Discard::Model
-    self.discard_column = :deleted_at
-
-    default_scope -> { kept }
+    include SoftDeletable
 
     belongs_to :organization
     belongs_to :feature, class_name: "Entitlement::Feature", foreign_key: :entitlement_feature_id

--- a/app/models/entitlement/entitlement_value.rb
+++ b/app/models/entitlement/entitlement_value.rb
@@ -2,10 +2,7 @@
 
 module Entitlement
   class EntitlementValue < ApplicationRecord
-    include Discard::Model
-    self.discard_column = :deleted_at
-
-    default_scope -> { kept }
+    include SoftDeletable
 
     belongs_to :organization
     belongs_to :privilege, class_name: "Entitlement::Privilege", foreign_key: :entitlement_privilege_id

--- a/app/models/entitlement/feature.rb
+++ b/app/models/entitlement/feature.rb
@@ -2,10 +2,7 @@
 
 module Entitlement
   class Feature < ApplicationRecord
-    include Discard::Model
-    self.discard_column = :deleted_at
-
-    default_scope -> { kept }
+    include SoftDeletable
 
     belongs_to :organization
     has_many :privileges, class_name: "Entitlement::Privilege", foreign_key: "entitlement_feature_id", dependent: :destroy

--- a/app/models/entitlement/privilege.rb
+++ b/app/models/entitlement/privilege.rb
@@ -2,10 +2,7 @@
 
 module Entitlement
   class Privilege < ApplicationRecord
-    include Discard::Model
-    self.discard_column = :deleted_at
-
-    default_scope -> { kept }
+    include SoftDeletable
 
     VALUE_TYPES = %w[integer string boolean select].freeze
 

--- a/app/models/entitlement/subscription_feature_removal.rb
+++ b/app/models/entitlement/subscription_feature_removal.rb
@@ -2,10 +2,7 @@
 
 module Entitlement
   class SubscriptionFeatureRemoval < ApplicationRecord
-    include Discard::Model
-    self.discard_column = :deleted_at
-
-    default_scope -> { kept }
+    include SoftDeletable
 
     belongs_to :organization
     belongs_to :feature, class_name: "Entitlement::Feature", foreign_key: :entitlement_feature_id

--- a/app/models/error_detail.rb
+++ b/app/models/error_detail.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class ErrorDetail < ApplicationRecord
-  include Discard::Model
-  self.discard_column = :deleted_at
-  default_scope -> { kept }
+  include SoftDeletable
 
   belongs_to :owner, polymorphic: true
   belongs_to :organization

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class Event < EventsRecord
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   include CustomerTimezone
   include OrganizationTimezone
@@ -11,7 +10,6 @@ class Event < EventsRecord
 
   validates :code, presence: true
 
-  default_scope -> { kept }
   scope :from_datetime, ->(from_datetime) { where("events.timestamp >= ?", from_datetime) }
   scope :to_datetime, ->(to_datetime) { where("events.timestamp <= ?", to_datetime) }
 

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -2,9 +2,7 @@
 
 class Fee < ApplicationRecord
   include Currencies
-  include Discard::Model
-  self.discard_column = :deleted_at
-  default_scope -> { kept }
+  include SoftDeletable
 
   belongs_to :invoice, optional: true
   belongs_to :charge, -> { with_discarded }, optional: true

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -2,10 +2,7 @@
 
 class FixedCharge < ApplicationRecord
   include PaperTrailTraceable
-  include Discard::Model
-
-  self.discard_column = :deleted_at
-  default_scope -> { kept }
+  include SoftDeletable
 
   belongs_to :organization
   belongs_to :plan, -> { with_discarded }, touch: true

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,8 +2,7 @@
 
 class Group < ApplicationRecord
   include PaperTrailTraceable
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   belongs_to :billable_metric, -> { with_discarded }
   belongs_to :parent, -> { with_discarded }, class_name: "Group", foreign_key: "parent_group_id", optional: true
@@ -13,7 +12,6 @@ class Group < ApplicationRecord
 
   validates :key, :value, presence: true
 
-  default_scope -> { kept }
   scope :parents, -> { where(parent_group_id: nil) }
   scope :children, -> { where.not(parent_group_id: nil) }
 

--- a/app/models/group_property.rb
+++ b/app/models/group_property.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
 class GroupProperty < ApplicationRecord
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   belongs_to :charge
   belongs_to :group, -> { with_discarded }
 
   validates :values, presence: true
   validates :group_id, presence: true, uniqueness: {scope: :charge_id}
-
-  default_scope -> { kept }
 end
 
 # == Schema Information

--- a/app/models/invoice_custom_section.rb
+++ b/app/models/invoice_custom_section.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class InvoiceCustomSection < ApplicationRecord
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   belongs_to :organization
   has_many :customer_applied_invoice_custom_sections,
@@ -19,8 +18,6 @@ class InvoiceCustomSection < ApplicationRecord
   validates :code,
     presence: true,
     uniqueness: {conditions: -> { where(deleted_at: nil) }, scope: :organization_id}
-
-  default_scope -> { kept }
 
   def selected_for_default_billing_entity?
     billing_entity_applied_invoice_custom_sections.exists?(billing_entity: organization.default_billing_entity)

--- a/app/models/lifetime_usage.rb
+++ b/app/models/lifetime_usage.rb
@@ -2,8 +2,7 @@
 
 class LifetimeUsage < ApplicationRecord
   include Currencies
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   belongs_to :organization
   belongs_to :subscription
@@ -16,8 +15,6 @@ class LifetimeUsage < ApplicationRecord
     :invoiced_usage_amount_cents,
     :historical_usage_amount_cents,
     with_currency: ->(lifetime_usage) { lifetime_usage.subscription.plan.amount_currency }
-
-  default_scope -> { kept }
 
   scope :needs_recalculation, -> { where(recalculate_current_usage: true).or(where(recalculate_invoiced_usage: true)) }
 

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -4,9 +4,7 @@ module PaymentProviderCustomers
   class BaseCustomer < ApplicationRecord
     include PaperTrailTraceable
     include SettingsStorable
-    include Discard::Model
-    self.discard_column = :deleted_at
-    default_scope -> { kept }
+    include SoftDeletable
 
     self.table_name = "payment_provider_customers"
 

--- a/app/models/payment_providers/base_provider.rb
+++ b/app/models/payment_providers/base_provider.rb
@@ -5,9 +5,7 @@ module PaymentProviders
     include PaperTrailTraceable
     include SecretsStorable
     include SettingsStorable
-    include Discard::Model
-    self.discard_column = :deleted_at
-    default_scope -> { kept }
+    include SoftDeletable
 
     self.table_name = "payment_providers"
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -3,8 +3,7 @@
 class Plan < ApplicationRecord
   include PaperTrailTraceable
   include Currencies
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   belongs_to :organization
   belongs_to :parent, class_name: "Plan", optional: true
@@ -50,7 +49,6 @@ class Plan < ApplicationRecord
   validates :pay_in_advance, inclusion: {in: [true, false]}
   validate :validate_code_unique
 
-  default_scope -> { kept }
   scope :parents, -> { where(parent_id: nil) }
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/models/quantified_event.rb
+++ b/app/models/quantified_event.rb
@@ -2,8 +2,7 @@
 
 class QuantifiedEvent < ApplicationRecord
   include PaperTrailTraceable
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   RECURRING_TOTAL_UNITS = "total_aggregated_units"
 
@@ -15,8 +14,6 @@ class QuantifiedEvent < ApplicationRecord
 
   validates :added_at, presence: true
   validates :external_subscription_id, presence: true
-
-  default_scope -> { kept }
 end
 
 # == Schema Information

--- a/app/models/subscription_fixed_charge_units_override.rb
+++ b/app/models/subscription_fixed_charge_units_override.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 class SubscriptionFixedChargeUnitsOverride < ApplicationRecord
-  include Discard::Model
   include PaperTrailTraceable
-  self.discard_column = :deleted_at
-  default_scope -> { kept }
 
   belongs_to :organization
   belongs_to :billing_entity

--- a/app/models/usage_monitoring/alert.rb
+++ b/app/models/usage_monitoring/alert.rb
@@ -2,9 +2,7 @@
 
 module UsageMonitoring
   class Alert < ApplicationRecord
-    include Discard::Model
-
-    self.discard_column = :deleted_at
+    include SoftDeletable
     self.inheritance_column = :alert_type
 
     STI_MAPPING = {
@@ -17,8 +15,6 @@ module UsageMonitoring
 
     CURRENT_USAGE_TYPES = %w[current_usage_amount billable_metric_current_usage_amount billable_metric_current_usage_units]
     BILLABLE_METRIC_TYPES = %w[billable_metric_current_usage_amount billable_metric_current_usage_units]
-
-    default_scope -> { kept }
 
     belongs_to :organization
     belongs_to :billable_metric, optional: true

--- a/app/models/usage_threshold.rb
+++ b/app/models/usage_threshold.rb
@@ -3,8 +3,7 @@
 class UsageThreshold < ApplicationRecord
   include PaperTrailTraceable
   include Currencies
-  include Discard::Model
-  self.discard_column = :deleted_at
+  include SoftDeletable
 
   belongs_to :organization
   belongs_to :plan
@@ -20,8 +19,6 @@ class UsageThreshold < ApplicationRecord
 
   scope :recurring, -> { where(recurring: true) }
   scope :not_recurring, -> { where(recurring: false) }
-
-  default_scope -> { kept }
 
   def invoice_name
     threshold_display_name || I18n.t("invoice.usage_threshold")


### PR DESCRIPTION
A few weeks back, I introduced a new way to spec helper thing to ensure:
- use the `deleted_at` column name
- use default scope kept

I think it was very useful but having a proper concern to use is probably better!

The goal is to add either override `discard_all!` or create a new helper to [avoid this mistake again](https://github.com/getlago/lago-api/pull/3747). 

- [ ] Ensure all models already had `kept` default scope
- [ ] Ensure all model use spec hleper