### PR TITLE
Feat(fixed_charges-8): add fixed_charge_serializer

### DIFF
--- a/app/serializers/v1/fixed_charge_serializer.rb
+++ b/app/serializers/v1/fixed_charge_serializer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module V1
+  class FixedChargeSerializer < ModelSerializer
+    def serialize
+      payload = {
+        lago_id: model.id,
+        add_on_id: model.add_on_id,
+        invoice_display_name: model.invoice_display_name,
+        created_at: model.created_at.iso8601,
+        charge_model: model.charge_model,
+        pay_in_advance: model.pay_in_advance,
+        prorated: model.prorated,
+        properties: model.properties
+      }
+
+      payload.merge!(taxes) if include?(:taxes)
+
+      payload
+    end
+
+    private
+
+    def taxes
+      ::CollectionSerializer.new(
+        model.taxes,
+        ::V1::TaxSerializer,
+        collection_name: "taxes"
+      ).serialize
+    end
+  end
+end

--- a/app/serializers/v1/fixed_charge_serializer.rb
+++ b/app/serializers/v1/fixed_charge_serializer.rb
@@ -11,7 +11,8 @@ module V1
         charge_model: model.charge_model,
         pay_in_advance: model.pay_in_advance,
         prorated: model.prorated,
-        properties: model.properties
+        properties: model.properties,
+        units: model.units
       }
 
       payload.merge!(taxes) if include?(:taxes)

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -24,6 +24,7 @@ module V1
       }
 
       payload.merge!(charges) if include?(:charges)
+      payload.merge!(fixed_charges) if include?(:fixed_charges)
       payload.merge!(entitlements) if include?(:entitlements)
       payload.merge!(usage_thresholds) if include?(:usage_thresholds)
       payload.merge!(taxes) if include?(:taxes)
@@ -40,6 +41,14 @@ module V1
         ::V1::ChargeSerializer,
         collection_name: "charges",
         includes: include?(:taxes) ? %i[taxes] : []
+      ).serialize
+    end
+
+    def fixed_charges
+      ::CollectionSerializer.new(
+        model.fixed_charges,
+        ::V1::FixedChargeSerializer,
+        collection_name: "fixed_charges"
       ).serialize
     end
 

--- a/spec/factories/fixed_charges.rb
+++ b/spec/factories/fixed_charges.rb
@@ -37,5 +37,17 @@ FactoryBot.define do
     trait :deleted do
       deleted_at { Time.current }
     end
+
+    trait :with_applied_taxes do
+      transient do
+        taxes { [create(:tax)] }
+      end
+
+      after(:create) do |fixed_charge, evaluator|
+        evaluator.taxes.each do |tax|
+          create(:fixed_charge_applied_tax, fixed_charge:, tax:)
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
         expect(json[:plan][:invoice_display_name]).to eq(create_params[:invoice_display_name])
         expect(json[:plan][:created_at]).to be_present
         expect(json[:plan][:charges].first[:lago_id]).to be_present
-        # expect(json[:plan][:fixed_charges].first[:lago_id]).to be_present
+        expect(json[:plan][:fixed_charges].first[:lago_id]).to be_present
       end
 
       context "when license is not premium" do
@@ -285,7 +285,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
           expect(json[:plan][:code]).to eq(create_params[:code])
           expect(json[:plan][:name]).to eq(create_params[:name])
           expect(json[:plan][:created_at]).to be_present
-          # expect(json[:plan][:fixed_charges].first[:lago_id]).to be_present
+          expect(json[:plan][:fixed_charges].first[:lago_id]).to be_present
         end
       end
 
@@ -313,7 +313,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
           expect(json[:plan][:name]).to eq(create_params[:name])
           expect(json[:plan][:created_at]).to be_present
           expect(json[:plan][:charges].count).to eq(0)
-          # expect(json[:plan][:fixed_charges].count).to eq(0)
+          expect(json[:plan][:fixed_charges].count).to eq(0)
         end
       end
 
@@ -678,9 +678,9 @@ RSpec.describe Api::V1::PlansController, type: :request do
         subject
 
         expect(response).to have_http_status(:success)
-        # expect(json[:plan][:fixed_charges].count).to eq(2)
-        # expect(json[:plan][:fixed_charges].first[:invoice_display_name]).to eq("Fixed charge 1 updated")
-        # expect(json[:plan][:fixed_charges].last[:invoice_display_name]).to eq("Fixed charge 2")
+        expect(json[:plan][:fixed_charges].count).to eq(2)
+        expect(json[:plan][:fixed_charges].first[:invoice_display_name]).to eq("Fixed charge 1 updated")
+        expect(json[:plan][:fixed_charges].last[:invoice_display_name]).to eq("Fixed charge 2")
       end
     end
 

