### PR TITLE
chore(payment-request): DRY payment request index in controller and test

### DIFF
--- a/app/controllers/api/v1/customers/payment_requests_controller.rb
+++ b/app/controllers/api/v1/customers/payment_requests_controller.rb
@@ -4,29 +4,10 @@ module Api
   module V1
     module Customers
       class PaymentRequestsController < BaseController
-        def index
-          result = PaymentRequestsQuery.call(
-            organization: current_organization,
-            pagination: {
-              page: params[:page],
-              limit: params[:per_page] || PER_PAGE
-            },
-            filters: params.permit(:payment_status).merge(external_customer_id: customer.external_id)
-          )
+        include PaymentRequestIndex
 
-          if result.success?
-            render(
-              json: ::CollectionSerializer.new(
-                result.payment_requests.preload(:customer, :invoices),
-                ::V1::PaymentRequestSerializer,
-                collection_name: "payment_requests",
-                meta: pagination_metadata(result.payment_requests),
-                includes: %i[customer invoices]
-              )
-            )
-          else
-            render_error_response(result)
-          end
+        def index
+          payment_request_index(external_customer_id: customer.external_id)
         end
 
         private

--- a/app/controllers/concerns/payment_request_index.rb
+++ b/app/controllers/concerns/payment_request_index.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module PaymentRequestIndex
+  include Pagination
+  extend ActiveSupport::Concern
+
+  def payment_request_index(external_customer_id:)
+    filters = params.permit(:payment_status)
+    filters[:external_customer_id] = external_customer_id
+    result = PaymentRequestsQuery.call(
+      organization: current_organization,
+      pagination: {
+        page: params[:page],
+        limit: params[:per_page] || PER_PAGE
+      },
+      filters: filters
+    )
+
+    if result.success?
+      render(
+        json: ::CollectionSerializer.new(
+          result.payment_requests.preload(:customer, :invoices),
+          ::V1::PaymentRequestSerializer,
+          collection_name: "payment_requests",
+          meta: pagination_metadata(result.payment_requests),
+          includes: %i[customer invoices]
+        )
+      )
+    else
+      render_error_response(result)
+    end
+  end
+end

--- a/spec/factories/payment_requests.rb
+++ b/spec/factories/payment_requests.rb
@@ -16,6 +16,14 @@ FactoryBot.define do
       invoices { [] }
     end
 
+    trait :succeeded do
+      payment_status { "succeeded" }
+    end
+
+    trait :failed do
+      payment_status { "failed" }
+    end
+
     after(:create) do |payment_request, evaluator|
       evaluator.invoices.each do |invoice|
         create(:payment_request_applied_invoice, payment_request:, invoice:)

--- a/spec/requests/api/v1/customers/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/customers/payment_requests_controller_spec.rb
@@ -3,70 +3,32 @@
 require "rails_helper"
 
 RSpec.describe Api::V1::Customers::PaymentRequestsController, type: :request do
-  let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization:) }
-
-  let(:external_id) { customer.external_id }
-
   describe "GET /api/v1/customers/:external_id/payment_requests" do
-    subject { get_with_token(organization, "/api/v1/customers/#{external_id}/payment_requests", params) }
+    include_examples "a payment request index endpoint" do
+      subject { get_with_token(organization, "/api/v1/customers/#{external_id}/payment_requests", params) }
 
-    let(:params) { {} }
+      let(:external_id) { customer.external_id }
 
-    include_examples "requires API permission", "payment_request", "read"
+      context "with unknown customer" do
+        let(:external_id) { SecureRandom.uuid }
 
-    it "returns customer's payment requests" do
-      first_payment_request = create(:payment_request, customer:)
-      second_payment_request = create(:payment_request, customer:)
+        it "returns a not found error" do
+          subject
 
-      subject
-
-      expect(response).to have_http_status(:success)
-      expect(json[:payment_requests].count).to eq(2)
-      expect(json[:payment_requests].map { |r| r[:lago_id] }).to contain_exactly(
-        first_payment_request.id,
-        second_payment_request.id
-      )
-    end
-
-    context "with unknown customer" do
-      let(:external_id) { SecureRandom.uuid }
-
-      it "returns a not found error" do
-        subject
-
-        expect(response).to have_http_status(:not_found)
-        expect(json[:code]).to eq("customer_not_found")
+          expect(response).to have_http_status(:not_found)
+          expect(json[:code]).to eq("customer_not_found")
+        end
       end
-    end
 
-    context "with customer from another organization" do
-      let(:customer) { create(:customer) }
+      context "with customer from another organization" do
+        let(:customer) { create(:customer) }
 
-      it "returns a not found error" do
-        subject
+        it "returns a not found error" do
+          subject
 
-        expect(response).to have_http_status(:not_found)
-        expect(json[:code]).to eq("customer_not_found")
-      end
-    end
-
-    context "with payment_status" do
-      let(:params) { {payment_status: ["failed"]} }
-
-      it "returns customer's payment requests" do
-        invoice = create(:invoice, customer:)
-        first_payment_request = create(:payment_request, customer:, invoices: [invoice], payment_status: "failed")
-        create(:payment_request)
-
-        subject
-
-        expect(response).to have_http_status(:success)
-        expect(json[:payment_requests].map { |r| r[:lago_id] }).to contain_exactly(
-          first_payment_request.id
-        )
-        expect(json[:payment_requests].first[:customer][:lago_id]).to eq(customer.id)
-        expect(json[:payment_requests].first[:invoices].first[:lago_id]).to eq(invoice.id)
+          expect(response).to have_http_status(:not_found)
+          expect(json[:code]).to eq("customer_not_found")
+        end
       end
     end
   end

--- a/spec/support/shared_examples/payment_request_index.rb
+++ b/spec/support/shared_examples/payment_request_index.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a payment request index endpoint" do
+  let(:organization) { create(:organization) }
+  let(:params) { {} }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:payment_request) { create(:payment_request, customer:) }
+  let(:second_payment_request) { create(:payment_request, customer:) }
+
+  include_examples "requires API permission", "payment_request", "read"
+
+  context "without filters" do
+    before do
+      payment_request
+      second_payment_request
+    end
+
+    it "returns organization's payment requests" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:payment_requests].count).to eq(2)
+      expect(json[:payment_requests].map { |r| r[:lago_id] }).to contain_exactly(
+        payment_request.id,
+        second_payment_request.id
+      )
+    end
+  end
+
+  context "with payment_status filter" do
+    let(:second_payment_request) { create(:payment_request, :succeeded, customer:) }
+    let(:params) { {payment_status: "pending"} }
+
+    before do
+      payment_request
+      second_payment_request
+    end
+
+    it "returns payment requests with the given payment status" do
+      subject
+
+      expect(response).to have_http_status(:success)
+      expect(json[:payment_requests].count).to eq(1)
+      expect(json[:payment_requests].map { |r| r[:lago_id] }).to contain_exactly(
+        payment_request.id
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

https://github.com/getlago/lago-api/commit/b2befc225a914ef65009f96232aa38e80cebc58c introduce a `GET /api/v1/customer/:external_customer_id/payment_requests` endpoint. This commit was mainly a copy-paste from the `GET /api/v1/payment_requests` endpoints without the `external_customer_id` filter.

The main issue here is that when updating one endpoint (adding a filter for instance), we might forgot to update the other one.

## Description

This refactors the controller and test to reuse as much code as possible and keep both controllers in sync.