### PR TITLE
feat(wallets): Validate top up min/max limit for new transactions

### DIFF
--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -90,6 +90,7 @@ module Api
           :voided_credits,
           :invoice_requires_successful_payment,
           :name,
+          :ignore_paid_top_up_limits,
           metadata: [
             :key,
             :value

--- a/app/graphql/mutations/wallet_transactions/create.rb
+++ b/app/graphql/mutations/wallet_transactions/create.rb
@@ -11,15 +11,7 @@ module Mutations
       graphql_name "CreateCustomerWalletTransaction"
       description "Creates a new Customer Wallet Transaction"
 
-      argument :wallet_id, ID, required: true
-
-      argument :granted_credits, String, required: false
-      argument :invoice_requires_successful_payment, Boolean, required: false
-      argument :metadata, [Types::WalletTransactions::MetadataInput], required: false
-      argument :name, String, required: false
-      argument :paid_credits, String, required: false
-      argument :priority, Integer, required: false
-      argument :voided_credits, String, required: false
+      input_object_class Types::WalletTransactions::CreateInput
 
       type Types::WalletTransactions::Object.collection_type
 

--- a/app/graphql/types/wallet_transactions/create_input.rb
+++ b/app/graphql/types/wallet_transactions/create_input.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Types
+  module WalletTransactions
+    class CreateInput < Types::BaseInputObject
+      graphql_name "CreateCustomerWalletTransactionInput"
+
+      argument :wallet_id, ID, required: true
+
+      argument :granted_credits, String, required: false
+      argument :ignore_paid_top_up_limits, Boolean, required: false
+      argument :invoice_requires_successful_payment, Boolean, required: false
+      argument :metadata, [Types::WalletTransactions::MetadataInput], required: false
+      argument :name, String, required: false
+      argument :paid_credits, String, required: false
+      argument :priority, Integer, required: false
+      argument :voided_credits, String, required: false
+    end
+  end
+end

--- a/app/services/validators/wallet_transaction_amount_limits_validator.rb
+++ b/app/services/validators/wallet_transaction_amount_limits_validator.rb
@@ -13,8 +13,7 @@ module Validators
 
     def raise_if_invalid!
       return if valid?
-      result.raise_if_error!
-      raise "invalid but no error set in result" # TODO: find generic error to raise instead
+      result.raise_if_error! # NOTE: if you didn't set the error in result, this won't raise if `valid?` is false
     end
 
     def valid?

--- a/app/services/validators/wallet_transaction_amount_limits_validator.rb
+++ b/app/services/validators/wallet_transaction_amount_limits_validator.rb
@@ -5,9 +5,16 @@ module Validators
     def initialize(result, wallet:, credits_amount:, ignore_validation: false, field_name: :paid_credits)
       @result = result
       @wallet = wallet
+      # NOTE: credits_amount must be a string to be able to use ::Validators::DecimalAmountService
       @credits_amount = credits_amount
       @ignore_validation = ActiveModel::Type::Boolean.new.cast(ignore_validation)
       @field_name = field_name
+    end
+
+    def raise_if_invalid!
+      return if valid?
+      result.raise_if_error!
+      raise "invalid but no error set in result" # TODO: find generic error to raise instead
     end
 
     def valid?

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -47,7 +47,7 @@ module Wallets
         wallet.currency = wallet.customer.currency
         wallet.save!
 
-        validate_wallet_amount! wallet
+        validate_wallet_initial_amount! wallet
 
         if params[:recurring_transaction_rules].present?
           Wallets::RecurringTransactionRules::CreateService.call(wallet:, wallet_params: params)
@@ -88,7 +88,7 @@ module Wallets
       Wallets::ValidateService.new(result, **params).valid?
     end
 
-    def validate_wallet_amount!(wallet)
+    def validate_wallet_initial_amount!(wallet)
       return unless positive_paid_credit_amount?
 
       Validators::WalletTransactionAmountLimitsValidator.new(
@@ -96,9 +96,7 @@ module Wallets
         wallet:,
         credits_amount: params[:paid_credits],
         ignore_validation: params[:ignore_paid_top_up_limits_on_creation]
-      ).valid?
-
-      result.raise_if_error!
+      ).raise_if_invalid!
     end
 
     def positive_paid_credit_amount?

