### PR TITLE
feat(fixed_charges): Compute date boundaries for Fixed Charges

### DIFF
--- a/app/services/subscriptions/dates/monthly_service.rb
+++ b/app/services/subscriptions/dates/monthly_service.rb
@@ -36,6 +36,9 @@ module Subscriptions
       end
 
       alias_method :compute_charges_duration, :compute_duration
+      alias_method :compute_fixed_charges_duration, :compute_charges_duration
+      alias_method :compute_fixed_charges_from_date, :compute_charges_from_date
+      alias_method :compute_fixed_charges_to_date, :compute_charges_to_date
 
       private
 

--- a/app/services/subscriptions/dates/quarterly_service.rb
+++ b/app/services/subscriptions/dates/quarterly_service.rb
@@ -37,6 +37,9 @@ module Subscriptions
       end
 
       alias_method :compute_charges_duration, :compute_duration
+      alias_method :compute_fixed_charges_duration, :compute_charges_duration
+      alias_method :compute_fixed_charges_from_date, :compute_charges_from_date
+      alias_method :compute_fixed_charges_to_date, :compute_charges_to_date
 
       def compute_base_date
         # NOTE: if subscription anniversary is on last day of month and current month days count

--- a/app/services/subscriptions/dates/weekly_service.rb
+++ b/app/services/subscriptions/dates/weekly_service.rb
@@ -72,6 +72,9 @@ module Subscriptions
       end
 
       alias_method :compute_charges_duration, :compute_duration
+      alias_method :compute_fixed_charges_duration, :compute_charges_duration
+      alias_method :compute_fixed_charges_from_date, :compute_charges_from_date
+      alias_method :compute_fixed_charges_to_date, :compute_charges_to_date
     end
   end
 end

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -64,6 +64,26 @@ module Subscriptions
         compute_to_date(compute_charges_from_date)
       end
 
+      def compute_fixed_charges_from_date
+        return monthly_service.compute_fixed_charges_from_date if plan.bill_fixed_charges_monthly
+
+        if terminated?
+          return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_year
+        end
+
+        return compute_from_date if plan.pay_in_arrears?
+        return base_date.beginning_of_year if calendar?
+
+        previous_anniversary_day(base_date)
+      end
+
+      def compute_fixed_charges_to_date
+        return monthly_service.compute_fixed_charges_to_date if plan.bill_fixed_charges_monthly
+        return compute_fixed_charges_from_date.end_of_year if calendar?
+
+        compute_to_date(compute_fixed_charges_from_date)
+      end
+
       def compute_next_end_of_period
         return billing_date.end_of_year if calendar?
 
@@ -104,6 +124,12 @@ module Subscriptions
 
       def compute_charges_duration(from_date:)
         return monthly_service.compute_charges_duration(from_date:) if plan.bill_charges_monthly
+
+        compute_duration(from_date:)
+      end
+
+      def compute_fixed_charges_duration(from_date:)
+        return monthly_service.compute_fixed_charges_duration(from_date:) if plan.bill_fixed_charges_monthly
 
         compute_duration(from_date:)
       end

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -173,6 +173,10 @@ module Subscriptions
       compute_charges_duration(from_date: compute_charges_from_date)
     end
 
+    def fixed_charges_duration_in_days
+      compute_fixed_charges_duration(from_date: compute_fixed_charges_from_date)
+    end
+
     private
 
     attr_accessor :subscription, :billing_at, :current_usage
@@ -273,6 +277,14 @@ module Subscriptions
     end
 
     def compute_charges_to_date
+      raise(NotImplementedError)
+    end
+
+    def compute_fixed_charges_from_date
+      raise(NotImplementedError)
+    end
+
+    def compute_fixed_charges_to_date
       raise(NotImplementedError)
     end
 

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -32,7 +32,9 @@ module Subscriptions
 
       {
         charges_from_date: date_service.charges_from_datetime&.to_date,
-        charges_to_date: date_service.charges_to_datetime&.to_date
+        charges_to_date: date_service.charges_to_datetime&.to_date,
+        fixed_charges_from_date: date_service.fixed_charges_from_datetime&.to_date,
+        fixed_charges_to_date: date_service.fixed_charges_to_datetime&.to_date
       }
     end
 
@@ -101,6 +103,37 @@ module Subscriptions
       return unless subscription.started_at
 
       datetime = customer_timezone_shift(compute_charges_to_date, end_of_day: true)
