### PR TITLE
Feat(fixed charges 9): fixed charges override service

### DIFF
--- a/app/services/fixed_charges/override_service.rb
+++ b/app/services/fixed_charges/override_service.rb
@@ -27,6 +27,7 @@ module FixedCharges
           c.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
           c.units = params[:units] if params.key?(:units)
           c.parent_id = fixed_charge.id
+          c.plan_id = params[:plan_id]
         end
         new_fixed_charge.save!
 


### PR DESCRIPTION
## Context

As fixed charges are part of a plan, when we create a plan override we should be able to override fixed_charges as well

## Description

introduced a service `FixedCharges::OverrideService`, that creates a child for a fixed_charge, allowing to update:
- properties (but runs a check to see that they are working for the charge_model)
- units
- inovice_display_name
- add taxes

also this service throws an error if user is trying to update charge_model of fixed_charge
