### PR TITLE
feat(entitlement): Allow privilege from plan to be removed from subscription

### DIFF
--- a/app/models/entitlement/subscription_entitlement.rb
+++ b/app/models/entitlement/subscription_entitlement.rb
@@ -27,5 +27,11 @@ module Entitlement
         }
       )
     end
+
+    def to_h
+      h = attributes
+      h["privileges"] = (h["privileges"] || []).map(&:to_h).index_by { |p| p[:code] }
+      h.with_indifferent_access
+    end
   end
 end

--- a/app/models/entitlement/subscription_entitlement_privilege.rb
+++ b/app/models/entitlement/subscription_entitlement_privilege.rb
@@ -22,7 +22,14 @@ module Entitlement
     attribute :sub_entitlement_value_id, :string
 
     def config
-      JSON.parse(super)
+      v = super
+      JSON.parse(v) if v.is_a?(String)
+    end
+
+    def to_h
+      h = attributes
+      h["config"] = config
+      h.with_indifferent_access
     end
   end
 end

--- a/app/models/entitlement/subscription_entitlement_privilege.rb
+++ b/app/models/entitlement/subscription_entitlement_privilege.rb
@@ -22,8 +22,7 @@ module Entitlement
     attribute :sub_entitlement_value_id, :string
 
     def config
-      v = super
-      JSON.parse(v) if v.is_a?(String)
+      super.then { it.is_a?(String) ? JSON.parse(it) : it }
     end
 
     def to_h

--- a/app/models/entitlement/subscription_feature_removal.rb
+++ b/app/models/entitlement/subscription_feature_removal.rb
@@ -8,8 +8,9 @@ module Entitlement
     default_scope -> { kept }
 
     belongs_to :organization
-    belongs_to :feature, class_name: "Entitlement::Feature", foreign_key: :entitlement_feature_id
     belongs_to :subscription
+    belongs_to :feature, optional: true, class_name: "Entitlement::Feature", foreign_key: :entitlement_feature_id
+    belongs_to :privilege, optional: true, class_name: "Entitlement::Privilege", foreign_key: :entitlement_privilege_id
   end
 end
 
@@ -32,7 +33,6 @@ end
 #  idx_on_entitlement_privilege_id_9946ccf514                     (entitlement_privilege_id)
 #  idx_on_organization_id_7020c3c43a                              (organization_id)
 #  idx_on_subscription_id_295edd8bb3                              (subscription_id)
-#  idx_on_subscription_id_entitlement_privilege_id_2d1f5978da     (subscription_id,entitlement_privilege_id) UNIQUE WHERE (deleted_at IS NULL)
 #  idx_unique_feature_removal_per_subscription                    (subscription_id,entitlement_feature_id) UNIQUE WHERE (deleted_at IS NULL)
 #  idx_unique_privilege_removal_per_subscription                  (subscription_id,entitlement_privilege_id) UNIQUE WHERE (deleted_at IS NULL)
 #  index_entitlement_subscription_feature_removals_on_deleted_at  (deleted_at)

--- a/app/models/entitlement/subscription_feature_removal.rb
+++ b/app/models/entitlement/subscription_feature_removal.rb
@@ -17,25 +17,30 @@ end
 #
 # Table name: entitlement_subscription_feature_removals
 #
-#  id                     :uuid             not null, primary key
-#  deleted_at             :datetime
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  entitlement_feature_id :uuid             not null
-#  organization_id        :uuid             not null
-#  subscription_id        :uuid             not null
+#  id                       :uuid             not null, primary key
+#  deleted_at               :datetime
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  entitlement_feature_id   :uuid
+#  entitlement_privilege_id :uuid
+#  organization_id          :uuid             not null
+#  subscription_id          :uuid             not null
 #
 # Indexes
 #
 #  idx_on_entitlement_feature_id_821ae72311                       (entitlement_feature_id)
+#  idx_on_entitlement_privilege_id_9946ccf514                     (entitlement_privilege_id)
 #  idx_on_organization_id_7020c3c43a                              (organization_id)
 #  idx_on_subscription_id_295edd8bb3                              (subscription_id)
