### PR TITLE
feat(fixed_charges-8): process fixed_charges from plans controller

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -161,7 +161,7 @@ module Api
             :charge_model,
             :pay_in_advance,
             :prorated,
-            { properties: {} },
+            {properties: {}}
           ],
           usage_thresholds: [
             :id,

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -23,6 +23,7 @@ module Api
           # Reload to eager-load relationships, like :entitlements
           plan = Plan.includes(
             :usage_thresholds,
+            :fixed_charges,
             charges: {filters: {values: :billable_metric_filter}},
             entitlements: [:feature, values: :privilege]
           ).find(result.plan.id)
@@ -112,6 +113,7 @@ module Api
           :trial_period,
           :pay_in_advance,
           :bill_charges_monthly,
+          :bill_fixed_charges_monthly,
           :cascade_updates,
           tax_codes: [],
           minimum_commitment: [
@@ -150,6 +152,17 @@ module Api
               ]
             }
           ],
+          fixed_charges: [
+            :id,
+            :invoice_display_name,
+            :units,
+            :add_on_id,
+            :apply_units_immediately,
+            :charge_model,
+            :pay_in_advance,
+            :prorated,
+            { properties: {} },
+          ],
           usage_thresholds: [
             :id,
             :threshold_display_name,
@@ -164,7 +177,7 @@ module Api
           json: ::V1::PlanSerializer.new(
             plan,
             root_name: "plan",
-            includes: %i[charges usage_thresholds taxes minimum_commitment entitlements]
+            includes: %i[charges fixed_charges usage_thresholds taxes minimum_commitment entitlements]
           )
         )
       end

--- a/app/serializers/v1/fixed_charge_serializer.rb
+++ b/app/serializers/v1/fixed_charge_serializer.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module V1
+  class FixedChargeSerializer < ModelSerializer
+    def serialize
+      payload = {
+        lago_id: model.id,
+        add_on_id: model.add_on_id,
+        invoice_display_name: model.invoice_display_name,
+        created_at: model.created_at.iso8601,
+        charge_model: model.charge_model,
+        pay_in_advance: model.pay_in_advance,
+        prorated: model.prorated,
+        properties: model.properties,
+        units: model.units
+      }
+
+      payload.merge!(taxes) if include?(:taxes)
+
+      payload
+    end
+
+    private
+
+    def taxes
+      ::CollectionSerializer.new(
+        model.taxes,
+        ::V1::TaxSerializer,
+        collection_name: "taxes"
+      ).serialize
+    end
+  end
+end

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -16,6 +16,7 @@ module V1
         trial_period: model.trial_period,
         pay_in_advance: model.pay_in_advance,
         bill_charges_monthly: model.bill_charges_monthly,
+        bill_fixed_charges_monthly: model.bill_fixed_charges_monthly,
         customers_count: 0,
         active_subscriptions_count: 0,
         draft_invoices_count: 0,

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -24,6 +24,7 @@ module V1
       }
 
       payload.merge!(charges) if include?(:charges)
+      payload.merge!(fixed_charges) if include?(:fixed_charges)
       payload.merge!(entitlements) if include?(:entitlements)
       payload.merge!(usage_thresholds) if include?(:usage_thresholds)
       payload.merge!(taxes) if include?(:taxes)
@@ -40,6 +41,14 @@ module V1
         ::V1::ChargeSerializer,
         collection_name: "charges",
         includes: include?(:taxes) ? %i[taxes] : []
+      ).serialize
+    end
+
+    def fixed_charges
+      ::CollectionSerializer.new(
+        model.fixed_charges,
+        ::V1::FixedChargeSerializer,
+        collection_name: "fixed_charges"
       ).serialize
     end
 

--- a/spec/factories/fixed_charges.rb
+++ b/spec/factories/fixed_charges.rb
@@ -37,5 +37,17 @@ FactoryBot.define do
     trait :deleted do
       deleted_at { Time.current }
     end
