### PR TITLE
misc(wallet-transaction): Refactor create service

### DIFF
--- a/app/services/wallet_transactions/create_from_params_service.rb
+++ b/app/services/wallet_transactions/create_from_params_service.rb
@@ -96,7 +96,7 @@ module WalletTransactions
         wallet_credit:,
         transaction_type: :inbound,
         status: :pending,
-        from_source: source,
+        source:,
         transaction_status: :purchased,
         invoice_requires_successful_payment:,
         metadata:
@@ -118,7 +118,7 @@ module WalletTransactions
           transaction_type: :inbound,
           status: :settled,
           settled_at: Time.current,
-          from_source: source,
+          source:,
           transaction_status: :granted,
           invoice_requires_successful_payment:,
           metadata:

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -4,43 +4,39 @@ module WalletTransactions
   class CreateService < BaseService
     Result = BaseResult[:wallet_transaction]
 
-    def initialize(wallet:, wallet_credit:, status:, transaction_type:, from_source: :manual, metadata: [], transaction_status: :purchased, invoice_requires_successful_payment: false, settled_at: nil, credit_note_id: nil, invoice_id: nil)
+    def initialize(wallet:, wallet_credit:, **transaction_params)
       @wallet = wallet
       @wallet_credit = wallet_credit
-      @status = status
-      @transaction_type = transaction_type
-      @from_source = from_source
-      @transaction_status = transaction_status
-      @invoice_requires_successful_payment = invoice_requires_successful_payment
-      @metadata = metadata
-      @settled_at = settled_at
-      @credit_note_id = credit_note_id
-      @invoice_id = invoice_id
+      @transaction_params = transaction_params
+
       super
     end
 
     def call
       result.wallet_transaction = wallet.wallet_transactions.create!(
+        **transaction_params.slice(
+          :credit_note_id,
+          :invoice_id,
+          :invoice_requires_successful_payment,
+          :settled_at,
+          :source,
+          :status,
+          :transaction_type,
+          :transaction_status
+        ),
         organization_id: wallet.organization_id,
         amount:,
-        status:,
         credit_amount:,
-        transaction_type:,
-        source: from_source,
-        transaction_status:,
-        invoice_requires_successful_payment:,
-        metadata:,
-        settled_at:,
-        credit_note_id:,
-        invoice_id:
+        metadata: transaction_params[:metadata] || []
       )
+
       result
     end
 
     private
 
-    delegate :credit_amount, :amount, to: :wallet_credit
+    attr_reader :wallet, :wallet_credit, :transaction_params
 
-    attr_reader :wallet, :wallet_credit, :status, :transaction_type, :from_source, :transaction_status, :invoice_requires_successful_payment, :metadata, :settled_at, :credit_note_id, :invoice_id
+    delegate :credit_amount, :amount, to: :wallet_credit
   end
 end

--- a/app/services/wallet_transactions/void_service.rb
+++ b/app/services/wallet_transactions/void_service.rb
@@ -22,7 +22,7 @@ module WalletTransactions
           transaction_type: :outbound,
           status: :settled,
           settled_at: Time.current,
-          from_source:,
+          source: from_source,
           transaction_status: :voided,
           metadata:,
           credit_note_id:

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -3,23 +3,11 @@
 require "rails_helper"
 
 RSpec.describe WalletTransactions::CreateService, type: :service do
-  subject(:create_service) do
-    described_class.call(wallet:,
-      wallet_credit:,
-      status:,
-      transaction_type:,
-      from_source:,
-      metadata:,
-      transaction_status:,
-      invoice_requires_successful_payment:,
-      settled_at:,
-      credit_note_id:,
-      invoice_id:)
-  end
-
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:, currency:) }
   let(:currency) { "EUR" }
+  let(:wallet_credit) { WalletCredit.new(wallet:, credit_amount:) }
+
   let(:wallet) do
     create(
       :wallet,
@@ -31,46 +19,66 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
       credits_ongoing_balance: 10.0
     )
   end
