### PR TITLE
feat(pre-aggregation): Implement max aggregation

### DIFF
--- a/app/services/events/stores/aggregated_clickhouse_store.rb
+++ b/app/services/events/stores/aggregated_clickhouse_store.rb
@@ -84,11 +84,11 @@ module Events
       end
 
       def max
-        # TODO(pre-aggregation): Implement
+        merge_aggregation("maxMerge", :max_state, "max_value")
       end
 
       def grouped_max
-        # TODO(pre-aggregation): Implement
+        grouped_merge_aggregation("maxMerge", :max_state, "max_value")
       end
 
       def last


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic, it follows https://github.com/getlago/lago-api/pull/4236.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This PR implements the `max` and `grouped_max` aggregations