+      datetime = subscription.terminated_at if subscription.terminated_at?(datetime)
+      datetime = subscription.started_at if datetime < subscription.started_at
+
+      datetime
+    end
+
+    def fixed_charges_from_datetime
+      return unless subscription.started_at
+
+      datetime = customer_timezone_shift(compute_fixed_charges_from_date)
+
+      # NOTE: If customer applicable timezone changes during a billing period, there is a risk to double count events
+      #       or to miss some. To prevent it, we have to ensure that invoice bounds does not overlap or that there is no
+      #       hole between a fixed_charges_from_datetime and the fixed_charges_to_datetime of the previous period
+      if timezone_has_changed? && previous_fixed_charge_to_datetime
+        new_datetime = previous_fixed_charge_to_datetime + 1.second
+
+        # NOTE: Ensure that the invoice is really the previous one
+        #       26 hours is the maximum time difference between two places in the world
+        datetime = new_datetime if ((datetime.in_time_zone - new_datetime.in_time_zone) / 1.hour).abs < 26
+      end
+
+      datetime = subscription.started_at if datetime < subscription.started_at
+
+      datetime
+    end
+
+    def fixed_charges_to_datetime
+      return unless subscription.started_at
+
+      datetime = customer_timezone_shift(compute_fixed_charges_to_date, end_of_day: true)
       datetime = subscription.terminated_at if subscription.terminated_at?(datetime)
       datetime = subscription.started_at if datetime < subscription.started_at
 
@@ -183,6 +216,12 @@ module Subscriptions
       return if last_invoice_subscription.blank?
 
       last_invoice_subscription.charges_to_datetime
+    end
+
+    def previous_fixed_charge_to_datetime
+      return if last_invoice_subscription.blank?
+
+      last_invoice_subscription.fixed_charges_to_datetime
     end
 
     def terminated_pay_in_arrears?

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -958,6 +958,44 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
     end
   end
 
+  describe "#fixed_charges_duration_in_days" do
+    subject(:result) { date_service.fixed_charges_duration_in_days }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+
+      it "returns the month duration" do
+        expect(result).to eq(28)
+      end
+
+      context "when on a leap year" do
+        let(:subscription_at) { Time.zone.parse("28 Feb 2019") }
+        let(:billing_at) { Time.zone.parse("01 Mar 2020") }
+
+        it "returns the month duration" do
+          expect(result).to eq(29)
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+
+      it "returns the month duration" do
+        expect(result).to eq(28)
+      end
+
+      context "when on a leap year" do
+        let(:subscription_at) { Time.zone.parse("02 Feb 2019") }
+        let(:billing_at) { Time.zone.parse("08 Mar 2020") }
+
+        it "returns the month duration" do
+          expect(result).to eq(29)
+        end
+      end
+    end
+  end
+
   # In February 2022, customer changed timezone from Asia/Tokyo to America/Los_Angeles.
   # The invoice generated in February 2022 had subscription from Feb 1st to Feb 28th
   # and usage-based charges from Jan 1st to Jan 31st.

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -551,6 +551,225 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
     end
   end
 
