### PR TITLE
test(log): Enable test log in dev environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,8 +11,10 @@ Rails.application.configure do
     "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }
 
-  config.logger = Logger.new(nil)
-  config.log_level = :fatal
+  if ENV["CI"].present?
+    config.logger = Logger.new(nil)
+    config.log_level = :fatal
+  end
 
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false


### PR DESCRIPTION
## Context

5e8cc0acb72e9992569698688a3f6f5b49ff06d9 disabled the logs in test to speed up the test suite. This make sense in a CI context but make it harder to debug in dev environment.

## Description

This update the Rails configuration to only disable test logging on CI.
