### PR TITLE
fix(clickhouse): Add more retry for lost connection

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -699,7 +699,7 @@ module Events
           attempts += 1
 
           yield
-        rescue Errno::ECONNRESET, ActiveRecord::ActiveRecordError
+        rescue Errno::ECONNRESET, ActiveRecord::ActiveRecordError, NoMethodError
           if attempts < MAX_RETRIES
             sleep(0.05)
             retry


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/3733

## Description

In some situation, a "NoMethodError: undefined method 'select_all' for nil" is raised when running `::Clickhouse::EventsEnriched.connection.select_all`. This is an issue with the Active record connector for Clickhouse.

This PR just handle an automatic retry when the error is raised