### PR TITLE
feat: change the calculations

### DIFF
--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -60,7 +60,13 @@ module Credits
 
     def apply_credit_to_fees(progressive_billing_invoice)
       progressive_billing_invoice.fees.charge.each do |progressive_fee|
-        fee = invoice.fees.find_by(charge_id: progressive_fee.charge_id)
+        fee = invoice.fees.find_by(
+          charge_id: progressive_fee.charge_id,
+          charge_filter_id: progressive_fee.charge_filter_id,
+          grouped_by: progressive_fee.grouped_by,
+        )
+        next unless fee
+
         fee.precise_coupons_amount_cents += progressive_fee.amount_cents
         fee.save!
       end

--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -63,7 +63,7 @@ module Credits
         fee = invoice.fees.find_by(
           charge_id: progressive_fee.charge_id,
           charge_filter_id: progressive_fee.charge_filter_id,
-          grouped_by: progressive_fee.grouped_by,
+          grouped_by: progressive_fee.grouped_by
         )
         next unless fee
 

--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -44,7 +44,7 @@ module Credits
             before_taxes: true
           )
 
-          apply_credit_to_fees(credit, total_charges_amount)
+          apply_credit_to_fees(progressive_billing_invoice)
 
           invoice.sub_total_excluding_taxes_amount_cents -= credit.amount_cents
           invoice.progressive_billing_credit_amount_cents += credit.amount_cents
@@ -58,17 +58,10 @@ module Credits
 
     attr_reader :invoice
 
-    def apply_credit_to_fees(credit, total_charges_amount)
-      base_amount = total_charges_amount - invoice.progressive_billing_credit_amount_cents
-
-      invoice.fees.charge.reload.each do |fee|
-        if base_amount.positive?
-          fee.precise_coupons_amount_cents += (
-            credit.amount_cents * (fee.amount_cents - fee.precise_coupons_amount_cents)
-          ).fdiv(base_amount)
-        end
-
-        fee.precise_coupons_amount_cents = fee.amount_cents if fee.amount_cents < fee.precise_coupons_amount_cents
+    def apply_credit_to_fees(progressive_billing_invoice)
+      progressive_billing_invoice.fees.charge.each do |progressive_fee|
+        fee = invoice.fees.find_by(charge_id: progressive_fee.charge_id)
+        fee.precise_coupons_amount_cents += progressive_fee.amount_cents
         fee.save!
       end
     end

--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -59,12 +59,13 @@ module Credits
     attr_reader :invoice
 
     def apply_credit_to_fees(progressive_billing_invoice)
+      invoice_fees = invoice.fees.charge.to_a
       progressive_billing_invoice.fees.charge.each do |progressive_fee|
-        fee = invoice.fees.find_by(
-          charge_id: progressive_fee.charge_id,
-          charge_filter_id: progressive_fee.charge_filter_id,
-          grouped_by: progressive_fee.grouped_by
-        )
+        fee = invoice_fees.find { |f|
+          f.charge_id == progressive_fee.charge_id &&
+            f.charge_filter_id == progressive_fee.charge_filter_id &&
+            f.grouped_by == progressive_fee.grouped_by
+        }
         next unless fee
 
         fee.precise_coupons_amount_cents += progressive_fee.amount_cents

--- a/spec/services/credits/progressive_billing_service_spec.rb
+++ b/spec/services/credits/progressive_billing_service_spec.rb
@@ -57,10 +57,9 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
 
     let(:progressive_billing_fee) {
       create(:charge_fee,
-             amount_cents: 20,
-             charge: subscription_fee1.charge,
-             invoice: progressive_billing_invoice
-      )
+        amount_cents: 20,
+        charge: subscription_fee1.charge,
+        invoice: progressive_billing_invoice)
     }
 
     before do
@@ -426,10 +425,9 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
 
     let(:progressive_billing_fee) {
       create(:charge_fee,
-             amount_cents: 20,
-             charge: subscription_fee1.charge,
-             invoice: progressive_billing_invoice
-      )
+        amount_cents: 20,
+        charge: subscription_fee1.charge,
+        invoice: progressive_billing_invoice)
     }
 
     let(:dummy_result) do

--- a/spec/services/credits/progressive_billing_service_spec.rb
+++ b/spec/services/credits/progressive_billing_service_spec.rb
@@ -55,7 +55,13 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
       )
     end
 
