### PR TITLE
feat(pre-aggregation): Implement events_values

### DIFF
--- a/app/services/events/stores/aggregated_clickhouse_store.rb
+++ b/app/services/events/stores/aggregated_clickhouse_store.rb
@@ -14,11 +14,11 @@ module Events
             .where(charge_filter_id: charge_filter_id || "")
 
           scope = scope.order(timestamp: :asc) if ordered
-          scope.where(timestamp: from_datetime..) if force_from || use_from_boundary
-          scope.where(timestamp: ..to_datetime) if to_datetime
+          scope = scope.where(timestamp: from_datetime..) if force_from || use_from_boundary
+          scope = scope.where(timestamp: ..to_datetime) if to_datetime
 
           scope = if grouped_by_values?
-            scope.where(sorted_grouped_by: formated_grouped_by_values)
+            scope.where("toJSONString(sorted_grouped_by) = ?", formated_grouped_by_values)
           else
             # TODO: take grouped by into account when no grouped_by_values
             scope.where(sorted_grouped_by: "{}")
@@ -53,15 +53,18 @@ module Events
           .where(subscription_id: subscription.id)
           .where(organization_id: subscription.organization_id)
           .where(timestamp: from_datetime..to_datetime)
+          .where.not(charge_filter_id: "")
           .pluck("DISTINCT(charge_filter_id)")
-          .reject(&:blank?)
       end
 
       def events_values(limit: nil, force_from: false, exclude_event: false)
         with_retry do
           scope = events(force_from:, ordered: true)
 
-          scope = scope.where.not(transaction_id: filters[:event].transaction_id) if exclude_event
+          if exclude_event && filters[:event].present?
+            scope = scope.where.not(transaction_id: filters[:event].transaction_id)
+          end
+
           scope = scope.limit(limit) if limit
 
           scope.pluck(:decimal_value)
@@ -93,7 +96,17 @@ module Events
       # NOTE: check if an event created before the current on belongs to an active (as in present and not removed)
       #       unique property
       def active_unique_property?(event)
-        # TODO(pre-aggregation): Implement
+        previous_event = with_retry do
+          events.where(value: event.properties[aggregation_property])
+            .where(timestamp: ...event.timestamp)
+            .order(timestamp: :desc)
+            .first
+        end
+
+        previous_event && (
+          previous_event.properties["operation_type"].nil? ||
+          previous_event.properties["operation_type"] == "add"
+        )
       end
 
       def unique_count
@@ -188,7 +201,7 @@ module Events
           .transform_values { |value| value || NIL_GROUP_VALUE }
           .sort_by { |key, _| key }
           .to_h
-          .to_json
+          .to_json(escape_html_entities: false) # to_json is escaping < and >, leading to invalid group keys when expecting "<nil>"
       end
 
       # NOTE: returns the values for each groups

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -10,8 +10,6 @@ module Events
 
         @filters = filters
 
-        @charge_id = filters[:charge_id]
-        @charge_filter_id = filters[:charge_filter_id]
         @grouped_by = filters[:grouped_by]
         @grouped_by_values = filters[:grouped_by_values]
 

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -10,6 +10,8 @@ module Events
 
         @filters = filters
 
+        @charge_id = filters[:charge_id]
+        @charge_filter_id = filters[:charge_filter_id]
         @grouped_by = filters[:grouped_by]
         @grouped_by_values = filters[:grouped_by_values]
 


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic, it follows https://github.com/getlago/lago-api/pull/4236.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This PR implements:
- the base "events" method, relying on the Clickhouse events_enriched_expanded allowing use to filter events using `charge_id`, `charge_filter_id` and `grouped_by`
- the `events_values` and `prorated_events_values` logic
- a new `distinct_charge_filter_ids` that will later allow a pre-filtering the aggregation queries to speedup the computation