### PR TITLE
fix(event): Kafka payload for batch events

### DIFF
--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -84,25 +84,7 @@ module Events
     end
 
     def produce_kafka_event(event)
-      return if ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"].blank?
-      return if ENV["LAGO_KAFKA_RAW_EVENTS_TOPIC"].blank?
-
-      Karafka.producer.produce_async(
-        topic: ENV["LAGO_KAFKA_RAW_EVENTS_TOPIC"],
-        key: "#{organization.id}-#{event.external_subscription_id}",
-        payload: {
-          organization_id: organization.id,
-          external_customer_id: event.external_customer_id,
-          external_subscription_id: event.external_subscription_id,
-          transaction_id: event.transaction_id,
-          timestamp: event.timestamp.to_f,
-          code: event.code,
-          properties: event.properties,
-          ingested_at: Time.zone.now.iso8601[...-1],
-          precise_total_amount_cents: event.precise_total_amount_cents.present? ? event.precise_total_amount_cents.to_s : "0.0",
-          source: "http_ruby"
-        }.to_json
-      )
+      Events::KafkaProducerService.call!(event:, organization:)
     end
   end
 end

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -47,30 +47,7 @@ module Events
     attr_reader :organization, :params, :timestamp, :metadata
 
     def produce_kafka_event(event)
-      return if ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"].blank?
-      return if ENV["LAGO_KAFKA_RAW_EVENTS_TOPIC"].blank?
-
-      Karafka.producer.produce_async(
-        topic: ENV["LAGO_KAFKA_RAW_EVENTS_TOPIC"],
-        key: "#{organization.id}-#{event.external_subscription_id}",
-        payload: {
-          organization_id: organization.id,
-          external_customer_id: event.external_customer_id,
-          external_subscription_id: event.external_subscription_id,
-          transaction_id: event.transaction_id,
-          # NOTE: Removes trailing 'Z' to allow clickhouse parsing
-          timestamp: event.timestamp.to_f.to_s,
-          code: event.code,
-          # NOTE: Default value to 0.0 is required for clickhouse parsing
-          precise_total_amount_cents: event.precise_total_amount_cents.present? ? event.precise_total_amount_cents.to_s : "0.0",
-          properties: event.properties,
-          ingested_at: Time.zone.now.iso8601[...-1],
-          source: "http_ruby",
-          source_metadata: {
-            api_post_processed: !organization.clickhouse_events_store?
-          }
-        }.to_json
-      )
+      Events::KafkaProducerService.call!(event:, organization:)
     end
   end
 end

--- a/app/services/events/kafka_producer_service.rb
+++ b/app/services/events/kafka_producer_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Events
+  class KafkaProducerService < BaseService
+    Result = BaseResult
+
+    EVENT_SOURCE = "http_ruby"
+
+    def initialize(event:, organization:)
+      @event = event
+      @organization = organization
+      super
+    end
+
+    def call
+      return result if ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"].blank?
+      return result if ENV["LAGO_KAFKA_RAW_EVENTS_TOPIC"].blank?
+
+      Karafka.producer.produce_async(
+        topic: ENV["LAGO_KAFKA_RAW_EVENTS_TOPIC"],
+        key: "#{organization.id}-#{event.external_subscription_id}",
+        payload: {
+          organization_id: organization.id,
+          external_customer_id: event.external_customer_id,
+          external_subscription_id: event.external_subscription_id,
+          transaction_id: event.transaction_id,
+          # NOTE: Removes trailing 'Z' to allow clickhouse parsing
+          timestamp: event.timestamp.to_f.to_s,
+          code: event.code,
+          # NOTE: Default value to 0.0 is required for clickhouse parsing
+          precise_total_amount_cents: event.precise_total_amount_cents.present? ? event.precise_total_amount_cents.to_s : "0.0",
+          properties: event.properties,
+          ingested_at: Time.zone.now.iso8601[...-1],
+          source: EVENT_SOURCE,
+          source_metadata: {
+            api_post_processed: !organization.clickhouse_events_store?
+          }
+        }.to_json
+      )
+
+      result
+    end
+
+    private
+
+    attr_reader :event, :organization
+  end
+end

--- a/spec/services/events/kafka_producer_service_spec.rb
+++ b/spec/services/events/kafka_producer_service_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe Events::KafkaProducerService, type: :service do
+  subject(:producer_service) { described_class.new(event: event, organization: organization) }
+
+  let(:event) { create(:event, organization:) }
+  let(:organization) { create(:organization) }
+
+  let(:karafka_producer) { instance_double(WaterDrop::Producer) }
+
+  describe "#call" do
+    before do
+      allow(Karafka).to receive(:producer).and_return(karafka_producer)
+      allow(karafka_producer).to receive(:produce_async)
+    end
+
+    context "with Kafka config" do
+      before do
+        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = "kafka"
+        ENV["LAGO_KAFKA_RAW_EVENTS_TOPIC"] = "raw_events"
+      end
+
+      it "produces the event on kafka" do
+        freeze_time do
+          allow(Karafka).to receive(:producer).and_return(karafka_producer)
+          allow(karafka_producer).to receive(:produce_async)
+
+          producer_service.call
+
+          expect(karafka_producer).to have_received(:produce_async)
+            .with(
+              topic: "raw_events",
+              key: "#{organization.id}-#{event.external_subscription_id}",
+              payload: {
+                organization_id: organization.id,
+                external_customer_id: event.external_customer_id,
+                external_subscription_id: event.external_subscription_id,
+                transaction_id: event.transaction_id,
+                timestamp: event.timestamp.to_f.to_s,
+                code: event.code,
+                precise_total_amount_cents: event.precise_total_amount_cents.present? ? event.precise_total_amount_cents.to_s : "0.0",
+                properties: event.properties,
+                ingested_at: Time.zone.now.iso8601[...-1],
+                source: "http_ruby",
+                source_metadata: {
+                  api_post_processed: true
+                }
+              }.to_json
+            )
+        end
+      end
+    end
+
+    context "without" do
+      before do
+        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = nil
+        ENV["LAGO_KAFKA_RAW_EVENTS_TOPIC"] = nil
+      end
+
+      it "produces the event on kafka" do
+        freeze_time do
+          producer_service.call
+
+          expect(karafka_producer).not_to have_received(:produce_async)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Kafka payload for raw events is built in two places, one in the `Events::CreateService` and one in `Events::CreateBatchService` this issue is that the one from the batch service is lacking the `metadata` fields.

This field is a hash used by the events processor to find if the event is already post processed in the API. If not and if the event matched an in advance charge, a message is produced in the `events_charged_in_advance` topic. 

As the metadata was missing the event processor was considering that the event was not post-processed by the API even if it was, leading to a double processing and a duplicated fee...

## Description

This PR makes sure that both  `Events::CreateService` and `Events::CreateBatchService` uses the same Kafka producer service to remove the duplicated payload handling.

NOTE: The duplication should have been avoided by the unique index defined at Posgres level but another bug have been identified at this level and will be fixed in a second PR.