### PR TITLE
fix(credit-note): Prevent 0 cent credit note issuance

### DIFF
--- a/app/services/credit_notes/validate_service.rb
+++ b/app/services/credit_notes/validate_service.rb
@@ -8,6 +8,7 @@ module CreditNotes
       valid_refund_amount?
       valid_credit_amount?
       valid_global_amount?
+      valid_total_amount?
 
       if errors?
         result.validation_failure!(errors:)
@@ -101,6 +102,13 @@ module CreditNotes
       return true if total_amount_cents <= invoice.fee_total_amount_cents - invoice_credit_note_total_amount_cents
 
       add_error(field: :base, error_code: "higher_than_remaining_invoice_amount")
+    end
+
+    # NOTE: Check if total amount is greater than 0
+    def valid_total_amount?
+      return true if total_amount_cents > 0
+
+      add_error(field: :base, error_code: "total_amount_must_be_positive")
     end
   end
 end

--- a/app/services/credit_notes/validate_service.rb
+++ b/app/services/credit_notes/validate_service.rb
@@ -7,8 +7,8 @@ module CreditNotes
       valid_items_amount?
       valid_refund_amount?
       valid_credit_amount?
-      valid_global_amount?
-      valid_total_amount?
+      valid_remaining_invoice_amount?
+      valid_total_amount_positive?
 
       if errors?
         result.validation_failure!(errors:)
@@ -98,14 +98,14 @@ module CreditNotes
     end
 
     # NOTE: Check if total amount is less than or equal to invoice fee amount
-    def valid_global_amount?
+    def valid_remaining_invoice_amount?
       return true if total_amount_cents <= invoice.fee_total_amount_cents - invoice_credit_note_total_amount_cents
 
       add_error(field: :base, error_code: "higher_than_remaining_invoice_amount")
     end
 
     # NOTE: Check if total amount is greater than 0
-    def valid_total_amount?
+    def valid_total_amount_positive?
       return true if total_amount_cents > 0
 
       add_error(field: :base, error_code: "total_amount_must_be_positive")

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -84,28 +84,26 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
 
     result_data = result["data"]["createCreditNote"]
 
-    aggregate_failures do
-      expect(result_data["id"]).to be_present
-      expect(result_data["creditStatus"]).to eq("available")
-      expect(result_data["refundStatus"]).to eq("pending")
-      expect(result_data["reason"]).to eq("duplicated_charge")
-      expect(result_data["description"]).to eq("Duplicated charge")
-      expect(result_data["currency"]).to eq("EUR")
-      expect(result_data["totalAmountCents"]).to eq("15")
-      expect(result_data["creditAmountCents"]).to eq("10")
-      expect(result_data["balanceAmountCents"]).to eq("10")
-      expect(result_data["refundAmountCents"]).to eq("5")
+    expect(result_data["id"]).to be_present
+    expect(result_data["creditStatus"]).to eq("available")
+    expect(result_data["refundStatus"]).to eq("pending")
+    expect(result_data["reason"]).to eq("duplicated_charge")
+    expect(result_data["description"]).to eq("Duplicated charge")
+    expect(result_data["currency"]).to eq("EUR")
+    expect(result_data["totalAmountCents"]).to eq("15")
+    expect(result_data["creditAmountCents"]).to eq("10")
+    expect(result_data["balanceAmountCents"]).to eq("10")
+    expect(result_data["refundAmountCents"]).to eq("5")
 
-      expect(result_data["items"][0]["id"]).to be_present
-      expect(result_data["items"][0]["amountCents"]).to eq("10")
-      expect(result_data["items"][0]["amountCurrency"]).to eq("EUR")
-      expect(result_data["items"][0]["fee"]["id"]).to eq(fee1.id)
+    expect(result_data["items"][0]["id"]).to be_present
+    expect(result_data["items"][0]["amountCents"]).to eq("10")
+    expect(result_data["items"][0]["amountCurrency"]).to eq("EUR")
+    expect(result_data["items"][0]["fee"]["id"]).to eq(fee1.id)
 
-      expect(result_data["items"][1]["id"]).to be_present
-      expect(result_data["items"][1]["amountCents"]).to eq("5")
-      expect(result_data["items"][1]["amountCurrency"]).to eq("EUR")
-      expect(result_data["items"][1]["fee"]["id"]).to eq(fee2.id)
-    end
+    expect(result_data["items"][1]["id"]).to be_present
+    expect(result_data["items"][1]["amountCents"]).to eq("5")
+    expect(result_data["items"][1]["amountCurrency"]).to eq("EUR")
+    expect(result_data["items"][1]["fee"]["id"]).to eq(fee2.id)
   end
 
   context "when invoice is not found" do
@@ -162,10 +160,7 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
         }
       )
 
