### PR TITLE
fix(delete-tax): Preserve invoice information when tax is deleted

### DIFF
--- a/app/models/fee/applied_tax.rb
+++ b/app/models/fee/applied_tax.rb
@@ -41,5 +41,5 @@ end
 #
 #  fk_rails_...  (fee_id => fees.id)
 #  fk_rails_...  (organization_id => organizations.id)
-#  fk_rails_...  (tax_id => taxes.id)
+#  fk_rails_...  (tax_id => taxes.id) ON DELETE => nullify
 #

--- a/app/models/invoice/applied_tax.rb
+++ b/app/models/invoice/applied_tax.rb
@@ -64,5 +64,5 @@ end
 #
 #  fk_rails_...  (invoice_id => invoices.id)
 #  fk_rails_...  (organization_id => organizations.id)
-#  fk_rails_...  (tax_id => taxes.id)
+#  fk_rails_...  (tax_id => taxes.id) ON DELETE => nullify
 #

--- a/app/models/tax.rb
+++ b/app/models/tax.rb
@@ -10,9 +10,11 @@ class Tax < ApplicationRecord
 
   has_many :billing_entities_taxes, class_name: "BillingEntity::AppliedTax", dependent: :destroy
   has_many :billing_entities, through: :billing_entities_taxes
-  has_many :fees_taxes, class_name: "Fee::AppliedTax", dependent: :destroy
+  has_many :draft_fee_taxes, -> { joins(fee: :invoice).where(invoices: {status: :draft}) }, class_name: "Fee::AppliedTax", dependent: :destroy
+  has_many :fees_taxes, class_name: "Fee::AppliedTax"
   has_many :fees, through: :fees_taxes
-  has_many :invoices_taxes, class_name: "Invoice::AppliedTax", dependent: :destroy
+  has_many :draft_invoice_taxes, -> { joins(:invoice).where(invoices: {status: :draft}) }, class_name: "Invoice::AppliedTax", dependent: :destroy
+  has_many :invoices_taxes, class_name: "Invoice::AppliedTax"
   has_many :invoices, through: :invoices_taxes
   has_many :credit_notes_taxes, class_name: "CreditNote::AppliedTax", dependent: :destroy
   has_many :credit_notes, through: :credit_notes_taxes

--- a/db/migrate/20250911124033_allow_null_taxes_for_applied_taxes.rb
+++ b/db/migrate/20250911124033_allow_null_taxes_for_applied_taxes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AllowNullTaxesForAppliedTaxes < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      [:invoices_taxes, :fees_taxes].each do |table|
+        remove_foreign_key table, :taxes
+        change_column_null table, :tax_id, true
+        add_foreign_key table, :taxes, on_delete: :nullify
+      end
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -8791,7 +8791,7 @@ ALTER TABLE ONLY public.adjusted_fees
 --
 
 ALTER TABLE ONLY public.invoices_taxes
-    ADD CONSTRAINT fk_rails_6e148ccbb1 FOREIGN KEY (tax_id) REFERENCES public.taxes(id);
+    ADD CONSTRAINT fk_rails_6e148ccbb1 FOREIGN KEY (tax_id) REFERENCES public.taxes(id) ON DELETE SET NULL;
 
 
 --
@@ -9727,7 +9727,7 @@ ALTER TABLE ONLY public.billing_entities
 --
 
 ALTER TABLE ONLY public.fees_taxes
-    ADD CONSTRAINT fk_rails_f98413d404 FOREIGN KEY (tax_id) REFERENCES public.taxes(id);
+    ADD CONSTRAINT fk_rails_f98413d404 FOREIGN KEY (tax_id) REFERENCES public.taxes(id) ON DELETE SET NULL;
 
 
 --
@@ -9770,6 +9770,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250912081524'),
+('20250911124033'),
 ('20250911111448'),
 ('20250908085959'),
 ('20250903165724'),


### PR DESCRIPTION
## Problem
When we delete a `Tax` record, it deletes all the `AppliedTaxes` that were created because of that `Tax`.
We do this for all `AppliedTaxes` records, regardless the owner of that record. Finalized Invoice and Fee can't have that info deleted otherwise they lose how they were calculated. 

## Fix
`AppliedTax` and `Tax` relation has to be loosened, so `AppliedTax` allow nil `Tax` reference.
Whenever we have a Tax deletion, we have to set `Invoice::AppliedTax#tax` and `Fee::AppliedTax#tax` to `nil`. 

We can only delete the `Invoice::AppliedTax#tax` and `Fee::AppliedTax#tax` for draft invoices.
The other types of AppliedTaxes can be deleted because they are used on execution time (i.e when the invoice is created/finalized).  