### PR TITLE
feat(fixed_charges): Emit fixed charge events on updates

### DIFF
--- a/app/graphql/types/fixed_charges/input.rb
+++ b/app/graphql/types/fixed_charges/input.rb
@@ -5,6 +5,7 @@ module Types
     class Input < Types::BaseInputObject
       graphql_name "FixedChargeInput"
 
+      argument :id, ID, required: false
       argument :add_on_id, ID, required: true
       argument :apply_units_immediately, Boolean, required: false
       argument :charge_model, Types::FixedCharges::ChargeModelEnum, required: true

--- a/app/graphql/types/subscriptions/fixed_charge_overrides_input.rb
+++ b/app/graphql/types/subscriptions/fixed_charge_overrides_input.rb
@@ -3,7 +3,7 @@
 module Types
   module Subscriptions
     class FixedChargeOverridesInput < Types::BaseInputObject
-      argument :add_on_id, ID, required: true
+      argument :add_on_id, ID, required: false
       argument :id, ID, required: false
 
       argument :apply_units_immediately, Boolean, required: false

--- a/app/graphql/types/subscriptions/fixed_charge_overrides_input.rb
+++ b/app/graphql/types/subscriptions/fixed_charge_overrides_input.rb
@@ -6,10 +6,11 @@ module Types
       argument :add_on_id, ID, required: true
       argument :id, ID, required: false
 
+      argument :apply_units_immediately, Boolean, required: false
       argument :invoice_display_name, String, required: false
       argument :properties, Types::FixedCharges::PropertiesInput, required: false
       argument :tax_codes, [String], required: false
-      argument :units, String, required: true
+      argument :units, String, required: false
     end
   end
 end

--- a/app/jobs/clock/emit_fixed_charge_events_job.rb
+++ b/app/jobs/clock/emit_fixed_charge_events_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Clock
+  class EmitFixedChargeEventsJob < ClockJob
+    unique :until_executed, on_conflict: :log
+
+    def perform
+      Organization.find_each do |organization|
+        Subscriptions::OrganizationEmitFixedChargeEventsJob.perform_later(organization:, timestamp: Time.current.to_i)
+      end
+    end
+  end
+end

--- a/app/jobs/subscriptions/emit_fixed_charge_events_job.rb
+++ b/app/jobs/subscriptions/emit_fixed_charge_events_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class EmitFixedChargeEventsJob < ApplicationJob
+    queue_as "default"
+
+    def perform(subscriptions:, timestamp: Time.current.to_i)
+      Subscriptions::EmitFixedChargeEventsService.call!(
+        subscriptions:,
+        timestamp: Time.zone.at(timestamp)
+      )
+    end
+  end
+end

--- a/app/jobs/subscriptions/organization_emit_fixed_charge_events_job.rb
+++ b/app/jobs/subscriptions/organization_emit_fixed_charge_events_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class OrganizationEmitFixedChargeEventsJob < ApplicationJob
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_CLOCK"])
+        :clock_worker
+      else
+        :clock
+      end
+    end
+
+    unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
+
+    def perform(organization:, timestamp: Time.current.to_i)
+      Subscriptions::OrganizationEmitFixedChargeEventsService.call!(
+        organization:,
+        timestamp: Time.at(timestamp || Time.current.to_i)
+      )
+    end
+  end
+end

--- a/app/jobs/subscriptions/organization_emit_fixed_charge_events_job.rb
+++ b/app/jobs/subscriptions/organization_emit_fixed_charge_events_job.rb
@@ -15,7 +15,7 @@ module Subscriptions
     def perform(organization:, timestamp: Time.current.to_i)
       Subscriptions::OrganizationEmitFixedChargeEventsService.call!(
         organization:,
-        timestamp: Time.at(timestamp || Time.current.to_i)
+        timestamp: Time.zone.at(timestamp || Time.current.to_i)
       )
     end
   end

--- a/app/models/fixed_charge.rb
+++ b/app/models/fixed_charge.rb
@@ -16,6 +16,7 @@ class FixedCharge < ApplicationRecord
   has_many :taxes, through: :applied_taxes
   has_many :subscription_fixed_charge_units_overrides, dependent: :destroy
   has_many :fees
+  has_many :events, class_name: "FixedChargeEvent", dependent: :destroy
 
   has_many :applied_taxes, class_name: "FixedCharge::AppliedTax", dependent: :destroy
   has_many :taxes, through: :applied_taxes

--- a/app/services/fixed_charge_events/create_service.rb
+++ b/app/services/fixed_charge_events/create_service.rb
@@ -4,11 +4,10 @@ module FixedChargeEvents
   class CreateService < BaseService
     Result = BaseResult[:fixed_charge_event]
 
-    def initialize(subscription:, fixed_charge:, units: 0.0, timestamp: Time.current)
+    def initialize(subscription:, fixed_charge:, timestamp: Time.current)
       @organization = subscription&.organization
       @subscription = subscription
       @fixed_charge = fixed_charge
-      @units = units
       @timestamp = timestamp
       super
     end
@@ -18,7 +17,7 @@ module FixedChargeEvents
         organization:,
         subscription:,
         fixed_charge:,
-        units:,
+        units: fixed_charge.units,
         timestamp:
       )
 
@@ -30,6 +29,6 @@ module FixedChargeEvents
 
     private
 
-    attr_reader :organization, :subscription, :fixed_charge, :units, :timestamp
+    attr_reader :organization, :subscription, :fixed_charge, :timestamp
   end
 end

--- a/app/services/fixed_charges/create_service.rb
+++ b/app/services/fixed_charges/create_service.rb
@@ -40,7 +40,7 @@ module FixedCharges
         end
 
         if params[:apply_units_immediately]
-          emit_events_for_active_subscriptions(fixed_charge)
+          FixedCharges::EmitEventsForActiveSubscriptionsService.call!(fixed_charge:)
         end
 
         result.fixed_charge = fixed_charge
@@ -68,15 +68,6 @@ module FixedCharges
         organization.add_ons.find_by!(code: params[:add_on_code])
       else
         raise ArgumentError, "Either add_on_id or add_on_code must be provided"
-      end
-    end
-
-    def emit_events_for_active_subscriptions(fixed_charge)
-      plan.subscriptions.active.find_each do |subscription|
-        FixedCharges::EmitFixedChargeEventService.call!(
-          subscription:,
-          fixed_charge:
-        )
       end
     end
   end

--- a/app/services/fixed_charges/emit_events_for_active_subscriptions_service.rb
+++ b/app/services/fixed_charges/emit_events_for_active_subscriptions_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module FixedCharges
+  class EmitEventsForActiveSubscriptionsService < BaseService
+    def initialize(fixed_charge:)
+      @fixed_charge = fixed_charge
+      super
+    end
+
+    def call
+      fixed_charge.plan.subscriptions.active.find_each do |subscription|
+        FixedCharges::EmitFixedChargeEventService.call!(
+          subscription:,
+          fixed_charge:
+        )
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :fixed_charge
+  end
+end

--- a/app/services/fixed_charges/emit_fixed_charge_event_service.rb
+++ b/app/services/fixed_charges/emit_fixed_charge_event_service.rb
@@ -15,7 +15,6 @@ module FixedCharges
       create_event_result = FixedChargeEvents::CreateService.call(
         subscription:,
         fixed_charge:,
-        units:,
         timestamp:
       )
 
@@ -28,9 +27,5 @@ module FixedCharges
     private
 
     attr_reader :subscription, :fixed_charge, :timestamp
-
-    def units
-      subscription.subscription_fixed_charge_units_overrides.find_by(fixed_charge:)&.units || fixed_charge.units
-    end
   end
 end

--- a/app/services/fixed_charges/emit_fixed_charge_event_service.rb
+++ b/app/services/fixed_charges/emit_fixed_charge_event_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module FixedCharges
+  class EmitFixedChargeEventService < BaseService
+    Result = BaseResult[:fixed_charge_event]
+
+    def initialize(subscription:, fixed_charge:, timestamp: Time.current)
+      @subscription = subscription
+      @fixed_charge = fixed_charge
+      @timestamp = timestamp
+      super
+    end
+
+    def call
+      create_event_result = FixedChargeEvents::CreateService.call(
+        subscription:,
+        fixed_charge:,
+        units:,
+        timestamp:
+      )
+
+      return create_event_result if create_event_result.failure?
+
+      result.fixed_charge_event = create_event_result.fixed_charge_event
+      result
+    end
+
+    private
+
+    attr_reader :subscription, :fixed_charge, :timestamp
+
+    def units
+      subscription.subscription_fixed_charge_units_overrides.find_by(fixed_charge:)&.units || fixed_charge.units
+    end
+  end
+end

--- a/app/services/fixed_charges/override_service.rb
+++ b/app/services/fixed_charges/override_service.rb
@@ -4,9 +4,10 @@ module FixedCharges
   class OverrideService < BaseService
     Result = BaseResult[:fixed_charge]
 
-    def initialize(fixed_charge:, params:)
+    def initialize(fixed_charge:, params:, subscription: nil)
       @fixed_charge = fixed_charge
       @params = params
+      @subscription = subscription
 
       super
     end
@@ -32,7 +33,7 @@ module FixedCharges
         new_fixed_charge.save!
 
         if params[:apply_units_immediately] && new_fixed_charge.units != fixed_charge.units
-          FixedCharges::EmitEventsForActiveSubscriptionsService.call!(fixed_charge: new_fixed_charge)
+          FixedCharges::EmitEventsForActiveSubscriptionsService.call!(fixed_charge: new_fixed_charge, subscription:)
         end
 
         if params.key?(:tax_codes)
@@ -52,6 +53,6 @@ module FixedCharges
 
     private
 
-    attr_reader :fixed_charge, :params
+    attr_reader :fixed_charge, :params, :subscription
   end
 end

