### PR TITLE
feat(pre-aggregation): Implement count aggregation

### DIFF
--- a/app/models/clickhouse/events_aggregated.rb
+++ b/app/models/clickhouse/events_aggregated.rb
@@ -3,6 +3,10 @@
 module Clickhouse
   class EventsAggregated < BaseRecord
     self.table_name = "events_aggregated"
+
+    def readonly?
+      true
+    end
   end
 end
 

--- a/app/models/clickhouse/events_enriched_expanded.rb
+++ b/app/models/clickhouse/events_enriched_expanded.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Clickhouse
+  class EventsEnrichedExpanded < BaseRecord
+    self.table_name = "events_enriched_expanded"
+  end
+end
+
+# == Schema Information
+#
+# Table name: events_enriched_expanded
+#
+#  aggregation_type           :string           not null
+#  charge_filter_version      :datetime
+#  charge_version             :datetime
+#  code                       :string           not null, primary key
+#  decimal_value              :decimal(38, 26)
+#  enriched_at                :datetime         not null
+#  grouped_by                 :json             not null
+#  precise_total_amount_cents :decimal(40, 15)
+#  properties                 :json             not null
+#  sorted_grouped_by          :string           not null
+#  sorted_properties          :string           not null
+#  timestamp                  :datetime         not null, primary key
+#  value                      :string
+#  charge_filter_id           :string           default(""), not null, primary key
+#  charge_id                  :string           default(""), not null, primary key
+#  external_subscription_id   :string           not null, primary key
+#  organization_id            :string           not null, primary key
+#  plan_id                    :string           default(""), not null
+#  subscription_id            :string           default(""), not null
+#  transaction_id             :string           not null
+#

--- a/app/services/events/stores/aggregated_clickhouse_store.rb
+++ b/app/services/events/stores/aggregated_clickhouse_store.rb
@@ -3,42 +3,46 @@
 module Events
   module Stores
     class AggregatedClickhouseStore < ClickhouseStore
+      NIL_GROUP_VALUE = "<nil>"
+
       def events(force_from: false, ordered: false)
-        with_retry do
-          scope = ::Clickhouse::EventsEnrichedExpanded.where(external_subscription_id: subscription.external_id)
-            .where(organization_id: subscription.organization.id)
-            .where(charge_id: charge_id)
-            .where(charge_filter_id: charge_filter_id)
-
-          # TODO: grouped by
-
-          scope = scope.order(timestamp: :asc) if ordered
-
-          scope = scope.where("events_enriched_expanded.timestamp >= ?", from_datetime) if force_from || use_from_boundary
-          scope = scope.where("events_enriched_expanded.timestamp <= ?", to_datetime) if to_datetime
-          scope = scope.limit_by(1, "events_enriched_expanded.transaction_id")
-
-          scope = apply_grouped_by_values(scope) if grouped_by_values?
-          scope
-        end
+        # TODO(pre-aggregation): Implement
       end
 
-      def aggregated_events_sql(force_from: false, ordered: false, select: aggregated_arel_table[Arel.star])
+      def aggregated_events_sql(force_from: false, select: aggregated_arel_table[Arel.star])
         query = aggregated_arel_table.where(
-          aggregated_arel_table[:external_subscription_id].eq(subscription.external_id)
+          aggregated_arel_table[:subscription_id].eq(subscription.id)
             .and(aggregated_arel_table[:organization_id].eq(subscription.organization_id)
             .and(aggregated_arel_table[:charge_id].eq(charge_id)
-            .and(aggregated_arel_table[:charge_filter_id].eq(charge_filter_id))))
+            .and(aggregated_arel_table[:charge_filter_id].eq(charge_filter_id || ""))))
         )
 
-        # TODO: make sure we are good with the boundaries
-        query = query.order(aggregated_arel_table[:started_at].desc) if ordered
-        query = query.where(aggregated_arel_table[:started_at].gteq(from_datetime)) if force_from || use_from_boundary
+        query = query.where(aggregated_arel_table[:started_at].gteq(from_datetime.beginning_of_minute)) if force_from || use_from_boundary
         query = query.where(aggregated_arel_table[:started_at].lteq(to_datetime)) if to_datetime
 
-        # TODO: group by
+        query = if grouped_by_values
+          query.where(aggregated_arel_table[:grouped_by].eq(formated_grouped_by_values))
+        else
+          query.group(aggregated_arel_table[:grouped_by])
+        end
 
         query.project(select).to_sql
