### PR TITLE
fix(applied-coupons): Fix `GET /api/v1/applied_coupons` when coupon is deleted

### DIFF
--- a/app/controllers/api/v1/applied_coupons_controller.rb
+++ b/app/controllers/api/v1/applied_coupons_controller.rb
@@ -41,7 +41,7 @@ module Api
         if result.success?
           render(
             json: ::CollectionSerializer.new(
-              result.applied_coupons.includes(:credits),
+              result.applied_coupons.includes(:credits, :coupon, :customer),
               ::V1::AppliedCouponSerializer,
               collection_name: "applied_coupons",
               meta: pagination_metadata(result.applied_coupons),

--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -4,7 +4,7 @@ class AppliedCoupon < ApplicationRecord
   include PaperTrailTraceable
   include Currencies
 
-  belongs_to :coupon
+  belongs_to :coupon, -> { with_discarded }
   belongs_to :customer
   belongs_to :organization
 

--- a/spec/factories/applied_coupons.rb
+++ b/spec/factories/applied_coupons.rb
@@ -10,5 +10,9 @@ FactoryBot.define do
     amount_currency { "EUR" }
     status { "active" }
     frequency { "once" }
+
+    trait :terminated do
+      terminated_at { 1.day.ago }
+    end
   end
 end

--- a/spec/factories/coupons.rb
+++ b/spec/factories/coupons.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     amount_currency { "EUR" }
     frequency { "once" }
     description { "Coupon Description" }
+
+    trait :deleted do
+      deleted_at { 1.day.ago }
+    end
   end
 end

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -7,6 +7,27 @@ RSpec.describe AppliedCoupon, type: :model do
 
   it_behaves_like "paper_trail traceable"
 
+  describe "associations" do
+    subject(:applied_coupon) { create(:applied_coupon, coupon: create(:coupon, :deleted)) }
+
+    it { is_expected.to belong_to(:coupon) }
+    it { expect(subject.coupon).not_to be_nil }
+
+    it { is_expected.to belong_to(:customer) }
+    it { is_expected.to belong_to(:organization) }
+    it { is_expected.to have_many(:credits) }
+  end
+
+  describe "enums" do
+    it { is_expected.to define_enum_for(:status).with_values(%i[active terminated]) }
+    it { is_expected.to define_enum_for(:frequency).with_values(%i[once recurring forever]) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than_or_equal_to(0) }
+    it { is_expected.to validate_inclusion_of(:amount_currency).in_array(described_class.currency_list) }
+  end
+
   describe "#remaining_amount" do
     let(:applied_coupon) { create(:applied_coupon, amount_cents: 50) }
     let(:invoice) { create(:invoice) }
@@ -27,6 +48,13 @@ RSpec.describe AppliedCoupon, type: :model do
       it "ignores the credit amount" do
         expect(applied_coupon.remaining_amount).to eq(50)
       end
+    end
+  end
+
+  describe "#mark_as_terminated!" do
+    it "marks the applied coupon as terminated" do
+      expect { applied_coupon.mark_as_terminated! }.to change(applied_coupon, :status).to("terminated").and \
+        change(applied_coupon, :terminated_at).to be_present
     end
   end
 end

--- a/spec/queries/applied_coupons_query_spec.rb
+++ b/spec/queries/applied_coupons_query_spec.rb
@@ -90,6 +90,24 @@ RSpec.describe AppliedCouponsQuery, type: :query do
       expect(result.applied_coupons).to match_array([applied_coupon_2])
     end
 
+    context "when the coupon is deleted" do
+      let(:coupon_2) { create(:coupon, :deleted, organization:) }
+      let!(:applied_coupon_2) do
+        create(
+          :applied_coupon,
+          :terminated,
+          customer: customer_2,
+          coupon: coupon_2
+        )
+      end
+
+      it "returns the applied coupon" do
+        expect(result).to be_success
+        expect(result.applied_coupons.count).to eq(1)
+        expect(result.applied_coupons).to match_array([applied_coupon_2])
+      end
+    end
+
     context "when coupon code is not found" do
       let(:filters) { {coupon_code: "nonexistent"} }
 


### PR DESCRIPTION
## Context

When fetching `GET /api/v1/applied_coupons`, if the related coupon was deleted, we would fail to retrieve and serialize the coupon data due to the coupon's default scope. This would result in:

```ruby
NoMethodError
undefined method 'id' for nil (NoMethodError)

        lago_coupon_id: model.coupon.id,
                                    ^^^
```

## Description

This fixes it by preloading the coupon using the `Coupon.with_discarded` scope.

I noticed while fixing that, when filtering by coupon code, we didn't take into account deleted coupons. So we could have ended up in the following situation:

```
# Context

Coupon 1 (Deleted)
Coupon 2
Applied coupon 1 (Terminated)
Applied coupon 2

# GET /api/v1/applied_coupons
[applied_coupon_2, applied_coupon_1]

# GET /api/v1/applied_coupons?coupon_code[]=applied_coupon_1&coupon_code[]=applied_coupon_2
[applied_coupon_2]
```

So I've updated the `AppliedCouponsQuery` to fix that as well.

Note that another solution would be to change `belongs_to :coupon` into `belongs_to :coupon, -> { with_discarded}` but that could have had a bigger impact.
