### PR TITLE
misc(wallet-transactions): Refactor void service

### DIFF
--- a/app/services/wallet_transactions/create_from_params_service.rb
+++ b/app/services/wallet_transactions/create_from_params_service.rb
@@ -55,13 +55,7 @@ module WalletTransactions
 
         if params[:voided_credits]
           wallet_credit = WalletCredit.new(wallet:, credit_amount: BigDecimal(params[:voided_credits]).floor(5), invoiceable: false)
-          void_result = WalletTransactions::VoidService.call(
-            wallet:,
-            wallet_credit:,
-            from_source: source,
-            metadata:,
-            priority:
-          )
+          void_result = WalletTransactions::VoidService.call(**params, wallet:, wallet_credit:)
           wallet_transactions << void_result.wallet_transaction
         end
       end

--- a/app/services/wallet_transactions/void_service.rb
+++ b/app/services/wallet_transactions/void_service.rb
@@ -2,13 +2,10 @@
 
 module WalletTransactions
   class VoidService < BaseService
-    def initialize(wallet:, wallet_credit:, from_source: :manual, metadata: {}, credit_note_id: nil, priority: 50)
+    def initialize(wallet:, wallet_credit:, **transaction_params)
       @wallet = wallet
       @wallet_credit = wallet_credit
-      @from_source = from_source
-      @metadata = metadata
-      @credit_note_id = credit_note_id
-      @priority = priority
+      @transaction_params = transaction_params
 
       super
     end
@@ -18,16 +15,13 @@ module WalletTransactions
 
       ActiveRecord::Base.transaction do
         wallet_transaction = CreateService.call!(
+          **transaction_params,
           wallet:,
           wallet_credit:,
           transaction_type: :outbound,
           status: :settled,
           settled_at: Time.current,
-          source: from_source,
-          transaction_status: :voided,
-          metadata:,
-          credit_note_id:,
-          priority:
+          transaction_status: :voided
         ).wallet_transaction
         Wallets::Balance::DecreaseService.new(wallet:, wallet_transaction:).call
         result.wallet_transaction = wallet_transaction
@@ -38,6 +32,6 @@ module WalletTransactions
 
     private
 
-    attr_reader :wallet, :wallet_credit, :from_source, :metadata, :credit_note_id, :priority
+    attr_reader :wallet, :wallet_credit, :transaction_params
   end
 end

--- a/spec/services/wallet_transactions/void_service_spec.rb
+++ b/spec/services/wallet_transactions/void_service_spec.rb
@@ -3,10 +3,7 @@
 require "rails_helper"
 
 RSpec.describe WalletTransactions::VoidService, type: :service do
-  subject(:void_service) { described_class.call(wallet:, wallet_credit:) }
-
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
+  let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) do
@@ -19,77 +16,101 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
       credits_ongoing_balance: 10.0
     )
   end
-  let(:credits_amount) { BigDecimal("10.00") }
-  let(:wallet_credit) { WalletCredit.new(wallet:, credit_amount: credits_amount) }
+  let(:credit_amount) { BigDecimal("10.00") }
+  let(:wallet_credit) { WalletCredit.new(wallet:, credit_amount:) }
 
   before do
     subscription
   end
 
   describe "#call" do
+    subject(:result) { described_class.call(wallet:, wallet_credit:, **args) }
+
+    let(:args) { {} }
+
     context "when credits amount is zero" do
-      let(:credits_amount) { BigDecimal("0.00") }
+      let(:credit_amount) { BigDecimal("0.00") }
 
       it "does not create a wallet transaction" do
-        expect { void_service }.not_to change(WalletTransaction, :count)
+        expect { subject }.not_to change(WalletTransaction, :count)
       end
     end
 
-    context "when transaction have metadata" do
-      subject(:void_service) { described_class.call(wallet:, wallet_credit:, metadata:) }
+    context "with minimum arguments" do
+      it "creates a wallet transaction" do
+        expect { subject }.to change(WalletTransaction, :count).by(1)
+      end
 
