### PR TITLE
feat(invoices): Add index scoped to customer

### DIFF
--- a/app/contracts/queries/invoices_query_filters_contract.rb
+++ b/app/contracts/queries/invoices_query_filters_contract.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Queries
+  class InvoicesQueryFiltersContract < Dry::Validation::Contract
+    params do
+      required(:filters).hash do
+        optional(:billing_entity_ids).maybe { array(:string, format?: Regex::UUID) }
+
+        optional(:payment_status).maybe do
+          value(:string, included_in?: Invoice.payment_statuses.keys) |
+            array(:string, included_in?: Invoice.payment_statuses.keys)
+        end
+
+        optional(:status).maybe do
+          value(:string, included_in?: Invoice::VISIBLE_STATUS.keys.map(&:to_s)) |
+            array(:string, included_in?: Invoice::VISIBLE_STATUS.keys.map(&:to_s))
+        end
+
+        optional(:self_billed).maybe(:bool)
+        optional(:partially_paid).maybe(:bool)
+        optional(:payment_overdue).maybe(:bool)
+      end
+
+      optional(:search_term).maybe(:string)
+    end
+  end
+end

--- a/app/controllers/api/v1/customers/base_controller.rb
+++ b/app/controllers/api/v1/customers/base_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Customers
+      class BaseController < Api::BaseController
+        before_action :find_customer
+
+        private
+
+        attr_reader :customer
+
+        def find_customer
+          @customer = current_organization.customers.find_by!(external_id: params[:customer_external_id])
+        rescue ActiveRecord::RecordNotFound
+          not_found_error(resource: "customer")
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/customers/invoices_controller.rb
+++ b/app/controllers/api/v1/customers/invoices_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Customers
+      class InvoicesController < BaseController
+        def index
+          billing_entities = current_organization.all_billing_entities.where(code: params[:billing_entity_codes]) if params[:billing_entity_codes].present?
+          return not_found_error(resource: "billing_entity") if params[:billing_entity_codes].present? && billing_entities.count != params[:billing_entity_codes].count
+
+          result = InvoicesQuery.call(
+            organization: current_organization,
+            pagination: {
+              page: params[:page],
+              limit: params[:per_page] || PER_PAGE
+            },
+            search_term: params[:search_term],
+            filters: {
+              amount_from: params[:amount_from],
+              amount_to: params[:amount_to],
+              billing_entity_ids: billing_entities&.ids,
+              currency: params[:currency],
+              customer_id: customer.id,
+              invoice_type: params[:invoice_type],
+              issuing_date_from: (Date.iso8601(params[:issuing_date_from]) if valid_date?(params[:issuing_date_from])),
+              issuing_date_to: (Date.iso8601(params[:issuing_date_to]) if valid_date?(params[:issuing_date_to])),
+              metadata: params[:metadata]&.permit!.to_h,
+              partially_paid: params[:partially_paid],
+              payment_dispute_lost: params[:payment_dispute_lost],
+              payment_overdue: params[:payment_overdue],
+              payment_status: params[:payment_status],
+              self_billed: params[:self_billed],
+              status: params[:status]
+            }
+          )
+
+          if result.success?
+            render(
+              json: ::CollectionSerializer.new(
+                result.invoices.includes(:metadata, :applied_taxes, :billing_entity, :applied_usage_thresholds),
+                ::V1::InvoiceSerializer,
+                collection_name: "invoices",
+                meta: pagination_metadata(result.invoices),
+                includes: %i[customer integration_customers metadata applied_taxes]
+              )
+            )
+          else
+            render_error_response(result)
+          end
+        end
+
+        private
+
+        def resource_name
+          "invoice"
+        end
+      end
+    end
+  end
+end

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -24,6 +24,8 @@ class InvoicesQuery < BaseQuery
   ]
 
   def call
