### PR TITLE
feat(wallet-transaction): Add a `name` to wallet transactions

### DIFF
--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -89,6 +89,7 @@ module Api
           :granted_credits,
           :voided_credits,
           :invoice_requires_successful_payment,
+          :name,
           metadata: [
             :key,
             :value

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -40,6 +40,7 @@ class WalletTransaction < ApplicationRecord
   enum :source, SOURCES
 
   validates :priority, presence: true, inclusion: {in: 1..50}
+  validates :name, length: {minimum: 1, maximum: 255}, allow_nil: true
 
   delegate :customer, to: :wallet
 
@@ -77,6 +78,7 @@ end
 #  invoice_requires_successful_payment :boolean          default(FALSE), not null
 #  lock_version                        :integer          default(0), not null
 #  metadata                            :jsonb
+#  name                                :string(255)
 #  priority                            :integer          default(50), not null
 #  settled_at                          :datetime
 #  source                              :integer          default("manual"), not null

--- a/app/serializers/v1/wallet_transaction_serializer.rb
+++ b/app/serializers/v1/wallet_transaction_serializer.rb
@@ -16,7 +16,8 @@ module V1
         failed_at: model.failed_at&.iso8601,
         created_at: model.created_at.iso8601,
         invoice_requires_successful_payment: model.invoice_requires_successful_payment?,
-        metadata: model.metadata
+        metadata: model.metadata,
+        name: model.name
       }
 
       payload.merge!(wallet) if include?(:wallet)

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -18,6 +18,7 @@ module WalletTransactions
           :credit_note_id,
           :invoice_id,
           :invoice_requires_successful_payment,
+          :name,
           :priority,
           :settled_at,
           :source,

--- a/app/services/wallet_transactions/validate_service.rb
+++ b/app/services/wallet_transactions/validate_service.rb
@@ -8,6 +8,7 @@ module WalletTransactions
       valid_granted_credits_amount? if args[:granted_credits]
       valid_voided_credits_amount? if args[:voided_credits] && result.current_wallet
       valid_metadata? if args[:metadata]
+      valid_name? if args[:name]
 
       if errors?
         result.validation_failure!(errors:)
@@ -64,6 +65,24 @@ module WalletTransactions
       end
 
       true
+    end
+
+    def valid_name?
+      name = args[:name]
+
+      return true if name.blank?
+
+      if !name.is_a?(String)
+        add_error(field: :name, error_code: "invalid_value")
+        return false
+      end
+
+      if name.length > 255
+        add_error(field: :name, error_code: "too_long")
+        return false
+      end
+
+      false
     end
   end
 end

--- a/app/services/wallet_transactions/void_service.rb
+++ b/app/services/wallet_transactions/void_service.rb
@@ -9,7 +9,8 @@ module WalletTransactions
         :source,
         :metadata,
         :priority,
-        :credit_note_id
+        :credit_note_id,
+        :name
       )
 
       super

--- a/db/migrate/20250903165724_add_name_to_wallet_transactions.rb
+++ b/db/migrate/20250903165724_add_name_to_wallet_transactions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNameToWalletTransactions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :wallet_transactions, :name, :string, limit: 255
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3224,7 +3224,8 @@ CREATE TABLE public.wallet_transactions (
     failed_at timestamp(6) without time zone,
     organization_id uuid NOT NULL,
     lock_version integer DEFAULT 0 NOT NULL,
-    priority integer DEFAULT 50 NOT NULL
+    priority integer DEFAULT 50 NOT NULL,
+    name character varying(255)
 );
 
 
@@ -9759,6 +9760,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250908085959'),
+('20250903165724'),
 ('20250901141844'),
 ('20250828153138'),
 ('20250828144553'),

--- a/spec/factories/wallet_transactions.rb
+++ b/spec/factories/wallet_transactions.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     amount { "1.00" }
     credit_amount { "1.00" }
     settled_at { Time.zone.now }
+    name { "Custom Transaction Name" }
 
     trait :failed do
       status { "failed" }

--- a/spec/models/wallet_transaction_spec.rb
+++ b/spec/models/wallet_transaction_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe WalletTransaction, type: :model do
   it { is_expected.to validate_presence_of(:priority) }
   it { is_expected.to validate_inclusion_of(:priority).in_range(1..50) }
+  it { is_expected.to validate_length_of(:name).is_at_most(255).is_at_least(1).allow_nil }
 
   describe "associations" do
     it { is_expected.to belong_to(:wallet) }

--- a/spec/requests/api/v1/wallet_transactions_controller_spec.rb
+++ b/spec/requests/api/v1/wallet_transactions_controller_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
       {
         wallet_id:,
         paid_credits: "10",
-        granted_credits: "10"
+        granted_credits: "10",
+        name: "Custom Top-up Name"
       }
     end
 
@@ -38,13 +39,18 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
 
       expect(response).to have_http_status(:success)
 
