### PR TITLE
Feat semiannual

### DIFF
--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -46,7 +46,7 @@ class InvoiceSubscription < ApplicationRecord
 
     base_query = base_query.recurring if recurring
 
-    if subscription.plan.yearly? && subscription.plan.bill_charges_monthly?
+    if (subscription.plan.yearly? || subscription.plan.semiannual?) && subscription.plan.bill_charges_monthly?
       base_query = base_query
         .where(charges_from_datetime: boundaries.charges_from_datetime)
         .where(charges_to_datetime: boundaries.charges_to_datetime)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -39,6 +39,7 @@ class Plan < ApplicationRecord
     monthly
     yearly
     quarterly
+    semiannual
   ].freeze
 
   enum :interval, INTERVALS
@@ -80,6 +81,7 @@ class Plan < ApplicationRecord
     return amount_cents if yearly?
     return amount_cents * 12 if monthly?
     return amount_cents * 4 if quarterly?
+    return amount_cents * 2 if semiannual?
 
     amount_cents * 52
   end

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -15,7 +15,8 @@ class RecurringTransactionRule < ApplicationRecord
     :weekly,
     :monthly,
     :quarterly,
-    :yearly
+    :yearly,
+    :semiannual
   ].freeze
 
   METHODS = [

--- a/app/services/commitments/minimum/in_advance/fetch_invoices_service.rb
+++ b/app/services/commitments/minimum/in_advance/fetch_invoices_service.rb
@@ -25,7 +25,7 @@ module Commitments
         def fetch_invoices
           plan = subscription.plan
 
-          if !subscription.plan.yearly? || !plan.bill_charges_monthly?
+          if (!subscription.plan.yearly? && !subscription.plan.semiannual?) || !plan.bill_charges_monthly?
             return Invoice.where(id: invoice_subscription.invoice_id)
           end
 

--- a/app/services/commitments/minimum/in_arrears/calculate_true_up_fee_service.rb
+++ b/app/services/commitments/minimum/in_arrears/calculate_true_up_fee_service.rb
@@ -68,11 +68,11 @@ module Commitments
 
         def charge_in_advance_recurring_fees
           if !invoice_subscription.previous_invoice_subscription &&
-              (!subscription.plan.yearly? || !subscription.plan.bill_charges_monthly?)
+              ((!subscription.plan.yearly? && !subscription.plan.semiannual?) || !subscription.plan.bill_charges_monthly?)
             return Fee.none
           end
 
-          is = if subscription.plan.yearly? && subscription.plan.bill_charges_monthly?
+          is = if (subscription.plan.yearly? || subscription.plan.semiannual?) && subscription.plan.bill_charges_monthly?
             invoice_subscription
           else
             invoice_subscription.previous_invoice_subscription
@@ -99,7 +99,7 @@ module Commitments
             )
 
           # rubocop:disable Style/ConditionalAssignment
