### PR TITLE
fix(integrations): Fix aggregator accounts service

### DIFF
--- a/app/services/integrations/aggregator/accounts_service.rb
+++ b/app/services/integrations/aggregator/accounts_service.rb
@@ -11,7 +11,7 @@ module Integrations
       end
 
       def call
-        @cursor = ""
+        @cursor = nil
         @items = []
 
         ActiveRecord::Base.transaction do
@@ -61,10 +61,9 @@ module Integrations
       end
 
       def params
-        {
-          limit: LIMIT,
-          cursor:
-        }
+        return {limit: LIMIT} if cursor.blank?
+
+        {limit: LIMIT, cursor:}
       end
     end
   end

--- a/spec/graphql/mutations/integration_items/fetch_accounts_spec.rb
+++ b/spec/graphql/mutations/integration_items/fetch_accounts_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Mutations::IntegrationItems::FetchAccounts, type: :graphql do
     allow(Integrations::Aggregator::SyncService).to receive(:new).and_return(sync_service)
     allow(sync_service).to receive(:call).and_return(true)
 
-    stub_request(:get, "https://api.nango.dev/v1/netsuite/accounts?cursor=&limit=450")
+    stub_request(:get, "https://api.nango.dev/v1/netsuite/accounts?limit=450")
       .to_return(status: 200, body: accounts_response, headers: {})
 
     integration_item

--- a/spec/services/integrations/aggregator/accounts_service_spec.rb
+++ b/spec/services/integrations/aggregator/accounts_service_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Integrations::Aggregator::AccountsService do
   describe ".call" do
     let(:lago_client) { instance_double(LagoHttpClient::Client) }
     let(:accounts_endpoint) { "https://api.nango.dev/v1/netsuite/accounts" }
+    let(:params) { {limit: 450} }
+
     let(:headers) do
       {
         "Connection-Id" => integration.connection_id,
@@ -17,12 +19,7 @@ RSpec.describe Integrations::Aggregator::AccountsService do
         "Provider-Config-Key" => "netsuite-tba"
       }
     end
-    let(:params) do
-      {
-        limit: 450,
-        cursor: ""
-      }
-    end
+
     let(:aggregator_response) do
       path = Rails.root.join("spec/fixtures/integration_aggregator/accounts_response.json")
       JSON.parse(File.read(path))
@@ -48,6 +45,39 @@ RSpec.describe Integrations::Aggregator::AccountsService do
         expect(account.external_id).to eq("12ec4c59-ad56-4a4f-93eb-fb0a7740f4e2")
         expect(account.external_account_code).to eq("1111")
         expect(account.external_name).to eq("Accounts Payable")
+      end
+    end
+  end
+
+  describe "#params" do
+    subject(:method_call) { accounts_service.send(:params) }
+
+    before { accounts_service.instance_variable_set(:@cursor, cursor) }
+
+    context "when cursor is nil" do
+      let(:cursor) { nil }
+      let(:params) { {limit: described_class::LIMIT} }
+
+      it "returns params without cursor" do
+        expect(subject).to eq(params)
+      end
+    end
+
+    context "when cursor is blank" do
+      let(:cursor) { "" }
+      let(:params) { {limit: described_class::LIMIT} }
+
+      it "returns params without cursor" do
+        expect(subject).to eq(params)
+      end
+    end
+
+    context "when cursor is present" do
+      let(:cursor) { "next_cursor_value" }
+      let(:params) { {limit: described_class::LIMIT, cursor: "next_cursor_value"} }
+
+      it "returns params with cursor" do
+        expect(subject).to eq(params)
       end
     end
   end


### PR DESCRIPTION
## Context

Xero integration started raising an error when fetching accounts, there must have been a change in the API endpoint.

## Description

Don't send empty `cursor` parameter in `Integrations::Aggregator::AccountsService`