### PR TITLE
feat(pre-aggregation): Implement latest aggregation

### DIFF
--- a/app/models/clickhouse/events_aggregated.rb
+++ b/app/models/clickhouse/events_aggregated.rb
@@ -14,18 +14,19 @@ end
 #
 # Table name: events_aggregated
 #
-#  aggregated_at            :datetime         not null
-#  code                     :string           not null, primary key
-#  count_state              :integer          not null
-#  grouped_by               :string           not null, primary key
-#  latest_state             :decimal(38, )    not null
-#  max_state                :decimal(38, 26)  not null
-#  started_at               :datetime         not null, primary key
-#  sum_state                :decimal(38, 26)  not null
-#  charge_filter_id         :string           default(""), not null, primary key
-#  charge_id                :string           not null, primary key
-#  external_subscription_id :string           not null, primary key
-#  organization_id          :string           not null, primary key
-#  plan_id                  :string           not null
-#  subscription_id          :string           not null, primary key
+#  aggregated_at                        :datetime         not null
+#  code                                 :string           not null, primary key
+#  count_state                          :integer          not null
+#  grouped_by                           :string           not null, primary key
+#  latest_state                         :decimal(38, )    not null
+#  max_state                            :decimal(38, 26)  not null
+#  precise_total_amount_cents_sum_state :decimal(40, 15)  not null
+#  started_at                           :datetime         not null, primary key
+#  sum_state                            :decimal(38, 26)  not null
+#  charge_filter_id                     :string           default(""), not null, primary key
+#  charge_id                            :string           not null, primary key
+#  external_subscription_id             :string           not null, primary key
+#  organization_id                      :string           not null, primary key
+#  plan_id                              :string           not null
+#  subscription_id                      :string           not null, primary key
 #

--- a/app/services/events/stores/aggregated_clickhouse_store.rb
+++ b/app/services/events/stores/aggregated_clickhouse_store.rb
@@ -92,11 +92,11 @@ module Events
       end
 
       def last
-        # TODO(pre-aggregation): Implement
+        merge_aggregation("argMaxMerge", :latest_state, "latest_value")
       end
 
       def grouped_last
-        # TODO(pre-aggregation): Implement
+        grouped_merge_aggregation("argMaxMerge", :latest_state, "latest_value")
       end
 
       def sum_precise_total_amount_cents


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic, it follows https://github.com/getlago/lago-api/pull/4236.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This PR implements the `last` and `grouped_last` aggregations