### PR TITLE
misc(clickhouse): Add clickhouse structure for cloud

### DIFF
--- a/db/clickhouse_migrate/20250814130828_create_events_aggregated.rb
+++ b/db/clickhouse_migrate/20250814130828_create_events_aggregated.rb
@@ -28,6 +28,7 @@ class CreateEventsAggregated < ActiveRecord::Migration[8.0]
       t.string :charge_id, null: false
       t.string :charge_filter_id, null: false, default: -> { "''" }
       t.string :grouped_by, null: false
+      t.column :precise_total_amount_cents_sum_state, "AggregateFunction(sum, Decimal(40, 15))", null: false
       # Multiple aggregation states for different charge models
       # Only one will be populated based on the charge's aggregation type
       t.column :sum_state, "AggregateFunction(sum, Decimal(38, 26))", null: false

--- a/db/clickhouse_migrate/20250814134106_create_events_aggregated_mv.rb
+++ b/db/clickhouse_migrate/20250814134106_create_events_aggregated_mv.rb
@@ -14,6 +14,7 @@ class CreateEventsAggregatedMv < ActiveRecord::Migration[8.0]
         charge_filter_id,
         sorted_grouped_by as grouped_by,
         -- Aggregate states based on aggregation type
+        sumState(coalesce(precise_total_amount_cents, toDecimal128(0, 15))) AS precise_total_amount_cents_sum_state,
         multiIf(aggregation_type = 'sum', sumState(coalesce(decimal_value, 0)), sumState(toDecimal128(0, 26))) AS sum_state,
         multiIf(aggregation_type = 'count', countState(), countStateIf(false)) AS count_state,
         multiIf(aggregation_type = 'max', maxState(coalesce(decimal_value, 0)), maxState(toDecimal128(0, 26))) AS max_state,

--- a/db/clickhouse_migrate/cloud/01_events_raw.sql
+++ b/db/clickhouse_migrate/cloud/01_events_raw.sql
@@ -1,0 +1,15 @@
+CREATE TABLE default.events_raw
+(
+    `organization_id` String,
+    `external_customer_id` String,
+    `external_subscription_id` String,
+    `transaction_id` String,
+    `timestamp` DateTime64(3),
+    `code` String,
+    `properties` Map(String, String),
+    `ingested_at` DateTime(3),
+    `precise_total_amount_cents` Nullable(Decimal(40, 15))
+)
+ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
+ORDER BY (organization_id, external_subscription_id, code, transaction_id, timestamp)
+SETTINGS index_granularity = 8192

--- a/db/clickhouse_migrate/cloud/02_events_enriched.sql
+++ b/db/clickhouse_migrate/cloud/02_events_enriched.sql
@@ -1,0 +1,18 @@
+CREATE TABLE default.events_enriched
+(
+    `organization_id` String,
+    `external_subscription_id` String,
+    `code` String,
+    `timestamp` DateTime64(3),
+    `transaction_id` String,
+    `properties` Map(String, String),
+    `sorted_properties` Map(String, String) DEFAULT mapSort(properties),
+    `enriched_at` DateTime64(3) DEFAULT now(),
+    `value` Nullable(String),
+    `decimal_value` Nullable(Decimal(38, 26) DEFAULT toDecimal128OrZero(value, 26)),
+    `precise_total_amount_cents` Nullable(Decimal(40, 15))
+)
+ENGINE = SharedReplacingMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}', timestamp)
+PRIMARY KEY (organization_id, code, external_subscription_id, toDate(timestamp))
+ORDER BY (organization_id, code, external_subscription_id, toDate(timestamp), timestamp, transaction_id)
+SETTINGS index_granularity = 8192

