### PR TITLE
feat(subscriptions): Add index scoped to customer

### DIFF
--- a/app/controllers/api/v1/customers/subscriptions_controller.rb
+++ b/app/controllers/api/v1/customers/subscriptions_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Customers
+      class SubscriptionsController < BaseController
+        def index
+          result = SubscriptionsQuery.call(
+            organization: current_organization,
+            pagination: {
+              page: params[:page],
+              limit: params[:per_page] || PER_PAGE
+            },
+            filters: index_filters.merge(external_customer_id: customer.external_id)
+          )
+
+          if result.success?
+            render(
+              json: ::CollectionSerializer.new(
+                result.subscriptions,
+                ::V1::SubscriptionSerializer,
+                collection_name: "subscriptions",
+                meta: pagination_metadata(result.subscriptions)
+              )
+            )
+          else
+            render_error_response(result)
+          end
+        end
+
+        private
+
+        def index_filters
+          filters = params.permit(:plan_code, status: [])
+          filters[:status] = ["active"] if filters[:status].blank?
+          filters
+        end
+
+        def resource_name
+          "subscription"
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
           resources :applied_coupons, only: %i[destroy]
           resources :invoices, only: %i[index]
           resources :payments, only: %i[index]
+          resources :subscriptions, only: %i[index]
         end
       end
 

--- a/spec/requests/api/v1/customers/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/customers/subscriptions_controller_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Customers::SubscriptionsController, type: :request do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:plan) { create(:plan, organization:) }
+
+  let(:external_id) { customer.external_id }
+
+  describe "GET /api/v1/customers/:external_id/subscriptions" do
+    subject { get_with_token(organization, "/api/v1/customers/#{external_id}/subscriptions", params) }
+
+    let!(:subscription) { create(:subscription, customer:, plan:) }
+
+    let(:params) { {} }
+
+    include_examples "requires API permission", "subscription", "read"
+
+    it "returns subscriptions" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:subscriptions].count).to eq(1)
+      expect(json[:subscriptions].first[:lago_id]).to eq(subscription.id)
+    end
+
+    context "with next and previous subscriptions" do
+      let(:previous_subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan: create(:plan, organization:),
+          status: :terminated
+        )
+      end
+
+      let(:next_subscription) do
+        create(
+          :subscription,
+          customer:,
+          plan: create(:plan, organization:),
+          status: :pending
+        )
+      end
+
+      before do
+        subscription.update!(previous_subscription:, next_subscriptions: [next_subscription])
+      end
+
+      it "returns next and previous plan code" do
+        subject
+
+        subscription = json[:subscriptions].first
+        expect(subscription[:previous_plan_code]).to eq(previous_subscription.plan.code)
+        expect(subscription[:next_plan_code]).to eq(next_subscription.plan.code)
+      end
+
+      it "returns the downgrade plan date" do
+        current_date = DateTime.parse("20 Jun 2022")
+
+        travel_to(current_date) do
+          subject
+
+          subscription = json[:subscriptions].first
+          expect(subscription[:downgrade_plan_date]).to eq("2022-07-01")
+        end
+      end
+    end
+
+    context "with pagination" do
+      let(:params) do
+        {
+          page: 1,
+          per_page: 1
+        }
+      end
+
+      before do
+        another_plan = create(:plan, organization:, amount_cents: 30_000)
+        create(:subscription, customer:, plan: another_plan)
+      end
+
+      it "returns subscriptions with correct meta data" do
+        subject
+
+        expect(response).to have_http_status(:success)
+
+        expect(json[:subscriptions].count).to eq(1)
+        expect(json[:meta][:current_page]).to eq(1)
+        expect(json[:meta][:next_page]).to eq(2)
+        expect(json[:meta][:prev_page]).to eq(nil)
+        expect(json[:meta][:total_pages]).to eq(2)
+        expect(json[:meta][:total_count]).to eq(2)
+      end
+    end
+
+    context "with plan code" do
+      let(:params) { {plan_code: plan.code} }
+
+      it "returns subscriptions" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscriptions].count).to eq(1)
+        expect(json[:subscriptions].first[:lago_id]).to eq(subscription.id)
+      end
+    end
+
+    context "with terminated status" do
+      let!(:terminated_subscription) do
+        create(:subscription, customer:, plan: create(:plan, organization:), status: :terminated)
+      end
+
+      let(:params) do
+        {
+          status: ["terminated"]
+        }
+      end
+
+      it "returns terminated subscriptions" do
+        subject
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscriptions].count).to eq(1)
+        expect(json[:subscriptions].first[:lago_id]).to eq(terminated_subscription.id)
+      end
+    end
+
+    context "with unknown customer id" do
+      let(:external_id) { "unknown_customer_id" }
+
+      it "returns an error" do
+        subject
+
+        expect(response).to have_http_status(:not_found)
+        expect(json[:code]).to eq("customer_not_found")
+      end
+    end
+
+    context "when customer does not belongs to the organization" do
+      let(:customer) { create(:customer) }
+
+      it "returns an error" do
+        subject
+
+        expect(response).to have_http_status(:not_found)
+        expect(json[:code]).to eq("customer_not_found")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR follows a critical issue on the `GET /api/v1/invoices` when requests were filtered by `external_customer_id` from the GO SDK client. See https://github.com/getlago/lago-go-client/pull/288

A new set of endpoints will be added to retrieve resources scoped to a specific customer.

## Description

This PR starts the list by introducing a new route `GET /api/v1/customers/:externa_id/subscriptions`.
It will accept all filters already present on `GET /api/v1/subscriptions` (except for `external_customer_id`)