+  describe "#fixed_charges_from_datetime" do
+    subject(:result) { date_service.fixed_charges_from_datetime }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:billing_at) { Time.zone.parse("01 Mar 2022") }
+
+      it "returns from_datetime" do
+        expect(result).to eq(date_service.from_datetime)
+      end
+
+      context "when subscription is not yet started" do
+        let(:started_at) { nil }
+
+        it "returns nil" do
+          expect(result).to be_nil
+        end
+      end
+
+      context "with customer timezone" do
+        let(:timezone) { "America/New_York" }
+
+        it "takes customer timezone into account and returns from_datetime" do
+          expect(result).to eq(date_service.from_datetime)
+        end
+
+        context "when timezone has changed" do
+          let(:billing_at) { Time.zone.parse("02 Mar 2022") }
+
+          let(:previous_invoice_subscription) do
+            create(
+              :invoice_subscription,
+              subscription:,
+              fixed_charges_to_datetime: "2022-01-31T23:59:59Z"
+            )
+          end
+
+          before do
+            previous_invoice_subscription
+            subscription.customer.update!(timezone: "America/Los_Angeles")
+          end
+
+          it "takes previous invoice into account and returns from_datetime" do
+            expect(result.to_s).to match_datetime("2022-02-01 00:00:00")
+          end
+        end
+
+        context "when timezone has changed and there are no invoices generated in the past" do
+          let(:billing_at) { Time.zone.parse("02 Mar 2022") }
+
+          before do
+            subscription.customer.update!(timezone: "America/Los_Angeles")
+          end
+
+          it "takes calculates correct datetime" do
+            expect(result).to eq(date_service.from_datetime)
+          end
+        end
+      end
+
+      context "when subscription started in the middle of a period" do
+        let(:started_at) { Time.zone.parse("03 Mar 2022") }
+
+        it "returns the start date" do
+          expect(result).to eq(subscription.started_at.utc)
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+        let(:subscription_at) { Time.zone.parse("02 Feb 2020") }
+
+        it "returns the start of the previous period" do
+          expect(result.to_s).to eq("2022-02-01 00:00:00 UTC")
+        end
+      end
+
+      context "when previous subscription is upgraded" do
+        let(:started_at) { Time.zone.parse("2024-02-22T16:13:00") }
+
+        before do
+          create(
+            :subscription,
+            :terminated,
+            terminated_at: started_at
+          )
+        end
+
+        it "returns the beginning of the start date" do
+          expect(result).to eq(subscription.started_at.utc) # boundary should be terminated_at
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:billing_at) { Time.zone.parse("02 Mar 2022") }
+
+      it "returns from_datetime" do
+        expect(result).to eq(date_service.from_datetime)
+      end
+
+      context "when subscription started in the middle of a period" do
+        let(:started_at) { Time.zone.parse("03 Mar 2022") }
+
+        it "returns the start date" do
+          expect(result).to eq(subscription.started_at.utc)
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+        let(:subscription_at) { Time.zone.parse("02 Feb 2020") }
+
+        it "returns the start of the previous period" do
+          expect(result.to_s).to eq("2022-02-02 00:00:00 UTC")
+        end
+      end
+    end
+  end
+
+  describe "#fixed_charges_to_datetime" do
+    subject(:result) { date_service.fixed_charges_to_datetime }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+
+      it "returns to_datetime" do
+        expect(result).to eq(date_service.to_datetime)
+      end
+
+      context "when subscription is not yet started" do
+        let(:started_at) { nil }
+
+        it "returns nil" do
+          expect(result).to be_nil
+        end
+      end
+
+      context "with customer timezone" do
+        let(:timezone) { "America/New_York" }
+
+        it "takes customer timezone into account" do
+          expect(result).to eq(date_service.to_datetime)
+        end
+      end
+
+      context "when subscription is terminated in the middle of a period" do
+        let(:terminated_at) { Time.zone.parse("2022-03-06T12:23:00") }
+
+        before do
+          subscription.update!(status: :terminated, terminated_at:)
+        end
+
+        it "returns the terminated date" do
+          expect(result).to eq(subscription.terminated_at.utc)
+        end
+
+        context "when subscription was upgraded" do
+          before do
+            create(
+              :subscription,
+              started_at: terminated_at,
+              previous_subscription: subscription
+            )
+          end
+
+          it "returns the terminated_at" do
+            expect(result).to eq(subscription.terminated_at)
+          end
+
+          context "when end of previous day is before fixed_charges_from_datetime" do
+            let(:started_at) { Time.zone.parse("2022-03-06T10:23:00") }
+            let(:terminated_at) { Time.zone.parse("2022-03-06T12:23:00") }
+
+            it "returns the fixed_charges_from_datetime" do
+              expect(result).to eq(subscription.terminated_at)
+            end
+          end
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+
+        it "returns the end of the previous period" do
+          expect(result).to eq((date_service.from_datetime - 1.day).end_of_day)
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:billing_at) { Time.zone.parse("02 Mar 2022") }
+
+      it "returns to_datetime" do
+        expect(result).to eq(date_service.to_datetime)
+      end
+
+      context "when subscription is terminated in the middle of a period" do
+        let(:terminated_at) { Time.zone.parse("1 Mar 2022") }
+
+        before { subscription.mark_as_terminated!(terminated_at) }
+
+        it "returns the terminated date" do
+          expect(result).to eq(subscription.terminated_at.utc)
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+
+        it "returns the end of the previous period" do
+          expect(result).to eq((date_service.from_datetime - 1.day).end_of_day)
+        end
+      end
+    end
+  end
+
   describe "#next_end_of_period" do
     let(:result) { date_service.next_end_of_period.to_s }
 

--- a/spec/services/subscriptions/dates/quarterly_service_spec.rb
+++ b/spec/services/subscriptions/dates/quarterly_service_spec.rb
@@ -488,6 +488,229 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
     end
   end
 
