### PR TITLE
fix(coupon-with-plans): Allow a coupon to be created when a plan has …

### DIFF
--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -181,6 +181,22 @@ RSpec.describe Coupons::CreateService, type: :service do
         expect { create_service.call }
           .to change(CouponTarget, :count).by(1)
       end
+
+      context "when a parent plan has childs" do
+        let(:child_plan) { create(:plan, organization:, parent: plan, code: plan.code) }
+
+        before { child_plan }
+
+        it "creates a coupon" do
+          expect { create_service.call }
+            .to change(Coupon, :count).by(1)
+        end
+
+        it "creates a coupon target" do
+          expect { create_service.call }
+            .to change(CouponTarget, :count).by(2)
+        end
+      end
     end
 
     context "with billable metric limitations in graphql context" do


### PR DESCRIPTION
## Scenario
Whenever the user tries to create a coupon for some plans, it fails if one of the plans has child plans.

## Problem
Right here https://github.com/getlago/lago-api/blob/main/app/services/coupons/create_service.rb#L41, we check by the plans count. 
But if any of the plans has a child with the same code, it will fail. 
```
"applies_to": {"plan_codes": ["plan_1"]}
```

```
Plan.where(code: ["plan_1"] , organization_id: 'some-org').count
=> 2
```

## Fix
Instead of counting, have the groups keys reduced and expect it to be empty. 
```
      if plan_identifiers.present? && (plan_identifiers - plans.pluck(plan_key)).present?
        return result.not_found_failure!(resource: "plans")
      end
```