-          if subscription.plan.yearly? && subscription.plan.bill_charges_monthly?
+          if (subscription.plan.yearly? || subscription.plan.semiannual?) && subscription.plan.bill_charges_monthly?
             scope = scope
               .where(
                 "(fees.properties->>'charges_from_datetime') >= ?",

--- a/app/services/commitments/minimum/in_arrears/fetch_invoices_service.rb
+++ b/app/services/commitments/minimum/in_arrears/fetch_invoices_service.rb
@@ -25,7 +25,7 @@ module Commitments
         def fetch_invoices
           plan = subscription.plan
 
-          if !subscription.plan.yearly? || !plan.bill_charges_monthly?
+          if (!subscription.plan.yearly? && !subscription.plan.semiannual?) || !plan.bill_charges_monthly?
             return Invoice.where(id: invoice_subscription.invoice_id)
           end
 

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -24,8 +24,8 @@ module Plans
         amount_cents: args[:amount_cents],
         amount_currency: args[:amount_currency],
         trial_period: args[:trial_period],
-        bill_charges_monthly: (args[:interval]&.to_sym == :yearly) ? args[:bill_charges_monthly] || false : nil,
-        bill_fixed_charges_monthly: (args[:interval]&.to_sym == :yearly) ? args[:bill_fixed_charges_monthly] || false : nil
+        bill_charges_monthly: (args[:interval]&.to_sym == :yearly || args[:interval]&.to_sym == :semiannual) ? args[:bill_charges_monthly] || false : nil,
+        bill_fixed_charges_monthly: (args[:interval]&.to_sym == :yearly || args[:interval]&.to_sym == :semiannual) ? args[:bill_fixed_charges_monthly] || false : nil
       )
 
       chargeables_validation_result = Plans::ChargeablesValidationService.call(

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -86,13 +86,13 @@ module Plans
     delegate :organization, to: :plan
 
     def bill_charges_monthly?
-      return unless params[:interval]&.to_sym == :yearly
+      return if params[:interval]&.to_sym != :yearly && params[:interval]&.to_sym != :semiannual
 
       params[:bill_charges_monthly] || false
     end
 
     def bill_fixed_charges_monthly?
-      return unless params[:interval]&.to_sym == :yearly
+      return if params[:interval]&.to_sym != :yearly && params[:interval]&.to_sym != :semiannual
 
       params[:bill_fixed_charges_monthly] || false
     end

--- a/app/services/subscriptions/dates/semiannual_service.rb
+++ b/app/services/subscriptions/dates/semiannual_service.rb
@@ -4,13 +4,15 @@ module Subscriptions
   module Dates
     class SemiannualService < Subscriptions::DatesService
       def first_month_in_semiannual_period?
-        return billing_date.month == 1 || billing_date.month == 6 if calendar?
+        return billing_date.month == 1 || billing_date.month == 7 if calendar?
 
-        billing_from_date.month == subscription_at.month || billing_from_date.month == (subscription_at.month + 6) % 12
+        start_month = subscription_at.month
+        second_half_month = (start_month <= 6) ? start_month + 6 : start_month - 6
+        [start_month, second_half_month].include?(billing_from_date.month)
       end
 
       def first_month_in_first_semiannual_period?
-        return (billing_date.month == 1 || billing_date.month == 6) && billing_date.year == subscription_at.year if calendar?
+        return (billing_date.month == 1 || billing_date.month == 7) && billing_date.year == subscription_at.year if calendar?
 
         billing_from_date.month == subscription_at.month && billing_from_date.year == subscription_at.year
       end

--- a/app/services/subscriptions/dates/semiannual_service.rb
+++ b/app/services/subscriptions/dates/semiannual_service.rb
@@ -3,7 +3,27 @@
 module Subscriptions
   module Dates
     class SemiannualService < Subscriptions::DatesService
+      def first_month_in_semiannual_period?
+        return billing_date.month == 1 || billing_date.month == 6 if calendar?
+
+        billing_from_date.month == subscription_at.month || billing_from_date.month == (subscription_at.month + 6) % 12
+      end
+
+      def first_month_in_first_semiannual_period?
+        return (billing_date.month == 1 || billing_date.month == 6) && billing_date.year == subscription_at.year if calendar?
+
+        billing_from_date.month == subscription_at.month && billing_from_date.year == subscription_at.year
+      end
+
       private
+
+      def monthly_service
+        @monthly_service ||= Subscriptions::Dates::MonthlyService.new(subscription, billing_date, current_usage)
+      end
+
+      def billing_from_date
+        @billing_from_date ||= monthly_service.compute_from_date(billing_date)
+      end
 
       def compute_from_date(date = base_date)
         if plan.pay_in_advance? || terminated_pay_in_arrears?

--- a/app/services/subscriptions/dates/semiannual_service.rb
+++ b/app/services/subscriptions/dates/semiannual_service.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  module Dates
+    class SemiannualService < Subscriptions::DatesService
+      private
+
+      def compute_from_date(date = base_date)
+        if plan.pay_in_advance? || terminated_pay_in_arrears?
+          return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_half_year
+        end
+
+        subscription.anniversary? ? previous_anniversary_day(date) : date.beginning_of_half_year
+      end
+
+      def compute_charges_from_date
+        if terminated?
+          return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_half_year
+        end
+
+        return compute_from_date if plan.pay_in_arrears?
+        return base_date.beginning_of_half_year if calendar?
+
+        previous_anniversary_day(base_date)
+      end
+
+      def compute_charges_to_date
+        return compute_charges_from_date.end_of_half_year if calendar?
+
+        compute_to_date(compute_charges_from_date)
+      end
+
+      def compute_duration(from_date:)
+        next_to_date = compute_to_date(from_date)
+
+        (next_to_date.to_date + 1.day - from_date.to_date).to_i
+      end
+
+      alias_method :compute_charges_duration, :compute_duration
+
+      def compute_base_date
+        # NOTE: if subscription anniversary is on last day of month and current month days count
+        #       is less than month anniversary day count, we need to use the last day of the previous month
+        if subscription.anniversary? && last_day_of_month?(billing_date) && (billing_date.day < subscription_at.day)
+          if (billing_date - 6.months).end_of_month.day >= subscription_at.day
+            return (billing_date - 6.months).end_of_month.change(day: subscription_at.day)
+          end
+
+          return (billing_date - 6.months).end_of_month
+        end
+
+        billing_date - 6.months
+      end
+
+      def compute_to_date(from_date = compute_from_date)
+        if subscription.calendar? || (subscription_at.day == 1 && [1, 7].include?(subscription_at.month))
+          return from_date.end_of_half_year
+        end
+
+        year = from_date.year
+        month = from_date.month + 6
+        day = subscription_at.day - 1
+
+        if month > 12
+          month = (month % 12).zero? ? 12 : (month % 12)
+          year += 1
+        end
+
+        date = build_date(year, month, day)
+
+        # NOTE: if subscription anniversary day is higher than the current last day of the month,
+        #       subscription period, will end on the previous end of day
+        return date - 1.day if last_day_of_month?(date) && subscription_at.day > date.day
+
+        date
+      end
+
+      def compute_next_end_of_period
+        return billing_date.end_of_half_year if calendar?
+
+        year = billing_date.year
+        month = billing_date.month
+        day = subscription_at.day
+
+        # NOTE: we need the last day of the period, and not the first of the next one
+        result_date = build_date(year, month, day) - 1.day
+        return result_date if result_date >= billing_date
+
+        month += 6
+        if month > 12
+          month = (month % 12).zero? ? 12 : (month % 12)
+          year += 1
+        end
+
+        build_date(year, month, day) - 1.day
+      end
+
+      def compute_previous_beginning_of_period(date)
+        return date.beginning_of_half_year if calendar?
+
+        previous_anniversary_day(date)
+      end
+
+      def previous_anniversary_day(date)
+        year = nil
+        month = nil
+
+        # NOTE: if subscription anniversary day is higher than the current last day of the month,
+        #       anniversary day is on the current day
+        day = if subscription.anniversary? && last_day_of_month?(date) && (date.day < subscription_at.day)
+          date.day
+        else
+          subscription_at.day
+        end
+
+        billing_months = [
+          (subscription_at.month % 12).zero? ? 12 : (subscription_at.month % 12),
+          ((subscription_at.month + 6) % 12).zero? ? 12 : ((subscription_at.month + 6) % 12)
+        ].sort
+
+        # This is the case when we terminate subscription on On February 10 but anniversary date is on
+        # 5 of March. In that case we need to fetch billing period in previous year
+        if should_find_billing_date_in_previous_year?(date, billing_months, day)
+          year = date.year - 1
+          month = billing_months[1]
+          day = Time.days_in_month(month, year) if last_day_of_month?(subscription_at)
+        # In case of termination that is in the middle of the year, previous period anniversary date has to be returned
+        elsif should_find_previous_billing_date?(date, billing_months, day)
+          year = date.year
+          month = billing_months.reverse.find { |m| m < date.month }
+          day = Time.days_in_month(month, year) if last_day_of_month?(subscription_at)
+        else
+          year = date.year
+          month = date.month
+        end
+
+        build_date(year, month, day)
+      end
+
+      def should_find_billing_date_in_previous_year?(date, billing_months, day)
+        return true if date.month < billing_months[0]
+
+        (date.month == billing_months[0]) && should_find_previous_billing_date?(date, billing_months, day)
+      end
+
+      def should_find_previous_billing_date?(date, billing_months, day)
+        return false if last_day_of_month?(date) && last_day_of_month?(subscription_at)
+
+        return true if date.day < day && terminated_pay_in_arrears?
+        return true if (date.day + 1) < day && last_day_of_month?(subscription_at)
+        return true if date.day < day && !last_day_of_month?(subscription_at)
+        return true if billing_months.exclude?(date.month)
+
+        false
+      end
+    end
+  end
+end

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -12,6 +12,8 @@ module Subscriptions
         Subscriptions::Dates::YearlyService
       when :quarterly
         Subscriptions::Dates::QuarterlyService
+      when :semiannual
+        Subscriptions::Dates::SemiannualService
       else
         raise(NotImplementedError)
       end
@@ -246,6 +248,14 @@ module Subscriptions
     end
 
     def first_month_in_first_yearly_period?
+      false
+    end
+
+    def first_month_in_semiannual_period?
+      false
+    end
+
+    def first_month_in_first_semiannual_period?
       false
     end
 

--- a/app/services/subscriptions/terminated_dates_service.rb
+++ b/app/services/subscriptions/terminated_dates_service.rb
@@ -43,7 +43,7 @@ module Subscriptions
         .where(from_datetime: date_service.from_datetime)
         .where(to_datetime: date_service.to_datetime)
 
-      if subscription.plan.yearly? && subscription.plan.bill_charges_monthly?
+      if (subscription.plan.yearly? || subscription.plan.semiannual?) && subscription.plan.bill_charges_monthly?
         base_query = base_query
           .where(charges_from_datetime: date_service.charges_from_datetime)
           .where(charges_to_datetime: date_service.charges_to_datetime)

--- a/schema.graphql
+++ b/schema.graphql
@@ -8000,6 +8000,7 @@ type PlanEntitlementPrivilegeObject {
 enum PlanInterval {
   monthly
   quarterly
+  semiannual
   weekly
   yearly
 }
@@ -9003,6 +9004,7 @@ type Query {
 enum RecurringTransactionIntervalEnum {
   monthly
   quarterly
+  semiannual
   weekly
   yearly
 }

--- a/schema.json
+++ b/schema.json
@@ -40015,6 +40015,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "semiannual",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -48225,6 +48231,12 @@
             },
             {
               "name": "yearly",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "semiannual",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -62,28 +62,48 @@ RSpec.describe Plan, type: :model do
   end
 
   describe "#yearly_amount_cents" do
-    let(:plan) do
-      build(:plan, interval: :yearly, amount_cents: 100)
+    subject(:method_call) { plan.yearly_amount_cents }
+
+    let(:plan) { build_stubbed(:plan, interval:, amount_cents: 100) }
+
+    context "when plan is yearly" do
+      let(:interval) { :yearly }
+
+      it "returns the correct amount" do
+        expect(subject).to eq(100)
+      end
     end
 
-    it { expect(plan.yearly_amount_cents).to eq(100) }
-
     context "when plan is monthly" do
-      before { plan.interval = "monthly" }
+      let(:interval) { :monthly }
 
-      it { expect(plan.yearly_amount_cents).to eq(1200) }
+      it "returns the correct amount" do
+        expect(subject).to eq(1200)
+      end
     end
 
     context "when plan is weekly" do
-      before { plan.interval = "weekly" }
+      let(:interval) { :weekly }
 
-      it { expect(plan.yearly_amount_cents).to eq(5200) }
+      it "returns the correct amount" do
+        expect(subject).to eq(5200)
+      end
     end
 
     context "when plan is quarterly" do
-      before { plan.interval = "quarterly" }
+      let(:interval) { :quarterly }
 
-      it { expect(plan.yearly_amount_cents).to eq(400) }
+      it "returns the correct amount" do
+        expect(subject).to eq(400)
+      end
+    end
+
+    context "when plan is semiannual" do
+      let(:interval) { :semiannual }
+
+      it "returns the correct amount" do
+        expect(subject).to eq(200)
+      end
     end
   end
 

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RecurringTransactionRule, type: :model do
   describe "enums" do
     it "defines expected enum values" do
       expect(described_class.defined_enums).to include(
-        "interval" => hash_including("weekly", "monthly", "quarterly", "yearly"),
+        "interval" => hash_including("weekly", "monthly", "quarterly", "yearly", "semiannual"),
         "method" => hash_including("fixed", "target"),
         "trigger" => hash_including("interval", "threshold"),
         "status" => hash_including("active", "terminated")

--- a/spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb
+++ b/spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService, type: :service d
   let(:customer) { create(:customer, organization:) }
   let(:subscription_at) { DateTime.parse("2024-01-01T00:00:00") }
   let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:, pay_in_advance:, interval: :yearly) }
+  let(:plan) { create(:plan, organization:, pay_in_advance:, interval: [:semiannual, :yearly].sample) }
   let(:billing_time) { :calendar }
   let(:bill_charges_monthly) { false }
   let(:pay_in_advance) { false }

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -1783,4 +1783,251 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       end
     end
   end
+
+  describe "#should_create_yearly_subscription_fee?" do
+    subject(:method_call) { invoice_service.send(:should_create_yearly_subscription_fee?, subscription) }
+
+    let(:timestamp) { DateTime.parse("01 Apr 2022") }
+    let(:started_at) { DateTime.parse("31 Mar 2021") }
+    let(:created_at) { started_at }
+    let(:terminated_at) { nil }
+
+    context "when plan is not yearly" do
+      let(:interval) { "monthly" }
+
+      it "returns true" do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context "when plan is yearly" do
+      let(:interval) { "yearly" }
+
+      context "when plan is pay in arrears" do
+        let(:pay_in_advance) { false }
+
+        context "when billing_time is anniversary" do
+          let(:billing_time) { :anniversary }
+
+          context "when subscription is terminated" do
+            it "returns true" do
+              subscription.status = :terminated
+              subscription.terminated_at = Time.zone.now
+              expect(subject).to eq(true)
+            end
+          end
+
+          context "when subscription is not terminated" do
+            context "when it's the first month" do
+              it "returns true " do
+                expect(subject).to eq(true)
+              end
+            end
+
+            context "when it's not the first month" do
+              let(:timestamp) { DateTime.parse("01 May 2022") }
+
+              it "returns false when it's not the first month" do
+                expect(subject).to eq(false)
+              end
+            end
+          end
+        end
+
+        context "when billing_time is calendar" do
+          let(:billing_time) { :calendar }
+
+          context "when subscription is terminated" do
+            it "returns true" do
+              subscription.status = :terminated
+              subscription.terminated_at = Time.zone.now
+              expect(subject).to eq(true)
+            end
+          end
+
+          context "when subscription is not terminated" do
+            context "when it's the first month" do
+              let(:timestamp) { DateTime.parse("01 Jan 2023") }
+
+              it "returns true " do
+                expect(subject).to eq(true)
+              end
+            end
+
+            context "when it's not the first month" do
+              it "returns false when it's not the first month" do
+                expect(subject).to eq(false)
+              end
+            end
+          end
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+
+        context "when billing_time is calendar" do
+          let(:billing_time) { :calendar }
+
+          context "when subscription started in the past" do
+            let(:created_at) { started_at + 1.month }
+
+            context "when it's the first month in yearly period" do
+              context "when it is not the first month in first yearly period" do
+                let(:started_at) { DateTime.parse("01 Jan 2022") }
+                let(:timestamp) { DateTime.parse("01 Jan 2022") + 3.years }
+
+                it "returns true" do
+                  expect(subject).to eq(true)
+                end
+              end
+
+              context "when it is the first month in first yearly period" do
+                let(:timestamp) { DateTime.parse("01 Jan 2022") }
+                let(:started_at) { DateTime.parse("01 Jan 2022") }
+
+                it "returns false" do
+                  expect(subject).to eq(false)
+                end
+              end
+            end
+
+            context "when it's not the first month in yearly period" do
+              let(:started_at) { DateTime.parse("01 Jan 2022") }
+              let(:timestamp) { DateTime.parse("01 Feb 2022") + 3.years }
+
+              it "returns false" do
+                expect(subject).to eq(false)
+              end
+            end
+          end
+
+          context "when subscription did not start in the past" do
+            context "when it's the first month in yearly period" do
+              let(:started_at) { DateTime.parse("01 Jan 2022") }
+              let(:timestamp) { DateTime.parse("01 Jan 2022") + 3.years }
+
+              context "when it has not been billed yet" do
+                it "returns true" do
+                  expect(subject).to eq(true)
+                end
+              end
+
+              context "when it has been billed" do
+                before do
+                  allow(subscription).to receive(:already_billed?).and_return(true)
+                end
+
+                it "returns true" do
+                  expect(subject).to eq(true)
+                end
+              end
+            end
+
+            context "when it's not the first month in yearly period" do
+              let(:started_at) { DateTime.parse("01 Jan 2022") }
+              let(:timestamp) { DateTime.parse("01 Feb 2022") + 3.years }
+
+              context "when it has not been billed yet" do
+                it "returns true" do
+                  expect(subject).to eq(true)
+                end
+              end
+
+              context "when it has been billed" do
+                before do
+                  allow(subscription).to receive(:already_billed?).and_return(true)
+                end
+
+                it "returns false" do
+                  expect(subject).to eq(false)
+                end
+              end
+            end
+          end
+        end
+
+        context "when billing_time is anniversary" do
+          let(:billing_time) { :anniversary }
+
+          context "when subscription started in the past" do
+            let(:created_at) { started_at + 1.month }
+
+            context "when it's the first month in yearly period" do
+              context "when it is not the first month in first yearly period" do
+                let(:started_at) { DateTime.parse("01 Jun 2022") }
+                let(:timestamp) { DateTime.parse("01 Jun 2022") + 3.years }
+
+                it "returns true" do
+                  expect(subject).to eq(true)
+                end
+              end
+
+              context "when it is the first month in first yearly period" do
+                let(:timestamp) { DateTime.parse("01 Jun 2022") }
+                let(:started_at) { DateTime.parse("01 Jun 2022") }
+
+                it "returns false" do
+                  expect(subject).to eq(false)
+                end
+              end
+            end
+
+            context "when it's not the first month in yearly period" do
+              let(:started_at) { DateTime.parse("01 Jun 2022") }
+              let(:timestamp) { DateTime.parse("01 Jul 2022") + 3.years }
+
+              it "returns false" do
+                expect(subject).to eq(false)
+              end
+            end
+          end
+
+          context "when subscription did not start in the past" do
+            context "when it's the first month in yearly period" do
+              let(:started_at) { DateTime.parse("01 Jun 2022") }
+              let(:timestamp) { DateTime.parse("01 Jun 2022") + 3.years }
+
+              context "when it has not been billed yet" do
+                it "returns true" do
+                  expect(subject).to eq(true)
+                end
+              end
+
+              context "when it has been billed" do
+                before do
+                  allow(subscription).to receive(:already_billed?).and_return(true)
+                end
+
+                it "returns true" do
+                  expect(subject).to eq(true)
+                end
+              end
+            end
+
+            context "when it's not the first month in yearly period" do
+              let(:started_at) { DateTime.parse("01 Jun 2022") }
+              let(:timestamp) { DateTime.parse("01 Jul 2022") + 3.years }
+
+              context "when it has not been billed yet" do
+                it "returns true" do
+                  expect(subject).to eq(true)
+                end
+              end
+
+              context "when it has been billed" do
+                before do
+                  allow(subscription).to receive(:already_billed?).and_return(true)
+                end
+
+                it "returns false" do
+                  expect(subject).to eq(false)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -310,6 +310,63 @@ RSpec.describe Plans::CreateService, type: :service do
       )
     end
 
+    describe "bill_charges_monthly" do
+      context "when plan is yearly" do
+        let(:create_args) do
+          super().merge(interval: "yearly", bill_charges_monthly: true)
+        end
+
+        it "persists bill_charges_monthly" do
+          plan = result.plan
+          expect(plan.bill_charges_monthly).to eq(true)
+        end
+
+        context "when not provided" do
+          let(:create_args) do
+            super().merge(interval: "yearly").except(:bill_charges_monthly)
+          end
+
+          it "defaults to false" do
+            plan = result.plan
+            expect(plan.bill_charges_monthly).to eq(false)
+          end
+        end
+      end
+
+      context "when plan is semiannual" do
+        let(:create_args) do
+          super().merge(interval: "semiannual", bill_fixed_charges_monthly: true)
+        end
+
+        it "persists bill_fixed_charges_monthly" do
+          plan = result.plan
+          expect(plan.bill_fixed_charges_monthly).to eq(true)
+        end
+
+        context "when not provided" do
+          let(:create_args) do
+            super().merge(interval: "semiannual").except(:bill_fixed_charges_monthly)
+          end
+
+          it "defaults to false" do
+            plan = result.plan
+            expect(plan.bill_fixed_charges_monthly).to eq(false)
+          end
+        end
+      end
+
+      context "when plan is monthly" do
+        let(:create_args) do
+          super().merge(interval: "monthly", bill_fixed_charges_monthly: true)
+        end
+
+        it "ignores the flag and sets it to nil" do
+          plan = result.plan
+          expect(plan.bill_fixed_charges_monthly).to be_nil
+        end
+      end
+    end
+
     describe "bill_fixed_charges_monthly" do
       context "when plan is yearly" do
         let(:create_args) do
@@ -324,6 +381,28 @@ RSpec.describe Plans::CreateService, type: :service do
         context "when not provided" do
           let(:create_args) do
             super().merge(interval: "yearly").except(:bill_fixed_charges_monthly)
+          end
+
+          it "defaults to false" do
+            plan = result.plan
+            expect(plan.bill_fixed_charges_monthly).to eq(false)
+          end
+        end
+      end
+
+      context "when plan is semiannual" do
+        let(:create_args) do
+          super().merge(interval: "semiannual", bill_fixed_charges_monthly: true)
+        end
+
+        it "persists bill_fixed_charges_monthly" do
+          plan = result.plan
+          expect(plan.bill_fixed_charges_monthly).to eq(true)
+        end
+
+        context "when not provided" do
+          let(:create_args) do
+            super().merge(interval: "semiannual").except(:bill_fixed_charges_monthly)
           end
 
           it "defaults to false" do

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -1187,6 +1187,86 @@ RSpec.describe Plans::UpdateService, type: :service do
       end
     end
 
+    context "with bill_charges_monthly functionality" do
+      context "when interval is yearly and bill_fixed_charges_monthly is sent" do
+        let(:update_args) do
+          {
+            name: plan_name,
+            interval: "yearly",
+            bill_charges_monthly: true
+          }
+        end
+
+        it "updates bill_charges_monthly" do
+          result = plans_service.call
+
+          expect(result.plan.bill_charges_monthly).to eq(true)
+        end
+      end
+
+      context "when interval is yearly and bill_charges_monthly is not provided" do
+        let(:update_args) do
+          {
+            name: plan_name,
+            interval: "yearly"
+          }
+        end
+
+        it "sets bill_charges_monthly to false" do
+          result = plans_service.call
+
+          expect(result.plan.bill_charges_monthly).to eq(false)
+        end
+      end
+
+      context "when interval is semiannual and bill_charges_monthly is sent" do
+        let(:update_args) do
+          {
+            name: plan_name,
+            interval: "semiannual",
+            bill_charges_monthly: true
+          }
+        end
+
+        it "updates bill_charges_monthly" do
+          result = plans_service.call
+
+          expect(result.plan.bill_charges_monthly).to eq(true)
+        end
+      end
+
+      context "when interval is semiannual and bill_charges_monthly is not provided" do
+        let(:update_args) do
+          {
+            name: plan_name,
+            interval: "semiannual"
+          }
+        end
+
+        it "sets bill_charges_monthly to false" do
+          result = plans_service.call
+
+          expect(result.plan.bill_charges_monthly).to eq(false)
+        end
+      end
+
+      context "when interval is not yearly or semiannual" do
+        let(:update_args) do
+          {
+            name: plan_name,
+            interval: "monthly",
+            bill_charges_monthly: true
+          }
+        end
+
+        it "does not set bill_charges_monthly" do
+          result = plans_service.call
+
+          expect(result.plan.bill_charges_monthly).to be_nil
+        end
+      end
+    end
+
     context "with bill_fixed_charges_monthly functionality" do
       context "when interval is yearly and bill_fixed_charges_monthly is sent" do
         let(:update_args) do
@@ -1219,7 +1299,38 @@ RSpec.describe Plans::UpdateService, type: :service do
         end
       end
 
-      context "when interval is not yearly" do
+      context "when interval is semiannual and bill_fixed_charges_monthly is sent" do
+        let(:update_args) do
+          {
+            name: plan_name,
+            interval: "semiannual",
+            bill_fixed_charges_monthly: true
+          }
+        end
+
+        it "updates bill_fixed_charges_monthly" do
+          result = plans_service.call
+
+          expect(result.plan.bill_fixed_charges_monthly).to eq(true)
+        end
+      end
+
+      context "when interval is semiannual and bill_fixed_charges_monthly is not provided" do
+        let(:update_args) do
+          {
+            name: plan_name,
+            interval: "semiannual"
+          }
+        end
+
+        it "sets bill_fixed_charges_monthly to false" do
+          result = plans_service.call
+
+          expect(result.plan.bill_fixed_charges_monthly).to eq(false)
+        end
+      end
+
+      context "when interval is not yearly or semiannual" do
         let(:update_args) do
           {
             name: plan_name,

--- a/spec/services/subscriptions/dates/semiannual_service_spec.rb
+++ b/spec/services/subscriptions/dates/semiannual_service_spec.rb
@@ -1,0 +1,678 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::Dates::SemiannualService, type: :service do
+  subject(:date_service) { described_class.new(subscription, billing_at, current_usage) }
+
+  let(:subscription) do
+    create(
+      :subscription,
+      plan:,
+      customer:,
+      subscription_at:,
+      billing_time:,
+      started_at:
+    )
+  end
+
+  let(:customer) { create(:customer, timezone:) }
+  let(:plan) { create(:plan, interval: :semiannual, pay_in_advance:) }
+  let(:pay_in_advance) { false }
+  let(:current_usage) { false }
+
+  let(:subscription_at) { Time.zone.parse("02 Feb 2021") }
+  # let(:billing_at) { Time.zone.parse("07 Mar 2022") }
+  let(:started_at) { subscription_at }
+  let(:timezone) { "UTC" }
+
+  describe "from_datetime" do
+    let(:result) { date_service.from_datetime.to_s }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+      it "returns the beginning of the previous half year" do
+        expect(result).to eq("2022-01-01 00:00:00 UTC")
+      end
+
+      context "when subscription is not yet started" do
+        let(:started_at) { nil }
+
+        it "returns nil" do
+          expect(date_service.from_datetime).to be_nil
+        end
+      end
+
+      context "with customer timezone" do
+        let(:timezone) { "America/New_York" }
+
+        it "takes customer timezone into account" do
+          expect(result).to eq("2021-07-01 04:00:00 UTC")
+        end
+      end
+
+      context "when date is before the start date" do
+        let(:started_at) { Time.zone.parse("07 Apr 2022") }
+
+        it "returns the start date" do
+          expect(result).to eq(started_at.beginning_of_day.utc.to_s)
+        end
+
+        context "with customer timezone" do
+          let(:timezone) { "America/New_York" }
+
+          it "returns the start date in the timezone" do
+            expect(result).to eq("2022-04-06 04:00:00 UTC")
+          end
+        end
+      end
+
+      context "when subscription is just terminated" do
+        let(:billing_at) { Time.zone.parse("10 Jul 2022") }
+
+        before { subscription.mark_as_terminated!("9 Jul 2022") }
+
+        it "returns the beginning of the half year" do
+          expect(result).to eq("2022-07-01 00:00:00 UTC")
+        end
+
+        context "when plan is pay in advance" do
+          let(:pay_in_advance) { true }
+
+          it "returns the beginning of the half year" do
+            expect(result).to eq("2022-07-01 00:00:00 UTC")
+          end
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:subscription_at) { Time.zone.parse("02 Nov 2021") }
+      let(:billing_at) { Time.zone.parse("02 May 2022") }
+
+      it "returns the same day in the previous half year" do
+        expect(result).to eq("2021-11-02 00:00:00 UTC")
+      end
+
+      context "when date is before the start date" do
+        let(:started_at) { Time.zone.parse("08 Feb 2022") }
+
+        it "returns the start date" do
+          expect(result).to eq(started_at.utc.to_s)
+        end
+      end
+
+      context "when date is in first half year" do
+        let(:billing_at) { Time.zone.parse("02 May 2022") }
+
+        it "returns the correct day in the previous year" do
+          expect(result).to eq("2021-11-02 00:00:00 UTC")
+        end
+      end
+
+      context "when date is on the last day of the month" do
+        let(:billing_at) { Time.zone.parse("31 May 2022") }
+        let(:subscription_at) { Time.zone.parse("30 Nov 2021") }
+
+        it "returns the last day in the previous half year" do
+          expect(result).to eq("2021-11-30 00:00:00 UTC")
+        end
+      end
+
+      context "when subscription is just terminated" do
+        let(:billing_at) { Time.zone.parse("10 May 2022") }
+
+        before { subscription.mark_as_terminated!("9 May 2022") }
+
+        it "returns the correct day at the beginning of the half year" do
+          expect(result).to eq("2022-05-02 00:00:00 UTC")
+        end
+
+        context "when plan is pay in advance" do
+          let(:pay_in_advance) { true }
+
+          it "returns the correct day in the current quarter" do
+            expect(result).to eq("2022-05-02 00:00:00 UTC")
+          end
+        end
+
+        context "when billing day after last day of billing month" do
+          let(:billing_at) { Time.zone.parse("29 May 2022") }
+          let(:subscription_at) { Time.zone.parse("30 May 2021") }
+
+          it "returns the previous half year last day" do
+            expect(result).to eq("2021-11-30 00:00:00 UTC")
+          end
+        end
+
+        context "when billing day in the second month of the year" do
+          let(:billing_at) { Time.zone.parse("27 Feb 2022") }
+          let(:subscription_at) { Time.zone.parse("28 Feb 2021") }
+
+          before { subscription.mark_as_terminated!("25 Feb 2022") }
+
+          it "returns the previous half year last day" do
+            expect(result).to eq("2021-08-28 00:00:00 UTC")
+          end
+        end
+      end
+
+      #   context "when plan is in advance and date is on the last day of month" do
+      #     let(:pay_in_advance) { true }
+
+      #     let(:billing_at) { Time.zone.parse("30 Apr 2021") }
+      #     let(:subscription_at) { Time.zone.parse("31 Jan 2021") }
+
+      #     it "returns the current day" do
+      #       expect(result).to eq("2021-04-30 00:00:00 UTC")
+      #     end
+      #   end
+
+      #   context "when date is not on a billing month" do
+      #     let(:billing_at) { Time.zone.parse("8 Aug 2023") }
+      #     let(:subscription_at) { Time.zone.parse("6 Apr 2023") }
+      #     let(:current_usage) { true }
+
+      #     it "returns the date in previous billing month" do
+      #       expect(result).to eq("2023-07-06 00:00:00 UTC")
+      #     end
+      #   end
+
+      #   context "when date is not on a billing month and day is less than subscription day" do
+      #     let(:billing_at) { Time.zone.parse("4 Aug 2023") }
+      #     let(:subscription_at) { Time.zone.parse("6 Apr 2023") }
+      #     let(:current_usage) { true }
+
+      #     it "returns the date in previous billing month" do
+      #       expect(result).to eq("2023-07-06 00:00:00 UTC")
+      #     end
+      #   end
+    end
+  end
+
+  # describe "to_datetime" do
+  #   let(:result) { date_service.to_datetime.to_s }
+
+  #   context "when billing_time is calendar" do
+  #     let(:billing_time) { :calendar }
+  #     let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+  #     it "returns the end of the previous quarter" do
+  #       expect(result).to eq("2022-06-30 23:59:59 UTC")
+  #     end
+
+  #     context "when subscription is not yet started" do
+  #       let(:started_at) { nil }
+
+  #       it "returns nil" do
+  #         expect(date_service.to_datetime).to be_nil
+  #       end
+  #     end
+
+  #     context "with customer timezone" do
+  #       let(:timezone) { "America/New_York" }
+
+  #       it "takes customer timezone into account" do
+  #         expect(result).to eq("2022-04-01 03:59:59 UTC")
+  #       end
+  #     end
+
+  #     context "when plan is pay in advance" do
+  #       let(:pay_in_advance) { true }
+
+  #       it "returns the end of the quarter" do
+  #         expect(result).to eq("2022-09-30 23:59:59 UTC")
+  #       end
+  #     end
+
+  #     context "when subscription is just terminated" do
+  #       let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+  #       before do
+  #         subscription.update!(
+  #           status: :terminated,
+  #           terminated_at: Time.zone.parse("27 Jun 2022")
+  #         )
+  #       end
+
+  #       it "returns the termination date" do
+  #         expect(result).to match_datetime(subscription.terminated_at.utc)
+  #       end
+
+  #       context "with customer timezone" do
+  #         let(:timezone) { "America/New_York" }
+
+  #         it "returns the termination date" do
+  #           expect(result).to match_datetime(subscription.terminated_at.utc)
+  #         end
+  #       end
+  #     end
+  #   end
+
+  #   context "when billing_time is anniversary" do
+  #     let(:billing_time) { :anniversary }
+  #     let(:billing_at) { Time.zone.parse("02 May 2022") }
+
+  #     it "returns the day in the previous month" do
+  #       expect(result).to eq("2022-05-01 23:59:59 UTC")
+  #     end
+
+  #     context "when billing last quarter of the year" do
+  #       let(:billing_at) { Time.zone.parse("02 Feb 2022") }
+
+  #       it "returns the day in the previous month" do
+  #         expect(result).to eq("2022-02-01 23:59:59 UTC")
+  #       end
+  #     end
+
+  #     context "when billing subscription day does not exist in the month" do
+  #       let(:subscription_at) { Time.zone.parse("30 Nov 2021") }
+  #       let(:billing_at) { Time.zone.parse("01 Mar 2022") }
+
+  #       it "returns the last day of the previous month" do
+  #         expect(result).to eq("2022-02-27 23:59:59 UTC")
+  #       end
+
+  #       context "when subscription is not the last day of the month" do
+  #         let(:subscription_at) { Time.zone.parse("30 Jan 2022") }
+  #         let(:billing_at) { Time.zone.parse("30 Apr 2022") }
+
+  #         it "returns the last day of the month" do
+  #           expect(result).to eq("2022-04-29 23:59:59 UTC")
+  #         end
+  #       end
+  #     end
+
+  #     context "when anniversary date is first day of the quarter" do
+  #       let(:subscription_at) { Time.zone.parse("01 Oct 2021") }
+  #       let(:billing_at) { Time.zone.parse("02 Apr 2022") }
+
+  #       it "returns the last day of the previous quarter" do
+  #         expect(result).to eq("2022-03-31 23:59:59 UTC")
+  #       end
+  #     end
+
+  #     context "when plan is pay in advance" do
+  #       before { plan.update!(pay_in_advance: true) }
+
+  #       it "returns the end of the current period" do
+  #         expect(result).to eq("2022-08-01 23:59:59 UTC")
+  #       end
+  #     end
+
+  #     context "when subscription is just terminated" do
+  #       before do
+  #         subscription.update!(
+  #           status: :terminated,
+  #           terminated_at: Time.zone.parse("30 Apr 2022")
+  #         )
+  #       end
+
+  #       it "returns the termination date" do
+  #         expect(result).to match_datetime(subscription.terminated_at.utc)
+  #       end
+  #     end
+  #   end
+  # end
+
+  # describe "charges_from_datetime" do
+  #   let(:result) { date_service.charges_from_datetime.to_s }
+
+  #   context "when billing_time is calendar" do
+  #     let(:billing_time) { :calendar }
+  #     let(:billing_at) { Time.zone.parse("01 Apr 2022") }
+
+  #     it "returns from_datetime" do
+  #       expect(result).to eq(date_service.from_datetime.to_s)
+  #     end
+
+  #     context "when subscription is not yet started" do
+  #       let(:started_at) { nil }
+
+  #       it "returns nil" do
+  #         expect(date_service.charges_from_datetime).to be_nil
+  #       end
+  #     end
+
+  #     context "with customer timezone" do
+  #       let(:timezone) { "America/New_York" }
+
+  #       it "takes customer timezone into account" do
+  #         expect(result).to eq(date_service.from_datetime.to_s)
+  #       end
+
+  #       context "when timezone has changed" do
+  #         let(:billing_at) { Time.zone.parse("02 Apr 2022") }
+
+  #         let(:previous_invoice_subscription) do
+  #           create(
+  #             :invoice_subscription,
+  #             subscription:,
+  #             charges_to_datetime: "2021-12-31T23:59:59Z"
+  #           )
+  #         end
+
+  #         before do
+  #           previous_invoice_subscription
+  #           subscription.customer.update!(timezone: "America/Los_Angeles")
+  #         end
+
+  #         it "takes previous invoice into account" do
+  #           expect(result).to match_datetime("2022-01-01 00:00:00")
+  #         end
+  #       end
+  #     end
+
+  #     context "when subscription started in the middle of a period" do
+  #       let(:started_at) { Time.zone.parse("03 Apr 2022") }
+
+  #       it "returns the start date" do
+  #         expect(result).to eq(subscription.started_at.utc.to_s)
+  #       end
+  #     end
+
+  #     context "when plan is pay in advance" do
+  #       let(:pay_in_advance) { true }
+  #       let(:subscription_at) { Time.zone.parse("01 Jan 2020") }
+
+  #       it "returns the start of the previous period" do
+  #         expect(result).to eq("2022-01-01 00:00:00 UTC")
+  #       end
+  #     end
+  #   end
+
+  #   context "when billing_time is anniversary" do
+  #     let(:billing_time) { :anniversary }
+  #     let(:billing_at) { Time.zone.parse("02 May 2022") }
+
+  #     it "returns from_datetime" do
+  #       expect(result).to eq(date_service.from_datetime.to_s)
+  #     end
+
+  #     context "when subscription started in the middle of a period" do
+  #       let(:started_at) { Time.zone.parse("03 May 2022") }
+
+  #       it "returns the start date" do
+  #         expect(result).to eq(subscription.started_at.utc.to_s)
+  #       end
+  #     end
+
+  #     context "when plan is pay in advance" do
+  #       let(:pay_in_advance) { true }
+  #       let(:subscription_at) { Time.zone.parse("02 Feb 2020") }
+
+  #       it "returns the start of the previous period" do
+  #         expect(result).to eq("2022-02-02 00:00:00 UTC")
+  #       end
+  #     end
+  #   end
+  # end
+
+  # describe "charges_to_datetime" do
+  #   let(:result) { date_service.charges_to_datetime.to_s }
+
+  #   context "when billing_time is calendar" do
+  #     let(:billing_time) { :calendar }
+  #     let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+  #     it "returns to_date" do
+  #       expect(result).to eq(date_service.to_datetime.to_s)
+  #     end
+
+  #     context "when subscription is not yet started" do
+  #       let(:started_at) { nil }
+
+  #       it "returns nil" do
+  #         expect(date_service.charges_to_datetime).to be_nil
+  #       end
+  #     end
+
+  #     context "with customer timezone" do
+  #       let(:timezone) { "America/New_York" }
+
+  #       it "takes customer timezone into account" do
+  #         expect(result).to eq(date_service.to_datetime.to_s)
+  #       end
+  #     end
+
+  #     context "when subscription is terminated in the middle of a period" do
+  #       let(:terminated_at) { Time.zone.parse("15 Jun 2022") }
+
+  #       before do
+  #         subscription.update!(status: :terminated, terminated_at:)
+  #       end
+
+  #       it "returns the terminated date" do
+  #         expect(result).to eq(subscription.terminated_at.utc.to_s)
+  #       end
+  #     end
+
+  #     context "when plan is pay in advance" do
+  #       let(:pay_in_advance) { true }
+
+  #       it "returns the end of the previous period" do
+  #         expect(result).to eq((date_service.from_datetime - 1.day).end_of_day.to_s)
+  #       end
+  #     end
+  #   end
+
+  #   context "when billing_time is anniversary" do
+  #     let(:billing_time) { :anniversary }
+  #     let(:billing_at) { Time.zone.parse("02 May 2022") }
+
+  #     it "returns to_date" do
+  #       expect(result).to eq(date_service.to_datetime.to_s)
+  #     end
+
+  #     context "when subscription is terminated in the middle of a period" do
+  #       let(:terminated_at) { Time.zone.parse("15 Apr 2022") }
+
+  #       before do
+  #         subscription.update!(status: :terminated, terminated_at:)
+  #       end
+
+  #       it "returns the terminated date" do
+  #         expect(result).to eq(subscription.terminated_at.utc.to_s)
+  #       end
+  #     end
+
+  #     context "when plan is pay in advance" do
+  #       let(:pay_in_advance) { true }
+
+  #       it "returns the end of the previous period" do
+  #         expect(result).to eq((date_service.from_datetime - 1.day).end_of_day.to_s)
+  #       end
+  #     end
+  #   end
+  # end
+
+  # describe "next_end_of_period" do
+  #   let(:result) { date_service.next_end_of_period.to_s }
+
+  #   context "when billing_time is calendar" do
+  #     let(:billing_time) { :calendar }
+  #     let(:billing_at) { Time.zone.parse("02 Jul 2022") }
+
+  #     it "returns the last day of the month" do
+  #       expect(result).to eq("2022-09-30 23:59:59 UTC")
+  #     end
+
+  #     context "with customer timezone" do
+  #       let(:timezone) { "America/New_York" }
+
+  #       it "takes customer timezone into account" do
+  #         expect(result).to eq("2022-10-01 03:59:59 UTC")
+  #       end
+  #     end
+  #   end
+
+  #   context "when billing_time is anniversary" do
+  #     let(:billing_time) { :anniversary }
+  #     let(:billing_at) { Time.zone.parse("07 May 2022") }
+
+  #     it "returns the end of the billing month" do
+  #       expect(result).to eq("2022-08-01 23:59:59 UTC")
+  #     end
+
+  #     context "with customer timezone" do
+  #       let(:timezone) { "America/New_York" }
+
+  #       it "takes customer timezone into account" do
+  #         expect(result).to eq("2022-08-01 03:59:59 UTC")
+  #       end
+  #     end
+
+  #     context "when end of billing month is in next year" do
+  #       let(:billing_at) { Time.zone.parse("02 Nov 2021") }
+
+  #       it { expect(result).to eq("2022-02-01 23:59:59 UTC") }
+  #     end
+
+  #     context "when date is the end of the period" do
+  #       let(:billing_at) { Time.zone.parse("01 May 2022") }
+
+  #       it "returns the date" do
+  #         expect(result).to eq(billing_at.utc.end_of_day.to_s)
+  #       end
+  #     end
+  #   end
+  # end
+
+  # describe "previous_beginning_of_period" do
+  #   let(:result) { date_service.previous_beginning_of_period(current_period:).to_s }
+
+  #   let(:current_period) { false }
+
+  #   context "when billing_time is calendar" do
+  #     let(:billing_time) { :calendar }
+  #     let(:billing_at) { Time.zone.parse("02 Jul 2022") }
+
+  #     it "returns the first day of the previous month" do
+  #       expect(result).to eq("2022-04-01 00:00:00 UTC")
+  #     end
+
+  #     context "with customer timezone" do
+  #       let(:timezone) { "America/New_York" }
+
+  #       it "takes customer timezone into account" do
+  #         expect(result).to eq("2022-04-01 04:00:00 UTC")
+  #       end
+  #     end
+
+  #     context "with current period argument" do
+  #       let(:current_period) { true }
+
+  #       it "returns the first day of the month" do
+  #         expect(result).to eq("2022-07-01 00:00:00 UTC")
+  #       end
+  #     end
+  #   end
+
+  #   context "when billing_time is anniversary" do
+  #     let(:billing_time) { :anniversary }
+  #     let(:billing_at) { Time.zone.parse("03 May 2022") }
+
+  #     it "returns the beginning of the previous period" do
+  #       expect(result).to eq("2022-02-02 00:00:00 UTC")
+  #     end
+
+  #     context "with customer timezone" do
+  #       let(:timezone) { "America/New_York" }
+
+  #       it "takes customer timezone into account" do
+  #         expect(result).to eq("2022-02-01 05:00:00 UTC")
+  #       end
+  #     end
+
+  #     context "with current period argument" do
+  #       let(:current_period) { true }
+
+  #       it "returns the beginning of the current period" do
+  #         expect(result).to eq("2022-05-02 00:00:00 UTC")
+  #       end
+  #     end
+  #   end
+  # end
+
+  # describe "single_day_price" do
+  #   let(:result) { date_service.single_day_price }
+
+  #   context "when billing_time is calendar" do
+  #     let(:billing_time) { :calendar }
+  #     let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+  #     it "returns the price of single day" do
+  #       expect(result).to eq(plan.amount_cents.fdiv(91))
+  #     end
+
+  #     context "when on a leap year" do
+  #       let(:subscription_at) { Time.zone.parse("28 Feb 2019") }
+  #       let(:billing_at) { Time.zone.parse("01 Apr 2020") }
+
+  #       it "returns the price of single day" do
+  #         expect(result).to eq(plan.amount_cents.fdiv(91))
+  #       end
+  #     end
+  #   end
+
+  #   context "when billing_time is anniversary" do
+  #     let(:billing_time) { :anniversary }
+  #     let(:billing_at) { Time.zone.parse("02 May 2020") }
+
+  #     it "returns the price of single day" do
+  #       expect(result).to eq(plan.amount_cents.fdiv(90))
+  #     end
+
+  #     context "when not on a leap year" do
+  #       let(:billing_at) { Time.zone.parse("02 May 2021") }
+
+  #       it "returns the month duration" do
+  #         expect(result).to eq(plan.amount_cents.fdiv(89))
+  #       end
+  #     end
+  #   end
+  # end
+
+  # describe "charges_duration_in_days" do
+  #   let(:result) { date_service.charges_duration_in_days }
+
+  #   context "when billing_time is calendar" do
+  #     let(:billing_time) { :calendar }
+  #     let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+  #     it "returns the quarter duration" do
+  #       expect(result).to eq(91)
+  #     end
+
+  #     context "when on a leap year" do
+  #       let(:subscription_at) { Time.zone.parse("28 Feb 2019") }
+  #       let(:billing_at) { Time.zone.parse("01 Apr 2020") }
+
+  #       it "returns the duration in days" do
+  #         expect(result).to eq(91)
+  #       end
+  #     end
+  #   end
+
+  #   context "when billing_time is anniversary" do
+  #     let(:billing_time) { :anniversary }
+  #     let(:billing_at) { Time.zone.parse("02 May 2020") }
+
+  #     it "returns the month duration" do
+  #       expect(result).to eq(90)
+  #     end
+
+  #     context "when not on a leap year" do
+  #       let(:subscription_at) { Time.zone.parse("02 Feb 2019") }
+  #       let(:billing_at) { Time.zone.parse("02 May 2021") }
+
+  #       it "returns the duration in days" do
+  #         expect(result).to eq(89)
+  #       end
+  #     end
+  #   end
+  # end
+end

--- a/spec/services/subscriptions/dates/semiannual_service_spec.rb
+++ b/spec/services/subscriptions/dates/semiannual_service_spec.rb
@@ -696,15 +696,15 @@ RSpec.describe Subscriptions::Dates::SemiannualService, type: :service do
         end
       end
 
-      context "when billing month is June" do
-        let(:billing_at) { Time.zone.parse("15 Jun 2022") }
+      context "when billing month is July" do
+        let(:billing_at) { Time.zone.parse("15 Jul 2022") }
 
         it "returns true" do
           expect(result).to be true
         end
       end
 
-      context "when billing month is not January or June" do
+      context "when billing month is not January or July" do
         let(:billing_at) { Time.zone.parse("15 Mar 2022") }
 
         it "returns false" do
@@ -758,8 +758,8 @@ RSpec.describe Subscriptions::Dates::SemiannualService, type: :service do
         end
       end
 
-      context "when in June of subscription year" do
-        let(:billing_at) { Time.zone.parse("15 Jun 2021") }
+      context "when in July of subscription year" do
+        let(:billing_at) { Time.zone.parse("15 Jul 2021") }
 
         it "returns true" do
           expect(result).to be true
@@ -774,7 +774,7 @@ RSpec.describe Subscriptions::Dates::SemiannualService, type: :service do
         end
       end
 
-      context "when not in January or June" do
+      context "when not in January or July" do
         let(:billing_at) { Time.zone.parse("15 Mar 2021") }
 
         it "returns false" do

--- a/spec/services/subscriptions/dates/semiannual_service_spec.rb
+++ b/spec/services/subscriptions/dates/semiannual_service_spec.rb
@@ -160,519 +160,664 @@ RSpec.describe Subscriptions::Dates::SemiannualService, type: :service do
         end
       end
 
-      #   context "when plan is in advance and date is on the last day of month" do
-      #     let(:pay_in_advance) { true }
+      context "when plan is in advance and date is on the last day of month" do
+        let(:pay_in_advance) { true }
 
-      #     let(:billing_at) { Time.zone.parse("30 Apr 2021") }
-      #     let(:subscription_at) { Time.zone.parse("31 Jan 2021") }
+        let(:billing_at) { Time.zone.parse("30 Apr 2021") }
+        let(:subscription_at) { Time.zone.parse("31 Jan 2021") }
 
-      #     it "returns the current day" do
-      #       expect(result).to eq("2021-04-30 00:00:00 UTC")
-      #     end
-      #   end
+        it "returns the current day" do
+          expect(result).to eq("2021-04-30 00:00:00 UTC")
+        end
+      end
 
-      #   context "when date is not on a billing month" do
-      #     let(:billing_at) { Time.zone.parse("8 Aug 2023") }
-      #     let(:subscription_at) { Time.zone.parse("6 Apr 2023") }
-      #     let(:current_usage) { true }
+      context "when date is not on a billing month" do
+        let(:billing_at) { Time.zone.parse("8 Aug 2023") }
+        let(:subscription_at) { Time.zone.parse("6 Jan 2023") }
+        let(:current_usage) { true }
 
-      #     it "returns the date in previous billing month" do
-      #       expect(result).to eq("2023-07-06 00:00:00 UTC")
-      #     end
-      #   end
+        it "returns the date in previous billing month" do
+          expect(result).to eq("2023-07-06 00:00:00 UTC")
+        end
+      end
 
-      #   context "when date is not on a billing month and day is less than subscription day" do
-      #     let(:billing_at) { Time.zone.parse("4 Aug 2023") }
-      #     let(:subscription_at) { Time.zone.parse("6 Apr 2023") }
-      #     let(:current_usage) { true }
+      context "when date is not on a billing month and day is less than subscription day" do
+        let(:billing_at) { Time.zone.parse("4 Aug 2023") }
+        let(:subscription_at) { Time.zone.parse("6 Jan 2023") }
+        let(:current_usage) { true }
 
-      #     it "returns the date in previous billing month" do
-      #       expect(result).to eq("2023-07-06 00:00:00 UTC")
-      #     end
-      #   end
+        it "returns the date in previous billing month" do
+          expect(result).to eq("2023-07-06 00:00:00 UTC")
+        end
+      end
     end
   end
 
-  # describe "to_datetime" do
-  #   let(:result) { date_service.to_datetime.to_s }
-
-  #   context "when billing_time is calendar" do
-  #     let(:billing_time) { :calendar }
-  #     let(:billing_at) { Time.zone.parse("01 Jul 2022") }
-
-  #     it "returns the end of the previous quarter" do
-  #       expect(result).to eq("2022-06-30 23:59:59 UTC")
-  #     end
-
-  #     context "when subscription is not yet started" do
-  #       let(:started_at) { nil }
-
-  #       it "returns nil" do
-  #         expect(date_service.to_datetime).to be_nil
-  #       end
-  #     end
-
-  #     context "with customer timezone" do
-  #       let(:timezone) { "America/New_York" }
-
-  #       it "takes customer timezone into account" do
-  #         expect(result).to eq("2022-04-01 03:59:59 UTC")
-  #       end
-  #     end
-
-  #     context "when plan is pay in advance" do
-  #       let(:pay_in_advance) { true }
-
-  #       it "returns the end of the quarter" do
-  #         expect(result).to eq("2022-09-30 23:59:59 UTC")
-  #       end
-  #     end
-
-  #     context "when subscription is just terminated" do
-  #       let(:billing_at) { Time.zone.parse("01 Jul 2022") }
-
-  #       before do
-  #         subscription.update!(
-  #           status: :terminated,
-  #           terminated_at: Time.zone.parse("27 Jun 2022")
-  #         )
-  #       end
-
-  #       it "returns the termination date" do
-  #         expect(result).to match_datetime(subscription.terminated_at.utc)
-  #       end
-
-  #       context "with customer timezone" do
-  #         let(:timezone) { "America/New_York" }
-
-  #         it "returns the termination date" do
-  #           expect(result).to match_datetime(subscription.terminated_at.utc)
-  #         end
-  #       end
-  #     end
-  #   end
-
-  #   context "when billing_time is anniversary" do
-  #     let(:billing_time) { :anniversary }
-  #     let(:billing_at) { Time.zone.parse("02 May 2022") }
-
-  #     it "returns the day in the previous month" do
-  #       expect(result).to eq("2022-05-01 23:59:59 UTC")
-  #     end
-
-  #     context "when billing last quarter of the year" do
-  #       let(:billing_at) { Time.zone.parse("02 Feb 2022") }
-
-  #       it "returns the day in the previous month" do
-  #         expect(result).to eq("2022-02-01 23:59:59 UTC")
-  #       end
-  #     end
-
-  #     context "when billing subscription day does not exist in the month" do
-  #       let(:subscription_at) { Time.zone.parse("30 Nov 2021") }
-  #       let(:billing_at) { Time.zone.parse("01 Mar 2022") }
-
-  #       it "returns the last day of the previous month" do
-  #         expect(result).to eq("2022-02-27 23:59:59 UTC")
-  #       end
-
-  #       context "when subscription is not the last day of the month" do
-  #         let(:subscription_at) { Time.zone.parse("30 Jan 2022") }
-  #         let(:billing_at) { Time.zone.parse("30 Apr 2022") }
-
-  #         it "returns the last day of the month" do
-  #           expect(result).to eq("2022-04-29 23:59:59 UTC")
-  #         end
-  #       end
-  #     end
-
-  #     context "when anniversary date is first day of the quarter" do
-  #       let(:subscription_at) { Time.zone.parse("01 Oct 2021") }
-  #       let(:billing_at) { Time.zone.parse("02 Apr 2022") }
-
-  #       it "returns the last day of the previous quarter" do
-  #         expect(result).to eq("2022-03-31 23:59:59 UTC")
-  #       end
-  #     end
-
-  #     context "when plan is pay in advance" do
-  #       before { plan.update!(pay_in_advance: true) }
-
-  #       it "returns the end of the current period" do
-  #         expect(result).to eq("2022-08-01 23:59:59 UTC")
-  #       end
-  #     end
-
-  #     context "when subscription is just terminated" do
-  #       before do
-  #         subscription.update!(
-  #           status: :terminated,
-  #           terminated_at: Time.zone.parse("30 Apr 2022")
-  #         )
-  #       end
-
-  #       it "returns the termination date" do
-  #         expect(result).to match_datetime(subscription.terminated_at.utc)
-  #       end
-  #     end
-  #   end
-  # end
-
-  # describe "charges_from_datetime" do
-  #   let(:result) { date_service.charges_from_datetime.to_s }
-
-  #   context "when billing_time is calendar" do
-  #     let(:billing_time) { :calendar }
-  #     let(:billing_at) { Time.zone.parse("01 Apr 2022") }
-
-  #     it "returns from_datetime" do
-  #       expect(result).to eq(date_service.from_datetime.to_s)
-  #     end
-
-  #     context "when subscription is not yet started" do
-  #       let(:started_at) { nil }
-
-  #       it "returns nil" do
-  #         expect(date_service.charges_from_datetime).to be_nil
-  #       end
-  #     end
-
-  #     context "with customer timezone" do
-  #       let(:timezone) { "America/New_York" }
-
-  #       it "takes customer timezone into account" do
-  #         expect(result).to eq(date_service.from_datetime.to_s)
-  #       end
-
-  #       context "when timezone has changed" do
-  #         let(:billing_at) { Time.zone.parse("02 Apr 2022") }
-
-  #         let(:previous_invoice_subscription) do
-  #           create(
-  #             :invoice_subscription,
-  #             subscription:,
-  #             charges_to_datetime: "2021-12-31T23:59:59Z"
-  #           )
-  #         end
-
-  #         before do
-  #           previous_invoice_subscription
-  #           subscription.customer.update!(timezone: "America/Los_Angeles")
-  #         end
-
-  #         it "takes previous invoice into account" do
-  #           expect(result).to match_datetime("2022-01-01 00:00:00")
-  #         end
-  #       end
-  #     end
-
-  #     context "when subscription started in the middle of a period" do
-  #       let(:started_at) { Time.zone.parse("03 Apr 2022") }
-
-  #       it "returns the start date" do
-  #         expect(result).to eq(subscription.started_at.utc.to_s)
-  #       end
-  #     end
-
-  #     context "when plan is pay in advance" do
-  #       let(:pay_in_advance) { true }
-  #       let(:subscription_at) { Time.zone.parse("01 Jan 2020") }
-
-  #       it "returns the start of the previous period" do
-  #         expect(result).to eq("2022-01-01 00:00:00 UTC")
-  #       end
-  #     end
-  #   end
-
-  #   context "when billing_time is anniversary" do
-  #     let(:billing_time) { :anniversary }
-  #     let(:billing_at) { Time.zone.parse("02 May 2022") }
-
-  #     it "returns from_datetime" do
-  #       expect(result).to eq(date_service.from_datetime.to_s)
-  #     end
-
-  #     context "when subscription started in the middle of a period" do
-  #       let(:started_at) { Time.zone.parse("03 May 2022") }
-
-  #       it "returns the start date" do
-  #         expect(result).to eq(subscription.started_at.utc.to_s)
-  #       end
-  #     end
-
-  #     context "when plan is pay in advance" do
-  #       let(:pay_in_advance) { true }
-  #       let(:subscription_at) { Time.zone.parse("02 Feb 2020") }
-
-  #       it "returns the start of the previous period" do
-  #         expect(result).to eq("2022-02-02 00:00:00 UTC")
-  #       end
-  #     end
-  #   end
-  # end
-
-  # describe "charges_to_datetime" do
-  #   let(:result) { date_service.charges_to_datetime.to_s }
-
-  #   context "when billing_time is calendar" do
-  #     let(:billing_time) { :calendar }
-  #     let(:billing_at) { Time.zone.parse("01 Jul 2022") }
-
-  #     it "returns to_date" do
-  #       expect(result).to eq(date_service.to_datetime.to_s)
-  #     end
-
-  #     context "when subscription is not yet started" do
-  #       let(:started_at) { nil }
-
-  #       it "returns nil" do
-  #         expect(date_service.charges_to_datetime).to be_nil
-  #       end
-  #     end
-
-  #     context "with customer timezone" do
-  #       let(:timezone) { "America/New_York" }
-
-  #       it "takes customer timezone into account" do
-  #         expect(result).to eq(date_service.to_datetime.to_s)
-  #       end
-  #     end
-
-  #     context "when subscription is terminated in the middle of a period" do
-  #       let(:terminated_at) { Time.zone.parse("15 Jun 2022") }
-
-  #       before do
-  #         subscription.update!(status: :terminated, terminated_at:)
-  #       end
-
-  #       it "returns the terminated date" do
-  #         expect(result).to eq(subscription.terminated_at.utc.to_s)
-  #       end
-  #     end
-
-  #     context "when plan is pay in advance" do
-  #       let(:pay_in_advance) { true }
-
-  #       it "returns the end of the previous period" do
-  #         expect(result).to eq((date_service.from_datetime - 1.day).end_of_day.to_s)
-  #       end
-  #     end
-  #   end
-
-  #   context "when billing_time is anniversary" do
-  #     let(:billing_time) { :anniversary }
-  #     let(:billing_at) { Time.zone.parse("02 May 2022") }
-
-  #     it "returns to_date" do
-  #       expect(result).to eq(date_service.to_datetime.to_s)
-  #     end
-
-  #     context "when subscription is terminated in the middle of a period" do
-  #       let(:terminated_at) { Time.zone.parse("15 Apr 2022") }
-
-  #       before do
-  #         subscription.update!(status: :terminated, terminated_at:)
-  #       end
-
-  #       it "returns the terminated date" do
-  #         expect(result).to eq(subscription.terminated_at.utc.to_s)
-  #       end
-  #     end
-
-  #     context "when plan is pay in advance" do
-  #       let(:pay_in_advance) { true }
-
-  #       it "returns the end of the previous period" do
-  #         expect(result).to eq((date_service.from_datetime - 1.day).end_of_day.to_s)
-  #       end
-  #     end
-  #   end
-  # end
-
-  # describe "next_end_of_period" do
-  #   let(:result) { date_service.next_end_of_period.to_s }
-
-  #   context "when billing_time is calendar" do
-  #     let(:billing_time) { :calendar }
-  #     let(:billing_at) { Time.zone.parse("02 Jul 2022") }
-
-  #     it "returns the last day of the month" do
-  #       expect(result).to eq("2022-09-30 23:59:59 UTC")
-  #     end
-
-  #     context "with customer timezone" do
-  #       let(:timezone) { "America/New_York" }
-
-  #       it "takes customer timezone into account" do
-  #         expect(result).to eq("2022-10-01 03:59:59 UTC")
-  #       end
-  #     end
-  #   end
-
-  #   context "when billing_time is anniversary" do
-  #     let(:billing_time) { :anniversary }
-  #     let(:billing_at) { Time.zone.parse("07 May 2022") }
-
-  #     it "returns the end of the billing month" do
-  #       expect(result).to eq("2022-08-01 23:59:59 UTC")
-  #     end
-
-  #     context "with customer timezone" do
-  #       let(:timezone) { "America/New_York" }
-
-  #       it "takes customer timezone into account" do
-  #         expect(result).to eq("2022-08-01 03:59:59 UTC")
-  #       end
-  #     end
-
-  #     context "when end of billing month is in next year" do
-  #       let(:billing_at) { Time.zone.parse("02 Nov 2021") }
-
-  #       it { expect(result).to eq("2022-02-01 23:59:59 UTC") }
-  #     end
-
-  #     context "when date is the end of the period" do
-  #       let(:billing_at) { Time.zone.parse("01 May 2022") }
-
-  #       it "returns the date" do
-  #         expect(result).to eq(billing_at.utc.end_of_day.to_s)
-  #       end
-  #     end
-  #   end
-  # end
-
-  # describe "previous_beginning_of_period" do
-  #   let(:result) { date_service.previous_beginning_of_period(current_period:).to_s }
-
-  #   let(:current_period) { false }
-
-  #   context "when billing_time is calendar" do
-  #     let(:billing_time) { :calendar }
-  #     let(:billing_at) { Time.zone.parse("02 Jul 2022") }
-
-  #     it "returns the first day of the previous month" do
-  #       expect(result).to eq("2022-04-01 00:00:00 UTC")
-  #     end
-
-  #     context "with customer timezone" do
-  #       let(:timezone) { "America/New_York" }
-
-  #       it "takes customer timezone into account" do
-  #         expect(result).to eq("2022-04-01 04:00:00 UTC")
-  #       end
-  #     end
-
-  #     context "with current period argument" do
-  #       let(:current_period) { true }
-
-  #       it "returns the first day of the month" do
-  #         expect(result).to eq("2022-07-01 00:00:00 UTC")
-  #       end
-  #     end
-  #   end
-
-  #   context "when billing_time is anniversary" do
-  #     let(:billing_time) { :anniversary }
-  #     let(:billing_at) { Time.zone.parse("03 May 2022") }
-
-  #     it "returns the beginning of the previous period" do
-  #       expect(result).to eq("2022-02-02 00:00:00 UTC")
-  #     end
-
-  #     context "with customer timezone" do
-  #       let(:timezone) { "America/New_York" }
-
-  #       it "takes customer timezone into account" do
-  #         expect(result).to eq("2022-02-01 05:00:00 UTC")
-  #       end
-  #     end
-
-  #     context "with current period argument" do
-  #       let(:current_period) { true }
-
-  #       it "returns the beginning of the current period" do
-  #         expect(result).to eq("2022-05-02 00:00:00 UTC")
-  #       end
-  #     end
-  #   end
-  # end
-
-  # describe "single_day_price" do
-  #   let(:result) { date_service.single_day_price }
-
-  #   context "when billing_time is calendar" do
-  #     let(:billing_time) { :calendar }
-  #     let(:billing_at) { Time.zone.parse("01 Jul 2022") }
-
-  #     it "returns the price of single day" do
-  #       expect(result).to eq(plan.amount_cents.fdiv(91))
-  #     end
-
-  #     context "when on a leap year" do
-  #       let(:subscription_at) { Time.zone.parse("28 Feb 2019") }
-  #       let(:billing_at) { Time.zone.parse("01 Apr 2020") }
-
-  #       it "returns the price of single day" do
-  #         expect(result).to eq(plan.amount_cents.fdiv(91))
-  #       end
-  #     end
-  #   end
-
-  #   context "when billing_time is anniversary" do
-  #     let(:billing_time) { :anniversary }
-  #     let(:billing_at) { Time.zone.parse("02 May 2020") }
-
-  #     it "returns the price of single day" do
-  #       expect(result).to eq(plan.amount_cents.fdiv(90))
-  #     end
-
-  #     context "when not on a leap year" do
-  #       let(:billing_at) { Time.zone.parse("02 May 2021") }
-
-  #       it "returns the month duration" do
-  #         expect(result).to eq(plan.amount_cents.fdiv(89))
-  #       end
-  #     end
-  #   end
-  # end
-
-  # describe "charges_duration_in_days" do
-  #   let(:result) { date_service.charges_duration_in_days }
-
-  #   context "when billing_time is calendar" do
-  #     let(:billing_time) { :calendar }
-  #     let(:billing_at) { Time.zone.parse("01 Jul 2022") }
-
-  #     it "returns the quarter duration" do
-  #       expect(result).to eq(91)
-  #     end
-
-  #     context "when on a leap year" do
-  #       let(:subscription_at) { Time.zone.parse("28 Feb 2019") }
-  #       let(:billing_at) { Time.zone.parse("01 Apr 2020") }
-
-  #       it "returns the duration in days" do
-  #         expect(result).to eq(91)
-  #       end
-  #     end
-  #   end
-
-  #   context "when billing_time is anniversary" do
-  #     let(:billing_time) { :anniversary }
-  #     let(:billing_at) { Time.zone.parse("02 May 2020") }
-
-  #     it "returns the month duration" do
-  #       expect(result).to eq(90)
-  #     end
-
-  #     context "when not on a leap year" do
-  #       let(:subscription_at) { Time.zone.parse("02 Feb 2019") }
-  #       let(:billing_at) { Time.zone.parse("02 May 2021") }
-
-  #       it "returns the duration in days" do
-  #         expect(result).to eq(89)
-  #       end
-  #     end
-  #   end
-  # end
+  describe "to_datetime" do
+    let(:result) { date_service.to_datetime.to_s }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+      it "returns the end of the previous half year" do
+        expect(result).to eq("2022-06-30 23:59:59 UTC")
+      end
+
+      context "when subscription is not yet started" do
+        let(:started_at) { nil }
+
+        it "returns nil" do
+          expect(date_service.to_datetime).to be_nil
+        end
+      end
+
+      context "with customer timezone" do
+        let(:timezone) { "America/New_York" }
+
+        it "takes customer timezone into account" do
+          expect(result).to eq("2022-01-01 04:59:59 UTC")
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+
+        it "returns the end of the half year" do
+          expect(result).to eq("2022-12-31 23:59:59 UTC")
+        end
+      end
+
+      context "when subscription is just terminated" do
+        let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+        before do
+          subscription.update!(
+            status: :terminated,
+            terminated_at: Time.zone.parse("27 Jun 2022")
+          )
+        end
+
+        it "returns the termination date" do
+          expect(result).to match_datetime(subscription.terminated_at.utc)
+        end
+
+        context "with customer timezone" do
+          let(:timezone) { "America/New_York" }
+
+          it "returns the termination date" do
+            expect(result).to match_datetime(subscription.terminated_at.utc)
+          end
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:subscription_at) { Time.zone.parse("02 Nov 2021") }
+      let(:billing_at) { Time.zone.parse("02 May 2022") }
+
+      it "returns the day in the previous month" do
+        expect(result).to eq("2022-05-01 23:59:59 UTC")
+      end
+
+      context "when billing last half year of the year" do
+        let(:subscription_at) { Time.zone.parse("02 Feb 2021") }
+        let(:billing_at) { Time.zone.parse("02 Feb 2022") }
+
+        it "returns the day in the previous month" do
+          expect(result).to eq("2022-02-01 23:59:59 UTC")
+        end
+      end
+
+      context "when billing subscription day does not exist in the month" do
+        let(:subscription_at) { Time.zone.parse("30 Nov 2021") }
+        let(:billing_at) { Time.zone.parse("01 Jun 2022") }
+
+        it "returns the last day of the previous month" do
+          expect(result).to eq("2022-05-29 23:59:59 UTC")
+        end
+
+        context "when subscription is not the last day of the month" do
+          let(:subscription_at) { Time.zone.parse("30 Jan 2022") }
+          let(:billing_at) { Time.zone.parse("30 Jul 2022") }
+
+          it "returns the last day of the month" do
+            expect(result).to eq("2022-07-29 23:59:59 UTC")
+          end
+        end
+      end
+
+      context "when anniversary date is first day of the half year" do
+        let(:subscription_at) { Time.zone.parse("01 Oct 2021") }
+        let(:billing_at) { Time.zone.parse("02 Apr 2022") }
+
+        it "returns the last day of the previous half year" do
+          expect(result).to eq("2022-03-31 23:59:59 UTC")
+        end
+      end
+
+      context "when plan is pay in advance" do
+        before { plan.update!(pay_in_advance: true) }
+
+        it "returns the end of the current period" do
+          expect(result).to eq("2022-11-01 23:59:59 UTC")
+        end
+      end
+
+      context "when subscription is just terminated" do
+        before do
+          subscription.update!(
+            status: :terminated,
+            terminated_at: Time.zone.parse("30 Apr 2022")
+          )
+        end
+
+        it "returns the termination date" do
+          expect(result).to match_datetime(subscription.terminated_at.utc)
+        end
+      end
+    end
+  end
+
+  describe "charges_from_datetime" do
+    let(:result) { date_service.charges_from_datetime.to_s }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+      it "returns from_datetime" do
+        expect(result).to eq(date_service.from_datetime.to_s)
+      end
+
+      context "when subscription is not yet started" do
+        let(:started_at) { nil }
+
+        it "returns nil" do
+          expect(date_service.charges_from_datetime).to be_nil
+        end
+      end
+
+      context "with customer timezone" do
+        let(:timezone) { "America/New_York" }
+
+        it "takes customer timezone into account" do
+          expect(result).to eq(date_service.from_datetime.to_s)
+        end
+
+        context "when timezone has changed" do
+          let(:billing_at) { Time.zone.parse("02 Jul 2022") }
+
+          let(:previous_invoice_subscription) do
+            create(
+              :invoice_subscription,
+              subscription:,
+              charges_to_datetime: "2021-12-31T23:59:59Z"
+            )
+          end
+
+          before do
+            previous_invoice_subscription
+            subscription.customer.update!(timezone: "America/Los_Angeles")
+          end
+
+          it "takes previous invoice into account" do
+            expect(result).to match_datetime("2022-01-01 00:00:00")
+          end
+        end
+      end
+
+      context "when subscription started in the middle of a period" do
+        let(:started_at) { Time.zone.parse("03 Apr 2022") }
+
+        it "returns the start date" do
+          expect(result).to eq(subscription.started_at.utc.to_s)
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+        let(:subscription_at) { Time.zone.parse("01 Jan 2020") }
+
+        it "returns the start of the previous period" do
+          expect(result).to eq("2022-01-01 00:00:00 UTC")
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:billing_at) { Time.zone.parse("02 Aug 2022") }
+
+      it "returns from_datetime" do
+        expect(result).to eq(date_service.from_datetime.to_s)
+      end
+
+      context "when subscription started in the middle of a period" do
+        let(:started_at) { Time.zone.parse("03 May 2022") }
+
+        it "returns the start date" do
+          expect(result).to eq(subscription.started_at.utc.to_s)
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+        let(:subscription_at) { Time.zone.parse("02 Feb 2020") }
+
+        it "returns the start of the previous period" do
+          expect(result).to eq("2022-02-02 00:00:00 UTC")
+        end
+      end
+    end
+  end
+
+  describe "charges_to_datetime" do
+    let(:result) { date_service.charges_to_datetime.to_s }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+      it "returns to_date" do
+        expect(result).to eq(date_service.to_datetime.to_s)
+      end
+
+      context "when subscription is not yet started" do
+        let(:started_at) { nil }
+
+        it "returns nil" do
+          expect(date_service.charges_to_datetime).to be_nil
+        end
+      end
+
+      context "with customer timezone" do
+        let(:timezone) { "America/New_York" }
+
+        it "takes customer timezone into account" do
+          expect(result).to eq(date_service.to_datetime.to_s)
+        end
+      end
+
+      context "when subscription is terminated in the middle of a period" do
+        let(:terminated_at) { Time.zone.parse("15 Jun 2022") }
+
+        before do
+          subscription.update!(status: :terminated, terminated_at:)
+        end
+
+        it "returns the terminated date" do
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+
+        it "returns the end of the previous period" do
+          expect(result).to eq((date_service.from_datetime - 1.day).end_of_day.to_s)
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:billing_at) { Time.zone.parse("02 May 2022") }
+
+      it "returns to_date" do
+        expect(result).to eq(date_service.to_datetime.to_s)
+      end
+
+      context "when subscription is terminated in the middle of a period" do
+        let(:terminated_at) { Time.zone.parse("15 Apr 2022") }
+
+        before do
+          subscription.update!(status: :terminated, terminated_at:)
+        end
+
+        it "returns the terminated date" do
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+
+        it "returns the end of the previous period" do
+          expect(result).to eq((date_service.from_datetime - 1.day).end_of_day.to_s)
+        end
+      end
+    end
+  end
+
+  describe "next_end_of_period" do
+    let(:result) { date_service.next_end_of_period.to_s }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:billing_at) { Time.zone.parse("02 Jul 2022") }
+
+      it "returns the last day of the month" do
+        expect(result).to eq("2022-12-31 23:59:59 UTC")
+      end
+
+      context "with customer timezone" do
+        let(:timezone) { "America/New_York" }
+
+        it "takes customer timezone into account" do
+          expect(result).to eq("2023-01-01 04:59:59 UTC")
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:billing_at) { Time.zone.parse("07 May 2022") }
+
+      it "returns the end of the billing month" do
+        expect(result).to eq("2022-11-01 23:59:59 UTC")
+      end
+
+      context "with customer timezone" do
+        let(:timezone) { "America/New_York" }
+
+        it "takes customer timezone into account" do
+          expect(result).to eq("2022-11-01 03:59:59 UTC")
+        end
+      end
+
+      context "when end of billing month is in next year" do
+        let(:billing_at) { Time.zone.parse("02 Nov 2021") }
+
+        it { expect(result).to eq("2022-05-01 23:59:59 UTC") }
+      end
+
+      context "when date is the end of the period" do
+        let(:billing_at) { Time.zone.parse("01 May 2022") }
+
+        it "returns the date" do
+          expect(result).to eq(billing_at.utc.end_of_day.to_s)
+        end
+      end
+    end
+  end
+
+  describe "previous_beginning_of_period" do
+    let(:result) { date_service.previous_beginning_of_period(current_period:).to_s }
+
+    let(:current_period) { false }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:billing_at) { Time.zone.parse("02 Jul 2022") }
+
+      it "returns the first day of the previous month" do
+        expect(result).to eq("2022-01-01 00:00:00 UTC")
+      end
+
+      context "with customer timezone" do
+        let(:timezone) { "America/New_York" }
+
+        it "takes customer timezone into account" do
+          expect(result).to eq("2022-01-01 05:00:00 UTC")
+        end
+      end
+
+      context "with current period argument" do
+        let(:current_period) { true }
+
+        it "returns the first day of the month" do
+          expect(result).to eq("2022-07-01 00:00:00 UTC")
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:billing_at) { Time.zone.parse("03 Aug 2022") }
+
+      it "returns the beginning of the previous period" do
+        expect(result).to eq("2022-02-02 00:00:00 UTC")
+      end
+
+      context "with customer timezone" do
+        let(:timezone) { "America/New_York" }
+
+        it "takes customer timezone into account" do
+          expect(result).to eq("2022-02-01 05:00:00 UTC")
+        end
+      end
+
+      context "with current period argument" do
+        let(:current_period) { true }
+
+        it "returns the beginning of the current period" do
+          expect(result).to eq("2022-08-02 00:00:00 UTC")
+        end
+      end
+    end
+  end
+
+  describe "single_day_price" do
+    let(:result) { date_service.single_day_price }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:subscription_at) { Time.zone.parse("01 Jan 2022") }
+      let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+      it "returns the price of single day" do
+        expect(result).to eq(plan.amount_cents.fdiv(181))
+      end
+
+      context "when on a leap year" do
+        let(:subscription_at) { Time.zone.parse("01 Jan 2020") }
+        let(:billing_at) { Time.zone.parse("01 Jul 2020") }
+
+        it "returns the price of single day" do
+          expect(result).to eq(plan.amount_cents.fdiv(182))
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:subscription_at) { Time.zone.parse("01 Jan 2024") }
+      let(:billing_at) { Time.zone.parse("01 Jul 2024") }
+
+      it "returns the price of single day" do
+        expect(result).to eq(plan.amount_cents.fdiv(182))
+      end
+
+      context "when not on a leap year" do
+        let(:subscription_at) { Time.zone.parse("01 Jan 2023") }
+        let(:billing_at) { Time.zone.parse("01 Jul 2023") }
+
+        it "returns the month duration" do
+          expect(result).to eq(plan.amount_cents.fdiv(181))
+        end
+      end
+    end
+  end
+
+  describe "charges_duration_in_days" do
+    let(:result) { date_service.charges_duration_in_days }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+      it "returns the quarter duration" do
+        expect(result).to eq(181)
+      end
+
+      context "when on a leap year" do
+        let(:subscription_at) { Time.zone.parse("28 Feb 2019") }
+        let(:billing_at) { Time.zone.parse("01 Jul 2020") }
+
+        it "returns the duration in days" do
+          expect(result).to eq(182)
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:subscription_at) { Time.zone.parse("01 Jan 2024") }
+      let(:billing_at) { Time.zone.parse("01 Jul 2024") }
+
+      it "returns the month duration" do
+        expect(result).to eq(182)
+      end
+
+      context "when not on a leap year" do
+        let(:subscription_at) { Time.zone.parse("01 Jan 2023") }
+        let(:billing_at) { Time.zone.parse("01 Jul 2023") }
+
+        it "returns the duration in days" do
+          expect(result).to eq(181)
+        end
+      end
+    end
+  end
+
+  describe "first_month_in_semiannual_period?" do
+    let(:result) { date_service.first_month_in_semiannual_period? }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+
+      context "when billing month is January" do
+        let(:billing_at) { Time.zone.parse("15 Jan 2022") }
+
+        it "returns true" do
+          expect(result).to be true
+        end
+      end
+
+      context "when billing month is June" do
+        let(:billing_at) { Time.zone.parse("15 Jun 2022") }
+
+        it "returns true" do
+          expect(result).to be true
+        end
+      end
+
+      context "when billing month is not January or June" do
+        let(:billing_at) { Time.zone.parse("15 Mar 2022") }
+
+        it "returns false" do
+          expect(result).to be false
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:subscription_at) { Time.zone.parse("10 Feb 2021") }
+
+      context "when billing month matches subscription month" do
+        let(:billing_at) { Time.zone.parse("15 Feb 2022") }
+
+        it "returns true" do
+          expect(result).to be true
+        end
+      end
+
+      context "when billing month is 6 months after subscription month" do
+        let(:billing_at) { Time.zone.parse("15 Aug 2022") }
+
+        it "returns true" do
+          expect(result).to be true
+        end
+      end
+
+      context "when billing month doesn't match subscription month pattern" do
+        let(:billing_at) { Time.zone.parse("15 Apr 2022") }
+
+        it "returns false" do
+          expect(result).to be false
+        end
+      end
+    end
+  end
+
+  describe "first_month_in_first_semiannual_period?" do
+    let(:result) { date_service.first_month_in_first_semiannual_period? }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:subscription_at) { Time.zone.parse("15 Mar 2021") }
+
+      context "when in January of subscription year" do
+        let(:billing_at) { Time.zone.parse("15 Jan 2021") }
+
+        it "returns true" do
+          expect(result).to be true
+        end
+      end
+
+      context "when in June of subscription year" do
+        let(:billing_at) { Time.zone.parse("15 Jun 2021") }
+
+        it "returns true" do
+          expect(result).to be true
+        end
+      end
+
+      context "when in January but not in subscription year" do
+        let(:billing_at) { Time.zone.parse("15 Jan 2022") }
+
+        it "returns false" do
+          expect(result).to be false
+        end
+      end
+
+      context "when not in January or June" do
+        let(:billing_at) { Time.zone.parse("15 Mar 2021") }
+
+        it "returns false" do
+          expect(result).to be false
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:subscription_at) { Time.zone.parse("10 Feb 2021") }
+
+      context "when billing month and year match subscription month and year" do
+        let(:billing_at) { Time.zone.parse("15 Feb 2021") }
+
+        it "returns true" do
+          expect(result).to be true
+        end
+      end
+
+      context "when billing month matches but year doesn't" do
+        let(:billing_at) { Time.zone.parse("15 Feb 2022") }
+
+        it "returns false" do
+          expect(result).to be false
+        end
+      end
+
+      context "when billing month is 6 months after subscription month in same year" do
+        let(:billing_at) { Time.zone.parse("15 Aug 2021") }
+
+        it "returns true" do
+          expect(result).to be false
+        end
+      end
+
+      context "when billing month is 6 months after subscription month but in next year" do
+        let(:billing_at) { Time.zone.parse("15 Aug 2022") }
+
+        it "returns false" do
+          expect(result).to be false
+        end
+      end
+    end
+  end
 end

