### PR TITLE
feat(payments): Add index scoped to customer

### DIFF
--- a/app/controllers/api/v1/customers/payments_controller.rb
+++ b/app/controllers/api/v1/customers/payments_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Customers
+      class PaymentsController < BaseController
+        def index
+          result = PaymentsQuery.call(
+            organization: current_organization,
+            pagination: {
+              page: params[:page],
+              limit: params[:per_page] || PER_PAGE
+            },
+            filters: params.permit(:invoice_id).merge(external_customer_id: customer.external_id)
+          )
+
+          if result.success?
+            render(
+              json: ::CollectionSerializer.new(
+                result.payments,
+                ::V1::PaymentSerializer,
+                collection_name: resource_name.pluralize,
+                meta: pagination_metadata(result.payments)
+              )
+            )
+          else
+            render_error_response(result)
+          end
+        end
+
+        private
+
+        def resource_name
+          "payment"
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
         scope module: :customers do
           resources :applied_coupons, only: %i[destroy]
           resources :invoices, only: %i[index]
+          resources :payments, only: %i[index]
         end
       end
 

--- a/spec/requests/api/v1/customers/payments_controller_spec.rb
+++ b/spec/requests/api/v1/customers/payments_controller_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Customers::PaymentsController, type: :request do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  describe "GET /api/v1/customers/:external_id/payments" do
+    subject { get_with_token(organization, "/api/v1/customers/#{customer.external_id}/payments", params) }
+
+    let(:params) { {} }
+
+    include_examples "requires API permission", "payment", "read"
+
+    context "with invalid customer id" do
+      subject { get_with_token(organization, "/api/v1/customers/foo/payments", {}) }
+
+      it "returns a 404" do
+        subject
+
+        expect(response).to have_http_status(:not_found)
+        expect(json[:code]).to eq("customer_not_found")
+      end
+    end
+
+    it "returns customer's payments", :aggregate_failures do
+      invoice = create(:invoice, organization:, customer:)
+      invoice2 = create(:invoice, organization:, customer:)
+      payment_request = create(:payment_request, organization:, customer:)
+      first_payment = create(:payment, payable: invoice, customer:)
+      second_payment = create(:payment, payable: invoice2, customer:)
+      third_payment = create(:payment, payable: payment_request, customer:)
+
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:payments].count).to eq(3)
+      expect(json[:payments].map { |r| r[:lago_id] }).to contain_exactly(
+        first_payment.id,
+        second_payment.id,
+        third_payment.id
+      )
+    end
+
+    context "with an invoice belonging to a different customer", :aggregate_failures do
+      let(:params) { {invoice_id: invoice.id} }
+      let(:invoice) { create(:invoice, organization:) }
+
+      before do
+        create(:payment, payable: invoice)
+      end
+
+      it "returns an empty result" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:payments]).to be_empty
+      end
+    end
+
+    context "with invoice" do
+      let(:invoice) { create(:invoice, organization:, customer:) }
+      let(:params) { {invoice_id: invoice.id} }
+      let(:first_payment) { create(:payment, payable: invoice, customer:) }
+
+      before do
+        first_payment
+        create(:payment)
+      end
+
+      it "returns invoice's payments", :aggregate_failures do
+        subject
+        expect(response).to have_http_status(:success)
+        expect(json[:payments].map { |r| r[:lago_id] }).to contain_exactly(first_payment.id)
+        expect(json[:payments].first[:invoice_ids].first).to eq(invoice.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR follows a critical issue on the `GET /api/v1/invoices` when requests were filtered by `external_customer_id` from the GO SDK client. See https://github.com/getlago/lago-go-client/pull/288

A new set of endpoints will be added to retrieve resources scoped to a specific customer.

## Description

This PR adds  new route `GET /api/v1/customers/:externa_id/payments`.
It will accept all filters already present on `GET /api/v1/payments` (except for `external_customer_id`)
