### PR TITLE
feat(semiannual): Prepend DateAndTime::HalfYearCalculations to DateAndTime::Calculations

### DIFF
--- a/config/initializers/half_year.rb
+++ b/config/initializers/half_year.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "date_and_time/half_year_calculations"
+
+DateAndTime::Calculations.prepend DateAndTime::HalfYearCalculations

--- a/lib/date_and_time/half_year_calculations.rb
+++ b/lib/date_and_time/half_year_calculations.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module DateAndTime
+  module HalfYearCalculations
+    def beginning_of_half_year
+      # If month is 1–6 → snap to 1 (January)
+      # If month is 7–12 → snap to 7 (July)
+      first_half_year_month = (month <= 6) ? 1 : 7
+      beginning_of_month.change(month: first_half_year_month)
+    end
+    alias_method :at_beginning_of_half_year, :beginning_of_half_year
+
+    def end_of_half_year
+      last_half_year_month = (month <= 6) ? 6 : 12
+      beginning_of_month.change(month: last_half_year_month).end_of_month
+    end
+    alias_method :at_end_of_half_year, :end_of_half_year
+  end
+end

--- a/spec/lib/date_and_time/half_year_calculations_spec.rb
+++ b/spec/lib/date_and_time/half_year_calculations_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DateAndTime::HalfYearCalculations do
+  describe "#beginning_of_half_year" do
+    it "returns January 1st for dates in the first half" do
+      expect(Date.new(2025, 1, 15).beginning_of_half_year).to eq(Date.new(2025, 1, 1))
+      expect(Date.new(2025, 6, 30).beginning_of_half_year).to eq(Date.new(2025, 1, 1))
+    end
+
+    it "returns July 1st for dates in the second half" do
+      expect(Date.new(2025, 7, 1).beginning_of_half_year).to eq(Date.new(2025, 7, 1))
+      expect(Date.new(2025, 12, 31).beginning_of_half_year).to eq(Date.new(2025, 7, 1))
+    end
+
+    it "works with Time and respects midnight" do
+      t = Time.zone.parse("2025-08-19 14:35")
+      expect(t.beginning_of_half_year).to eq(Time.zone.parse("2025-07-01 00:00:00"))
+    end
+
+    context "when date is on exact half-year boundaries" do
+      it "returns Jan 1 for Jan 1" do
+        expect(Date.new(2025, 1, 1).beginning_of_half_year).to eq(Date.new(2025, 1, 1))
+      end
+
+      it "returns Jul 1 for Jul 1" do
+        expect(Date.new(2025, 7, 1).beginning_of_half_year).to eq(Date.new(2025, 7, 1))
+      end
+    end
+  end
+
+  describe "#end_of_half_year" do
+    it "returns June 30th for first half-year" do
+      expect(Date.new(2025, 3, 10).end_of_half_year).to eq(Date.new(2025, 6, 30))
+    end
+
+    it "returns December 31st for second half-year" do
+      expect(Date.new(2025, 10, 5).end_of_half_year).to eq(Date.new(2025, 12, 31))
+    end
+
+    it "works with Time and respects end of day" do
+      t = Time.zone.parse("2025-03-20 10:00")
+      expect(t.end_of_half_year).to eq(Time.zone.parse("2025-06-30 23:59:59.999999999"))
+    end
+
+    context "when it is a leap year" do
+      it "still returns June 30th for first half" do
+        expect(Date.new(2024, 2, 29).end_of_half_year).to eq(Date.new(2024, 6, 30))
+      end
+
+      it "still returns December 31st for second half" do
+        expect(Date.new(2024, 11, 15).end_of_half_year).to eq(Date.new(2024, 12, 31))
+      end
+    end
+
+    context "when date is on exact half-year boundaries" do
+      it "returns June 30 for June 30" do
+        expect(Date.new(2025, 6, 30).end_of_half_year).to eq(Date.new(2025, 6, 30))
+      end
+
+      it "returns Dec 31 for Dec 31" do
+        expect(Date.new(2025, 12, 31).end_of_half_year).to eq(Date.new(2025, 12, 31))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

A prerequisite to semiannual plans: We need to calculate start and end of half-year for some further calculations.

## Description

Prepend `DateAndTime::HalfYearCalculations` to `DateAndTime::Calculations`