### PR TITLE
fix: enable PDF breakdown for clickhouse store and fix edge case

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -239,7 +239,7 @@ class Invoice < ApplicationRecord
     end
 
     service.new(
-      event_store_class: Events::Stores::PostgresStore,
+      event_store_class: Events::Stores::StoreFactory.store_class(organization:),
       charge: fee.charge,
       subscription: fee.subscription,
       boundaries: {

--- a/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
@@ -334,6 +334,36 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service, t
           end
         end
       end
+
+      context "when added, removed and added again" do
+        let(:added_at) { from_datetime + 1.day }
+        let(:removed_at) { added_at.end_of_day }
+        let(:new_event) do
+          create(
+            :event,
+            organization_id: organization.id,
+            timestamp: to_datetime - 1.day,
+            external_subscription_id: subscription.external_id,
+            code: billable_metric.code,
+            properties: {unique_id: "111"}
+          )
+        end
+
+        before { new_event }
+
+        it "returns the detail the persisted metrics" do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(added_at.to_date.to_s)
+            expect(item.action).to eq("add")
+            expect(item.amount).to eq(1)
+            expect(item.duration).to eq(3)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

PDF breakdown was only enabled for postgres store

## Description

This PR enables it for Clickhouse as well.

Also, edge case, where unit is added, removed and added again has not been displayed correctly. This PR also fixes it
