### PR TITLE
feat(pre-aggregation): Implement weighted_sum

### DIFF
--- a/app/services/events/stores/aggregated_clickhouse/weighted_sum_query.rb
+++ b/app/services/events/stores/aggregated_clickhouse/weighted_sum_query.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module AggregatedClickhouse
+      class WeightedSumQuery
+        def initialize(store:)
+          @store = store
+        end
+
+        def query
+          <<-SQL
+            #{events_cte_sql}
+
+            SELECT sum(period_ratio) as aggregation
+            FROM (
+              SELECT (#{period_ratio_sql}) as period_ratio
+              FROM events_data
+            ) cumulated_ratios
+          SQL
+        end
+
+        def grouped_query(initial_values:)
+          <<-SQL
+            #{grouped_events_cte_sql(initial_values)}
+
+            SELECT
+              grouped_by,
+              SUM(period_ratio) as aggregation
+            FROM (
+              SELECT
+                grouped_by,
+                (#{grouped_period_ratio_sql}) AS period_ratio
+              FROM events_data
+            ) cumulated_ratios
+            GROUP BY grouped_by
+          SQL
+        end
+
+        # NOTE: not used in production, only for debug purpose to check the computed values before aggregation
+        def breakdown_query
+          <<-SQL
+            #{events_cte_sql}
+
+            SELECT
+              timestamp,
+              difference,
+              SUM(difference) OVER (ORDER BY timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS cumul,
+              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) AS second_duration,
+              (#{period_ratio_sql}) AS period_ratio
+            FROM events_data
+            ORDER BY timestamp ASC
+          SQL
+        end
+
+        private
+
+        attr_reader :store
+
+        delegate :charges_duration, :events_sql, :arel_enriched_table, :grouped_arel_columns, to: :store
+
+        def events_cte_sql
+          <<~SQL
+            WITH events_data AS (
+              (#{initial_value_sql})
+              UNION ALL
+              (#{
+                events_sql(
+                  ordered: true,
+                  select: [
+                    arel_enriched_table[:timestamp].as("timestamp"),
+                    arel_enriched_table[:decimal_value].as("difference")
+                  ]
+                )
+              })
+              UNION ALL
+              (#{end_of_period_value_sql})
+            )
+          SQL
+        end
+
+        def initial_value_sql
+          <<-SQL
+            SELECT
+              toDateTime64(:from_datetime, 5, 'UTC') as timestamp,
+              toDecimal128(:initial_value, :decimal_scale) as difference
+          SQL
+        end
+
+        def end_of_period_value_sql
+          <<-SQL
+            SELECT
+              toDateTime64(:to_datetime, 5, 'UTC') as timestamp,
+              toDecimal128(0, :decimal_scale) as difference
+          SQL
+        end
+
+        def period_ratio_sql
+          <<-SQL
+            if(
+              -- NOTE: duration in seconds between current event and next one
+              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) > 0,
+
+              -- NOTE: cumulative sum from previous events in the period
+              (SUM(difference) OVER (ORDER BY timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))
+              *
+              -- NOTE: duration in seconds between current event and next one - using end of period as final boundaries
+              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING))
+              /
+              -- NOTE: full duration of the period
+              #{charges_duration.days.to_i},
+
+              -- NOTE: duration was null so usage is null
+              toDecimal128(0, :decimal_scale)
+            )
+          SQL
+        end
+
+        def grouped_events_cte_sql(initial_values)
+          <<-SQL
+            WITH events_data AS (
+              (#{grouped_initial_value_sql(initial_values)})
+              UNION ALL
+              (#{
+                events_sql(
+                  ordered: true,
+                  select: [
+                    Arel::Nodes::NamedFunction.new(
+                      "toJSONString",
+                      [arel_enriched_table[:sorted_grouped_by]]
+                    ).as("grouped_by"),
+                    arel_enriched_table[:timestamp].as("timestamp"),
+                    arel_enriched_table[:decimal_value].as("difference")
+                  ]
+                )
+              })
+              UNION ALL
+              (#{grouped_end_of_period_value_sql(initial_values)})
+            )
+          SQL
+        end
+
+        def grouped_initial_value_sql(initial_values)
+          values = initial_values.map do |initial_value|
+            groups = store.grouped_by.map do |g|
+              "'#{ActiveRecord::Base.sanitize_sql_for_conditions(initial_value[:groups][g])}'"
+            end
+
+            [
+              groups,
+              "toDateTime64(:from_datetime, 5, 'UTC')",
+              "toDecimal128(#{initial_value[:value]}, :decimal_scale)"
+            ].flatten.join(", ")
+          end
+
+          <<-SQL
+            SELECT
+              #{store.grouped_by.map.with_index { |_, index| "tuple.#{index + 1} AS g_#{index}" }.join(", ")},
+              tuple.#{store.grouped_by.count + 1} AS timestamp,
+              tuple.#{store.grouped_by.count + 2} AS difference
+            FROM ( SELECT arrayJoin([#{values.map { "tuple(#{it})" }.join(", ")}]) AS tuple )
+          SQL
+        end
+
+        def grouped_end_of_period_value_sql(initial_values)
+          values = initial_values.map do |initial_value|
+            groups = store.grouped_by.map do |g|
+              "'#{ActiveRecord::Base.sanitize_sql_for_conditions(initial_value[:groups][g])}'"
+            end
+
+            [
+              groups,
+              "toDateTime64(:to_datetime, 5, 'UTC')",
+              "toDecimal128(0, :decimal_scale)"
+            ].flatten.join(", ")
+          end
+
+          <<-SQL
+            SELECT
+              #{store.grouped_by.map.with_index { |_, index| "tuple.#{index + 1} AS g_#{index}" }.join(", ")},
+              tuple.#{store.grouped_by.count + 1} AS timestamp,
+              tuple.#{store.grouped_by.count + 2} AS difference
+            FROM ( SELECT arrayJoin([#{values.map { "tuple(#{it})" }.join(", ")}]) AS tuple )
+          SQL
+        end
+
+        def grouped_period_ratio_sql
+          <<-SQL
+            if(
+              -- NOTE: duration in seconds between current event and next one
+              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (PARTITION BY grouped_by ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) > 0,
+
+              -- NOTE: cumulative sum from previous events in the period
+              (SUM(difference) OVER (PARTITION BY grouped_by ORDER BY timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))
+              *
+              -- NOTE: duration in seconds between current event and next one - using end of period as final boundaries
+              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (PARTITION BY grouped_by ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING))
+              /
+              -- NOTE: full duration of the period
+              #{charges_duration.days.to_i},
+
+              -- NOTE: duration was null so usage is null
+              toDecimal128(0, :decimal_scale)
+            )
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/app/services/events/stores/aggregated_clickhouse_store.rb
+++ b/app/services/events/stores/aggregated_clickhouse_store.rb
@@ -309,7 +309,39 @@ module Events
       end
 
       def grouped_weighted_sum(initial_values: [])
-        # TODO(pre-aggregation): Implement
+        connection_with_retry do |connection|
+          query = AggregatedClickhouse::WeightedSumQuery.new(store: self)
+
+          # NOTE: build the list of initial values for each groups
+          #       from the events in the period
+          formated_initial_values = grouped_count.map do |group|
+            value = 0
+            previous_group = initial_values.find { |g| g[:groups] == group[:groups] }
+            value = previous_group[:value] if previous_group
+            {groups: group[:groups], value:}
+          end
+
+          # NOTE: add the initial values for groups that are not in the events
+          initial_values.each do |intial_value|
+            next if formated_initial_values.find { |g| g[:groups] == intial_value[:groups] }
+
+            formated_initial_values << intial_value
+          end
+          return [] if formated_initial_values.empty?
+
+          sql = ActiveRecord::Base.sanitize_sql_for_conditions(
+            [
+              sanitize_colon(query.grouped_query(initial_values: formated_initial_values)),
+              {
+                from_datetime:,
+                to_datetime: to_datetime.ceil,
+                decimal_scale: DECIMAL_SCALE
+              }
+            ]
+          )
+
+          prepare_grouped_result(connection.select_all(sql).rows)
+        end
       end
 
       # NOTE: not used in production, only for debug purpose to check the computed values before aggregation

--- a/app/services/events/stores/aggregated_clickhouse_store.rb
+++ b/app/services/events/stores/aggregated_clickhouse_store.rb
@@ -287,7 +287,25 @@ module Events
       end
 
       def weighted_sum(initial_value: 0)
-        # TODO(pre-aggregation): Implement
+        result = connection_with_retry do |connection|
+          query = Events::Stores::AggregatedClickhouse::WeightedSumQuery.new(store: self)
+
+          sql = ActiveRecord::Base.sanitize_sql_for_conditions(
+            [
+              sanitize_colon(query.query),
+              {
+                from_datetime:,
+                to_datetime: to_datetime.ceil,
+                decimal_scale: DECIMAL_SCALE,
+                initial_value: initial_value || 0
+              }
+            ]
+          )
+
+          connection.select_one(sql)
+        end
+
+        result["aggregation"]
       end
 
       def grouped_weighted_sum(initial_values: [])

--- a/app/services/events/stores/aggregated_clickhouse_store.rb
+++ b/app/services/events/stores/aggregated_clickhouse_store.rb
@@ -314,7 +314,23 @@ module Events
 
       # NOTE: not used in production, only for debug purpose to check the computed values before aggregation
       def weighted_sum_breakdown(initial_value: 0)
-        # TODO(pre-aggregation): Implement
+        connection_with_retry do |connection|
+          query = Events::Stores::AggregatedClickhouse::WeightedSumQuery.new(store: self)
+
+          connection.select_all(
+            ActiveRecord::Base.sanitize_sql_for_conditions(
+              [
+                sanitize_colon(query.breakdown_query),
+                {
+                  from_datetime:,
+                  to_datetime: to_datetime.ceil,
+                  decimal_scale: DECIMAL_SCALE,
+                  initial_value: initial_value || 0
+                }
+              ]
+            )
+          ).rows
+        end
       end
 
       def aggregated_arel_table

--- a/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
+++ b/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
@@ -759,6 +759,7 @@ RSpec.describe Events::Stores::AggregatedClickhouseStore, type: :service, clickh
     end
 
     it "returns the weighted sum of event properties" do
+      byebug
       expect(event_store.weighted_sum.round(5)).to eq(0.02218)
     end
 

--- a/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
+++ b/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
@@ -759,7 +759,6 @@ RSpec.describe Events::Stores::AggregatedClickhouseStore, type: :service, clickh
     end
 
     it "returns the weighted sum of event properties" do
-      byebug
       expect(event_store.weighted_sum.round(5)).to eq(0.02218)
     end
 
@@ -823,6 +822,146 @@ RSpec.describe Events::Stores::AggregatedClickhouseStore, type: :service, clickh
 
       it "returns the weighted sum of event properties scoped to the group" do
         expect(event_store.weighted_sum.round(5)).to eq(1000.0)
+      end
+    end
+  end
+
+  describe ".grouped_weighted_sum" do
+    let(:grouped_by) { %w[agent_name other] }
+
+    let(:started_at) { Time.zone.parse("2023-03-01") }
+
+    let(:events_values) do
+      [
+        {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2, agent_name: "frodo"},
+        {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3, agent_name: "frodo"},
+        {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1, agent_name: "frodo"},
+        {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4, agent_name: "frodo"},
+        {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2, agent_name: "frodo"},
+        {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10, agent_name: "frodo"},
+        {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10, agent_name: "frodo"},
+
+        {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2, agent_name: "aragorn"},
+        {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3, agent_name: "aragorn"},
+        {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1, agent_name: "aragorn"},
+        {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4, agent_name: "aragorn"},
+        {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2, agent_name: "aragorn"},
+        {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10, agent_name: "aragorn"},
+        {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10, agent_name: "aragorn"},
+
+        {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2},
+        {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3},
+        {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1},
+        {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4},
+        {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2},
+        {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10},
+        {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10}
+      ]
+    end
+
+    let(:events) do
+      events_values.map do |values|
+        ::Clickhouse::EventsEnrichedExpanded.create!(
+          transaction_id: SecureRandom.uuid,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          subscription_id: subscription.id,
+          plan_id: plan.id,
+          code:,
+          aggregation_type: "unique_count",
+          charge_id:,
+          charge_version: charge.updated_at,
+          charge_filter_id: charge_filter&.id,
+          charge_filter_version: charge_filter&.updated_at,
+          timestamp: values[:timestamp],
+          properties: {},
+          value: values[:value].to_s,
+          decimal_value: values[:value].to_d,
+          grouped_by: {
+            "agent_name" => values[:agent_name] || described_class::NIL_GROUP_VALUE,
+            "other" => described_class::NIL_GROUP_VALUE
+          }
+        )
+      end
+    end
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it "returns the weighted sum of event properties" do
+      result = event_store.grouped_weighted_sum
+
+      expect(result.count).to eq(3)
+
+      null_group = result.find { |v| v[:groups]["agent_name"].nil? }
+      expect(null_group[:groups]["agent_name"]).to be_nil
+      expect(null_group[:groups]["other"]).to be_nil
+      expect(null_group[:value].round(5)).to eq(0.02218)
+
+      (result - [null_group]).each do |row|
+        expect(row[:groups]["agent_name"]).not_to be_nil
+        expect(row[:groups]["other"]).to be_nil
+        expect(row[:value].round(5)).to eq(0.02218)
+      end
+    end
+
+    context "with no events" do
+      let(:events_values) { [] }
+
+      it "returns the weighted sum of event properties" do
+        result = event_store.grouped_weighted_sum
+
+        expect(result.count).to eq(0)
+      end
+    end
+
+    context "with initial values" do
+      let(:initial_values) do
+        [
+          {groups: {"agent_name" => "frodo", "other" => nil}, value: 1000},
+          {groups: {"agent_name" => "aragorn", "other" => nil}, value: 1000},
+          {groups: {"agent_name" => nil, "other" => nil}, value: 1000}
+        ]
+      end
+
+      it "uses the initial value in the aggregation" do
+        result = event_store.grouped_weighted_sum(initial_values:)
+
+        expect(result.count).to eq(3)
+
+        null_group = result.find { |v| v[:groups]["agent_name"].nil? }
+        expect(null_group[:groups]["agent_name"]).to be_nil
+        expect(null_group[:groups]["other"]).to be_nil
+        expect(null_group[:value].round(5)).to eq(1000.02218)
+
+        (result - [null_group]).each do |row|
+          expect(row[:groups]["agent_name"]).not_to be_nil
+          expect(row[:groups]["other"]).to be_nil
+          expect(row[:value].round(5)).to eq(1000.02218)
+        end
+      end
+
+      context "without events" do
+        let(:events_values) { [] }
+
+        it "uses only the initial value in the aggregation" do
+          result = event_store.grouped_weighted_sum(initial_values:)
+
+          expect(result.count).to eq(3)
+
+          null_group = result.find { |v| v[:groups]["agent_name"].nil? }
+          expect(null_group[:groups]["agent_name"]).to be_nil
+          expect(null_group[:groups]["other"]).to be_nil
+          expect(null_group[:value].round(5)).to eq(1000)
+
+          (result - [null_group]).each do |row|
+            expect(row[:groups]["agent_name"]).not_to be_nil
+            expect(row[:groups]["other"]).to be_nil
+            expect(row[:value].round(5)).to eq(1000)
+          end
+        end
       end
     end
   end

--- a/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
+++ b/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
@@ -714,4 +714,115 @@ RSpec.describe Events::Stores::AggregatedClickhouseStore, type: :service, clickh
       end
     end
   end
+
+  describe ".weighted_sum" do
+    let(:started_at) { Time.zone.parse("2023-03-01") }
+
+    let(:events_values) do
+      [
+        {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2},
+        {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3},
+        {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1},
+        {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4},
+        {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2},
+        {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10},
+        {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10}
+      ]
+    end
+
+    let(:events) do
+      events_values.map do |values|
+        ::Clickhouse::EventsEnrichedExpanded.create!(
+          transaction_id: SecureRandom.uuid,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          subscription_id: subscription.id,
+          plan_id: plan.id,
+          code:,
+          aggregation_type: "unique_count",
+          charge_id:,
+          charge_version: charge.updated_at,
+          charge_filter_id: charge_filter&.id,
+          charge_filter_version: charge_filter&.updated_at,
+          timestamp: values[:timestamp],
+          properties: {},
+          value: values[:value].to_s,
+          decimal_value: values[:value].to_d,
+          grouped_by: {}
+        )
+      end
+    end
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it "returns the weighted sum of event properties" do
+      expect(event_store.weighted_sum.round(5)).to eq(0.02218)
+    end
+
+    context "with a single event" do
+      let(:events_values) do
+        [
+          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 1000}
+        ]
+      end
+
+      it "returns the weighted sum of event properties" do
+        expect(event_store.weighted_sum.round(5)).to eq(1000.0)
+      end
+    end
+
+    context "with no events" do
+      let(:events_values) { [] }
+
+      it "returns the weighted sum of event properties" do
+        expect(event_store.weighted_sum.round(5)).to eq(0.0)
+      end
+    end
+
+    context "with events with the same timestamp" do
+      let(:events_values) do
+        [
+          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 3},
+          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 3}
+        ]
+      end
+
+      it "returns the weighted sum of event properties" do
+        expect(event_store.weighted_sum.round(5)).to eq(6.0)
+      end
+    end
+
+    context "with initial value" do
+      let(:initial_value) { 1000 }
+
+      it "uses the initial value in the aggregation" do
+        expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.02218)
+      end
+
+      context "without events" do
+        let(:events_values) { [] }
+
+        it "uses only the initial value in the aggregation" do
+          expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.0)
+        end
+      end
+    end
+
+    context "with filters" do
+      let(:charge_filter) { create(:charge_filter, charge:) }
+
+      let(:events_values) do
+        [
+          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 1000, region: "europe"}
+        ]
+      end
+
+      it "returns the weighted sum of event properties scoped to the group" do
+        expect(event_store.weighted_sum.round(5)).to eq(1000.0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic, it follows https://github.com/getlago/lago-api/pull/4236.

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This PR implements:
- The `unique_count` aggregation
- The `weighted_sum` aggregation
- The `weighted_sum_breakdown` method