-      expect_graphql_error(
-        result:,
-        message: "Total amount must be positive"
-      )
+      expect_unprocessable_entity(result)
     end
   end
 end

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -134,4 +134,38 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
       expect_not_found(result)
     end
   end
+
+  context "when total amount is zero" do
+    it "returns an error" do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query: mutation,
+        variables: {
+          input: {
+            reason: "duplicated_charge",
+            invoiceId: invoice.id,
+            creditAmountCents: 0,
+            refundAmountCents: 0,
+            items: [
+              {
+                feeId: fee1.id,
+                amountCents: 0
+              },
+              {
+                feeId: fee2.id,
+                amountCents: 0
+              }
+            ]
+          }
+        }
+      )
+
+      expect_graphql_error(
+        result:,
+        message: "Total amount must be positive"
+      )
+    end
+  end
 end

--- a/spec/requests/api/v1/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes_controller_spec.rb
@@ -566,6 +566,34 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context "when total amount is zero" do
+      let(:create_params) do
+        {
+          invoice_id:,
+          reason: "duplicated_charge",
+          description: "Duplicated charge",
+          credit_amount_cents: 0,
+          refund_amount_cents: 0,
+          items: [
+            {
+              fee_id: fee1.id,
+              amount_cents: 0
+            },
+            {
+              fee_id: fee2.id,
+              amount_cents: 0
+            }
+          ]
+        }
+      end
+
+      it "returns validation error" do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:base]).to eq(["total_amount_must_be_positive"])
+      end
+    end
   end
 
   describe "PUT /api/v1/credit_notes/:id/void" do

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -653,6 +653,32 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       end
     end
 
+    context "when total amount is zero" do
+      let(:credit_amount_cents) { 0 }
+      let(:refund_amount_cents) { 0 }
+      let(:items) do
+        [
+          {
+            fee_id: fee1.id,
+            amount_cents: 0
+          },
+          {
+            fee_id: fee2.id,
+            amount_cents: 0
+          }
+        ]
+      end
+
+      it "returns a failure" do
+        result = create_service.call
+
+        expect(result).not_to be_success
+        expect(CreditNote.count).to eq(0)
+
+        expect(result.error.messages).to eq(base: ["total_amount_must_be_positive"])
+      end
+    end
+
     context "when reason is invalid" do
       let(:args) { {reason: "invalid"} }
 

--- a/spec/services/credit_notes/validate_service_spec.rb
+++ b/spec/services/credit_notes/validate_service_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
   let(:amount_cents) { 10 }
   let(:credit_amount_cents) { 12 }
   let(:refund_amount_cents) { 0 }
+  let(:precise_taxes_amount_cents) { 2 }
+  let(:precise_coupons_adjustment_amount_cents) { 0 }
   let(:credit_note) do
     create(
       :credit_note,
@@ -16,8 +18,8 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       customer:,
       credit_amount_cents:,
       refund_amount_cents:,
-      precise_coupons_adjustment_amount_cents: 0,
-      precise_taxes_amount_cents: 2
+      precise_coupons_adjustment_amount_cents:,
+      precise_taxes_amount_cents:
     )
   end
   let(:item) do
@@ -80,12 +82,10 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       let(:amount_cents) { 1 }
 
       it "fails the validation" do
-        aggregate_failures do
-          expect(validator).not_to be_valid
+        expect(validator).not_to be_valid
 
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:base]).to eq(["does_not_match_item_amounts"])
-        end
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:base]).to eq(["does_not_match_item_amounts"])
       end
     end
 
@@ -97,12 +97,10 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       end
 
       it "fails the validation" do
-        aggregate_failures do
-          expect(validator).not_to be_valid
+        expect(validator).not_to be_valid
 
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:credit_amount_cents]).to eq(["higher_than_remaining_invoice_amount"])
-        end
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:credit_amount_cents]).to eq(["higher_than_remaining_invoice_amount"])
       end
     end
 
@@ -115,12 +113,10 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       end
 
       it "fails the validation" do
-        aggregate_failures do
-          expect(validator).not_to be_valid
+        expect(validator).not_to be_valid
 
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:refund_amount_cents]).to eq(["higher_than_remaining_invoice_amount"])
-        end
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:refund_amount_cents]).to eq(["higher_than_remaining_invoice_amount"])
       end
     end
 
@@ -130,12 +126,10 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       end
 
       it "fails the validation" do
-        aggregate_failures do
-          expect(validator).not_to be_valid
+        expect(validator).not_to be_valid
 
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:credit_amount_cents]).to eq(["higher_than_remaining_invoice_amount"])
-        end
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:credit_amount_cents]).to eq(["higher_than_remaining_invoice_amount"])
       end
     end
 
@@ -149,12 +143,10 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       let(:refund_amount_cents) { 10 }
 
       it "fails the validation" do