--- a/spec/services/subscriptions/dates_service_spec.rb
+++ b/spec/services/subscriptions/dates_service_spec.rb
@@ -58,6 +58,14 @@ RSpec.describe Subscriptions::DatesService, type: :service do
       end
     end
 
+    context "when interval is semiannual" do
+      let(:interval) { :semiannual }
+
+      it "returns a semiannual service instance" do
+        expect(result).to be_kind_of(Subscriptions::Dates::SemiannualService)
+      end
+    end
+
     context "when interval is invalid" do
       let(:interval) { :weekly }
 

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -192,6 +192,46 @@ RSpec.describe Subscriptions::OrganizationBillingService, type: :service do
       end
     end
 
+    context "when billed semiannual with calendar billing time" do
+      let(:interval) { :semiannual }
+      let(:billing_time) { :calendar }
+      let(:current_date) { DateTime.parse("01 Jul 2022") }
+
+      it "enqueues a job on billing day" do
+        billing_service.call
+
+        expect(BillSubscriptionJob).to have_been_enqueued
+          .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+        expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+          .with([subscription], current_date)
+      end
+
+      it "does not enqueue a job on other day" do
+        current_date = DateTime.parse("01 Aug 2022")
+
+        billing_service.call
+
+        expect(BillSubscriptionJob).not_to have_been_enqueued
+          .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+        expect(BillNonInvoiceableFeesJob).not_to have_been_enqueued
+          .with([subscription], current_date)
+      end
+
+      context "when charges are billed monthly" do
+        let(:bill_charges_monthly) { true }
+        let(:current_date) { DateTime.parse("01 Aug 2022") }
+
+        it "enqueues a job on billing day" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription], current_date)
+        end
+      end
+    end
+
     context "when billed yearly with calendar billing time" do
       let(:interval) { :yearly }
       let(:billing_time) { :calendar }