-      expect(json[:wallet_transactions].count).to eq(2)
-      expect(json[:wallet_transactions].first[:lago_id]).to be_present
-      expect(json[:wallet_transactions].second[:lago_id]).to be_present
-      expect(json[:wallet_transactions].first[:status]).to eq("pending")
-      expect(json[:wallet_transactions].second[:status]).to eq("settled")
-      expect(json[:wallet_transactions].first[:lago_wallet_id]).to eq(wallet.id)
-      expect(json[:wallet_transactions].second[:lago_wallet_id]).to eq(wallet.id)
+      wallet_transactions = json[:wallet_transactions]
+
+      expect(wallet_transactions.count).to eq(2)
+
+      paid_transaction = wallet_transactions.first
+      granted_transaction = wallet_transactions.second
+
+      expect(paid_transaction[:lago_id]).to be_present
+      expect(paid_transaction[:status]).to eq("pending")
+      expect(granted_transaction[:status]).to eq("settled")
+      expect(granted_transaction[:lago_id]).to be_present
+      expect(wallet_transactions).to all(include(name: "Custom Top-up Name", lago_wallet_id: wallet.id))
     end
 
     context "with voided credits" do

--- a/spec/serializers/v1/wallet_transaction_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_serializer_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe ::V1::WalletTransactionSerializer do
         "failed_at" => wallet_transaction.failed_at&.iso8601,
         "created_at" => wallet_transaction.created_at.iso8601,
         "invoice_requires_successful_payment" => wallet_transaction.invoice_requires_successful_payment?,
-        "metadata" => wallet_transaction.metadata
+        "metadata" => wallet_transaction.metadata,
+        "name" => "Custom Transaction Name"
       )
     end
   end

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
           settled_at: Date.yesterday,
           credit_note_id: credit_note.id,
           invoice_id: invoice.id,
-          priority: 25
+          priority: 25,
+          name: "Custom Transaction Name"
         }
       end
 
@@ -93,6 +94,7 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
         expect(wallet_transaction.invoice_id).to eq(invoice.id)
         expect(wallet_transaction.credit_amount).to eq(credit_amount)
         expect(wallet_transaction.priority).to eq 25
+        expect(wallet_transaction.name).to eq("Custom Transaction Name")
       end
     end
   end

--- a/spec/services/wallet_transactions/validate_service_spec.rb
+++ b/spec/services/wallet_transactions/validate_service_spec.rb
@@ -22,9 +22,11 @@ RSpec.describe WalletTransactions::ValidateService, type: :service do
       organization_id: organization.id,
       paid_credits:,
       granted_credits:,
-      voided_credits:
+      voided_credits:,
+      **((name == :undefined) ? {} : {name:})
     }
   end
+  let(:name) { :undefined }
 
   before { subscription }
 
@@ -94,6 +96,48 @@ RSpec.describe WalletTransactions::ValidateService, type: :service do
       it "returns false and result has errors for metadata" do
         expect(validate_service).not_to be_valid
         expect(result.error.messages[:metadata]).to eq(["nested_structure_not_allowed"])
+      end
+    end
+
+    context "with valid name" do
+      let(:name) { "Valid Transaction Name" }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "with blank name" do
+      let(:name) { "" }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "with nil name" do
+      let(:name) { nil }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "with name at maximum length" do
+      let(:name) { "a" * 255 }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "with name that is too long" do
+      let(:name) { "a" * 256 }
+
+      it "returns false and result has errors" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:name]).to eq(["too_long"])
+      end
+    end
+
+    context "with name that is not a string" do
+      let(:name) { 123 }
+
+      it "returns false and result has errors" do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:name]).to eq(["invalid_value"])
       end
     end
   end

--- a/spec/services/wallet_transactions/void_service_spec.rb
+++ b/spec/services/wallet_transactions/void_service_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
               source: "manual",
               metadata: [],
               priority: 50,
-              credit_note_id: nil
+              credit_note_id: nil,
+              name: nil
             )
         end
       end
@@ -78,7 +79,8 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
           metadata:,
           credit_note_id:,
           source: :threshold,
-          priority: 25
+          priority: 25,
+          name: "Void Transaction"
         }
       end
 
@@ -101,7 +103,8 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
               metadata:,
               credit_note_id:,
               source: "threshold",
-              priority: 25
+              priority: 25,
+              name: "Void Transaction"
             )
         end
       end
@@ -111,6 +114,14 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
 
         expect(wallet.balance_cents).to eq(0)
         expect(wallet.credits_balance).to eq(0.0)
+      end
+    end
+
+    context "with nil name" do
+      let(:args) { {name: nil} }
+
+      it "creates a wallet transaction with nil name" do
+        expect(result.wallet_transaction.name).to be_nil
       end
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-the-name-of-a-wallet-transaction-at-top-up

## Context

When creating a wallet transaction, the name displayed on the invoice defaults to the wallet name. However, for organizations managing multiple types of top-ups, it would be beneficial to display specific naming on invoices that corresponds to the particular transaction being made.

## Description 

This change adds a `name` attribute to the wallet transaction models, params and serializers.