### PR TITLE
fix(deprecation): Use `:unprocessable_content` over `:unprocessable_entity`

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -41,7 +41,7 @@ module Api
                 code: "stripe_required",
                 message: "Only Stripe is supported for authorization"
               },
-              status: :unprocessable_entity
+              status: :unprocessable_content
             )
           end
 

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -31,7 +31,7 @@ module ApiErrors
         code: "validation_errors",
         error_details: errors
       },
-      status: :unprocessable_entity
+      status: :unprocessable_content
     )
   end
 
@@ -68,7 +68,7 @@ module ApiErrors
       error_details: V1::Errors::ErrorSerializerFactory.new_instance(error).serialize
     }
 
-    render json: response, status: :unprocessable_entity
+    render json: response, status: :unprocessable_content
   end
 
   def thirdpary_error(error:)
@@ -82,7 +82,7 @@ module ApiErrors
           thirdparty_error: error.error_message
         }
       },
-      status: :unprocessable_entity
+      status: :unprocessable_content
     )
   end
 

--- a/spec/requests/api/v1/add_ons_controller_spec.rb
+++ b/spec/requests/api/v1/add_ons_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Api::V1::AddOnsController, type: :request do
 
       it "returns unprocessable_entity error" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/requests/api/v1/billable_metrics_controller_spec.rb
+++ b/spec/requests/api/v1/billable_metrics_controller_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
 
       it "returns unprocessable_entity error" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -287,7 +287,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
       it "returns unprocessable_entity error", :aggregate_failures do
         subject
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:error_details][:expression]).to eq(["value_is_mandatory"])
       end
     end

--- a/spec/requests/api/v1/billing_entities_controller_spec.rb
+++ b/spec/requests/api/v1/billing_entities_controller_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Api::V1::BillingEntitiesController, type: :request do
       it "returns a 422" do
         subject
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:error]).to eq("Unprocessable Entity")
         expect(json[:error_details]).to eq(code: ["value_already_exist"])
       end

--- a/spec/requests/api/v1/coupons_controller_spec.rb
+++ b/spec/requests/api/v1/coupons_controller_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Api::V1::CouponsController, type: :request do
 
       it "returns unprocessable_entity error" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/requests/api/v1/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes_controller_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
 
       it "returns an unprocessable entity error" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end
@@ -312,7 +312,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
 
       it "returns validation error" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:error_details][:base]).to eq(["total_amount_must_be_positive"])
       end
     end

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -436,7 +436,7 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
 
       it "returns an unprocessable entity" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
 
       it "returns an unprocessable_entity" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -339,7 +339,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         let(:invoice_custom_section_codes) { invoice_custom_sections.map(&:code) }
 
         it "returns an error" do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
 
           expect(json[:error_details][:invoice_custom_sections]).to include("skip_sections_and_selected_ids_sent_together")
         end

--- a/spec/requests/api/v1/events_controller_spec.rb
+++ b/spec/requests/api/v1/events_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
       it "returns a not found response" do
         expect { subject }.not_to change(Event, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
       it "returns a not found response" do
         expect { subject }.not_to change(Event, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:error_details]).to eq({timestamp: ["invalid_format"]})
       end
     end
@@ -122,7 +122,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
 
         it "fails with a 422 error" do
           expect { subject }.not_to change(Event, :count)
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(json[:error_details]).to include("Variable: b not found")
         end
       end
@@ -187,7 +187,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
       it "returns an error indicating which event contained which error" do
         expect { subject }.not_to change(Event, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:error_details]).to eq({"1": {timestamp: ["invalid_format"]}})
       end
     end
@@ -230,7 +230,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
 
         it "fails with a 422 error" do
           expect { subject }.not_to change(Event, :count)
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(json[:error_details]).to include("0": "expression_evaluation_failed: Variable: b not found")
         end
       end
@@ -471,7 +471,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
 
       it "returns a validation error" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end
@@ -646,7 +646,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
 
       it "returns a validation error" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/requests/api/v1/features_controller_spec.rb
+++ b/spec/requests/api/v1/features_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Api::V1::FeaturesController, type: :request do
       it "returns validation error" do
         subject
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:code]).to include("validation_errors")
       end
     end
@@ -91,7 +91,7 @@ RSpec.describe Api::V1::FeaturesController, type: :request do
       it "returns validation error" do
         subject
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:code]).to include("validation_errors")
       end
     end
@@ -110,7 +110,7 @@ RSpec.describe Api::V1::FeaturesController, type: :request do
       it "returns validation error" do
         subject
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:code]).to include("validation_errors")
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe Api::V1::FeaturesController, type: :request do
       it "returns validation error" do
         subject
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:error_details][:"privilege.value_type"]).to eq ["value_is_invalid"]
       end
     end
@@ -152,7 +152,7 @@ RSpec.describe Api::V1::FeaturesController, type: :request do
       it "returns validation error" do
         subject
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:code]).to include("validation_errors")
       end
     end

--- a/spec/requests/api/v1/fees_controller_spec.rb
+++ b/spec/requests/api/v1/fees_controller_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe Api::V1::FeesController, type: :request do
         subject
 
         aggregate_failures do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(json[:error_details]).to eq({fee_type: %w[value_is_invalid]})
         end
       end

