### PR TITLE
chore(payment): DRY payment index in controller and test

### DIFF
--- a/app/controllers/api/v1/customers/payments_controller.rb
+++ b/app/controllers/api/v1/customers/payments_controller.rb
@@ -4,28 +4,10 @@ module Api
   module V1
     module Customers
       class PaymentsController < BaseController
-        def index
-          result = PaymentsQuery.call(
-            organization: current_organization,
-            pagination: {
-              page: params[:page],
-              limit: params[:per_page] || PER_PAGE
-            },
-            filters: params.permit(:invoice_id).merge(external_customer_id: customer.external_id)
-          )
+        include PaymentIndex
 
-          if result.success?
-            render(
-              json: ::CollectionSerializer.new(
-                result.payments,
-                ::V1::PaymentSerializer,
-                collection_name: resource_name.pluralize,
-                meta: pagination_metadata(result.payments)
-              )
-            )
-          else
-            render_error_response(result)
-          end
+        def index
+          payment_index(customer_external_id: customer.external_id)
         end
 
         private

--- a/app/controllers/concerns/payment_index.rb
+++ b/app/controllers/concerns/payment_index.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module PaymentIndex
+  include Pagination
+  extend ActiveSupport::Concern
+
+  def payment_index(customer_external_id: nil)
+    filters = params.permit(:invoice_id)
+    filters[:external_customer_id] = customer_external_id
+    result = PaymentsQuery.call(
+      organization: current_organization,
+      pagination: {
+        page: params[:page],
+        limit: params[:per_page] || PER_PAGE
+      },
+      filters: filters
+    )
+
+    if result.success?
+      render(
+        json: ::CollectionSerializer.new(
+          result.payments,
+          ::V1::PaymentSerializer,
+          collection_name: resource_name.pluralize,
+          meta: pagination_metadata(result.payments)
+        )
+      )
+    else
+      render_error_response(result)
+    end
+  end
+end

--- a/spec/requests/api/v1/customers/payments_controller_spec.rb
+++ b/spec/requests/api/v1/customers/payments_controller_spec.rb
@@ -3,77 +3,35 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Customers::PaymentsController, type: :request do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-
   describe "GET /api/v1/customers/:external_id/payments" do
-    subject { get_with_token(organization, "/api/v1/customers/#{customer.external_id}/payments", params) }
+    it_behaves_like "a payment index endpoint" do
+      subject { get_with_token(organization, "/api/v1/customers/#{customer.external_id}/payments", params) }
 
-    let(:params) { {} }
+      context "with invalid customer id" do
+        subject { get_with_token(organization, "/api/v1/customers/foo/payments", {}) }
 
-    include_examples "requires API permission", "payment", "read"
+        it "returns a 404" do
+          subject
 
-    context "with invalid customer id" do
-      subject { get_with_token(organization, "/api/v1/customers/foo/payments", {}) }
-
-      it "returns a 404" do
-        subject
-
-        expect(response).to have_http_status(:not_found)
-        expect(json[:code]).to eq("customer_not_found")
-      end
-    end
-
-    it "returns customer's payments", :aggregate_failures do
-      invoice = create(:invoice, organization:, customer:)
-      invoice2 = create(:invoice, organization:, customer:)
-      payment_request = create(:payment_request, organization:, customer:)
-      first_payment = create(:payment, payable: invoice, customer:)
-      second_payment = create(:payment, payable: invoice2, customer:)
-      third_payment = create(:payment, payable: payment_request, customer:)
-
-      subject
-
-      expect(response).to have_http_status(:success)
-      expect(json[:payments].count).to eq(3)
-      expect(json[:payments].map { |r| r[:lago_id] }).to contain_exactly(
-        first_payment.id,
-        second_payment.id,
-        third_payment.id
-      )
-    end
-
-    context "with an invoice belonging to a different customer", :aggregate_failures do
-      let(:params) { {invoice_id: invoice.id} }
-      let(:invoice) { create(:invoice, organization:) }
-
-      before do
-        create(:payment, payable: invoice)
+          expect(response).to have_http_status(:not_found)
+          expect(json[:code]).to eq("customer_not_found")
+        end
       end
 
-      it "returns an empty result" do
-        subject
+      context "with an invoice belonging to a different customer" do
+        let(:params) { {invoice_id: invoice.id} }
+        let(:invoice) { create(:invoice, organization:) }
 
-        expect(response).to have_http_status(:success)
-        expect(json[:payments]).to be_empty
-      end
-    end
+        before do
+          create(:payment, payable: invoice)
+        end
 
-    context "with invoice" do
-      let(:invoice) { create(:invoice, organization:, customer:) }
-      let(:params) { {invoice_id: invoice.id} }
-      let(:first_payment) { create(:payment, payable: invoice, customer:) }
+        it "returns an empty result" do
+          subject
 
-      before do
-        first_payment
-        create(:payment)
-      end
-
-      it "returns invoice's payments", :aggregate_failures do
-        subject
-        expect(response).to have_http_status(:success)
-        expect(json[:payments].map { |r| r[:lago_id] }).to contain_exactly(first_payment.id)
-        expect(json[:payments].first[:invoice_ids].first).to eq(invoice.id)
+          expect(response).to have_http_status(:success)
+          expect(json[:payments]).to be_empty
+        end
       end
     end
   end

