### PR TITLE
feat(wallet-transactions): Add wallet to wallet transaction webhooks

### DIFF
--- a/app/serializers/v1/wallet_transaction_serializer.rb
+++ b/app/serializers/v1/wallet_transaction_serializer.rb
@@ -3,7 +3,7 @@
 module V1
   class WalletTransactionSerializer < ModelSerializer
     def serialize
-      {
+      payload = {
         lago_id: model.id,
         lago_wallet_id: model.wallet_id,
         status: model.status,
@@ -17,6 +17,17 @@ module V1
         created_at: model.created_at.iso8601,
         invoice_requires_successful_payment: model.invoice_requires_successful_payment?,
         metadata: model.metadata
+      }
+
+      payload.merge!(wallet) if include?(:wallet)
+      payload
+    end
+
+    private
+
+    def wallet
+      {
+        wallet: ::V1::WalletSerializer.new(model.wallet).serialize
       }
     end
   end

--- a/app/services/webhooks/wallet_transactions/created_service.rb
+++ b/app/services/webhooks/wallet_transactions/created_service.rb
@@ -6,7 +6,7 @@ module Webhooks
       private
 
       def object_serializer
-        ::V1::WalletTransactionSerializer.new(object, root_name: "wallet_transaction")
+        ::V1::WalletTransactionSerializer.new(object, root_name: "wallet_transaction", includes: %i[wallet])
       end
 
       def webhook_type

--- a/app/services/webhooks/wallet_transactions/updated_service.rb
+++ b/app/services/webhooks/wallet_transactions/updated_service.rb
@@ -6,7 +6,7 @@ module Webhooks
       private
 
       def object_serializer
-        ::V1::WalletTransactionSerializer.new(object, root_name: "wallet_transaction")
+        ::V1::WalletTransactionSerializer.new(object, root_name: "wallet_transaction", includes: %i[wallet])
       end
 
       def webhook_type

--- a/spec/serializers/v1/wallet_transaction_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_serializer_spec.rb
@@ -4,15 +4,17 @@ require "rails_helper"
 
 RSpec.describe ::V1::WalletTransactionSerializer do
   subject(:serializer) do
-    described_class.new(wallet_transaction, root_name: "wallet_transaction")
+    described_class.new(wallet_transaction, root_name: "wallet_transaction", includes:)
   end
 
   let(:wallet_transaction) { create(:wallet_transaction) }
 
-  it "serializes the object" do
-    result = JSON.parse(serializer.to_json)
+  context "when includes is empty" do
+    let(:includes) { [] }
 
-    aggregate_failures do
+    it "serializes the object" do
+      result = JSON.parse(serializer.to_json)
+
       expect(result["wallet_transaction"]).to include(
         "lago_id" => wallet_transaction.id,
         "lago_wallet_id" => wallet_transaction.wallet_id,
@@ -27,6 +29,22 @@ RSpec.describe ::V1::WalletTransactionSerializer do
         "created_at" => wallet_transaction.created_at.iso8601,
         "invoice_requires_successful_payment" => wallet_transaction.invoice_requires_successful_payment?,
         "metadata" => wallet_transaction.metadata
+      )
+    end
+  end
+
+  context "when includes wallet is set" do
+    let(:includes) { %i[wallet] }
+    let(:wallet) { wallet_transaction.wallet }
+
+    it "includes the wallet" do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result["wallet_transaction"]["wallet"]).to include(
+        "lago_id" => wallet.id,
+        "status" => wallet.status,
+        "created_at" => wallet.created_at.iso8601,
+        "expiration_at" => wallet.expiration_at&.iso8601
       )
     end
   end

--- a/spec/services/webhooks/wallet_transactions/created_service_spec.rb
+++ b/spec/services/webhooks/wallet_transactions/created_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Webhooks::WalletTransactions::CreatedService do
   let(:wallet_transaction) { create(:wallet_transaction, wallet:) }
 
   describe ".call" do
-    it_behaves_like "creates webhook", "wallet_transaction.created", "wallet_transaction"
+    it_behaves_like "creates webhook", "wallet_transaction.created", "wallet_transaction",
+      {"lago_id" => String, "wallet" => Hash}
   end
 end

--- a/spec/services/webhooks/wallet_transactions/updated_service_spec.rb
+++ b/spec/services/webhooks/wallet_transactions/updated_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Webhooks::WalletTransactions::UpdatedService do
   let(:wallet_transaction) { create(:wallet_transaction, wallet:) }
 
   describe ".call" do
-    it_behaves_like "creates webhook", "wallet_transaction.updated", "wallet_transaction"
+    it_behaves_like "creates webhook", "wallet_transaction.updated", "wallet_transaction",
+      {"lago_id" => String, "wallet" => Hash}
   end
 end


### PR DESCRIPTION
## Context

`wallet_transaction.created` and `wallet_transaction.updated` webhooks did not contain wallet object only the wallet id.
That required an extra request to be made to fetch the wallet.

## Description

This PR adds the whole `wallet` object to `wallet_transaction.created` and `wallet_transaction.updated` webhooks.