### PR TITLE
fix(credit-notes): Prevent `ArgumentError` masking with proper `reason` validation

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -56,7 +56,7 @@ class CreditNote < ApplicationRecord
 
   enum :credit_status, CREDIT_STATUS
   enum :refund_status, REFUND_STATUS
-  enum :reason, REASON
+  enum :reason, REASON, validate: true
   enum :status, STATUS
 
   sequenced scope: ->(credit_note) { CreditNote.where(invoice_id: credit_note.invoice_id) },

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -23,7 +23,6 @@ module CreditNotes
       return result.not_found_failure!(resource: "invoice") unless invoice
       return result.forbidden_failure! unless should_create_credit_note?
       return result.not_allowed_failure!(code: "invalid_type_or_status") unless valid_type_or_status?
-      return result.single_validation_failure!(field: :reason, error_code: "value_is_invalid") if invalid_reason?
 
       ActiveRecord::Base.transaction do
         result.credit_note = CreditNote.new(

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       credit_amount_cents:,
       refund_amount_cents:,
       automatic:,
-      context:
+      context:,
+      **args
     )
   end
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
+  let(:args) { {} }
 
   let(:invoice) do
     create(
@@ -66,45 +68,43 @@ RSpec.describe CreditNotes::CreateService, type: :service do
     it "creates a credit note" do
       result = create_service.call
 
-      aggregate_failures do
-        expect(result).to be_success
+      expect(result).to be_success
 
-        credit_note = result.credit_note
-        expect(credit_note.invoice).to eq(invoice)
-        expect(credit_note.customer).to eq(invoice.customer)
-        expect(credit_note.issuing_date.to_s).to eq(Time.zone.today.to_s)
+      credit_note = result.credit_note
+      expect(credit_note.invoice).to eq(invoice)
+      expect(credit_note.customer).to eq(invoice.customer)
+      expect(credit_note.issuing_date.to_s).to eq(Time.zone.today.to_s)
 
-        expect(credit_note.coupons_adjustment_amount_cents).to eq(0)
-        expect(credit_note.taxes_amount_cents).to eq(3)
-        expect(credit_note.taxes_rate).to eq(20)
-        expect(credit_note.applied_taxes.count).to eq(1)
+      expect(credit_note.coupons_adjustment_amount_cents).to eq(0)
+      expect(credit_note.taxes_amount_cents).to eq(3)
+      expect(credit_note.taxes_rate).to eq(20)
+      expect(credit_note.applied_taxes.count).to eq(1)
 
-        expect(credit_note.total_amount_currency).to eq(invoice.currency)
-        expect(credit_note.total_amount_cents).to eq(18)
+      expect(credit_note.total_amount_currency).to eq(invoice.currency)
+      expect(credit_note.total_amount_cents).to eq(18)
 
-        expect(credit_note.credit_amount_currency).to eq(invoice.currency)
-        expect(credit_note.credit_amount_cents).to eq(12)
-        expect(credit_note.balance_amount_currency).to eq(invoice.currency)
-        expect(credit_note.balance_amount_cents).to eq(12)
-        expect(credit_note.credit_status).to eq("available")
+      expect(credit_note.credit_amount_currency).to eq(invoice.currency)
+      expect(credit_note.credit_amount_cents).to eq(12)
+      expect(credit_note.balance_amount_currency).to eq(invoice.currency)
+      expect(credit_note.balance_amount_cents).to eq(12)
+      expect(credit_note.credit_status).to eq("available")
 
-        expect(credit_note.refund_amount_currency).to eq(invoice.currency)
-        expect(credit_note.refund_amount_cents).to eq(6)
-        expect(credit_note.refund_status).to eq("pending")
+      expect(credit_note.refund_amount_currency).to eq(invoice.currency)
+      expect(credit_note.refund_amount_cents).to eq(6)
+      expect(credit_note.refund_status).to eq("pending")
 
-        expect(credit_note).to be_other
+      expect(credit_note).to be_other
 
-        expect(credit_note.items.count).to eq(2)
-        item1 = credit_note.items.order(created_at: :asc).first
-        expect(item1.fee).to eq(fee1)
-        expect(item1.amount_cents).to eq(10)
-        expect(item1.amount_currency).to eq(invoice.currency)
+      expect(credit_note.items.count).to eq(2)
+      item1 = credit_note.items.order(created_at: :asc).first
+      expect(item1.fee).to eq(fee1)
+      expect(item1.amount_cents).to eq(10)
+      expect(item1.amount_currency).to eq(invoice.currency)
 
-        item2 = credit_note.items.order(created_at: :asc).last
-        expect(item2.fee).to eq(fee2)
-        expect(item2.amount_cents).to eq(5)
-        expect(item2.amount_currency).to eq(invoice.currency)
-      end
+      item2 = credit_note.items.order(created_at: :asc).last
+      expect(item2.fee).to eq(fee2)
+      expect(item2.amount_cents).to eq(5)
+      expect(item2.amount_currency).to eq(invoice.currency)
     end
 
     it "enqueues SegmentTrackJob after commit" do
@@ -359,12 +359,10 @@ RSpec.describe CreditNotes::CreateService, type: :service do
           it "returns a failure" do
             result = create_service.call
 
-            aggregate_failures do
-              expect(result).not_to be_success
+            expect(result).not_to be_success
 
-              expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-              expect(result.error.code).to eq("invalid_type_or_status")
-            end
+            expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+            expect(result.error.code).to eq("invalid_type_or_status")
           end
         end
       end
@@ -413,43 +411,41 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       it "takes coupons amount into account" do
         result = create_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
+        expect(result).to be_success
 
-          credit_note = result.credit_note
-          expect(credit_note).to have_attributes(
-            invoice:,
-            customer: invoice.customer,
-            currency: invoice.currency,
-            credit_status: "available",
-            refund_status: "pending",
-            reason: "other",
-            total_amount_cents: 9,
-            credit_amount_cents: 6,
-            refund_amount_cents: 3,
-            balance_amount_cents: 6,
-            coupons_adjustment_amount_cents: 8,
-            taxes_amount_cents: 2,
-            taxes_rate: 20
-          )
-          expect(credit_note.applied_taxes.count).to eq(1)
+        credit_note = result.credit_note
+        expect(credit_note).to have_attributes(
+          invoice:,
+          customer: invoice.customer,
+          currency: invoice.currency,
+          credit_status: "available",
+          refund_status: "pending",
+          reason: "other",
+          total_amount_cents: 9,
+          credit_amount_cents: 6,
+          refund_amount_cents: 3,
+          balance_amount_cents: 6,
+          coupons_adjustment_amount_cents: 8,
+          taxes_amount_cents: 2,
+          taxes_rate: 20
+        )
+        expect(credit_note.applied_taxes.count).to eq(1)
 
-          expect(credit_note.items.count).to eq(2)
+        expect(credit_note.items.count).to eq(2)
 
-          item1 = credit_note.items.order(created_at: :asc).first
-          expect(item1).to have_attributes(
-            fee: fee1,
-            amount_cents: 10,
-            amount_currency: invoice.currency
-          )
+        item1 = credit_note.items.order(created_at: :asc).first
+        expect(item1).to have_attributes(
+          fee: fee1,
+          amount_cents: 10,
+          amount_currency: invoice.currency
+        )
 
-          item2 = credit_note.items.order(created_at: :asc).last
-          expect(item2).to have_attributes(
-            fee: fee2,
-            amount_cents: 5,
-            amount_currency: invoice.currency
-          )
-        end
+        item2 = credit_note.items.order(created_at: :asc).last
+        expect(item2).to have_attributes(
+          fee: fee2,
+          amount_cents: 5,
+          amount_currency: invoice.currency
+        )
       end
     end
 
@@ -492,20 +488,18 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       it "Creates credit note and voids corresponding amount of credits from the wallet" do
         result = create_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
+        expect(result).to be_success
 
-          credit_note = result.credit_note
-          expect(credit_note.refund_amount_cents).to eq(1000)
-          wallet_transaction = wallet.wallet_transactions.order(:created_at).last
-          # we're refunding 10_00 cents -> 10 euros, the rate of the wallet, 1 credit = 10 euros, so amount credits
-          # in the transaction is 1, while the "money" amount is 10
-          expect(wallet_transaction.credit_amount).to eq(1)
-          expect(wallet_transaction.amount).to eq(10)
-          expect(wallet_transaction.transaction_status).to eq("voided")
-          expect(wallet_transaction.transaction_type).to eq("outbound")
-          expect(wallet.reload.balance_cents).to eq(0)
-        end
+        credit_note = result.credit_note
+        expect(credit_note.refund_amount_cents).to eq(1000)
+        wallet_transaction = wallet.wallet_transactions.order(:created_at).last
+        # we're refunding 10_00 cents -> 10 euros, the rate of the wallet, 1 credit = 10 euros, so amount credits
+        # in the transaction is 1, while the "money" amount is 10
+        expect(wallet_transaction.credit_amount).to eq(1)
+        expect(wallet_transaction.amount).to eq(10)
+        expect(wallet_transaction.transaction_status).to eq("voided")
+        expect(wallet_transaction.transaction_type).to eq("outbound")
+        expect(wallet.reload.balance_cents).to eq(0)
       end
 
       context "with different rate amount" do
@@ -514,15 +508,13 @@ RSpec.describe CreditNotes::CreateService, type: :service do
         it "calculates correct credits amount" do
           result = create_service.call
 
-          aggregate_failures do
-            expect(result).to be_success
+          expect(result).to be_success
 
-            credit_note = result.credit_note
-            expect(credit_note.refund_amount_cents).to eq(1000)
-            wallet_transaction = wallet.wallet_transactions.order(:created_at).last
-            expect(wallet_transaction.credit_amount).to eq(0.5)
-            expect(wallet_transaction.amount).to eq(10)
-          end
+          credit_note = result.credit_note
+          expect(credit_note.refund_amount_cents).to eq(1000)
+          wallet_transaction = wallet.wallet_transactions.order(:created_at).last
+          expect(wallet_transaction.credit_amount).to eq(0.5)
+          expect(wallet_transaction.amount).to eq(10)
         end
       end
 
@@ -532,12 +524,10 @@ RSpec.describe CreditNotes::CreateService, type: :service do
         it "returns error" do
           result = create_service.call
 
-          aggregate_failures do
-            expect(result).not_to be_success
+          expect(result).not_to be_success
 
-            expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-            expect(result.error.code).to eq("invalid_type_or_status")
-          end
+          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(result.error.code).to eq("invalid_type_or_status")
         end
       end
 
@@ -547,12 +537,10 @@ RSpec.describe CreditNotes::CreateService, type: :service do
         it "returns error" do
           result = create_service.call
 
-          aggregate_failures do
-            expect(result).not_to be_success
+          expect(result).not_to be_success
 
-            expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages.keys).to include(:amount_cents)
-          end
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to include(:amount_cents)
         end
       end
 
@@ -562,12 +550,10 @@ RSpec.describe CreditNotes::CreateService, type: :service do
         it "returns error" do
           result = create_service.call
 
-          aggregate_failures do
-            expect(result).not_to be_success
+          expect(result).not_to be_success
 
-            expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages.keys).to include(:credit_amount_cents)
-          end
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to include(:credit_amount_cents)
         end
       end
     end
@@ -664,6 +650,19 @@ RSpec.describe CreditNotes::CreateService, type: :service do
 
       it "does not send an email" do
         expect { subject }.not_to have_enqueued_job(SendEmailJob)
+      end
+    end
+
+    context "when reason is invalid" do
+      let(:args) { {reason: "invalid"} }
+
+      it "returns a failure" do
+        result = create_service.call
+
+        expect(result).not_to be_success
+        expect(CreditNote.count).to eq(0)
+
+        expect(result.error.messages).to eq(reason: ["value_is_invalid"])
       end
     end
   end


### PR DESCRIPTION
## Context

The `CreditNote::Create` service was catching all `ArgumentError` exceptions and converting them to `reason` validation errors, which could mask legitimate errors from other parts of the code. This made debugging difficult and could hide real bugs.

## Description

This fixes the issue by adding an explicit validation.

