### PR TITLE
fix(invoice-pdf): Fix the address on the invoice PDF based on the country

### DIFF
--- a/app/views/helpers/slim_helper.rb
+++ b/app/views/helpers/slim_helper.rb
@@ -11,4 +11,46 @@ class SlimHelper
       )
     end.render(context, **locals)
   end
+
+  def self.format_address(address_line1, address_line2, city, state, zipcode, country_code)
+    country = ISO3166::Country.new(country_code)&.common_name
+
+    case country_code&.upcase
+    when "DE", "FR", "IT"
+      [
+        address_line1,
+        address_line2,
+        [zipcode, city].compact.join(" "),
+        country
+      ].compact.reject(&:empty?)
+    when "US", "CA", "GB", "AU"
+      [
+        address_line1,
+        address_line2,
+        [city, [state, zipcode].compact.join(" ")].compact.join(", "),
+        country
+      ].compact.reject(&:empty?)
+    when "BR"
+      [
+        address_line1,
+        address_line2,
+        [city, state].compact.join(" - ") + (zipcode.present? ? ", #{zipcode}" : ""),
+        country
+      ].compact.reject(&:empty?)
+    when "ES"
+      [
+        address_line1,
+        address_line2,
+        [zipcode, [city, state].compact.join(", ")].compact.join(" "),
+        country
+      ].compact.reject(&:empty?)
+    else
+      [
+        address_line1,
+        address_line2,
+        [city, [state, zipcode].compact.join(" ")].compact.join(", "),
+        country
+      ].compact.reject(&:empty?)
+    end
+  end
 end

--- a/app/views/templates/invoices/v1.slim
+++ b/app/views/templates/invoices/v1.slim
@@ -395,35 +395,14 @@ html
               | #{billing_entity.legal_name}
             - else
               | #{billing_entity.name}
-          .body-2 = billing_entity.address_line1
-          .body-2 = billing_entity.address_line2
-          .body-2
-            span
-              = billing_entity.zipcode
-            - if billing_entity.zipcode.present? && billing_entity.city.present?
-              span
-                | , &nbsp;
-            span
-              = billing_entity.city
-          - if billing_entity.state.present?
-            .body-2 = billing_entity.state
-          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          - SlimHelper.format_address(billing_entity.address_line1, billing_entity.address_line2, billing_entity.city, billing_entity.state, billing_entity.zipcode, billing_entity.country).each do |line|
+            .body-2 = line
           .body-2 = billing_entity.email
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
           .body-2 = customer.display_name
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
-          .body-2
-            span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
-              span
-                | , &nbsp;
-            span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
+          - SlimHelper.format_address(customer.address_line1, customer.address_line2, customer.city, customer.state, customer.zipcode, customer.country).each do |line|
+            .body-2 = line
           .body-2 = customer.email
 
       .mb-24

--- a/app/views/templates/invoices/v2.slim
+++ b/app/views/templates/invoices/v2.slim
@@ -395,35 +395,14 @@ html
               | #{billing_entity.legal_name}
             - else
               | #{billing_entity.name}
-          .body-2 = billing_entity.address_line1
-          .body-2 = billing_entity.address_line2
-          .body-2
-            span
-              = billing_entity.zipcode
-            - if billing_entity.zipcode.present? && billing_entity.city.present?
-              span
-                | , &nbsp;
-            span
-              = billing_entity.city
-          - if billing_entity.state.present?
-            .body-2 = billing_entity.state
-          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          - SlimHelper.format_address(billing_entity.address_line1, billing_entity.address_line2, billing_entity.city, billing_entity.state, billing_entity.zipcode, billing_entity.country).each do |line|
+            .body-2 = line
           .body-2 = billing_entity.email
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
           .body-2 = customer.display_name
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
-          .body-2
-            span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
-              span
-                | , &nbsp;
-            span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
+          - SlimHelper.format_address(customer.address_line1, customer.address_line2, customer.city, customer.state, customer.zipcode, customer.country).each do |line|
+            .body-2 = line
           .body-2 = customer.email
 
       .mb-24

--- a/app/views/templates/invoices/v3.slim
+++ b/app/views/templates/invoices/v3.slim
@@ -376,19 +376,8 @@ html
               | #{billing_entity.name}
           - if billing_entity.legal_number.present?
             .body-2 #{billing_entity.legal_number}
-          .body-2 = billing_entity.address_line1
-          .body-2 = billing_entity.address_line2
-          .body-2
-            span
-              = billing_entity.zipcode
-            - if billing_entity.zipcode.present? && billing_entity.city.present?
-              span
-                | , &nbsp;
-            span
-              = billing_entity.city
-          - if billing_entity.state.present?
-            .body-2 = billing_entity.state
-          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          - SlimHelper.format_address(billing_entity.address_line1, billing_entity.address_line2, billing_entity.city, billing_entity.state, billing_entity.zipcode, billing_entity.country).each do |line|
+            .body-2 = line
           .body-2 = billing_entity.email
           - if billing_entity.tax_identification_number.present?
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
@@ -397,18 +386,8 @@ html
           .body-2 = customer.display_name
           - if customer.legal_number.present?
             .body-2 #{customer.legal_number}
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
-          .body-2
-            span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
-              span
-                | , &nbsp;
-            span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
+          - SlimHelper.format_address(customer.address_line1, customer.address_line2, customer.city, customer.state, customer.zipcode, customer.country).each do |line|
+            .body-2 = line
           .body-2 = customer.email
           - if customer.tax_identification_number.present?
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)

--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -428,19 +428,8 @@ html
               | #{billing_entity.name}
           - if billing_entity.legal_number.present?
             .body-2 #{billing_entity.legal_number}
-          .body-2 = billing_entity.address_line1
-          .body-2 = billing_entity.address_line2
-          .body-2
-            span
-              = billing_entity.zipcode
-            - if billing_entity.zipcode.present? && billing_entity.city.present?
-              span
-                | , &nbsp;
-            span
-              = billing_entity.city
-          - if billing_entity.state.present?
-            .body-2 = billing_entity.state
-          .body-2 = ISO3166::Country.new(billing_entity.country)&.common_name
+          - SlimHelper.format_address(billing_entity.address_line1, billing_entity.address_line2, billing_entity.city, billing_entity.state, billing_entity.zipcode, billing_entity.country).each do |line|
+            .body-2 = line
           .body-2 = billing_entity.email
           - if billing_entity.tax_identification_number.present?
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
@@ -449,18 +438,8 @@ html
           .body-2 = customer.display_name
           - if customer.legal_number.present?
             .body-2 #{customer.legal_number}
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
-          .body-2
-            span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
-              span
-                | , &nbsp;
-            span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
+          - SlimHelper.format_address(customer.address_line1, customer.address_line2, customer.city, customer.state, customer.zipcode, customer.country).each do |line|
+            .body-2 = line
           .body-2 = customer.email&.gsub(/,\s*/, ', ')
           - if customer.tax_identification_number.present?
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)


### PR DESCRIPTION
## Context

There is a need to format the address in the invoice PDF based on the billing entity and the customer country.

## Description

Created a helper function to format the address and use it on all versions of the invoice PDFs.