--- a/db/clickhouse_migrate/cloud/03_activity_logs.sql
+++ b/db/clickhouse_migrate/cloud/03_activity_logs.sql
@@ -1,0 +1,21 @@
+CREATE TABLE default.activity_logs
+(
+    `organization_id` String,
+    `user_id` Nullable(String),
+    `api_key_id` Nullable(String),
+    `external_customer_id` Nullable(String),
+    `external_subscription_id` Nullable(String),
+    `activity_id` String,
+    `activity_type` String,
+    `activity_source` Enum8('api' = 1, 'front' = 2, 'system' = 3),
+    `activity_object` Map(String, Nullable(String)),
+    `activity_object_changes` Map(String, Nullable(String)),
+    `resource_id` String,
+    `resource_type` String,
+    `logged_at` DateTime64(3),
+    `created_at` DateTime64(3)
+)
+ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
+PRIMARY KEY (organization_id, activity_type, activity_id, logged_at)
+ORDER BY (organization_id, activity_type, activity_id, logged_at)
+SETTINGS index_granularity = 8192

--- a/db/clickhouse_migrate/cloud/04_api_logs.sql
+++ b/db/clickhouse_migrate/cloud/04_api_logs.sql
@@ -1,0 +1,20 @@
+CREATE TABLE default.api_logs
+(
+    `request_id` String,
+    `organization_id` String,
+    `api_key_id` String,
+    `api_version` String,
+    `client` String,
+    `request_body` Map(String, String),
+    `request_response` Map(String, Nullable(String)),
+    `request_path` String,
+    `request_origin` String,
+    `http_method` Enum8('get' = 1, 'post' = 2, 'put' = 3, 'delete' = 4),
+    `http_status` UInt32,
+    `logged_at` DateTime64(3),
+    `created_at` DateTime64(3)
+)
+ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
+PRIMARY KEY (organization_id, api_key_id, request_id, logged_at)
+ORDER BY (organization_id, api_key_id, request_id, logged_at)
+SETTINGS index_granularity = 8192

--- a/db/clickhouse_migrate/cloud/05_events_enriched_expanded.sql
+++ b/db/clickhouse_migrate/cloud/05_events_enriched_expanded.sql
@@ -1,0 +1,29 @@
+SET enable_json_type = 1;
+
+CREATE TABLE events_enriched_expanded
+(
+    `organization_id` String,
+    `external_subscription_id` String,
+    `code` String,
+    `timestamp` DateTime64(3),
+    `transaction_id` String,
+    `properties` JSON,
+    `sorted_properties` Map(String, String) DEFAULT mapSort(JSONExtract(CAST(properties, 'String'), 'Map(String, String)')),
+    `value` Nullable(String),
+    `decimal_value` Nullable(Decimal(38, 26)) DEFAULT toDecimal128OrZero(value, 26),
+    `enriched_at` DateTime64(3) DEFAULT now(),
+    `precise_total_amount_cents` Nullable(Decimal(40, 15)),
+    `subscription_id` String DEFAULT '',
+    `plan_id` String DEFAULT '',
+    `charge_id` String DEFAULT '',
+    `charge_version` Nullable(DateTime),
+    `charge_filter_id` String DEFAULT '',
+    `charge_filter_version` Nullable(DateTime),
+    `aggregation_type` String,
+    `grouped_by` JSON,
+    `sorted_grouped_by` Map(String, String) DEFAULT mapSort(JSONExtract(CAST(grouped_by, 'String'), 'Map(String, String)'))
+)
+ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
+PRIMARY KEY (organization_id, code, external_subscription_id, charge_id, charge_filter_id, toDate(timestamp))
+ORDER BY (organization_id, code, external_subscription_id, charge_id, charge_filter_id, toDate(timestamp), timestamp, transaction_id)
+SETTINGS index_granularity = 8192