+
+    trait :with_applied_taxes do
+      transient do
+        taxes { [create(:tax)] }
+      end
+
+      after(:create) do |fixed_charge, evaluator|
+        evaluator.taxes.each do |tax|
+          create(:fixed_charge_applied_tax, fixed_charge:, tax:)
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
         expect(json[:plan][:invoice_display_name]).to eq(create_params[:invoice_display_name])
         expect(json[:plan][:created_at]).to be_present
         expect(json[:plan][:charges].first[:lago_id]).to be_present
-        # expect(json[:plan][:fixed_charges].first[:lago_id]).to be_present
+        expect(json[:plan][:fixed_charges].first[:lago_id]).to be_present
       end
 
       context "when license is not premium" do
@@ -285,7 +285,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
           expect(json[:plan][:code]).to eq(create_params[:code])
           expect(json[:plan][:name]).to eq(create_params[:name])
           expect(json[:plan][:created_at]).to be_present
-          # expect(json[:plan][:fixed_charges].first[:lago_id]).to be_present
+          expect(json[:plan][:fixed_charges].first[:lago_id]).to be_present
         end
       end
 
@@ -313,7 +313,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
           expect(json[:plan][:name]).to eq(create_params[:name])
           expect(json[:plan][:created_at]).to be_present
           expect(json[:plan][:charges].count).to eq(0)
-          # expect(json[:plan][:fixed_charges].count).to eq(0)
+          expect(json[:plan][:fixed_charges].count).to eq(0)
         end
       end
 
@@ -678,9 +678,9 @@ RSpec.describe Api::V1::PlansController, type: :request do
         subject
 
         expect(response).to have_http_status(:success)
-        # expect(json[:plan][:fixed_charges].count).to eq(2)
-        # expect(json[:plan][:fixed_charges].first[:invoice_display_name]).to eq("Fixed charge 1 updated")
-        # expect(json[:plan][:fixed_charges].last[:invoice_display_name]).to eq("Fixed charge 2")
+        expect(json[:plan][:fixed_charges].count).to eq(2)
+        expect(json[:plan][:fixed_charges].first[:invoice_display_name]).to eq("Fixed charge 1 updated")
+        expect(json[:plan][:fixed_charges].last[:invoice_display_name]).to eq("Fixed charge 2")
       end
     end
 

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
   let(:tax) { create(:tax, organization:) }
   let(:organization) { create(:organization) }
   let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
   let(:plan) { create(:plan, code: "plan_code") }
 
   describe "POST /api/v1/plans" do
@@ -41,6 +42,20 @@ RSpec.describe Api::V1::PlansController, type: :request do
               code: pricing_unit.code,
               conversion_rate: 1.25
             }