--- a/schema.graphql
+++ b/schema.graphql
@@ -2643,6 +2643,7 @@ input CreateCustomerWalletTransactionInput {
   """
   clientMutationId: String
   grantedCredits: String
+  ignorePaidTopUpLimits: Boolean
   invoiceRequiresSuccessfulPayment: Boolean
   metadata: [WalletTransactionMetadataInput!]
   name: String

--- a/schema.json
+++ b/schema.json
@@ -10790,18 +10790,6 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "clientMutationId",
-              "description": "A unique identifier for the client performing the mutation.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "walletId",
               "description": null,
               "type": {
@@ -10823,6 +10811,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ignorePaidTopUpLimits",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,
@@ -10900,6 +10900,18 @@
             {
               "name": "voidedCredits",
               "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",

--- a/spec/graphql/mutations/customer_portal/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/customer_portal/wallet_transactions/create_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe Mutations::CustomerPortal::WalletTransactions::Create, type: :gra
     expect(result_data["collection"].first["amount"]).to eq "5.0"
   end
 
+  context "when wallet has a minimum amount" do
+    it "returns an error" do
+      wallet.update!(paid_top_up_min_amount_cents: 10_00)
+
+      result = execute_graphql(
+        customer_portal_user: wallet.customer,
+        query: mutation,
+        variables: {
+          input: {
+            walletId: wallet.id,
+            paidCredits: "5.123459999"
+          }
+        }
+      )
+
+      # TODO: improve when we have metadata on errors
+      expect_unprocessable_entity(result)
+    end
+  end
+
   context "without customer portal user" do
     it "returns an error" do
       result = execute_graphql(

--- a/spec/graphql/mutations/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/wallet_transactions/create_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
       end
 
       it "creates the transaction" do
-        expect { result }.to change(organization.wallet_transactions, :count).by(1)
+        expect { subject }.to change(organization.wallet_transactions, :count).by(1)
 
         result_data = result["data"]["createCustomerWalletTransaction"]
         expect(result_data["collection"].count).to eq 1

--- a/spec/graphql/mutations/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/wallet_transactions/create_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
+  subject(:result) { execute_query(query:, input:) }
+
   let(:required_permission) { "wallets:top_up" }
   let(:organization) { create(:organization) }
   let(:membership) { create(:membership, organization:) }
@@ -10,7 +12,7 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:, balance: 10.0, credits_balance: 10.0) }
 
-  let(:mutation) do
+  let(:query) do
     <<-GQL
     mutation ($input: CreateCustomerWalletTransactionInput!) {
       createCustomerWalletTransaction(input: $input) {
@@ -35,6 +37,27 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
     GQL
   end
 
+  let(:input) do
+    {
+      walletId: wallet.id,
+      name: "Test Transaction",
+      paidCredits: "5.00",
+      grantedCredits: "15.00",
+      invoiceRequiresSuccessfulPayment: true,
+      priority: 25,
+      metadata: [
+        {
+          key: "fixed",
+          value: "0"
+        },
+        {
+          key: "test 2",
+          value: "mew meta"
+        }
+      ]
+    }
+  end
+
   before do
     subscription
     wallet
@@ -45,28 +68,6 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
   it_behaves_like "requires permission", "wallets:top_up"
 
   it "creates a wallet transaction" do
-    result = execute_query(
-      query: mutation,
-      input: {
-        walletId: wallet.id,
-        name: "Test Transaction",
-        paidCredits: "5.00",
-        grantedCredits: "15.00",
-        invoiceRequiresSuccessfulPayment: true,
-        priority: 25,
-        metadata: [
-          {
-            key: "fixed",
-            value: "0"
-          },
-          {
-            key: "test 2",
-            value: "mew meta"
-          }
-        ]
-      }
-    )
-
     result_data = result["data"]["createCustomerWalletTransaction"]
     transactions = result_data["collection"].sort_by { |wt| wt["transactionStatus"] }
 
@@ -100,5 +101,33 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
       "amount" => "5.0",
       "invoiceRequiresSuccessfulPayment" => true
     )
+  end
+
+  context "when wallet has a minimum amount" do
+    before do
+      wallet.update!(paid_top_up_min_amount_cents: 10_00)
+    end
+
+    it "returns an error" do
+      # TODO: check error content when we return metadata
+      expect_unprocessable_entity(result)
+    end
+
+    context "when the ignore_paid_top_up_limits is passed" do
+      let(:input) do
+        {
+          walletId: wallet.id,
+          paidCredits: "5.00",
+          ignorePaidTopUpLimits: true
+        }
+      end
+
+      it "creates the transaction" do
+        expect { result }.to change(organization.wallet_transactions, :count).by(1)
+
+        result_data = result["data"]["createCustomerWalletTransaction"]
+        expect(result_data["collection"].count).to eq 1
+      end
+    end
   end
 end

--- a/spec/graphql/types/wallet_transactions/create_input_spec.rb
+++ b/spec/graphql/types/wallet_transactions/create_input_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::WalletTransactions::CreateInput do
+  subject { described_class }
+
+  it "has the expected arguments" do
+    expect(subject).to accept_argument(:wallet_id).of_type("ID!")
+
+    expect(subject).to accept_argument(:granted_credits).of_type("String")
+    expect(subject).to accept_argument(:name).of_type("String")
+    expect(subject).to accept_argument(:ignore_paid_top_up_limits).of_type("Boolean")
+    expect(subject).to accept_argument(:invoice_requires_successful_payment).of_type("Boolean")
+    expect(subject).to accept_argument(:metadata).of_type("[WalletTransactionMetadataInput!]")
+    expect(subject).to accept_argument(:paid_credits).of_type("String")
+    expect(subject).to accept_argument(:priority).of_type("Int")
+    expect(subject).to accept_argument(:voided_credits).of_type("String")
+  end
+end

--- a/spec/requests/api/v1/wallet_transactions_controller_spec.rb
+++ b/spec/requests/api/v1/wallet_transactions_controller_spec.rb
@@ -53,6 +53,15 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
       expect(wallet_transactions).to all(include(name: "Custom Top-up Name", lago_wallet_id: wallet.id))
     end
 
+    context "when paid credits is below the wallet minimum" do
+      it "returns an error" do
+        wallet.update!(paid_top_up_min_amount_cents: 20_00)
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:paid_credits]).to eq(["amount_below_minimum"])
+      end
+    end
+
     context "with voided credits" do
       let(:wallet) { create(:wallet, customer:, credits_balance: 20, balance_cents: 2000) }
       let(:params) do

--- a/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
+++ b/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe Validators::WalletTransactionAmountLimitsValidator, type: :validator do
-  subject { described_class.new(result, wallet:, credits_amount:, ignore_validation:).valid? }
-
   let(:result) { BaseService::LegacyResult.new }
   let(:wallet) { create(:wallet, paid_top_up_min_amount_cents:, paid_top_up_max_amount_cents:) }
   let(:paid_top_up_min_amount_cents) { 5_00 }
@@ -12,7 +10,15 @@ RSpec.describe Validators::WalletTransactionAmountLimitsValidator, type: :valida
   let(:credits_amount) { "1.0" }
   let(:ignore_validation) { false }
 
+  describe "#raise_if_invalid!" do
+    subject { described_class.new(result, wallet:, credits_amount:, ignore_validation:).raise_if_invalid! }
+
+    it { expect { subject }.to raise_error(BaseService::ValidationFailure) }
+  end
+
   describe "#valid?" do
+    subject { described_class.new(result, wallet:, credits_amount:, ignore_validation:).valid? }
+
     context "when  ignore_validation is true" do
       let(:ignore_validation) { true }
 

--- a/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
+++ b/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
@@ -11,9 +11,17 @@ RSpec.describe Validators::WalletTransactionAmountLimitsValidator, type: :valida
   let(:ignore_validation) { false }
 
   describe "#raise_if_invalid!" do
-    subject { described_class.new(result, wallet:, credits_amount:, ignore_validation:).raise_if_invalid! }
+    context "when invalid" do
+      subject { described_class.new(result, wallet:, credits_amount:, ignore_validation:).raise_if_invalid! }
 
-    it { expect { subject }.to raise_error(BaseService::ValidationFailure) }
+      it { expect { subject }.to raise_error(BaseService::ValidationFailure) }
+    end
+
+    context "when valid" do
+      subject { described_class.new(result, wallet:, credits_amount:, ignore_validation: true).raise_if_invalid! }
+
+      it { expect { subject }.not_to raise_error }
+    end
   end
 
   describe "#valid?" do


### PR DESCRIPTION
New wallet transaction are validated against the wallet min/max limits
- [x] API
- [x] GraphQL