--- a/app/services/fixed_charges/override_service.rb
+++ b/app/services/fixed_charges/override_service.rb
@@ -32,7 +32,7 @@ module FixedCharges
         new_fixed_charge.save!
 
         if params[:apply_units_immediately] && new_fixed_charge.units != fixed_charge.units
-          emit_events_for_active_subscriptions(new_fixed_charge)
+          FixedCharges::EmitEventsForActiveSubscriptionsService.call!(fixed_charge: new_fixed_charge)
         end
 
         if params.key?(:tax_codes)
@@ -53,14 +53,5 @@ module FixedCharges
     private
 
     attr_reader :fixed_charge, :params
-
-    def emit_events_for_active_subscriptions(new_fixed_charge)
-      new_fixed_charge.plan.subscriptions.active.find_each do |subscription|
-        FixedCharges::EmitFixedChargeEventService.call!(
-          subscription:,
-          fixed_charge: new_fixed_charge
-        )
-      end
-    end
   end
 end

--- a/app/services/fixed_charges/update_service.rb
+++ b/app/services/fixed_charges/update_service.rb
@@ -33,7 +33,7 @@ module FixedCharges
         result.fixed_charge = fixed_charge
 
         if params[:apply_units_immediately] && fixed_charge.units_previously_changed?
-          emit_events_for_active_subscriptions(fixed_charge)
+          FixedCharges::EmitEventsForActiveSubscriptionsService.call!(fixed_charge:)
         end
 
         unless cascade || plan.attached_to_subscriptions?
@@ -56,14 +56,5 @@ module FixedCharges
     attr_reader :fixed_charge, :params, :cascade_options, :cascade
 
     delegate :plan, to: :fixed_charge
-
-    def emit_events_for_active_subscriptions(fixed_charge)
-      plan.subscriptions.active.find_each do |subscription|
-        FixedCharges::EmitFixedChargeEventService.call!(
-          subscription:,
-          fixed_charge:
-        )
-      end
-    end
   end
 end

--- a/app/services/plans/override_service.rb
+++ b/app/services/plans/override_service.rb
@@ -2,9 +2,10 @@
 
 module Plans
   class OverrideService < BaseService
-    def initialize(plan:, params:)
+    def initialize(plan:, params:, subscription: nil)
       @plan = plan
       @params = params
+      @subscription = subscription
 
       super
     end
@@ -40,7 +41,7 @@ module Plans
           fixed_charge_params = (
             params[:fixed_charges]&.find { |p| p[:id] == fixed_charge.id } || {}
           ).merge(plan_id: new_plan.id)
-          FixedCharges::OverrideService.call(fixed_charge:, params: fixed_charge_params)
+          FixedCharges::OverrideService.call(fixed_charge:, params: fixed_charge_params, subscription:)
         end
 
         if params[:usage_thresholds].present? &&
@@ -74,7 +75,7 @@ module Plans
 
     private
 
-    attr_reader :plan, :params
+    attr_reader :plan, :params, :subscription
 
     def track_plan_created(plan)
       count_by_charge_model = plan.charges.group(:charge_model).count

--- a/app/services/subscriptions/emit_fixed_charge_events_service.rb
+++ b/app/services/subscriptions/emit_fixed_charge_events_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class EmitFixedChargeEventsService < BaseService
+    def initialize(subscriptions:, timestamp: Time.current)
+      @subscriptions = subscriptions
+      @timestamp = timestamp
+      super
+    end
+
+    def call
+      subscriptions.each do |subscription|
+        subscription.fixed_charges.find_each do |fixed_charge|
+          FixedCharges::EmitFixedChargeEventService.call(
+            subscription:,
+            fixed_charge:,
+            timestamp:
+          )
+        end
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :subscriptions, :timestamp
+  end
+end

