### PR TITLE
test(wallet): Improve wallet scenario tests

### DIFF
--- a/spec/scenarios/wallets/topup_with_open_invoices_spec.rb
+++ b/spec/scenarios/wallets/topup_with_open_invoices_spec.rb
@@ -10,25 +10,22 @@ describe "Wallet Transaction with invoice after payment", :scenarios, type: :req
 
   context "when the wallet does not require successful payment before invoicing" do
     it "allows wallet transaction to require successful payment" do
-      create_wallet({
+      wallet = create_wallet({
         external_customer_id: customer.external_id,
         rate_amount: "1",
         name: "Wallet1",
         currency: "EUR",
         granted_credits: "10",
         invoice_requires_successful_payment: false # default
-      })
-
-      wallet = customer.wallets.sole
+      }, as: :model)
 
       expect(wallet.credits_balance).to eq 10
 
-      create_wallet_transaction({
+      wt = create_wallet_transaction({
         wallet_id: wallet.id,
         paid_credits: "15",
         invoice_requires_successful_payment: true
-      })
-      wt = WalletTransaction.find json[:wallet_transactions].first[:lago_id]
+      }, as: :model).first
 
       expect(wt.status).to eq "pending"
       expect(wt.transaction_status).to eq "purchased"
@@ -83,22 +80,20 @@ describe "Wallet Transaction with invoice after payment", :scenarios, type: :req
             )
           )
 
-        create_wallet({
+        wallet = create_wallet({
           external_customer_id: customer.external_id,
           rate_amount: "1",
           name: "Wallet1",
           currency: "EUR",
           granted_credits: "10",
           invoice_requires_successful_payment: false # default
-        })
-        wallet = customer.wallets.sole
+        }, as: :model)
 
-        create_wallet_transaction({
+        wt = create_wallet_transaction({
           wallet_id: wallet.id,
           paid_credits: "15",
           invoice_requires_successful_payment: true
-        })
-        wt = WalletTransaction.find json[:wallet_transactions].first[:lago_id]
+        }, as: :model).first
 
         # Customer does not have a payment_provider set yet
         invoice = customer.invoices.credit.sole

--- a/spec/scenarios/wallets/topup_with_rounding_spec.rb
+++ b/spec/scenarios/wallets/topup_with_rounding_spec.rb
@@ -9,29 +9,29 @@ describe "Wallet Transaction with rounding", :scenarios, type: :request do
   around { |test| lago_premium!(&test) }
 
   it "rounds the amount field when handling paid_credits" do
-    create_wallet({
+    wallet = create_wallet({
       external_customer_id: customer.external_id,
       rate_amount: "1",
       name: "Wallet1",
       currency: "EUR",
       invoice_requires_successful_payment: false
-    })
-    wallet = customer.wallets.sole
+    }, as: :model)
 
     expect(wallet.rate_amount).to eq(1)
 
-    create_wallet_transaction({
+    wt = create_wallet_transaction({
       wallet_id: wallet.id,
       paid_credits: "17.9699999999999988631316",
-      invoice_requires_successful_payment: false
-    })
+      invoice_requires_successful_payment: false,
+      metadata: [{key: "transaction_id", value: "123"}]
+    }, as: :model).first
 
-    wt = WalletTransaction.find json[:wallet_transactions].first[:lago_id]
     expect(wt.status).to eq "pending"
     expect(wt.transaction_status).to eq "purchased"
     expect(wt.invoice_requires_successful_payment).to be false
     expect(wt.credit_amount).to eq(17.97)
     expect(wt.amount).to eq(17.97)
+    expect(wt.metadata).to eq([{"key" => "transaction_id", "value" => "123"}])
 
     # Customer does not have a payment_provider set yet
     invoice = customer.invoices.credit.sole
@@ -52,24 +52,22 @@ describe "Wallet Transaction with rounding", :scenarios, type: :request do
   end
 
   it "does not apply rounding handling granted_credits" do
-    create_wallet({
+    wallet = create_wallet({
       external_customer_id: customer.external_id,
       rate_amount: "1",
       name: "Wallet1",
       currency: "EUR",
       invoice_requires_successful_payment: false
-    })
-    wallet = customer.wallets.sole
+    }, as: :model)
 
     expect(wallet.rate_amount).to eq(1)
 
-    create_wallet_transaction({
+    wt = create_wallet_transaction({
       wallet_id: wallet.id,
       granted_credits: "17.9699999999999988631316",
       invoice_requires_successful_payment: false
-    })
+    }, as: :model).first
 
-    wt = WalletTransaction.find json[:wallet_transactions].first[:lago_id]
     expect(wt.status).to eq "settled"
     expect(wt.transaction_status).to eq "granted"
     expect(wt.invoice_requires_successful_payment).to be false


### PR DESCRIPTION
## Context

The current wallet scenario tests do not assert the presence of `outbound` wallet transactions.

## Description

This adds those missing assertions.

It also refactors the tests by:

- Defining helper methods.
- Updating the `create_wallet` and `create_wallet_transaction` to return the models directly if `as: :model` is provided.
