### PR TITLE
fix(events): Deduplicate clickhouse events in the Graphql resolver

### DIFF
--- a/app/graphql/resolvers/events_resolver.rb
+++ b/app/graphql/resolvers/events_resolver.rb
@@ -18,6 +18,7 @@ module Resolvers
       if current_organization.clickhouse_events_store?
         Clickhouse::EventsRaw.where(organization_id: current_organization.id)
           .order(ingested_at: :desc)
+          .limit_by(1, "transaction_id, timestamp, external_subscription_id, code")
           .page(page)
           .per((limit >= MAX_LIMIT) ? MAX_LIMIT : limit)
       else


### PR DESCRIPTION
## Context

Idem-potency logic is different between Postgres and Clickhouse. This creates some confusion on the customer side.

The main problem is that to render the list of event in the front-end, when an organization is configured to use Clickhouse we relies on `EventRaw` which does not do any deduplication. It means that if a customer send two events with the same transaction_id, external_subsciption_id, code and timestamp, all events will appears in the event view, while only one will be considered when doing the aggregation (which relies on `EventEnriched` and that already has a deduplication logic)

## Description
This PR makes sure that the events rendered in the GraphQL API are not showing duplicated events, by applying the same deduplication rule than the `EventEnriched` table