### PR TITLE
fix(subscription): Handle invalid ending at time format

### DIFF
--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -58,6 +58,9 @@ module Subscriptions
       add_error(field: :ending_at, error_code: "invalid_date")
 
       false
+    rescue Date::Error
+      add_error(field: :ending_at, error_code: "invalid_date")
+      false
     end
 
     def valid_on_termination_credit_note?

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -137,6 +137,15 @@ RSpec.describe Subscriptions::ValidateService, type: :service do
         end
       end
 
+      context "when ending_at uses an invalid date format" do
+        let(:ending_at) { "2025-08-20T16:11:39.061+02:00" }
+
+        it "returns false and result has errors" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:ending_at]).to eq(["invalid_date"])
+        end
+      end
+
       context "when ending_at is less than subscription_at and current time" do
         let(:ending_at) { (Time.current - 1.year).iso8601 }
 


### PR DESCRIPTION
## Description

This PR fixes the following error:
```
Date::Error
invalid date (Date::Error) DateTime.strptime(args[:ending_at], "%Y-%m-%dT%H:%M:%S.%LZ""
```

It raising when trying to update a subscription with an `ending_at` value using an invalid date format