### PR TITLE
fix(activity_log.customer): Separate customer.created from customer.u…

### DIFF
--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -507,6 +507,12 @@ RSpec.describe Customers::UpsertFromApiService, type: :service do
       expect(SendWebhookJob).to have_received(:perform_later).with("customer.updated", customer)
     end
 
+    it "produces an activity log" do
+      result = described_class.call(organization:, params: create_args)
+
+      expect(Utils::ActivityLog).to have_produced("customer.updated").after_commit.with(result.customer)
+    end
+
     context "with provider customer" do
       let(:payment_provider) { create(:stripe_provider, organization:) }
       let(:stripe_customer) { create(:stripe_customer, customer:, payment_provider:) }


### PR DESCRIPTION
## Problem
Updating a customer from the API logs the wrong activity logs

## Reproduce

1. Create a customer from the API
2. Update this customer from the API

The activity logs in both cases is `customer.created`. The second one should be `customer.updated` though.

## Fix
Have the activity logged different in `Customers::UpsertFromApiService`. 