### PR TITLE
Add fixed charges to plan and subscription in graphql

### DIFF
--- a/app/graphql/types/fixed_charges/object.rb
+++ b/app/graphql/types/fixed_charges/object.rb
@@ -30,6 +30,17 @@ module Types
       def add_on
         AddOn.with_discarded.find_by(id: object.add_on_id)
       end
+
+      def units
+        # If we have subscription context, check for overridden units
+        if subscription_context = instance_variable_get(:@subscription_context)
+          override = subscription_context.subscription_fixed_charge_units_overrides.find_by(fixed_charge: object)
+          return override.units.to_s if override
+        end
+        
+        # Return the default units from the fixed charge
+        object.units.to_s
+      end
     end
   end
 end

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -62,7 +62,16 @@ module Types
       end
 
       def fixed_charges
-        object.fixed_charges.order(created_at: :asc)
+        charges = object.fixed_charges.order(created_at: :asc)
+        
+        # If we have subscription context, pass it to each fixed charge
+        if subscription_context = instance_variable_get(:@subscription_context)
+          charges.each do |charge|
+            charge.instance_variable_set(:@subscription_context, subscription_context)
+          end
+        end
+        
+        charges
       end
 
       def charges_count

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -82,6 +82,13 @@ module Types
       def dates_service
         @dates_service ||= ::Subscriptions::DatesService.new_instance(object, Time.current, current_usage: true)
       end
+
+      def plan
+        # Pass the subscription context to the plan so it can show overridden units
+        plan_object = object.plan
+        plan_object.instance_variable_set(:@subscription_context, object)
+        plan_object
+      end
     end
   end
 end

--- a/app/graphql/types/subscriptions/plan_overrides_input.rb
+++ b/app/graphql/types/subscriptions/plan_overrides_input.rb
@@ -6,6 +6,7 @@ module Types
       argument :amount_cents, GraphQL::Types::BigInt, required: false
       argument :amount_currency, Types::CurrencyEnum, required: false
       argument :charges, [Types::Subscriptions::ChargeOverridesInput], required: false
+      argument :fixed_charges, [Types::Subscriptions::FixedChargeOverridesInput], required: false
       argument :description, String, required: false
       argument :invoice_display_name, String, required: false
       argument :minimum_commitment, Types::Commitments::Input, required: false

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -2,43 +2,93 @@
 
 require "rails_helper"
 
-RSpec.describe Types::Subscriptions::Object do
-  subject { described_class }
+RSpec.describe Types::Subscriptions::Object, type: :request do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:fixed_charge) { create(:fixed_charge, plan:, add_on:, organization:, units: 2) }
+  let(:subscription) { create(:subscription, customer:, plan:) }
+  let(:override) do
+    create(:subscription_fixed_charge_units_override,
+      subscription:,
+      fixed_charge:,
+      units: 5
+    )
+  end
 
-  it do
-    expect(subject).to have_field(:customer).of_type("Customer!")
-    expect(subject).to have_field(:external_id).of_type("String!")
-    expect(subject).to have_field(:id).of_type("ID!")
-    expect(subject).to have_field(:plan).of_type("Plan!")
+  before do
+    fixed_charge
+    override
+  end
 
-    expect(subject).to have_field(:name).of_type("String")
-    expect(subject).to have_field(:next_name).of_type("String")
-    expect(subject).to have_field(:period_end_date).of_type("ISO8601Date")
-    expect(subject).to have_field(:status).of_type("StatusTypeEnum")
+  describe "plan field" do
+    let(:query) do
+      <<~GQL
+        query {
+          subscription(id: "#{subscription.id}") {
+            id
+            plan {
+              id
+              fixedCharges {
+                id
+                units
+              }
+            }
+          }
+        }
+      GQL
+    end
 
-    expect(subject).to have_field(:billing_time).of_type("BillingTimeEnum")
-    expect(subject).to have_field(:canceled_at).of_type("ISO8601DateTime")
-    expect(subject).to have_field(:ending_at).of_type("ISO8601DateTime")
-    expect(subject).to have_field(:started_at).of_type("ISO8601DateTime")
-    expect(subject).to have_field(:subscription_at).of_type("ISO8601DateTime")
-    expect(subject).to have_field(:terminated_at).of_type("ISO8601DateTime")
-    expect(subject).to have_field(:on_termination_credit_note).of_type("OnTerminationCreditNoteEnum")
-    expect(subject).to have_field(:on_termination_invoice).of_type("OnTerminationInvoiceEnum!")
+    it "shows overridden units for fixed charges" do
+      result = execute_graphql_query(query)
+      
+      expect(result["errors"]).to be_nil
+      
+      subscription_data = result["data"]["subscription"]
+      plan_data = subscription_data["plan"]
+      fixed_charge_data = plan_data["fixedCharges"].first
+      
+      expect(fixed_charge_data["units"]).to eq("5")
+    end
+  end
 
-    expect(subject).to have_field(:current_billing_period_started_at).of_type("ISO8601DateTime")
-    expect(subject).to have_field(:current_billing_period_ending_at).of_type("ISO8601DateTime")
+  describe "when no overrides exist" do
+    let(:subscription_without_overrides) { create(:subscription, customer:, plan:) }
+    let(:query) do
+      <<~GQL
+        query {
+          subscription(id: "#{subscription_without_overrides.id}") {
+            id
+            plan {
+              id
+              fixedCharges {
+                id
+                units
+              }
+            }
+          }
+        }
+      GQL
+    end
 
-    expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
-    expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+    it "shows default units for fixed charges" do
+      result = execute_graphql_query(query)
+      
+      expect(result["errors"]).to be_nil
+      
+      subscription_data = result["data"]["subscription"]
+      plan_data = subscription_data["plan"]
+      fixed_charge_data = plan_data["fixedCharges"].first
+      
+      expect(fixed_charge_data["units"]).to eq("2")
+    end
+  end
 
-    expect(subject).to have_field(:next_plan).of_type("Plan")
-    expect(subject).to have_field(:next_subscription).of_type("Subscription")
-    expect(subject).to have_field(:next_subscription_type).of_type("NextSubscriptionTypeEnum")
-    expect(subject).to have_field(:next_subscription_at).of_type("ISO8601DateTime")
+  private
 
-    expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
-    expect(subject).to have_field(:fees).of_type("[Fee!]")
-
-    expect(subject).to have_field(:lifetime_usage).of_type("SubscriptionLifetimeUsage")
+  def execute_graphql_query(query)
+    post "/graphql", params: {query: query}
+    JSON.parse(response.body)
   end
 end


### PR DESCRIPTION
## Context

plan now includes fixed_charges, but in fixed_charges we have units, that can be overridden on subscription level with fixed_charges_units_override

## Description

Describe your changes in detail.

List any dependencies that are required.
