### PR TITLE
fix(wallet-transaction): Set `invoice_requires_successful_payment` to `false` for granted credits

### DIFF
--- a/app/services/wallet_transactions/create_from_params_service.rb
+++ b/app/services/wallet_transactions/create_from_params_service.rb
@@ -47,8 +47,7 @@ module WalletTransactions
           transaction = handle_granted_credits(
             wallet:,
             credits_amount: BigDecimal(params[:granted_credits]).floor(5),
-            reset_consumed_credits: ActiveModel::Type::Boolean.new.cast(params[:reset_consumed_credits]),
-            invoice_requires_successful_payment:
+            reset_consumed_credits: ActiveModel::Type::Boolean.new.cast(params[:reset_consumed_credits])
           )
           wallet_transactions << transaction
         end
@@ -105,7 +104,7 @@ module WalletTransactions
       wallet_transaction
     end
 
-    def handle_granted_credits(wallet:, credits_amount:, invoice_requires_successful_payment:, reset_consumed_credits: false)
+    def handle_granted_credits(wallet:, credits_amount:, reset_consumed_credits: false)
       return if credits_amount.zero?
 
       wallet_credit = WalletCredit.new(wallet:, credit_amount: credits_amount, invoiceable: false)
@@ -118,7 +117,6 @@ module WalletTransactions
           settled_at: Time.current,
           source:,
           transaction_status: :granted,
-          invoice_requires_successful_payment:,
           metadata:,
           priority:
         ).wallet_transaction

--- a/spec/graphql/mutations/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/wallet_transactions/create_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
     result_data = result["data"]["createCustomerWalletTransaction"]
     expect(result_data["collection"].map { |wt| wt["status"] })
       .to contain_exactly("pending", "settled")
-    expect(result_data["collection"].map { |wt| wt["invoiceRequiresSuccessfulPayment"] }).to all be true
+    expect(result_data["collection"].map { |wt| wt["invoiceRequiresSuccessfulPayment"] }).to eq([true, false])
     expect(result_data["collection"].map { |wt| wt["priority"] }).to all eq(25)
     expect(result_data["collection"]).to all(include(
       "metadata" => contain_exactly(


### PR DESCRIPTION
## Context

Granted credit never triggers payment not generates invoices. So their `invoice_requires_successful_payment` attribute should always be set to `false`.

## Description

This ensures that it is the case.