-        aggregate_failures do
-          expect(validator).not_to be_valid
+        expect(validator).not_to be_valid
 
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:refund_amount_cents]).to eq(["higher_than_remaining_invoice_amount"])
-        end
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:refund_amount_cents]).to eq(["higher_than_remaining_invoice_amount"])
       end
     end
 
@@ -170,12 +162,10 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       end
 
       it "fails the validation" do
-        aggregate_failures do
-          expect(validator).not_to be_valid
+        expect(validator).not_to be_valid
 
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:base]).to eq(["higher_than_remaining_invoice_amount"])
-        end
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:base]).to eq(["higher_than_remaining_invoice_amount"])
       end
     end
 
@@ -197,26 +187,8 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       let(:amount_cents) { 20 }
       let(:credit_amount_cents) { 22 }
       let(:refund_amount_cents) { 0 }
-      let(:credit_note) do
-        create(
-          :credit_note,
-          invoice:,
-          customer:,
-          credit_amount_cents:,
-          refund_amount_cents:,
-          precise_coupons_adjustment_amount_cents: 2,
-          precise_taxes_amount_cents: 3.6
-        )
-      end
-      let(:item) do
-        create(
-          :credit_note_item,
-          credit_note:,
-          amount_cents:,
-          precise_amount_cents: amount_cents,
-          fee:
-        )
-      end
+      let(:precise_taxes_amount_cents) { 3.6 }
+      let(:precise_coupons_adjustment_amount_cents) { 2 }
 
       it "validates the credit_note" do
         expect(validator).to be_valid
@@ -226,26 +198,25 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
         let(:amount_cents) { 1 }
 
         it "fails the validation" do
-          aggregate_failures do
-            expect(validator).not_to be_valid
+          expect(validator).not_to be_valid
 
-            expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages[:base]).to eq(["does_not_match_item_amounts"])
-          end
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:base]).to eq(["does_not_match_item_amounts"])
         end
       end
 
       context "when total amount is zero" do
         let(:credit_amount_cents) { 0 }
         let(:refund_amount_cents) { 0 }
+        let(:amount_cents) { 0 }
+        let(:precise_taxes_amount_cents) { 0 }
+        let(:precise_coupons_adjustment_amount_cents) { 0 }
 
         it "fails the validation" do
-          aggregate_failures do
-            expect(validator).not_to be_valid
+          expect(validator).not_to be_valid
 
-            expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages[:base]).to eq(["total_amount_must_be_positive"])
-          end
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:base]).to eq(["total_amount_must_be_positive"])
         end
       end
     end

--- a/spec/services/credit_notes/validate_service_spec.rb
+++ b/spec/services/credit_notes/validate_service_spec.rb
@@ -234,6 +234,20 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
           end
         end
       end
+
+      context "when total amount is zero" do
+        let(:credit_amount_cents) { 0 }
+        let(:refund_amount_cents) { 0 }
+
+        it "fails the validation" do
+          aggregate_failures do
+            expect(validator).not_to be_valid
+
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:base]).to eq(["total_amount_must_be_positive"])
+          end
+        end
+      end
     end
   end
 end

--- a/spec/support/graphql_helper.rb
+++ b/spec/support/graphql_helper.rb
@@ -73,7 +73,13 @@ module GraphQLHelper
       e[:message].to_s == message.to_s || e[:extensions][:code].to_s == message.to_s
     end
 
-    errors = symbolized_result[:errors].map { |e| "- #{e[:message]} (#{e[:extensions][:code]})" }.join("\n")
+    errors = symbolized_result[:errors].map do |error|
+      formatted_error = "- #{error[:message]}"
+      if (code = error.dig(:extensions, :code))
+        formatted_error += " (#{code})"
+      end
+      formatted_error
+    end.join("\n")
     expect(error).to be_present, "error message for #{message} is not present, got:\n#{errors}"
   end
 

--- a/spec/support/graphql_helper.rb
+++ b/spec/support/graphql_helper.rb
@@ -73,7 +73,8 @@ module GraphQLHelper
       e[:message].to_s == message.to_s || e[:extensions][:code].to_s == message.to_s
     end
 
-    expect(error).to be_present, "error message for #{message} is not present"
+    errors = symbolized_result[:errors].map { |e| "- #{e[:message]} (#{e[:extensions][:code]})" }.join("\n")
+    expect(error).to be_present, "error message for #{message} is not present, got:\n#{errors}"
   end
 
   def expect_unauthorized_error(result)


### PR DESCRIPTION
## Context

This PR addresses an issue which allows users to generate credit notes with a total amount of 0 cents. This behavior is incorrect and should be prevented.

## Description

This change introduces a new validation to prevent the creation of credit notes with a total amount of 0.