### PR TITLE
fix(plan): Add validation on interval enum

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -41,11 +41,11 @@ class Plan < ApplicationRecord
     quarterly
   ].freeze
 
-  enum :interval, INTERVALS
+  enum :interval, INTERVALS, validate: true
 
   monetize :amount_cents
 
-  validates :name, :code, :interval, presence: true
+  validates :name, :code, presence: true
   validates :amount_currency, inclusion: {in: currency_list}
   validates :pay_in_advance, inclusion: {in: [true, false]}
   validate :validate_code_unique

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe Plan, type: :model do
     expect(subject).to have_many(:entitlements).class_name("Entitlement::Entitlement").dependent(:destroy)
     expect(subject).to have_many(:entitlement_values).through(:entitlements).source(:values).class_name("Entitlement::EntitlementValue").dependent(:destroy)
 
-    expect(subject).to validate_presence_of(:interval)
-    expect(subject).to define_enum_for(:interval).with_values(Plan::INTERVALS)
+    expect(subject).to define_enum_for(:interval).with_values(Plan::INTERVALS).validating
   end
 
   describe "Clickhouse associations", clickhouse: true do

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
 
         aggregate_failures do
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(json[:error_details]).to eq({interval: %w[value_is_mandatory]})
+          expect(json[:error_details]).to eq({interval: %w[value_is_invalid]})
         end
       end
     end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Plans::CreateService, type: :service do
     let(:plan_tax) { create(:tax, organization:) }
     let(:charge_tax) { create(:tax, organization:) }
     let(:pricing_unit) { create(:pricing_unit, organization:) }
+    let(:interval) { "monthly" }
 
     let(:billable_metric_filter) do
       create(:billable_metric_filter, billable_metric:, key: "payment_method", values: %w[card physical])
@@ -30,7 +31,7 @@ RSpec.describe Plans::CreateService, type: :service do
         invoice_display_name: plan_invoice_display_name,
         organization_id: organization.id,
         code: "new_plan",
-        interval: "monthly",
+        interval:,
         pay_in_advance: false,
         amount_cents: 200,
         amount_currency: "EUR",
@@ -496,6 +497,16 @@ RSpec.describe Plans::CreateService, type: :service do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages[:charge_model]).to eq(["graduated_percentage_requires_premium_license"])
+        end
+      end
+
+      context "with invalid interval" do
+        let(:interval) { "daily" }
+
+        it "returns an error" do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:interval]).to eq(["value_is_invalid"])
         end
       end
     end


### PR DESCRIPTION
## Description
This PR adds a new validation on the `interval` enum of the `Plan` model

The goal is to avoid an `ArgumentError` when an invalid value is provided via the API as it results in an `HTTP 500` instead of a `422`