### PR TITLE
misc: Add kosovo country code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
-    countries (5.7.2)
+    countries (8.0.3)
       unaccent (~> 0.3)
     crack (0.4.6)
       bigdecimal

--- a/config/initializers/countries.rb
+++ b/config/initializers/countries.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# NOTE: Kosovo does not have an ISO 3166-1 alpha-2 code yet and as such
+# is not included in the "countries" gem.
+# See related issue: https://github.com/countries/countries/issues/793
+#
+# As it was requested by multiple customers, we are registering as it an
+# available country until the ISO 3166-1 alpha-2 code is assigned.
+ISO3166::Data.register(
+  alpha2: "XK",
+  alpha3: "XKX",
+  continent: "Europe",
+  country_code: "383",
+  currency_code: "EUR",
+  distance_unit: "KM",
+  gec: "KV",
+  geo: {
+    latitude: 42.5833,
+    longitude: 21.0001,
+    max_latitude: 43.139,
+    max_longitude: 21.835,
+    min_latitude: 41.877,
+    min_longitude: 19.949,
+    bounds: {
+      northeast: {
+        lat: 41.877,
+        lng: 19.949
+      },
+      southwest: {
+        lat: 43.139,
+        lng: 21.835
+      }
+    }
+  },
+  international_prefix: "00",
+  ioc: "KOS",
+  iso_long_name: "Republic of Kosovo",
+  iso_short_name: "Kosovo",
+  languages_official: ["sq", "sr"],
+  languages_spoken: ["sq", "sr"],
+  nationality: "Kosovar",
+  postal_code: true,
+  postal_code_format: "\\d{5}",
+  region: "Europe",
+  start_of_week: "monday",
+  subregion: "Southern Europe",
+  unofficial_names: ["Kosovo", "Kosova", "Косово"],
+  world_region: "EMEA",
+  translations: {
+    "en" => "Kosovo"
+  }
+)

