### PR TITLE
fix: update trigger for dunning_campaign finished webhook

### DIFF
--- a/app/services/dunning_campaigns/bulk_process_service.rb
+++ b/app/services/dunning_campaigns/bulk_process_service.rb
@@ -69,8 +69,6 @@ module DunningCampaigns
       end
 
       def send_campaign_finished_webhook
-        return result unless customer.overdue_balance_cents.positive?
-
         SendWebhookJob.perform_later(
           "dunning_campaign.finished",
           customer,


### PR DESCRIPTION
`dunning_campaign.finished` webhook should be trigger whenever dunning campaign is done for certain customer, not just when overdue balance is greater than zero