### PR TITLE
fix(clickhouse): Ensure presence of AR internal tables

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -26,6 +26,7 @@ development:
     migrations_paths: db/clickhouse_migrate
     debug: true
     database_tasks: <% if ENV['LAGO_CLICKHOUSE_MIGRATIONS_ENABLED'].present? %> true <% else %> false <% end %>
+    schema_dump: false
 
 test:
   primary:
@@ -46,7 +47,7 @@ test:
     migrations_paths: db/clickhouse_migrate
     debug: true
     database_tasks: <% if ENV['LAGO_CLICKHOUSE_MIGRATIONS_ENABLED'].present? %> true <% else %> false <% end %>
-    schema_dump: <% if ENV['LAGO_DISABLE_SCHEMA_DUMP'].present? %> false <% else %> clickhouse_structure.sql <% end %>
+    schema_dump: false
 
 staging:
   primary:


### PR DESCRIPTION
## Context

Creating the initial database structure fails with clickhouse raising the following error:

```
lago-migrate_dev  | ActiveRecord::ActiveRecordError: Response code: 404: (ActiveRecord::ActiveRecordError)
lago-migrate_dev  | Code: 60. DB::Exception: Table default.schema_migrations does not exist. (UNKNOWN_TABLE) (version 25.4.13.22 (official build))
lago-migrate_dev  |
```

## Description

The root cause of the issue is that the `clickhouse-activerecord` gem is not exporting these tables when the `config.active_record.schema_format` app config is set to `:sql`

See https://github.com/PNixx/clickhouse-activerecord/issues/138 for more details

This PR fixes the migration for Clickhouse database by setting `schema_dump` to false for clickhouse database. It's not mandatory as the setup in local, test and CI environment all uses the migrations to create the DB structure rather the structure file to manage the database environment.