### PR TITLE
Feat pre aggregation event enriched extended

### DIFF
--- a/db/clickhouse_migrate/20250814090557_create_events_enriched_expanded.rb
+++ b/db/clickhouse_migrate/20250814090557_create_events_enriched_expanded.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class CreateEventsEnrichedExpanded < ActiveRecord::Migration[8.0]
+  def change
+    options = <<-SQL
+        ReplacingMergeTree(timestamp)
+        PRIMARY KEY (
+          organization_id,
+          code,
+          external_subscription_id,
+          charge_id,
+          charge_filter_id,
+          toDate(timestamp)
+        )
+        ORDER BY (
+          organization_id,
+          code,
+          external_subscription_id,
+          charge_id,
+          charge_filter_id,
+          toDate(timestamp),
+          timestamp,
+          transaction_id
+        )
+    SQL
+
+    create_table :events_enriched_expanded, id: false, options: do |t|
+      t.string :organization_id, null: false
+      t.string :external_subscription_id, null: false
+      t.string :code, null: false
+      t.datetime :timestamp, null: false, precision: 3
+      t.string :transaction_id, null: false
+      t.json :properties, null: false
+      t.string :sorted_properties, map: true, null: false, default: -> { "mapSort(JSONExtract(properties, 'Map(String, String)'))" }
+      t.string :value
+      t.decimal :decimal_value, precision: 38, scale: 26, default: -> { "toDecimal128OrZero(value, 26)" }
+      t.datetime :enriched_at, null: false, precision: 3, default: -> { "now()" }
+      t.decimal :precise_total_amount_cents, precision: 40, scale: 15
+      t.string :subscription_id, null: false, default: -> { "''" }
+      t.string :plan_id, null: false, default: -> { "''" }
+      t.string :charge_id, null: false, default: -> { "''" }
+      t.datetime :charge_version
+      t.string :charge_filter_id, null: false, default: -> { "''" }
+      t.datetime :charge_filter_version
+      t.string :aggregation_type, null: false
+      t.json :grouped_by, null: false
+      t.string :sorted_grouped_by, map: true, null: false, default: -> { "mapSort(JSONExtract(grouped_by, 'Map(String, String)'))" }
+    end
+  end
+end

--- a/db/clickhouse_migrate/20250814124830_create_events_enriched_expanded_queue.rb
+++ b/db/clickhouse_migrate/20250814124830_create_events_enriched_expanded_queue.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class CreateEventsEnrichedExpandedQueue < ActiveRecord::Migration[8.0]
+  def change
+    options = <<-SQL
+          Kafka()
+          SETTINGS
+            kafka_broker_list = '#{ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"]}',
+            kafka_topic_list = '#{ENV["LAGO_KAFKA_ENRICHED_EVENTS_EXPANDED_TOPIC"]}',
+            kafka_group_name = '#{ENV["LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP"]}',
+            kafka_format = 'JSONEachRow';
+    SQL
+
+    create_table :events_enriched_expanded_queue, id: false, options: do |t|
+      t.string :organization_id, null: false
+      t.string :external_subscription_id, null: false
+      t.string :transaction_id, null: false
+      t.string :code, null: false
+      t.string :aggregation_type
+      t.string :subscription_id
+      t.string :plan_id
+      t.string :properties, null: false
+      t.decimal :precise_total_amount_cents, precision: 40, scale: 15
+      t.string :value
+      t.string :timestamp, null: false
+      t.string :charge_id
+      t.string :charge_updated_at
+      t.string :charge_filter_id
+      t.string :charge_filter_updated_at
+      t.string :grouped_by
+    end
+  end
+end

--- a/db/clickhouse_migrate/20250814125620_create_events_enriched_expanded_mv.rb
+++ b/db/clickhouse_migrate/20250814125620_create_events_enriched_expanded_mv.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: false
+
+class CreateEventsEnrichedExpandedMv < ActiveRecord::Migration[8.0]
+  def change
+    sql = <<-SQL
+      SELECT
+       	organization_id,
+       	external_subscription_id,
+       	code,
+       	toDateTime64(timestamp, 3) AS timestamp,
+       	transaction_id,
+        properties,
+       	value,
+       	precise_total_amount_cents,
+       	subscription_id,
+       	plan_id,
+       	coalesce(charge_id, '') AS charge_id,
+        charge_updated_at AS charge_version,
+       	coalesce(charge_filter_id, '') AS charge_filter_id,
+        charge_filter_updated_at AS charge_filter_version,
+        aggregation_type,
+       	grouped_by
+      FROM events_enriched_expanded_queue;
+    SQL
+
+    create_view :events_enriched_expanded_mv, materialized: true, as: sql, to: "events_enriched_expanded"
+  end
+end