+      end
+
+      def events_values
+        # TODO(pre-aggregation): Implement
+      end
+
+      def prorated_events_values(total_duration)
+        # TODO(pre-aggregation): Implement
+      end
+
+      def last_event
+        # TODO(pre-aggregation): Implement
+      end
+
+      def grouped_last_event
+        # TODO(pre-aggregation): Implement
       end
 
       def count
@@ -54,36 +58,152 @@ module Events
         end
       end
 
-      def max
+      def grouped_count
         connection_with_retry do |connection|
           sql = aggregated_events_sql(select: [
-            Arel::Nodes::NamedFunction.new(
-              "maxMerge",
+            cast_to_json(aggregated_arel_table[:grouped_by]),
+            to_decimal128(Arel::Nodes::NamedFunction.new(
+              "countMerge",
               [aggregated_arel_table[:count_state]]
-            ).as("total_sum")
+            )).as("total_count")
           ])
 
-          connection.select_value(sql)
+          prepare_grouped_result(connection.select_all(sql).rows)
         end
+      end
+
+      # NOTE: check if an event created before the current on belongs to an active (as in present and not removed)
+      #       unique property
+      def active_unique_property?(event)
+        # TODO(pre-aggregation): Implement
+      end
+
+      def unique_count
+        # TODO(pre-aggregation): Implement
+      end
+
+      def unique_count_breakdown
+        # TODO(pre-aggregation): Implement
+      end
+
+      def prorated_unique_count
+        # TODO(pre-aggregation): Implement
+      end
+
+      def prorated_unique_count_breakdown(with_remove: false)
+        # TODO(pre-aggregation): Implement
+      end
+
+      def grouped_unique_count
+        # TODO(pre-aggregation): Implement
+      end
+
+      def grouped_prorated_unique_count
+        # TODO(pre-aggregation): Implement
+      end
+
+      def max
+        # TODO(pre-aggregation): Implement
+      end
+
+      def grouped_max
+        # TODO(pre-aggregation): Implement
+      end
+
+      def last
+        # TODO(pre-aggregation): Implement
+      end
+
+      def grouped_last
+        # TODO(pre-aggregation): Implement
+      end
+
+      def sum_precise_total_amount_cents
+        # TODO(pre-aggregation): Implement
+      end
+
+      def grouped_sum_precise_total_amount_cents
+        # TODO(pre-aggregation): Implement
       end
 
       def sum
-        connection_with_retry do |connection|
-          sql = aggregated_events_sql(select: [
-            Arel::Nodes::NamedFunction.new(
-              "sumMerge",
-              [aggregated_arel_table[:count_state]]
-            ).as("max_value")
-          ])
-
-          connection.select_value(sql)
-        end
+        # TODO(pre-aggregation): Implement
       end
 
-      private
+      def grouped_sum
+        # TODO(pre-aggregation): Implement
+      end
+
+      def prorated_sum(period_duration:, persisted_duration: nil)
+        # TODO(pre-aggregation): Implement
+      end
+
+      def grouped_prorated_sum(period_duration:, persisted_duration: nil)
+        # TODO(pre-aggregation): Implement
+      end
+
+      def sum_date_breakdown
+        # TODO(pre-aggregation): Implement
+      end
+
+      def weighted_sum(initial_value: 0)
+        # TODO(pre-aggregation): Implement
+      end
+
+      def grouped_weighted_sum(initial_values: [])
+        # TODO(pre-aggregation): Implement
+      end
+
+      # NOTE: not used in production, only for debug purpose to check the computed values before aggregation
+      def weighted_sum_breakdown(initial_value: 0)
+        # TODO(pre-aggregation): Implement
+      end
 
       def aggregated_arel_table
         @aggregated_arel_table ||= ::Clickhouse::EventsAggregated.arel_table
