### PR TITLE
Proposal: Validation error extra details

### DIFF
--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -23,13 +23,14 @@ module ApiErrors
     )
   end
 
-  def validation_errors(errors:)
+  def validation_errors(error:)
     render(
       json: {
         status: 422,
         error: "Unprocessable Entity",
         code: "validation_errors",
-        error_details: errors
+        error_details: error.messages,
+        error_extra: error.extra || {}
       },
       status: :unprocessable_entity
     )
@@ -71,7 +72,7 @@ module ApiErrors
     render json: response, status: :unprocessable_entity
   end
 
-  def thirdpary_error(error:)
+  def thirdparty_error(error:)
     render(
       json: {
         status: 422,
@@ -108,7 +109,7 @@ module ApiErrors
     when BaseService::MethodNotAllowedFailure
       method_not_allowed_error(code: error_result.error.code)
     when BaseService::ValidationFailure
-      validation_errors(errors: error_result.error.messages)
+      validation_errors(error: error_result.error)
     when BaseService::ForbiddenFailure
       forbidden_error(code: error_result.error.code)
     when BaseService::UnauthorizedFailure
@@ -118,7 +119,7 @@ module ApiErrors
     when BaseService::TooManyProviderRequestsFailure
       too_many_provider_requests_error(error: error_result.error)
     when BaseService::ThirdPartyFailure
-      thirdpary_error(error: error_result.error)
+      thirdparty_error(error: error_result.error)
     else
       raise(error_result.error)
     end

--- a/app/services/base_result.rb
+++ b/app/services/base_result.rb
@@ -39,8 +39,8 @@ class BaseResult
     validation_failure!(errors: record.errors.messages)
   end
 
-  def validation_failure!(errors:)
-    fail_with_error!(BaseService::ValidationFailure.new(self, messages: errors))
+  def validation_failure!(errors:, extra: nil)
+    fail_with_error!(BaseService::ValidationFailure.new(self, messages: errors, extra:))
   end
 
   def single_validation_failure!(error_code:, field: :base)

--- a/spec/requests/api/v1/subscriptions/alerts_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/alerts_controller_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Api::V1::Subscriptions::AlertsController, type: :request do
           code: "validation_errors",
           error: "Unprocessable Entity",
           error_details: {code: ["value_already_exist"]},
+          error_extra: {},
           status: 422
         })
       end
@@ -120,6 +121,7 @@ RSpec.describe Api::V1::Subscriptions::AlertsController, type: :request do
             code: "validation_errors",
             error: "Unprocessable Entity",
             error_details: {field => array_including("value_is_mandatory")},
+            error_extra: {},
             status: 422
           })
         end
@@ -141,6 +143,7 @@ RSpec.describe Api::V1::Subscriptions::AlertsController, type: :request do
           code: "validation_errors",
           error: "Unprocessable Entity",
           error_details: {alert_type: ["invalid_type"]},
+          error_extra: {},
           status: 422
         })
       end
@@ -238,6 +241,7 @@ RSpec.describe Api::V1::Subscriptions::AlertsController, type: :request do
           code: "validation_errors",
           error: "Unprocessable Entity",
           error_details: {code: ["value_already_exist"]},
+          error_extra: {},
           status: 422
         })
 
@@ -261,6 +265,7 @@ RSpec.describe Api::V1::Subscriptions::AlertsController, type: :request do
           code: "validation_errors",
           error: "Unprocessable Entity",
           error_details: {billable_metric: ["value_must_be_blank"]}, # Because `param[:alert_type] as ignored
+          error_extra: {},
           status: 422
         })
       end


### PR DESCRIPTION
In my next feature, I'd need to return details about the validation error. I'll add a min and max on wallet transaction if we fail because they amount is outside the min and max range, we'd need to return the min and max values.
They could be retrieved from the wallet configuration but we believe it would be great to return this kind of extra details.

Recently, I added the orignal error to the response when the error is from an external provider (Stripe typically). I'm taking a similar approach here.
https://github.com/getlago/lago-api/pull/3457

Our errors details are a hash of fields mapping to an array of error code. I'd rather not break that so I'm thinking about adding a second hash named `extra` which maps fields error to a free hash of details.

### Pros

* Fully backward compatible
* Optional

### Cons

* Ugly?

### Naming

* `error_extra` ?
* `error_data` ?
* `error_context` ?
* `error_meta` ?
* `error_details_details` ? 😄 

## How we set errors in the codebase

```rb
return result.validation_failure!(
  errors: {items: ["must_be_an_array"]},
  extra: {items: {must_be_an_array: {min: 12, max: 100}}}
)
```

## How users access errors

```rb
response["error_details"].each do |field_name, error_codes|
  error_codes.each do |code|
    response["error_extra"][field_name][code]   #<-- extra details for the error code
  end
end
```

```rb
amount_errors = response.dig("error_details", "amount_cents")
if amount_errors&.includes? "amount_too_low"
          # response["error_extra"][field][error_code][extra_key_youre_looking_for]
  min_val = response["error_extra"]["amount_cents"]["amount_too_low"]["min"]

 puts "Transaction amount too low, must be at least #{min_val}"
end
```

## Examples

### API

```rb
{
  "status"        => 422,
  "error"         => "Unprocessable Entity",
  "code"          => "validation_errors",
  "error_details" => {
    "items" => [
      "new_error_for_demo"
    ]
  },
  "error_extra"   => {
    "items" => {
      "new_error_for_demo" => {
        "min"  => 12,
        "max"  => 100,
        "yolo" => true
      }
    }
  }
}
```

### GraphQL

```json
[
    {
        "message": "Unprocessable Entity",
        "locations":
        [
            {
                "line": 2,
                "column": 3
            }
        ],
        "path":
        [
            "createCreditNote"
        ],
        "extensions":
        {
            "status": 422,
            "code": "unprocessable_entity",
            "details":
            {
                "items":
                [
                    "new_error_for_demo"
                ]
            },
            "extra":
            {
                "items":
                {
                    "new_error_for_demo":
                    {
                        "min": 12,
                        "max": 100,
                        "yolo": true
                    }
                }
            }
        }
    }
]
```

# Alternative approach

One way that would work well in my case and require less work is to put the value in the error_code, after `:`.
I think it's more brittle, people must split the string to compare error code :/ 
If your extra is not "just" a number, it can be limited.

```json
{
    "status": 422,
    "error": "Unprocessable Entity",
    "code": "validation_errors",
    "error_details":
    {
        "items":
        [
            "transaction_too_low:12"
        ]
    }
}
```