### PR TITLE
feat(fixed_charges): Add fixed charge events

### DIFF
--- a/app/models/fixed_charge_event.rb
+++ b/app/models/fixed_charge_event.rb
@@ -9,7 +9,6 @@ class FixedChargeEvent < ApplicationRecord
   belongs_to :fixed_charge
 
   validates :units, numericality: {greater_than_or_equal_to: 0}
-  validates :properties, presence: true
 
   default_scope -> { kept }
 end
@@ -20,7 +19,6 @@ end
 #
 #  id              :uuid             not null, primary key
 #  deleted_at      :datetime
-#  properties      :jsonb            not null
 #  timestamp       :datetime
 #  units           :decimal(30, 10)  default(0.0), not null
 #  created_at      :datetime         not null

--- a/db/migrate/20250826081205_create_fixed_charge_events.rb
+++ b/db/migrate/20250826081205_create_fixed_charge_events.rb
@@ -7,7 +7,6 @@ class CreateFixedChargeEvents < ActiveRecord::Migration[8.0]
       t.belongs_to :subscription, null: false, foreign_key: true, type: :uuid
       t.belongs_to :fixed_charge, null: false, foreign_key: true, type: :uuid
 
-      t.jsonb :properties, null: false, default: {}
       t.decimal :units, precision: 30, scale: 10, null: false, default: 0.0
       t.datetime :timestamp
       t.datetime :deleted_at, index: true

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3346,7 +3346,6 @@ CREATE TABLE public.fixed_charge_events (
     organization_id uuid NOT NULL,
     subscription_id uuid NOT NULL,
     fixed_charge_id uuid NOT NULL,
-    properties jsonb DEFAULT '{}'::jsonb NOT NULL,
     units numeric(30,10) DEFAULT 0.0 NOT NULL,
     "timestamp" timestamp(6) without time zone,
     deleted_at timestamp(6) without time zone,

--- a/spec/factories/fixed_charge_events.rb
+++ b/spec/factories/fixed_charge_events.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     organization { subscription&.organization || association(:organization) }
     subscription
     fixed_charge
-    properties { {amount: Faker::Number.between(from: 100, to: 200).to_s} }
     units { "9.99" }
     timestamp { Time.current }
     deleted_at { nil }

--- a/spec/models/fixed_charge_event_spec.rb
+++ b/spec/models/fixed_charge_event_spec.rb
@@ -11,5 +11,4 @@ RSpec.describe FixedChargeEvent, type: :model do
   it { is_expected.to belong_to(:fixed_charge) }
 
   it { is_expected.to validate_numericality_of(:units).is_greater_than_or_equal_to(0) }
-  it { is_expected.to validate_presence_of(:properties) }
 end


### PR DESCRIPTION
 ## Roadmap Task

 👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

 👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

 ## Context

 What is the current situation?

 **Option 1:** User has to create a one off invoice alongside the
 subscription, it will create 2 different invoices.

 **Option 2:** User can add a recurring billable metric and use event to
 have this fee invoice on subscription renewal, but it won’t appear on
 the first billing subscription.

 What problem are we trying to solve?

 At subscription creation or afterward, there is no clear way to invoice
 a fixed fee that is not tied to events, aside from the subscription fee
 itself. This fee could be either a one-time charge or a recurring one.

 ## Description

 Add fixed charge events table and model, initial setup.

 Fixed charge events are only created internally, users won't be able to
 emit this kind of events. We only need to the fixed_charge_id and
 subscription_id as foreign keys.