-#  idx_on_subscription_id_entitlement_feature_id_02bee9883b       (subscription_id,entitlement_feature_id) UNIQUE WHERE (deleted_at IS NULL)
+#  idx_on_subscription_id_entitlement_privilege_id_2d1f5978da     (subscription_id,entitlement_privilege_id) UNIQUE WHERE (deleted_at IS NULL)
+#  idx_unique_feature_removal_per_subscription                    (subscription_id,entitlement_feature_id) UNIQUE WHERE (deleted_at IS NULL)
+#  idx_unique_privilege_removal_per_subscription                  (subscription_id,entitlement_privilege_id) UNIQUE WHERE (deleted_at IS NULL)
 #  index_entitlement_subscription_feature_removals_on_deleted_at  (deleted_at)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (entitlement_feature_id => entitlement_features.id)
+#  fk_rails_...  (entitlement_privilege_id => entitlement_privileges.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (subscription_id => subscriptions.id)
 #

--- a/db/migrate/20250822100111_add_privilege_removal.rb
+++ b/db/migrate/20250822100111_add_privilege_removal.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class AddPrivilegeRemoval < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      # Adding foreign key blocks writes, but the feature isn't released yet. Table is empty.
+      add_reference :entitlement_subscription_feature_removals, :entitlement_privilege,
+        foreign_key: true,
+        index: {algorithm: :concurrently},
+        type: :uuid,
+        if_not_exists: true
+    end
+
+    remove_index :entitlement_subscription_feature_removals,
+      name: "idx_on_subscription_id_entitlement_feature_id_02bee9883b",
+      column: [:subscription_id, :entitlement_feature_id],
+      unique: true,
+      where: "(deleted_at IS NULL)",
+      algorithm: :concurrently,
+      if_exists: true
+
+    change_column_null :entitlement_subscription_feature_removals, :entitlement_feature_id, true
+
+    add_index :entitlement_subscription_feature_removals, [:subscription_id, :entitlement_feature_id],
+      unique: true,
+      where: "deleted_at IS NULL",
+      name: "idx_unique_feature_removal_per_subscription",
+      algorithm: :concurrently,
+      if_not_exists: true
+
+    add_index :entitlement_subscription_feature_removals, [:subscription_id, :entitlement_privilege_id],
+      unique: true,
+      where: "deleted_at IS NULL",
+      name: "idx_unique_privilege_removal_per_subscription",
+      algorithm: :concurrently,
+      if_not_exists: true
+
+    safety_assured do
+      # Adding a check constraint, blocks reads and writes while every row is checked,
+      # but the feature isn't released yet. Table is empty.
+      add_check_constraint :entitlement_subscription_feature_removals,
+        "(entitlement_feature_id IS NOT NULL) != (entitlement_privilege_id IS NOT NULL)",
+        name: "check_exactly_one_feature_or_privilege_removal",
+        validate: true,
+        if_not_exists: true
+    end
+  end
+end

--- a/spec/factories/entitlement/subscription_feature_removals.rb
+++ b/spec/factories/entitlement/subscription_feature_removals.rb
@@ -2,8 +2,10 @@
 
 FactoryBot.define do
   factory :subscription_feature_removal, class: "Entitlement::SubscriptionFeatureRemoval" do
-    organization { feature&.organization || association(:organization) }
-    association :feature, factory: :feature
+    organization { feature&.organization || privilege&.organization || association(:organization) }
     subscription { association(:subscription, organization:) }
+
+    entitlement_feature_id { nil }
+    entitlement_privilege_id { nil }
   end
 end