+  describe "#fixed_charges_from_datetime" do
+    subject(:result) { date_service.fixed_charges_from_datetime }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:billing_at) { Time.zone.parse("01 Apr 2022") }
+
+      it "returns from_datetime" do
+        expect(result).to eq(date_service.from_datetime)
+      end
+
+      context "when subscription is not yet started" do
+        let(:started_at) { nil }
+
+        it "returns nil" do
+          expect(result).to be_nil
+        end
+      end
+
+      context "with customer timezone" do
+        let(:timezone) { "America/New_York" }
+
+        it "takes customer timezone into account and returns from_datetime" do
+          expect(result).to eq(date_service.from_datetime)
+        end
+
+        context "when timezone has changed" do
+          let(:billing_at) { Time.zone.parse("02 Apr 2022") }
+
+          let(:previous_invoice_subscription) do
+            create(
+              :invoice_subscription,
+              subscription:,
+              fixed_charges_to_datetime: "2021-12-31T23:59:59Z"
+            )
+          end
+
+          before do
+            previous_invoice_subscription
+            subscription.customer.update!(timezone: "America/Los_Angeles")
+          end
+
+          it "takes previous invoice into account and returns from_datetime" do
+            expect(result.to_s).to match_datetime("2022-01-01 00:00:00")
+          end
+        end
+
+        context "when timezone has changed and there are no invoices generated in the past" do
+          let(:billing_at) { Time.zone.parse("02 Apr 2022") }
+
+          before do
+            subscription.customer.update!(timezone: "America/Los_Angeles")
+          end
+
+          it "takes calculates correct datetime" do
+            expect(result).to eq(date_service.from_datetime)
+          end
+        end
+      end
+
+      context "when subscription started in the middle of a period" do
+        let(:started_at) { Time.zone.parse("03 Apr 2022") }
+
+        it "returns the start date" do
+          expect(result).to eq(subscription.started_at.utc)
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+        let(:subscription_at) { Time.zone.parse("01 Jan 2020") }
+
+        it "returns the start of the previous period" do
+          expect(result.to_s).to eq("2022-01-01 00:00:00 UTC")
+        end
+      end
+
+      context "when previous subscription is upgraded" do
+        let(:started_at) { Time.zone.parse("2024-02-22T16:13:00") }
+
+        before do
+          create(
+            :subscription,
+            :terminated,
+            terminated_at: started_at
+          )
+        end
+
+        it "returns the beginning of the start date" do
+          expect(result).to eq(subscription.started_at.utc) # boundary should be terminated_at
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:billing_at) { Time.zone.parse("02 May 2022") }
+
+      it "returns from_datetime" do
+        expect(result).to eq(date_service.from_datetime)
+      end
+
+      context "when subscription started in the middle of a period" do
+        let(:started_at) { Time.zone.parse("03 May 2022") }
+
+        it "returns the start date" do
+          expect(result).to eq(subscription.started_at.utc)
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+        let(:subscription_at) { Time.zone.parse("02 Feb 2020") }
+
+        it "returns the start of the previous period" do
+          expect(result.to_s).to eq("2022-02-02 00:00:00 UTC")
+        end
+      end
+    end
+  end
+
+  describe "#fixed_charges_to_datetime" do
+    subject(:result) { date_service.fixed_charges_to_datetime }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+      it "returns to_datetime" do
+        expect(result).to eq(date_service.to_datetime)
+      end
+
+      context "when subscription is not yet started" do
+        let(:started_at) { nil }
+
+        it "returns nil" do
+          expect(result).to be_nil
+        end
+      end
+
+      context "with customer timezone" do
+        let(:timezone) { "America/New_York" }
+
+        it "takes customer timezone into account" do
+          expect(result).to eq(date_service.to_datetime)
+        end
+      end
+
+      context "when subscription is terminated in the middle of a period" do
+        let(:terminated_at) { Time.zone.parse("2022-06-15T12:23:00") }
+
+        before do
+          subscription.update!(status: :terminated, terminated_at:)
+        end
+
+        it "returns the terminated date" do
+          expect(result).to eq(subscription.terminated_at.utc)
+        end
+
+        context "when subscription was upgraded" do
+          before do
+            create(
+              :subscription,
+              started_at: terminated_at,
+              previous_subscription: subscription
+            )
+          end
+
+          it "returns the terminated_at" do
+            expect(result).to eq(subscription.terminated_at)
+          end
+
+          context "when end of previous day is before fixed_charges_from_datetime" do
+            let(:started_at) { Time.zone.parse("2022-03-06T10:23:00") }
+            let(:terminated_at) { Time.zone.parse("2022-03-06T12:23:00") }
+
+            it "returns the fixed_charges_from_datetime" do
+              expect(result).to eq(subscription.terminated_at)
+            end
+          end
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+
+        it "returns the end of the previous period" do
+          expect(result).to eq((date_service.from_datetime - 1.day).end_of_day)
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:billing_at) { Time.zone.parse("02 May 2022") }
+
+      it "returns to_datetime" do
+        expect(result).to eq(date_service.to_datetime)
+      end
+
+      context "when subscription is terminated in the middle of a period" do
+        let(:terminated_at) { Time.zone.parse("15 Apr 2022") }
+
+        before do
+          subscription.update!(status: :terminated, terminated_at:)
+        end
+
+        it "returns the terminated date" do
+          expect(result).to eq(subscription.terminated_at.utc)
+        end
+      end
+
+      context "when plan is pay in advance" do
+        let(:pay_in_advance) { true }
+
+        # FAILS
+        it "returns the end of the previous period" do
+          expect(result).to eq((date_service.from_datetime - 1.day).end_of_day)
+        end
+      end
+    end
+  end
+
   describe "next_end_of_period" do
     let(:result) { date_service.next_end_of_period.to_s }
 