-  let(:status) { :pending }
-  let(:transaction_type) { :inbound }
-  let(:transaction_status) { :purchased }
-  let(:from_source) { :manual }
-  let(:metadata) { [] }
-  let(:invoice_requires_successful_payment) { false }
-  let(:settled_at) { nil }
-  let(:credit_note_id) { nil }
-  let(:invoice_id) { nil }
-  let(:wallet_credit) { WalletCredit.new(wallet:, credit_amount:) }
-  let(:credit_amount) { 100 }
 
   before do
     wallet
   end
 
   describe "#call" do
-    it "creates a wallet transaction" do
-      expect { create_service }.to change(WalletTransaction, :count).by(1)
+    subject(:result) { described_class.call(wallet:, wallet_credit:, **transaction_params) }
+
+    context "with minimum arguments" do
+      let(:credit_amount) { 100 }
+
+      let(:transaction_params) do
+        {
+          status: :pending,
+          transaction_type: :inbound,
+          transaction_status: :purchased
+        }
+      end
+
+      it "creates a wallet transaction" do
+        expect { subject }.to change(WalletTransaction, :count).by(1)
+      end
+
+      it "sets default values" do
+        expect(result.wallet_transaction)
+          .to be_a(WalletTransaction)
+          .and be_persisted
+          .and have_attributes(
+            source: "manual",
+            metadata: [],
+            invoice_requires_successful_payment: false
+          )
+      end
     end
-  end
 
-  context "with non-default arguments" do
-    let(:status) { :pending }
-    let(:transaction_type) { :outbound }
-    let(:transaction_status) { :granted }
-    let(:from_source) { :threshold }
-    let(:metadata) { [{key: "value"}] }
-    let(:invoice_requires_successful_payment) { true }
-    let(:settled_at) { Date.yesterday }
-    let(:credit_note) { create(:credit_note) }
-    let(:credit_note_id) { credit_note.id }
-    let(:invoice) { create(:invoice) }
-    let(:invoice_id) { invoice.id }
-    let(:wallet_credit) { WalletCredit.new(wallet:, credit_amount:) }
-    let(:credit_amount) { 1000 }
+    context "with all arguments" do
+      let(:credit_amount) { 1000 }
+      let(:credit_note) { create(:credit_note) }
+      let(:invoice) { create(:invoice) }
 
-    describe "#call" do
-      it "creates a wallet transaction and sets all attributes" do
-        wallet_transaction = create_service.wallet_transaction
+      let(:transaction_params) do
+        {
+          status: :pending,
+          transaction_type: :outbound,
+          transaction_status: :granted,
+          source: :threshold,
+          metadata: [{key: "value"}],
+          invoice_requires_successful_payment: true,
+          settled_at: Date.yesterday,
+          credit_note_id: credit_note.id,
+          invoice_id: invoice.id,
+        }
+      end
+
+      it "creates a wallet transaction" do
+        expect { subject }.to change(WalletTransaction, :count).by(1)
+      end
+
+      it "sets all attributes" do
+        wallet_transaction = result.wallet_transaction
 
         expect(wallet_transaction.status).to eq("pending")
         expect(wallet_transaction.transaction_type).to eq("outbound")
@@ -79,8 +87,8 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
         expect(wallet_transaction.metadata).to eq([{"key" => "value"}])
         expect(wallet_transaction.invoice_requires_successful_payment).to be_truthy
         expect(wallet_transaction.settled_at).to eq(Date.yesterday)
-        expect(wallet_transaction.credit_note_id).to eq(credit_note_id)
-        expect(wallet_transaction.invoice_id).to eq(invoice_id)
+        expect(wallet_transaction.credit_note_id).to eq(credit_note.id)
+        expect(wallet_transaction.invoice_id).to eq(invoice.id)
         expect(wallet_transaction.credit_amount).to eq(credit_amount)
       end
     end

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
           invoice_requires_successful_payment: true,
           settled_at: Date.yesterday,
           credit_note_id: credit_note.id,
-          invoice_id: invoice.id,
+          invoice_id: invoice.id
         }
       end
 


### PR DESCRIPTION
## Context

Small preparation step for wallet calculation feature.
Currently this service accept each attribute as separate keyword argument creating a very long list of attributes in the `.initialize`, also we're duplicating default values set in the database.

## Description

Receive almost all params in `**transaction_params` simplifying `.initialize`.
Rely on DB defaults for non-provided attributes instead of duplicating the default values.
Rewrite specs to actually cover default DB values being assigned when not provided.