+    return result unless validate_filters.success?
+
     invoices = base_scope.result.includes(:customer).includes(file_attachment: :blob)
     invoices = paginate(invoices)
     invoices = apply_consistent_ordering(
@@ -55,6 +57,10 @@ class InvoicesQuery < BaseQuery
   end
 
   private
+
+  def filters_contract
+    @filters_contract ||= Queries::InvoicesQueryFiltersContract.new
+  end
 
   def base_scope
     organization.invoices.visible.ransack(search_params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
 
         scope module: :customers do
           resources :applied_coupons, only: %i[destroy]
+          resources :invoices, only: %i[index]
         end
       end
 

--- a/spec/contracts/queries/invoices_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/invoices_query_filters_contract_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Queries::InvoicesQueryFiltersContract, type: :contract do
+  subject(:result) { described_class.new.call(filters:, search_term:) }
+
+  let(:filters) { {} }
+  let(:search_term) { nil }
+
+  context "when filtering by payment status" do
+    let(:filters) { {payment_status: "succeeded"} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+
+    context "when filter is an array" do
+      let(:filters) { {payment_status: ["succeeded", "failed"]} }
+
+      it "is valid" do
+        expect(result.success?).to be(true)
+      end
+    end
+  end
+
+  context "when filtering by status" do
+    let(:filters) { {status: "draft"} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filtering by billing entity ids" do
+    let(:filters) { {billing_entity_ids: ["123e4567-e89b-12d3-a456-426614174000"]} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filtering by self billed" do
+    let(:filters) { {self_billed: false} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filtering by partially paid" do
+    let(:filters) { {partially_paid: false} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filtering payment overdue" do
+    let(:filters) { {payment_overdue: false} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when search_term is provided and valid" do
+    let(:search_term) { "valid_search_term" }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when search_term is invalid" do
+    let(:search_term) { 12345 }
+
+    it "is invalid" do
+      expect(result.success?).to be(false)
+      expect(result.errors.to_h).to include(search_term: ["must be a string"])
+    end
+  end
+
+  context "when filters are invalid" do
+    shared_examples "an invalid filter" do |filter, value, error_message|
+      let(:filters) { {filter => value} }
+
+      it "is invalid when #{filter} is set to #{value.inspect}" do
+        expect(result.success?).to be(false)
+        expect(result.errors.to_h).to include(filters: {filter => error_message})
+      end
+    end
+
+    it_behaves_like "an invalid filter", :payment_status, "random", ["must be one of: pending, succeeded, failed or must be an array"]
+    it_behaves_like "an invalid filter", :payment_status, ["succeeded", "random"], {1 => ["must be one of: pending, succeeded, failed"]}
+    it_behaves_like "an invalid filter", :status, "random", ["must be one of: draft, finalized, voided, failed, pending or must be an array"]
+    it_behaves_like "an invalid filter", :status, ["draft", "random"], {1 => ["must be one of: draft, finalized, voided, failed, pending"]}
+    it_behaves_like "an invalid filter", :self_billed, "invalid", ["must be boolean"]
+    it_behaves_like "an invalid filter", :partially_paid, "invalid", ["must be boolean"]
+    it_behaves_like "an invalid filter", :payment_overdue, "invalid", ["must be boolean"]
+    it_behaves_like "an invalid filter", :billing_entity_ids, SecureRandom.uuid, ["must be an array"]
+    it_behaves_like "an invalid filter", :billing_entity_ids, %w[random], {0 => ["is in invalid format"]}
+  end
+end

--- a/spec/requests/api/v1/customers/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/customers/invoices_controller_spec.rb
@@ -1,0 +1,373 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Customers::InvoicesController, type: :request do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
+
+  before { tax }
+
+  describe "GET /api/v1/customers/:external_id/invoices" do
+    subject { get_with_token(organization, "/api/v1/customers/#{customer.external_id}/invoices", params) }
+
+    context "with invalid customer id" do
+      subject { get_with_token(organization, "/api/v1/customers/foo/invoices", {}) }
+
+      it "returns a 404" do
+        subject
+
+        expect(response).to have_http_status(:not_found)
+        expect(json[:code]).to eq("customer_not_found")
+      end
+    end
+
+    context "without params" do
+      let(:params) { {} }
+      let!(:invoice) { create(:invoice, :draft, customer:, organization:) }
+
+      include_examples "requires API permission", "invoice", "read"
+
+      it "returns invoices" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(1)
+        expect(json[:invoices].first).to include(
+          lago_id: invoice.id,
+          payment_status: invoice.payment_status,
+          status: invoice.status
+        )
+      end
+
+      context "when customer has an integration customer" do
+        let!(:netsuite_customer) { create(:netsuite_customer, customer:) }
+
+        it "returns an invoice with customer having integration customers" do
+          subject
+
+          expect(json[:invoices].first[:customer][:integration_customers].first)
+            .to include(lago_id: netsuite_customer.id)
+        end
+      end
+    end
+
+    context "with pagination" do
+      let(:params) { {page: 1, per_page: 1} }
+
+      before do
+        create(:invoice, :draft, customer:, organization:)
+        create(:invoice, customer:, organization:)
+      end
+
+      it "returns invoices with correct meta data" do
+        subject
+
+        expect(response).to have_http_status(:success)
+
+        expect(json[:invoices].count).to eq(1)
+        expect(json[:meta]).to include(
+          current_page: 1,
+          next_page: 2,
+          prev_page: nil,
+          total_pages: 2,
+          total_count: 2
+        )
+      end
+    end
+
+    context "with issuing_date params" do
+      let(:params) do
+        {issuing_date_from: 2.days.ago.to_date, issuing_date_to: Date.tomorrow.to_date}
+      end
+
+      let!(:matching_invoice) do
+        create(:invoice, customer:, issuing_date: 1.day.ago.to_date, organization:)
+      end
+
+      before { create(:invoice, customer:, issuing_date: 3.days.ago.to_date, organization:) }
+
+      it "returns invoices with correct issuing date" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(1)
+        expect(json[:invoices].first[:lago_id]).to eq(matching_invoice.id)
+      end
+
+      context "when issuing date is not a valid date" do
+        let(:params) { {issuing_date_from: "2020 01 01", issuing_date_to: "01/01/2030"} }
+
+        it "returns the result without filtering" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:invoices].count).to eq(2)
+        end
+      end
+    end
+
+    context "with status params" do
+      let(:params) { {status: "finalized"} }
+      let!(:matching_invoice) { create(:invoice, customer:, organization:) }
+
+      before { create(:invoice, :draft, customer:, organization:) }
+
+      it "returns invoices for the given status" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(1)
+        expect(json[:invoices].first[:lago_id]).to eq(matching_invoice.id)
+      end
+    end
+
+    context "with payment status param" do
+      let(:params) { {payment_status: "pending"} }
+
+      let!(:matching_invoice) do
+        create(:invoice, customer:, payment_status: :pending, organization:)
+      end
+
+      before do
+        create(:invoice, customer:, payment_status: :succeeded, organization:)
+        create(:invoice, customer:, payment_status: :failed, organization:)
+      end
+
+      it "returns invoices with correct payment status" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(1)
+        expect(json[:invoices].first[:lago_id]).to eq(matching_invoice.id)
+      end
+    end
+
+    context "with payment overdue param" do
+      let(:params) { {payment_overdue: true} }
+
+      let!(:matching_invoice) do
+        create(:invoice, customer:, payment_overdue: true, organization:)
+      end
+
+      before { create(:invoice, customer:, organization:) }
+
+      it "returns payment overdue invoices" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(1)
+        expect(json[:invoices].first[:lago_id]).to eq(matching_invoice.id)
+      end
+    end
+
+    context "with invoice type param" do
+      let(:params) { {invoice_type: "advance_charges"} }
+
+      let!(:matching_invoice) do
+        create(:invoice, customer:, invoice_type: :advance_charges, organization:)
+      end
+
+      before { create(:invoice, customer:, invoice_type: :add_on, organization:) }
+
+      it "returns invoices with correct invoice type" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(1)
+        expect(json[:invoices].first[:lago_id]).to eq(matching_invoice.id)
+      end
+    end
+
+    context "with currency param" do
+      let(:params) { {currency: "USD"} }
+
+      let!(:matching_invoice) { create(:invoice, customer:, currency: "USD", organization:) }
+
+      before { create(:invoice, customer:, currency: "EUR", organization:) }
+
+      it "returns invoices with correct currency" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(1)
+        expect(json[:invoices].first[:lago_id]).to eq(matching_invoice.id)
+      end
+    end
+
+    context "with payment dispute lost param" do
+      let(:params) { {payment_dispute_lost: true} }
+
+      let!(:matching_invoice) { create(:invoice, :dispute_lost, customer:, organization:) }
+
+      before { create(:invoice, customer:, organization:) }
+
+      it "returns invoices with payment dispute lost" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(1)
+        expect(json[:invoices].first[:lago_id]).to eq(matching_invoice.id)
+      end
+    end
+
+    context "with search term param" do
+      let(:params) { {search_term: matching_invoice.number} }
+
+      let!(:matching_invoice) do
+        create(:invoice, customer:, number: SecureRandom.uuid, organization:)
+      end
+
+      before { create(:invoice, customer:, number: "not-relevant-number", organization:) }
+
+      it "returns invoices matching the search terms" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(1)
+        expect(json[:invoices].first[:lago_id]).to eq(matching_invoice.id)
+      end
+    end
+
+    context "with amount filters" do
+      let(:params) do
+        {
+          amount_from: invoices.second.total_amount_cents,
+          amount_to: invoices.fourth.total_amount_cents
+        }
+      end
+
+      let!(:invoices) do
+        (1..5).to_a.map do |i|
+          create(:invoice, customer:, total_amount_cents: i.succ * 1_000, organization:)
+        end # from smallest to biggest
+      end
+
+      it "returns invoices with total cents amount in provided range" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].pluck(:lago_id)).to match_array invoices[1..3].pluck(:id)
+      end
+    end
+
+    context "with metadata filters" do
+      let(:params) do
+        metadata = matching_invoice.metadata.first
+
+        {
+          metadata: {
+            metadata.key => metadata.value
+          }
+        }
+      end
+
+      let(:matching_invoice) { create(:invoice, organization:, customer:) }
+
+      before do
+        create(:invoice_metadata, invoice: matching_invoice)
+        create(:invoice, organization:)
+      end
+
+      it "returns invoices with matching metadata filters" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].pluck(:lago_id)).to contain_exactly matching_invoice.id
+      end
+    end
+
+    context "with self billed filters" do
+      let(:params) { {self_billed: true} }
+
+      let(:self_billed_invoice) do
+        create(:invoice, :self_billed, customer:, organization:)
+      end
+
+      let(:non_self_billed_invoice) do
+        create(:invoice, customer:, organization:)
+      end
+
+      before do
+        self_billed_invoice
+        non_self_billed_invoice
+      end
+
+      it "returns self billed invoices" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(1)
+        expect(json[:invoices].first[:lago_id]).to eq(self_billed_invoice.id)
+      end
+
+      context "when self billed is false" do
+        let(:params) { {self_billed: false} }
+
+        it "returns non self billed invoices" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:invoices].count).to eq(1)
+          expect(json[:invoices].first[:lago_id]).to eq(non_self_billed_invoice.id)
+        end
+      end
+
+      context "when self billed is nil" do
+        let(:params) { {self_billed: nil} }
+
+        it "returns all invoices" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:invoices].count).to eq(2)
+        end
+      end
+    end
+
+    context "when invoices are created in multiple billing entities" do
+      let(:billing_entity2) { create(:billing_entity, organization:) }
+      let(:params) { {} }
+
+      let(:invoice1) { create(:invoice, :self_billed, customer:, organization:) }
+      let(:invoice2) { create(:invoice, :self_billed, customer:, organization:, billing_entity: billing_entity2) }
+
+      before do
+        invoice1
+        invoice2
+      end
+
+      it "returns all invoices when not filtering by billing entity" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(2)
+        expect(json[:invoices].pluck(:lago_id)).to match_array([invoice1.id, invoice2.id])
+      end
+
+      context "when filtering by billing entity" do
+        let(:params) { {billing_entity_codes: [billing_entity2.code]} }
+
+        it "returns invoices for the specified billing entity" do
+          subject
+
+          expect(response).to have_http_status(:success)
+          expect(json[:invoices].count).to eq(1)
+          expect(json[:invoices].first[:lago_id]).to eq(invoice2.id)
+        end
+
+        context "when one of billing entities does not exist" do
+          let(:params) { {billing_entity_codes: [billing_entity2.code, SecureRandom.uuid]} }
+
+          it "returns a not found error" do
+            subject
+
+            expect(response).to have_http_status(:not_found)
+            expect(json[:code]).to eq("billing_entity_not_found")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR follows a critical issue on the `GET /api/v1/invoices` when requests were filtered by `external_customer_id` from the GO SDK client. See https://github.com/getlago/lago-go-client/pull/288

A new set of endpoints will be added to retrieve resources scoped to a specific customer.

## Description

This PR starts the list by introducing a new route `GET /api/v1/customers/:externa_id/invoices`.
It will accept all filters already present on `GET /api/v1/invoices` (except for `external_customer_id`)
