### PR TITLE
chore(subscription): DRY subscription index in controller and test

### DIFF
--- a/app/controllers/api/v1/customers/subscriptions_controller.rb
+++ b/app/controllers/api/v1/customers/subscriptions_controller.rb
@@ -4,37 +4,13 @@ module Api
   module V1
     module Customers
       class SubscriptionsController < BaseController
-        def index
-          result = SubscriptionsQuery.call(
-            organization: current_organization,
-            pagination: {
-              page: params[:page],
-              limit: params[:per_page] || PER_PAGE
-            },
-            filters: index_filters.merge(external_customer_id: customer.external_id)
-          )
+        include SubscriptionIndex
 
-          if result.success?
-            render(
-              json: ::CollectionSerializer.new(
-                result.subscriptions,
-                ::V1::SubscriptionSerializer,
-                collection_name: "subscriptions",
-                meta: pagination_metadata(result.subscriptions)
-              )
-            )
-          else
-            render_error_response(result)
-          end
+        def index
+          subscription_index(external_customer_id: customer.external_id)
         end
 
         private
-
-        def index_filters
-          filters = params.permit(:plan_code, status: [])
-          filters[:status] = ["active"] if filters[:status].blank?
-          filters
-        end
 
         def resource_name
           "subscription"

--- a/app/controllers/concerns/subscription_index.rb
+++ b/app/controllers/concerns/subscription_index.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module SubscriptionIndex
+  include Pagination
+  extend ActiveSupport::Concern
+
+  def subscription_index(external_customer_id: nil)
+    filters = params.permit(:plan_code, status: [])
+    filters[:status] = ["active"] if filters[:status].blank?
+    filters[:external_customer_id] = external_customer_id
+    result = SubscriptionsQuery.call(
+      organization: current_organization,
+      pagination: {
+        page: params[:page],
+        limit: params[:per_page] || PER_PAGE
+      },
+      filters: filters
+    )
+
+    if result.success?
+      render(
+        json: ::CollectionSerializer.new(
+          result.subscriptions,
+          ::V1::SubscriptionSerializer,
+          collection_name: "subscriptions",
+          meta: pagination_metadata(result.subscriptions)
+        )
+      )
+    else
+      render_error_response(result)
+    end
+  end
+end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -1111,121 +1111,20 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
   describe "GET /api/v1/subscriptions" do
     subject { get_with_token(organization, "/api/v1/subscriptions", params) }
 
-    let!(:subscription) { create(:subscription, customer:, plan:) }
-    let(:params) { {external_customer_id: external_customer_id} }
-    let(:external_customer_id) { customer.external_id }
+    it_behaves_like "a subscription index endpoint" do
+      context "when external customer id is given" do
+        let!(:subscription_2) { create(:subscription, customer: customer_2, organization:, plan:) }
+        let(:customer_2) { create(:customer, organization:) }
 
-    include_examples "requires API permission", "subscription", "read"
+        let(:params) { {external_customer_id: customer_2.external_id} }
 
-    it "returns subscriptions" do
-      subject
-
-      expect(response).to have_http_status(:success)
-      expect(json[:subscriptions].count).to eq(1)
-      expect(json[:subscriptions].first[:lago_id]).to eq(subscription.id)
-    end
-
-    context "with next and previous subscriptions" do
-      let(:previous_subscription) do
-        create(
-          :subscription,
-          customer:,
-          plan: create(:plan, organization:),
-          status: :terminated
-        )
-      end
-
-      let(:next_subscription) do
-        create(
-          :subscription,
-          customer:,
-          plan: create(:plan, organization:),
-          status: :pending
-        )
-      end
-
-      before do
-        subscription.update!(previous_subscription:, next_subscriptions: [next_subscription])
-      end
-
-      it "returns next and previous plan code" do
-        subject
-
-        subscription = json[:subscriptions].first
-        expect(subscription[:previous_plan_code]).to eq(previous_subscription.plan.code)
-        expect(subscription[:next_plan_code]).to eq(next_subscription.plan.code)
-      end
-
-      it "returns the downgrade plan date" do
-        current_date = DateTime.parse("20 Jun 2022")
-
-        travel_to(current_date) do
+        it "returns subscriptions" do
           subject
 
-          subscription = json[:subscriptions].first
-          expect(subscription[:downgrade_plan_date]).to eq("2022-07-01")
+          expect(response).to have_http_status(:success)
+          expect(json[:subscriptions].count).to eq(1)
+          expect(json[:subscriptions].first[:lago_id]).to eq(subscription_2.id)
         end
