### PR TITLE
test(invoice): Introduce invoice rendering tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,6 +132,10 @@ end
 group :test do
   gem "guard-rspec", require: false
   gem "karafka-testing"
+
+  # HTML testing (invoice rendering)
+  gem "rspec-snapshot", "~> 2.0"
+  gem "htmlbeautifier", "~> 1.4"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,6 +337,7 @@ GEM
     hashie (5.0.0)
     highline (3.1.2)
       reline
+    htmlbeautifier (1.4.3)
     httpclient (2.8.3)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
@@ -786,6 +787,9 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
+    rspec-snapshot (2.0.3)
+      awesome_print (> 1.0.0)
+      rspec (> 3.0.0)
     rspec-support (3.13.2)
     rubocop (1.75.5)
       json (~> 2.3)
@@ -1004,6 +1008,7 @@ DEPENDENCIES
   graphql
   graphql-pagination
   guard-rspec
+  htmlbeautifier (~> 1.4)
   i18n-tasks!
   jwt
   kaminari-activerecord
@@ -1035,6 +1040,7 @@ DEPENDENCIES
   redis
   rspec-graphql_matchers
   rspec-rails
+  rspec-snapshot (~> 2.0)
   rubocop-graphql
   rubocop-performance
   rubocop-rails

--- a/spec/views/app/views/templates/invoices/__snapshots__/invoices_v4__credit.slim/when_invoice_type_is_credit/when_wallet_has_a_name/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/invoices_v4__credit.slim/when_invoice_type_is_credit/when_wallet_has_a_name/renders_correctly.html.snap
@@ -1,0 +1,528 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta content="IE=edge" http-equiv="X-UA-Compatible" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Invoice</title>
+  </head>
+  <body>
+    <style type="text/css">
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 100;
+        font-display: swap;
+        src: local("Inter-Thin");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 100;
+        font-display: swap;
+        src: local("Inter-ThinItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 200;
+        font-display: swap;
+        src: local("Inter-ExtraLight");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 200;
+        font-display: swap;
+        src: local("Inter-ExtraLightItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 300;
+        font-display: swap;
+        src: local("Inter-Light");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 300;
+        font-display: swap;
+        src: local("Inter-LightItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 400;
+        font-display: swap;
+        src: local("Inter-Regular");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 400;
+        font-display: swap;
+        src: local("Inter-Italic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 500;
+        font-display: swap;
+        src: local("Inter-Medium");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 500;
+        font-display: swap;
+        src: local("Inter-MediumItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 600;
+        font-display: swap;
+        src: local("Inter-SemiBold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 600;
+        font-display: swap;
+        src: local("Inter-SemiBoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 700;
+        font-display: swap;
+        src: local("Inter-Bold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 700;
+        font-display: swap;
+        src: local("Inter-BoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 800;
+        font-display: swap;
+        src: local("Inter-ExtraBold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 800;
+        font-display: swap;
+        src: local("Inter-ExtraBoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 900;
+        font-display: swap;
+        src: local("Inter-Black");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 900;
+        font-display: swap;
+        src: local("Inter-BlackItalic");
+      }
+
+
+      /* ----------------------- variable ----------------------- */
+      :root {
+        --border-color: #D9DEE7;
+      }
+
+      @font-face {
+        font-family: 'Inter var';
+        font-style: normal;
+        font-weight: 100 900;
+        font-display: swap;
+        src: local('Inter-roman') format('woff2');
+        font-named-instance: 'Regular';
+      }
+
+      @font-face {
+        font-family: 'Inter var';
+        font-style: italic;
+        font-weight: 100 900;
+        font-display: swap;
+        src: local('Inter-italic') format('woff2');
+        font-named-instance: 'Italic';
+      }
+      h1, h2, p { margin: 0; padding: 0; }
+      html { font-family: Inter, sans-serif; }
+      h1 { color: #19212e; font-weight: 700; font-size: 24px; line-height: 32px; }
+      h2 {
+        color: #19212e;
+        font-weight: 700;
+        font-size: 18px;
+        line-height: 24px;
+      }
+      .body-1 {
+        color: #19212e;
+        font-weight: 600;
+        font-size: 10px;
+        line-height: 16px;
+      }
+      .body-2 {
+        color: #19212e;
+        font-weight: 400;
+        font-size: 10px;
+        line-height: 16px;
+      }
+      .body-3 {
+        color: #66758f;
+        font-weight: 400;
+        font-size: 9px;
+        line-height: 16px;
+      }
+
+      .mb-4 {
+        margin-bottom: 4px;
+      }
+      .mb-24 {
+        margin-bottom: 24px;
+      }
+      .mt-24 {
+        margin-top: 24px;
+      }
+
+      .overflow-auto {
+        overflow: auto;
+      }
+      tr {
+        break-inside: avoid;
+      }
+
+      .invoice-title {
+        display: inline;
+      }
+      .header-logo {
+        float: right;
+        max-height: 32px;
+      }
+
+      .invoice-information-column {
+        float: left;
+        width: 50%;
+      }
+      .invoice-information-table tr td:first-child {
+        padding: 0 16px 0 0;
+      }
+      .invoice-information-table tr td:last-child {
+        width: 55%;
+      }
+      .invoice-information-table, tr td {
+        text-wrap: normal;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
+      .invoice-information-table {
+        border-collapse: collapse;
+        table-layout: fixed;
+        width: 100%;
+      }
+
+      .billing-information-column {
+        float: left;
+        width: 50%;
+      }
+
+      .invoice-resume-table tr td {
+        padding-top: 4px;
+        padding-bottom: 4px;
+        text-align: right;
+        word-wrap: break-word;
+      }
+      .invoice-resume-table td:first-child {
+        width: 50%;
+        text-align: left;
+      }
+      .invoice-resume-table td:nth-child(2) {
+        width: 12.5%;
+        max-width: 10vw;
+      }
+      .invoice-resume-table td:nth-child(3) {
+        width: 12.5%;
+        max-width: 10vw;
+      }
+      .invoice-resume-table td:nth-child(4) {
+        width: 12.5%;
+      }
+      .invoice-resume-table td:nth-child(5) {
+        width: 12.5%;
+        max-width: 10vw;
+      }
+
+      .invoice-resume-table tr.first_child td {
+        color: #66758F;
+      }
+
+      .invoice-resume-table tr.charge-name td {
+        padding-bottom: 0;
+        color: #19212e;
+      }
+
+      .invoice-resume-table tr.details td {
+        color: #66758F;
+        padding-top: 4px;
+        padding-bottom: 4px;
+      }
+
+      .invoice-resume-table tr.details td:first-child {
+        padding-left: 8px;
+      }
+
+      .invoice-resume-table tr.details.subtotal td {
+        color: #19212e;
+      }
+
+      .invoice-resume-table tr.fee:first-child {
+        border-top: none;
+      }
+      /* Each first tr representing fee draws border above it */
+      .invoice-resume-table tr.fee {
+        border-top: 1px solid var(--border-color);
+      }
+      .invoice-resume-table tr:last-child {
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      .invoice-resume-table tr.fee td {
+        padding-top: 8px;
+      }
+      /* If tr has next element tr.fee means that current fee info ended and we need bigger padding */
+      .invoice-resume-table tr:has(+ tr.fee) td {
+        padding-bottom: 8px;
+      }
+      .invoice-resume-table tr:last-child td {
+        padding-bottom: 8px;
+      }
+
+      .invoice-resume table {
+        border-collapse: collapse;
+      }
+      .invoice-resume .total-table tr td {
+        padding-top: 8px;
+        padding-bottom: 8px;
+        text-align: right;
+      }
+      .invoice-resume .total-table td:first-child {
+        width: 50%;
+      }
+      .invoice-resume .total-table tr:not(:last-child) td:nth-child(2) {
+        border-bottom: 1px solid var(--border-color);
+        text-align: left;
+        width: 35%;
+      }
+      .invoice-resume .total-table tr:not(:last-child) td:nth-child(3) {
+        border-bottom: 1px solid var(--border-color);
+        text-align: right;
+        width: 15%;
+      }
+      .invoice-resume .total-table tr:last-child td:nth-child(2) {
+        text-align: left;
+        width: 25%;
+      }
+      .invoice-resume .total-table tr:last-child td:nth-child(3) {
+        text-align: right;
+        width: 25%;
+      }
+
+      .invoice-details-title {
+        page-break-before: always;
+      }
+
+      .breakdown-details table {
+        border-collapse: collapse;
+      }
+      .breakdown-details {
+        margin-top: -15px;
+      }
+      .breakdown-details-table tr td {
+        padding-bottom: 8px;
+        padding-top: 8px;
+      }
+      .breakdown-details-table tr td:last-child {
+        text-align: right;
+      }
+      .breakdown-details-table tr td {
+        border-bottom: 1px solid var(--border-color);
+      }
+      .breakdown-details-table tr:first-child td {
+        border-top: 1px solid var(--border-color);
+      }
+
+      .powered-by {
+        width: 100%;
+        text-align: right;
+      }
+      .powered-by span {
+        color: #8c95a6;
+      }
+      .powered-by img {
+        width: 37px;
+        height: 11px;
+        vertical-align: middle;
+        margin-top: 2px;
+      }
+      .alert {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        padding: 16px;
+        gap: 16px;
+        background: #F3F4F6;
+        border-radius: 12px;
+      }
+    </style>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">
+          Advance invoice
+        </h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">
+                Invoice Number
+              </td>
+              <td class="body-2">
+                LAGO-202509-001
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Issue Date
+              </td>
+              <td class="body-2">
+                Sep 04, 2025
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Payment term
+              </td>
+              <td class="body-2">
+                0 days
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+          </table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">
+            From
+          </div>
+          <div class="body-2">ACME Corporation
+          </div>
+          <div class="body-2">
+            123 Business St
+          </div>
+          <div class="body-2">
+            Suite 100
+          </div>
+          <div class="body-2">
+            <span>94105</span><span>, &nbsp;</span><span>San Francisco</span>
+          </div>
+          <div class="body-2">
+            CA
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            billing@acme.com
+          </div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">
+            Bill to
+          </div>
+          <div class="body-2">
+            John Doe
+          </div>
+          <div class="body-2">
+            1234567890
+          </div>
+          <div class="body-2">
+            456 Customer Ave
+          </div>
+          <div class="body-2">
+            Apt 202
+          </div>
+          <div class="body-2">
+            <span>10001</span><span>, &nbsp;</span><span>New York</span>
+          </div>
+          <div class="body-2">
+            NY
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            john.doe@example.com
+          </div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-4">
+          $10.50
+        </h2>
+        <div class="body-1">
+          Due Sep 04, 2025
+        </div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td class="body-2">Item</td>
+            <td class="body-2">Units</td>
+            <td class="body-2">Unit price</td>
+            <td class="body-2">Amount</td>
+          </tr>
+          <tr>
+            <td class="body-1">Prepaid credits - Premium Wallet</td>
+            <td class="body-2">10.5</td>
+            <td class="body-2">1.0</td>
+            <td class="body-2">$10.50</td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2"></td>
+            <td class="body-1">Total</td>
+            <td class="body-1">$10.50</td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24">
+      </p>
+      <div class="powered-by"><span class="body-2">Powered by &nbsp;</span><img alt="Lago Logo" src="lago-logo-invoice.png" /></div>
+    </div>
+  </body>
+</html>

--- a/spec/views/app/views/templates/invoices/__snapshots__/invoices_v4__credit.slim/when_invoice_type_is_credit/when_wallet_has_no_name/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/invoices_v4__credit.slim/when_invoice_type_is_credit/when_wallet_has_no_name/renders_correctly.html.snap
@@ -1,0 +1,528 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta content="IE=edge" http-equiv="X-UA-Compatible" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Invoice</title>
+  </head>
+  <body>
+    <style type="text/css">
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 100;
+        font-display: swap;
+        src: local("Inter-Thin");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 100;
+        font-display: swap;
+        src: local("Inter-ThinItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 200;
+        font-display: swap;
+        src: local("Inter-ExtraLight");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 200;
+        font-display: swap;
+        src: local("Inter-ExtraLightItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 300;
+        font-display: swap;
+        src: local("Inter-Light");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 300;
+        font-display: swap;
+        src: local("Inter-LightItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 400;
+        font-display: swap;
+        src: local("Inter-Regular");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 400;
+        font-display: swap;
+        src: local("Inter-Italic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 500;
+        font-display: swap;
+        src: local("Inter-Medium");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 500;
+        font-display: swap;
+        src: local("Inter-MediumItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 600;
+        font-display: swap;
+        src: local("Inter-SemiBold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 600;
+        font-display: swap;
+        src: local("Inter-SemiBoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 700;
+        font-display: swap;
+        src: local("Inter-Bold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 700;
+        font-display: swap;
+        src: local("Inter-BoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 800;
+        font-display: swap;
+        src: local("Inter-ExtraBold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 800;
+        font-display: swap;
+        src: local("Inter-ExtraBoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 900;
+        font-display: swap;
+        src: local("Inter-Black");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 900;
+        font-display: swap;
+        src: local("Inter-BlackItalic");
+      }
+
+
+      /* ----------------------- variable ----------------------- */
+      :root {
+        --border-color: #D9DEE7;
+      }
+
+      @font-face {
+        font-family: 'Inter var';
+        font-style: normal;
+        font-weight: 100 900;
+        font-display: swap;
+        src: local('Inter-roman') format('woff2');
+        font-named-instance: 'Regular';
+      }
+
+      @font-face {
+        font-family: 'Inter var';
+        font-style: italic;
+        font-weight: 100 900;
+        font-display: swap;
+        src: local('Inter-italic') format('woff2');
+        font-named-instance: 'Italic';
+      }
+      h1, h2, p { margin: 0; padding: 0; }
+      html { font-family: Inter, sans-serif; }
+      h1 { color: #19212e; font-weight: 700; font-size: 24px; line-height: 32px; }
+      h2 {
+        color: #19212e;
+        font-weight: 700;
+        font-size: 18px;
+        line-height: 24px;
+      }
+      .body-1 {
+        color: #19212e;
+        font-weight: 600;
+        font-size: 10px;
+        line-height: 16px;
+      }
+      .body-2 {
+        color: #19212e;
+        font-weight: 400;
+        font-size: 10px;
+        line-height: 16px;
+      }
+      .body-3 {
+        color: #66758f;
+        font-weight: 400;
+        font-size: 9px;
+        line-height: 16px;
+      }
+
+      .mb-4 {
+        margin-bottom: 4px;
+      }
+      .mb-24 {
+        margin-bottom: 24px;
+      }
+      .mt-24 {
+        margin-top: 24px;
+      }
+
+      .overflow-auto {
+        overflow: auto;
+      }
+      tr {
+        break-inside: avoid;
+      }
+
+      .invoice-title {
+        display: inline;
+      }
+      .header-logo {
+        float: right;
+        max-height: 32px;
+      }
+
+      .invoice-information-column {
+        float: left;
+        width: 50%;
+      }
+      .invoice-information-table tr td:first-child {
+        padding: 0 16px 0 0;
+      }
+      .invoice-information-table tr td:last-child {
+        width: 55%;
+      }
+      .invoice-information-table, tr td {
+        text-wrap: normal;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
+      .invoice-information-table {
+        border-collapse: collapse;
+        table-layout: fixed;
+        width: 100%;
+      }
+
+      .billing-information-column {
+        float: left;
+        width: 50%;
+      }
+
+      .invoice-resume-table tr td {
+        padding-top: 4px;
+        padding-bottom: 4px;
+        text-align: right;
+        word-wrap: break-word;
+      }
+      .invoice-resume-table td:first-child {
+        width: 50%;
+        text-align: left;
+      }
+      .invoice-resume-table td:nth-child(2) {
+        width: 12.5%;
+        max-width: 10vw;
+      }
+      .invoice-resume-table td:nth-child(3) {
+        width: 12.5%;
+        max-width: 10vw;
+      }
+      .invoice-resume-table td:nth-child(4) {
+        width: 12.5%;
+      }
+      .invoice-resume-table td:nth-child(5) {
+        width: 12.5%;
+        max-width: 10vw;
+      }
+
+      .invoice-resume-table tr.first_child td {
+        color: #66758F;
+      }
+
+      .invoice-resume-table tr.charge-name td {
+        padding-bottom: 0;
+        color: #19212e;
+      }
+
+      .invoice-resume-table tr.details td {
+        color: #66758F;
+        padding-top: 4px;
+        padding-bottom: 4px;
+      }
+
+      .invoice-resume-table tr.details td:first-child {
+        padding-left: 8px;
+      }
+
+      .invoice-resume-table tr.details.subtotal td {
+        color: #19212e;
+      }
+
+      .invoice-resume-table tr.fee:first-child {
+        border-top: none;
+      }
+      /* Each first tr representing fee draws border above it */
+      .invoice-resume-table tr.fee {
+        border-top: 1px solid var(--border-color);
+      }
+      .invoice-resume-table tr:last-child {
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      .invoice-resume-table tr.fee td {
+        padding-top: 8px;
+      }
+      /* If tr has next element tr.fee means that current fee info ended and we need bigger padding */
+      .invoice-resume-table tr:has(+ tr.fee) td {
+        padding-bottom: 8px;
+      }
+      .invoice-resume-table tr:last-child td {
+        padding-bottom: 8px;
+      }
+
+      .invoice-resume table {
+        border-collapse: collapse;
+      }
+      .invoice-resume .total-table tr td {
+        padding-top: 8px;
+        padding-bottom: 8px;
+        text-align: right;
+      }
+      .invoice-resume .total-table td:first-child {
+        width: 50%;
+      }
+      .invoice-resume .total-table tr:not(:last-child) td:nth-child(2) {
+        border-bottom: 1px solid var(--border-color);
+        text-align: left;
+        width: 35%;
+      }
+      .invoice-resume .total-table tr:not(:last-child) td:nth-child(3) {
+        border-bottom: 1px solid var(--border-color);
+        text-align: right;
+        width: 15%;
+      }
+      .invoice-resume .total-table tr:last-child td:nth-child(2) {
+        text-align: left;
+        width: 25%;
+      }
+      .invoice-resume .total-table tr:last-child td:nth-child(3) {
+        text-align: right;
+        width: 25%;
+      }
+
+      .invoice-details-title {
+        page-break-before: always;
+      }
+
+      .breakdown-details table {
+        border-collapse: collapse;
+      }
+      .breakdown-details {
+        margin-top: -15px;
+      }
+      .breakdown-details-table tr td {
+        padding-bottom: 8px;
+        padding-top: 8px;
+      }
+      .breakdown-details-table tr td:last-child {
+        text-align: right;
+      }
+      .breakdown-details-table tr td {
+        border-bottom: 1px solid var(--border-color);
+      }
+      .breakdown-details-table tr:first-child td {
+        border-top: 1px solid var(--border-color);
+      }
+
+      .powered-by {
+        width: 100%;
+        text-align: right;
+      }
+      .powered-by span {
+        color: #8c95a6;
+      }
+      .powered-by img {
+        width: 37px;
+        height: 11px;
+        vertical-align: middle;
+        margin-top: 2px;
+      }
+      .alert {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        padding: 16px;
+        gap: 16px;
+        background: #F3F4F6;
+        border-radius: 12px;
+      }
+    </style>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">
+          Advance invoice
+        </h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">
+                Invoice Number
+              </td>
+              <td class="body-2">
+                LAGO-202509-001
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Issue Date
+              </td>
+              <td class="body-2">
+                Sep 04, 2025
+              </td>
+            </tr>
+            <tr>
+              <td class="body-1">
+                Payment term
+              </td>
+              <td class="body-2">
+                0 days
+              </td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+          </table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">
+            From
+          </div>
+          <div class="body-2">ACME Corporation
+          </div>
+          <div class="body-2">
+            123 Business St
+          </div>
+          <div class="body-2">
+            Suite 100
+          </div>
+          <div class="body-2">
+            <span>94105</span><span>, &nbsp;</span><span>San Francisco</span>
+          </div>
+          <div class="body-2">
+            CA
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            billing@acme.com
+          </div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">
+            Bill to
+          </div>
+          <div class="body-2">
+            John Doe
+          </div>
+          <div class="body-2">
+            1234567890
+          </div>
+          <div class="body-2">
+            456 Customer Ave
+          </div>
+          <div class="body-2">
+            Apt 202
+          </div>
+          <div class="body-2">
+            <span>10001</span><span>, &nbsp;</span><span>New York</span>
+          </div>
+          <div class="body-2">
+            NY
+          </div>
+          <div class="body-2">
+            United States
+          </div>
+          <div class="body-2">
+            john.doe@example.com
+          </div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-4">
+          $10.50
+        </h2>
+        <div class="body-1">
+          Due Sep 04, 2025
+        </div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td class="body-2">Item</td>
+            <td class="body-2">Units</td>
+            <td class="body-2">Unit price</td>
+            <td class="body-2">Amount</td>
+          </tr>
+          <tr>
+            <td class="body-1">Prepaid credits</td>
+            <td class="body-2">10.5</td>
+            <td class="body-2">1.0</td>
+            <td class="body-2">$10.50</td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2"></td>
+            <td class="body-1">Total</td>
+            <td class="body-1">$10.50</td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24">
+      </p>
+      <div class="powered-by"><span class="body-2">Powered by &nbsp;</span><img alt="Lago Logo" src="lago-logo-invoice.png" /></div>
+    </div>
+  </body>
+</html>

--- a/spec/views/app/views/templates/invoices/v4.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4.slim_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "invoices/v4/_credit.slim", type: :view do
+  subject(:rendered_template) do
+    html = Slim::Template.new(template, 1, pretty: true).render(invoice)
+    HtmlBeautifier.beautify(html, stop_on_errors: true)
+  end
+
+  let(:template) { Rails.root.join("app/views/templates/invoices/v4.slim") }
+  let(:invoice) do
+    build_stubbed(
+      :invoice,
+      :credit,
+      organization: organization,
+      billing_entity: billing_entity,
+      customer: customer,
+      number: "LAGO-202509-001",
+      payment_due_date: Date.parse("2025-09-04"),
+      issuing_date: Date.parse("2025-09-04"),
+      total_amount_cents: 1050,
+      currency: "USD",
+      fees: [fee]
+    )
+  end
+  # Static organization data for consistent rendering
+  let(:organization) do
+    build_stubbed(
+      :organization,
+      name: "ACME Corporation",
+      default_currency: "USD",
+      country: "US"
+    )
+  end
+
+  # Static billing entity data for consistent rendering
+  let(:billing_entity) do
+    build_stubbed(
+      :billing_entity,
+      organization: organization,
+      name: "ACME Corporation",
+      email: "billing@acme.com",
+      address_line1: "123 Business St",
+      address_line2: "Suite 100",
+      city: "San Francisco",
+      state: "CA",
+      zipcode: "94105",
+      country: "US"
+    )
+  end
+  # Static customer data
+  let(:customer) do
+    build_stubbed(
+      :customer,
+      organization: organization,
+      firstname: nil,
+      lastname: nil,
+      name: "John Doe",
+      legal_name: "John Doe",
+      legal_number: "1234567890",
+      external_id: "customer_123",
+      email: "john.doe@example.com",
+      address_line1: "456 Customer Ave",
+      address_line2: "Apt 202",
+      city: "New York",
+      state: "NY",
+      zipcode: "10001",
+      country: "US",
+      phone: "+1-555-123-4567"
+    )
+  end
+
+  # Static wallet data
+  let(:wallet) do
+    build_stubbed(
+      :wallet,
+      customer: customer,
+      name: wallet_name,
+      balance_currency: "USD",
+      rate_amount: BigDecimal("1.0")
+    )
+  end
+
+  # Static wallet transaction data
+  let(:wallet_transaction) do
+    build_stubbed(
+      :wallet_transaction,
+      wallet: wallet,
+      credit_amount: BigDecimal("10.50"),
+      amount: BigDecimal("10.50")
+    )
+  end
+
+  # Static fee data
+  let(:fee) do
+    build_stubbed(
+      :fee,
+      id: "87654321-0fed-cba9-8765-4321fedcba90",
+      fee_type: :credit,
+      invoiceable: wallet_transaction,
+      amount_cents: 1050,
+      amount_currency: "USD"
+    )
+  end
+
+  let(:wallet_name) { "Premium Wallet" }
+
+  before do
+    # Set locale to ensure consistent translations
+    I18n.locale = :en
+  end
+
+  def snapshot_name(metadata)
+    description =
+      if metadata[:description].empty?
+        # we have an "it { is_expected.to be something }" block
+        metadata[:scoped_id]
+      else
+        metadata[:description]
+      end
+    example_group =
+      if metadata.key?(:example_group)
+        metadata[:example_group]
+      else
+        metadata[:parent_example_group]
+      end
+
+    description = description.tr("/", "_").tr(" ", "_")
+    if example_group
+      [snapshot_name(example_group), description].join("/")
+    else
+      description
+    end
+  end
+
+  def expect_to_match_snapshot
+    snapshot_name = self.snapshot_name(RSpec.current_example.metadata)
+    expect(rendered_template).to match_snapshot("#{snapshot_name}.html")
+  end
+
+  context "when invoice_type is credit" do
+    context "when wallet has no name" do
+      let(:wallet_name) { nil }
+
+      it "renders correctly" do
+        expect_to_match_snapshot
+      end
+    end
+
+    context "when wallet has a name" do
+      let(:wallet_name) { "Premium Wallet" }
+
+      it "renders correctly" do
+        expect_to_match_snapshot
+      end
+    end
+  end
+end

--- a/spec/views/app/views/templates/invoices/v4.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4.slim_spec.rb
@@ -2,8 +2,15 @@
 
 require "rails_helper"
 
+# This spec relies on `rspec-snapshot` gem (https://github.com/levinmr/rspec-snapshot) in order to serialize and compare
+# the rendered invoice HTML.
+#
+# To update a snapshot, either delete it, or run the tests with `UPDATE_SNAPSHOTS=true` environment variable.
+
 RSpec.describe "invoices/v4/_credit.slim", type: :view do
   subject(:rendered_template) do
+    # We have to use both `pretty: true` and `HtmlBeautifier.beautify` to ensure proper formatting which eases the
+    # snapshot diff review.
     html = Slim::Template.new(template, 1, pretty: true).render(invoice)
     HtmlBeautifier.beautify(html, stop_on_errors: true)
   end


### PR DESCRIPTION
## Context

I am currently working on a task that modifies the behavior of the invoice rendering for `credit` invoices. I noticed there were no spec for the rendering of those invoices. So I decided to add some tests and ended up extracting the logic into this PR.

## Description

In order to test the invoice rendering, I relied on the same code used by the `Utils::PdfGenerator`: `Slim::Template.new(template).render(invoice)`. The test is also using `build_stubbed` factory with constant data to have fast and consistent test setup. 

In order to make assertions on the view, I used the [`rspec-snapshots`](https://github.com/levinmr/rspec-snapshot) which serialize the HTML content into a snapshot on the first run and compares with the snapshot on the next runs. This allows us to easily diff the HTML changes and ensure there's no breaking change in the rendering.

One issue I faced though was that:

1. Slim rendering was not properly pretty printing tables:

   ```html
          <div class="mb-24">
            <h2 class="title-2 mb-4">
              $10.50
            </h2>
            <div class="body-1">
              Due Sep 04, 2025
            </div>
          </div>
          <div class="invoice-resume mb-24 overflow-auto">
            <table class="invoice-resume-table" width="100%"><tr><td class="body-2">Item</td><td class="body-2">Units</td><td class="body-2">Unit price</td><td class="body-2">Amount</td></tr><tr><td class="body-1">Prepaid credits - Premium Wallet</td><td class="body-2">10.5</td><td class="body-2">1.0</td><td class="body-2">$10.50</td></tr></table><table class="total-table" width="100%"><tr><td class="body-2"></td><td class="body-1">Total</td><td class="body-1">$10.50</td></tr></table>
          </div>
          
          <p class="body-3 mb-24">
            
          </p>
    ```

2. Nokogiri was not pretty printing with indentations:

    ```html
    <table class="total-table" width="100%"><tr>
    <td class="body-2"></td>
    <td class="body-1">Total</td>
    <td class="body-1">$10.50</td>
    </tr></table>
          </div>
          
          <p class="body-3 mb-24">
            
          </p>
          <div class="powered-by">
    <span class="body-2">Powered by  </span><img alt="Lago Logo" src="lago-logo-invoice.png">
    </div>
    ```
    
So I had to combine Slim with [`htmlbeautifier`](https://github.com/threedaymonk/htmlbeautifier/) gem.