### PR TITLE
chore(tests): Fix flacky tests in customerportals

### DIFF
--- a/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
@@ -162,9 +162,8 @@ RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver, typ
         expect(usage_response["totalAmountCents"]).to eq("105")
         expect(usage_response["taxesAmountCents"]).to eq("0")
 
-        charge_usage = usage_response["chargesUsage"].first
+        charge_usage = usage_response["chargesUsage"].find { it["billableMetric"]["code"] == metric.code }
         expect(charge_usage["billableMetric"]["name"]).to eq(metric.name)
-        expect(charge_usage["billableMetric"]["code"]).to eq(metric.code)
         expect(charge_usage["billableMetric"]["aggregationType"]).to eq("count_agg")
         expect(charge_usage["charge"]["chargeModel"]).to eq("graduated")
         expect(charge_usage["pricingUnitAmountCents"]).to eq(nil)
@@ -173,9 +172,8 @@ RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver, typ
         expect(charge_usage["amountCents"]).to eq("5")
         expect(charge_usage["projectedAmountCents"]).to eq("9")
 
-        charge_usage = usage_response["chargesUsage"].last
+        charge_usage = usage_response["chargesUsage"].find { it["billableMetric"]["code"] == sum_metric.code }
         expect(charge_usage["billableMetric"]["name"]).to eq(sum_metric.name)
-        expect(charge_usage["billableMetric"]["code"]).to eq(sum_metric.code)
         expect(charge_usage["billableMetric"]["aggregationType"]).to eq("sum_agg")
         expect(charge_usage["charge"]["chargeModel"]).to eq("standard")
         expect(charge_usage["pricingUnitAmountCents"]).to eq("400")


### PR DESCRIPTION
Since our primary keys are uuid v4, they are not ordered so we should avoid using `first` or `last` when inspecting API response. 