### PR TITLE
Feat(fixed_charges): update graphql for updating plan fixed charges

### DIFF
--- a/app/graphql/mutations/plans/update.rb
+++ b/app/graphql/mutations/plans/update.rb
@@ -15,6 +15,7 @@ module Mutations
 
       def resolve(entitlements: nil, **args)
         args[:charges].map!(&:to_h)
+        args[:fixed_charges]&.map!(&:to_h)
         plan = context[:current_user].plans.find_by(id: args[:id])
 
         result = ::Plans::UpdateService.call(plan:, params: args)

--- a/app/graphql/types/fixed_charges/input.rb
+++ b/app/graphql/types/fixed_charges/input.rb
@@ -6,6 +6,7 @@ module Types
       graphql_name "FixedChargeInput"
 
       argument :add_on_id, ID, required: true
+      argument :apply_units_immediately, Boolean, required: false
       argument :charge_model, Types::FixedCharges::ChargeModelEnum, required: true
       argument :invoice_display_name, String, required: false
       argument :pay_in_advance, Boolean, required: false

--- a/app/graphql/types/fixed_charges/object.rb
+++ b/app/graphql/types/fixed_charges/object.rb
@@ -13,6 +13,7 @@ module Types
       field :pay_in_advance, Boolean, null: false
       field :properties, Types::FixedCharges::Properties, null: true
       field :prorated, Boolean, null: false
+      field :units, String, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -61,6 +61,10 @@ module Types
         object.charges.includes(filters: {values: :billable_metric_filter}).order(created_at: :asc)
       end
 
+      def fixed_charges
+        object.fixed_charges.order(created_at: :asc)
+      end
+
       def charges_count
         object.charges.count
       end

--- a/app/graphql/types/plans/update_input.rb
+++ b/app/graphql/types/plans/update_input.rb
@@ -10,6 +10,7 @@ module Types
       argument :amount_cents, GraphQL::Types::BigInt, required: true
       argument :amount_currency, Types::CurrencyEnum, required: true
       argument :bill_charges_monthly, Boolean, required: false
+      argument :bill_fixed_charges_monthly, Boolean, required: false
       argument :cascade_updates, Boolean, required: false
       argument :code, String, required: true
       argument :description, String, required: false
@@ -21,6 +22,7 @@ module Types
       argument :trial_period, Float, required: false
 
       argument :charges, [Types::Charges::Input]
+      argument :fixed_charges, [Types::FixedCharges::Input], required: false
       argument :minimum_commitment, Types::Commitments::Input, required: false
       argument :usage_thresholds, [Types::UsageThresholds::Input], required: false
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -5309,6 +5309,7 @@ type FixedCharge {
   properties: FixedChargeProperties
   prorated: Boolean!
   taxes: [Tax!]
+  units: String!
   updatedAt: ISO8601DateTime!
 }
 
