### PR TITLE
feat(pre-aggregation): Pass charge_id and charge_filter_id to the event stores

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -230,7 +230,7 @@ class Invoice < ApplicationRecord
       raise(NotImplementedError)
     end
 
-    filters = {}
+    filters = {charge_id: fee.charge_id}
     if fee.charge_filter
       result = ChargeFilters::MatchingAndIgnoredService.call(charge: fee.charge, filter: fee.charge_filter)
       filters[:charge_filter] = fee.charge_filter if fee.charge_filter

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -42,7 +42,7 @@ module Charges
     end
 
     def aggregation_filters
-      filters = {event:}
+      filters = {event:, charge_id: charge.id}
 
       model = charge_filter.presence || charge
       if model.pricing_group_keys.present?

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -13,6 +13,8 @@ module Events
         @grouped_by = filters[:grouped_by]
         @grouped_by_values = filters[:grouped_by_values]
 
+        @charge_id = filters[:charge_id]
+        @charge_filter_id = filters[:charge_filter]&.id
         @matching_filters = filters[:matching_filters] || {}
         @ignored_filters = filters[:ignored_filters] || []
 
@@ -129,7 +131,7 @@ module Events
         query.gsub("'#{code}'", "'#{code.gsub(":", "\\:")}'")
       end
 
-      attr_accessor :numeric_property, :aggregation_property, :use_from_boundary, :grouped_by
+      attr_accessor :numeric_property, :aggregation_property, :use_from_boundary, :grouped_by, :charge_id, :charge_filter_id
 
       protected
 

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -344,7 +344,7 @@ module Fees
     end
 
     def aggregation_filters(charge_filter: nil)
-      filters = {}
+      filters = {charge_id: charge.id}
 
       model = charge_filter.presence || charge
       filters[:grouped_by] = model.pricing_group_keys if model.pricing_group_keys.present?

--- a/app/services/fees/projection_service.rb
+++ b/app/services/fees/projection_service.rb
@@ -36,9 +36,9 @@ module Fees
       end
 
       if fees.blank? || !(period_ratio > 0 && period_ratio < 1)
-        result.projected_amount_cents = BigDecimal("0")
-        result.projected_units = BigDecimal("0")
-        result.projected_pricing_unit_amount_cents = BigDecimal("0")
+        result.projected_amount_cents = BigDecimal(0)
+        result.projected_units = BigDecimal(0)
+        result.projected_pricing_unit_amount_cents = BigDecimal(0)
         return result
       end
 
@@ -117,7 +117,7 @@ module Fees
         local_charge_filter = ChargeFilter.new(charge: charge)
       end
 
-      filters = {}
+      filters = {charge_id: charge.id}
       model = local_charge_filter.presence || charge
       filters[:grouped_by] = model.pricing_group_keys if model.pricing_group_keys.present?
 

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
               charges_duration: boundaries.charges_duration
             },
             filters: {
-              event:
+              event:,
+              charge_id: charge.id
             }
           )
 
@@ -100,6 +101,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
               },
               filters: {
                 event:,
+                charge_id: charge.id,
                 grouped_by_values: {"operator" => "foo"}
               }
             )
@@ -146,6 +148,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
               },
               filters: {
                 event:,
+                charge_id: charge.id,
                 grouped_by_values: {"operator" => "foo"}
               }
             )
@@ -188,6 +191,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
               },
               filters: {
                 event:,
+                charge_id: charge.id,
                 charge_filter:,
                 matching_filters: charge_filter.to_h,
                 ignored_filters: []
@@ -224,7 +228,8 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
               charges_duration: boundaries.charges_duration
             },
             filters: {
-              event:
+              event:,
+              charge_id: charge.id
             }
           )
 
@@ -256,7 +261,8 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
               charges_duration: boundaries.charges_duration
             },
             filters: {
-              event:
+              event:,
+              charge_id: charge.id
             }
           )
 

--- a/spec/services/fees/projection_service_spec.rb
+++ b/spec/services/fees/projection_service_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Fees::ProjectionService do
   let(:charge) do
     instance_double(
       "Charge",
+      id: SecureRandom.uuid,
       properties: charge_properties,
       applied_pricing_unit: applied_pricing_unit,
       filters: [],
@@ -93,7 +94,7 @@ RSpec.describe Fees::ProjectionService do
       success?: true,
       error: nil,
       projected_amount: BigDecimal("100.50"),
-      projected_units: BigDecimal("10"),
+      projected_units: BigDecimal(10),
       unit_amount: BigDecimal("10.05")
     )
   end
@@ -158,7 +159,7 @@ RSpec.describe Fees::ProjectionService do
 
         expect(result).to be_success
         expect(result.projected_amount_cents).to eq(10050) # 100.50 * 100
-        expect(result.projected_units).to eq(BigDecimal("10"))
+        expect(result.projected_units).to eq(BigDecimal(10))
         expect(result.projected_pricing_unit_amount_cents).to eq(nil) # No applied_pricing_unit
       end
 
@@ -174,7 +175,7 @@ RSpec.describe Fees::ProjectionService do
             to_datetime: to_datetime.to_date,
             charges_duration: charges_duration
           },
-          filters: {},
+          filters: {charge_id: charge.id},
           current_usage: true
         )
         expect(aggregator).to have_received(:aggregate).with(options: {is_current_usage: true})
@@ -237,6 +238,7 @@ RSpec.describe Fees::ProjectionService do
             charges_duration: charges_duration
           },
           filters: {
+            charge_id: charge.id,
             charge_filter: charge_filter,
             matching_filters: ["filter1"],
             ignored_filters: ["filter2"]
@@ -320,7 +322,7 @@ RSpec.describe Fees::ProjectionService do
           success?: true,
           error: nil,
           projected_amount: nil,
-          projected_units: BigDecimal("10"),
+          projected_units: BigDecimal(10),
           unit_amount: nil
         )
       end


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This pull request pass the `charge_id` and `charge_filter_id` to the event stores. They will be used later to filter events and pre-aggregated events