--- a/schema.graphql
+++ b/schema.graphql
@@ -1045,7 +1045,7 @@ enum CountryCode {
   AD
 
   """
-  United Arab Emirates
+  United Arab Emirates (the)
   """
   AE
 
@@ -1195,7 +1195,7 @@ enum CountryCode {
   BR
 
   """
-  Bahamas
+  Bahamas (the)
   """
   BS
 
@@ -1230,22 +1230,22 @@ enum CountryCode {
   CA
 
   """
-  Cocos (Keeling) Islands
+  Cocos (Keeling) Islands (the)
   """
   CC
 
   """
-  Congo (Democratic Republic of the)
+  Congo (the Democratic Republic of the)
   """
   CD
 
   """
-  Central African Republic
+  Central African Republic (the)
   """
   CF
 
   """
-  Congo
+  Congo (the)
   """
   CG
 
@@ -1260,7 +1260,7 @@ enum CountryCode {
   CI
 
   """
-  Cook Islands
+  Cook Islands (the)
   """
   CK
 
@@ -1340,7 +1340,7 @@ enum CountryCode {
   DM
 
   """
-  Dominican Republic
+  Dominican Republic (the)
   """
   DO
 
@@ -1395,7 +1395,7 @@ enum CountryCode {
   FJ
 
   """
-  Falkland Islands (Malvinas)
+  Falkland Islands (the) [Malvinas]
   """
   FK
 
@@ -1405,7 +1405,7 @@ enum CountryCode {
   FM
 
   """
-  Faroe Islands
+  Faroe Islands (the)
   """
   FO
 
@@ -1420,7 +1420,7 @@ enum CountryCode {
   GA
 
   """
-  United Kingdom of Great Britain and Northern Ireland
+  United Kingdom of Great Britain and Northern Ireland (the)
   """
   GB
 
@@ -1460,7 +1460,7 @@ enum CountryCode {
   GL
 
   """
-  Gambia
+  Gambia (the)
   """
   GM
 
@@ -1565,7 +1565,7 @@ enum CountryCode {
   IN
 
   """
-  British Indian Ocean Territory
+  British Indian Ocean Territory (the)
   """
   IO
 
@@ -1630,7 +1630,7 @@ enum CountryCode {
   KI
 
   """
-  Comoros
+  Comoros (the)
   """
   KM
 
@@ -1640,12 +1640,12 @@ enum CountryCode {
   KN
 
   """
-  Korea (Democratic People's Republic of)
+  Korea (the Democratic People's Republic of)
   """
   KP
 
   """
-  Korea (Republic of)
+  Korea (the Republic of)
   """
   KR
 
@@ -1655,7 +1655,7 @@ enum CountryCode {
   KW
 
   """
-  Cayman Islands
+  Cayman Islands (the)
   """
   KY
 
@@ -1665,7 +1665,7 @@ enum CountryCode {
   KZ
 
   """
-  Lao People's Democratic Republic
+  Lao People's Democratic Republic (the)
   """
   LA
 
@@ -1730,7 +1730,7 @@ enum CountryCode {
   MC
 
   """
-  Moldova (Republic of)
+  Moldova (the Republic of)
   """
   MD
 
@@ -1750,7 +1750,7 @@ enum CountryCode {
   MG
 
   """
-  Marshall Islands
+  Marshall Islands (the)
   """
   MH
 
@@ -1780,7 +1780,7 @@ enum CountryCode {
   MO
 
   """
-  Northern Mariana Islands
+  Northern Mariana Islands (the)
   """
   MP
 
@@ -1845,7 +1845,7 @@ enum CountryCode {
   NC
 
   """
-  Niger
+  Niger (the)
   """
   NE
 
@@ -1865,7 +1865,7 @@ enum CountryCode {
   NI
 
   """
-  Netherlands
+  Netherlands (the)
   """
   NL
 
@@ -1920,7 +1920,7 @@ enum CountryCode {
   PG
 
   """
-  Philippines
+  Philippines (the)
   """
   PH
 
@@ -1990,7 +1990,7 @@ enum CountryCode {
   RS
 
   """
-  Russian Federation
+  Russian Federation (the)
   """
   RU
 
@@ -2015,7 +2015,7 @@ enum CountryCode {
   SC
 
   """
-  Sudan
+  Sudan (the)
   """
   SD
 
@@ -2105,7 +2105,7 @@ enum CountryCode {
   SZ
 
   """
-  Turks and Caicos Islands
+  Turks and Caicos Islands (the)
   """
   TC
 
@@ -2115,7 +2115,7 @@ enum CountryCode {
   TD
 
   """
-  French Southern Territories
+  French Southern Territories (the)
   """
   TF
 
@@ -2175,7 +2175,7 @@ enum CountryCode {
   TV
 
   """
-  Taiwan, Province of China
+  Taiwan (Province of China)
   """
   TW
 
@@ -2195,12 +2195,12 @@ enum CountryCode {
   UG
 
   """
-  United States Minor Outlying Islands
+  United States Minor Outlying Islands (the)
   """
   UM
 
   """
-  United States of America
+  United States of America (the)
   """
   US
 
@@ -2215,7 +2215,7 @@ enum CountryCode {
   UZ
 
   """
-  Holy See
+  Holy See (the)
   """
   VA
 
@@ -2258,6 +2258,11 @@ enum CountryCode {
   Samoa
   """
   WS
+
+  """
+  Kosovo
+  """
+  XK
 
   """
   Yemen

--- a/schema.json
+++ b/schema.json
@@ -6608,7 +6608,7 @@
             },
             {
               "name": "AE",
-              "description": "United Arab Emirates",
+              "description": "United Arab Emirates (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -6788,7 +6788,7 @@
             },
             {
               "name": "BS",
-              "description": "Bahamas",
+              "description": "Bahamas (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -6830,25 +6830,25 @@
             },
             {
               "name": "CC",
-              "description": "Cocos (Keeling) Islands",
+              "description": "Cocos (Keeling) Islands (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CD",
-              "description": "Congo (Democratic Republic of the)",
+              "description": "Congo (the Democratic Republic of the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CF",
-              "description": "Central African Republic",
+              "description": "Central African Republic (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "CG",
-              "description": "Congo",
+              "description": "Congo (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -6866,7 +6866,7 @@
             },
             {
               "name": "CK",
-              "description": "Cook Islands",
+              "description": "Cook Islands (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -6962,7 +6962,7 @@
             },
             {
               "name": "DO",
-              "description": "Dominican Republic",
+              "description": "Dominican Republic (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7028,7 +7028,7 @@
             },
             {
               "name": "FK",
-              "description": "Falkland Islands (Malvinas)",
+              "description": "Falkland Islands (the) [Malvinas]",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7040,7 +7040,7 @@
             },
             {
               "name": "FO",
-              "description": "Faroe Islands",
+              "description": "Faroe Islands (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7058,7 +7058,7 @@
             },
             {
               "name": "GB",
-              "description": "United Kingdom of Great Britain and Northern Ireland",
+              "description": "United Kingdom of Great Britain and Northern Ireland (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7106,7 +7106,7 @@
             },
             {
               "name": "GM",
-              "description": "Gambia",
+              "description": "Gambia (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7232,7 +7232,7 @@
             },
             {
               "name": "IO",
-              "description": "British Indian Ocean Territory",
+              "description": "British Indian Ocean Territory (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7310,7 +7310,7 @@
             },
             {
               "name": "KM",
-              "description": "Comoros",
+              "description": "Comoros (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7322,13 +7322,13 @@
             },
             {
               "name": "KP",
-              "description": "Korea (Democratic People's Republic of)",
+              "description": "Korea (the Democratic People's Republic of)",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "KR",
-              "description": "Korea (Republic of)",
+              "description": "Korea (the Republic of)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7340,7 +7340,7 @@
             },
             {
               "name": "KY",
-              "description": "Cayman Islands",
+              "description": "Cayman Islands (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7352,7 +7352,7 @@
             },
             {
               "name": "LA",
-              "description": "Lao People's Democratic Republic",
+              "description": "Lao People's Democratic Republic (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7430,7 +7430,7 @@
             },
             {
               "name": "MD",
-              "description": "Moldova (Republic of)",
+              "description": "Moldova (the Republic of)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7454,7 +7454,7 @@
             },
             {
               "name": "MH",
-              "description": "Marshall Islands",
+              "description": "Marshall Islands (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7490,7 +7490,7 @@
             },
             {
               "name": "MP",
-              "description": "Northern Mariana Islands",
+              "description": "Northern Mariana Islands (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7568,7 +7568,7 @@
             },
             {
               "name": "NE",
-              "description": "Niger",
+              "description": "Niger (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7592,7 +7592,7 @@
             },
             {
               "name": "NL",
-              "description": "Netherlands",
+              "description": "Netherlands (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7658,7 +7658,7 @@
             },
             {
               "name": "PH",
-              "description": "Philippines",
+              "description": "Philippines (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7742,7 +7742,7 @@
             },
             {
               "name": "RU",
-              "description": "Russian Federation",
+              "description": "Russian Federation (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7772,7 +7772,7 @@
             },
             {
               "name": "SD",
-              "description": "Sudan",
+              "description": "Sudan (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7880,7 +7880,7 @@
             },
             {
               "name": "TC",
-              "description": "Turks and Caicos Islands",
+              "description": "Turks and Caicos Islands (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7892,7 +7892,7 @@
             },
             {
               "name": "TF",
-              "description": "French Southern Territories",
+              "description": "French Southern Territories (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7964,7 +7964,7 @@
             },
             {
               "name": "TW",
-              "description": "Taiwan, Province of China",
+              "description": "Taiwan (Province of China)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7988,13 +7988,13 @@
             },
             {
               "name": "UM",
-              "description": "United States Minor Outlying Islands",
+              "description": "United States Minor Outlying Islands (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "US",
-              "description": "United States of America",
+              "description": "United States of America (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -8012,7 +8012,7 @@
             },
             {
               "name": "VA",
-              "description": "Holy See",
+              "description": "Holy See (the)",
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -8091,6 +8091,12 @@
             {
               "name": "ZW",
               "description": "Zimbabwe",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "XK",
+              "description": "Kosovo",
               "isDeprecated": false,
               "deprecationReason": null
             }


### PR DESCRIPTION
## Context

Lago relies on the https://github.com/countries/countries gem to get the list of available country. It is using the list of ISO 3166 country codes.

Some customers recently ask for the inclusion of the Kosovo in the list of countries. The issue is that for now, no ISO 3166 country code is assigne to the Kosovo. 

An issue is opened on the countries repository about it: https://github.com/countries/countries/issues/793
I appears that it will not be fixed until the Kosovo officially received an ISO 3166 country code.

## Description

To address the request from customers, this PR is using the proposed workaround from the source repository issue.
The PR also updates the `countries` gem
