### PR TITLE
fix(prepaid_credits): Use precise amounts

### DIFF
--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -102,7 +102,7 @@ module Credits
 
     def limited_fees_total(applicable_fees)
       applicable_fees.sum do |f|
-        f.sub_total_excluding_taxes_amount_cents + f.taxes_amount_cents - f.precise_credit_notes_amount_cents
+        f.sub_total_excluding_taxes_precise_amount_cents + f.taxes_precise_amount_cents - f.precise_credit_notes_amount_cents
       end
     end
   end

--- a/spec/services/credits/applied_prepaid_credit_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credit_service_spec.rb
@@ -104,8 +104,8 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
 
     context "with fee type limitations" do
       let(:subscription_fees) { [fee1, fee2] }
-      let(:fee1) { create(:fee, invoice:, subscription:, amount_cents: 60, taxes_amount_cents: 6) }
-      let(:fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 40, taxes_amount_cents: 4) }
+      let(:fee1) { create(:fee, invoice:, subscription:, precise_amount_cents: 60, taxes_precise_amount_cents: 6) }
+      let(:fee2) { create(:charge_fee, invoice:, subscription:, precise_amount_cents: 40, taxes_precise_amount_cents: 4) }
       let(:wallet) { create(:wallet, customer:, balance_cents: 1000, credits_balance: 10.0, allowed_fee_types: %w[charge]) }
 
       before { subscription_fees }
@@ -137,8 +137,8 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
 
       context "when wallet credits are less than invoice amount" do
         let(:amount_cents) { 10_000 }
-        let(:fee1) { create(:fee, invoice:, subscription:, amount_cents: 6_000, taxes_amount_cents: 600) }
-        let(:fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 4_000, taxes_amount_cents: 400) }
+        let(:fee1) { create(:fee, invoice:, subscription:, precise_amount_cents: 6_000, taxes_precise_amount_cents: 600) }
+        let(:fee2) { create(:charge_fee, invoice:, subscription:, precise_amount_cents: 4_000, taxes_precise_amount_cents: 400) }
 
         it "calculates prepaid credit" do
           result = credit_service.call
@@ -167,8 +167,8 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
 
     context "with billable metric limitations" do
       let(:subscription_fees) { [fee1, fee2] }
-      let(:fee1) { create(:fee, invoice:, subscription:, amount_cents: 60, taxes_amount_cents: 6) }
-      let(:fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 40, taxes_amount_cents: 4, charge:) }
+      let(:fee1) { create(:fee, invoice:, subscription:, precise_amount_cents: 60, taxes_precise_amount_cents: 6) }
+      let(:fee2) { create(:charge_fee, invoice:, subscription:, precise_amount_cents: 40, taxes_precise_amount_cents: 4, charge:) }
       let(:charge) { create(:standard_charge, organization: wallet.organization, billable_metric:) }
       let(:wallet) { create(:wallet, customer:, balance_cents: 1000, credits_balance: 10.0) }
       let(:billable_metric) { create(:billable_metric, organization: wallet.organization) }
@@ -206,8 +206,8 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
 
       context "when wallet credits are less than invoice amount" do
         let(:amount_cents) { 10_000 }
-        let(:fee1) { create(:fee, invoice:, subscription:, amount_cents: 6_000, taxes_amount_cents: 600) }
-        let(:fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 4_000, taxes_amount_cents: 400, charge:) }
+        let(:fee1) { create(:fee, invoice:, subscription:, precise_amount_cents: 6_000, taxes_precise_amount_cents: 600) }
+        let(:fee2) { create(:charge_fee, invoice:, subscription:, precise_amount_cents: 4_000, taxes_precise_amount_cents: 400, charge:) }
 
         it "calculates prepaid credit" do
           result = credit_service.call
@@ -236,9 +236,9 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
 
     context "with billable metric limitations and fee type limitation" do
       let(:subscription_fees) { [fee1, fee2, fee3] }
-      let(:fee1) { create(:fee, invoice:, subscription:, amount_cents: 60, taxes_amount_cents: 6) }
-      let(:fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 20, taxes_amount_cents: 2, charge:) }
-      let(:fee3) { create(:charge_fee, invoice:, subscription:, amount_cents: 20, taxes_amount_cents: 2) }
+      let(:fee1) { create(:fee, invoice:, subscription:, precise_amount_cents: 60, taxes_precise_amount_cents: 6) }
+      let(:fee2) { create(:charge_fee, invoice:, subscription:, precise_amount_cents: 20, taxes_precise_amount_cents: 2, charge:) }
+      let(:fee3) { create(:charge_fee, invoice:, subscription:, precise_amount_cents: 20, taxes_precise_amount_cents: 2) }
       let(:charge) { create(:standard_charge, organization: wallet.organization, billable_metric:) }
       let(:wallet) { create(:wallet, customer:, balance_cents: 1000, credits_balance: 10.0, allowed_fee_types: %w[subscription]) }
       let(:billable_metric) { create(:billable_metric, organization: wallet.organization) }

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -1778,7 +1778,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           expect(result.invoice.sub_total_excluding_taxes_amount_cents).to eq(15_500)
           expect(result.invoice.sub_total_including_taxes_amount_cents).to eq(17_050)
           expect(result.invoice.progressive_billing_credit_amount_cents).to eq(3_000)
-          expect(result.invoice.total_amount_cents).to eq(9_726) # 17_050 - 1_000 (credit note) - 6_323 (wallet)
+          expect(result.invoice.total_amount_cents).to eq(9_727) # 17_050 - 1_000 (credit note) - 6_323 (wallet)
         end
       end
     end


### PR DESCRIPTION
We use this to calculate the amount if prepaid credits in an Invoice. 
Sometime the rounding numbers are ceiling and reduce more than the total invoice costs; producing a negative`total_amounts_cents` and failing the validation, preventing it from finalize.