### PR TITLE
Fix(billing_entities): upsert customer without billing entity

### DIFF
--- a/app/services/customers/upsert_from_api_service.rb
+++ b/app/services/customers/upsert_from_api_service.rb
@@ -53,7 +53,7 @@ module Customers
       ActiveRecord::Base.transaction do
         original_tax_values = customer.slice(:tax_identification_number, :zipcode, :country).symbolize_keys
 
-        customer.billing_entity = billing_entity if customer.editable?
+        customer.billing_entity = billing_entity if new_customer || (customer.editable? && params.key?(:billing_entity_code))
         customer.name = params[:name] if params.key?(:name)
         customer.country = params[:country]&.upcase if params.key?(:country)
         customer.address_line1 = params[:address_line1] if params.key?(:address_line1)

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Customers::UpsertFromApiService, type: :service do
     end
   end
 
-  context "with an external_id already in use in a different billing entity" do
+  context "with an external_id already in use in a not-default billing entity" do
     let(:customer) do
       create(:customer, organization:, billing_entity: billing_entity_2, external_id:)
     end
@@ -257,6 +257,21 @@ RSpec.describe Customers::UpsertFromApiService, type: :service do
     context "when the customer already has an invoice" do
       before do
         create(:invoice, customer: customer)
+      end
+
+      it "does not update the billing_entity of the customer" do
+        expect(result).to be_success
+        expect(result.customer).to eq(customer)
+        expect(result.customer.billing_entity).to eq(billing_entity_2)
+      end
+    end
+
+    context "when not sending billing_entity_code" do
+      let(:create_args) do
+        {
+          external_id:,
+          name: "Updated name"
+        }
       end
 
       it "does not update the billing_entity of the customer" do


### PR DESCRIPTION
## Context

Because we're using upsert service, and billing_entity is required on a customer, the behaviour when we do not receive billing_entity should be different for  if we create or update the customer:
when we use this service to create a customer and if no billing_entity_code is provided, we should assign default billing_entity
when we update customer, and no billing_entity_code is provided, we shouldn't update the billing_entity of the customer

## Description

- Updated upsert service to only set billing entity if it's a new record or if it's a persisted editable record and new billing_entity code is provided
