### PR TITLE
fix(config): remove host authorization config in staging

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -41,11 +41,6 @@ Rails.application.configure do
 
   config.active_record.dump_schema_after_migration = false
 
-  config.hosts << /[a-z0-9-]+\.staging\.getlago\.com/
-  config.host_authorization = {
-    exclude: ->(request) { request.path == "/health" }
-  }
-
   config.license_url = "http://license-staging-web.default.svc.cluster.local"
 
   if ENV["LAGO_MEMCACHE_SERVERS"].present?


### PR DESCRIPTION
Staging was using https://api.rubyonrails.org/classes/ActionDispatch/HostAuthorization.html for an unknown reason. It caused some troubleshooting issues and do not provide that much of a protection. Furthermore, this config was not present in production configuration making the whole setup inconsistent.