+      it "sets default values" do
+        freeze_time do
+          expect(result.wallet_transaction)
+            .to be_a(WalletTransaction)
+            .and be_persisted
+            .and have_attributes(
+              amount: 10,
+              credit_amount: 10,
+              transaction_type: "outbound",
+              status: "settled",
+              transaction_status: "voided",
+              settled_at: Time.current,
+              source: "manual",
+              metadata: [],
+              priority: 50,
+              credit_note_id: nil
+            )
+        end
+      end
+
+      it "updates wallet balance" do
+        wallet = result.wallet_transaction.wallet
+
+        expect(wallet.balance_cents).to eq(0)
+        expect(wallet.credits_balance).to eq(0.0)
+      end
+    end
+
+    context "with all arguments" do
       let(:metadata) { [{"key" => "valid_value", "value" => "also_valid"}] }
-
-      it "sets expected attributes" do
-        expect(void_service.wallet_transaction).to have_attributes(
-          amount: 10,
-          credit_amount: 10,
-          transaction_type: "outbound",
-          status: "settled",
-          source: "manual",
-          transaction_status: "voided",
-          metadata: metadata
-        )
-      end
-    end
-
-    it "creates a wallet transaction" do
-      expect { void_service }.to change(WalletTransaction, :count).by(1)
-    end
-
-    it "sets expected attributes" do
-      freeze_time do
-        result = void_service
-        expect(result.wallet_transaction).to have_attributes(
-          amount: 10,
-          credit_amount: 10,
-          transaction_type: "outbound",
-          status: "settled",
-          source: "manual",
-          transaction_status: "voided",
-          settled_at: Time.current
-        )
-      end
-    end
-
-    it "updates wallet balance" do
-      result = void_service
-      wallet = result.wallet_transaction.wallet
-
-      expect(wallet.balance_cents).to eq(0)
-      expect(wallet.credits_balance).to eq(0.0)
-    end
-
-    context "when credit_note_id is passed" do
-      subject(:void_service) { described_class.call(wallet:, wallet_credit:, credit_note_id:) }
-
       let(:credit_note_id) { create(:credit_note, organization: organization).id }
 
-      it "saves credit_note_id in wallet_transaction" do
-        result = void_service
-        wallet_transaction = result.wallet_transaction
+      let(:args) do
+        {
+          metadata:,
+          credit_note_id:,
+          source: :threshold,
+          priority: 25
+        }
+      end
 
-        expect(wallet_transaction.credit_note_id).to eq(credit_note_id)
+      it "creates a wallet transaction" do
+        expect { subject }.to change(WalletTransaction, :count).by(1)
+      end
+
+      it "sets all attributes" do
+        freeze_time do
+          expect(result.wallet_transaction)
+            .to be_a(WalletTransaction)
+            .and be_persisted
+            .and have_attributes(
+              amount: 10,
+              credit_amount: 10,
+              transaction_type: "outbound",
+              status: "settled",
+              transaction_status: "voided",
+              settled_at: Time.current,
+              metadata:,
+              credit_note_id:,
+              source: "threshold",
+              priority: 25
+            )
+        end
+      end
+
+      it "updates wallet balance" do
+        wallet = result.wallet_transaction.wallet
+
+        expect(wallet.balance_cents).to eq(0)
+        expect(wallet.credits_balance).to eq(0.0)
       end
     end
   end


### PR DESCRIPTION
## Context

Small preparation step for wallet calculation feature.
Currently this service accept each attribute as separate keyword argument creating a very long list of attributes in the `.initialize`, also we're duplicating default values set in the database.

## Description

Receive almost all params in `**transaction_params` simplifying `.initialize`.
Rely on DB defaults for non-provided attributes instead of duplicating the default values.
Rewrite specs to actually cover default DB values being assigned when not provided.
