### PR TITLE
feat(fixed_charges): Add fixed charges boundaries to billing period

### DIFF
--- a/app/models/billing_period_boundaries.rb
+++ b/app/models/billing_period_boundaries.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class BillingPeriodBoundaries
-  attr_reader :from_datetime, :to_datetime, :charges_from_datetime, :charges_duration, :timestamp, :issuing_date
+  attr_reader :from_datetime,
+    :to_datetime,
+    :charges_from_datetime,
+    :charges_duration,
+    :timestamp,
+    :issuing_date,
+    :fixed_charges_from_datetime,
+    :fixed_charges_to_datetime,
+    :fixed_charges_duration
   attr_accessor :charges_to_datetime
 
   def self.from_fee(fee)
@@ -14,11 +22,26 @@ class BillingPeriodBoundaries
       charges_to_datetime: props["charges_to_datetime"],
       charges_duration: props["charges_duration"],
       timestamp: props["timestamp"],
-      issuing_date: props["issuing_date"]
+      issuing_date: props["issuing_date"],
+      fixed_charges_from_datetime: props["fixed_charges_from_datetime"],
+      fixed_charges_to_datetime: props["fixed_charges_to_datetime"],
+      fixed_charges_duration: props["fixed_charges_duration"]
     )
   end
 
-  def initialize(from_datetime:, to_datetime:, charges_from_datetime:, charges_to_datetime:, charges_duration:, timestamp:, issuing_date: nil)
+  def initialize(
+    from_datetime:,
+    to_datetime:,
+    charges_from_datetime:,
+    charges_to_datetime:,
+    charges_duration:,
+    timestamp:,
+    issuing_date: nil,
+    fixed_charges_from_datetime:,
+    fixed_charges_to_datetime:,
+    fixed_charges_duration:
+    )
+
     @from_datetime = from_datetime
     @to_datetime = to_datetime
     @charges_from_datetime = charges_from_datetime
@@ -26,6 +49,9 @@ class BillingPeriodBoundaries
     @charges_duration = charges_duration
     @timestamp = timestamp
     @issuing_date = issuing_date
+    @fixed_charges_from_datetime = fixed_charges_from_datetime
+    @fixed_charges_to_datetime = fixed_charges_to_datetime
+    @fixed_charges_duration = fixed_charges_duration
   end
 
   def to_h
@@ -35,7 +61,10 @@ class BillingPeriodBoundaries
       "charges_from_datetime" => charges_from_datetime,
       "charges_to_datetime" => charges_to_datetime,
       "charges_duration" => charges_duration,
-      "timestamp" => timestamp
+      "timestamp" => timestamp,
+      "fixed_charges_from_datetime" => fixed_charges_from_datetime,
+      "fixed_charges_to_datetime" => fixed_charges_to_datetime,
+      "fixed_charges_duration" => fixed_charges_duration
     }.with_indifferent_access
     h["issuing_date"] = issuing_date if issuing_date.present?
     h

--- a/app/models/billing_period_boundaries.rb
+++ b/app/models/billing_period_boundaries.rb
@@ -36,12 +36,11 @@ class BillingPeriodBoundaries
     charges_to_datetime:,
     charges_duration:,
     timestamp:,
-    issuing_date: nil,
     fixed_charges_from_datetime:,
     fixed_charges_to_datetime:,
-    fixed_charges_duration:
-    )
-
+    fixed_charges_duration:,
+    issuing_date: nil
+  )
     @from_datetime = from_datetime
     @to_datetime = to_datetime
     @charges_from_datetime = charges_from_datetime

--- a/app/models/billing_period_boundaries.rb
+++ b/app/models/billing_period_boundaries.rb
@@ -36,9 +36,9 @@ class BillingPeriodBoundaries
     charges_to_datetime:,
     charges_duration:,
     timestamp:,
