### PR TITLE
feat(semiannual): Add semiannual interval to models

### DIFF
--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -46,7 +46,7 @@ class InvoiceSubscription < ApplicationRecord
 
     base_query = base_query.recurring if recurring
 
-    if subscription.plan.yearly? && subscription.plan.bill_charges_monthly?
+    if subscription.plan.charges_billed_in_monthly_split_intervals?
       base_query = base_query
         .where(charges_from_datetime: boundaries.charges_from_datetime)
         .where(charges_to_datetime: boundaries.charges_to_datetime)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -39,6 +39,7 @@ class Plan < ApplicationRecord
     monthly
     yearly
     quarterly
+    semiannual
   ].freeze
 
   enum :interval, INTERVALS
@@ -69,6 +70,10 @@ class Plan < ApplicationRecord
     trial_period.present? && trial_period.positive?
   end
 
+  def charges_billed_in_monthly_split_intervals?
+    bill_charges_monthly? && (yearly? || semiannual?)
+  end
+
   def invoice_name
     invoice_display_name.presence || name
   end
@@ -80,6 +85,7 @@ class Plan < ApplicationRecord
     return amount_cents if yearly?
     return amount_cents * 12 if monthly?
     return amount_cents * 4 if quarterly?
+    return amount_cents * 2 if semiannual?
 
     amount_cents * 52
   end

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -15,7 +15,8 @@ class RecurringTransactionRule < ApplicationRecord
     :weekly,
     :monthly,
     :quarterly,
-    :yearly
+    :yearly,
+    :semiannual
   ].freeze
 
   METHODS = [

--- a/schema.graphql
+++ b/schema.graphql
@@ -8028,6 +8028,7 @@ type PlanEntitlementPrivilegeObject {
 enum PlanInterval {
   monthly
   quarterly
+  semiannual
   weekly
   yearly
 }
@@ -9032,6 +9033,7 @@ type Query {
 enum RecurringTransactionIntervalEnum {
   monthly
   quarterly
+  semiannual
   weekly
   yearly
 }

--- a/schema.json
+++ b/schema.json
@@ -40248,6 +40248,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "semiannual",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -48478,6 +48484,12 @@
             },
             {
               "name": "yearly",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "semiannual",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -61,29 +61,195 @@ RSpec.describe Plan, type: :model do
     end
   end
 
-  describe "#yearly_amount_cents" do
-    let(:plan) do
-      build(:plan, interval: :yearly, amount_cents: 100)
+  describe "#billed_in_monthly_split_intervals?" do
+    subject(:method_call) { plan.charges_billed_in_monthly_split_intervals? }
+
+    let(:plan) { build_stubbed(:plan, interval:, bill_charges_monthly:) }
+
+    context "when interval is yearly" do
+      let(:interval) { :yearly }
+
+      context "when bill charges monthly is true" do
+        let(:bill_charges_monthly) { true }
+
+        it "returns true" do
+          expect(subject).to be true
+        end
+      end
+
+      context "when bill charges monthly is false" do
+        let(:bill_charges_monthly) { false }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+
+      context "when bill charges monthly is nil" do
+        let(:bill_charges_monthly) { nil }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
     end
 
-    it { expect(plan.yearly_amount_cents).to eq(100) }
+    context "when interval is semiannual" do
+      let(:interval) { :semiannual }
+
+      context "when bill charges monthly is true" do
+        let(:bill_charges_monthly) { true }
+
+        it "returns true" do
+          expect(subject).to be true
+        end
+      end
+
+      context "when bill charges monthly is false" do
+        let(:bill_charges_monthly) { false }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+
+      context "when bill charges monthly is nil" do
+        let(:bill_charges_monthly) { nil }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+    end
+
+    context "when interval is quarterly" do
+      let(:interval) { :quarterly }
+
+      context "when bill charges monthly is true" do
+        let(:bill_charges_monthly) { true }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+
+      context "when bill charges monthly is false" do
+        let(:bill_charges_monthly) { false }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+
+      context "when bill charges monthly is nil" do
+        let(:bill_charges_monthly) { nil }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+    end
+
+    context "when interval is monthly" do
+      let(:interval) { :monthly }
+
+      context "when bill charges monthly is true" do
+        let(:bill_charges_monthly) { true }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+
+      context "when bill charges monthly is false" do
+        let(:bill_charges_monthly) { false }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+
+      context "when bill charges monthly is nil" do
+        let(:bill_charges_monthly) { nil }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+    end
+
+    context "when interval is weekly" do
+      let(:interval) { :weekly }
+
+      context "when bill charges monthly is true" do
+        let(:bill_charges_monthly) { true }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+
+      context "when bill charges monthly is false" do
+        let(:bill_charges_monthly) { false }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+
+      context "when bill charges monthly is nil" do
+        let(:bill_charges_monthly) { nil }
+
+        it "returns false" do
+          expect(subject).to be false
+        end
+      end
+    end
+  end
+
+  describe "#yearly_amount_cents" do
+    subject(:method_call) { plan.yearly_amount_cents }
+
+    let(:plan) { build_stubbed(:plan, interval:, amount_cents: 100) }
+
+    context "when plan is yearly" do
+      let(:interval) { :yearly }
+
+      it "returns the correct amount" do
+        expect(subject).to eq(100)
+      end
+    end
 
     context "when plan is monthly" do
-      before { plan.interval = "monthly" }
+      let(:interval) { :monthly }
 
-      it { expect(plan.yearly_amount_cents).to eq(1200) }
+      it "returns the correct amount" do
+        expect(subject).to eq(1200)
+      end
     end
 
     context "when plan is weekly" do
-      before { plan.interval = "weekly" }
+      let(:interval) { :weekly }
 
-      it { expect(plan.yearly_amount_cents).to eq(5200) }
+      it "returns the correct amount" do
+        expect(subject).to eq(5200)
+      end
     end
 
     context "when plan is quarterly" do
-      before { plan.interval = "quarterly" }
+      let(:interval) { :quarterly }
 
-      it { expect(plan.yearly_amount_cents).to eq(400) }
+      it "returns the correct amount" do
+        expect(subject).to eq(400)
+      end
+    end
+
+    context "when plan is semiannual" do
+      let(:interval) { :semiannual }
+
+      it "returns the correct amount" do
+        expect(subject).to eq(200)
+      end
     end
   end
 

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RecurringTransactionRule, type: :model do
   describe "enums" do
     it "defines expected enum values" do
       expect(described_class.defined_enums).to include(
-        "interval" => hash_including("weekly", "monthly", "quarterly", "yearly"),
+        "interval" => hash_including("weekly", "monthly", "quarterly", "yearly", "semiannual"),
         "method" => hash_including("fixed", "target"),
         "trigger" => hash_including("interval", "threshold"),
         "status" => hash_including("active", "terminated")


### PR DESCRIPTION
## Context

When creating a plan, a new interval option should be available: `semiannual`.
In order to enable that, we’ll need to add it to the model, services and GQL.

## Description

This PR adds the new interval `semiannual` to all the models and it also updates the GraphQL schema.