### PR TITLE
fix(stripe): Fix `customer.updated` Stripe webhook when stripe customer not found in DB

### DIFF
--- a/app/services/payment_providers/stripe/webhooks/base_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/base_service.rb
@@ -25,14 +25,29 @@ module PaymentProviders
         end
 
         def handle_missing_customer
-          # NOTE: Stripe customer was not created from lago
-          return result unless metadata&.key?(:lago_customer_id)
+          return result if stripe_customer_created_outside_lago?
 
-          # NOTE: Customer does not exist or exists but does not belong to the organizations
-          #       (Happens when the Stripe API key is shared between organizations)
-          return result if Customer.find_by(id: metadata[:lago_customer_id], organization_id: organization.id).nil?
+          # NOTE: Lago customer either:
+          #         - does not exist
+          #         - exists but does not belong to the organization (Happens when the Stripe API key is shared between organizations)
+          #         - exists but was updated to be linked to another stripe customer
+          return result if metadata_does_not_match_lago_customer?
 
           result.not_found_failure!(resource: "stripe_customer")
+        end
+
+        def metadata_does_not_match_lago_customer?
+          lago_customer = Customer.find_by(id: metadata[:lago_customer_id], organization_id: organization.id)
+
+          lago_customer.nil? || linked_to_another_stripe_customer?(lago_customer)
+        end
+
+        def linked_to_another_stripe_customer?(lago_customer)
+          lago_customer.stripe_customer.present?
+        end
+
+        def stripe_customer_created_outside_lago?
+          metadata.nil? || !metadata.key?(:lago_customer_id)
         end
 
         # TODO: Move this to a proper factory

--- a/spec/services/payment_providers/stripe/webhooks/customer_updated_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/customer_updated_service_spec.rb
@@ -81,12 +81,25 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerUpdatedService, type:
             end
           end
 
-          it "returns a not found error" do
-            result = webhook_service.call
+          context "when customer is linked to another stripe customer" do
+            it "returns an empty result" do
+              result = webhook_service.call
 
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq("stripe_customer_not_found")
+              expect(result).to be_success
+              expect(result.stripe_customer).to be_nil
+            end
+          end
+
+          context "when customer is not linked to another stripe customer" do
+            let(:stripe_customer) { nil }
+
+            it "returns a not found error" do
+              result = webhook_service.call
+
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::NotFoundFailure)
+              expect(result.error.message).to eq("stripe_customer_not_found")
+            end
           end
         end
       end

--- a/spec/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service_spec.rb
@@ -119,15 +119,28 @@ RSpec.describe PaymentProviders::Stripe::Webhooks::SetupIntentSucceededService, 
           end
         end
 
-        context "when customer in metadata exists in this org but has a different provider_customer_id" do
+        context "when customer in metadata exists in this org" do
           let(:metadata) { {lago_customer_id: customer.id} }
 
-          it "returns a not found error" do
-            result = webhook_service.call
+          context "when is linked to another stripe customer" do
+            it "returns an empty result" do
+              result = webhook_service.call
 
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq("stripe_customer_not_found")
+              expect(result).to be_success
+              expect(result.payment_method).to be_nil
+            end
+          end
+
+          context "when is not linked to another stripe customer" do
+            let(:stripe_customer) { nil }
+
+            it "returns a not found error" do
+              result = webhook_service.call
+
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::NotFoundFailure)
+              expect(result.error.message).to eq("stripe_customer_not_found")
+            end
           end
         end
       end


### PR DESCRIPTION
## Context

When a customer is updated on Stripe, we receive a `customer.updated` webhook from Stripe. If we cannot match the payload with a `PaymentProviderCustomers::StripeCustomer`, we do the following:

- If the payload does not include the `metadata.lago_customer_id` value, it means the customer was created outside Lago and we can ignore the webhook.
- If the payload include the `metadata.lago_customer_id` but we cannot find it in the database, it means the customer was deleted or belong to another organization and we can ignore the webhook.
- Otherwise, we'll return a `stripe_customer_not_found` error.

There is an edge-case that wasn't handled here though. If someone manually updated the Stripe customer information when updating a Lago customer, the previous Stripe customer will no longer be linked to a record in our database. Not that even if the `provider_customer_id` is set to `nil`, the `PaymentProviderCustomers::StripeCustomer` will still be present but with a nil `provider_customer_id`.

## Description

This makes sure we ignore the webhook in the case mentioned above.