@@ -340,6 +380,89 @@ RSpec.describe Subscriptions::OrganizationBillingService, type: :service do
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
           expect(BillNonInvoiceableFeesJob).to have_been_enqueued
             .with([subscription], current_date)
+        end
+      end
+    end
+
+    context "when billed semiannually with anniversary billing time" do
+      let(:interval) { :semiannual }
+      let(:billing_time) { :anniversary }
+      let(:current_date) { subscription_at + 6.months }
+
+      it "enqueues a job on billing day" do
+        billing_service.call
+
+        expect(BillSubscriptionJob).to have_been_enqueued
+          .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+        expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+          .with([subscription], current_date)
+      end
+
+      context "when billing_at is a different day" do
+        let(:billing_at) { current_date + 1.day }
+
+        it "does not enqueue a job on other day" do
+          expect { billing_service.call }.not_to have_enqueued_job
+        end
+      end
+
+      context "when subscription anniversary is in March" do
+        let(:subscription_at) { DateTime.parse("15 Mar 2021") }
+        let(:current_date) { DateTime.parse("15 Sep 2022") }
+
+        it "enqueues a job" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription], current_date)
+        end
+      end
+
+      context "when subscription anniversary is on a 31st" do
+        let(:subscription_at) { DateTime.parse("31 Mar 2021") }
+        let(:current_date) { DateTime.parse("30 Sep 2022") }
+
+        it "enqueues a job if the month count less than 31 days" do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription], current_date)
+        end
+      end
+
+      context "when charges are billed monthly" do
+        let(:bill_charges_monthly) { true }
+        let(:current_date) { subscription_at.next_month }
+
+        context "when billing_at is the next month" do
+          let(:billing_at) { current_date.next_month }
+
+          it "enqueues a job on billing day" do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([subscription], billing_at.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+              .with([subscription], billing_at)
+          end
+        end
+
+        context "when subscription anniversary is on a 31st" do
+          let(:subscription_at) { DateTime.parse("31 Mar 2021") }
+          let(:current_date) { DateTime.parse("28 Feb 2022") }
+
+          it "enqueues a job if the month count less than 31 days" do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+              .with([subscription], current_date)
+          end
         end
       end
     end


### PR DESCRIPTION
## Context

When creating a plan, a new interval option should be available: `semiannual`.
In order to enable that, we’ll need to add it to the model, services and GQL.

## Description

This PR adds the new interval `semiannual` to all the necessary services, models and it also updates the GraphQL schema.