### PR TITLE
feat(pre-aggregation): Implement precise_total_amount aggregation

### DIFF
--- a/app/services/events/stores/aggregated_clickhouse_store.rb
+++ b/app/services/events/stores/aggregated_clickhouse_store.rb
@@ -100,11 +100,11 @@ module Events
       end
 
       def sum_precise_total_amount_cents
-        # TODO(pre-aggregation): Implement
+        merge_aggregation("sumMerge", :precise_total_amount_cents_sum_state, "sum_value")
       end
 
       def grouped_sum_precise_total_amount_cents
-        # TODO(pre-aggregation): Implement
+        grouped_merge_aggregation("sumMerge", :precise_total_amount_cents_sum_state, "sum_value")
       end
 
       def sum


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic, it follows https://github.com/getlago/lago-api/pull/4236.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This PR implements the `sum_precise_total_amount_cents` and `grouped_sum_precise_total_amount_cents` aggregations