### PR TITLE
feat(wallet-transactions): Add priority

### DIFF
--- a/app/graphql/mutations/wallet_transactions/create.rb
+++ b/app/graphql/mutations/wallet_transactions/create.rb
@@ -17,6 +17,7 @@ module Mutations
       argument :invoice_requires_successful_payment, Boolean, required: false
       argument :metadata, [Types::WalletTransactions::MetadataInput], required: false
       argument :paid_credits, String, required: false
+      argument :priority, Integer, required: false
       argument :voided_credits, String, required: false
 
       type Types::WalletTransactions::Object.collection_type

--- a/app/graphql/types/wallet_transactions/object.rb
+++ b/app/graphql/types/wallet_transactions/object.rb
@@ -11,6 +11,7 @@ module Types
       field :amount, String, null: false
       field :credit_amount, String, null: false
       field :invoice_requires_successful_payment, Boolean, null: false
+      field :priority, Integer, null: false
       field :source, Types::WalletTransactions::SourceEnum, null: false
       field :status, Types::WalletTransactions::StatusEnum, null: false
       field :transaction_status, Types::WalletTransactions::TransactionStatusEnum, null: false

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -39,9 +39,17 @@ class WalletTransaction < ApplicationRecord
   enum :transaction_type, TRANSACTION_TYPES
   enum :source, SOURCES
 
+  validates :priority, presence: true, inclusion: {in: 1..50}
+
   delegate :customer, to: :wallet
 
   scope :pending, -> { where(status: :pending) }
+
+  def self.order_by_priority
+    order(:priority)
+      .in_order_of(:transaction_status, [:granted, :purchased, :voided, :invoiced])
+      .order(:created_at)
+  end
 
   def amount_cents
     amount * wallet.currency_for_balance.subunit_to_unit
@@ -69,6 +77,7 @@ end
 #  invoice_requires_successful_payment :boolean          default(FALSE), not null
 #  lock_version                        :integer          default(0), not null
 #  metadata                            :jsonb
+#  priority                            :integer          default(50), not null
 #  settled_at                          :datetime
 #  source                              :integer          default("manual"), not null
 #  status                              :integer          not null

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -65,8 +65,11 @@ module CreditNotes
         credit_note.save!
 
         if wallet_credit
-          WalletTransactions::VoidService.call(wallet: associated_wallet,
-            wallet_credit:, credit_note_id: credit_note.id)
+          WalletTransactions::VoidService.call(
+            wallet: associated_wallet,
+            wallet_credit:,
+            credit_note_id: credit_note.id
+          )
         end
       end
       return result if context == :preview

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -18,6 +18,7 @@ module WalletTransactions
           :credit_note_id,
           :invoice_id,
           :invoice_requires_successful_payment,
+          :priority,
           :settled_at,
           :source,
           :status,

--- a/app/services/wallet_transactions/void_service.rb
+++ b/app/services/wallet_transactions/void_service.rb
@@ -2,12 +2,13 @@
 
 module WalletTransactions
   class VoidService < BaseService
-    def initialize(wallet:, wallet_credit:, from_source: :manual, metadata: {}, credit_note_id: nil)
+    def initialize(wallet:, wallet_credit:, from_source: :manual, metadata: {}, credit_note_id: nil, priority: 50)
       @wallet = wallet
       @wallet_credit = wallet_credit
       @from_source = from_source
       @metadata = metadata
       @credit_note_id = credit_note_id
+      @priority = priority
 
       super
     end
@@ -25,7 +26,8 @@ module WalletTransactions
           source: from_source,
           transaction_status: :voided,
           metadata:,
-          credit_note_id:
+          credit_note_id:,
+          priority:
         ).wallet_transaction
         Wallets::Balance::DecreaseService.new(wallet:, wallet_transaction:).call
         result.wallet_transaction = wallet_transaction
@@ -36,6 +38,6 @@ module WalletTransactions
 
     private
 
-    attr_reader :wallet, :wallet_credit, :from_source, :metadata, :credit_note_id
+    attr_reader :wallet, :wallet_credit, :from_source, :metadata, :credit_note_id, :priority
   end
 end

