### PR TITLE
chore(errors): Fix non-standard errors because of `enum validate: false`

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -55,7 +55,7 @@ class CreditNote < ApplicationRecord
   STATUS = %i[draft finalized].freeze
 
   enum :credit_status, CREDIT_STATUS
-  enum :refund_status, REFUND_STATUS
+  enum :refund_status, REFUND_STATUS, validate: {allow_nil: true}
   enum :reason, REASON, validate: true
   enum :status, STATUS
 

--- a/app/models/error_detail.rb
+++ b/app/models/error_detail.rb
@@ -14,7 +14,7 @@ class ErrorDetail < ApplicationRecord
     tax_voiding_error: 2,
     invoice_generation_error: 3
   }.freeze
-  enum :error_code, ERROR_CODES
+  enum :error_code, ERROR_CODES, validate: true
 
   def self.create_generation_error_for(invoice:, error:)
     return unless invoice

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -123,7 +123,7 @@ class Organization < ApplicationRecord
 
   INTEGRATIONS = (NON_PREMIUM_INTEGRATIONS + PREMIUM_INTEGRATIONS).freeze
 
-  enum :document_numbering, DOCUMENT_NUMBERINGS
+  enum :document_numbering, DOCUMENT_NUMBERINGS, validate: true
 
   validates :country, country_code: true, unless: -> { country.nil? }
   validates :default_currency, inclusion: {in: currency_list}

--- a/app/services/billing_entities/update_service.rb
+++ b/app/services/billing_entities/update_service.rb
@@ -85,8 +85,6 @@ module BillingEntities
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    rescue ArgumentError => e
-      result.single_validation_failure!(error_code: e.message)
     rescue BaseService::FailedResult => e
       result.fail_with_error!(e)
     end

--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -56,8 +56,8 @@ module CreditNotes
         end
 
         result
-      rescue ArgumentError
-        result.single_validation_failure!(field: :refund_status, error_code: "value_is_invalid")
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
       end
 
       private

--- a/app/services/credit_notes/refunds/gocardless_service.rb
+++ b/app/services/credit_notes/refunds/gocardless_service.rb
@@ -39,6 +39,8 @@ module CreditNotes
 
         result.refund = refund
         result
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
       rescue GoCardlessPro::Error, GoCardlessPro::ValidationError => e
         deliver_error_webhook(message: e.message, code: e.code)
         update_credit_note_status(:failed)
@@ -70,8 +72,8 @@ module CreditNotes
         end
 
         result
-      rescue ArgumentError
-        result.single_validation_failure!(field: :refund_status, error_code: "value_is_invalid")
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
       end
 
       private

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -37,6 +37,8 @@ module CreditNotes
 
         result.refund = refund
         result
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
       rescue ::Stripe::InvalidRequestError => e
         deliver_error_webhook(message: e.message, code: e.code)
         update_credit_note_status(:failed)
@@ -65,8 +67,8 @@ module CreditNotes
         end
 
         result
-      rescue ArgumentError
-        result.single_validation_failure!(field: :refund_status, error_code: "value_is_invalid")
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
       end
 
       private

--- a/app/services/credit_notes/update_service.rb
+++ b/app/services/credit_notes/update_service.rb
@@ -23,8 +23,8 @@ module CreditNotes
       Utils::SegmentTrack.refund_status_changed(credit_note.refund_status, credit_note.id, credit_note.organization.id)
 
       result
-    rescue ArgumentError
-      result.single_validation_failure!(field: :refund_status, error_code: "value_is_invalid")
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
     end
 
     private

--- a/app/services/error_details/create_service.rb
+++ b/app/services/error_details/create_service.rb
@@ -21,8 +21,6 @@ module ErrorDetails
 
       result.error_details = new_error
       result
-    rescue ArgumentError => e
-      result.validation_failure!(errors: e.message)
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     end

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -82,8 +82,6 @@ module Organizations
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    rescue ArgumentError => e
-      result.single_validation_failure!(error_code: e.message)
     rescue BaseService::FailedResult => e
       result.fail_with_error!(e)
     end

--- a/spec/services/error_details/create_service_spec.rb
+++ b/spec/services/error_details/create_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ErrorDetails::CreateService, type: :service do
       }
     end
 
-    context "when created succesfully" do
+    context "when created successfully" do
       context "when all - owner and organization are provided" do
         it "creates an error_detail" do
           expect { service_call }.to change(ErrorDetail, :count).by(1)
@@ -27,18 +27,16 @@ RSpec.describe ErrorDetails::CreateService, type: :service do
         it "returns created error_detail" do
           result = service_call
 
-          aggregate_failures do
-            expect(result).to be_success
-            expect(result.error_details.owner_id).to eq(owner.id)
-            expect(result.error_details.owner_type).to eq(owner.class.to_s)
-            expect(result.error_details.organization_id).to eq(organization.id)
-            expect(result.error_details.details).to eq(params[:details])
-          end
+          expect(result).to be_success
+          expect(result.error_details.owner_id).to eq(owner.id)
+          expect(result.error_details.owner_type).to eq(owner.class.to_s)
+          expect(result.error_details.organization_id).to eq(organization.id)
+          expect(result.error_details.details).to eq(params[:details])
         end
       end
     end
 
-    context "when not created succesfully" do
+    context "when not created successfully" do
       context "when no owner is provided" do
         subject(:service_call) { described_class.call(params:, organization:, owner: nil) }
 
@@ -48,10 +46,8 @@ RSpec.describe ErrorDetails::CreateService, type: :service do
 
         it "returns error for error_detail" do
           result = service_call
-          aggregate_failures do
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to include("owner_not_found")
-          end
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to include("owner_not_found")
         end
       end
 
@@ -71,10 +67,8 @@ RSpec.describe ErrorDetails::CreateService, type: :service do
 
         it "returns error for error_detail" do
           result = service_call
-          aggregate_failures do
-            expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.message).to include("'this_error_code_will_never_achieve_its_goal' is not a valid error_code")
-          end
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.message).to eq('Validation errors: {"error_code":["value_is_invalid"]}')
         end
       end
     end

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -317,7 +317,7 @@ RSpec.describe Organizations::UpdateService do
 
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:base].first).to include("not a valid document_numbering")
+          expect(result.error.messages[:document_numbering]).to eq(["value_is_invalid"])
         end
       end
     end


### PR DESCRIPTION
When handling some enum error, we sometimes returned the wrong format (string instead of array of string).

Ideally, we should use `validate: true` for ALL enum.