--- a/spec/requests/api/v1/plans/entitlements_controller_spec.rb
+++ b/spec/requests/api/v1/plans/entitlements_controller_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
       it "returns not found error" do
         subject
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:code]).to eq("validation_errors")
         expect(json[:error_details][:max_privilege_value]).to eq(["value_is_invalid"])
       end
@@ -206,7 +206,7 @@ RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
       it "returns not found error" do
         subject
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:code]).to eq("validation_errors")
         expect(json[:error_details][:invitation_privilege_value]).to eq(["value_not_in_select_options"])
       end

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
         subject
 
         aggregate_failures do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(json[:error_details]).to eq({interval: %w[value_is_invalid]})
         end
       end
@@ -451,7 +451,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
 
       it "returns unprocessable_entity error" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       it "returns an unprocessable_entity error" do
         subject
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:error_details]).to eq({external_customer_id: %w[value_is_mandatory]})
       end
     end
@@ -228,7 +228,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
 
       it "returns an unprocessable_entity error" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -344,7 +344,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
 
               subject
 
-              expect(response).to have_http_status(:unprocessable_entity)
+              expect(response).to have_http_status(:unprocessable_content)
               expect(json[:error_details][:payment_method_id]).to include "customer_has_no_payment_method"
             end
           end
@@ -360,7 +360,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
             )
             subject
 
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
             expect(json[:code]).to eq "provider_error"
             expect(json[:provider][:code]).to start_with "stripe_account_"
             expect(json[:error_details]).to include({
@@ -450,7 +450,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
           it "returns validation error" do
             subject
 
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
             expect(json[:error_details]).to include(
               on_termination_credit_note: ["invalid_value"]
             )
@@ -482,7 +482,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
         it "returns validation error" do
           subject
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(json[:error_details]).to include(
             on_termination_invoice: ["invalid_value"]
           )

--- a/spec/requests/api/v1/taxes_controller_spec.rb
+++ b/spec/requests/api/v1/taxes_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Api::V1::TaxesController, type: :request do
 
       it "returns unprocessable_entity error" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/requests/api/v1/wallet_transactions_controller_spec.rb
+++ b/spec/requests/api/v1/wallet_transactions_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
       it "returns an error" do
         wallet.update!(paid_top_up_min_amount_cents: 20_00)
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:error_details][:paid_credits]).to eq(["amount_below_minimum"])
       end
     end
@@ -115,7 +115,7 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
 
       it "returns unprocessable_entity error" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
 
       it "returns a validation error" do
         subject
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json[:error_details][:paid_credits]).to eq ["amount_below_minimum"]
       end
 
@@ -158,7 +158,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
         end
 
         it "returns a validation error" do
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(json[:error_details][:metadata]).to include("invalid_type")
         end
       end
@@ -342,7 +342,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
 
           it "returns a validation error" do
             subject
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
             expect(json[:error_details][:recurring_transaction_rules]).to include("invalid_recurring_rule")
           end
         end

--- a/spec/scenarios/credit_note_spec.rb
+++ b/spec/scenarios/credit_note_spec.rb
@@ -1016,7 +1016,7 @@ describe "Create credit note Scenarios", :scenarios, type: :request do
           }
         ]
       }, raise_on_error: false)
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("higher_than_wallet_balance")
 
       # when creating a credit note with amount higher than remaining balance, it throws an error
@@ -1031,7 +1031,7 @@ describe "Create credit note Scenarios", :scenarios, type: :request do
           }
         ]
       }, raise_on_error: false)
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("higher_than_wallet_balance")
 
       expect(wallet.reload.balance_cents).to eq(5)

--- a/spec/scenarios/subscriptions/terminate_manually_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_manually_spec.rb
@@ -332,7 +332,7 @@ describe "Subscription manual termination", :scenarios, type: :request do
       # when the on_termination_credit_note is invalid
       terminate_subscription_without_jobs(subscription, {on_termination_credit_note: "invalid"}, raise_on_error: false)
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(json).to eq(
         {code: "validation_errors", error: "Unprocessable Entity", error_details: {on_termination_credit_note: ["invalid_value"]}, status: 422}
       )
@@ -340,7 +340,7 @@ describe "Subscription manual termination", :scenarios, type: :request do
       # when the on_termination_invoice is invalid
       terminate_subscription_without_jobs(subscription, {on_termination_invoice: "invalid"}, raise_on_error: false)
 
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(json).to eq(
         {code: "validation_errors", error: "Unprocessable Entity", error_details: {on_termination_invoice: ["invalid_value"]}, status: 422}
       )


### PR DESCRIPTION
## Context

`:unprocessable_entity` has been deprecated:

```sh
/usr/local/bundle/gems/actionpack-8.0.2.1/lib/action_controller/metal/rendering.rb:235: warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.
/usr/local/bundle/gems/rspec-rails-6.1.5/lib/rspec/rails/matchers/have_http_status.rb:219: warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.
```

We should now use `:unprocessable_content`.

## Description

This updates all occurrences of `:unprocessable_entity` in the controllers and request tests. Note that the GraphQL still uses the `"unprocessable_entity"` code.