### PR TITLE
fix(coupons): Do not display child plans on UI and JSON api

### DIFF
--- a/app/graphql/types/coupons/object.rb
+++ b/app/graphql/types/coupons/object.rb
@@ -43,6 +43,10 @@ module Types
       def applied_coupons_count
         object.applied_coupons.count
       end
+
+      def plans
+        object.plans.parents
+      end
     end
   end
 end

--- a/app/serializers/v1/coupon_serializer.rb
+++ b/app/serializers/v1/coupon_serializer.rb
@@ -17,7 +17,7 @@ module V1
         reusable: model.reusable,
         limited_plans: model.limited_plans,
         limited_billable_metrics: model.limited_billable_metrics,
-        plan_codes: model.plans.pluck(:code),
+        plan_codes: model.plans.parents.pluck(:code),
         billable_metric_codes: model.billable_metrics.pluck(:code),
         created_at: model.created_at.iso8601,
         expiration: model.expiration,

--- a/spec/graphql/types/coupons/object_spec.rb
+++ b/spec/graphql/types/coupons/object_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Coupons::Object do
+  subject { described_class }
+
+  it do
+    expect(subject).to have_field(:id).of_type("ID!")
+    expect(subject).to have_field(:organization).of_type("Organization")
+    expect(subject).to have_field(:amount_cents).of_type("BigInt")
+    expect(subject).to have_field(:amount_currency).of_type("CurrencyEnum")
+    expect(subject).to have_field(:code).of_type("String")
+    expect(subject).to have_field(:coupon_type).of_type("CouponTypeEnum!")
+    expect(subject).to have_field(:description).of_type("String")
+    expect(subject).to have_field(:frequency).of_type("CouponFrequency!")
+    expect(subject).to have_field(:frequency_duration).of_type("Int")
+    expect(subject).to have_field(:name).of_type("String!")
+    expect(subject).to have_field(:percentage_rate).of_type("Float")
+    expect(subject).to have_field(:reusable).of_type("Boolean!")
+    expect(subject).to have_field(:status).of_type("CouponStatusEnum!")
+    expect(subject).to have_field(:expiration).of_type("CouponExpiration!")
+    expect(subject).to have_field(:expiration_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:activity_logs).of_type("[ActivityLog!]")
+    expect(subject).to have_field(:billable_metrics).of_type("[BillableMetric!]")
+    expect(subject).to have_field(:limited_billable_metrics).of_type("Boolean!")
+    expect(subject).to have_field(:limited_plans).of_type("Boolean!")
+    expect(subject).to have_field(:plans).of_type("[Plan!]")
+    expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:terminated_at).of_type("ISO8601DateTime")
+    expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")
+    expect(subject).to have_field(:applied_coupons_count).of_type("Int!")
+    expect(subject).to have_field(:customers_count).of_type("Int!")
+  end
+
+  describe "#plans" do
+    subject { run_graphql_field("Coupon.plans", coupon) }
+
+    let(:coupon_plan) { create(:coupon_plan) }
+    let(:coupon) { coupon_plan.coupon }
+    let(:parent_plan) { coupon_plan.plan }
+
+    before do
+      create(:coupon_plan, coupon:, plan: create(:plan, parent: parent_plan, code: parent_plan.code))
+    end
+
+    context "when coupon has multiple plans" do
+      it "only list parent plans" do
+        expect(coupon.plans.count).to eq(2)
+        expect(subject).to be_present
+        expect(subject).to eq([parent_plan])
+      end
+    end
+  end
+end

--- a/spec/serializers/v1/coupon_serializer_spec.rb
+++ b/spec/serializers/v1/coupon_serializer_spec.rb
@@ -30,4 +30,17 @@ RSpec.describe ::V1::CouponSerializer do
       expect(result["coupon"]["billable_metric_codes"]).to eq([])
     end
   end
+
+  context "when plan has childs" do
+    before do
+      child_plan = create(:plan, parent: coupon_plan.plan, code: coupon_plan.plan.code)
+      create(:coupon_plan, coupon:, plan: child_plan)
+    end
+
+    it "only list parent plans" do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result["coupon"]["plan_codes"]).to eq([coupon_plan.plan.code])
+    end
+  end
 end


### PR DESCRIPTION
We should not display coupons that are applicable to child plans, only parent plans. 

UI only allow attach coupons to parent plans. 
API allows attach a coupon using the code, which can attach to child plans as well. 

### e.g of the fix
This coupon can be applied to 3 plans, but 2 are child plans of `testando_taxes`. 
```
lago-api(dev)> Coupon.last.plans.count
=> 3
```

```
{lago_id: "f861c0e9-5001-4efd-949f-ad63ba8a4a22",
 name: "Startup Deal",
 code: "startup_deal",
 description: "I am a coupon description",
 coupon_type: "fixed_amount",
 amount_cents: 5000,
 amount_currency: "USD",
 percentage_rate: 0.4e1,
 frequency: "recurring",
 frequency_duration: 6,
 reusable: false,
 limited_plans: true,
 limited_billable_metrics: false,
 plan_codes: ["testando_taxes"],
 billable_metric_codes: [],
 created_at: "2025-09-10T13:49:34Z",
 expiration: "time_limit",
 expiration_at: "2026-08-08T23:59:59Z",
 terminated_at: nil}
```

<img width="1340" height="274" alt="image" src="https://github.com/user-attachments/assets/84d24ed4-22da-40a6-953b-fed204fcca05" />

