### PR TITLE
fix(charge): Handle missing graduated_ranges

### DIFF
--- a/app/services/charges/validators/graduated_service.rb
+++ b/app/services/charges/validators/graduated_service.rb
@@ -27,7 +27,7 @@ module Charges
       private
 
       def ranges
-        properties["graduated_ranges"].map(&:with_indifferent_access)
+        (properties["graduated_ranges"] || []).map(&:with_indifferent_access)
       end
 
       def validate_amounts(range)

--- a/spec/services/charges/validators/graduated_service_spec.rb
+++ b/spec/services/charges/validators/graduated_service_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
       end
     end
 
+    context "with no ranges" do
+      let(:ranges) { nil }
+
+      it "ensures the presence of ranges" do
+        aggregate_failures do
+          expect(validation_service).not_to be_valid
+          expect(validation_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(validation_service.result.error.messages.keys).to include(:graduated_ranges)
+          expect(validation_service.result.error.messages[:graduated_ranges]).to include("missing_graduated_ranges")
+        end
+      end
+    end
+
     context "when ranges does not starts at 0" do
       let(:ranges) do
         [{from_value: -1, to_value: 100}]


### PR DESCRIPTION
## Context

Some error were raised by the API:

```
undefined method 'map' for nil (NoMethodError)
properties["graduated_ranges"].map(&:with_indifferent_access)
```

This happen in the `Charges::Validators::GraduatedService` when the provided `graduated_range` argument is nil.

## Description

Ensure the arguments fallback to an empty array when missing so that the existing validation rule on missing range can be applied.
