### PR TITLE
fix(charge): Handle invalid charge model values

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -36,7 +36,7 @@ class Charge < ApplicationRecord
 
   REGROUPING_PAID_FEES_OPTIONS = %i[invoice].freeze
 
-  enum :charge_model, CHARGE_MODELS
+  enum :charge_model, CHARGE_MODELS, validate: true
 
   attribute :regroup_paid_fees, :integer
   enum :regroup_paid_fees, REGROUPING_PAID_FEES_OPTIONS

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -440,6 +440,29 @@ RSpec.describe Plans::CreateService, type: :service do
         expect(result.error.messages[:name]).to eq(["value_is_mandatory"])
       end
 
+      context "with invalid charges" do
+        let(:plan_name) { "Some plan name" }
+
+        let(:charges_args) do
+          [
+            {
+              applied_pricing_unit: applied_pricing_unit_args,
+              billable_metric_id: billable_metric.id,
+              charge_model: "custom_properties",
+              min_amount_cents: 100,
+              tax_codes: [charge_tax.code],
+              filters: []
+            }
+          ]
+        end
+
+        it "returns an error" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:charge_model]).to eq(["value_is_invalid"])
+        end
+      end
+
       context "with premium charge model" do
         let(:plan_name) { "foo" }
         let(:charges_args) do


### PR DESCRIPTION
## Context

Some error were raised by the API:

```
'custom_properties' is not a valid charge_model (ArgumentError)
raise ArgumentError, "'#{value}' is not a valid #{name}"
```

This happen in the `Plans::CreateService` when the provided `charge_model` of a charge is invalid. It renders an HTTP 500 to the end-user when it should return a 422 with a clear message of what is happening.

## Description

This PR adds the `validate: true` on the `Charge#charge_model` enum to make sure it returns a validation error instead of raising when an invalid value is provided
