### PR TITLE
chore(test): Improve Bullet gem configuration for N+1 query detection

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -55,4 +55,9 @@ Rails.application.configure do
 
   # Set default API URL for test environment
   ENV["LAGO_API_URL"] ||= "http://localhost:3000"
+
+  config.after_initialize do
+    Bullet.bullet_logger = true
+    Bullet.raise = true # raise an error if n+1 query occurs
+  end
 end

--- a/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
@@ -72,17 +72,13 @@ RSpec.describe Resolvers::Entitlement::FeaturesResolver, type: :graphql do
     expect(result["data"]["features"]["metadata"]["totalCount"]).to eq(2)
   end
 
-  it "does not trigger N+1 queries for privileges", with_bullet: true do
+  it "does not trigger N+1 queries for privileges", :with_bullet do
     features = create_list(:feature, 3, organization:)
     features.each do |feature|
       create(:privilege, feature:)
     end
 
-    Bullet.start_request
-
     subject
-
-    expect(Bullet).not_to be_notification
   end
 
   context "when search_term is provided" do

--- a/spec/graphql/resolvers/entitlement/subscription_entitlements_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/subscription_entitlements_resolver_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Resolvers::Entitlement::SubscriptionEntitlementsResolver, type: :
     end
   end
 
-  it "does not trigger N+1 queries for privileges", with_bullet: true do
+  it "does not trigger N+1 queries for privileges", :with_bullet do
     features = create_list(:feature, 3, organization:)
     features.each do |feature|
       privilege = create(:privilege, feature:)
@@ -135,10 +135,6 @@ RSpec.describe Resolvers::Entitlement::SubscriptionEntitlementsResolver, type: :
       Entitlement::EntitlementValue.create(organization:, entitlement:, privilege:, value: "val")
     end
 
-    Bullet.start_request
-
     subject
-
-    expect(Bullet).not_to be_notification
   end
 end

--- a/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe Entitlement::PlanEntitlementsUpdateService, type: :service do
       end
     end
 
-    context "with bullet gem to detect N+1 queries", with_bullet: true do
+    context "with bullet gem to detect N+1 queries", bullet: {unused_eager_loading: false} do
       context "when updating multiple features with multiple privileges" do
         let(:feature) { create(:feature, organization:) }
         let(:feature2) { create(:feature, organization:, code: "storage") }
@@ -294,13 +294,8 @@ RSpec.describe Entitlement::PlanEntitlementsUpdateService, type: :service do
         end
 
         it "does not trigger N+1 queries when updating multiple features and privileges" do
-          Bullet.start_request
-
           result
 
-          # NOTE: the final `plan.entitlements.includes(...).reload` triggers Bullet::Notification::UnusedEagerLoading
-          #       but the eager loading is important for the serializer
-          expect(Bullet.text_notifications).to be_empty
           expect(result).to be_success
           expect(result.entitlements.count).to eq(3)
         end

--- a/spec/services/entitlement/plan_entitlements_update_service-partial_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-partial_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Entitlement::PlanEntitlementsUpdateService, type: :service do
       end
     end
 
-    context "with bullet gem to detect N+1 queries", with_bullet: true do
+    context "with bullet gem to detect N+1 queries", bullet: {unused_eager_loading: false} do
       context "when updating multiple features with multiple privileges" do
         let(:feature) { create(:feature, organization:) }
         let(:feature2) { create(:feature, organization:, code: "storage") }
@@ -258,13 +258,8 @@ RSpec.describe Entitlement::PlanEntitlementsUpdateService, type: :service do
         end
 
         it "does not trigger N+1 queries when updating multiple features and privileges" do
-          Bullet.start_request
-
           result
 
-          # NOTE: the final `plan.entitlements.includes(...).reload` triggers Bullet::Notification::UnusedEagerLoading
-          #       but the eager loading is important for the serializer
-          expect(Bullet.text_notifications).to be_empty
           expect(result).to be_success
           expect(result.entitlements.count).to eq(3)
         end


### PR DESCRIPTION
## Context

The current Bullet setup required to explicitly call `Bullet` in the test:

```ruby
    Bullet.start_request

    subject

    expect(Bullet).not_to be_notification
```

This was a bit confusing as the example metadata already included `with_bullet: true` which made it seem like it was the only thing required to enable bullet.

## Description

This changes the configuration of Bullet to be able to automatically enable Bullet using the following example metadata:

- `:with_bullet`: Enables both N+1 and unused eager loading.
- `bullet: { n_plus_one_query: true/false, unused_eager_loading: true/false }`: Provides more flexibility on what to enable/disable.