--- a/db/clickhouse_migrate/20250814130828_create_events_aggregated.rb
+++ b/db/clickhouse_migrate/20250814130828_create_events_aggregated.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: false
+
+class CreateEventsAggregated < ActiveRecord::Migration[8.0]
+  def change
+    options = <<-SQL
+        AggregatingMergeTree
+        ORDER BY (
+          organization_id,
+          code,
+          started_at,
+          external_subscription_id,
+          subscription_id,
+          charge_id,
+          charge_filter_id,
+          grouped_by
+        )
+    SQL
+
+    create_table :events_aggregated, id: false, options: do |t|
+      t.string :organization_id, null: false
+      t.string :code, null: false
+
+      t.datetime :started_at, null: false, precision: 3
+
+      t.string :external_subscription_id, null: false
+      t.string :subscription_id, null: false
+      t.string :plan_id, null: false
+      t.string :charge_id, null: false
+      t.string :charge_filter_id, null: false, default: -> { "''" }
+      t.string :grouped_by, null: false
+      # Multiple aggregation states for different charge models
+      # Only one will be populated based on the charge's aggregation type
+      t.column :sum_state, "AggregateFunction(sum, Decimal(38, 26))", null: false
+      t.column :count_state, "AggregateFunction(count, UInt64)", null: false
+      t.column :max_state, "AggregateFunction(max, Decimal(38, 26))", null: false
+      # Latest aggregation using argMax - stores the latest value based on timestamp
+      # argMax(value, timestamp) returns the value corresponding to the maximum timestamp
+      t.column :latest_state, "AggregateFunction(argMax, Decimal(38, 26), DateTime64(3))", null: false
+      t.datetime :aggregated_at, null: false, precision: 3, default: -> { "now()" }
+    end
+  end
+end

--- a/db/clickhouse_migrate/20250814134106_create_events_aggregated_mv.rb
+++ b/db/clickhouse_migrate/20250814134106_create_events_aggregated_mv.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: false
+
+class CreateEventsAggregatedMv < ActiveRecord::Migration[8.0]
+  def change
+    sql = <<-SQL
+      SELECT
+        organization_id,
+        code,
+        toStartOfMinute(timestamp) AS started_at,
+        external_subscription_id,
+        subscription_id,
+        plan_id,
+        charge_id,
+        charge_filter_id,
+        sorted_grouped_by as grouped_by,
+        -- Aggregate states based on aggregation type
+        multiIf(aggregation_type = 'sum', sumState(coalesce(decimal_value, 0)), sumState(toDecimal128(0, 26))) AS sum_state,
+        multiIf(aggregation_type = 'count', countState(), countStateIf(false)) AS count_state,
+        multiIf(aggregation_type = 'max', maxState(coalesce(decimal_value, 0)), maxState(toDecimal128(0, 26))) AS max_state,
+        multiIf(aggregation_type = 'latest', argMaxState(coalesce(decimal_value, 0), timestamp), argMaxState(toDecimal128(0, 26), toDateTime64('1970-01-01', 3))) AS latest_state
+      FROM events_enriched_expanded
+      WHERE decimal_value IS NOT NULL
+        AND subscription_id IS NOT NULL
+        AND plan_id IS NOT NULL
+        AND charge_id <> ''
+      GROUP BY
+        organization_id,
+        code,
+        toStartOfMinute(timestamp),
+        external_subscription_id,
+        subscription_id,
+        plan_id,
+        charge_id,
+        charge_filter_id,
+        sorted_grouped_by,
+        aggregation_type
+    SQL
+
+    create_view :events_aggregated_mv, materialized: true, as: sql, to: "events_aggregated"
+  end
+end


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This pull request adds the complete Clickhouse pipeline to process enriched event expanded and aggregates them on a per-minute basis