--- a/db/migrate/20250818154000_add_priority_to_wallet_transactions.rb
+++ b/db/migrate/20250818154000_add_priority_to_wallet_transactions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPriorityToWalletTransactions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :wallet_transactions, :priority, :integer, default: 50, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3267,7 +3267,8 @@ CREATE TABLE public.wallet_transactions (
     credit_note_id uuid,
     failed_at timestamp(6) without time zone,
     organization_id uuid NOT NULL,
-    lock_version integer DEFAULT 0 NOT NULL
+    lock_version integer DEFAULT 0 NOT NULL,
+    priority integer DEFAULT 50 NOT NULL
 );
 
 
@@ -9692,6 +9693,7 @@ ALTER TABLE ONLY public.fixed_charges_taxes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250818154000'),
 ('20250812132802'),
 ('20250812082721'),
 ('20250806174150'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -2638,6 +2638,7 @@ input CreateCustomerWalletTransactionInput {
   invoiceRequiresSuccessfulPayment: Boolean
   metadata: [WalletTransactionMetadataInput!]
   paidCredits: String
+  priority: Int
   voidedCredits: String
   walletId: ID!
 }
@@ -9739,11 +9740,6 @@ enum TimezoneEnum {
   TZ_AMERICA_DENVER
 
   """
-  America/Godthab
-  """
-  TZ_AMERICA_GODTHAB
-
-  """
   America/Guatemala
   """
   TZ_AMERICA_GUATEMALA
@@ -9954,11 +9950,6 @@ enum TimezoneEnum {
   TZ_ASIA_NOVOSIBIRSK
 
   """
-  Asia/Rangoon
-  """
-  TZ_ASIA_RANGOON
-
-  """
   Asia/Riyadh
   """
   TZ_ASIA_RIYADH
@@ -10162,11 +10153,6 @@ enum TimezoneEnum {
   Europe/Kaliningrad
   """
   TZ_EUROPE_KALININGRAD
-
-  """
-  Europe/Kiev
-  """
-  TZ_EUROPE_KIEV
 
   """
   Europe/Lisbon
@@ -11237,6 +11223,7 @@ type WalletTransaction {
   invoice: Invoice
   invoiceRequiresSuccessfulPayment: Boolean!
   metadata: [WalletTransactionMetadataObject!]
+  priority: Int!
   settledAt: ISO8601DateTime
   source: WalletTransactionSourceEnum!
   status: WalletTransactionStatusEnum!

--- a/schema.json
+++ b/schema.json
@@ -10832,6 +10832,18 @@
               "deprecationReason": null
             },
             {
+              "name": "priority",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "voidedCredits",
               "description": null,
               "type": {
@@ -51851,12 +51863,6 @@
               "deprecationReason": null
             },
             {
-              "name": "TZ_AMERICA_GODTHAB",
-              "description": "America/Godthab",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "TZ_AMERICA_GUATEMALA",
               "description": "America/Guatemala",
               "isDeprecated": false,
@@ -52109,12 +52115,6 @@
               "deprecationReason": null
             },
             {
-              "name": "TZ_ASIA_RANGOON",
-              "description": "Asia/Rangoon",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "TZ_ASIA_RIYADH",
               "description": "Asia/Riyadh",
               "isDeprecated": false,
@@ -52363,12 +52363,6 @@
             {
               "name": "TZ_EUROPE_KALININGRAD",
               "description": "Europe/Kaliningrad",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TZ_EUROPE_KIEV",
-              "description": "Europe/Kiev",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -59070,6 +59064,22 @@
                     "name": "WalletTransactionMetadataObject",
                     "ofType": null
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "priority",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,

--- a/spec/graphql/mutations/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/wallet_transactions/create_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
         collection {
           id
           status
+          priority
           invoiceRequiresSuccessfulPayment
           metadata {
             key
@@ -48,6 +49,7 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
           paidCredits: "5.00",
           grantedCredits: "5.00",
           invoiceRequiresSuccessfulPayment: true,
+          priority: 25,
           metadata: [
             {
               key: "fixed",
@@ -66,6 +68,7 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
     expect(result_data["collection"].map { |wt| wt["status"] })
       .to contain_exactly("pending", "settled")
     expect(result_data["collection"].map { |wt| wt["invoiceRequiresSuccessfulPayment"] }).to all be true
+    expect(result_data["collection"].map { |wt| wt["priority"] }).to all eq(25)
     expect(result_data["collection"]).to all(include(
       "metadata" => contain_exactly(
         {"key" => "fixed", "value" => "0"},

--- a/spec/graphql/types/wallet_transactions/object_spec.rb
+++ b/spec/graphql/types/wallet_transactions/object_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Types::WalletTransactions::Object do
     expect(subject).to have_field(:amount).of_type("String!")
     expect(subject).to have_field(:credit_amount).of_type("String!")
     expect(subject).to have_field(:invoice_requires_successful_payment).of_type("Boolean!")
+    expect(subject).to have_field(:priority).of_type("Int!")
     expect(subject).to have_field(:source).of_type("WalletTransactionSourceEnum!")
     expect(subject).to have_field(:status).of_type("WalletTransactionStatusEnum!")
     expect(subject).to have_field(:transaction_status).of_type("WalletTransactionTransactionStatusEnum!")

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -3,10 +3,7 @@
 require "rails_helper"
 
 RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
-  subject(:create_service) { described_class.call(organization:, params:) }
-
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:, currency:) }
   let(:currency) { "EUR" }
   let(:subscription) { create(:subscription, customer:) }
@@ -29,6 +26,8 @@ RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
   end
 
   describe "#call" do
+    subject(:result) { described_class.call(organization:, params:) }
+
     let(:paid_credits) { "10.00" }
     let(:granted_credits) { "15.00" }
     let(:voided_credits) { "3.00" }
@@ -43,11 +42,15 @@ RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
     end
 
     it "creates wallet transactions" do
-      expect { create_service }.to change(WalletTransaction, :count).by(3)
+      expect { subject }.to change(WalletTransaction, :count).by(3)
     end
 
-    it "sets expected transaction status", :aggregate_failures do
-      create_service
+    it "sets priority to default (50)" do
+      expect(result.wallet_transactions).to all(have_attributes(priority: 50))
+    end
+
+    it "sets expected transaction status" do
+      subject
       transactions = WalletTransaction.where(wallet_id: wallet.id)
 
       expect(transactions.purchased.first.credit_amount).to eq(10)
@@ -56,23 +59,23 @@ RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
     end
 
     it "sets expected source" do
-      create_service
+      subject
       expect(WalletTransaction.where(wallet_id: wallet.id).pluck(:source).uniq).to eq(["manual"])
     end
 
     it "enqueues the BillPaidCreditJob" do
-      expect { create_service }.to have_enqueued_job_after_commit(BillPaidCreditJob)
+      expect { subject }.to have_enqueued_job_after_commit(BillPaidCreditJob)
     end
 
     it "updates wallet balance based on granted and voided credits" do
-      create_service
+      subject
 
       expect(wallet.reload.balance_cents).to eq(2200)
       expect(wallet.reload.credits_balance).to eq(22.0)
     end
 
     it "updates wallet ongoing balance based on granted and voided credits" do
-      create_service
+      subject
 
       expect(wallet.reload.ongoing_balance_cents).to eq(2200)
       expect(wallet.reload.credits_ongoing_balance).to eq(22.0)
@@ -80,12 +83,12 @@ RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
 
     it "enqueues a SendWebhookJob for each wallet transaction" do
       expect do
-        create_service
+        subject
       end.to have_enqueued_job(SendWebhookJob).thrice.with("wallet_transaction.created", WalletTransaction)
     end
 
     it "produces an activity log" do
-      create_service
+      subject
 
       expect(Utils::ActivityLog).to have_received(:produce).thrice.with(an_instance_of(WalletTransaction), "wallet_transaction.created")
     end
@@ -104,7 +107,7 @@ RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
       end
 
       it "processes the transaction normally and includes the metadata" do
-        expect(create_service).to be_success
+        expect(result).to be_success
         transactions = WalletTransaction.where(wallet_id: wallet.id)
         expect(transactions.first.metadata).to include("key" => "valid_value", "value" => "also_valid")
         expect(transactions.second.metadata).to include("key" => "valid_value", "value" => "also_valid")
@@ -116,8 +119,6 @@ RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
       let(:paid_credits) { "-15.00" }
 
       it "returns an error" do
-        result = create_service
-
         expect(result).not_to be_success
         expect(result.error.messages[:paid_credits]).to eq(["invalid_paid_credits"])
       end
@@ -127,7 +128,6 @@ RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
       let(:paid_credits) { "4.399999" }
 
       it "creates wallet transaction with rounded value" do
-        result = create_service
         expect(result.wallet_transactions.first.credit_amount).to eq(4.40)
         expect(result.wallet_transactions.first.amount).to eq(4.40)
       end
@@ -138,7 +138,6 @@ RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
       let(:rate_amount) { 0.01 }
 
       it "creates wallet transaction with rounded value" do
-        result = create_service
         expect(result.wallet_transactions.first.credit_amount).to eq(4)
         expect(result.wallet_transactions.first.amount).to eq(0.04)
       end
@@ -149,7 +148,6 @@ RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
       let(:rate_amount) { 100 }
 
       it "creates wallet transaction with rounded value" do
-        result = create_service
         expect(result.wallet_transactions.first.credit_amount).to eq(4.3789)
         expect(result.wallet_transactions.first.amount).to eq(437.89)
       end
@@ -160,9 +158,27 @@ RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
       let(:currency) { "JPY" }
 
       it "creates wallet transaction with rounded value" do
-        result = create_service
         expect(result.wallet_transactions.first.credit_amount).to eq(4)
         expect(result.wallet_transactions.first.amount).to eq(4)
+      end
+    end
+
+    context "when priority parameter specified" do
+      let(:params) do
+        {
+          wallet_id: wallet.id,
+          paid_credits:,
+          granted_credits:,
+          voided_credits:,
+          priority:,
+          source: :manual
+        }
+      end
+
+      let(:priority) { 25 }
+
+      it "creates wallet transactions with specified priority" do
+        expect(result.wallet_transactions).to all(have_attributes(priority:))
       end
     end
   end

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -47,9 +47,10 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
           .to be_a(WalletTransaction)
           .and be_persisted
           .and have_attributes(
-            source: "manual",
+            invoice_requires_successful_payment: false,
             metadata: [],
-            invoice_requires_successful_payment: false
+            priority: 50,
+            source: "manual"
           )
       end
     end
@@ -69,7 +70,8 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
           invoice_requires_successful_payment: true,
           settled_at: Date.yesterday,
           credit_note_id: credit_note.id,
-          invoice_id: invoice.id
+          invoice_id: invoice.id,
+          priority: 25
         }
       end
 
@@ -85,11 +87,12 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
         expect(wallet_transaction.transaction_status).to eq("granted")
         expect(wallet_transaction.source).to eq("threshold")
         expect(wallet_transaction.metadata).to eq([{"key" => "value"}])
-        expect(wallet_transaction.invoice_requires_successful_payment).to be_truthy
+        expect(wallet_transaction.invoice_requires_successful_payment).to be true
         expect(wallet_transaction.settled_at).to eq(Date.yesterday)
         expect(wallet_transaction.credit_note_id).to eq(credit_note.id)
         expect(wallet_transaction.invoice_id).to eq(invoice.id)
         expect(wallet_transaction.credit_amount).to eq(credit_amount)
+        expect(wallet_transaction.priority).to eq 25
       end
     end
   end


### PR DESCRIPTION
## Context

Part of rework wallet calculation feature, as part of that feature we want have control over inbound transactions "consume" ordering.

## Description

Add `priority` attribute.
Adjust services and GQL to accept new column.
