### PR TITLE
feat(fixed_charges): Add fixed charges boundaries to InvoiceSubscription

### DIFF
--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -103,20 +103,22 @@ end
 #
 # Table name: invoice_subscriptions
 #
-#  id                     :uuid             not null, primary key
-#  charges_from_datetime  :datetime
-#  charges_to_datetime    :datetime
-#  from_datetime          :datetime
-#  invoicing_reason       :enum
-#  recurring              :boolean
-#  timestamp              :datetime
-#  to_datetime            :datetime
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  invoice_id             :uuid             not null
-#  organization_id        :uuid             not null
-#  regenerated_invoice_id :uuid
-#  subscription_id        :uuid             not null
+#  id                          :uuid             not null, primary key
+#  charges_from_datetime       :datetime
+#  charges_to_datetime         :datetime
+#  fixed_charges_from_datetime :datetime
+#  fixed_charges_to_datetime   :datetime
+#  from_datetime               :datetime
+#  invoicing_reason            :enum
+#  recurring                   :boolean
+#  timestamp                   :datetime
+#  to_datetime                 :datetime
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  invoice_id                  :uuid             not null
+#  organization_id             :uuid             not null
+#  regenerated_invoice_id      :uuid
+#  subscription_id             :uuid             not null
 #
 # Indexes
 #
@@ -127,6 +129,7 @@ end
 #  index_invoice_subscriptions_on_regenerated_invoice_id          (regenerated_invoice_id)
 #  index_invoice_subscriptions_on_subscription_id                 (subscription_id)
 #  index_uniq_invoice_subscriptions_on_charges_from_to_datetime   (subscription_id,charges_from_datetime,charges_to_datetime) UNIQUE WHERE ((created_at >= '2023-06-09 00:00:00'::timestamp without time zone) AND (recurring IS TRUE) AND (regenerated_invoice_id IS NULL))
+#  index_uniq_invoice_subscriptions_on_fixed_charges_boundaries   (subscription_id,fixed_charges_from_datetime,fixed_charges_to_datetime) UNIQUE WHERE ((recurring IS TRUE) AND (regenerated_invoice_id IS NULL))
 #  index_unique_starting_invoice_subscription                     (subscription_id,invoicing_reason) UNIQUE WHERE ((invoicing_reason = 'subscription_starting'::subscription_invoicing_reason) AND (regenerated_invoice_id IS NULL))
 #  index_unique_terminating_invoice_subscription                  (subscription_id,invoicing_reason) UNIQUE WHERE ((invoicing_reason = 'subscription_terminating'::subscription_invoicing_reason) AND (regenerated_invoice_id IS NULL))
 #

--- a/db/migrate/20250911111448_add_fixed_charges_boundaries_to_invoice_subscriptions.rb
+++ b/db/migrate/20250911111448_add_fixed_charges_boundaries_to_invoice_subscriptions.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddFixedChargesBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :invoice_subscriptions, :fixed_charges_from_datetime, :datetime
+    add_column :invoice_subscriptions, :fixed_charges_to_datetime, :datetime
+
+    add_index(
+      :invoice_subscriptions,
+      %i[
+        subscription_id
+        fixed_charges_from_datetime
+        fixed_charges_to_datetime
+      ],
+      unique: true,
+      name: :index_uniq_invoice_subscriptions_on_fixed_charges_boundaries,
+      where: "recurring IS TRUE AND regenerated_invoice_id IS NULL",
+      algorithm: :concurrently
+    )
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -298,6 +298,7 @@ DROP INDEX IF EXISTS public.index_unique_transaction_id;
 DROP INDEX IF EXISTS public.index_unique_terminating_invoice_subscription;
 DROP INDEX IF EXISTS public.index_unique_starting_invoice_subscription;
 DROP INDEX IF EXISTS public.index_unique_applied_to_organization_per_organization;
+DROP INDEX IF EXISTS public.index_uniq_invoice_subscriptions_on_fixed_charges_boundaries;
 DROP INDEX IF EXISTS public.index_uniq_invoice_subscriptions_on_charges_from_to_datetime;
 DROP INDEX IF EXISTS public.index_taxes_on_organization_id;
 DROP INDEX IF EXISTS public.index_taxes_on_code_and_organization_id;
@@ -2758,7 +2759,9 @@ CREATE TABLE public.invoice_subscriptions (
     charges_to_datetime timestamp(6) without time zone,
     invoicing_reason public.subscription_invoicing_reason,
     organization_id uuid NOT NULL,
-    regenerated_invoice_id uuid
+    regenerated_invoice_id uuid,
+    fixed_charges_from_datetime timestamp(6) without time zone,
+    fixed_charges_to_datetime timestamp(6) without time zone
 );
 
 
@@ -7615,6 +7618,13 @@ CREATE UNIQUE INDEX index_uniq_invoice_subscriptions_on_charges_from_to_datetime
 
 
 --
+-- Name: index_uniq_invoice_subscriptions_on_fixed_charges_boundaries; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_uniq_invoice_subscriptions_on_fixed_charges_boundaries ON public.invoice_subscriptions USING btree (subscription_id, fixed_charges_from_datetime, fixed_charges_to_datetime) WHERE ((recurring IS TRUE) AND (regenerated_invoice_id IS NULL));
+
+
+--
 -- Name: index_unique_applied_to_organization_per_organization; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9759,6 +9769,7 @@ ALTER TABLE ONLY public.fixed_charges_taxes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250911111448'),
 ('20250908085959'),
 ('20250903165724'),
 ('20250901141844'),


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

 ## Context

 ### What is the current situation?

**Option 1:**
User has to create a one off invoice alongside the subscription, it will create 2 different invoices.

**Option 2:**
User can add a recurring billable metric and use event to have this fee invoice on subscription renewal, but it won’t appear on the first billing subscription.

 ### What problem are we trying to solve?

At subscription creation or afterward, there is no clear way to invoice a fixed fee that is not tied to events, aside from the subscription fee itself. This fee could be either a one-time charge or a recurring one.

Add fixed charges boundaries to InvoiceSubscriptions records...

Includes a uniq index for recurring invoices.

this is required for minimum commitments computation with fixed charges.