### PR TITLE
misc(invoice): Remove OpenStruct for taxes in pay in advance

### DIFF
--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -234,7 +234,7 @@ module Fees
     def invoice
       result.invoice_id = SecureRandom.uuid
 
-      OpenStruct.new(
+      Invoice.new(
         id: result.invoice_id,
         issuing_date: Time.current.in_time_zone(customer.applicable_timezone).to_date,
         currency: subscription.plan.amount_currency,


### PR DESCRIPTION
## Description

This PR replaces an instantiation of an `OpenStruct` with a proper `Invoice` class in the `Fees::CreatePayInAdvanceService. It is used in the service to compute de axes that should be applied to the fee
