### PR TITLE
fix(invoice) Fix typo in locales and PDF template

### DIFF
--- a/app/views/templates/invoices/v4/_one_off.slim
+++ b/app/views/templates/invoices/v4/_one_off.slim
@@ -13,6 +13,7 @@ table.invoice-resume-table width="100%"
           .body-3 = fee.description
           - if fee.properties["from_datetime"] && fee.properties["to_datetime"]
             .body-3 #{I18n.t('invoice.from_to_date', from_date: I18n.l(fee.properties["from_datetime"]&.to_date, format: :default), to_date: I18n.l(fee.properties["to_datetime"]&.to_date, format: :default))}
+        td.body-2 = RoundingHelper.round_decimal_part(fee.units)
         td.body-2 = MoneyHelper.format(fee.unit_amount)
         td.body-2 == TaxHelper.applied_taxes(fee)
         td.body-2 = FeeDisplayHelper.format_amount(fee)

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -208,7 +208,7 @@
 
           h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.invoice_name)
 
-          - number_of_days_in_period = 0
+          - number_of_days_in_period = 30
 
           / Fees for filters
           - if fees.all? { |f| f.charge_filter_id? }

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -52,7 +52,7 @@ en:
     month: month
     monthly: Monthly
     notice_full: Regardless of when an event is received, the unit is not prorated, we charge the full price.
-    notice_prorated: If a unit is added or removed during the monthly plan, we calculate the prorated price based on the ratio of days remaining or used to the total number of days in the plan. For instance, if 15 days are left in the plan, we multiply the price by 15/%{days_in_month}, and if a unit was used for 10 days, we multiply the price by 10/%{days_in_month}.
+    notice_prorated: If a unit is added or removed during the monthly plan, we calculate the prorated price based on the ratio of days remaining or used to the total number of days in the plan. For example, if 15 days are left in a %{days_in_month}-day period, we charge 15/%{days_in_month} of the period price. If a unit was used for 10 days, we charge 10/%{days_in_month} of the period price.
     package:
       fee_per_package: Fee per package
       fee_per_package_unit_price: "%{amount} per %{package_size}"


### PR DESCRIPTION
## Description
This PR updates the subscription invoice PDF template when a breakdown of fees is rendered. 

It changes a bit the wording and make sure that the message uses a default `30 days` month instead of 0 when no fees exists for a unique count metric

The PR also add back the "units" for fees on the one_off invoice