--- a/app/services/subscriptions/organization_emit_fixed_charge_events_service.rb
+++ b/app/services/subscriptions/organization_emit_fixed_charge_events_service.rb
@@ -1,0 +1,314 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class OrganizationEmitFixedChargeEventsService < BaseService
+    def initialize(organization:, timestamp: Time.current)
+      @organization = organization
+      @timestamp = timestamp
+      super
+    end
+
+    def call
+      eligible_subscriptions_by_customer.each do |_customer_id, customer_subscriptions|
+        emitting_subscriptions = []
+        customer_subscriptions.each do |subscription|
+          next if subscription.next_subscription&.pending?
+
+          emitting_subscriptions << subscription
+        end
+
+        Subscriptions::EmitFixedChargeEventsJob.perform_later(
+          subscriptions: emitting_subscriptions,
+          timestamp: timestamp.to_i
+        )
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :organization, :timestamp
+
+    def eligible_subscriptions_by_customer
+      eligible_subscriptions.group_by(&:customer_id)
+    end
+
+    # NOTE: Retrieve list of subscriptions that should have fixed charges
+    #       events emitted on timestamp.
+    def eligible_subscriptions
+      sql = <<-SQL
+        WITH
+          emittable_subscriptions AS (
+            -- Calendar subscriptions
+            (#{weekly_calendar})
+            UNION
+            (#{monthly_calendar})
+            UNION
+            (#{quarterly_calendar})
+            UNION
+            (#{yearly_with_monthly_fixed_charges_calendar})
+            UNION
+            (#{yearly_calendar})
+
+            UNION
+            -- Anniversary subscriptions
+            (#{weekly_anniversary})
+            UNION
+            (#{monthly_anniversary})
+            UNION
+            (#{quarterly_anniversary})
+            UNION
+            (#{yearly_with_monthly_fixed_charges_anniversary})
+            UNION
+            (#{yearly_anniversary})
+          ),
+          -- Filter subscriptions that already have fixed charge events emitted on timestamp
+          already_emitted_on_timestamp AS (#{already_emitted_on_timestamp})
+
+        SELECT DISTINCT(subscriptions.*)
+        FROM subscriptions
+          INNER JOIN emittable_subscriptions ON emittable_subscriptions.subscription_id = subscriptions.id
+          INNER JOIN customers ON customers.id = subscriptions.customer_id
+          INNER JOIN billing_entities ON billing_entities.id = customers.billing_entity_id
+          LEFT JOIN already_emitted_on_timestamp ON already_emitted_on_timestamp.subscription_id = subscriptions.id
+        WHERE
+          billing_entities.organization_id = '#{organization.id}'
+
+        GROUP BY subscriptions.id
+      SQL
+
+      Subscription.find_by_sql([sql, {timestamp:}])
+    end
+
+    def at_time_zone(customer: "customers", billing_entity: "billing_entities")
+      <<-SQL
+        AT TIME ZONE COALESCE(#{customer}.timezone, #{billing_entity}.timezone, 'UTC')
+      SQL
+    end
+
+    def base_subscription_scope(billing_time: nil, interval: nil, conditions: nil)
+      <<-SQL
+        SELECT subscriptions.id AS subscription_id
+        FROM subscriptions
+          INNER JOIN plans ON plans.id = subscriptions.plan_id
+          INNER JOIN customers ON customers.id = subscriptions.customer_id
+          INNER JOIN billing_entities ON billing_entities.id = customers.billing_entity_id
+        WHERE subscriptions.status = #{Subscription.statuses[:active]}
+          AND subscriptions.billing_time = #{Subscription.billing_times[billing_time]}
+          AND plans.interval = #{Plan.intervals[interval]}
+          AND billing_entities.organization_id = '#{organization.id}'
+          AND #{conditions.join(" AND ")}
+        GROUP BY subscriptions.id
+      SQL
+    end
+
+    # NOTE: For weekly interval we send invoices on Monday (ISODOW = 1)
+    def weekly_calendar
+      base_subscription_scope(
+        billing_time: :calendar,
+        interval: :weekly,
+        conditions: ["EXTRACT(ISODOW FROM (:timestamp#{at_time_zone})) = 1"]
+      )
+    end
+
+    # NOTE: Billed monthly on 1st day of the month
+    def monthly_calendar
+      base_subscription_scope(
+        billing_time: :calendar,
+        interval: :monthly,
+        conditions: ["DATE_PART('day', (:timestamp#{at_time_zone})) = 1"]
+      )
+    end
+
+    # NOTE: Billed quarterly on 1st day of the January, April, July and October
+    def quarterly_calendar
+      billing_month = <<-SQL
+        (DATE_PART('month', (:timestamp#{at_time_zone})) IN (1, 4, 7, 10))
+      SQL
+
+      billing_day = <<-SQL
+        (DATE_PART('day', (:timestamp#{at_time_zone})) = 1)
+      SQL
+
+      base_subscription_scope(
+        billing_time: :calendar,
+        interval: :quarterly,
+        conditions: [billing_month, billing_day]
+      )
+    end
+
+    # NOTE: Bill fixed charges monthly for yearly plans on 1st day of the month
+    def yearly_with_monthly_fixed_charges_calendar
+      base_subscription_scope(
+        billing_time: :calendar,
+        interval: :yearly,
+        conditions: [
+          "DATE_PART('day', (:timestamp#{at_time_zone})) = 1",
+          "plans.bill_fixed_charges_monthly = 't'"
+        ]
+      )
+    end
+
+    # NOTE: Billed yearly on first day of the year
+    def yearly_calendar
+      base_subscription_scope(
+        billing_time: :calendar,
+        interval: :yearly,
+        conditions: [
+          "DATE_PART('month', (:timestamp#{at_time_zone})) = 1",
+          "DATE_PART('day', (:timestamp#{at_time_zone})) = 1"
+        ]
+      )
+    end
+
+    def weekly_anniversary
+      base_subscription_scope(
+        billing_time: :anniversary,
+        interval: :weekly,
+        conditions: [
+          "EXTRACT(ISODOW FROM (subscriptions.subscription_at#{at_time_zone})) =
+          EXTRACT(ISODOW FROM (:timestamp#{at_time_zone}))"
+        ]
+      )
+    end
+
+    def monthly_anniversary
+      base_subscription_scope(
+        billing_time: :anniversary,
+        interval: :monthly,
+        conditions: [<<-SQL]
+          DATE_PART('day', (subscriptions.subscription_at#{at_time_zone})) = ANY (
+            -- Check if timestamp is the last day of the month
+            CASE WHEN DATE_PART('day', (#{end_of_month})) = DATE_PART('day', :timestamp#{at_time_zone})
+            THEN
+              -- If so and if it counts less than 31 days, we need to take all days up to 31 into account
+              (SELECT ARRAY(SELECT generate_series(DATE_PART('day', :timestamp#{at_time_zone})::integer, 31)))
+            ELSE
+              -- Otherwise, we just need the current day
+              (SELECT ARRAY[DATE_PART('day', :timestamp#{at_time_zone})])
+            END
+          )
+        SQL
+      )
+    end
+
+    # NOTE: Billed quarterly on anniversary date
+    def quarterly_anniversary
+      billing_day = <<-SQL
+        DATE_PART('day', (subscriptions.subscription_at#{at_time_zone})) = ANY (
+          -- Check if timestamp is the last day of the month
+          CASE WHEN DATE_PART('day', (#{end_of_month})) = DATE_PART('day', :timestamp#{at_time_zone})
+          THEN
+            -- If so and if it counts less than 31 days, we need to take all days up to 31 into account
+            (SELECT ARRAY(SELECT generate_series(DATE_PART('day', :timestamp#{at_time_zone})::integer, 31)))
+          ELSE
+            -- Otherwise, we just need the current day
+            (SELECT ARRAY[DATE_PART('day', :timestamp#{at_time_zone})])
+          END
+        )
+      SQL
+
+      billing_month = <<-SQL
+        (
+          -- We need to avoid zero and instead of it use 12. E.g.: (3 + 9) % 12 = 0 -> 12
+          CASE WHEN MOD(CAST(DATE_PART('month', (subscriptions.subscription_at#{at_time_zone})) AS INTEGER), 3) = 0
+          THEN
+            (DATE_PART('month', :timestamp#{at_time_zone}) IN (3, 6, 9, 12))
+          ELSE (
+            DATE_PART('month', (subscriptions.subscription_at#{at_time_zone})) = DATE_PART('month', :timestamp#{at_time_zone})
+              OR MOD(CAST(DATE_PART('month', (subscriptions.subscription_at#{at_time_zone})) + 3 AS INTEGER), 12) = DATE_PART('month', :timestamp#{at_time_zone})
+              OR MOD(CAST(DATE_PART('month', (subscriptions.subscription_at#{at_time_zone})) + 6 AS INTEGER), 12) = DATE_PART('month', :timestamp#{at_time_zone})
+              OR MOD(CAST(DATE_PART('month', (subscriptions.subscription_at#{at_time_zone})) + 9 AS INTEGER), 12) = DATE_PART('month', :timestamp#{at_time_zone})
+          )
+          END
+        )
+      SQL
+
+      base_subscription_scope(
+        billing_time: :anniversary,
+        interval: :quarterly,
+        conditions: [billing_month, billing_day]
+      )
+    end
+
+    def yearly_anniversary
+      billing_month = <<-SQL
+        -- Ensure we are on the billing month
+        DATE_PART('month', (subscriptions.subscription_at#{at_time_zone})) = DATE_PART('month', :timestamp#{at_time_zone})
+      SQL
+
+      billing_day = <<-SQL
+        -- Check if we are not in a leap year when timestamp is february the 28th
+        DATE_PART('day', (subscriptions.subscription_at#{at_time_zone})) = ANY (
+          CASE WHEN (
+            DATE_PART('month', :timestamp#{at_time_zone}) = 2
+            AND DATE_PART('day', :timestamp#{at_time_zone}) = 28
+            AND DATE_PART('day', (#{end_of_month})) = 28
+          )
+          THEN
+            -- If not a leap year, we have to tale february the 29th into account
+            ARRAY[28, 29]
+          ELSE
+            -- Otherwise, we just need the current day
+            ARRAY[DATE_PART('day', :timestamp#{at_time_zone})]
+          END
+        )
+      SQL
+
+      base_subscription_scope(
+        billing_time: :anniversary,
+        interval: :yearly,
+        conditions: [billing_month, billing_day]
+      )
+    end
+
+    def yearly_with_monthly_fixed_charges_anniversary
+      billing_day = <<-SQL
+        DATE_PART('day', (subscriptions.subscription_at#{at_time_zone})) = ANY (
+          -- Check if timestamp is the last day of the month
+          CASE WHEN DATE_PART('day', (#{end_of_month})) = DATE_PART('day', :timestamp#{at_time_zone})
+          THEN
+            -- If so and if it counts less than 31 days, we need to take all days up to 31 into account
+            (SELECT ARRAY(SELECT generate_series(DATE_PART('day', :timestamp#{at_time_zone})::integer, 31)))
+          ELSE
+            -- Otherwise, we just need the current day
+            (SELECT ARRAY[DATE_PART('day', :timestamp#{at_time_zone})])
+          END
+        )
+      SQL
+
+      base_subscription_scope(
+        billing_time: :anniversary,
+        interval: :yearly,
+        conditions: [
+          "plans.bill_fixed_charges_monthly = 't'",
+          billing_day
+        ]
+      )
+    end
+
+    def end_of_month
+      <<-SQL
+        (DATE_TRUNC('month', :timestamp#{at_time_zone}) + INTERVAL '1 month - 1 day')::date
+      SQL
+    end
+
+    def already_emitted_on_timestamp
+      <<-SQL
+        SELECT DISTINCT
+          fixed_charge_events.subscription_id,
+          COUNT(fixed_charge_events.id) AS emitted_count
+        FROM fixed_charge_events
+          INNER JOIN subscriptions ON fixed_charge_events.subscription_id = subscriptions.id
+          INNER JOIN customers ON subscriptions.customer_id = customers.id
+          INNER JOIN billing_entities ON customers.billing_entity_id = billing_entities.id
+        WHERE fixed_charge_events.deleted_at IS NULL
+          AND fixed_charge_events.organization_id = '#{organization.id}'
+          AND fixed_charge_events.timestamp IS NOT NULL
+          AND DATE(fixed_charge_events.timestamp#{at_time_zone}) = DATE(:timestamp#{at_time_zone})
+        GROUP BY fixed_charge_events.subscription_id
+      SQL
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -174,6 +174,12 @@ module Clockwork
       .perform_later
   end
 
+  every(1.day, "schedule:emit_fixed_charge_events", at: "01:10") do
+    Clock::EmitFixedChargeEventsJob
+      .set(sentry: {"slug" => "lago_emit_fixed_charge_events", "cron" => "10 1 * * *"})
+      .perform_later
+  end
+
   # NOTE: Enable wallets and lifetime usage refresh from the events-processor
   if ENV["LAGO_REDIS_STORE_URL"].present?
     every(1.minute, "schedule:refresh_flagged_subscriptions") do

--- a/schema.graphql
+++ b/schema.graphql
@@ -5338,12 +5338,13 @@ input FixedChargeInput {
 }
 
 input FixedChargeOverridesInput {
-  addOnId: ID!
+  addOnId: ID
+  applyUnitsImmediately: Boolean
   id: ID
   invoiceDisplayName: String
   properties: FixedChargePropertiesInput
   taxCodes: [String!]
-  units: String!
+  units: String
 }
 
 type FixedChargeProperties {

--- a/schema.graphql
+++ b/schema.graphql
@@ -5328,6 +5328,7 @@ input FixedChargeInput {
   addOnId: ID!
   applyUnitsImmediately: Boolean
   chargeModel: FixedChargeChargeModelEnum!
+  id: ID
   invoiceDisplayName: String
   payInAdvance: Boolean
   properties: FixedChargePropertiesInput

--- a/schema.json
+++ b/schema.json
@@ -25724,6 +25724,18 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "addOnId",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -25874,13 +25874,9 @@
               "name": "addOnId",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -25892,6 +25888,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "applyUnitsImmediately",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,
@@ -25946,13 +25954,9 @@
               "name": "units",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/clockwork_spec.rb
+++ b/spec/clockwork_spec.rb
@@ -312,4 +312,25 @@ describe Clockwork do
       expect(Clock::ConsumeSubscriptionRefreshedQueueJob).to have_been_enqueued
     end
   end
+
+  describe "schedule:emit_fixed_charge_events" do
+    let(:job) { "schedule:emit_fixed_charge_events" }
+    let(:start_time) { Time.zone.parse("2025-08-27T01:10:00") }
+    let(:end_time) { Time.zone.parse("2025-08-28T01:09:00") }
+
+    it "enqueue a emit fixed charge events job" do
+      Clockwork::Test.run(
+        file: clock_file,
+        start_time:,
+        end_time:,
+        tick_speed: 1.minute
+      )
+
+      expect(Clockwork::Test).to be_ran_job(job)
+      expect(Clockwork::Test.times_run(job)).to eq(1)
+
+      Clockwork::Test.block_for(job).call
+      expect(Clock::EmitFixedChargeEventsJob).to have_been_enqueued
+    end
+  end
 end

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -433,9 +433,23 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
   end
 
   context "when fixed charges are provided" do
-    let(:add_on_1) { create(:add_on, organization:) }
-    let(:add_on_2) { create(:add_on, organization:) }
-    let(:add_on_3) { create(:add_on, organization:) }
+    let(:add_ons) { create_list(:add_on, 5, organization:) }
+    let(:add_on_1) { add_ons[0] }
+    let(:add_on_2) { add_ons[1] }
+    let(:add_on_3) { add_ons[2] }
+    let(:add_on_4) { add_ons[3] }
+    let(:add_on_5) { add_ons[4] }
+
+    let(:fixed_charge_1) { create(:fixed_charge, plan:, add_on: add_on_1, units: 10) }
+    let(:fixed_charge_2) { create(:fixed_charge, plan:, add_on: add_on_2, units: 5) }
+
+    let(:active_subscription) { create(:subscription, plan:) }
+
+    before do
+      fixed_charge_1
+      fixed_charge_2
+      active_subscription
+    end
 
     it "updates the plan with the provided fixed charges" do
       result = execute_graphql(
@@ -455,15 +469,34 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
             charges: [],
             fixedCharges: [
               {
+                id: fixed_charge_1.id,
                 addOnId: add_on_1.id,
+                # does not change units
                 units: "10",
+                chargeModel: "standard",
+                properties: {amount: "10.00"},
+                applyUnitsImmediately: true
+              },
+              {
+                id: fixed_charge_2.id,
+                addOnId: add_on_2.id,
+                # changes units
+                units: "20",
                 chargeModel: "standard",
                 properties: {amount: "100.00"},
                 applyUnitsImmediately: true
               },
               {
-                addOnId: add_on_2.id,
-                units: "5",
+                # newly added fixed charge
+                addOnId: add_on_3.id,
+                units: "30",
+                chargeModel: "standard",
+                properties: {amount: "1000.00"},
+                applyUnitsImmediately: true
+              },
+              {
+                addOnId: add_on_4.id,
+                units: "40",
                 chargeModel: "graduated",
                 properties: {
                   graduatedRanges: [
@@ -473,8 +506,8 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
                 }
               },
               {
-                addOnId: add_on_3.id,
-                units: "1",
+                addOnId: add_on_5.id,
+                units: "50",
                 chargeModel: "volume",
                 properties: {
                   volumeRanges: [
@@ -489,25 +522,39 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
 
       result_data = result["data"]["updatePlan"]
 
-      expect(result_data["fixedCharges"].count).to eq(3)
+      expect(result_data["fixedCharges"].count).to eq(5)
 
-      expect(result_data["fixedCharges"].first["chargeModel"]).to eq("standard")
+      expect(result_data["fixedCharges"].first["id"]).to eq(fixed_charge_1.id)
       expect(result_data["fixedCharges"].first["units"]).to eq("10.0")
-      expect(result_data["fixedCharges"].first["properties"]["amount"]).to eq("100.00")
-      expect(result_data["fixedCharges"].first["addOn"]["id"]).to eq(add_on_1.id)
-      expect(result_data["fixedCharges"].first["addOn"]["name"]).to eq(add_on_1.name)
+      expect(result_data["fixedCharges"].first["properties"]["amount"]).to eq("10.00")
+      expect(result_data["fixedCharges"].first["addOn"]["id"]).to eq(fixed_charge_1.add_on_id)
 
-      expect(result_data["fixedCharges"].second["chargeModel"]).to eq("graduated")
-      expect(result_data["fixedCharges"].second["units"]).to eq("5.0")
-      expect(result_data["fixedCharges"].second["properties"]["graduatedRanges"].count).to eq(2)
-      expect(result_data["fixedCharges"].second["addOn"]["id"]).to eq(add_on_2.id)
-      expect(result_data["fixedCharges"].second["addOn"]["name"]).to eq(add_on_2.name)
+      expect(result_data["fixedCharges"].second["id"]).to eq(fixed_charge_2.id)
+      expect(result_data["fixedCharges"].second["units"]).to eq("20.0")
+      expect(result_data["fixedCharges"].second["properties"]["amount"]).to eq("100.00")
+      expect(result_data["fixedCharges"].second["addOn"]["id"]).to eq(fixed_charge_2.add_on_id)
 
-      expect(result_data["fixedCharges"].third["chargeModel"]).to eq("volume")
-      expect(result_data["fixedCharges"].third["units"]).to eq("1.0")
-      expect(result_data["fixedCharges"].third["properties"]["volumeRanges"].count).to eq(1)
+      expect(result_data["fixedCharges"].third["chargeModel"]).to eq("standard")
+      expect(result_data["fixedCharges"].third["units"]).to eq("30.0")
+      expect(result_data["fixedCharges"].third["properties"]["amount"]).to eq("1000.00")
       expect(result_data["fixedCharges"].third["addOn"]["id"]).to eq(add_on_3.id)
       expect(result_data["fixedCharges"].third["addOn"]["name"]).to eq(add_on_3.name)
+
+      expect(result_data["fixedCharges"].fourth["chargeModel"]).to eq("graduated")
+      expect(result_data["fixedCharges"].fourth["units"]).to eq("40.0")
+      expect(result_data["fixedCharges"].fourth["properties"]["graduatedRanges"].count).to eq(2)
+      expect(result_data["fixedCharges"].fourth["addOn"]["id"]).to eq(add_on_4.id)
+      expect(result_data["fixedCharges"].fourth["addOn"]["name"]).to eq(add_on_4.name)
+
+      expect(result_data["fixedCharges"].fifth["chargeModel"]).to eq("volume")
+      expect(result_data["fixedCharges"].fifth["units"]).to eq("50.0")
+      expect(result_data["fixedCharges"].fifth["properties"]["volumeRanges"].count).to eq(1)
+      expect(result_data["fixedCharges"].fifth["addOn"]["id"]).to eq(add_on_5.id)
+      expect(result_data["fixedCharges"].fifth["addOn"]["name"]).to eq(add_on_5.name)
+
+      expect(FixedChargeEvent.count).to eq(2)
+      expect(FixedChargeEvent.order(created_at: :asc).first).to have_attributes(units: BigDecimal("20"))
+      expect(FixedChargeEvent.order(created_at: :asc).second).to have_attributes(units: BigDecimal("30"))
     end
   end
 

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
   let(:organization) { membership.organization }
   let(:plan) { create(:plan, organization:) }
   let(:charge) { create(:standard_charge, plan:) }
+  let(:fixed_charge) { create(:fixed_charge, plan:) }
   let(:threshold) { create(:usage_threshold, plan:) }
   let(:ending_at) { Time.current.beginning_of_day + 1.year }
   let(:customer) { create(:customer, organization:) }
@@ -40,6 +41,10 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
             usageThresholds {
               amountCents
               thresholdDisplayName
+            }
+            fixedCharges {
+              invoiceDisplayName
+              units
             }
           }
         }
@@ -76,6 +81,13 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
               billableMetricId: charge.billable_metric_id,
               invoiceDisplayName: "invoice display name"
             ],
+            fixedCharges: [
+              {
+                id: fixed_charge.id,
+                invoiceDisplayName: "NEW fixed charge display name",
+                units: "99"
+              }
+            ],
             usageThresholds: [
               amountCents: 100,
               thresholdDisplayName: "threshold display name"
@@ -106,6 +118,10 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
     expect(result_data["plan"]["usageThresholds"].first).to include(
       "thresholdDisplayName" => "threshold display name",
       "amountCents" => "100"
+    )
+    expect(result_data["plan"]["fixedCharges"].first).to include(
+      "invoiceDisplayName" => "NEW fixed charge display name",
+      "units" => "99.0"
     )
   end
 end

--- a/spec/graphql/mutations/subscriptions/update_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_spec.rb
@@ -8,11 +8,14 @@ RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
   let(:required_permission) { "subscriptions:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
+  let(:plan) { create(:plan, organization:) }
+  let(:fixed_charge) { create(:fixed_charge, plan:) }
 
   let(:subscription) do
     create(
       :subscription,
       organization:,
+      plan:,
       subscription_at: Time.current + 3.days
     )
   end
@@ -24,6 +27,12 @@ RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
           id
           name
           subscriptionAt
+          plan {
+            fixedCharges {
+              invoiceDisplayName
+              units
+            }
+          }
         }
       }
     GQL
@@ -31,11 +40,27 @@ RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
   let(:input) do
     {
       id: subscription.id,
-      name: "New name"
+      name: "New name",
+      planOverrides: {
+        fixedCharges: [
+          {
+            id: fixed_charge.id,
+            invoiceDisplayName: "NEW fixed charge display name",
+            units: "99",
+            applyUnitsImmediately: true
+          }
+        ]
+      }
     }
   end
 
   around { |test| lago_premium!(&test) }
+
+  before do
+    plan
+    fixed_charge
+    subscription
+  end
 
   it_behaves_like "requires current user"
   it_behaves_like "requires permission", "subscriptions:update"
@@ -46,5 +71,20 @@ RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
     result_data = result["data"]["updateSubscription"]
 
     expect(result_data["name"]).to eq("New name")
+
+    expect(result_data["plan"]["fixedCharges"].first).to include(
+      "invoiceDisplayName" => "NEW fixed charge display name",
+      "units" => "99.0"
+    )
+  end
+
+  context "when subscription is active" do
+    let(:subscription) { create(:subscription, plan:, organization:) }
+
+    it "emits a fixed charge event" do
+      expect { subject }.to change(FixedChargeEvent, :count).by(1)
+
+      expect(FixedChargeEvent.first).to have_attributes(units: BigDecimal("99"))
+    end
   end
 end

--- a/spec/graphql/types/fixed_charges/input_spec.rb
+++ b/spec/graphql/types/fixed_charges/input_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe Types::FixedCharges::Input do
   subject { described_class }
 
+  it { is_expected.to accept_argument(:id).of_type("ID") }
   it { is_expected.to accept_argument(:add_on_id).of_type("ID!") }
   it { is_expected.to accept_argument(:apply_units_immediately).of_type("Boolean") }
   it { is_expected.to accept_argument(:charge_model).of_type("FixedChargeChargeModelEnum!") }

--- a/spec/graphql/types/subscriptions/fixed_charge_overrides_input_spec.rb
+++ b/spec/graphql/types/subscriptions/fixed_charge_overrides_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Types::Subscriptions::FixedChargeOverridesInput do
   subject { described_class }
 
   it { is_expected.to accept_argument(:id).of_type("ID") }
-  it { is_expected.to accept_argument(:add_on_id).of_type("ID!") }
+  it { is_expected.to accept_argument(:add_on_id).of_type("ID") }
   it { is_expected.to accept_argument(:apply_units_immediately).of_type("Boolean") }
   it { is_expected.to accept_argument(:invoice_display_name).of_type("String") }
   it { is_expected.to accept_argument(:properties).of_type("FixedChargePropertiesInput") }

--- a/spec/graphql/types/subscriptions/fixed_charge_overrides_input_spec.rb
+++ b/spec/graphql/types/subscriptions/fixed_charge_overrides_input_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Subscriptions::FixedChargeOverridesInput do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:id).of_type("ID") }
+  it { is_expected.to accept_argument(:add_on_id).of_type("ID!") }
+  it { is_expected.to accept_argument(:apply_units_immediately).of_type("Boolean") }
+  it { is_expected.to accept_argument(:invoice_display_name).of_type("String") }
+  it { is_expected.to accept_argument(:properties).of_type("FixedChargePropertiesInput") }
+  it { is_expected.to accept_argument(:tax_codes).of_type("[String!]") }
+  it { is_expected.to accept_argument(:units).of_type("String") }
+end

--- a/spec/jobs/clock/emit_fixed_charge_events_job_spec.rb
+++ b/spec/jobs/clock/emit_fixed_charge_events_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Clock::EmitFixedChargeEventsJob, job: true do
+  subject(:job) { described_class }
+
+  describe ".perform" do
+    let(:organization_1) { create(:organization) }
+    let(:organization_2) { create(:organization) }
+
+    before do
+      organization_1
+      organization_2
+    end
+
+    it "enqueues Subscriptions::OrganizationEmitFixedChargeEventsJob for each organization" do
+      freeze_time do
+        described_class.perform_now
+
+        expect(Subscriptions::OrganizationEmitFixedChargeEventsJob)
+          .to have_been_enqueued
+          .with(organization: organization_1, timestamp: Time.current.to_i)
+          .once
+
+        expect(Subscriptions::OrganizationEmitFixedChargeEventsJob)
+          .to have_been_enqueued
+          .with(organization: organization_2, timestamp: Time.current.to_i)
+          .once
+      end
+    end
+  end
+end

--- a/spec/jobs/subscriptions/emit_fixed_charge_events_job_spec.rb
+++ b/spec/jobs/subscriptions/emit_fixed_charge_events_job_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::EmitFixedChargeEventsJob, type: :job do
+  let(:subscriptions) { [create(:subscription)] }
+  let(:timestamp) { Time.current.to_i }
+  let(:emit_fixed_charge_events_service) do
+    Subscriptions::EmitFixedChargeEventsService
+  end
+
+  before do
+    allow(emit_fixed_charge_events_service).to receive(:call!)
+  end
+
+  it "calls Subscriptions::EmitFixedChargeEventsService" do
+    described_class.perform_now(subscriptions:, timestamp:)
+
+    expect(emit_fixed_charge_events_service)
+      .to have_received(:call!)
+      .with(
+        subscriptions:,
+        timestamp: Time.zone.at(timestamp)
+      )
+      .once
+  end
+
+  it "uses current timestamp when not provided" do
+    freeze_time do
+      described_class.perform_now(subscriptions:)
+
+      expect(emit_fixed_charge_events_service)
+        .to have_received(:call!)
+        .with(
+          subscriptions:,
+          timestamp: Time.current
+        )
+        .once
+    end
+  end
+end

--- a/spec/jobs/subscriptions/organization_emit_fixed_charge_events_job_spec.rb
+++ b/spec/jobs/subscriptions/organization_emit_fixed_charge_events_job_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::OrganizationEmitFixedChargeEventsJob, type: :job do
+  let(:service) { Subscriptions::OrganizationEmitFixedChargeEventsService }
+  let(:organization) { create(:organization) }
+  let(:timestamp) { Time.current.to_i }
+
+  describe ".perform" do
+    before do
+      allow(service).to receive(:call!)
+    end
+
+    it "calls Subscriptions::OrganizationEmitFixedChargeEventsService" do
+      described_class.perform_now(organization:, timestamp:)
+
+      expect(service)
+        .to have_received(:call!)
+        .with(organization:, timestamp: Time.zone.at(timestamp))
+        .once
+    end
+
+    it "uses current timestamp when not provided" do
+      freeze_time do
+        described_class.perform_now(organization:)
+
+        expect(service)
+          .to have_received(:call!)
+          .with(organization:, timestamp: Time.current)
+          .once
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -684,6 +684,74 @@ RSpec.describe Api::V1::PlansController, type: :request do
       end
     end
 
+    context "when adding a fixed charge with apply_units_immediately" do
+      let(:subscription) { create(:subscription, plan:) }
+
+      let(:fixed_charges_params) do
+        [
+          {
+            apply_units_immediately: true,
+            invoice_display_name: "Fixed charge 2",
+            units: 100,
+            add_on_id: add_on.id,
+            charge_model: "standard",
+            properties: {amount: "10"}
+          }
+        ]
+      end
+
+      before { subscription }
+
+      it "adds a fixed charge and creates fixed charge events for all active subscriptions" do
+        expect { subject }.to change(FixedChargeEvent, :count).by(1)
+
+        fixed_charge = FixedCharge.find(json[:plan][:fixed_charges].first[:lago_id])
+
+        expect(fixed_charge.events.first).to have_attributes(
+          subscription:,
+          fixed_charge:,
+          units: 100
+        )
+
+        expect(response).to have_http_status(:success)
+        expect(json[:plan][:fixed_charges].count).to eq(1)
+        expect(json[:plan][:fixed_charges].first[:invoice_display_name]).to eq("Fixed charge 2")
+        expect(json[:plan][:fixed_charges].first[:units]).to eq("100.0")
+      end
+    end
+
+    context "when editing a fixed charge with apply_units_immediately" do
+      let(:subscription) { create(:subscription, plan:) }
+      let(:fixed_charge) { create(:fixed_charge, plan:, add_on:, units: 1) }
+
+      let(:fixed_charges_params) do
+        [
+          {
+            id: fixed_charge.id,
+            apply_units_immediately: true,
+            units: 25,
+            properties: {amount: "10"}
+          }
+        ]
+      end
+
+      before { subscription }
+
+      it "updates a fixed charge and creates fixed charge events for all active subscriptions" do
+        expect { subject }.to change(FixedChargeEvent, :count).by(1)
+
+        expect(fixed_charge.events.first).to have_attributes(
+          subscription:,
+          fixed_charge:,
+          units: 25
+        )
+
+        expect(response).to have_http_status(:success)
+        expect(json[:plan][:fixed_charges].count).to eq(1)
+        expect(json[:plan][:fixed_charges].first[:units]).to eq("25.0")
+      end
+    end
+
     describe "update conversion rate on charges" do
       let(:charge) { create(:standard_charge, plan:, billable_metric:) }
       let!(:applied_pricing_unit) { create(:applied_pricing_unit, pricing_unitable: charge) }

--- a/spec/services/fixed_charge_events/create_service_spec.rb
+++ b/spec/services/fixed_charge_events/create_service_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe FixedChargeEvents::CreateService, type: :service do
     described_class.new(
       subscription:,
       fixed_charge:,
-      units:,
       timestamp:
     )
   end
@@ -19,7 +18,6 @@ RSpec.describe FixedChargeEvents::CreateService, type: :service do
   let(:add_on) { create(:add_on, organization:) }
   let(:fixed_charge) { create(:fixed_charge, organization:, plan:, add_on:) }
   let(:timestamp) { Time.current }
-  let(:units) { 5.0 }
 
   describe "#call" do
     subject(:result) { create_service.call }
@@ -37,29 +35,9 @@ RSpec.describe FixedChargeEvents::CreateService, type: :service do
           organization:,
           subscription:,
           fixed_charge:,
-          units: BigDecimal("5.0"),
+          units: fixed_charge.units,
           timestamp:
         )
-      end
-    end
-
-    context "when units is nil" do
-      let(:units) { nil }
-
-      it "returns a validation error" do
-        expect(result).to be_a_failure
-        expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages[:units]).to include("is not a number")
-      end
-    end
-
-    context "when units is negative" do
-      let(:units) { -1.0 }
-
-      it "returns a validation error" do
-        expect(result).to be_a_failure
-        expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages[:units]).to include("value_is_out_of_range")
       end
     end
 

--- a/spec/services/fixed_charges/create_service_spec.rb
+++ b/spec/services/fixed_charges/create_service_spec.rb
@@ -306,6 +306,88 @@ RSpec.describe FixedCharges::CreateService, type: :service do
             expect(result.fixed_charge.properties["invalid_property"]).to be_nil
           end
         end
+
+        context "when apply_units_immediately is true" do
+          let(:customer_1) { create(:customer, organization:) }
+          let(:customer_2) { create(:customer, organization:) }
+          let(:active_subscription_1) { create(:subscription, :active, plan:, customer: customer_1) }
+          let(:active_subscription_2) { create(:subscription, :active, plan:, customer: customer_2) }
+          let(:terminated_subscription) { create(:subscription, :terminated, plan:, customer: customer_1) }
+
+          let(:params) do
+            {
+              add_on_id: add_on.id,
+              charge_model: "standard",
+              apply_units_immediately: true
+            }
+          end
+
+          before do
+            active_subscription_1
+            active_subscription_2
+            terminated_subscription
+            allow(FixedCharges::EmitFixedChargeEventService).to receive(:call!)
+          end
+
+          it "creates new fixed charge" do
+            expect { subject }.to change(FixedCharge, :count).by(1)
+          end
+
+          it "emits fixed charge events for all active subscriptions" do
+            result
+
+            expect(FixedCharges::EmitFixedChargeEventService)
+              .to have_received(:call!)
+              .with(subscription: active_subscription_1, fixed_charge: result.fixed_charge)
+              .once
+
+            expect(FixedCharges::EmitFixedChargeEventService)
+              .to have_received(:call!)
+              .with(subscription: active_subscription_2, fixed_charge: result.fixed_charge)
+              .once
+          end
+
+          it "does not emit events for terminated subscriptions" do
+            result
+
+            expect(FixedCharges::EmitFixedChargeEventService)
+              .not_to have_received(:call!)
+              .with(subscription: terminated_subscription, fixed_charge: result.fixed_charge)
+          end
+
+          it "returns success result" do
+            expect(result).to be_success
+            expect(result.fixed_charge).to be_persisted
+          end
+        end
+
+        context "when apply_units_immediately is false" do
+          let(:customer) { create(:customer, organization:) }
+          let(:subscription) { create(:subscription, plan:, customer:) }
+
+          let(:params) do
+            {
+              add_on_id: add_on.id,
+              charge_model: "standard",
+              apply_units_immediately: false
+            }
+          end
+
+          before do
+            subscription
+            allow(FixedCharges::EmitFixedChargeEventService).to receive(:call!)
+          end
+
+          it "creates new fixed charge" do
+            expect { subject }.to change(FixedCharge, :count).by(1)
+          end
+
+          it "does not emit any fixed charge events" do
+            result
+
+            expect(FixedCharges::EmitFixedChargeEventService).not_to have_received(:call!)
+          end
+        end
       end
     end
   end

--- a/spec/services/fixed_charges/emit_events_for_active_subscriptions_service_spec.rb
+++ b/spec/services/fixed_charges/emit_events_for_active_subscriptions_service_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FixedCharges::EmitEventsForActiveSubscriptionsService, type: :service do
+  subject(:service) { described_class.new(fixed_charge:) }
+
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }
+
+  let(:customer_1) { create(:customer, organization:) }
+  let(:customer_2) { create(:customer, organization:) }
+  let(:active_subscription_1) { create(:subscription, :active, plan:, customer: customer_1) }
+  let(:active_subscription_2) { create(:subscription, :active, plan:, customer: customer_2) }
+  let(:terminated_subscription) { create(:subscription, :terminated, plan:, customer: customer_1) }
+
+  describe "#call" do
+    subject(:result) { service.call }
+
+    before do
+      active_subscription_1
+      active_subscription_2
+      terminated_subscription
+      allow(FixedCharges::EmitFixedChargeEventService).to receive(:call!)
+    end
+
+    it "returns success result" do
+      expect(result).to be_success
+    end
+
+    it "emits fixed charge events for all active subscriptions" do
+      result
+
+      expect(FixedCharges::EmitFixedChargeEventService)
+        .to have_received(:call!)
+        .with(subscription: active_subscription_1, fixed_charge:)
+        .once
+
+      expect(FixedCharges::EmitFixedChargeEventService)
+        .to have_received(:call!)
+        .with(subscription: active_subscription_2, fixed_charge:)
+        .once
+    end
+
+    it "does not emit events for terminated subscriptions" do
+      result
+
+      expect(FixedCharges::EmitFixedChargeEventService)
+        .not_to have_received(:call!)
+        .with(subscription: terminated_subscription, fixed_charge:)
+    end
+
+    context "when there are no active subscriptions" do
+      let(:active_subscription_1) { nil }
+      let(:active_subscription_2) { nil }
+
+      it "does not emit any events" do
+        result
+
+        expect(FixedCharges::EmitFixedChargeEventService).not_to have_received(:call!)
+      end
+
+      it "returns success result" do
+        expect(result).to be_success
+      end
+    end
+  end
+end

--- a/spec/services/fixed_charges/emit_fixed_charge_event_service_spec.rb
+++ b/spec/services/fixed_charges/emit_fixed_charge_event_service_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FixedCharges::EmitFixedChargeEventService, type: :service do
+  subject(:emit_service) do
+    described_class.new(
+      subscription:,
+      fixed_charge:,
+      timestamp:
+    )
+  end
+
+  let(:organization) { create(:organization) }
+  let(:billing_entity) { create(:billing_entity, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:fixed_charge) do
+    create(
+      :fixed_charge,
+      organization:,
+      plan:,
+      add_on:,
+      units: 10.0,
+      pay_in_advance: false
+    )
+  end
+  let(:timestamp) { Time.current }
+  let(:customer) { create(:customer, organization:, billing_entity:) }
+  let(:subscription) { create(:subscription, customer:, plan:, organization:, billing_entity:) }
+
+  describe "#call" do
+    subject(:result) { emit_service.call }
+
+    it "returns a successful result with the created fixed charge event" do
+      freeze_time do
+        expect(result).to be_success
+        expect(result.fixed_charge_event).to be_a(FixedChargeEvent)
+        expect(result.fixed_charge_event).to have_attributes(
+          organization:,
+          subscription:,
+          fixed_charge:,
+          units: BigDecimal("10.0"),
+          timestamp:
+        )
+      end
+    end
+
+    context "when subscription has units override" do
+      let(:subscription_override) do
+        create(
+          :subscription_fixed_charge_units_override,
+          subscription:,
+          fixed_charge:,
+          units: 20.0,
+          organization:,
+          billing_entity:
+        )
+      end
+
+      before do
+        subscription_override
+      end
+
+      it "uses the subscription override units" do
+        expect(result).to be_success
+        expect(result.fixed_charge_event.units).to eq(BigDecimal("20.0"))
+      end
+    end
+
+    context "when fixed charge event creation fails" do
+      let(:service_failure) do
+        BaseResult.new.record_validation_failure!(record: fixed_charge)
+      end
+
+      before do
+        allow(FixedChargeEvents::CreateService).to receive(:call).and_return(service_failure)
+      end
+
+      it "returns the failed result from the create service" do
+        expect(result).to be_failure
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+      end
+    end
+  end
+end

--- a/spec/services/fixed_charges/emit_fixed_charge_event_service_spec.rb
+++ b/spec/services/fixed_charges/emit_fixed_charge_event_service_spec.rb
@@ -46,28 +46,6 @@ RSpec.describe FixedCharges::EmitFixedChargeEventService, type: :service do
       end
     end
 
-    context "when subscription has units override" do
-      let(:subscription_override) do
-        create(
-          :subscription_fixed_charge_units_override,
-          subscription:,
-          fixed_charge:,
-          units: 20.0,
-          organization:,
-          billing_entity:
-        )
-      end
-
-      before do
-        subscription_override
-      end
-
-      it "uses the subscription override units" do
-        expect(result).to be_success
-        expect(result.fixed_charge_event.units).to eq(BigDecimal("20.0"))
-      end
-    end
-
     context "when fixed charge event creation fails" do
       let(:service_failure) do
         BaseResult.new.record_validation_failure!(record: fixed_charge)

--- a/spec/services/fixed_charges/override_service_spec.rb
+++ b/spec/services/fixed_charges/override_service_spec.rb
@@ -337,6 +337,43 @@ RSpec.describe FixedCharges::OverrideService, type: :service do
           expect(FixedCharges::EmitFixedChargeEventService).not_to have_received(:call!)
         end
       end
+
+      context "when subscription parameter is passed during plan override" do
+        # Subscription update with plan override
+        subject(:override_service) { described_class.new(fixed_charge:, params:, subscription:) }
+
+        let(:subscription) { create(:subscription, plan:, organization:) }
+        let(:params) do
+          {
+            apply_units_immediately: true,
+            units: 15,
+            plan_id: plan2.id
+          }
+        end
+
+        before do
+          allow(FixedCharges::EmitFixedChargeEventService).to receive(:call!)
+        end
+
+        it "creates a fixed charge for the new plan" do
+          result = override_service.call
+
+          expect(result).to be_success
+
+          override_fixed_charge = result.fixed_charge
+          expect(override_fixed_charge.plan_id).to eq(plan2.id)
+          expect(override_fixed_charge.units).to eq(15)
+        end
+
+        it "emits fixed charge events for the specific subscription" do
+          result = override_service.call
+
+          expect(FixedCharges::EmitFixedChargeEventService)
+            .to have_received(:call!)
+            .with(subscription:, fixed_charge: result.fixed_charge)
+            .once
+        end
+      end
     end
   end
 end

--- a/spec/services/fixed_charges/override_service_spec.rb
+++ b/spec/services/fixed_charges/override_service_spec.rb
@@ -236,6 +236,107 @@ RSpec.describe FixedCharges::OverrideService, type: :service do
           expect(result.error.messages[:properties]).to eq(["value_is_mandatory"])
         end
       end
+
+      context "when apply_units_immediately is true" do
+        let(:customer_1) { create(:customer, organization:) }
+        let(:customer_2) { create(:customer, organization:) }
+        let(:active_subscription_1) { create(:subscription, :active, plan: plan2, customer: customer_1) }
+        let(:active_subscription_2) { create(:subscription, :active, plan: plan2, customer: customer_2) }
+        let(:terminated_subscription) { create(:subscription, :terminated, plan: plan2, customer: customer_1) }
+
+        let(:params) do
+          {
+            apply_units_immediately: true,
+            units: 25,
+            plan_id: plan2.id
+          }
+        end
+
+        before do
+          active_subscription_1
+          active_subscription_2
+          terminated_subscription
+          allow(FixedCharges::EmitFixedChargeEventService).to receive(:call!)
+        end
+
+        it "updates the fixed charge" do
+          result = override_service.call
+
+          expect(result).to be_success
+          expect(result.fixed_charge.units).to eq(25)
+        end
+
+        it "emits fixed charge events for all active subscriptions" do
+          result = override_service.call
+
+          expect(FixedCharges::EmitFixedChargeEventService)
+            .to have_received(:call!)
+            .with(subscription: active_subscription_1, fixed_charge: result.fixed_charge)
+            .once
+
+          expect(FixedCharges::EmitFixedChargeEventService)
+            .to have_received(:call!)
+            .with(subscription: active_subscription_2, fixed_charge: result.fixed_charge)
+            .once
+        end
+
+        it "does not emit events for terminated subscriptions" do
+          result = override_service.call
+
+          expect(FixedCharges::EmitFixedChargeEventService)
+            .not_to have_received(:call!)
+            .with(subscription: terminated_subscription, fixed_charge: result.fixed_charge)
+        end
+
+        context "when units does not change" do
+          let(:params) do
+            {
+              apply_units_immediately: true,
+              units: fixed_charge.units,
+              properties: {amount: "200"},
+              plan_id: plan2.id
+            }
+          end
+
+          it "does not emit any fixed charge events" do
+            override_service.call
+
+            expect(FixedCharges::EmitFixedChargeEventService).not_to have_received(:call!)
+          end
+        end
+      end
+
+      context "when apply_units_immediately is false" do
+        let(:customer) { create(:customer, organization:) }
+        let(:subscription) { create(:subscription, plan:, customer:) }
+
+        let(:params) do
+          {
+            apply_units_immediately: false,
+            units: 1_000,
+            properties: {amount: "200"},
+            plan_id: plan2.id
+          }
+        end
+
+        before do
+          subscription
+          allow(FixedCharges::EmitFixedChargeEventService).to receive(:call!)
+        end
+
+        it "updates the fixed charge" do
+          result = override_service.call
+
+          expect(result).to be_success
+          expect(result.fixed_charge.units).to eq(1_000)
+        end
+
+        it "does not emit any fixed charge events" do
+          override_service.call
+
+          expect(FixedCharges::EmitFixedChargeEventService).not_to have_received(:call!)
+        end
+      end
     end
   end
 end

--- a/spec/services/fixed_charges/update_service_spec.rb
+++ b/spec/services/fixed_charges/update_service_spec.rb
@@ -5,8 +5,9 @@ require "rails_helper"
 RSpec.describe FixedCharges::UpdateService, type: :service do
   subject(:update_service) { described_class.new(fixed_charge:, params:, cascade_options:) }
 
-  let(:plan) { create(:plan) }
-  let(:add_on) { create(:add_on, organization: plan.organization) }
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
 
   let(:fixed_charge) do
     create(:fixed_charge, plan:, add_on:, prorated: false, pay_in_advance: false, units: 10)
@@ -200,6 +201,101 @@ RSpec.describe FixedCharges::UpdateService, type: :service do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::NotFoundFailure)
           expect(result.error.error_code).to eq("tax_not_found")
+        end
+      end
+
+      context "when apply_units_immediately is true" do
+        let(:customer_1) { create(:customer, organization:) }
+        let(:customer_2) { create(:customer, organization:) }
+        let(:active_subscription_1) { create(:subscription, :active, plan:, customer: customer_1) }
+        let(:active_subscription_2) { create(:subscription, :active, plan:, customer: customer_2) }
+        let(:terminated_subscription) { create(:subscription, :terminated, plan:, customer: customer_1) }
+
+        let(:params) do
+          {
+            apply_units_immediately: true,
+            units: 25,
+            properties: {amount: "200"}
+          }
+        end
+
+        before do
+          active_subscription_1
+          active_subscription_2
+          terminated_subscription
+          allow(FixedCharges::EmitFixedChargeEventService).to receive(:call!)
+        end
+
+        it "updates the fixed charge" do
+          expect(result).to be_success
+          expect(result.fixed_charge.units).to eq(25)
+        end
+
+        it "emits fixed charge events for all active subscriptions" do
+          result
+
+          expect(FixedCharges::EmitFixedChargeEventService)
+            .to have_received(:call!)
+            .with(subscription: active_subscription_1, fixed_charge: result.fixed_charge)
+            .once
+
+          expect(FixedCharges::EmitFixedChargeEventService)
+            .to have_received(:call!)
+            .with(subscription: active_subscription_2, fixed_charge: result.fixed_charge)
+            .once
+        end
+
+        it "does not emit events for terminated subscriptions" do
+          result
+
+          expect(FixedCharges::EmitFixedChargeEventService)
+            .not_to have_received(:call!)
+            .with(subscription: terminated_subscription, fixed_charge: result.fixed_charge)
+        end
+
+        context "when units does not change" do
+          let(:params) do
+            {
+              apply_units_immediately: true,
+              units: fixed_charge.units,
+              properties: {amount: "200"}
+            }
+          end
+
+          it "does not emit any fixed charge events" do
+            result
+
+            expect(FixedCharges::EmitFixedChargeEventService).not_to have_received(:call!)
+          end
+        end
+      end
+
+      context "when apply_units_immediately is false" do
+        let(:customer) { create(:customer, organization:) }
+        let(:subscription) { create(:subscription, plan:, customer:) }
+
+        let(:params) do
+          {
+            apply_units_immediately: false,
+            units: 1_000,
+            properties: {amount: "200"}
+          }
+        end
+
+        before do
+          subscription
+          allow(FixedCharges::EmitFixedChargeEventService).to receive(:call!)
+        end
+
+        it "updates the fixed charge" do
+          expect(result).to be_success
+          expect(result.fixed_charge.units).to eq(1_000)
+        end
+
+        it "does not emit any fixed charge events" do
+          result
+
+          expect(FixedCharges::EmitFixedChargeEventService).not_to have_received(:call!)
         end
       end
     end

--- a/spec/services/plans/override_service_spec.rb
+++ b/spec/services/plans/override_service_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Plans::OverrideService, type: :service do
-  subject(:override_service) { described_class.new(plan: parent_plan, params:) }
+  subject(:override_service) { described_class.new(plan: parent_plan, params:, subscription:) }
+
+  let(:subscription) { nil }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
@@ -113,7 +115,7 @@ RSpec.describe Plans::OverrideService, type: :service do
       filter_value
     end
 
-    it "creates a plan based from the parent plan", :aggregate_failures do
+    it "creates a plan based from the parent plan" do
       expect { override_service.call }.to change(Plan, :count).by(1)
 
       plan = Plan.order(:created_at).last
@@ -180,7 +182,7 @@ RSpec.describe Plans::OverrideService, type: :service do
       )
     end
 
-    it "creates charges based from the parent plan", :aggregate_failures do
+    it "creates charges based from the parent plan" do
       charge2 = create(
         :graduated_charge,
         plan: parent_plan,
@@ -240,6 +242,54 @@ RSpec.describe Plans::OverrideService, type: :service do
       it "returns error", :aggregate_failures do
         expect { override_service.call }.not_to change(Plan, :count)
         expect(override_service.call).not_to be_success
+      end
+    end
+
+    context "when subscription parameter is provided" do
+      let(:customer) { create(:customer, organization:) }
+      let(:subscription) { create(:subscription, plan: parent_plan, customer:) }
+
+      it "creates a plan successfully with subscription parameter" do
+        expect { override_service.call }.to change(Plan, :count).by(1)
+
+        result = override_service.call
+        expect(result).to be_success
+        expect(result.plan.parent_id).to eq(parent_plan.id)
+      end
+
+      context "when fixed charge has apply_units_immediately set to true" do
+        let(:fixed_charges_params) do
+          [
+            {
+              id: fixed_charge.id,
+              properties: {amount: "1000"},
+              units: 25,
+              apply_units_immediately: true
+            }
+          ]
+        end
+
+        before do
+          allow(FixedCharges::OverrideService).to receive(:call).and_call_original
+        end
+
+        it "passes subscription parameter to FixedCharges::OverrideService" do
+          override_service.call
+
+          expect(FixedCharges::OverrideService)
+            .to have_received(:call)
+            .with(
+              fixed_charge: fixed_charge,
+              params: {
+                id: fixed_charge.id,
+                properties: {amount: "1000"},
+                units: 25,
+                apply_units_immediately: true,
+                plan_id: kind_of(String)
+              },
+              subscription: subscription
+            )
+        end
       end
     end
   end

--- a/spec/services/subscriptions/emit_fixed_charge_events_service_spec.rb
+++ b/spec/services/subscriptions/emit_fixed_charge_events_service_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::EmitFixedChargeEventsService, type: :service do
+  subject(:service) { described_class.new(subscriptions:, timestamp:) }
+
+  let(:timestamp) { Time.current }
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:) }
+  let(:add_on) { create(:add_on, organization:) }
+
+  let(:fixed_charge_1) { create(:fixed_charge, plan:, add_on:) }
+  let(:fixed_charge_2) { create(:fixed_charge, plan:, add_on:) }
+
+  let(:subscription_1) { create(:subscription, :active, plan:) }
+  let(:subscription_2) { create(:subscription, :active, plan:) }
+  let(:subscriptions) { [subscription_1, subscription_2] }
+
+  let(:fixed_charge_emit_service) { FixedCharges::EmitFixedChargeEventService }
+
+  before do
+    fixed_charge_1
+    fixed_charge_2
+    allow(fixed_charge_emit_service).to receive(:call)
+  end
+
+  describe "#call" do
+    subject(:result) { service.call }
+
+    it "calls FixedCharges::EmitFixedChargeEventService for each subscription and fixed charge" do
+      expect(result).to be_success
+
+      expect(fixed_charge_emit_service).to have_received(:call).exactly(4).times
+
+      expect(fixed_charge_emit_service).to have_received(:call).with(
+        subscription: subscription_1,
+        fixed_charge: fixed_charge_1,
+        timestamp:
+      ).once
+
+      expect(fixed_charge_emit_service).to have_received(:call).with(
+        subscription: subscription_1,
+        fixed_charge: fixed_charge_2,
+        timestamp:
+      ).once
+
+      expect(fixed_charge_emit_service).to have_received(:call).with(
+        subscription: subscription_2,
+        fixed_charge: fixed_charge_1,
+        timestamp:
+      ).once
+
+      expect(fixed_charge_emit_service).to have_received(:call).with(
+        subscription: subscription_2,
+        fixed_charge: fixed_charge_2,
+        timestamp:
+      ).once
+    end
+
+    context "when subscriptions have no fixed charges" do
+      let(:plan_without_fixed_charges) { create(:plan, organization:) }
+      let(:subscription_without_fixed_charges) { create(:subscription, :active, plan: plan_without_fixed_charges) }
+      let(:subscriptions) { [subscription_without_fixed_charges] }
+
+      it "does not call the emit service" do
+        expect(result).to be_success
+        expect(fixed_charge_emit_service).not_to have_received(:call)
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/organization_emit_fixed_charge_events_service_spec.rb
+++ b/spec/services/subscriptions/organization_emit_fixed_charge_events_service_spec.rb
@@ -1,0 +1,265 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subscriptions::OrganizationEmitFixedChargeEventsService, type: :service do
+  include ActiveJob::TestHelper
+
+  subject(:service) { described_class.new(organization:, timestamp:) }
+
+  shared_examples "enqueues jobs for each customer" do
+    it "enqueues a Subscriptions::EmitFixedChargeEventsJob for each customer" do
+      travel_to(timestamp) do
+        expect { service.call }.to have_enqueued_job(Subscriptions::EmitFixedChargeEventsJob).exactly(2)
+
+        expect(Subscriptions::EmitFixedChargeEventsJob)
+          .to have_been_enqueued
+          .with(
+            subscriptions: contain_exactly(subscription_1, subscription_2),
+            timestamp: timestamp.to_i
+          )
+
+        expect(Subscriptions::EmitFixedChargeEventsJob)
+          .to have_been_enqueued
+          .with(
+            subscriptions: contain_exactly(subscription_3),
+            timestamp: timestamp.to_i
+          )
+      end
+    end
+  end
+
+  shared_examples "does not enqueue any jobs" do
+    it "does not enqueue any jobs" do
+      travel_to(timestamp) do
+        expect { service.call }.not_to have_enqueued_job(Subscriptions::EmitFixedChargeEventsJob)
+      end
+    end
+  end
+
+  let(:timestamp) { Time.current }
+  let(:organization) { create(:organization) }
+
+  describe "#call" do
+    let(:plan) { create(:plan, organization:, interval:, bill_fixed_charges_monthly:) }
+    let(:bill_fixed_charges_monthly) { false }
+    let(:fixed_charge) { create(:fixed_charge, plan:, add_on:) }
+    let(:customer_1) { create(:customer, organization:) }
+    let(:customer_2) { create(:customer, organization:) }
+    let(:add_on) { create(:add_on, organization:) }
+    let(:subscription_1) do
+      create(
+        :subscription,
+        billing_time:,
+        plan:,
+        customer: customer_1,
+        subscription_at:,
+        created_at: subscription_created_at
+      )
+    end
+    let(:subscription_2) do
+      create(
+        :subscription,
+        billing_time:,
+        plan:,
+        customer: customer_1,
+        subscription_at:,
+        created_at: subscription_created_at
+      )
+    end
+    let(:subscription_3) do
+      create(
+        :subscription,
+        billing_time:,
+        plan:,
+        customer: customer_2,
+        subscription_at:,
+        created_at: subscription_created_at
+      )
+    end
+    let(:subscription_at) { timestamp - 10.days }
+    let(:subscription_created_at) { timestamp - 15.days }
+
+    context "when billed weekly with calendar billing time" do
+      let(:interval) { :weekly }
+      let(:billing_time) { :calendar }
+      let(:timestamp) { Time.zone.parse("2024-01-01") } # This is a Monday
+
+      before do
+        fixed_charge
+        subscription_1
+        subscription_2
+        subscription_3
+      end
+
+      include_examples "enqueues jobs for each customer"
+
+      context "when not on a Monday" do
+        let(:timestamp) { Time.zone.parse("2024-01-02") } # Tuesday
+
+        include_examples "does not enqueue any jobs"
+      end
+    end
+
+    context "when billed monthly with calendar billing time" do
+      let(:interval) { :monthly }
+      let(:billing_time) { :calendar }
+      let(:timestamp) { Time.zone.parse("2024-02-01") } # This is a 1st day of the month (not Monday)
+
+      before do
+        fixed_charge
+        subscription_1
+        subscription_2
+        subscription_3
+      end
+
+      include_examples "enqueues jobs for each customer"
+
+      context "when not on a 1st day of the month" do
+        let(:timestamp) { Time.zone.parse("2024-02-02") } # 2nd day of the month
+
+        include_examples "does not enqueue any jobs"
+      end
+    end
+
+    context "when billed quarterly with calendar billing time" do
+      let(:interval) { :quarterly }
+      let(:billing_time) { :calendar }
+      let(:timestamp) { Time.zone.parse("2024-10-01") } # 1st day of the quarter
+
+      before do
+        fixed_charge
+        subscription_1
+        subscription_2
+        subscription_3
+      end
+
+      include_examples "enqueues jobs for each customer"
+
+      context "when not on a 1st day of the quarter" do
+        let(:timestamp) { Time.zone.parse("2024-11-01") } # not 1st day of the quarter
+
+        include_examples "does not enqueue any jobs"
+      end
+    end
+
+    context "when billed yearly with calendar billing time" do
+      let(:interval) { :yearly }
+      let(:billing_time) { :calendar }
+      let(:timestamp) { Time.zone.parse("2024-01-01") } # 1st day of the year
+
+      before do
+        fixed_charge
+        subscription_1
+        subscription_2
+        subscription_3
+      end
+
+      include_examples "enqueues jobs for each customer"
+
+      context "when fixed charges are billed monthly" do
+        let(:bill_fixed_charges_monthly) { true }
+        let(:timestamp) { Time.zone.parse("2025-02-01") } # not 1st day of the year but 1st day of the month
+
+        include_examples "enqueues jobs for each customer"
+      end
+
+      context "when not on a 1st day of the year" do
+        let(:timestamp) { Time.zone.parse("2024-03-01") } # not 1st day of the year but 1st day of the month
+
+        include_examples "does not enqueue any jobs"
+      end
+    end
+
+    context "when billed weekly with anniversary billing time" do
+      let(:interval) { :weekly }
+      let(:billing_time) { :anniversary }
+      let(:subscription_at) { timestamp - 7.days }
+
+      before do
+        fixed_charge
+        subscription_1
+        subscription_2
+        subscription_3
+      end
+
+      include_examples "enqueues jobs for each customer"
+
+      context "when not a week after the subscription anniversary" do
+        let(:subscription_at) { timestamp - 2.days }
+
+        include_examples "does not enqueue any jobs"
+      end
+    end
+
+    context "when billed monthly with anniversary billing time" do
+      let(:interval) { :monthly }
+      let(:billing_time) { :anniversary }
+      let(:subscription_at) { timestamp - 1.month }
+
+      before do
+        fixed_charge
+        subscription_1
+        subscription_2
+        subscription_3
+      end
+
+      include_examples "enqueues jobs for each customer"
+
+      context "when not a month after the subscription anniversary" do
+        let(:subscription_at) { timestamp - 3.weeks }
+
+        include_examples "does not enqueue any jobs"
+      end
+    end
+
+    context "when billed quarterly with anniversary billing time" do
+      let(:interval) { :quarterly }
+      let(:billing_time) { :anniversary }
+      let(:subscription_at) { timestamp - 3.months }
+
+      before do
+        fixed_charge
+        subscription_1
+        subscription_2
+        subscription_3
+      end
+
+      include_examples "enqueues jobs for each customer"
+
+      context "when not a quarter after the subscription anniversary" do
+        let(:subscription_at) { timestamp - 2.months }
+
+        include_examples "does not enqueue any jobs"
+      end
+    end
+
+    context "when billed yearly with anniversary billing time" do
+      let(:interval) { :yearly }
+      let(:billing_time) { :anniversary }
+      let(:subscription_at) { timestamp - 1.year }
+
+      before do
+        fixed_charge
+        subscription_1
+        subscription_2
+        subscription_3
+      end
+
+      include_examples "enqueues jobs for each customer"
+
+      context "when fixed charges are billed monthly" do
+        let(:bill_fixed_charges_monthly) { true }
+        let(:subscription_at) { timestamp - 2.months }
+
+        include_examples "enqueues jobs for each customer"
+      end
+
+      context "when not a year after the subscription anniversary" do
+        let(:subscription_at) { timestamp - 11.months }
+
+        include_examples "does not enqueue any jobs"
+      end
+    end
+  end
+end


### PR DESCRIPTION
 ## Roadmap Task

 👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

 👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

 ## Context

 ### What is the current situation?

 **Option 1:** User has to create a one off invoice alongside the
 subscription, it will create 2 different invoices.

 **Option 2:** User can add a recurring billable metric and use event to  have this fee invoice on subscription renewal, but it won’t appear on  the first billing subscription.

 ### What problem are we trying to solve?

 At subscription creation or afterward, there is no clear way to invoice  a fixed fee that is not tied to events, aside from the subscription fee  itself. This fee could be either a one-time charge or a recurring one.

 ## Description

Trigger emission of fixed charge events on plan updates and subscription overrides when units are changed and user selects to apply the change immediately. Events will be emitted for all active subscriptions belonging to the fixed charge's plan.

Also, this change fixes a few bugs like;
- not able to update an existing fixed charge through graphql (UI).
- 