+      end
+
+      def formated_grouped_by_values
+        # NOTE: grouped_by is populated from a sorted Map(String, String) converted into a String
+        #       to make it comparable, we need to sort the group keys and replace nil values with "<nil>" string
+        grouped_by_values
+          .transform_values { |value| value || NIL_GROUP_VALUE }
+          .sort_by { |key, _| key }
+          .to_h
+          .to_json
+      end
+
+      # NOTE: returns the values for each groups
+      #       The result format will be an array of hash with the format:
+      #       [{ groups: { 'cloud' => 'aws', 'region' => 'us_east_1' }, value: 12.9 }, ...]
+      def prepare_grouped_result(rows, timestamp: false)
+        rows.map do |row|
+          group_by_string, value = row
+
+          groups = group_by_string.transform_values! { |v| (v == NIL_GROUP_VALUE) ? nil : v }
+          next unless groups.keys.sort == grouped_by.sort
+
+          result = {
+            groups: groups,
+            value: value
+          }
+
+          result
+        end
+      end
+
+      def to_decimal128(value)
+        Arel::Nodes::NamedFunction.new(
+          "toDecimal128",
+          [
+            value,
+            DECIMAL_SCALE
+          ]
+        )
+      end
+
+      def cast_to_json(attribute)
+        Arel::Nodes::SqlLiteral.new("#{attribute.relation.name}.#{attribute.name}::JSON")
       end
     end
   end

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -10,8 +10,6 @@ module Events
 
         @filters = filters
 
-        @charge_id = filters[:charge_id]
-        @charge_filter_id = filters[:charge_filter_id]
         @grouped_by = filters[:grouped_by]
         @grouped_by_values = filters[:grouped_by_values]
 

--- a/db/clickhouse_migrate/20250814134106_create_events_aggregated_mv.rb
+++ b/db/clickhouse_migrate/20250814134106_create_events_aggregated_mv.rb
@@ -12,13 +12,13 @@ class CreateEventsAggregatedMv < ActiveRecord::Migration[8.0]
         plan_id,
         charge_id,
         charge_filter_id,
-        sorted_grouped_by as grouped_by,
+        toJSONString(sorted_grouped_by) as grouped_by,
         -- Aggregate states based on aggregation type
         sumState(coalesce(precise_total_amount_cents, toDecimal128(0, 15))) AS precise_total_amount_cents_sum_state,
-        multiIf(aggregation_type = 'sum', sumState(coalesce(decimal_value, 0)), sumState(toDecimal128(0, 26))) AS sum_state,
-        multiIf(aggregation_type = 'count', countState(), countStateIf(false)) AS count_state,
-        multiIf(aggregation_type = 'max', maxState(coalesce(decimal_value, 0)), maxState(toDecimal128(0, 26))) AS max_state,
-        multiIf(aggregation_type = 'latest', argMaxState(coalesce(decimal_value, 0), timestamp), argMaxState(toDecimal128(0, 26), toDateTime64('1970-01-01', 3))) AS latest_state
+        if(aggregation_type = 'sum', sumState(coalesce(decimal_value, 0)), sumState(toDecimal128(0, 26))) AS sum_state,
+        if(aggregation_type = 'count', countState(), countStateIf(false)) AS count_state,
+        if(aggregation_type = 'max', maxState(coalesce(decimal_value, 0)), maxState(toDecimal128(0, 26))) AS max_state,
+        if(aggregation_type = 'latest', argMaxState(coalesce(decimal_value, 0), timestamp), argMaxState(toDecimal128(0, 26), toDateTime64('1970-01-01', 3))) AS latest_state
       FROM events_enriched_expanded
       WHERE decimal_value IS NOT NULL
         AND subscription_id IS NOT NULL

