### PR TITLE
fix(api_logs): Do not logout the user when api logs is not available

### DIFF
--- a/app/graphql/resolvers/api_log_resolver.rb
+++ b/app/graphql/resolvers/api_log_resolver.rb
@@ -14,7 +14,8 @@ module Resolvers
     type Types::ApiLogs::Object, null: true
 
     def resolve(request_id: nil)
-      raise unauthorized_error unless License.premium? && Utils::ApiLog.available?
+      raise unauthorized_error unless License.premium?
+      raise forbidden_error(code: "feature_unavailable") unless Utils::ApiLog.available?
 
       current_organization.api_logs.find_by!(request_id:)
     rescue ActiveRecord::RecordNotFound

--- a/app/graphql/resolvers/api_logs_resolver.rb
+++ b/app/graphql/resolvers/api_logs_resolver.rb
@@ -24,7 +24,8 @@ module Resolvers
     type Types::ApiLogs::Object.collection_type, null: true
 
     def resolve(**args)
-      raise unauthorized_error unless License.premium? && Utils::ApiLog.available?
+      raise unauthorized_error unless License.premium?
+      raise forbidden_error(code: "feature_unavailable") unless Utils::ApiLog.available?
 
       result = ApiLogsQuery.call(
         organization: current_organization,

--- a/spec/graphql/resolvers/api_log_resolver_spec.rb
+++ b/spec/graphql/resolvers/api_log_resolver_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Resolvers::ApiLogResolver, type: :graphql, clickhouse: true do
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "audit_logs:view"
 
-  shared_examples "unauthorized error" do
+  shared_examples "blocked feature" do |message|
     it "returns an error" do
       result = execute_graphql(
         current_user: membership.user,
@@ -32,12 +32,12 @@ RSpec.describe Resolvers::ApiLogResolver, type: :graphql, clickhouse: true do
         variables: {requestId: clickhouse_api_log.request_id}
       )
 
-      expect_graphql_error(result:, message: "unauthorized")
+      expect_graphql_error(result:, message:)
     end
   end
 
   context "without premium feature" do
-    it_behaves_like "unauthorized error"
+    it_behaves_like "blocked feature", "unauthorized"
   end
 
   context "without database configuration" do
@@ -49,7 +49,7 @@ RSpec.describe Resolvers::ApiLogResolver, type: :graphql, clickhouse: true do
       ENV["LAGO_CLICKHOUSE_ENABLED"] = nil
     end
 
-    it_behaves_like "unauthorized error"
+    it_behaves_like "blocked feature", "feature_unavailable"
   end
 
   context "with premium feature" do

--- a/spec/graphql/resolvers/api_logs_resolver_spec.rb
+++ b/spec/graphql/resolvers/api_logs_resolver_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Resolvers::ApiLogsResolver, type: :graphql, clickhouse: true do
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "audit_logs:view"
 
-  shared_examples "unauthorized error" do
+  shared_examples "blocked feature" do |message|
     it "returns an error" do
       result = execute_graphql(
         current_user: membership.user,
@@ -36,12 +36,12 @@ RSpec.describe Resolvers::ApiLogsResolver, type: :graphql, clickhouse: true do
         query:
       )
 
-      expect_graphql_error(result:, message: "unauthorized")
+      expect_graphql_error(result:, message:)
     end
   end
 
   context "without premium feature" do
-    it_behaves_like "unauthorized error"
+    it_behaves_like "blocked feature", "unauthorized"
   end
 
   context "without database configuration" do
@@ -53,7 +53,7 @@ RSpec.describe Resolvers::ApiLogsResolver, type: :graphql, clickhouse: true do
       ENV["LAGO_CLICKHOUSE_ENABLED"] = nil
     end
 
-    it_behaves_like "unauthorized error"
+    it_behaves_like "blocked feature", "feature_unavailable"
   end
 
   context "with premium feature" do


### PR DESCRIPTION
Whenever we don't have API logs available, we should not logout the user, we should return that the action is forbidden, which does not logout the user.