### PR TITLE
feat(recurring-transaction-rules): Apply wallet's min and max limits on create

### DIFF
--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -50,7 +50,7 @@ module Wallets
         validate_wallet_initial_amount! wallet
 
         if params[:recurring_transaction_rules].present?
-          Wallets::RecurringTransactionRules::CreateService.call(wallet:, wallet_params: params)
+          Wallets::RecurringTransactionRules::CreateService.call!(wallet:, wallet_params: params)
         end
 
         billable_metrics.each do |bm|

--- a/app/services/wallets/recurring_transaction_rules/create_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/create_service.rb
@@ -68,14 +68,19 @@ module Wallets
       end
 
       def validate_paid_credits!(credits_amount:, ignore_validation:)
-        return unless method == "fixed"
+        return if method != "fixed" || BigDecimal(credits_amount).floor(5).zero?
 
-        Validators::WalletTransactionAmountLimitsValidator.new(
+        validator = Validators::WalletTransactionAmountLimitsValidator.new(
           result,
           wallet:,
           credits_amount:,
           ignore_validation:
-        ).raise_if_invalid!
+        )
+
+        unless validator.valid?
+          result.single_validation_failure!(field: :recurring_transaction_rules, error_code: "invalid_recurring_rule")
+          result.raise_if_error!
+        end
       end
     end
   end

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -189,7 +189,8 @@ RSpec.describe Wallets::CreateService, type: :service do
           expiration_at:,
           paid_credits:,
           granted_credits:,
-          recurring_transaction_rules: rules
+          recurring_transaction_rules: rules,
+          paid_top_up_max_amount_cents: "5000"
         }
       end
 
@@ -253,6 +254,23 @@ RSpec.describe Wallets::CreateService, type: :service do
 
         it "returns an error" do
           expect(service_result).not_to be_success
+          expect(service_result.error.messages[:recurring_transaction_rules]).to eq(["invalid_recurring_rule"])
+        end
+      end
+
+      context "when paid credits exceeds wallet limits" do
+        let(:rules) do
+          [
+            {
+              trigger: "interval",
+              interval: "monthly",
+              paid_credits: "100"
+            }
+          ]
+        end
+
+        it "returns an error" do
+          expect(service_result).to be_failure
           expect(service_result.error.messages[:recurring_transaction_rules]).to eq(["invalid_recurring_rule"])
         end
       end

--- a/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
@@ -109,7 +109,24 @@ RSpec.describe Wallets::RecurringTransactionRules::CreateService do
             expect { create_service.call }.not_to change { wallet.reload.recurring_transaction_rules.count }
 
             expect(create_service.call).to be_failure
-            expect(create_service.call.error.messages).to match({paid_credits: ["amount_below_minimum"]})
+            expect(create_service.call.error.messages).to match({recurring_transaction_rules: ["invalid_recurring_rule"]})
+          end
+        end
+
+        context "when paid credits amount is zero" do
+          let(:paid_credits) { "0" }
+
+          it "creates rule with expected attributes" do
+            expect { create_service.call }.to change { wallet.reload.recurring_transaction_rules.count }.by(1)
+
+            expect(wallet.recurring_transaction_rules.first).to have_attributes(
+              granted_credits: 0.0,
+              method: "fixed",
+              paid_credits: 0.0,
+              target_ongoing_balance: nil,
+              threshold_credits: 1.0,
+              trigger: "threshold"
+            )
           end
         end
       end


### PR DESCRIPTION
# Description

Make sure that recurring rules `paid_credits` are aligned with limitations on min/max set on wallet in case of `fixed` rule.
`target` rules does not need this validation as it's amounts calculated dynamically depending on `ongoing` and `target` balance.