--- a/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
+++ b/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Stores::AggregatedClickhouseStore, type: :service, clickhouse: true do
+  subject(:event_store) do
+    described_class.new(
+      code:,
+      subscription:,
+      boundaries:,
+      filters: {
+        grouped_by:,
+        grouped_by_values:,
+        charge_id:,
+        charge_filter:,
+        matching_filters:,
+        ignored_filters:
+      }
+    )
+  end
+
+  let(:billable_metric) { create(:billable_metric, field_name: "value", code: "bm:code") }
+  let(:organization) { billable_metric.organization }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, customer:, plan:, started_at:) }
+
+  let(:started_at) { Time.zone.parse("2023-03-15") }
+  let(:code) { billable_metric.code }
+
+  let(:boundaries) do
+    {
+      from_datetime: subscription.started_at.beginning_of_day,
+      to_datetime: subscription.started_at.end_of_month.end_of_day,
+      charges_duration: 31
+    }
+  end
+
+  let(:charge) { create(:standard_charge, plan:, billable_metric:) }
+
+  let(:grouped_by) { nil }
+  let(:grouped_by_values) { nil }
+  let(:with_grouped_by_values) { nil }
+
+  let(:charge_id) { charge.id }
+  let(:charge_filter) { nil }
+  let(:matching_filters) { {} }
+  let(:ignored_filters) { [] }
+
+  let(:events) do
+    events = []
+
+    5.times do |i|
+      properties = {billable_metric.field_name => i + 1}
+      groups = {}
+
+      if i.even?
+        # matching_filters.each { |key, values| properties[key] = values.first }
+
+        applied_grouped_by_values = grouped_by_values || with_grouped_by_values
+
+        if applied_grouped_by_values.present?
+          applied_grouped_by_values.each { |grouped_by, value| groups[grouped_by] = value }
+        elsif grouped_by.present?
+          grouped_by.each do |group|
+            groups[group] = "#{Faker::Fantasy::Tolkien.character.delete("'")}_#{i}"
+          end
+        end
+      elsif grouped_by.present?
+        grouped_by.each do |group|
+          groups[group] = described_class::NIL_GROUP_VALUE
+        end
+      end
+
+      (ignored_filters.first || {}).each { |key, values| properties[key] = values.first } if i.zero?
+
+      events << Clickhouse::EventsEnrichedExpanded.create!(
+        transaction_id: SecureRandom.uuid,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        subscription_id: subscription.id,
+        plan_id: plan.id,
+        code:,
+        aggregation_type: "count",
+        charge_id:,
+        charge_version: charge.updated_at,
+        charge_filter_id: charge_filter&.id || "",
+        charge_filter_version: charge_filter&.updated_at || "",
+        timestamp: boundaries[:from_datetime] + (i + 1).days,
+        properties:,
+        value: (i + 1).to_s,
+        decimal_value: (i + 1).to_d,
+        precise_total_amount_cents: i + 1,
+        grouped_by: groups
+      )
+    end
+
+    events
+  end
+
+  # NOTE: this does not include test with real values yet as we have to figure out
+  #       how to add factories of fixtures in spec env and to setup clickhouse on the CI
+  before do
+    if ENV["LAGO_CLICKHOUSE_ENABLED"].blank?
+      skip
+    else
+      events
+    end
+  end
+
+  after do
+    next if ENV["LAGO_CLICKHOUSE_ENABLED"].blank?
+
+    Clickhouse::BaseRecord.connection.execute("TRUNCATE TABLE events_enriched")
+    Clickhouse::BaseRecord.connection.execute("TRUNCATE TABLE events_enriched_expanded")
+    Clickhouse::BaseRecord.connection.execute("TRUNCATE TABLE events_aggregated")
+  end
+
+  describe ".count" do
+    it "returns the number of unique events" do
+      expect(event_store.count).to eq(5)
+    end
+
+    context "with grouped_by_values" do
+      let(:grouped_by_values) { {"cloud" => "aws"} }
+
+      it "returns the number of unique events matching the group" do
+        expect(event_store.count).to eq(3)
+      end
+    end
+  end
+
+  describe ".grouped_count" do
+    let(:grouped_by) { %w[cloud] }
+
+    it "returns the number of unique events grouped by the provided group" do
+      result = event_store.grouped_count
+
+      expect(result.count).to eq(4)
+
+      null_group = result.find { |v| v[:groups]["cloud"].nil? }
+      expect(null_group[:value]).to eq(2)
+
+      result.each do |row|
+        next if row[:groups]["cloud"].nil?
+
+        expect(row[:groups]["cloud"]).not_to be_nil
+        expect(row[:value]).to eq(1)
+      end
+    end
+
+    context "with multiple groups" do
+      let(:grouped_by) { %w[region cloud] }
+
+      it "returns the number of unique events grouped by the provided groups" do
+        result = event_store.grouped_count
+
+        expect(result.count).to eq(4)
+
+        null_group = result.find { |v| v[:groups]["cloud"].nil? }
+        expect(null_group[:groups]["region"]).to be_nil
+        expect(null_group[:value]).to eq(2)
+
+        result[...-1].each do |row|
+          next if row[:groups]["cloud"].nil?
+
+          expect(row[:groups]["cloud"]).not_to be_nil
+          expect(row[:groups]["region"]).not_to be_nil
+          expect(row[:value]).to eq(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This PR
- The basic skeleton of the new `Events::Store::AggregatedClickhouseStore` event store
- Implements the `count` and `grouped_count` aggregations
- Fixes the migration for the `events_aggregated_mv` materialized view