### PR TITLE
fix(entitlements): strong params expects hash for privilege.config

### DIFF
--- a/app/controllers/api/v1/features_controller.rb
+++ b/app/controllers/api/v1/features_controller.rb
@@ -102,13 +102,13 @@ module Api
 
       def feature_create_params
         params.require(:feature).permit(:code, :name, :description, privileges: [
-          :code, :name, :value_type, :config
+          :code, :name, :value_type, config: {}
         ])
       end
 
       def feature_update_params
         params.require(:feature).permit(:name, :description, privileges: [
-          :code, :name, :value_type, :config
+          :code, :name, :value_type, config: {}
         ])
       end
 

--- a/spec/requests/api/v1/features_controller_spec.rb
+++ b/spec/requests/api/v1/features_controller_spec.rb
@@ -32,8 +32,10 @@ RSpec.describe Api::V1::FeaturesController, type: :request do
           name: "New Feature",
           description: "A new feature",
           privileges: [
-            {code: "priv1", value_type: "boolean"},
-            {code: "priv2", name: "Maximum", value_type: "boolean"}
+            {code: "priv1", value_type: "string"},
+            {code: "priv2", name: "Maximum", value_type: "integer"},
+            {code: "priv3", value_type: "boolean"},
+            {code: "priv4", name: "SELECT", value_type: "select", config: {select_options: %w[a b c]}}
           ]
         }
       }
@@ -43,15 +45,17 @@ RSpec.describe Api::V1::FeaturesController, type: :request do
 
     it "creates a new feature with privileges" do
       expect { subject }.to change(organization.features, :count).by(1)
-        .and change(organization.privileges, :count).by(2)
+        .and change(organization.privileges, :count).by(4)
 
       expect(response).to have_http_status(:success)
       expect(json[:feature][:code]).to eq("new_feature")
       expect(json[:feature][:name]).to eq("New Feature")
       expect(json[:feature][:description]).to eq("A new feature")
       expect(json[:feature][:privileges]).to contain_exactly(
-        {code: "priv1", name: nil, value_type: "boolean", config: {}},
-        {code: "priv2", name: "Maximum", value_type: "boolean", config: {}}
+        {code: "priv1", name: nil, value_type: "string", config: {}},
+        {code: "priv2", name: "Maximum", value_type: "integer", config: {}},
+        {code: "priv3", name: nil, value_type: "boolean", config: {}},
+        {code: "priv4", name: "SELECT", value_type: "select", config: {select_options: %w[a b c]}}
       )
     end
 


### PR DESCRIPTION
The controller strong params were incorrect, `config` is not a scalar value but a hash.
The feature is correctly created in service or via GQL but in the API controller would swallow the `config` arg so the service would return `invalid_value` error.