--- a/db/clickhouse_migrate/cloud/06_events_aggregated.sql
+++ b/db/clickhouse_migrate/cloud/06_events_aggregated.sql
@@ -1,0 +1,21 @@
+CREATE TABLE events_aggregated
+(
+    `organization_id` String,
+    `code` String,
+    `started_at` DateTime64(3),
+    `external_subscription_id` String,
+    `subscription_id` String,
+    `plan_id` String,
+    `charge_id` String,
+    `charge_filter_id` String DEFAULT '',
+    `grouped_by` String,
+    `precise_total_amount_cents_sum_state` AggregateFunction(sum, Decimal(40, 15)),
+    `sum_state` AggregateFunction(sum, Decimal(38, 26)),
+    `count_state` AggregateFunction(count, UInt64),
+    `max_state` AggregateFunction(max, Decimal(38, 26)),
+    `latest_state` AggregateFunction(argMax, Decimal(38, 26), DateTime64(3)),
+    `aggregated_at` DateTime64(3) DEFAULT now()
+)
+ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')
+ORDER BY (organization_id, code, started_at, external_subscription_id, subscription_id, charge_id, charge_filter_id, grouped_by)
+SETTINGS index_granularity = 8192;

--- a/db/clickhouse_migrate/cloud/07_events_aggregated_mv.sql
+++ b/db/clickhouse_migrate/cloud/07_events_aggregated_mv.sql
@@ -1,0 +1,45 @@
+CREATE MATERIALIZED VIEW events_aggregated_mv TO events_aggregated
+(
+    `organization_id` String,
+    `code` String,
+    `started_at` DateTime,
+    `external_subscription_id` String,
+    `subscription_id` String,
+    `plan_id` String,
+    `charge_id` String,
+    `charge_filter_id` String,
+    `grouped_by` Map(String, String),
+    `precise_total_amount_cents_sum_state` AggregateFunction(sum, Decimal(76, 15)),
+    `sum_state` AggregateFunction(sum, Decimal(38, 26)),
+    `count_state` AggregateFunction(count),
+    `max_state` AggregateFunction(max, Decimal(38, 26)),
+    `latest_state` AggregateFunction(argMax, Decimal(38, 26), DateTime64(3))
+)
+AS SELECT
+    organization_id,
+    code,
+    toStartOfMinute(timestamp) AS started_at,
+    external_subscription_id,
+    subscription_id,
+    plan_id,
+    charge_id,
+    charge_filter_id,
+    sorted_grouped_by AS grouped_by,
+    sumState(coalesce(precise_total_amount_cents, toDecimal128(0, 15))) AS precise_total_amount_cents_sum_state,
+    multiIf(aggregation_type = 'sum', sumState(coalesce(decimal_value, 0)), sumState(toDecimal128(0, 26))) AS sum_state,
+    multiIf(aggregation_type = 'count', countState(), countStateIf(false)) AS count_state,
+    multiIf(aggregation_type = 'max', maxState(coalesce(decimal_value, 0)), maxState(toDecimal128(0, 26))) AS max_state,
+    multiIf(aggregation_type = 'latest', argMaxState(coalesce(decimal_value, 0), timestamp), argMaxState(toDecimal128(0, 26), toDateTime64('1970-01-01', 3))) AS latest_state
+FROM events_enriched_expanded
+WHERE (decimal_value IS NOT NULL) AND (subscription_id IS NOT NULL) AND (plan_id IS NOT NULL) AND (charge_id != '')
+GROUP BY
+    organization_id,
+    code,
+    toStartOfMinute(timestamp),
+    external_subscription_id,
+    subscription_id,
+    plan_id,
+    charge_id,
+    charge_filter_id,
+    sorted_grouped_by,
+    aggregation_type;


### PR DESCRIPTION
## Context
Today Cliickhouse cloud data structure structure is not stored anywhere outside Clickhouse cloud itself this makes it a bit difficult to setup a new instance when required.

## Description

This PR adds:
- All SQL scripts to create the database table and materialized view on a Clickhouse cloud instance.
- Add the missing pre-aggregation logic on `precise_total_amount_cents` 

**NOTE**: the clickpipe configuration used to configure the Redpanda consumers and the mapping of the fields from the topics to the table fields is not exposed here.