### PR TITLE
misc: Add missing specs for discarded billable metric filters

### DIFF
--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -126,15 +126,20 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
           []
         end
 
+        let(:charge) { create(:standard_charge, billable_metric:) }
+        let(:charge_filter) { create(:charge_filter, charge:) }
+
         before do
           create(
             :charge_filter_value,
+            charge_filter:,
             billable_metric_filter: filter,
             values: ["US"]
           )
 
           create(
             :charge_filter_value,
+            charge_filter:,
             billable_metric_filter: filter,
             values: ["Europe"]
           )


### PR DESCRIPTION
This PR follows https://github.com/getlago/lago-api/pull/4328 and adds the missing specs