### PR TITLE
fix(customer): Fix payment job race-condition on customer deletion

### DIFF
--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -82,7 +82,7 @@ module Invoices
       def call_async
         return result unless provider
 
-        Invoices::Payments::CreateJob.perform_later(invoice:, payment_provider: provider)
+        Invoices::Payments::CreateJob.perform_after_commit(invoice:, payment_provider: provider)
 
         result.payment_provider = provider
         result


### PR DESCRIPTION
## Context

When a customer is deleted, we terminate all active subscriptions and generate a termination invoice for each one. Each invoice may trigger an asynchronous payment.

Currently, some payment jobs begin executing before the surrounding database transaction commits. Because the invoices are not yet persisted, the job cannot find them, causing the payment creation to fail.

## Description

This PR ensures the payment job is only scheduled once the transaction is committed.