-    fixed_charges_from_datetime:,
-    fixed_charges_to_datetime:,
-    fixed_charges_duration:,
+    fixed_charges_from_datetime: nil,
+    fixed_charges_to_datetime: nil,
+    fixed_charges_duration: nil,
     issuing_date: nil
   )
     @from_datetime = from_datetime

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -136,6 +136,18 @@ FactoryBot.define do
 
     invoice_display_name { Faker::Fantasy::Tolkien.character }
 
+    properties do
+      {
+        "timestamp" => Date.parse("2022-08-01 00:03:24"),
+        "from_datetime" => Date.parse("2022-08-01 00:00:00"),
+        "to_datetime" => Date.parse("2022-08-31 23:59:59"),
+        "charges_from_datetime" => Date.parse("2022-08-01 00:00:00"),
+        "charges_to_datetime" => Date.parse("2022-08-31 23:59:59"),
+        "fixed_charges_from_datetime" => Date.parse("2022-07-01 00:00:00"),
+        "fixed_charges_to_datetime" => Date.parse("2022-07-31 23:59:59")
+      }
+    end
+
     transient do
       fixed_charge { create(:fixed_charge) }
     end

--- a/spec/models/billing_period_boundaries_spec.rb
+++ b/spec/models/billing_period_boundaries_spec.rb
@@ -9,8 +9,11 @@ RSpec.describe BillingPeriodBoundaries, type: :model do
       to_datetime:,
       charges_from_datetime:,
       charges_to_datetime:,
-      timestamp:,
-      charges_duration:
+      charges_duration:,
+      fixed_charges_from_datetime:,
+      fixed_charges_to_datetime:,
+      fixed_charges_duration:,
+      timestamp:
     )
   end
 
@@ -20,6 +23,9 @@ RSpec.describe BillingPeriodBoundaries, type: :model do
   let(:charges_to_datetime) { (timestamp - 1.month).end_of_month }
   let(:timestamp) { Time.current }
   let(:charges_duration) { charges_to_datetime - charges_from_datetime }
+  let(:fixed_charges_from_datetime) { (timestamp - 2.months).beginning_of_month }
+  let(:fixed_charges_to_datetime) { (timestamp - 2.months).end_of_month }
+  let(:fixed_charges_duration) { fixed_charges_to_datetime - fixed_charges_from_datetime }
 
   describe "#to_h" do
     it "returns a hash with the boundaries" do
@@ -29,7 +35,10 @@ RSpec.describe BillingPeriodBoundaries, type: :model do
         "charges_from_datetime" => charges_from_datetime,
         "charges_to_datetime" => charges_to_datetime,
         "timestamp" => timestamp,
-        "charges_duration" => charges_duration
+        "charges_duration" => charges_duration,
+        "fixed_charges_from_datetime" => fixed_charges_from_datetime,
+        "fixed_charges_to_datetime" => fixed_charges_to_datetime,
+        "fixed_charges_duration" => fixed_charges_duration
       )
     end
   end
@@ -47,6 +56,25 @@ RSpec.describe BillingPeriodBoundaries, type: :model do
       expect(instance.charges_to_datetime).to eq(fee.properties["charges_to_datetime"])
       expect(instance.charges_duration).to eq(fee.properties["charges_duration"])
       expect(instance.timestamp).to eq(fee.properties["timestamp"])
+    end
+
+    context "when fee belongs to a fixed charge" do
+      let(:fee) { build(:fixed_charge_fee) }
+
+      it "returns a BillingPeriodBoundaries instance" do
+        instance = described_class.from_fee(fee)
+
+        expect(instance).to be_a(described_class)
+        expect(instance.from_datetime).to eq(fee.properties["from_datetime"])
+        expect(instance.to_datetime).to eq(fee.properties["to_datetime"])
+        expect(instance.charges_from_datetime).to eq(fee.properties["charges_from_datetime"])
+        expect(instance.charges_to_datetime).to eq(fee.properties["charges_to_datetime"])
+        expect(instance.charges_duration).to eq(fee.properties["charges_duration"])
+        expect(instance.timestamp).to eq(fee.properties["timestamp"])
+        expect(instance.fixed_charges_from_datetime).to eq(fee.properties["fixed_charges_from_datetime"])
+        expect(instance.fixed_charges_to_datetime).to eq(fee.properties["fixed_charges_to_datetime"])
+        expect(instance.fixed_charges_duration).to eq(fee.properties["fixed_charges_duration"])
+      end
     end
   end
 end