--- a/spec/serializers/v1/fixed_charge_serializer_spec.rb
+++ b/spec/serializers/v1/fixed_charge_serializer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::V1::FixedChargeSerializer do
+  subject(:result) { JSON.parse(serializer.to_json) }
+
+  let(:serializer) { described_class.new(fixed_charge, root_name: "fixed_charge", includes: %i[taxes]) }
+  let(:fixed_charge) { create(:fixed_charge, properties:) }
+  let(:properties) { {"amount" => "1000"} }
+
+  it "serializes the object" do
+    expect(result["fixed_charge"]["lago_id"]).to eq(fixed_charge.id)
+    expect(result["fixed_charge"]["add_on_id"]).to eq(fixed_charge.add_on_id)
+    expect(result["fixed_charge"]["invoice_display_name"]).to eq(fixed_charge.invoice_display_name)
+    expect(result["fixed_charge"]["created_at"]).to eq(fixed_charge.created_at.iso8601)
+    expect(result["fixed_charge"]["charge_model"]).to eq(fixed_charge.charge_model)
+    expect(result["fixed_charge"]["pay_in_advance"]).to eq(fixed_charge.pay_in_advance)
+    expect(result["fixed_charge"]["properties"]).to eq(fixed_charge.properties)
+    expect(result["fixed_charge"]["taxes"]).to eq([])
+  end
+
+  context "when fixed charge has taxes" do
+    let(:fixed_charge) { create(:fixed_charge, :with_applied_taxes, properties:, taxes:) }
+    let(:taxes) { create_list(:tax, 2) }
+
+    it "serializes the object" do
+      expect(result["fixed_charge"]["taxes"].map { |tax| tax["lago_id"] }).to match_array(taxes.map(&:id))
+    end
+  end
+end

--- a/spec/serializers/v1/fixed_charge_serializer_spec.rb
+++ b/spec/serializers/v1/fixed_charge_serializer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ::V1::FixedChargeSerializer do
     expect(result["fixed_charge"]["pay_in_advance"]).to eq(fixed_charge.pay_in_advance)
     expect(result["fixed_charge"]["properties"]).to eq(fixed_charge.properties)
     expect(result["fixed_charge"]["taxes"]).to eq([])
-    expect(result["fixed_charge"]["units"]).to eq(fixed_charge.units)
+    expect(result["fixed_charge"]["units"]).to eq(fixed_charge.units.to_s)
   end
 
   context "when fixed charge has taxes" do

--- a/spec/serializers/v1/fixed_charge_serializer_spec.rb
+++ b/spec/serializers/v1/fixed_charge_serializer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ::V1::FixedChargeSerializer do
     expect(result["fixed_charge"]["pay_in_advance"]).to eq(fixed_charge.pay_in_advance)
     expect(result["fixed_charge"]["properties"]).to eq(fixed_charge.properties)
     expect(result["fixed_charge"]["taxes"]).to eq([])
+    expect(result["fixed_charge"]["units"]).to eq(fixed_charge.units)
   end
 
   context "when fixed charge has taxes" do

--- a/spec/serializers/v1/fixed_charge_serializer_spec.rb
+++ b/spec/serializers/v1/fixed_charge_serializer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ::V1::FixedChargeSerializer do
     expect(result["fixed_charge"]["created_at"]).to eq(fixed_charge.created_at.iso8601)
     expect(result["fixed_charge"]["charge_model"]).to eq(fixed_charge.charge_model)
     expect(result["fixed_charge"]["pay_in_advance"]).to eq(fixed_charge.pay_in_advance)
+    expect(result["fixed_charge"]["prorated"]).to eq(fixed_charge.prorated)
     expect(result["fixed_charge"]["properties"]).to eq(fixed_charge.properties)
     expect(result["fixed_charge"]["taxes"]).to eq([])
     expect(result["fixed_charge"]["units"]).to eq(fixed_charge.units.to_s)
@@ -23,7 +24,7 @@ RSpec.describe ::V1::FixedChargeSerializer do
 
   context "when fixed charge has taxes" do
     let(:fixed_charge) { create(:fixed_charge, :with_applied_taxes, properties:, taxes:) }
-    let(:taxes) { create_list(:tax, 2) }
+    let(:taxes) { create_pair(:tax) }
 
     it "serializes the object" do
       expect(result["fixed_charge"]["taxes"].map { |tax| tax["lago_id"] }).to match_array(taxes.map(&:id))

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe Plans::UpdateService, type: :service do
       amount_cents: 200,
       amount_currency: "EUR",
       tax_codes: [tax2.code],
-      charges: charges_args
+      charges: charges_args,
+      fixed_charges: fixed_charges_args
     }
   end
 
@@ -164,6 +165,9 @@ RSpec.describe Plans::UpdateService, type: :service do
       expect(plan.charges.count).to eq(2)
       expect(plan.charges.order(created_at: :asc).first.invoice_display_name).to eq("charge1")
       expect(plan.charges.order(created_at: :asc).second.invoice_display_name).to eq("charge2")
+      expect(plan.fixed_charges.count).to eq(2)
+      expect(plan.fixed_charges.order(created_at: :asc).first.invoice_display_name).to eq("fixed_charge1")
+      expect(plan.fixed_charges.order(created_at: :asc).second.invoice_display_name).to eq("fixed_charge2")
     end
 
     it "marks invoices as ready to be refreshed" do


### PR DESCRIPTION
## Context

After we added managing fixed_charges on plan level, we should also be able to receive updated fixed_charges information.
Goal of this PR is to add fixed_charge serializer and include fixed_charges in plans_serializer