--- a/spec/requests/api/v1/payments_controller_spec.rb
+++ b/spec/requests/api/v1/payments_controller_spec.rb
@@ -46,62 +46,28 @@ RSpec.describe Api::V1::PaymentsController, type: :request do
   end
 
   describe "GET /api/v1/payments" do
-    subject { get_with_token(organization, "/api/v1/payments", params) }
+    it_behaves_like "a payment index endpoint" do
+      subject { get_with_token(organization, "/api/v1/payments", params) }
 
-    let(:params) { {} }
+      context "with external customer id" do
+        let(:params) { {external_customer_id: customer.external_id} }
 
-    include_examples "requires API permission", "payment", "read"
+        let(:invoice_1) { create(:invoice, organization:, customer:) }
+        let(:invoice_2) { create(:invoice, organization:, customer: create(:customer, organization:)) }
+        let(:payment_1) { create(:payment, organization:, payable: invoice_1) }
+        let(:payment_2) { create(:payment, organization:, payable: invoice_2) }
 
-    it "returns organization's payments", :aggregate_failures do
-      invoice = create(:invoice, organization:)
-      invoice2 = create(:invoice, organization:)
-      payment_request = create(:payment_request, organization:)
-      first_payment = create(:payment, payable: invoice)
-      second_payment = create(:payment, payable: invoice2)
-      third_payment = create(:payment, payable: payment_request)
+        before do
+          payment_1
+          payment_2
+        end
 
-      subject
-
-      expect(response).to have_http_status(:success)
-      expect(json[:payments].count).to eq(3)
-      expect(json[:payments].map { |r| r[:lago_id] }).to contain_exactly(
-        first_payment.id,
-        second_payment.id,
-        third_payment.id
-      )
-    end
-
-    context "with a not found invoice", :aggregate_failures do
-      let(:params) { {invoice_id: SecureRandom.uuid} }
-
-      before do
-        invoice = create(:invoice, organization:)
-        create(:payment, payable: invoice)
-      end
-
-      it "returns an empty result" do
-        subject
-
-        expect(response).to have_http_status(:success)
-        expect(json[:payments]).to be_empty
-      end
-    end
-
-    context "with invoice" do
-      let(:invoice) { create(:invoice, organization:) }
-      let(:params) { {invoice_id: invoice.id} }
-      let(:first_payment) { create(:payment, payable: invoice) }
-
-      before do
-        first_payment
-        create(:payment)
-      end
-
-      it "returns invoices's payments", :aggregate_failures do
-        subject
-        expect(response).to have_http_status(:success)
-        expect(json[:payments].map { |r| r[:lago_id] }).to contain_exactly(first_payment.id)
-        expect(json[:payments].first[:invoice_ids].first).to eq(invoice.id)
+        it "returns the payments of the customer" do
+          subject
+          expect(response).to have_http_status(:ok)
+          expect(json[:payments].count).to eq(1)
+          expect(json[:payments].first[:lago_id]).to eq(payment_1.id)
+        end
       end
     end
   end

--- a/spec/support/shared_examples/payment_index.rb
+++ b/spec/support/shared_examples/payment_index.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a payment index endpoint" do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:params) { {} }
+
+  include_examples "requires API permission", "payment", "read"
+
+  it "returns customer's payments" do
+    invoice = create(:invoice, organization:, customer:)
+    invoice2 = create(:invoice, organization:, customer:)
+    payment_request = create(:payment_request, organization:, customer:)
+    first_payment = create(:payment, payable: invoice, customer:)
+    second_payment = create(:payment, payable: invoice2, customer:)
+    third_payment = create(:payment, payable: payment_request, customer:)
+
+    subject
+
+    expect(response).to have_http_status(:success)
+    expect(json[:payments].count).to eq(3)
+    expect(json[:payments].map { |r| r[:lago_id] }).to contain_exactly(
+      first_payment.id,
+      second_payment.id,
+      third_payment.id
+    )
+  end
+
+  context "with invoice_id filter" do
+    let(:invoice) { create(:invoice, organization:, customer:) }
+    let(:params) { {invoice_id: invoice.id} }
+    let(:first_payment) { create(:payment, payable: invoice, customer:) }
+
+    before do
+      first_payment
+      create(:payment)
+    end
+
+    it "returns invoice's payments" do
+      subject
+      expect(response).to have_http_status(:success)
+      expect(json[:payments].map { |r| r[:lago_id] }).to contain_exactly(first_payment.id)
+      expect(json[:payments].first[:invoice_ids].first).to eq(invoice.id)
+    end
+  end
+end


### PR DESCRIPTION
## Context

https://github.com/getlago/lago-api/commit/e7b95dc43fd920fa552f2973a75375191c213066 introduce a `GET /api/v1/customer/:external_customer_id/payments` endpoint. This commit was mainly a copy-paste from the `GET /api/v1/payments` endpoints without the `external_customer_id` filter.

The main issue here is that when updating one endpoint (adding a filter for instance), we might forgot to update the other one.

## Description

This refactors the controller and test to reuse as much code as possible and keep both controllers in sync.