--- a/spec/scenarios/invoices/advance_charges_dates_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_dates_spec.rb
@@ -106,7 +106,10 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
           "from_datetime" => "2024-06-05T00:00:00.000Z",
           "charges_duration" => 30,
           "charges_to_datetime" => "2024-06-30T23:59:59.999Z",
-          "charges_from_datetime" => "2024-06-05T10:00:00.000Z"
+          "charges_from_datetime" => "2024-06-05T10:00:00.000Z",
+          "fixed_charges_to_datetime" => nil,
+          "fixed_charges_from_datetime" => nil,
+          "fixed_charges_duration" => nil
         })
         expect(invoice_fees.second.properties).to eq({
           "timestamp" => "2024-07-22T10:00:00.000Z",
@@ -114,7 +117,10 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
           "from_datetime" => "2024-07-07T00:00:00.000Z",
           "charges_duration" => 31,
           "charges_to_datetime" => "2024-07-31T23:59:59.999Z",
-          "charges_from_datetime" => "2024-07-07T10:00:00.000Z"
+          "charges_from_datetime" => "2024-07-07T10:00:00.000Z",
+          "fixed_charges_to_datetime" => nil,
+          "fixed_charges_from_datetime" => nil,
+          "fixed_charges_duration" => nil
         })
 
         invoice_periods = billing_periods_hash(invoice)
@@ -252,7 +258,10 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
           "from_datetime" => "2024-06-05T00:00:00.000Z",
           "charges_duration" => 30,
           "charges_to_datetime" => "2024-06-30T23:59:59.999Z",
-          "charges_from_datetime" => "2024-06-05T10:00:00.000Z"
+          "charges_from_datetime" => "2024-06-05T10:00:00.000Z",
+          "fixed_charges_to_datetime" => nil,
+          "fixed_charges_from_datetime" => nil,
+          "fixed_charges_duration" => nil
         })
         expect(invoice_fees.second.properties).to eq({
           "timestamp" => "2024-07-22T10:00:00.000Z",
@@ -260,7 +269,10 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
           "from_datetime" => "2024-07-01T00:00:00.000Z",
           "charges_duration" => 31,
           "charges_to_datetime" => "2024-07-31T23:59:59.999Z",
-          "charges_from_datetime" => "2024-07-01T00:00:00.000Z"
+          "charges_from_datetime" => "2024-07-01T00:00:00.000Z",
+          "fixed_charges_to_datetime" => nil,
+          "fixed_charges_from_datetime" => nil,
+          "fixed_charges_duration" => nil
         })
 
         invoice_periods = billing_periods_hash(invoice)
@@ -337,7 +349,10 @@ describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
           "from_datetime" => "2024-06-05T00:00:00.000Z",
           "charges_duration" => 30,
           "charges_to_datetime" => "2024-06-30T23:59:59.999Z",
-          "charges_from_datetime" => "2024-06-05T10:00:00.000Z"
+          "charges_from_datetime" => "2024-06-05T10:00:00.000Z",
+          "fixed_charges_to_datetime" => nil,
+          "fixed_charges_from_datetime" => nil,
+          "fixed_charges_duration" => nil
         })
 
         invoice_periods = billing_periods_hash(invoice)


### PR DESCRIPTION
Include into `BillingPeriodBoundaries`:
- `fixed_charges_from_datetime`
- `fixed_charges_to_datetime`
- `fixed_charges_duration`