@@ -5320,6 +5321,7 @@ enum FixedChargeChargeModelEnum {
 
 input FixedChargeInput {
   addOnId: ID!
+  applyUnitsImmediately: Boolean
   chargeModel: FixedChargeChargeModelEnum!
   invoiceDisplayName: String
   payInAdvance: Boolean
@@ -11003,6 +11005,7 @@ input UpdatePlanInput {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   billChargesMonthly: Boolean
+  billFixedChargesMonthly: Boolean
   cascadeUpdates: Boolean
   charges: [ChargeInput!]!
 
@@ -11013,6 +11016,7 @@ input UpdatePlanInput {
   code: String!
   description: String
   entitlements: [EntitlementInput!]
+  fixedCharges: [FixedChargeInput!]
   id: ID!
   interval: PlanInterval!
   invoiceDisplayName: String

--- a/schema.json
+++ b/schema.json
@@ -25645,6 +25645,22 @@
               "args": []
             },
             {
+              "name": "units",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "updatedAt",
               "description": null,
               "type": {
@@ -25712,6 +25728,18 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "applyUnitsImmediately",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -56942,6 +56970,18 @@
               "deprecationReason": null
             },
             {
+              "name": "billFixedChargesMonthly",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "cascadeUpdates",
               "description": null,
               "type": {
@@ -57090,6 +57130,26 @@
                       "name": "ChargeInput",
                       "ofType": null
                     }
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fixedCharges",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "FixedChargeInput",
+                    "ofType": null
                   }
                 }
               },

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
           payInAdvance,
           amountCents,
           amountCurrency,
+          billChargesMonthly,
+          billFixedChargesMonthly,
           minimumCommitment {
             id,
             amountCents,
@@ -61,6 +63,13 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
               values
               properties { amount }
             }
+          },
+          fixedCharges {
+            id,
+            units,
+            addOn { id name code },
+            chargeModel,
+            properties { amount }
           },
           usageThresholds {
             id,
@@ -382,6 +391,149 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
         "invoiceDisplayName" => minimum_commitment.invoice_display_name,
         "amountCents" => minimum_commitment.amount_cents.to_s
       )
+    end
+  end
+
+  context "when fixed charges are not provided" do
+    let(:fixed_charge) { create(:fixed_charge, plan:, charge_model: "standard", properties: {amount: "100.00"}) }
+
+    before do
+      fixed_charge
+    end
+
+    it "updates the plan without changing fixed charges" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            id: plan.id,
+            name: "Updated plan",
+            code: "updated_plan",
+            interval: "monthly",
+            payInAdvance: true,
+            amountCents: 200,
+            amountCurrency: "EUR",
+            charges: []
+          }
+        }
+      )
+
+      result_data = result["data"]["updatePlan"]
+
+      expect(result_data["fixedCharges"].count).to eq(1)
+      expect(result_data["fixedCharges"].first["id"]).to eq(fixed_charge.id)
+    end
+  end
+
+  context "when fixed charges are provided" do
+    let(:add_on_1) { create(:add_on, organization:) }
+    let(:add_on_2) { create(:add_on, organization:) }
+    let(:add_on_3) { create(:add_on, organization:) }
+
+    it "updates the plan with the provided fixed charges" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            id: plan.id,
+            name: "Updated plan",
+            code: "updated_plan",
+            interval: "monthly",
+            payInAdvance: true,
+            amountCents: 200,
+            amountCurrency: "EUR",
+            charges: [],
+            fixedCharges: [
+              {
+                addOnId: add_on_1.id,
+                units: "10",
+                chargeModel: "standard",
+                properties: {amount: "100.00"},
+                applyUnitsImmediately: true
+              },
+              {
+                addOnId: add_on_2.id,
+                units: "5",
+                chargeModel: "graduated",
+                properties: {
+                  graduatedRanges: [
+                    {fromValue: 0, toValue: 10, perUnitAmount: "10.00", flatAmount: "0"},
+                    {fromValue: 11, toValue: nil, perUnitAmount: "15.00", flatAmount: "100"}
+                  ]
+                }
+              },
+              {
+                addOnId: add_on_3.id,
+                units: "1",
+                chargeModel: "volume",
+                properties: {
+                  volumeRanges: [
+                    {fromValue: 0, toValue: 10, perUnitAmount: "10.00", flatAmount: "0"}
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      )
+
+      result_data = result["data"]["updatePlan"]
+
+      expect(result_data["fixedCharges"].count).to eq(3)
+
+      expect(result_data["fixedCharges"].first["chargeModel"]).to eq("standard")
+      expect(result_data["fixedCharges"].first["units"]).to eq(10)
+      expect(result_data["fixedCharges"].first["properties"]["amount"]).to eq("100.00")
+      expect(result_data["fixedCharges"].first["addOn"]["id"]).to eq(add_on_1.id)
+      expect(result_data["fixedCharges"].first["addOn"]["name"]).to eq(add_on_1.name)
+
+      expect(result_data["fixedCharges"].second["chargeModel"]).to eq("graduated")
+      expect(result_data["fixedCharges"].second["units"]).to eq(5)
+      expect(result_data["fixedCharges"].second["properties"]["graduatedRanges"].count).to eq(2)
+      expect(result_data["fixedCharges"].second["addOn"]["id"]).to eq(add_on_2.id)
+      expect(result_data["fixedCharges"].second["addOn"]["name"]).to eq(add_on_2.name)
+
+      expect(result_data["fixedCharges"].third["chargeModel"]).to eq("volume")
+      expect(result_data["fixedCharges"].third["units"]).to eq(1)
+      expect(result_data["fixedCharges"].third["properties"]["volumeRanges"].count).to eq(1)
+      expect(result_data["fixedCharges"].third["addOn"]["id"]).to eq(add_on_3.id)
+      expect(result_data["fixedCharges"].third["addOn"]["name"]).to eq(add_on_3.name)
+    end
+  end
+
+  context "when interval is yearly" do
+    it "updates a plan with monthly billing for charges and fixed charges" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            id: plan.id,
+            name: "Updated plan",
+            code: "updated_plan",
+            interval: "yearly",
+            payInAdvance: true,
+            amountCents: 200,
+            amountCurrency: "EUR",
+            billChargesMonthly: true,
+            billFixedChargesMonthly: true,
+            charges: []
+          }
+        }
+      )
+
+      result_data = result["data"]["updatePlan"]
+
+      expect(result_data["billChargesMonthly"]).to be true
+      expect(result_data["billFixedChargesMonthly"]).to be true
     end
   end
 end

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -69,7 +69,11 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
             units,
             addOn { id name code },
             chargeModel,
