### PR TITLE
feat(webhooks): Send entitlements in `plan.*` webhooks payload

### DIFF
--- a/app/services/webhooks/plans/created_service.rb
+++ b/app/services/webhooks/plans/created_service.rb
@@ -9,7 +9,7 @@ module Webhooks
         ::V1::PlanSerializer.new(
           object,
           root_name: "plan",
-          includes: %i[charges usage_thresholds taxes minimum_commitment]
+          includes: %i[charges usage_thresholds taxes minimum_commitment entitlements]
         )
       end
 

--- a/app/services/webhooks/plans/updated_service.rb
+++ b/app/services/webhooks/plans/updated_service.rb
@@ -9,7 +9,7 @@ module Webhooks
         ::V1::PlanSerializer.new(
           object,
           root_name: "plan",
-          includes: %i[charges usage_thresholds taxes minimum_commitment]
+          includes: %i[charges usage_thresholds taxes minimum_commitment entitlements]
         )
       end
 

--- a/spec/services/webhooks/plans/created_service_spec.rb
+++ b/spec/services/webhooks/plans/created_service_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Webhooks::Plans::CreatedService do
   let(:plan) { create(:plan, organization:) }
 
   describe ".call" do
-    it_behaves_like "creates webhook", "plan.created", "plan"
+    it_behaves_like "creates webhook", "plan.created", "plan", {
+      "code" => String,
+      "charges" => Array,
+      "usage_thresholds" => Array,
+      "taxes" => Array,
+      "entitlements" => Array
+    }
   end
 end

--- a/spec/services/webhooks/plans/updated_service_spec.rb
+++ b/spec/services/webhooks/plans/updated_service_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Webhooks::Plans::UpdatedService do
   let(:plan) { create(:plan, organization:) }
 
   describe ".call" do
-    it_behaves_like "creates webhook", "plan.updated", "plan"
+    it_behaves_like "creates webhook", "plan.updated", "plan", {
+      "code" => String,
+      "charges" => Array,
+      "usage_thresholds" => Array,
+      "taxes" => Array,
+      "entitlements" => Array
+    }
   end
 end


### PR DESCRIPTION
Updating entitlements of a plan will trigger the `plan.*` webhooks.

In the serializer, we take care of the eager loading.