### PR TITLE
feat(wallet-transaction): Add `name` field to wallet transactions in GraphQL

### DIFF
--- a/app/graphql/mutations/wallet_transactions/create.rb
+++ b/app/graphql/mutations/wallet_transactions/create.rb
@@ -16,6 +16,7 @@ module Mutations
       argument :granted_credits, String, required: false
       argument :invoice_requires_successful_payment, Boolean, required: false
       argument :metadata, [Types::WalletTransactions::MetadataInput], required: false
+      argument :name, String, required: false
       argument :paid_credits, String, required: false
       argument :priority, Integer, required: false
       argument :voided_credits, String, required: false

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -18,6 +18,7 @@ module Types
       field :subscription, Types::Subscriptions::Object, null: true
       field :true_up_fee, Types::Fees::Object, null: true
       field :true_up_parent_fee, Types::Fees::Object, null: true
+      field :wallet_transaction, Types::WalletTransactions::Object, null: true
 
       field :creditable_amount_cents, GraphQL::Types::BigInt, null: false
       field :events_count, GraphQL::Types::BigInt, null: true
@@ -38,6 +39,10 @@ module Types
       field :charge_filter, Types::ChargeFilters::Object, null: true
       field :pricing_unit_usage, Types::PricingUnitUsages::Object, null: true
       field :properties, Types::Fees::Properties, null: true, method: :itself
+
+      def wallet_transaction
+        object.invoiceable if object.credit?
+      end
 
       def item_type
         object.fee_type

--- a/app/graphql/types/wallet_transactions/object.rb
+++ b/app/graphql/types/wallet_transactions/object.rb
@@ -11,11 +11,13 @@ module Types
       field :amount, String, null: false
       field :credit_amount, String, null: false
       field :invoice_requires_successful_payment, Boolean, null: false
+      field :name, String, null: true
       field :priority, Integer, null: false
       field :source, Types::WalletTransactions::SourceEnum, null: false
       field :status, Types::WalletTransactions::StatusEnum, null: false
       field :transaction_status, Types::WalletTransactions::TransactionStatusEnum, null: false
       field :transaction_type, Types::WalletTransactions::TransactionTypeEnum, null: false
+      field :wallet_name, String, null: true
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :failed_at, GraphQL::Types::ISO8601DateTime, null: true
@@ -26,6 +28,10 @@ module Types
 
       def invoice
         object.invoice&.visible? ? object.invoice : nil