--- a/spec/services/subscriptions/dates/quarterly_service_spec.rb
+++ b/spec/services/subscriptions/dates/quarterly_service_spec.rb
@@ -897,4 +897,44 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       end
     end
   end
+
+  describe "fixed_charges_duration_in_days" do
+    subject(:result) { date_service.fixed_charges_duration_in_days }
+
+    context "when billing_time is calendar" do
+      let(:billing_time) { :calendar }
+      let(:billing_at) { Time.zone.parse("01 Jul 2022") }
+
+      it "returns the quarter duration" do
+        expect(result).to eq(91)
+      end
+
+      context "when on a leap year" do
+        let(:subscription_at) { Time.zone.parse("28 Feb 2019") }
+        let(:billing_at) { Time.zone.parse("01 Apr 2020") }
+
+        it "returns the duration in days" do
+          expect(result).to eq(91)
+        end
+      end
+    end
+
+    context "when billing_time is anniversary" do
+      let(:billing_time) { :anniversary }
+      let(:billing_at) { Time.zone.parse("02 May 2020") }
+
+      it "returns the month duration" do
+        expect(result).to eq(90)
+      end
+
+      context "when not on a leap year" do
+        let(:subscription_at) { Time.zone.parse("02 Feb 2019") }
+        let(:billing_at) { Time.zone.parse("02 May 2021") }
+
+        it "returns the duration in days" do
+          expect(result).to eq(89)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -720,4 +720,15 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       expect(result).to eq(7)
     end
   end
+
+  describe "#fixed_charges_duration_in_days" do
+    subject(:result) { date_service.fixed_charges_duration_in_days }
+
+    let(:billing_time) { :anniversary }
+    let(:billing_at) { Time.zone.parse("08 Mar 2022") }
+
+    it "returns the duration of the period" do
+      expect(result).to eq(7)
+    end
+  end
 end

--- a/spec/services/subscriptions/dates_service_spec.rb
+++ b/spec/services/subscriptions/dates_service_spec.rb
@@ -101,6 +101,20 @@ RSpec.describe Subscriptions::DatesService, type: :service do
     end
   end
 
+  describe "fixed_charges_from_datetime" do
+    it "raises a not implemented error" do
+      expect { date_service.fixed_charges_from_datetime }
+        .to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "fixed_charges_to_datetime" do
+    it "raises a not implemented error" do
+      expect { date_service.fixed_charges_to_datetime }
+        .to raise_error(NotImplementedError)
+    end
+  end
+
   describe "next_end_of_period" do
     it "raises a not implemented error" do
       expect { date_service.next_end_of_period }
@@ -118,6 +132,13 @@ RSpec.describe Subscriptions::DatesService, type: :service do
   describe "charges_duration_in_days" do
     it "raises a not implemented error" do
       expect { date_service.charges_duration_in_days }
+        .to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "fixed_charges_duration_in_days" do
+    it "raises a not implemented error" do
+      expect { date_service.fixed_charges_duration_in_days }
         .to raise_error(NotImplementedError)
     end
   end


### PR DESCRIPTION
 ## Roadmap Task

 👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

 👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

 ## Context

 ### What is the current situation?

 **Option 1:** User has to create a one off invoice alongside the
 subscription, it will create 2 different invoices.

 **Option 2:** User can add a recurring billable metric and use event to  have this fee invoice on subscription renewal, but it won’t appear on  the first billing subscription.

 ### What problem are we trying to solve?

 At subscription creation or afterward, there is no clear way to invoice  a fixed fee that is not tied to events, aside from the subscription fee  itself. This fee could be either a one-time charge or a recurring one.

 ## Description

Define fixed charge from/to datetime, and duration in days in subscriptions date service.

Fixed Charge boundaries follows Metered Charges boundaries.