### PR TITLE
fix(fees): Avoid duplicated in advance - Phase 1

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -4,6 +4,7 @@ class Fee < ApplicationRecord
   include Currencies
   include Discard::Model
   self.discard_column = :deleted_at
+  self.ignored_columns += %w[duplicated_in_advance]
   default_scope -> { kept }
 
   belongs_to :invoice, optional: true
@@ -236,6 +237,7 @@ end
 #  amount_details                      :jsonb            not null
 #  deleted_at                          :datetime
 #  description                         :string
+#  duplicated_in_advance               :boolean          default(FALSE)
 #  events_count                        :integer
 #  failed_at                           :datetime
 #  fee_type                            :integer

--- a/db/migrate/20250828142848_add_duplicated_to_fees.rb
+++ b/db/migrate/20250828142848_add_duplicated_to_fees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDuplicatedToFees < ActiveRecord::Migration[8.0]
+  def change
+    add_column :fees, :duplicated_in_advance, :boolean, default: false
+  end
+end

--- a/db/migrate/20250828144553_populate_duplicated_in_advance_fees.rb
+++ b/db/migrate/20250828144553_populate_duplicated_in_advance_fees.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class PopulateDuplicatedInAdvanceFees < ActiveRecord::Migration[8.0]
+  def up
+    query = <<~SQL
+      WITH duplicated_fees AS (
+        SELECT organization_id, pay_in_advance_event_transaction_id, charge_id, charge_filter_id
+        FROM fees
+        WHERE fees.deleted_at IS NULL
+          AND fees.pay_in_advance = TRUE
+          AND fees.pay_in_advance_event_transaction_id IS NOT NULL
+          AND (created_at > '2025-01-21 00:00:00')  -- TODO: check what happened before...
+        GROUP BY pay_in_advance_event_transaction_id, charge_id, charge_filter_id, organization_id
+        HAVING COUNT(*) > 1
+      )
+      UPDATE fees f
+      SET duplicated_in_advance = TRUE
+      FROM duplicated_fees df
+      WHERE f.pay_in_advance_event_transaction_id = df.pay_in_advance_event_transaction_id
+        AND f.charge_id = df.charge_id
+        AND f.charge_filter_id = df.charge_filter_id
+        AND f.organization_id = df.organization_id
+        AND f.pay_in_advance = TRUE
+        AND f.deleted_at IS NULL;
+    SQL
+
+    safety_assured { execute(query) }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2535,7 +2535,8 @@ CREATE TABLE public.fees (
     organization_id uuid NOT NULL,
     billing_entity_id uuid NOT NULL,
     precise_credit_notes_amount_cents numeric(30,5) DEFAULT 0.0 NOT NULL,
-    fixed_charge_id uuid
+    fixed_charge_id uuid,
+    duplicated_in_advance boolean DEFAULT false
 );
 
 
@@ -9746,6 +9747,8 @@ ALTER TABLE ONLY public.fixed_charges_taxes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250828144553'),
+('20250828142848'),
 ('20250826081205'),
 ('20250822100111'),
 ('20250821094638'),


### PR DESCRIPTION
## Context

We recently identified a bug in the processing of events for pay in advance charges that led to some duplicated fees in the database. See https://github.com/getlago/lago-api/pull/4220 for the fix of the initial bug.

On the fees table, an index named `idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167` was supposed to prevent duplicated in advance fees:

```sql
CREATE UNIQUE INDEX idx_on_pay_in_advance_event_transaction_id_charge_i_16302ca167 ON public.fees 
USING btree (pay_in_advance_event_transaction_id, charge_id, charge_filter_id) 
WHERE ((created_at > '2025-01-21 00:00:00'::timestamp without time zone) 
  AND (pay_in_advance_event_transaction_id IS NOT NULL) 
  AND (pay_in_advance = true));
```

The issue reside in the way Postgres handles null values in indexes. Each null value is considered a distinct value meaning the index is useless in its current form as since `charge_filter_id` is null most of the time...

## Goal

The main goal of the fix is to add a new set of index to really prevent duplication in the database.
The difficulty will reside in the fact that we already have duplicated values in DB and we cannot remove them as they have already impacted the customers.

The complete fix will follow these steps:
- Phase 1:
  - Add a new `duplicated_in_advance` flag on the fees table with default value to false
  - Set this field to true for all existing duplicated fees
- Phase 2: 
  - Add new indexes making preventing the duplication of fees making sure that null values are not considered distinct and ignoring pre-existing duplication
  - Remove the existing index 

## Description

This PR is the phase 1.
It adds two migrations to:
- Add the new `duplicated_in_advance` field to the fees table
- Fill the field for all existing duplicated fees