+      end
+
+      def wallet_name
+        object.wallet.name
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2644,6 +2644,7 @@ input CreateCustomerWalletTransactionInput {
   grantedCredits: String
   invoiceRequiresSuccessfulPayment: Boolean
   metadata: [WalletTransactionMetadataInput!]
+  name: String
   paidCredits: String
   priority: Int
   voidedCredits: String
@@ -5136,6 +5137,7 @@ type Fee implements InvoiceItem {
   trueUpFee: Fee
   trueUpParentFee: Fee
   units: Float!
+  walletTransaction: WalletTransaction
 }
 
 type FeeAmountDetails {
@@ -11325,6 +11327,7 @@ type WalletTransaction {
   invoice: Invoice
   invoiceRequiresSuccessfulPayment: Boolean!
   metadata: [WalletTransactionMetadataObject!]
+  name: String
   priority: Int!
   settledAt: ISO8601DateTime
   source: WalletTransactionSourceEnum!
@@ -11333,6 +11336,7 @@ type WalletTransaction {
   transactionType: WalletTransactionTransactionTypeEnum!
   updatedAt: ISO8601DateTime!
   wallet: Wallet
+  walletName: String
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -10850,6 +10850,18 @@
               "deprecationReason": null
             },
             {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "paidCredits",
               "description": null,
               "type": {
@@ -24317,6 +24329,18 @@
                   "name": "Float",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "walletTransaction",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "WalletTransaction",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -59604,6 +59628,18 @@
               "args": []
             },
             {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "priority",
               "description": null,
               "type": {
@@ -59717,6 +59753,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Wallet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "name": "walletName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -144,4 +144,15 @@ FactoryBot.define do
       fee.write_attribute(:fixed_charge_id, evaluator.fixed_charge.id)
     end
   end
+
+  factory :credit_fee, parent: :fee do
+    transient do
+      wallet_transaction { association(:wallet_transaction, organization:) }
+    end
+    fee_type { "credit" }
+    invoiceable_id { wallet_transaction.id }
+    invoiceable_type { "WalletTransaction" }
+    subscription { nil }
+    charge { nil }
+  end
 end

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -6,26 +6,60 @@ RSpec.describe Types::Fees::Object do
   subject { described_class }
 
   it do
-    expect(subject).to have_field(:invoice_display_name).of_type("String")
+    expect(subject).to have_field(:id).of_type("ID!")
+
     expect(subject).to have_field(:add_on).of_type("AddOn")
     expect(subject).to have_field(:charge).of_type("Charge")
     expect(subject).to have_field(:currency).of_type("CurrencyEnum!")
+    expect(subject).to have_field(:description).of_type("String")
+    expect(subject).to have_field(:grouped_by).of_type("JSON!")
+    expect(subject).to have_field(:invoice_display_name).of_type("String")
+    expect(subject).to have_field(:invoice_name).of_type("String")
     expect(subject).to have_field(:subscription).of_type("Subscription")
     expect(subject).to have_field(:true_up_fee).of_type("Fee")
     expect(subject).to have_field(:true_up_parent_fee).of_type("Fee")
+    expect(subject).to have_field(:wallet_transaction).of_type("WalletTransaction")
+
     expect(subject).to have_field(:creditable_amount_cents).of_type("BigInt!")
     expect(subject).to have_field(:events_count).of_type("BigInt")
     expect(subject).to have_field(:fee_type).of_type("FeeTypesEnum!")
+    expect(subject).to have_field(:precise_unit_amount).of_type("Float!")
+    expect(subject).to have_field(:succeeded_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:taxes_amount_cents).of_type("BigInt!")
     expect(subject).to have_field(:taxes_rate).of_type("Float")
     expect(subject).to have_field(:units).of_type("Float!")
+
     expect(subject).to have_field(:applied_taxes).of_type("[FeeAppliedTax!]")
+
+    expect(subject).to have_field(:amount_details).of_type("FeeAmountDetails")
+
     expect(subject).to have_field(:adjusted_fee).of_type("Boolean!")
     expect(subject).to have_field(:adjusted_fee_type).of_type("AdjustedFeeTypeEnum")
-    expect(subject).to have_field(:grouped_by).of_type("JSON!")
 
     expect(subject).to have_field(:charge_filter).of_type("ChargeFilter")
     expect(subject).to have_field(:pricing_unit_usage).of_type("PricingUnitUsage")
     expect(subject).to have_field(:properties).of_type("FeeProperties")
+  end
+
+  describe "#wallet_transaction" do
+    subject { run_graphql_field("Fee.walletTransaction", fee) }
+
+    context "when fee is a credit" do
+      let(:fee) { create(:credit_fee) }
+      let(:wallet_transaction) { fee.invoiceable }
+
+      it "returns the wallet transaction" do
+        expect(subject).to be_present
+        expect(subject).to eq(wallet_transaction)
+      end
+    end
+
+    context "when fee is not a credit" do
+      let(:fee) { create(:charge_fee) }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
   end
 end

--- a/spec/graphql/types/wallet_transactions/object_spec.rb
+++ b/spec/graphql/types/wallet_transactions/object_spec.rb
@@ -11,18 +11,40 @@ RSpec.describe Types::WalletTransactions::Object do
     expect(subject).to have_field(:amount).of_type("String!")
     expect(subject).to have_field(:credit_amount).of_type("String!")
     expect(subject).to have_field(:invoice_requires_successful_payment).of_type("Boolean!")
+    expect(subject).to have_field(:name).of_type("String")
     expect(subject).to have_field(:priority).of_type("Int!")
     expect(subject).to have_field(:source).of_type("WalletTransactionSourceEnum!")
     expect(subject).to have_field(:status).of_type("WalletTransactionStatusEnum!")
     expect(subject).to have_field(:transaction_status).of_type("WalletTransactionTransactionStatusEnum!")
     expect(subject).to have_field(:transaction_type).of_type("WalletTransactionTransactionTypeEnum!")
+    expect(subject).to have_field(:wallet_name).of_type("String")
 
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:failed_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:invoice).of_type("Invoice")
+    expect(subject).to have_field(:metadata).of_type("[WalletTransactionMetadataObject!]")
     expect(subject).to have_field(:settled_at).of_type("ISO8601DateTime")
     expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+  end
 
-    expect(subject).to have_field(:metadata).of_type("[WalletTransactionMetadataObject!]")
-    expect(subject).to have_field(:invoice).of_type("Invoice")
+  describe "#wallet_name" do
+    subject { run_graphql_field("WalletTransaction.walletName", wallet_transaction) }
+
+    let(:wallet_transaction) { create(:wallet_transaction) }
+
+    context "when wallet has a name" do
+      it "returns the wallet name" do
+        expect(subject).to be_present
+        expect(subject).to eq(wallet_transaction.wallet.name)
+      end
+    end
+
+    context "when wallet has no name" do
+      let(:wallet_transaction) { create(:wallet_transaction, wallet: create(:wallet, name: nil)) }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,7 +49,7 @@ require "sidekiq/testing"
 Sidekiq::Testing.fake!
 ActiveJob::Uniqueness.test_mode!
 
-Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.reject { |f| f.include?("_spec.rb") }.each { |f| require f }
 
 begin
   ActiveRecord::Migration.check_all_pending!
@@ -72,6 +72,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ActiveStorageValidations::Matchers
   config.include Karafka::Testing::RSpec::Helpers
+  config.include GraphQL::Testing::Helpers.for(LagoApiSchema)
 
   # NOTE: these files make real API calls and should be excluded from build
   #       run them manually when needed


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-the-name-of-a-wallet-transaction-at-top-up

## Context

Follow up of https://github.com/getlago/lago-api/pull/4256.

## Description

This change introduces a `name` field to wallet transactions in the GraphQL API. The implementation adds a new name argument to the wallet transaction creation mutation, allowing clients to specify a custom name when creating transactions. The `WalletTransaction` GraphQL object type now exposes this field.

Additionally, the GraphQL `Fee` and `WalletTransaction` objects respectively gain a `walletTransaction` and `walletName` fields in order for the frontend to easily compute the label to display on invoices based on the following rules:

> - If `walletTransaction.name` is defined
>     
>     ```handlebars
>     {{walletTransaction.name}}
>     ```
>     
> - If `walletTransaction.name` is not defined but `walletTransaction.walletName` is defined
>     
>     ```handlebars
>     Prepaid credits - {{wallet.name}}
>     ```
>     
> - If `walletTransaction.name` is not defined and `walletTransaction.walletName` is not defined
>     
>     ```handlebars
>     Prepaid credits
>     ``` 

This should have no impact on performance and should not cause N+1 query as:

1. There only one credit fee per credit invoice
2. There is no fee resolver, ensuring that the only way to retrieve a credit fee via GraphQL is through the invoice and the frontend should not be requesting this field on the `invoices` query.

When it comes to testing, the GraphQL tests were enhanced with the introduction of a [`run_graphql_field`](https://graphql-ruby.org/testing/helpers.html) helper method that simplifies GraphQL field testing. Also a new `:credit_fee` factory is added to support testing of credit fees.

This also fixes an issue `spec/support/regex_spec.rb` tests would be included in every test run.