### PR TITLE
fix(timezones): Fix timezone names

### DIFF
--- a/app/graphql/types/timezone_enum.rb
+++ b/app/graphql/types/timezone_enum.rb
@@ -2,7 +2,7 @@
 
 module Types
   class TimezoneEnum < Types::BaseEnum
-    ActiveSupport::TimeZone.all
+    Timezones.all
       .uniq { |tz| tz.tzinfo.identifier }
       .each_with_object([]) { |tz, result| result << tz.tzinfo.identifier }
       .sort_by { |tz| tz.split("/") }

--- a/app/support/timezones.rb
+++ b/app/support/timezones.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Timezones
+  # Fixes a desync between the timezone names and the timezone identifiers
+  # in rails and ruby
+  MAPPING = ActiveSupport::TimeZone::MAPPING.merge({
+    "Yangon" => "Asia/Yangon",
+    "Kyiv" => "Europe/Kyiv",
+    "Greenland" => "America/Nuuk"
+  }).except("Rangoon")
+
+  class << self
+    def all
+      MAPPING.each_with_object([]) do |(_, zone), result|
+        result << ActiveSupport::TimeZone.new(zone)
+      end
+    end
+  end
+end

--- a/app/validators/timezone_validator.rb
+++ b/app/validators/timezone_validator.rb
@@ -8,6 +8,6 @@ class TimezoneValidator < ActiveModel::EachValidator
   protected
 
   def valid?(value)
-    value == "UTC" || ActiveSupport::TimeZone::MAPPING.value?(value)
+    value == "UTC" || Timezones::MAPPING.value?(value)
   end
 end

--- a/db/migrate/20250821094638_update_timezones.rb
+++ b/db/migrate/20250821094638_update_timezones.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class UpdateTimezones < ActiveRecord::Migration[8.0]
+  def change
+    mapping = {
+      "Asia/Rangoon" => "Asia/Yangon",
+      "Europe/Kiev" => "Europe/Kyiv",
+      "America/Godthab" => "America/Nuuk"
+    }
+
+    mapping.each do |old_timezone, new_timezone|
+      # rubocop:disable Rails/SkipsModelValidations
+      Organization.where(timezone: old_timezone).update_all(timezone: new_timezone)
+      Customer.where(timezone: old_timezone).update_all(timezone: new_timezone)
+      Invoice.where(timezone: old_timezone).update_all(timezone: new_timezone)
+      BillingEntity.where(timezone: old_timezone).update_all(timezone: new_timezone)
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -9693,6 +9693,7 @@ ALTER TABLE ONLY public.fixed_charges_taxes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250821094638'),
 ('20250818154000'),
 ('20250812132802'),
 ('20250812082721'),

--- a/schema.graphql
+++ b/schema.graphql
@@ -9752,11 +9752,6 @@ enum TimezoneEnum {
   TZ_AMERICA_DENVER
 
   """
-  America/Godthab
-  """
-  TZ_AMERICA_GODTHAB
-
-  """
   America/Guatemala
   """
   TZ_AMERICA_GUATEMALA
@@ -9820,6 +9815,11 @@ enum TimezoneEnum {
   America/New_York
   """
   TZ_AMERICA_NEW_YORK
+
+  """
+  America/Nuuk
+  """
+  TZ_AMERICA_NUUK
 
   """
   America/Phoenix
@@ -9967,11 +9967,6 @@ enum TimezoneEnum {
   TZ_ASIA_NOVOSIBIRSK
 
   """
-  Asia/Rangoon
-  """
-  TZ_ASIA_RANGOON
-
-  """
   Asia/Riyadh
   """
   TZ_ASIA_RIYADH
@@ -10040,6 +10035,11 @@ enum TimezoneEnum {
   Asia/Yakutsk
   """
   TZ_ASIA_YAKUTSK
+
+  """
+  Asia/Yangon
+  """
+  TZ_ASIA_YANGON
 
   """
   Asia/Yekaterinburg
@@ -10177,9 +10177,9 @@ enum TimezoneEnum {
   TZ_EUROPE_KALININGRAD
 
   """
-  Europe/Kiev
+  Europe/Kyiv
   """
-  TZ_EUROPE_KIEV
+  TZ_EUROPE_KYIV
 
   """
   Europe/Lisbon

--- a/schema.json
+++ b/schema.json
@@ -51968,12 +51968,6 @@
               "deprecationReason": null
             },
             {
-              "name": "TZ_AMERICA_GODTHAB",
-              "description": "America/Godthab",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "TZ_AMERICA_GUATEMALA",
               "description": "America/Guatemala",
               "isDeprecated": false,
@@ -52048,6 +52042,12 @@
             {
               "name": "TZ_AMERICA_NEW_YORK",
               "description": "America/New_York",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_NUUK",
+              "description": "America/Nuuk",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -52226,12 +52226,6 @@
               "deprecationReason": null
             },
             {
-              "name": "TZ_ASIA_RANGOON",
-              "description": "Asia/Rangoon",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "TZ_ASIA_RIYADH",
               "description": "Asia/Riyadh",
               "isDeprecated": false,
@@ -52312,6 +52306,12 @@
             {
               "name": "TZ_ASIA_YAKUTSK",
               "description": "Asia/Yakutsk",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_YANGON",
+              "description": "Asia/Yangon",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -52484,8 +52484,8 @@
               "deprecationReason": null
             },
             {
-              "name": "TZ_EUROPE_KIEV",
-              "description": "Europe/Kiev",
+              "name": "TZ_EUROPE_KYIV",
+              "description": "Europe/Kyiv",
               "isDeprecated": false,
               "deprecationReason": null
             },


### PR DESCRIPTION
## Context

Following the update of Ruby to version 3.4.5, some issues where spotted in the timezone especially when exporting the Timezone enum for the GraphQL API.

It appears that some zone were renamed in ruby but that the support for rails has not yet been changed accordingly.

## Description

This PR:
- Fixes the Timezone mapping by adding a new `Timezones` module that will be used for both validations and GraphQL export.
- Add the correct handling for the impacted timezones:
  - Asia/Rangoon => Asia/Yangon
  - Europe/Kiev => Europe/Kyiv
  - America/Godthab => America/Nuuk
- Migrates the customers, organizations, invoices and billing entities impacted by these changes