-            properties { amount }
+            properties {
+             amount
+             graduatedRanges { fromValue, toValue },
+             volumeRanges { fromValue, toValue }
+            }
           },
           usageThresholds {
             id,
@@ -488,19 +492,19 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
       expect(result_data["fixedCharges"].count).to eq(3)
 
       expect(result_data["fixedCharges"].first["chargeModel"]).to eq("standard")
-      expect(result_data["fixedCharges"].first["units"]).to eq(10)
+      expect(result_data["fixedCharges"].first["units"]).to eq("10.0")
       expect(result_data["fixedCharges"].first["properties"]["amount"]).to eq("100.00")
       expect(result_data["fixedCharges"].first["addOn"]["id"]).to eq(add_on_1.id)
       expect(result_data["fixedCharges"].first["addOn"]["name"]).to eq(add_on_1.name)
 
       expect(result_data["fixedCharges"].second["chargeModel"]).to eq("graduated")
-      expect(result_data["fixedCharges"].second["units"]).to eq(5)
+      expect(result_data["fixedCharges"].second["units"]).to eq("5.0")
       expect(result_data["fixedCharges"].second["properties"]["graduatedRanges"].count).to eq(2)
       expect(result_data["fixedCharges"].second["addOn"]["id"]).to eq(add_on_2.id)
       expect(result_data["fixedCharges"].second["addOn"]["name"]).to eq(add_on_2.name)
 
       expect(result_data["fixedCharges"].third["chargeModel"]).to eq("volume")
-      expect(result_data["fixedCharges"].third["units"]).to eq(1)
+      expect(result_data["fixedCharges"].third["units"]).to eq("1.0")
       expect(result_data["fixedCharges"].third["properties"]["volumeRanges"].count).to eq(1)
       expect(result_data["fixedCharges"].third["addOn"]["id"]).to eq(add_on_3.id)
       expect(result_data["fixedCharges"].third["addOn"]["name"]).to eq(add_on_3.name)

--- a/spec/graphql/types/fixed_charges/input_spec.rb
+++ b/spec/graphql/types/fixed_charges/input_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe Types::FixedCharges::Input do
   subject { described_class }
 
   it { is_expected.to accept_argument(:add_on_id).of_type("ID!") }
+  it { is_expected.to accept_argument(:apply_units_immediately).of_type("Boolean") }
   it { is_expected.to accept_argument(:charge_model).of_type("FixedChargeChargeModelEnum!") }
   it { is_expected.to accept_argument(:invoice_display_name).of_type("String") }
   it { is_expected.to accept_argument(:pay_in_advance).of_type("Boolean") }
   it { is_expected.to accept_argument(:prorated).of_type("Boolean") }
   it { is_expected.to accept_argument(:properties).of_type("FixedChargePropertiesInput") }
   it { is_expected.to accept_argument(:tax_codes).of_type("[String!]") }
+  it { is_expected.to accept_argument(:units).of_type("String") }
 end

--- a/spec/graphql/types/fixed_charges/object_spec.rb
+++ b/spec/graphql/types/fixed_charges/object_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Types::FixedCharges::Object do
   it { is_expected.to have_field(:pay_in_advance).of_type("Boolean!") }
   it { is_expected.to have_field(:properties).of_type("FixedChargeProperties") }
   it { is_expected.to have_field(:prorated).of_type("Boolean!") }
+  it { is_expected.to have_field(:units).of_type("String!") }
 
   it { is_expected.to have_field(:created_at).of_type("ISO8601DateTime!") }
   it { is_expected.to have_field(:deleted_at).of_type("ISO8601DateTime") }

--- a/spec/graphql/types/plans/update_input_spec.rb
+++ b/spec/graphql/types/plans/update_input_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Types::Plans::UpdateInput do
   it { is_expected.to accept_argument(:amount_cents).of_type("BigInt!") }
   it { is_expected.to accept_argument(:amount_currency).of_type("CurrencyEnum!") }
   it { is_expected.to accept_argument(:bill_charges_monthly).of_type("Boolean") }
+  it { is_expected.to accept_argument(:bill_fixed_charges_monthly).of_type("Boolean") }
   it { is_expected.to accept_argument(:cascade_updates).of_type("Boolean") }
   it { is_expected.to accept_argument(:code).of_type("String!") }
   it { is_expected.to accept_argument(:description).of_type("String") }
@@ -20,6 +21,7 @@ RSpec.describe Types::Plans::UpdateInput do
   it { is_expected.to accept_argument(:trial_period).of_type("Float") }
 
   it { is_expected.to accept_argument(:charges).of_type("[ChargeInput!]!") }
+  it { is_expected.to accept_argument(:fixed_charges).of_type("[FixedChargeInput!]") }
   it { is_expected.to accept_argument(:minimum_commitment).of_type("CommitmentInput") }
   it { is_expected.to accept_argument(:usage_thresholds).of_type("[UsageThresholdInput!]") }
 

--- a/spec/graphql/types/plans/update_input_spec.rb
+++ b/spec/graphql/types/plans/update_input_spec.rb
@@ -5,25 +5,23 @@ require "rails_helper"
 RSpec.describe Types::Plans::UpdateInput do
   subject { described_class }
 
-  it do
-    expect(subject).to accept_argument(:id).of_type("ID!")
-    expect(subject).to accept_argument(:amount_cents).of_type("BigInt!")
-    expect(subject).to accept_argument(:amount_currency).of_type("CurrencyEnum!")
-    expect(subject).to accept_argument(:bill_charges_monthly).of_type("Boolean")
-    expect(subject).to accept_argument(:cascade_updates).of_type("Boolean")
-    expect(subject).to accept_argument(:code).of_type("String!")
-    expect(subject).to accept_argument(:description).of_type("String")
-    expect(subject).to accept_argument(:interval).of_type("PlanInterval!")
-    expect(subject).to accept_argument(:invoice_display_name).of_type("String")
-    expect(subject).to accept_argument(:name).of_type("String!")
-    expect(subject).to accept_argument(:pay_in_advance).of_type("Boolean!")
-    expect(subject).to accept_argument(:tax_codes).of_type("[String!]")
-    expect(subject).to accept_argument(:trial_period).of_type("Float")
+  it { is_expected.to accept_argument(:id).of_type("ID!") }
+  it { is_expected.to accept_argument(:amount_cents).of_type("BigInt!") }
+  it { is_expected.to accept_argument(:amount_currency).of_type("CurrencyEnum!") }
+  it { is_expected.to accept_argument(:bill_charges_monthly).of_type("Boolean") }
+  it { is_expected.to accept_argument(:cascade_updates).of_type("Boolean") }
+  it { is_expected.to accept_argument(:code).of_type("String!") }
+  it { is_expected.to accept_argument(:description).of_type("String") }
+  it { is_expected.to accept_argument(:interval).of_type("PlanInterval!") }
+  it { is_expected.to accept_argument(:invoice_display_name).of_type("String") }
+  it { is_expected.to accept_argument(:name).of_type("String!") }
+  it { is_expected.to accept_argument(:pay_in_advance).of_type("Boolean!") }
+  it { is_expected.to accept_argument(:tax_codes).of_type("[String!]") }
+  it { is_expected.to accept_argument(:trial_period).of_type("Float") }
 
-    expect(subject).to accept_argument(:charges).of_type("[ChargeInput!]!")
-    expect(subject).to accept_argument(:minimum_commitment).of_type("CommitmentInput")
-    expect(subject).to accept_argument(:usage_thresholds).of_type("[UsageThresholdInput!]")
+  it { is_expected.to accept_argument(:charges).of_type("[ChargeInput!]!") }
+  it { is_expected.to accept_argument(:minimum_commitment).of_type("CommitmentInput") }
+  it { is_expected.to accept_argument(:usage_thresholds).of_type("[UsageThresholdInput!]") }
 
-    expect(subject).to accept_argument(:entitlements).of_type("[EntitlementInput!]")
-  end
+  it { is_expected.to accept_argument(:entitlements).of_type("[EntitlementInput!]") }
 end


### PR DESCRIPTION
 ## Roadmap Task

 👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

 👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

 ## Context

 What is the current situation?

 **Option 1:** User has to create a one off invoice alongside the
 subscription, it will create 2 different invoices.

 **Option 2:** User can add a recurring billable metric and use event to
 have this fee invoice on subscription renewal, but it won’t appear on      the first billing subscription.

 What problem are we trying to solve?

 At subscription creation or afterward, there is no clear way to invoice
 a fixed fee that is not tied to events, aside from the subscription fee
 itself. This fee could be either a one-time charge or a recurring one.

 ## Description

 Update graphQL type Plans::UpdateInput...
    - accept `bill_fixed_charges_monthly`
    - accept `fixed_charges` collection

 Update graphQL type FixedCharges::Input
    - accept `apply_units_immediately`

 Update graphQL type FixedCharges::Object
    - return `units` -> this was missed in a previous PR

 Add Plans::Update mutation spec scneario for fixed charges
