### PR TITLE
Feat(fixed_charges): add fixed_charges_units_override service

### DIFF
--- a/app/models/subscription_fixed_charge_units_override.rb
+++ b/app/models/subscription_fixed_charge_units_override.rb
@@ -11,7 +11,7 @@ class SubscriptionFixedChargeUnitsOverride < ApplicationRecord
   belongs_to :subscription
   belongs_to :fixed_charge
 
-  validates :units, presence: true, numericality: {greater_than: 0}
+  validates :units, presence: true, numericality: {greater_than_or_equal_to: 0}
 end
 
 # == Schema Information

--- a/spec/models/subscription_fixed_charge_units_override_spec.rb
+++ b/spec/models/subscription_fixed_charge_units_override_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe SubscriptionFixedChargeUnitsOverride, type: :model do
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:units) }
-    it { is_expected.to validate_numericality_of(:units).is_greater_than(0) }
+    it { is_expected.to validate_numericality_of(:units).is_greater_than_or_equal_to(0) }
   end
 end

--- a/spec/services/subscriptions/fixed_charge_unit_override_service_spec.rb
+++ b/spec/services/subscriptions/fixed_charge_unit_override_service_spec.rb
@@ -35,17 +35,6 @@ RSpec.describe Subscriptions::FixedChargeUnitOverrideService, type: :service do
     end
 
     context "when validation fails" do
-      context "with zero units" do
-        let(:units) { 0 }
-
-        it "sets zero units" do
-          result = service.call
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:units]).to eq(["value_is_out_of_range"])
-        end
-      end
-
       context "with negative units" do
         let(:units) { -1 }
 


### PR DESCRIPTION
## Context

we're implementing a mechanism to override units of a fixed charge for a subscription without creating a plan override. It's done through `SubscriptionFixedChargeUnitsOverride`. This PR creates service that'll be used to create these records

## Description

- Added `SubscriptionFixedChargeUnitsOverride`