### PR TITLE
misc(dunning): Include invoice numbers in stripe payments

### DIFF
--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -134,7 +134,7 @@ module PaymentRequests
             price_data: {
               currency: invoice.currency.downcase,
               unit_amount: invoice.total_due_amount_cents,
-              product_data: { name: invoice.number }
+              product_data: {name: invoice.number}
             }
           }
         end

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -22,9 +22,11 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
       customer:,
       amount_cents: 799,
       amount_currency: "EUR",
-      invoices: [invoice_1, invoice_2]
+      invoices:
     )
   end
+
+  let(:invoices) { [invoice_1, invoice_2] }
 
   let(:invoice_1) do
     create(
@@ -114,7 +116,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
                 {
                   quantity: 1,
                   price_data: {
-                    currency: invocie_1.currency.downcase,
+                    currency: invoice_1.currency.downcase,
                     unit_amount: invoice_1.total_amount_cents,
                     product_data: {name: invoice_1.number}
                   }
@@ -125,7 +127,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
               customer: customer.stripe_customer.provider_customer_id,
               payment_method_types: customer.stripe_customer.provider_payment_methods,
               payment_intent_data: {
-                description: "#{billing_entity.name} - Overdue invoices #{invoice_1.number}",
+                description: "#{billing_entity.name} - Overdue invoices: #{invoice_1.number}",
                 metadata: {
                   lago_customer_id: customer.id,
                   lago_payable_id: payment_request.id,

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
                 price_data: {
                   currency: invoice_1.currency.downcase,
                   unit_amount: invoice_1.total_amount_cents,
-                  product_data: { name: invoice_1.number }
+                  product_data: {name: invoice_1.number}
                 }
               },
               {
@@ -78,8 +78,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
                 price_data: {
                   currency: invoice_2.currency.downcase,
                   unit_amount: invoice_2.total_amount_cents,
-                  product_data: { name: invoice_2.number }
-                  }
+                  product_data: {name: invoice_2.number}
                 }
               }
             ],
@@ -117,7 +116,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
                   price_data: {
                     currency: invocie_1.currency.downcase,
                     unit_amount: invoice_1.total_amount_cents,
-                    product_data: { name: invoice_1.number }
+                    product_data: {name: invoice_1.number}
                   }
                 }
               ],
@@ -135,6 +134,8 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
                 }
               }
             },
+            hash_including({api_key: an_instance_of(String)})
+          )
       end
     end
 

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -68,10 +68,17 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
               {
                 quantity: 1,
                 price_data: {
-                  currency: payment_request.currency.downcase,
-                  unit_amount: payment_request.total_amount_cents,
-                  product_data: {
-                    name: "Overdue invoices"
+                  currency: invoice_1.currency.downcase,
+                  unit_amount: invoice_1.total_amount_cents,
+                  product_data: { name: invoice_1.number }
+                }
+              },
+              {
+                quantity: 1,
+                price_data: {
+                  currency: invoice_2.currency.downcase,
+                  unit_amount: invoice_2.total_amount_cents,
+                  product_data: { name: invoice_2.number }
                   }
                 }
               }
@@ -92,6 +99,43 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
           },
           hash_including({api_key: an_instance_of(String)})
         )
+    end
+
+    context "when payment request is related to a single overdue invoice" do
+      let(:invoices) { [invoice_1] }
+
+      it "includes the invoice number in stripe data" do
+        stripe_service.generate_payment_url
+
+        expect(::Stripe::Checkout::Session)
+          .to have_received(:create)
+          .with(
+            {
+              line_items: [
+                {
+                  quantity: 1,
+                  price_data: {
+                    currency: invocie_1.currency.downcase,
+                    unit_amount: invoice_1.total_amount_cents,
+                    product_data: { name: invoice_1.number }
+                  }
+                }
+              ],
+              mode: "payment",
+              success_url: stripe_payment_provider.success_redirect_url,
+              customer: customer.stripe_customer.provider_customer_id,
+              payment_method_types: customer.stripe_customer.provider_payment_methods,
+              payment_intent_data: {
+                description: "#{billing_entity.name} - Overdue invoices #{invoice_1.number}",
+                metadata: {
+                  lago_customer_id: customer.id,
+                  lago_payable_id: payment_request.id,
+                  lago_payable_type: "PaymentRequest",
+                  payment_type: "one-time"
+                }
+              }
+            },
+      end
     end
 
     context "with an error on Stripe" do


### PR DESCRIPTION
add a line item for each overdue invoice included in the payment request.

also, when payment request include one single invoice, include its number in the description...