### PR TITLE
fix(seeds): Fix automatic seeding in dev environment

### DIFF
--- a/scripts/migrate.dev.sh
+++ b/scripts/migrate.dev.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
 ./scripts/generate.rsa.sh
 
 bundle install
-bundle exec rails db:migrate
+bundle exec rails db:prepare

--- a/scripts/start.dev.sh
+++ b/scripts/start.dev.sh
@@ -6,6 +6,6 @@
 rm -f ./tmp/pids/server.pid
 bundle install
 
-rake db:prepare
+bundle exec rails db:prepare
 bundle exec rails signup:seed_organization
 rails s -b 0.0.0.0


### PR DESCRIPTION
## Context

It seems that https://github.com/getlago/lago/commit/3a94e3d86b2823e9c76a0f0bc3d08ad6fc338aeb introduced an issue with the seed.

Before that commit, `api` container would not depend on `migrate` and would run `rake db:prepare` which would create the database, run migrations AND seed the database.

Since `migrate` now runs before `api`, we will run `db:migrate` which will create the database and run migrations. Then, when `api` will start, the `rake db:prepare` will see that the database is already created and will only run migrations.

## Description

This ensures we run `bundle exec rails db:prepare` in `migrate` container.
