### PR TITLE
fix(entitlements): Retrive only parents plan

### DIFF
--- a/app/controllers/api/v1/plans/entitlements/privileges_controller.rb
+++ b/app/controllers/api/v1/plans/entitlements/privileges_controller.rb
@@ -41,7 +41,7 @@ module Api
           end
 
           def find_plan
-            @plan = current_organization.plans.find_by!(
+            @plan = current_organization.plans.parents.find_by!(
               code: params[:plan_code]
             )
           rescue ActiveRecord::RecordNotFound

--- a/app/controllers/api/v1/plans/entitlements_controller.rb
+++ b/app/controllers/api/v1/plans/entitlements_controller.rb
@@ -106,7 +106,7 @@ module Api
         end
 
         def find_plan
-          @plan = current_organization.plans.find_by!(
+          @plan = current_organization.plans.parents.find_by!(
             code: params[:plan_code]
           )
         rescue ActiveRecord::RecordNotFound


### PR DESCRIPTION
It's not possible to set entitlements on override plans, they should only work on parent plans.
The entitlements retrieved in `/v1/plans/:code` are correct because the main controller only allow you modify parent plans. 
It's possible right now to retrieve different entitlements from `/v1/plan/:code/entitlements` if the plan has children, since our primary keys are not ordered.

I will ensure in a following PR that the services cannot be called with a child plan (and double check gql).