### PR TITLE
feat(wallet-transaction): Add `transaction_name` to wallet transaction rules GraphQL types

### DIFF
--- a/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
@@ -17,6 +17,7 @@ module Types
         argument :target_ongoing_balance, String, required: false
         argument :threshold_credits, String, required: false
         argument :transaction_metadata, [Types::Wallets::RecurringTransactionRules::TransactionMetadataInput], required: false
+        argument :transaction_name, String, required: false
         argument :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, required: true
       end
     end

--- a/app/graphql/types/wallets/recurring_transaction_rules/object.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/object.rb
@@ -20,6 +20,7 @@ module Types
         field :target_ongoing_balance, String, null: true
         field :threshold_credits, String, null: true
         field :transaction_metadata, [Types::Wallets::RecurringTransactionRules::TransactionMetadataObject], null: true
+        field :transaction_name, String, null: true
         field :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, null: false
 
         def resolver_method

--- a/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
@@ -18,6 +18,7 @@ module Types
         argument :target_ongoing_balance, String, required: false
         argument :threshold_credits, String, required: false
         argument :transaction_metadata, [Types::Wallets::RecurringTransactionRules::TransactionMetadataInput], required: false
+        argument :transaction_name, String, required: false
         argument :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, required: false
       end
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2960,6 +2960,7 @@ input CreateRecurringTransactionRuleInput {
   targetOngoingBalance: String
   thresholdCredits: String
   transactionMetadata: [CreateTransactionMetadataInput!]
+  transactionName: String
   trigger: RecurringTransactionTriggerEnum!
 }
 
@@ -9055,6 +9056,7 @@ type RecurringTransactionRule {
   targetOngoingBalance: String
   thresholdCredits: String
   transactionMetadata: [TransactionMetadata!]
+  transactionName: String
   trigger: RecurringTransactionTriggerEnum!
 }
 
@@ -11094,6 +11096,7 @@ input UpdateRecurringTransactionRuleInput {
   targetOngoingBalance: String
   thresholdCredits: String
   transactionMetadata: [CreateTransactionMetadataInput!]
+  transactionName: String
   trigger: RecurringTransactionTriggerEnum
 }
 

--- a/schema.json
+++ b/schema.json
@@ -12935,6 +12935,18 @@
               "deprecationReason": null
             },
             {
+              "name": "transactionName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "trigger",
               "description": null,
               "type": {
@@ -48739,6 +48751,18 @@
               "args": []
             },
             {
+              "name": "transactionName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
               "name": "trigger",
               "description": null,
               "type": {
@@ -57802,6 +57826,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "transactionName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/factories/wallets.rb
+++ b/spec/factories/wallets.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
     trait :terminated do
       status { "terminated" }
     end
+
+    trait :with_recurring_transaction_rules do
+      recurring_transaction_rules { [association(:recurring_transaction_rule)] }
+    end
   end
 end

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
               key
               value
             }
+            transactionName
           }
           appliesTo {
             feeTypes
@@ -92,7 +93,8 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
               transactionMetadata: [
                 {key: "example_key", value: "example_value"},
                 {key: "another_key", value: "another_value"}
-              ]
+              ],
+              transactionName: "Updated Credits Transaction"
             }
           ],
           appliesTo: {
@@ -120,6 +122,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
       {"key" => "example_key", "value" => "example_value"},
       {"key" => "another_key", "value" => "another_value"}
     )
+    expect(result_data["recurringTransactionRules"][0]["transactionName"]).to eq("Updated Credits Transaction")
     expect(result_data["recurringTransactionRules"][0]).to include(
       "lagoId" => recurring_transaction_rule.id,
       "method" => "target",

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Wallets::ThresholdTopUpService, type: :service do
       end
     end
 
-    context "when rule contains nil transaction_name" do
+    context "when rule does not contain transaction_name" do
       let(:recurring_transaction_rule) do
         create(
           :recurring_transaction_rule,


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-the-name-of-a-wallet-transaction-at-top-up

## Context

Follow up of https://github.com/getlago/lago-api/pull/4282.

## Description

This adds a `transaction_name` to the wallet transaction recurring rule GraphQL types that are then used to populate the name of the triggered wallet transactions.