--- a/spec/models/entitlement/subscription_entitlement_privilege_spec.rb
+++ b/spec/models/entitlement/subscription_entitlement_privilege_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Entitlement::SubscriptionEntitlementPrivilege, type: :model do
+  describe "initialization" do
+    it "creates an instance with no attributes" do
+      privilege = described_class.new
+
+      expect(privilege.organization_id).to be_nil
+      expect(privilege.entitlement_feature_id).to be_nil
+      expect(privilege.code).to be_nil
+      expect(privilege.value).to be_nil
+      expect(privilege.value_type).to be_nil
+      expect(privilege.plan_value).to be_nil
+      expect(privilege.subscription_value).to be_nil
+      expect(privilege.name).to be_nil
+      expect(privilege.config).to be_nil
+      expect(privilege.ordering_date).to be_nil
+      expect(privilege.plan_entitlement_id).to be_nil
+      expect(privilege.sub_entitlement_id).to be_nil
+      expect(privilege.plan_entitlement_value_id).to be_nil
+      expect(privilege.sub_entitlement_value_id).to be_nil
+    end
+  end
+
+  describe "ActiveModel compliance" do
+    it "includes ActiveModel::Attributes" do
+      expect(described_class.ancestors).to include(ActiveModel::Model)
+      expect(described_class.ancestors).to include(ActiveModel::Attributes)
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash" do
+      entitlement = described_class.new(code: "seats", config: {json: true}.to_json)
+      hash = entitlement.to_h
+      expect(hash).to be_a(HashWithIndifferentAccess)
+      expect(hash[:config]).to be_a(HashWithIndifferentAccess)
+    end
+  end
+end

--- a/spec/models/entitlement/subscription_entitlement_spec.rb
+++ b/spec/models/entitlement/subscription_entitlement_spec.rb
@@ -3,10 +3,6 @@
 require "rails_helper"
 
 RSpec.describe Entitlement::SubscriptionEntitlement, type: :model do
-  let(:organization) { create(:organization) }
-  let(:parent) { create(:plan, organization:) }
-  let(:subscription) { create(:subscription, organization:, plan: create(:plan, parent:)) }
-
   describe "initialization" do
     it "creates an instance with no attributes" do
       entitlement = described_class.new
@@ -26,9 +22,6 @@ RSpec.describe Entitlement::SubscriptionEntitlement, type: :model do
   end
 
   describe "ActiveModel compliance" do
-    it "includes ActiveModel::Model" do
-    end
-
     it "includes ActiveModel::Attributes" do
       expect(described_class.ancestors).to include(ActiveModel::Model)
       expect(described_class.ancestors).to include(ActiveModel::Attributes)
@@ -36,6 +29,10 @@ RSpec.describe Entitlement::SubscriptionEntitlement, type: :model do
   end
 
   describe ".for_subscription" do
