### PR TITLE
feat(fixed-charges): Add fixed charges amounts in invoice subscription

### DIFF
--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -93,7 +93,7 @@ class InvoiceSubscription < ApplicationRecord
   end
 
   def total_amount_cents
-    charge_amount_cents + subscription_amount_cents
+    charge_amount_cents + subscription_amount_cents + fixed_charge_amount_cents
   end
 
   def total_amount_currency
@@ -102,6 +102,7 @@ class InvoiceSubscription < ApplicationRecord
 
   alias_method :charge_amount_currency, :total_amount_currency
   alias_method :subscription_amount_currency, :total_amount_currency
+  alias_method :fixed_charge_amount_currency, :total_amount_currency
 end
 
 # == Schema Information

--- a/spec/models/invoice_subscription_spec.rb
+++ b/spec/models/invoice_subscription_spec.rb
@@ -139,7 +139,14 @@ RSpec.describe InvoiceSubscription, type: :model do
         amount_cents: 100
       )
 
-      expect(invoice_subscription.total_amount_cents).to eq(350)
+      create(
+        :fixed_charge_fee,
+        subscription_id: subscription.id,
+        invoice_id: invoice.id,
+        amount_cents: 25
+      )
+
+      expect(invoice_subscription.total_amount_cents).to eq(375)
     end
   end
 
@@ -152,6 +159,12 @@ RSpec.describe InvoiceSubscription, type: :model do
   describe "#charge_amount_currency" do
     it "returns the currency of the charge amount" do
       expect(invoice_subscription.charge_amount_currency).to eq(subscription.plan.amount_currency)
+    end
+  end
+
+  describe "#fixed_charge_amount_currency" do
+    it "returns the currency of the fixed charge amount" do
+      expect(invoice_subscription.fixed_charge_amount_currency).to eq(subscription.plan.amount_currency)
     end
   end
 


### PR DESCRIPTION
 ## Roadmap Task

 👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

 👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

 ## Context

 ### What is the current situation?

 **Option 1:** User has to create a one off invoice alongside the
 subscription, it will create 2 different invoices.

 **Option 2:** User can add a recurring billable metric and use event to  have this fee invoice on subscription renewal, but it won’t appear on  the first billing subscription.

 ### What problem are we trying to solve?

 At subscription creation or afterward, there is no clear way to invoice  a fixed fee that is not tied to events, aside from the subscription fee  itself. This fee could be either a one-time charge or a recurring one.

 ## Description

 Add `#fixed_charge_amount_cents` to InvoiceSubscriptions,
 also includes it into `#total_amount_cents`