+          }
+        ],
+        fixed_charges: [
+          {
+            invoice_display_name: "Fixed charge 1",
+            units: 1,
+            add_on_id: add_on.id,
+            charge_model: "standard",
+            pay_in_advance: true,
+            prorated: true,
+            properties: {
+              amount: "10"
+            },
+            tax_codes:
           }
         ],
         usage_thresholds: [
@@ -81,6 +96,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
         expect(json[:plan][:invoice_display_name]).to eq(create_params[:invoice_display_name])
         expect(json[:plan][:created_at]).to be_present
         expect(json[:plan][:charges].first[:lago_id]).to be_present
+        # expect(json[:plan][:fixed_charges].first[:lago_id]).to be_present
       end
 
       context "when license is not premium" do
@@ -222,6 +238,57 @@ RSpec.describe Api::V1::PlansController, type: :request do
         end
       end
 
+      context "with graduated fixed charges" do
+        let(:create_params) do
+          {
+            name: "P1",
+            code: "plan_code",
+            interval: "weekly",
+            description: "description",
+            amount_cents: 100,
+            amount_currency: "EUR",
+            trial_period: 1,
+            pay_in_advance: false,
+            fixed_charges: [
+              {
+                invoice_display_name: "Fixed charge 1",
+                units: 1,
+                add_on_id: add_on.id,
+                charge_model: "graduated",
+                properties: {
+                  graduated_ranges: [
+                    {
+                      to_value: 1,
+                      from_value: 0,
+                      flat_amount: "0",
+                      per_unit_amount: "0"
+                    },
+                    {
+                      to_value: nil,
+                      from_value: 2,
+                      flat_amount: "0",
+                      per_unit_amount: "3200"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        end
+
+        it "creates a plan" do
+          subject
+
+          expect(response).to have_http_status(:success)
+
+          expect(json[:plan][:lago_id]).to be_present
+          expect(json[:plan][:code]).to eq(create_params[:code])
+          expect(json[:plan][:name]).to eq(create_params[:name])
+          expect(json[:plan][:created_at]).to be_present
+          # expect(json[:plan][:fixed_charges].first[:lago_id]).to be_present
+        end
+      end
+
       context "without charges" do
         let(:create_params) do
           {
@@ -246,6 +313,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
           expect(json[:plan][:name]).to eq(create_params[:name])
           expect(json[:plan][:created_at]).to be_present
           expect(json[:plan][:charges].count).to eq(0)
+          # expect(json[:plan][:fixed_charges].count).to eq(0)
         end
       end
 
@@ -255,6 +323,26 @@ RSpec.describe Api::V1::PlansController, type: :request do
         it "returns a 404 response" do
           subject
           expect(response).to be_not_found_error("tax")
+        end
+      end
+
+      context "with not found models for charges and fixed charges" do
+        context "when billable_metric for charge is not found" do
+          before { create_params[:charges].first[:billable_metric_id] = "unknown" }
+
+          it "returns a 404 response" do
+            subject
+            expect(response).to be_not_found_error("billable_metrics")
+          end
+        end
+
+        context "when add_on for fixed charge is not found" do
+          before { create_params[:fixed_charges].first[:add_on_id] = "unknown" }
+
+          it "returns a 404 response" do
+            subject
+            expect(response).to be_not_found_error("add_ons")
+          end
         end
       end
     end
@@ -286,6 +374,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
         trial_period: 1,
         pay_in_advance: false,
         charges: charges_params,
+        fixed_charges: fixed_charges_params,
         usage_thresholds: usage_thresholds_params
       }
     end
@@ -307,6 +396,20 @@ RSpec.describe Api::V1::PlansController, type: :request do
           charge_model: "standard",
           properties: {
             amount: "0.22"
+          },
+          tax_codes:
+        }
+      ]
+    end
+
+    let(:fixed_charges_params) do
+      [
+        {
+          units: 1,
+          add_on_id: add_on.id,
+          charge_model: "standard",
+          properties: {
+            amount: "10"
           },
           tax_codes:
         }
@@ -538,6 +641,45 @@ RSpec.describe Api::V1::PlansController, type: :request do
             expect(json[:plan][:minimum_commitment][:amount_cents]).to eq(minimum_commitment.amount_cents)
           end
         end
+      end
+    end
+
+    context "when plan has fixed charges" do
+      let(:fixed_charge) { create(:fixed_charge, plan:, invoice_display_name: "Fixed charge 1") }
+      let(:fixed_charges_params) do
+        [
+          {
+            id: fixed_charge.id,
+            invoice_display_name: "Fixed charge 1 updated",
+            units: 1,
+            add_on_id: add_on.id,
+            charge_model: "standard",
+            properties: {
+              amount: "15"
+            },
+            tax_codes:
+          },
+          {
+            invoice_display_name: "Fixed charge 2",
+            units: 1,
+            add_on_id: add_on.id,
+            charge_model: "standard",
+            properties: {
+              amount: "10"
+            },
+            tax_codes:
+          }
+        ]
+      end
+      before { fixed_charge }
+
+      it "returns plan with updated fixed charges" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        # expect(json[:plan][:fixed_charges].count).to eq(2)
+        # expect(json[:plan][:fixed_charges].first[:invoice_display_name]).to eq("Fixed charge 1 updated")
+        # expect(json[:plan][:fixed_charges].last[:invoice_display_name]).to eq("Fixed charge 2")
       end
     end
 

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -671,6 +671,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
           }
         ]
       end
+
       before { fixed_charge }
 
       it "returns plan with updated fixed charges" do

--- a/spec/serializers/v1/fixed_charge_serializer_spec.rb
+++ b/spec/serializers/v1/fixed_charge_serializer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::V1::FixedChargeSerializer do
+  subject(:result) { JSON.parse(serializer.to_json) }
+
+  let(:serializer) { described_class.new(fixed_charge, root_name: "fixed_charge", includes: %i[taxes]) }
+  let(:fixed_charge) { create(:fixed_charge, properties:) }
+  let(:properties) { {"amount" => "1000"} }
+
+  it "serializes the object" do
+    expect(result["fixed_charge"]["lago_id"]).to eq(fixed_charge.id)
+    expect(result["fixed_charge"]["add_on_id"]).to eq(fixed_charge.add_on_id)
+    expect(result["fixed_charge"]["invoice_display_name"]).to eq(fixed_charge.invoice_display_name)
+    expect(result["fixed_charge"]["created_at"]).to eq(fixed_charge.created_at.iso8601)
+    expect(result["fixed_charge"]["charge_model"]).to eq(fixed_charge.charge_model)
+    expect(result["fixed_charge"]["pay_in_advance"]).to eq(fixed_charge.pay_in_advance)
+    expect(result["fixed_charge"]["prorated"]).to eq(fixed_charge.prorated)
+    expect(result["fixed_charge"]["properties"]).to eq(fixed_charge.properties)
+    expect(result["fixed_charge"]["taxes"]).to eq([])
+    expect(result["fixed_charge"]["units"]).to eq(fixed_charge.units.to_s)
+  end
+
+  context "when fixed charge has taxes" do
+    let(:fixed_charge) { create(:fixed_charge, :with_applied_taxes, properties:, taxes:) }
+    let(:taxes) { create_pair(:tax) }
+
+    it "serializes the object" do
+      expect(result["fixed_charge"]["taxes"].map { |tax| tax["lago_id"] }).to match_array(taxes.map(&:id))
+    end
+  end
+end

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe ::V1::PlanSerializer do
         "trial_period" => plan.trial_period,
         "pay_in_advance" => plan.pay_in_advance,
         "bill_charges_monthly" => plan.bill_charges_monthly,
+        "bill_fixed_charges_monthly" => plan.bill_fixed_charges_monthly,
         "customers_count" => 0,
         "active_subscriptions_count" => 0,
         "draft_invoices_count" => 0,

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe Plans::UpdateService, type: :service do
       amount_cents: 200,
       amount_currency: "EUR",
       tax_codes: [tax2.code],
-      charges: charges_args
+      charges: charges_args,
+      fixed_charges: fixed_charges_args
     }
   end
 
@@ -164,6 +165,9 @@ RSpec.describe Plans::UpdateService, type: :service do
       expect(plan.charges.count).to eq(2)
       expect(plan.charges.order(created_at: :asc).first.invoice_display_name).to eq("charge1")
       expect(plan.charges.order(created_at: :asc).second.invoice_display_name).to eq("charge2")
+      expect(plan.fixed_charges.count).to eq(2)
+      expect(plan.fixed_charges.order(created_at: :asc).first.invoice_display_name).to eq("fixed_charge1")
+      expect(plan.fixed_charges.order(created_at: :asc).second.invoice_display_name).to eq("fixed_charge2")
     end
 
     it "marks invoices as ready to be refreshed" do


### PR DESCRIPTION
## Context

With this PR we're allowing users to send us fixed_charges params when creating and updating plan, so we'll also create, update, delete fixed charges for the plan

## Description

- updated plans controller to receive fixed_charges specific params and pass them to plans services
