### PR TITLE
fix(wallet): Fix `GET /api/v1/wallets` when no params is provided

### DIFF
--- a/app/controllers/concerns/invoice_index.rb
+++ b/app/controllers/concerns/invoice_index.rb
@@ -4,7 +4,7 @@ module InvoiceIndex
   include Pagination
   extend ActiveSupport::Concern
 
-  def invoice_index(customer_external_id: nil)
+  def invoice_index(customer_external_id:)
     billing_entities = current_organization.all_billing_entities.where(code: params[:billing_entity_codes]) if params[:billing_entity_codes].present?
     return not_found_error(resource: "billing_entity") if params[:billing_entity_codes].present? && billing_entities.count != params[:billing_entity_codes].count
 

--- a/app/controllers/concerns/payment_index.rb
+++ b/app/controllers/concerns/payment_index.rb
@@ -4,7 +4,7 @@ module PaymentIndex
   include Pagination
   extend ActiveSupport::Concern
 
-  def payment_index(customer_external_id: nil)
+  def payment_index(customer_external_id:)
     filters = params.permit(:invoice_id)
     filters[:external_customer_id] = customer_external_id
     result = PaymentsQuery.call(

--- a/app/controllers/concerns/subscription_index.rb
+++ b/app/controllers/concerns/subscription_index.rb
@@ -4,7 +4,7 @@ module SubscriptionIndex
   include Pagination
   extend ActiveSupport::Concern
 
-  def subscription_index(external_customer_id: nil)
+  def subscription_index(external_customer_id:)
     filters = params.permit(:plan_code, status: [])
     filters[:status] = ["active"] if filters[:status].blank?
     filters[:external_customer_id] = external_customer_id

--- a/app/queries/wallets_query.rb
+++ b/app/queries/wallets_query.rb
@@ -29,7 +29,7 @@ class WalletsQuery < BaseQuery
   end
 
   def validate_filters
-    if filters.to_h.key? :external_customer_id
+    if filters.external_customer_id
       result.not_found_failure!(resource: "customer") unless customer_exists?
     end
   end

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -760,12 +760,14 @@ RSpec.describe Api::V1::WalletsController, type: :request do
   describe "GET /api/v1/wallets" do
     it_behaves_like "a wallet index endpoint" do
       subject do
-        get_with_token(organization, "/api/v1/wallets?external_customer_id=#{external_id}", params)
+        get_with_token(organization, "/api/v1/wallets", params)
       end
 
       context "when external_customer_id does not belong to the current organization" do
         let(:other_org_customer) { create(:customer) }
         let(:external_id) { other_org_customer.external_id }
+
+        let(:params) { {external_customer_id: external_id} }
 
         it "returns a not found error" do
           subject

--- a/spec/support/shared_examples/wallet_index.rb
+++ b/spec/support/shared_examples/wallet_index.rb
@@ -2,7 +2,6 @@
 
 RSpec.shared_examples "a wallet index endpoint" do
   let!(:wallet) { create(:wallet, customer:) }
-  let(:external_id) { customer.external_id }
   let(:params) { {page: 1, per_page: 1} }
 
   include_examples "requires API permission", "wallet", "read"


### PR DESCRIPTION
## Context

If we call `GET /api/v1/wallets` without `external_customer_id` parameter, we end up with a 404 error:

```json
{
	"status": 404,
	"error": "Not Found",
	"code": "customer_not_found"
}
```

## Description

This fixes that bug.