-    let(:progressive_billing_fee) { create(:charge_fee, amount_cents: 20, invoice: progressive_billing_invoice) }
+    let(:progressive_billing_fee) {
+      create(:charge_fee,
+             amount_cents: 20,
+             charge: subscription_fee1.charge,
+             invoice: progressive_billing_invoice
+      )
+    }
 
     before do
       progressive_billing_invoice
@@ -74,9 +80,8 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
         credit = result.credits.sole
         expect(credit.amount_cents).to eq(20)
         expect(invoice.progressive_billing_credit_amount_cents).to eq(20)
-
-        expect(subscription_fee1.reload.precise_coupons_amount_cents).to eq(10)
-        expect(subscription_fee2.reload.precise_coupons_amount_cents).to eq(10)
+        expect(subscription_fee1.reload.precise_coupons_amount_cents).to eq(20)
+        expect(subscription_fee2.reload.precise_coupons_amount_cents).to eq(0)
       end
 
       context "with additional subscription fee" do
@@ -93,8 +98,8 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
           expect(credit.amount_cents).to eq(20)
           expect(invoice.progressive_billing_credit_amount_cents).to eq(20)
 
-          expect(subscription_fee1.reload.precise_coupons_amount_cents).to eq(10)
-          expect(subscription_fee2.reload.precise_coupons_amount_cents).to eq(10)
+          expect(subscription_fee1.reload.precise_coupons_amount_cents).to eq(20)
+          expect(subscription_fee2.reload.precise_coupons_amount_cents).to eq(0)
           expect(subscription_fee3.reload.precise_coupons_amount_cents).to eq(0)
         end
       end
@@ -419,7 +424,14 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
       )
     end
 
-    let(:progressive_billing_fee) { create(:charge_fee, amount_cents: 20, invoice: progressive_billing_invoice) }
+    let(:progressive_billing_fee) {
+      create(:charge_fee,
+             amount_cents: 20,
+             charge: subscription_fee1.charge,
+             invoice: progressive_billing_invoice
+      )
+    }
+
     let(:dummy_result) do
       BaseService::Result.new.tap do |r|
         r.to_
@@ -450,8 +462,8 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
         expect(credit.amount_cents).to eq(20)
         expect(invoice.progressive_billing_credit_amount_cents).to eq(20)
 
-        expect(subscription_fee1.reload.precise_coupons_amount_cents).to eq(10)
-        expect(subscription_fee2.reload.precise_coupons_amount_cents).to eq(10)
+        expect(subscription_fee1.reload.precise_coupons_amount_cents).to eq(20)
+        expect(subscription_fee2.reload.precise_coupons_amount_cents).to eq(0)
       end
     end
   end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -1728,7 +1728,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         )
       end
       let(:progressive_fee) do
-        create(:charge_fee, amount_cents: 3_000, invoice: progressive_invoice)
+        create(:charge_fee, amount_cents: 3_000, charge: charge3, invoice: progressive_invoice)
       end
       let(:credit_note) do
         create(
@@ -1774,11 +1774,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         aggregate_failures do
           expect(result).to be_success
           expect(result.invoice.fees_amount_cents).to eq(20_000)
-          expect(result.invoice.taxes_amount_cents).to eq(1_565)
-          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(15_650)
-          expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(17_215)
+          expect(result.invoice.taxes_amount_cents).to eq(1_550)
+          expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(15_500)
+          expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(17_050)
           expect(result.invoice.progressive_billing_credit_amount_cents).to eq(3_000)
-          expect(result.invoice.total_amount_cents).to eq(9_738) # 17_215 - 1_000 (credit note) - 6_477 (wallet)
+          expect(result.invoice.total_amount_cents).to eq(9_726) # 17_050 - 1_000 (credit note) - 6_323 (wallet)
         end
       end
     end

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service, transaction:
 
         create(
           :charge_fee,
+          charge:,
           invoice:,
           amount_cents: 20
         )


### PR DESCRIPTION
## Context

Progressive billing credits were being distributed across all invoice fees, regardless of whether a fee belonged to the same charge as the progressive billing invoice. 

## Description

This PR updates Credits::ProgressiveBillingService so that credits from a progressive billing invoice are only applied to matching fees on the target invoice (same charge_id/context), instead of being spread across all fees.

This change was needed so that when we apply the credits from the wallet, we need to know the remaining fee, removing the progressive billing part 

This issue would be more evident if we had multiple wallets, and some of them only applied to specific fees, the amount we need to take would not be correct (because the calculations would be affected by the progressive billing )  