### PR TITLE
feat(pre-aggregation): Implement prorated_sum

### DIFF
--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -10,8 +10,6 @@ module Events
 
         @filters = filters
 
-        @charge_id = filters[:charge_id]
-        @charge_filter_id = filters[:charge_filter_id]
         @grouped_by = filters[:grouped_by]
         @grouped_by_values = filters[:grouped_by_values]
 

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -10,6 +10,8 @@ module Events
 
         @filters = filters
 
+        @charge_id = filters[:charge_id]
+        @charge_filter_id = filters[:charge_filter_id]
         @grouped_by = filters[:grouped_by]
         @grouped_by_values = filters[:grouped_by_values]
 

--- a/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
+++ b/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
@@ -422,6 +422,18 @@ RSpec.describe Events::Stores::AggregatedClickhouseStore, type: :service, clickh
     end
   end
 
+  describe ".prorated_sum" do
+    it "returns the prorated sum of event properties" do
+      expect(event_store.prorated_sum(period_duration: 31).round(5)).to eq(6.45161)
+    end
+
+    context "with persisted_duration" do
+      it "returns the prorated sum of event properties" do
+        expect(event_store.prorated_sum(period_duration: 31, persisted_duration: 10).round(5)).to eq(4.83871)
+      end
+    end
+  end
+
   describe ".max" do
     let(:aggregation_type) { "max" }
 

--- a/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
+++ b/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
@@ -495,6 +495,21 @@ RSpec.describe Events::Stores::AggregatedClickhouseStore, type: :service, clickh
     end
   end
 
+  describe ".sum_date_breakdown" do
+    let(:aggregation_type) { "sum" }
+
+    it "returns the sum grouped by day" do
+      expect(event_store.sum_date_breakdown).to eq(
+        events.map do |e|
+          {
+            date: e.timestamp.to_date,
+            value: e.decimal_value
+          }
+        end
+      )
+    end
+  end
+
   describe ".max" do
     let(:aggregation_type) { "max" }
 


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic, it follows https://github.com/getlago/lago-api/pull/4236.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This PR implements:
- The base "events_sql" method, relying on the Clickhouse events_enriched_expanded, used to build queries that cannot use the `events_aggregated` table.
- The `prorated_sum`
- The `grouped_prorated_sum`
- The `sum_date_breakdown`