### PR TITLE
fix(billable_metric_filter): Fix batch remove

### DIFF
--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -86,7 +86,7 @@ module BillableMetricFilters
       filter_value.discard!
       return if filter_value.charge_filter.values.where.not(id: filter_value.id).exists?
 
-      filter_value.charge_filter.discard!
+      filter_value.charge_filter.discard! unless filter_value.charge_filter.discarded?
     end
 
     def refresh_draft_invoices

--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -120,6 +120,33 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
 
         expect(filter_value.reload).to be_discarded
       end
+
+      context "when removing all values" do
+        let(:filters_params) do
+          []
+        end
+
+        before do
+          create(
+            :charge_filter_value,
+            billable_metric_filter: filter,
+            values: ["US"]
+          )
+
+          create(
+            :charge_filter_value,
+            billable_metric_filter: filter,
+            values: ["Europe"]
+          )
+        end
+
+        it "discards the removed value" do
+          expect { service }.to change(BillableMetricFilter, :count).by(-1)
+
+          expect(filter.reload).to be_discarded
+          expect(filter.filter_values.with_discarded).to all(be_discarded)
+        end
+      end
     end
 
     context "when a filter is removed" do


### PR DESCRIPTION
## Context

This PR fixes the `Discard::RecordNotDiscarded - A discarded record cannot be discarded (Discard::RecordNotDiscarded)` that is raised in `BillableMetricFilters::CreateOrUpdateBatchService` when try to remove all filters on a billable metric.

The issue was raised because the same billable_metric_filter was used multiple time on the same charge filter.

## Description

This PR makes sure that the filter value that we are trying to soft delete is not already soft deleted, to avoid raising the exception
