### PR TITLE
fix(entitlements): Convert boolean string for frontend

### DIFF
--- a/app/graphql/types/entitlement/plan_entitlement_privilege_object.rb
+++ b/app/graphql/types/entitlement/plan_entitlement_privilege_object.rb
@@ -25,6 +25,17 @@ module Types
       def value_type
         object.privilege.value_type
       end
+
+      def value
+        # NOTE: If the boolean `true`/`false` were sent to via the API, ActiveRecord will store them as `"t"`/`"f"`
+        #       We convert them to full words, as string, for the frontent
+        if object.privilege.value_type == "boolean"
+          return "false" if object.value == "f"
+          return "true" if object.value == "t"
+        end
+
+        object.value
+      end
     end
   end
 end


### PR DESCRIPTION
With ActiveRecord if you do `EntitlementValue.update value: true`, it will convert the value to `"t"` because the db column is string.
This is intentional and the serializer will use `ActiveModel::Type::Boolean.new.cast("t")` to convert it to `true.

In GQL, we rely on `"true"` and `"false"` string to display the select box. So we need to convert on read.
On write it's fine because the value will always be casted when returned via the API.