### PR TITLE
Fix(billing_entity): api key doesn't work for billing entities endpoint

### DIFF
--- a/app/controllers/api/v1/billing_entities_controller.rb
+++ b/app/controllers/api/v1/billing_entities_controller.rb
@@ -128,6 +128,10 @@ module Api
           invoice_custom_section_codes: []
         )
       end
+
+      def resource_name
+        "billing_entity"
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Billing_entities_controller was missing resource name, so when checking api keys permissions,  we were not able to get the resource_name

## Description

- added resource_name method to billing_entities_controller