+    let(:organization) { create(:organization) }
+    let(:parent) { create(:plan, organization:) }
+    let(:subscription) { create(:subscription, organization:, plan: create(:plan, parent:)) }
+
     it "returns the result from SubscriptionEntitlementQuery" do
       allow(Entitlement::SubscriptionEntitlementQuery).to receive(:call).with(
         organization: subscription.organization,
@@ -45,6 +42,23 @@ RSpec.describe Entitlement::SubscriptionEntitlement, type: :model do
       result = described_class.for_subscription(subscription)
 
       expect(result).to eq("works")
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash" do
+      privilege = Entitlement::SubscriptionEntitlementPrivilege.new(code: "max")
+      entitlement = described_class.new(code: "seats", privileges: [privilege])
+      hash = entitlement.to_h
+      expect(hash).to be_a(HashWithIndifferentAccess)
+      expect(hash[:privileges].values).to all be_a(HashWithIndifferentAccess)
+      expect(hash[:privileges].keys).to eq ["max"]
+
+      entitlement = described_class.new(code: "seats")
+      hash = entitlement.to_h
+
+      expect(hash).to be_a(HashWithIndifferentAccess)
+      expect(hash[:privileges]).to eq({})
     end
   end
 end

--- a/spec/models/entitlement/subscription_feature_removal_spec.rb
+++ b/spec/models/entitlement/subscription_feature_removal_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe Entitlement::SubscriptionFeatureRemoval, type: :model do
   describe "associations" do
     it do
       expect(subject).to belong_to(:organization)
-      expect(subject).to belong_to(:feature).class_name("Entitlement::Feature")
       expect(subject).to belong_to(:subscription)
+      expect(subject).to belong_to(:feature).class_name("Entitlement::Feature").optional
+      expect(subject).to belong_to(:privilege).class_name("Entitlement::Privilege").optional
     end
   end
 end

--- a/spec/queries/entitlement/subscription_entitlement_query_spec.rb
+++ b/spec/queries/entitlement/subscription_entitlement_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::SubscriptionEntitlementQuery, type: :service, transaction: false do
+RSpec.describe Entitlement::SubscriptionEntitlementQuery, type: :service do
   subject do
     described_class.call(
       organization:,

--- a/spec/queries/entitlement/subscription_entitlement_query_spec.rb
+++ b/spec/queries/entitlement/subscription_entitlement_query_spec.rb
@@ -1,0 +1,378 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Entitlement::SubscriptionEntitlementQuery, type: :service, transaction: false do
+  subject do
+    described_class.call(
+      organization:,
+      filters: {
+        subscription_id:,
+        plan_id:
+      }
+    )
+  end
+
+  let(:organization) { create(:organization) }
+
+  let(:subscription_id) { subscription.id }
+  let(:plan_id) { subscription.plan.parent_id || subscription.plan.id }
+
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, organization:, plan:) }
+
+  let(:seats) { create(:feature, organization:, code: "seats", name: "Nb users") }
+  let(:seats_max) { create(:privilege, feature: seats, code: "max", name: "Max", value_type: "integer") }
+  let(:seats_reset) { create(:privilege, feature: seats, code: "reset", name: "Password Reset", value_type: "boolean") }
+
+  let(:storage) { create(:feature, organization:, code: "storage", name: "Storage") }
+  let(:storage_limit) { create(:privilege, feature: storage, code: "limit", name: "Limit", value_type: "string") }
+  let(:storage_type) { create(:privilege, feature: storage, code: "type", name: "Type", value_type: "select", config: {select_options: ["rom", "ram"]}) }
+
+  let(:support) { create(:feature, organization:, code: "support", name: "Premium Support") }
+
+  let(:other_organization_feature) { create(:feature, organization: create(:organization), code: "other") }
+
+  before do
+    storage_type
+    storage_limit
+    seats_reset
+    seats_max
+    support
+    other_organization_feature
+
+    # Other data that should not be retrieved
+    other_plan = create(:plan, organization:)
+    create_feature_entitlement(other_plan, seats, {seats_max => 555, seats_reset => true})
+
+    other_subscription = create(:subscription, organization:, plan: other_plan)
+    create_feature_entitlement(other_subscription, support)
+    create_feature_entitlement(other_subscription, seats, {seats_max => 999})
+    create_feature_entitlement(other_subscription, storage, {storage_limit => 999_888})
+    create(:subscription_feature_removal, subscription: other_subscription, privilege: seats_reset)
+  end
+
+  def create_feature_entitlement(parent, feature, privileges = {})
+    entitlement = if parent.is_a? Plan
+      create(:entitlement, feature:, plan: parent)
+    else
+      create(:entitlement, feature:, subscription: parent, plan: nil)
+    end
+
+    privileges.each do |privilege, value|
+      create(:entitlement_value, entitlement:, privilege:, value:)
+    end
+  end
+
+  def expect_subject_to_match(expected)
+    expect(subject.count).to eq expected.count
+
+    result = subject.map(&:to_h).index_by { |h| h[:code] }
+
+    expected.each do |code, feature_expectations|
+      privileges_expectations = feature_expectations.delete(:privileges) || {}
+      feature_expectations[:code] = code
+      expect(result[code]).to include(feature_expectations.stringify_keys)
+
+      expect(result[code][:privileges].count).to eq privileges_expectations.count
+
+      privileges_expectations.each do |expected_privilege|
+        expect(result[code][:privileges][expected_privilege[:code]]).to include expected_privilege.stringify_keys
+      end
+    end
+  end
+
+  describe "#call" do
+    context "when plan has no features" do
+      context "when subscription has no overrides" do
+        it "returns empty result" do
+          expect(subject).to be_empty
+        end
+      end
+
+      context "when subscription has feature overrides" do
+        it "returns only subscription features" do
+          create_feature_entitlement(subscription, seats, {seats_max => 100, seats_reset => true})
+          create_feature_entitlement(subscription, storage, {storage_limit => "100GB", storage_type => "ram"})
+          create_feature_entitlement(subscription, support)
+
+          expect_subject_to_match({
+            "seats" => {name: "Nb users", privileges: [
+              {code: "max", value: "100"},
+              {code: "reset", value: "t"}
+            ]},
+            "storage" => {privileges: [
+              {code: "limit", value: "100GB"},
+              {code: "type", value: "ram"}
+            ]},
+            "support" => {privileges: []}
+          })
+        end
+      end
+    end
+
+    context "when plan has features" do
+      before do
+        create_feature_entitlement(plan, seats, {seats_max => 20, seats_reset => false})
+        create_feature_entitlement(plan, storage, {storage_limit => "50GB", storage_type => "rom"})
+        create_feature_entitlement(plan, support)
+      end
+
+      context "when subscription has no overrides" do
+        it "returns only plans feature" do
+          expect_subject_to_match({
+            "seats" => {name: "Nb users", privileges: [
+              {code: "max", value: "20", plan_value: "20", subscription_value: nil},
+              {code: "reset", value: "f", plan_value: "f", subscription_value: nil}
+            ]},
+            "storage" => {privileges: [
+              {code: "limit", value: "50GB", plan_value: "50GB", subscription_value: nil},
+              {code: "type", value: "rom", plan_value: "rom", subscription_value: nil}
+            ]},
+            "support" => {privileges: []}
+          })
+        end
+      end
+
+      context "when subscription has privilege value overrides" do
+        it "returns all features with overridden values" do
+          create_feature_entitlement(subscription, seats, {seats_max => 100, seats_reset => true})
+          create_feature_entitlement(subscription, storage, {storage_type => "ram"})
+
+          expect_subject_to_match({
+            "seats" => {name: "Nb users", privileges: [
+              {code: "max", value: "100", plan_value: "20", subscription_value: "100"},
+              {code: "reset", value: "t", plan_value: "f", subscription_value: "t"}
+            ]},
+            "storage" => {privileges: [
+              {code: "limit", value: "50GB", plan_value: "50GB", subscription_value: nil},
+              {code: "type", value: "ram", plan_value: "rom", subscription_value: "ram"}
+            ]},
+            "support" => {privileges: []}
+          })
+        end
+      end
+
+      context "when a plan feature was removed" do
+        it "doesn't return the removed feature" do
+          create(:subscription_feature_removal, subscription:, feature: seats)
+          create(:subscription_feature_removal, subscription:, feature: support)
+          create_feature_entitlement(subscription, storage, {storage_type => "ram"})
+
+          expect_subject_to_match({
+            "storage" => {privileges: [
+              {code: "limit", value: "50GB", plan_value: "50GB", subscription_value: nil},
+              {code: "type", value: "ram", plan_value: "rom", subscription_value: "ram"}
+            ]}
+          })
+        end
+      end
+
+      context "when a plan feature privilege was removed" do
+        it "doesn't return the removed privilege" do
+          create(:subscription_feature_removal, subscription:, privilege: seats_reset)
+          create(:subscription_feature_removal, subscription:, privilege: storage_limit)
+          create(:subscription_feature_removal, subscription:, feature: support)
+          create_feature_entitlement(subscription, storage, {storage_type => "ram"})
+
+          expect_subject_to_match({
+            "seats" => {name: "Nb users", privileges: [
+              {code: "max", value: "20", plan_value: "20", subscription_value: nil}
+            ]},
+            "storage" => {privileges: [
+              {code: "type", value: "ram", plan_value: "rom", subscription_value: "ram"}
+            ]}
+          })
+        end
+      end
+    end
+
+    describe "soft deletion" do
+      before do
+        create_feature_entitlement(plan, seats, {seats_max => 20, seats_reset => false})
+        create_feature_entitlement(plan, storage, {storage_limit => "50GB", storage_type => "rom"})
+        create_feature_entitlement(plan, support)
+
+        create_feature_entitlement(subscription, seats, {seats_max => 100, seats_reset => true})
+        create_feature_entitlement(subscription, storage, {storage_type => "ram"})
+
+        create(:subscription_feature_removal, subscription:, privilege: storage_limit)
+        create(:subscription_feature_removal, subscription:, feature: support)
+      end
+
+      context "when features are deleted" do
+        it "doesn't return the deleted features" do
+          seats.discard!
+
+          expect_subject_to_match({
+            "storage" => {privileges: [
+              {code: "type", value: "ram", plan_value: "rom", subscription_value: "ram"}
+            ]}
+          })
+        end
+      end
+
+      context "when privileges are deleted" do
+        it "doesn't return the deleted features" do
+          storage_type.discard!
+
+          expect_subject_to_match({
+            "seats" => {name: "Nb users", privileges: [
+              {code: "max", value: "100", plan_value: "20", subscription_value: "100"},
+              {code: "reset", value: "t", plan_value: "f", subscription_value: "t"}
+            ]},
+            "storage" => {privileges: []}
+          })
+        end
+      end
+
+      context "when plan entitlement is deleted" do
+        it "doesn't return the feature" do
+          # NOTE: Notice that we soft delete the entitlement but don't even cleanup the entitlement_values
+          Entitlement::Entitlement.where(plan:, feature: seats).discard_all!
+
+          expect_subject_to_match({
+            "seats" => {name: "Nb users", privileges: [
+              {code: "max", value: "100", plan_value: nil, subscription_value: "100"},
+              {code: "reset", value: "t", plan_value: nil, subscription_value: "t"}
+            ]},
+            "storage" => {privileges: [
+              {code: "type", value: "ram", plan_value: "rom", subscription_value: "ram"}
+            ]}
+          })
+        end
+      end
+
+      context "when subscription entitlement is deleted" do
+        it "doesn't return the feature" do
+          # NOTE: Notice that we soft delete the entitlement but don't even cleanup the entitlement_values
+          #       To retrieve values, the entitlement relation must exist
+          Entitlement::Entitlement.where(subscription:, feature: seats).discard_all!
+
+          expect_subject_to_match({
+            "seats" => {name: "Nb users", privileges: [
+              {code: "max", value: "20", plan_value: "20", subscription_value: nil},
+              {code: "reset", value: "f", plan_value: "f", subscription_value: nil}
+            ]},
+            "storage" => {privileges: [
+              {code: "type", value: "ram", plan_value: "rom", subscription_value: "ram"}
+            ]}
+          })
+        end
+      end
+
+      context "when plan entitlement value is deleted" do
+        it "doesn't return the privilege value from plan" do
+          Entitlement::EntitlementValue.where(
+            entitlement: Entitlement::Entitlement.where(plan:, feature: storage),
+            privilege: storage_type
+          ).discard_all!
+
+          expect_subject_to_match({
+            "seats" => {name: "Nb users", privileges: [
+              {code: "max", value: "100", plan_value: "20", subscription_value: "100"},
+              {code: "reset", value: "t", plan_value: "f", subscription_value: "t"}
+            ]},
+            "storage" => {privileges: [
+              {code: "type", value: "ram", plan_value: nil, subscription_value: "ram"}
+            ]}
+          })
+        end
+      end
+
+      context "when subscription entitlement value is deleted" do
+        it "doesn't return the privilege value from subscription" do
+          Entitlement::EntitlementValue.where(
+            entitlement: Entitlement::Entitlement.where(subscription:, feature: storage),
+            privilege: storage_type
+          ).discard_all!
+
+          expect_subject_to_match({
+            "seats" => {name: "Nb users", privileges: [
+              {code: "max", value: "100", plan_value: "20", subscription_value: "100"},
+              {code: "reset", value: "t", plan_value: "f", subscription_value: "t"}
+            ]},
+            "storage" => {privileges: [
+              {code: "type", value: "rom", plan_value: "rom", subscription_value: nil}
+            ]}
+          })
+        end
+      end
+
+      context "when plan and subscription entitlement value is deleted" do
+        it "doesn't return the privilege" do
+          Entitlement::EntitlementValue.where(
+            entitlement: Entitlement::Entitlement.where(plan:, feature: storage),
+            privilege: storage_type
+          ).discard_all!
+
+          Entitlement::EntitlementValue.where(
+            entitlement: Entitlement::Entitlement.where(subscription:, feature: storage),
+            privilege: storage_type
+          ).discard_all!
+
+          expect_subject_to_match({
+            "seats" => {name: "Nb users", privileges: [
+              {code: "max", value: "100", plan_value: "20", subscription_value: "100"},
+              {code: "reset", value: "t", plan_value: "f", subscription_value: "t"}
+            ]},
+            "storage" => {privileges: []}
+          })
+        end
+      end
+
+      context "when subscription feature removal is deleted" do
+        it "returns the feature" do
+          Entitlement::SubscriptionFeatureRemoval.where(subscription:, feature: support).discard_all!
+
+          expect_subject_to_match({
+            "seats" => {name: "Nb users", privileges: [
+              {code: "max", value: "100", plan_value: "20", subscription_value: "100"},
+              {code: "reset", value: "t", plan_value: "f", subscription_value: "t"}
+            ]},
+            "storage" => {privileges: [
+              {code: "type", value: "ram", plan_value: "rom", subscription_value: "ram"}
+            ]},
+            "support" => {privileges: []}
+          })
+        end
+      end
+
+      context "when subscription privilege removal is deleted" do
+        it "returns the feature" do
+          Entitlement::SubscriptionFeatureRemoval.where(subscription:, privilege: storage_limit).discard_all!
+
+          expect_subject_to_match({
+            "seats" => {name: "Nb users", privileges: [
+              {code: "max", value: "100", plan_value: "20", subscription_value: "100"},
+              {code: "reset", value: "t", plan_value: "f", subscription_value: "t"}
+            ]},
+            "storage" => {privileges: [
+              {code: "limit", value: "50GB", plan_value: "50GB", subscription_value: nil},
+              {code: "type", value: "ram", plan_value: "rom", subscription_value: "ram"}
+            ]}
+          })
+        end
+      end
+    end
+
+    describe "ordering_date" do
+      before do
+        seats_plan_ent = Entitlement::Entitlement.create!(created_at: 1.day.ago, organization:, plan:, feature: seats)
+        Entitlement::Entitlement.create!(created_at: 9.days.ago, organization:, plan:, feature: support)
+
+        seats_sub_ent = Entitlement::Entitlement.create!(created_at: Time.current, organization:, subscription:, feature: seats)
+
+        Entitlement::EntitlementValue.create!(created_at: 5.days.ago, organization:, entitlement: seats_plan_ent, value: "100", privilege: seats_max)
+
+        Entitlement::EntitlementValue.create!(created_at: 10.days.ago, organization:, entitlement: seats_plan_ent, value: "f", privilege: seats_reset)
+        Entitlement::EntitlementValue.create!(created_at: 2.days.ago, organization:, entitlement: seats_sub_ent, value: "t", privilege: seats_reset)
+      end
+
+      it "returns the feature ordered by plan entitlement date" do
+        expect(subject.map(&:code)).to eq %w[support seats]
+        expect(subject.find { it.code == "seats" }.privileges.map(&:code)).to eq %w[reset max]
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/subscriptions/entitlements_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/entitlements_controller_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe Api::V1::Subscriptions::EntitlementsController, type: :request do
   describe "POST /api/v1/subscriptions/external_id/entitlements/:feature_code/restore" do
     subject { post_with_token organization, "/api/v1/subscriptions/#{subscription.external_id}/entitlements/#{feature.code}/restore" }
 
-    let(:subscription_feature_removal) { create(:subscription_feature_removal, organization:, feature:, subscription_id: subscription.id) }
+    let(:subscription_feature_removal) { create(:subscription_feature_removal, organization:, feature:, subscription: subscription) }
 
     before do
       subscription_feature_removal


### PR DESCRIPTION
- Add new db column so `Entitlement::SubscriptionFeatureRemoval` can belong to a privilege.
- modify the query so we ignore privileges listed in the subscription feature removals.
- Add beautiful hand-crafted test suite to the SubscriptionEntitlementQuery object.
- Add `to_h` to active model to make them much easier to work with

Next PR, will create the removals in services when needed