### PR TITLE
misc(taxes): Send error webhook for address error

### DIFF
--- a/app/services/integrations/aggregator/taxes/invoices/create_draft_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_draft_service.rb
@@ -5,6 +5,8 @@ module Integrations
     module Taxes
       module Invoices
         class CreateDraftService < BaseService
+          ADDRESS_RESOLVE_ERROR = "customerAddressCouldNotResolve"
+
           def action_path
             "v1/#{provider}/draft_invoices"
           end
@@ -28,6 +30,8 @@ module Integrations
             code = code(e)
             message = message(e)
 
+            deliver_tax_error_webhook(customer:, code:, message:) if customer_address_error?(code)
+
             result.service_failure!(code:, message:)
           end
 
@@ -41,6 +45,10 @@ module Integrations
               integration_customer:,
               fees:
             ).body
+          end
+
+          def customer_address_error?(code)
+            code == ADDRESS_RESOLVE_ERROR
           end
         end
       end

--- a/spec/fixtures/integration_aggregator/address_error_response.json
+++ b/spec/fixtures/integration_aggregator/address_error_response.json
@@ -1,0 +1,6 @@
+{
+  "type": "customerAddressCouldNotResolve",
+  "payload": {
+    "message": "Invalid address"
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a new delivery of a tax provider error webhook when the fetch of the taxes failed with a `customerAddressCouldNotResolve` error. The goal is to notify the owner of the account that the customer is missing or has some invalid address details. It will avoid recurring dead jobs with the refresh wallet job allowing the organization owner to fix the root cause of the issue.
