### PR TITLE
fix(events): Fix resolver with Clickhouse

### DIFF
--- a/app/graphql/resolvers/events_resolver.rb
+++ b/app/graphql/resolvers/events_resolver.rb
@@ -16,9 +16,13 @@ module Resolvers
 
     def resolve(page: nil, limit: nil)
       if current_organization.clickhouse_events_store?
-        Clickhouse::EventsRaw.where(organization_id: current_organization.id)
-          .order(ingested_at: :desc)
+        cte = Clickhouse::EventsRaw
+          .where(organization_id: current_organization.id)
           .limit_by(1, "transaction_id, timestamp, external_subscription_id, code")
+          .order(ingested_at: :desc)
+
+        Clickhouse::EventsRaw
+          .from("(#{cte.to_sql}) as events_raw")
           .page(page)
           .per((limit >= MAX_LIMIT) ? MAX_LIMIT : limit)
       else

--- a/spec/graphql/resolvers/events_resolver_spec.rb
+++ b/spec/graphql/resolvers/events_resolver_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Resolvers::EventsResolver, type: :graphql, transaction: false, clickhouse: true do
   let(:query) do
     <<~GQL
-      query {
-        events(limit: 5) {
+      query($page: Int) {
+        events(page: $page, limit: 5) {
           collection {
             id
             code
@@ -220,6 +220,20 @@ RSpec.describe Resolvers::EventsResolver, type: :graphql, transaction: false, cl
         expect(events_response["collection"].first["billableMetricName"]).to eq(billable_metric.name)
         expect(events_response["collection"].first["matchBillableMetric"]).to be_truthy
         expect(events_response["collection"].first["matchCustomField"]).to be_truthy
+      end
+    end
+
+    context "when querying an empty page" do
+      it "returns an empty list of events" do
+        result = execute_graphql(
+          current_user: user,
+          current_organization: organization,
+          query:,
+          variables: {page: 5}
+        )
+
+        events_response = result["data"]["events"]
+        expect(events_response["collection"].count).to be_zero
       end
     end
   end


### PR DESCRIPTION
## Description
This PR is a fix for the following rails exception:

```
ActiveRecord::ActiveRecordError
Response code: 500: (ActiveRecord::ActiveRecordError)
["Code: 215. DB::Exception: Column `transaction_id` is not under aggregate function and not in GROUP BY. Have columns: ['count()']: While processing transaction_id, timestamp, external_subscription_id, code. (NOT_AN_AGGREGATE)"]
```

It's a regression introduced by a previous pull-request (https://github.com/getlago/lago-api/pull/4163) that was made to de-duplicates Clickhouse events in the GraphQL events resolver. The issue is happening when querying an empty event page.