### PR TITLE
fix(entitlements): return validation error when value is invalid

### DIFF
--- a/app/services/entitlement/subscription_entitlement_update_service.rb
+++ b/app/services/entitlement/subscription_entitlement_update_service.rb
@@ -39,6 +39,8 @@ module Entitlement
       result.entitlement = SubscriptionEntitlement.for_subscription(subscription).find { it.code == feature_code }
 
       result
+    rescue BaseService::FailedResult => e
+      result.fail_with_error!(e)
     rescue ActiveRecord::RecordNotFound => e
       if e.message.include?("Entitlement::Feature")
         result.not_found_failure!(resource: "feature")

--- a/app/services/entitlement/subscription_entitlements_update_service.rb
+++ b/app/services/entitlement/subscription_entitlements_update_service.rb
@@ -31,9 +31,7 @@ module Entitlement
       SendWebhookJob.perform_after_commit("subscription.updated", subscription)
 
       result
-    rescue BaseService::FailedResult => inner_result
-      inner_result.result
-    rescue ValidationFailure => e
+    rescue BaseService::FailedResult => e
       result.fail_with_error!(e)
     rescue ActiveRecord::RecordInvalid => e
       if e.record.is_a?(Entitlement::EntitlementValue)

--- a/spec/requests/api/v1/plans/entitlements_controller_spec.rb
+++ b/spec/requests/api/v1/plans/entitlements_controller_spec.rb
@@ -340,6 +340,25 @@ RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
       end
     end
 
+    context "when privilege value is invalid" do
+      let(:params) do
+        {
+          "entitlements" => {
+            "seats" => {
+              "max" => "one thousand!!"
+            }
+          }
+        }
+      end
+
+      it "returns a validation error" do
+        subject
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details][:max_privilege_value]).to eq(["value_is_invalid"])
+      end
+    end
+
     context "when entitlement does not exist" do
       let(:new_feature) { create(:feature, organization:, code: "storage") }
       let(:new_privilege) { create(:privilege, organization:, feature: new_feature, code: "max_gb", value_type: "integer") }

--- a/spec/services/entitlement/subscription_entitlement_update_service_spec.rb
+++ b/spec/services/entitlement/subscription_entitlement_update_service_spec.rb
@@ -100,5 +100,18 @@ RSpec.describe Entitlement::SubscriptionEntitlementUpdateService, type: :service
         expect(result.error.error_code).to eq("privilege_not_found")
       end
     end
+
+    context "when value is invalid" do
+      let(:privilege_params) do
+        {
+          "max" => "invalid"
+        }
+      end
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages).to eq({max_privilege_value: ["value_is_invalid"]})
+      end
+    end
   end
 end

--- a/spec/services/entitlement/subscription_entitlements_update_service-full_spec.rb
+++ b/spec/services/entitlement/subscription_entitlements_update_service-full_spec.rb
@@ -337,5 +337,20 @@ RSpec.describe Entitlement::SubscriptionEntitlementsUpdateService, type: :servic
         expect(result.error.error_code).to eq("privilege_not_found")
       end
     end
+
+    context "when value is invalid" do
+      let(:entitlements_params) do
+        {
+          "seats" => {
+            "max" => "invalid"
+          }
+        }
+      end
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages).to eq({max_privilege_value: ["value_is_invalid"]})
+      end
+    end
   end
 end

--- a/spec/services/entitlement/subscription_entitlements_update_service-partial_spec.rb
+++ b/spec/services/entitlement/subscription_entitlements_update_service-partial_spec.rb
@@ -107,5 +107,20 @@ RSpec.describe Entitlement::SubscriptionEntitlementsUpdateService, type: :servic
         expect(result.error.error_code).to eq("privilege_not_found")
       end
     end
+
+    context "when value is invalid" do
+      let(:entitlements_params) do
+        {
+          "seats" => {
+            "max" => "invalid"
+          }
+        }
+      end
+
+      it "returns validation failure" do
+        expect(result).not_to be_success
+        expect(result.error.messages).to eq({max_privilege_value: ["value_is_invalid"]})
+      end
+    end
   end
 end


### PR DESCRIPTION
Today, `SubscriptionEntitlementCoreUpdateService` raises an error in something is invalid. This error wasn't set to the outer result, which instead return the result of the error...which doesn't contain the error 😬