-      end
-    end
-
-    context "with pagination" do
-      let(:params) do
-        {
-          external_customer_id:,
-          page: 1,
-          per_page: 1
-        }
-      end
-
-      before do
-        another_plan = create(:plan, organization:, amount_cents: 30_000)
-        create(:subscription, customer:, plan: another_plan)
-      end
-
-      it "returns subscriptions with correct meta data" do
-        subject
-
-        expect(response).to have_http_status(:success)
-
-        expect(json[:subscriptions].count).to eq(1)
-        expect(json[:meta][:current_page]).to eq(1)
-        expect(json[:meta][:next_page]).to eq(2)
-        expect(json[:meta][:prev_page]).to eq(nil)
-        expect(json[:meta][:total_pages]).to eq(2)
-        expect(json[:meta][:total_count]).to eq(2)
-      end
-    end
-
-    context "with plan code" do
-      let(:params) { {plan_code: plan.code} }
-
-      it "returns subscriptions" do
-        subject
-
-        expect(response).to have_http_status(:success)
-        expect(json[:subscriptions].count).to eq(1)
-        expect(json[:subscriptions].first[:lago_id]).to eq(subscription.id)
-      end
-    end
-
-    context "with terminated status" do
-      let!(:terminated_subscription) do
-        create(:subscription, customer:, plan: create(:plan, organization:), status: :terminated)
-      end
-
-      let(:params) do
-        {
-          external_customer_id:,
-          status: ["terminated"]
-        }
-      end
-
-      it "returns terminated subscriptions" do
-        subject
-
-        expect(response).to have_http_status(:success)
-        expect(json[:subscriptions].count).to eq(1)
-        expect(json[:subscriptions].first[:lago_id]).to eq(terminated_subscription.id)
       end
     end
   end

--- a/spec/support/shared_examples/subscription_index.rb
+++ b/spec/support/shared_examples/subscription_index.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a subscription index endpoint" do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:, amount_cents: 500, description: "desc") }
+  let!(:subscription) { create(:subscription, customer:, plan:) }
+  let(:external_customer_id) { customer.external_id }
+  let(:params) { {} }
+
+  include_examples "requires API permission", "subscription", "read"
+
+  it "returns subscriptions" do
+    subject
+
+    expect(response).to have_http_status(:success)
+    expect(json[:subscriptions].count).to eq(1)
+    expect(json[:subscriptions].first[:lago_id]).to eq(subscription.id)
+  end
+
+  context "with next and previous subscriptions" do
+    let(:previous_subscription) do
+      create(
+        :subscription,
+        customer:,
+        plan: create(:plan, organization:),
+        status: :terminated
+      )
+    end
+
+    let(:next_subscription) do
+      create(
+        :subscription,
+        customer:,
+        plan: create(:plan, organization:),
+        status: :pending
+      )
+    end
+
+    before do
+      subscription.update!(previous_subscription:, next_subscriptions: [next_subscription])
+    end
+
+    it "returns next and previous plan code" do
+      subject
+
+      subscription = json[:subscriptions].first
+      expect(subscription[:previous_plan_code]).to eq(previous_subscription.plan.code)
+      expect(subscription[:next_plan_code]).to eq(next_subscription.plan.code)
+    end
+
+    it "returns the downgrade plan date" do
+      current_date = DateTime.parse("20 Jun 2022")
+
+      travel_to(current_date) do
+        subject
+
+        subscription = json[:subscriptions].first
+        expect(subscription[:downgrade_plan_date]).to eq("2022-07-01")
+      end
+    end
+  end
+
+  context "with pagination" do
+    let(:params) do
+      {
+        page: 1,
+        per_page: 1
+      }
+    end
+
+    before do
+      another_plan = create(:plan, organization:, amount_cents: 30_000)
+      create(:subscription, customer:, plan: another_plan)
+    end
+
+    it "returns subscriptions with correct meta data" do
+      subject
+
+      expect(response).to have_http_status(:success)
+
+      expect(json[:subscriptions].count).to eq(1)
+      expect(json[:meta][:current_page]).to eq(1)
+      expect(json[:meta][:next_page]).to eq(2)
+      expect(json[:meta][:prev_page]).to eq(nil)
+      expect(json[:meta][:total_pages]).to eq(2)
+      expect(json[:meta][:total_count]).to eq(2)
+    end
+  end
+
+  context "with plan code" do
+    let(:params) { {plan_code: plan.code} }
+
+    it "returns subscriptions" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:subscriptions].count).to eq(1)
+      expect(json[:subscriptions].first[:lago_id]).to eq(subscription.id)
+    end
+  end
+
+  context "with terminated status" do
+    let!(:terminated_subscription) do
+      create(:subscription, customer:, plan: create(:plan, organization:), status: :terminated)
+    end
+
+    let(:params) do
+      {
+        status: ["terminated"]
+      }
+    end
+
+    it "returns terminated subscriptions" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:subscriptions].count).to eq(1)
+      expect(json[:subscriptions].first[:lago_id]).to eq(terminated_subscription.id)
+    end
+  end
+end


### PR DESCRIPTION
## Context

https://github.com/getlago/lago-api/commit/16622f7119121592f05908e3f75609f9bf84fdd0 introduce a `GET /api/v1/customer/:external_customer_id/subscriptions` endpoint. This commit was mainly a copy-paste from the `GET /api/v1/subscriptions` endpoints without the `external_customer_id` filter.

The main issue here is that when updating one endpoint (adding a filter for instance), we might forgot to update the other one.

## Description

This refactors the controller and test to reuse as much code as possible and keep both controllers in sync.