### PR TITLE
fix(invoice): Fix pay-in-advance charge invoicing when Anrok is enabled

### DIFF
--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -222,7 +222,8 @@ module Fees
       result.fees_taxes = taxes_result.fees
 
       fees_result.each do |fee|
-        fee_taxes = result.fees_taxes.find { |item| item.item_id == fee.id }
+        item_id = fee.id || fee.item_id
+        fee_taxes = result.fees_taxes.find { |item| item.item_id == item_id }
 
         res = Fees::ApplyProviderTaxesService.call(fee:, fee_taxes:)
         res.raise_if_error!


### PR DESCRIPTION
## Context

The pay-in-advance charge invoicing process was failing when Anrok tax integration was enabled. For pay-in-advance charge invoicing, the `Fees::CreatePayInAdvanceService` is called with `estimate: true`. This will not persist the fees and the fees won't have an `id`. When sending those fees to Anrok, we'll default to the fee `item_id`, which is the billable metric ID:

https://github.com/getlago/lago-api/blob/d476c33e3abb41bc88701cd13d562d20111e10a7/app/services/integrations/aggregator/taxes/invoices/payloads/anrok.rb#L52

But when we try to look up the tax result for a specific fee, we were relying on the fee `id` which is `nil`:

https://github.com/getlago/lago-api/blob/e142bf11cf449cde27d379dbad9115d54bdc70a7/app/services/fees/create_pay_in_advance_service.rb#L200

## Description

This change corrects the tax resolution in the `Fees::CreatePayInAdvanceService` by using a fallback to the fee's `item_id`. 

