### PR TITLE
Feat(fixed_charges-16): generate fees

### DIFF
--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -66,8 +66,9 @@ module Fees
       return customer.organization.taxes.where(code: tax_codes) if tax_codes
       return fee.add_on.taxes if fee.add_on? && fee.add_on.taxes.any?
       return fee.charge.taxes if fee.charge? && fee.charge.taxes.any?
+      return fee.fixed_charge.taxes if fee.fixed_charge? && fee.fixed_charge.taxes.any?
       return fee.invoiceable.taxes if fee.commitment? && fee.invoiceable.taxes.any?
-      if (fee.charge? || fee.subscription? || fee.commitment?) && fee.subscription.plan.taxes.any?
+      if (fee.charge? || fee.subscription? || fee.commitment? || fee.fixed_charge?) && fee.subscription.plan.taxes.any?
         return fee.subscription.plan.taxes
       end
       return customer.taxes if customer.taxes.any?

--- a/app/services/fees/fixed_charge_service.rb
+++ b/app/services/fees/fixed_charge_service.rb
@@ -100,8 +100,8 @@ module Fees
     def apply_aggregation_and_charge_model
       aggregation_result = aggregator.call
 
-      Charges::ChargeModelFactory.new_instance(
-        charge: fixed_charge,
+      ChargeModels::Factory.new_instance(
+        chargeable: fixed_charge,
         aggregation_result:,
         properties: fixed_charge.properties,
         period_ratio: calculate_period_ratio,

--- a/app/services/fees/fixed_charge_service.rb
+++ b/app/services/fees/fixed_charge_service.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+module Fees
+  class FixedChargeService < BaseService
+    Result = BaseResult[:fee]
+
+    def initialize(
+      invoice:,
+      fixed_charge:,
+      subscription:,
+      boundaries:,
+      apply_taxes: false,
+      context: nil
+    )
+      @invoice = invoice
+      @fixed_charge = fixed_charge
+      @subscription = subscription
+      @organization = subscription.organization
+      @boundaries = boundaries
+      @currency = subscription.plan.amount.currency
+      @apply_taxes = apply_taxes
+      @context = context
+      @current_usage = context == :current_usage
+
+      super(nil)
+    end
+
+    def call
+      return result if already_billed?
+
+      init_fee
+      return result if current_usage
+
+      result.fee.save! if context != :invoice_preview && should_persist_fee?
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :invoice, :fixed_charge, :subscription, :boundaries, :apply_taxes, :context, :current_usage, :currency, :organization
+
+    def already_billed?
+      invoice.fees.fixed_charge.exists?(fixed_charge_id: fixed_charge.id)
+    end
+
+    def init_fee
+      amount_result = apply_aggregation_and_charge_model
+
+      # Prevent trying to create a fee with negative units or amount.
+      if amount_result.units.negative? || amount_result.amount.negative?
+        amount_result.amount = amount_result.unit_amount = BigDecimal(0)
+        amount_result.full_units_number = amount_result.units = amount_result.total_aggregated_units = BigDecimal(0)
+      end
+
+      # TODO: add pricing units
+      pricing_unit_usage = nil
+      rounded_amount = amount_result.amount.round(currency.exponent)
+      amount_cents = rounded_amount * currency.subunit_to_unit
+      precise_amount_cents = amount_result.amount * currency.subunit_to_unit.to_d
+      unit_amount_cents = amount_result.unit_amount * currency.subunit_to_unit
+      precise_unit_amount = amount_result.unit_amount
+
+      units = amount_result.units
+
+      new_fee = Fee.new(
+        invoice:,
+        organization_id: organization.id,
+        billing_entity_id: subscription.customer.billing_entity_id,
+        subscription:,
+        fixed_charge:,
+        amount_cents:,
+        precise_amount_cents:,
+        amount_currency: currency,
+        fee_type: :fixed_charge,
+        invoiceable_type: "FixedCharge",
+        invoiceable: fixed_charge,
+        units:,
+        total_aggregated_units: amount_result.total_aggregated_units || units,
+        properties: boundaries.to_h,
+        payment_status: :pending,
+        taxes_amount_cents: 0,
+        taxes_precise_amount_cents: 0.to_d,
+        unit_amount_cents:,
+        precise_unit_amount:,
+        amount_details: amount_result.amount_details,
+        pricing_unit_usage:,
+        pay_in_advance: fixed_charge.pay_in_advance?
+      )
+
+      if apply_taxes
+        taxes_result = Fees::ApplyTaxesService.call(fee: new_fee)
+        taxes_result.raise_if_error!
+      end
+
+      result.fee = new_fee
+    end
+
+    def apply_aggregation_and_charge_model
+      aggregation_result = aggregator.call
+
+      Charges::ChargeModelFactory.new_instance(
+        charge: fixed_charge,
+        aggregation_result:,
+        properties: fixed_charge.properties,
+        period_ratio: calculate_period_ratio,
+        calculate_projected_usage: false
+      ).apply
+    end
+
+    def aggregator
+      if fixed_charge.prorated?
+        return FixedChargeEvents::Aggregations::ProratedAggregationService.new(fixed_charge:, subscription:, boundaries:)
+      end
+
+      FixedChargeEvents::Aggregations::SimpleAggregationService.new(fixed_charge:, subscription:, boundaries:)
+    end
+
+    def calculate_period_ratio
+      from_date = boundaries.charges_from_datetime.to_date
+      to_date = boundaries.charges_to_datetime.to_date
+      current_date = Time.current.to_date
+
+      total_days = (to_date - from_date).to_i + 1
+
+      charges_duration = boundaries.charges_duration || total_days
+
+      return 1.0 if current_date >= to_date
+      return 0.0 if current_date < from_date
+
+      days_passed = (current_date - from_date).to_i + 1
+
+      ratio = days_passed.fdiv(charges_duration)
+      ratio.clamp(0.0, 1.0)
+    end
+
+    def should_persist_fee?
+      return true if context == :recurring
+      return true if organization.zero_amount_fees_enabled?
+      return true if result.fee.units != 0 || result.fee.amount_cents != 0
+
+      false
+    end
+  end
+end

--- a/app/services/fixed_charge_events/aggregations/base_service.rb
+++ b/app/services/fixed_charge_events/aggregations/base_service.rb
@@ -3,7 +3,8 @@
 module FixedChargeEvents
   module Aggregations
     class BaseService < BaseService
-      Result = BaseResult[:count, :aggregation, :current_usage_units, :full_units_number, :total_aggregated_units]
+      Result = BaseResult[:count, :aggregation, :current_usage_units, :full_units_number, :total_aggregated_units, :aggregator, :grouped_by]
+      PerEventAggregationResult = BaseResult[:event_aggregation]
 
       def initialize(fixed_charge:, subscription:, boundaries:)
         @fixed_charge = fixed_charge
@@ -14,10 +15,17 @@ module FixedChargeEvents
         @charges_duration = boundaries.fixed_charges_duration
 
         super(nil)
+        result.aggregator = self
       end
 
       def call
         raise NotImplementedError
+      end
+
+      def per_event_aggregation
+        PerEventAggregationResult.new.tap do |result|
+          result.event_aggregation = compute_per_event_aggregation
+        end
       end
 
       private

--- a/spec/services/fees/apply_taxes_service_spec.rb
+++ b/spec/services/fees/apply_taxes_service_spec.rb
@@ -342,5 +342,32 @@ RSpec.describe Fees::ApplyTaxesService do
         end.not_to change { fee.applied_taxes.count }
       end
     end
+
+    context "when fee is a fixed charge type with taxes" do
+      let(:fixed_charge) { create(:fixed_charge, organization:) }
+      let(:fee) { create(:fixed_charge_fee, invoice:, amount_cents: 1000, precise_amount_cents: 1000.0, fixed_charge:) }
+      let(:applied_tax) { create(:fixed_charge_applied_tax, fixed_charge:, tax: tax1) }
+
+      before { applied_tax }
+
+      it "creates applied_taxes based on the fixed charge taxes" do
+        result = apply_service.call
+        expect(result).to be_success
+        applied_taxes = result.applied_taxes
+        expect(applied_taxes.count).to eq(1)
+
+        expect(applied_taxes[0]).to have_attributes(
+          fee:,
+          tax: tax1,
+          tax_description: tax1.description,
+          tax_code: tax1.code,
+          tax_name: tax1.name,
+          tax_rate: 10,
+          amount_currency: fee.currency,
+          amount_cents: 100,
+          precise_amount_cents: 100.0
+        )
+      end
+    end
   end
 end

--- a/spec/services/fees/fixed_charge_service_spec.rb
+++ b/spec/services/fees/fixed_charge_service_spec.rb
@@ -1,0 +1,424 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Fees::FixedChargeService do
+  subject(:fixed_charge_service) do
+    described_class.new(invoice:, fixed_charge:, subscription:, boundaries:, context:, apply_taxes:)
+  end
+
+  around { |test| lago_premium!(&test) }
+
+  let(:customer) { create(:customer) }
+  let(:organization) { customer.organization }
+  let(:context) { :finalize }
+  let(:apply_taxes) { false }
+
+  let(:subscription) do
+    create(
+      :subscription,
+      organization:,
+      status: :active,
+      started_at: Time.zone.parse("2022-03-17"),
+      customer:
+    )
+  end
+
+  let(:boundaries) do
+    BillingPeriodBoundaries.new(
+      from_datetime: subscription.started_at.to_date.beginning_of_day,
+      to_datetime: subscription.started_at.end_of_month.end_of_day,
+      charges_from_datetime: subscription.started_at.beginning_of_day,
+      charges_to_datetime: subscription.started_at.end_of_month.end_of_day,
+      fixed_charges_from_datetime: subscription.started_at.beginning_of_day,
+      fixed_charges_to_datetime: subscription.started_at.end_of_month.end_of_day,
+      timestamp: subscription.started_at.end_of_month.end_of_day + 1.second,
+      charges_duration: (
+        subscription.started_at.end_of_month.end_of_day - subscription.started_at.beginning_of_month
+      ).fdiv(1.day).ceil,
+      fixed_charges_duration: (
+        subscription.started_at.end_of_month.end_of_day - subscription.started_at.beginning_of_month
+      ).fdiv(1.day).ceil
+    )
+  end
+
+  let(:invoice) do
+    create(:invoice, customer:, organization:)
+  end
+  let(:fixed_charge) do
+    create(
+      :fixed_charge,
+      plan: subscription.plan,
+      charge_model: "standard",
+      properties: {
+        amount: "20"
+      }
+    )
+  end
+  let(:fixed_charge_tax) { create(:fixed_charge_applied_tax, fixed_charge:) }
+
+  describe ".call" do
+    context "with standard charge model" do
+      it "creates a fee but does not persist it" do
+        result = fixed_charge_service.call
+        expect(result).to be_success
+        expect(result.fee.id).to be_nil
+        expect(result.fee.amount_cents).to eq(0)
+      end
+
+      context "with an event" do
+        let(:event) do
+          create(
+            :fixed_charge_event,
+            organization: subscription.organization,
+            subscription:,
+            fixed_charge:,
+            timestamp: boundaries.charges_to_datetime - 2.days,
+            units: 10
+          )
+        end
+
+        before do
+          event
+          fixed_charge_tax
+        end
+
+        it "creates a fee" do
+          result = fixed_charge_service.call
+          expect(result).to be_success
+          expect(result.fee).to have_attributes(
+            id: String,
+            organization_id: organization.id,
+            billing_entity_id: invoice.customer.billing_entity_id,
+            invoice_id: invoice.id,
+            fixed_charge_id: fixed_charge.id,
+            amount_cents: 20000,
+            precise_amount_cents: 20000.0,
+            taxes_precise_amount_cents: 0.0,
+            amount_currency: "EUR",
+            units: 10,
+            unit_amount_cents: 2000,
+            precise_unit_amount: 20,
+            events_count: nil,
+            payment_status: "pending"
+          )
+        end
+
+        it "persists fee" do
+          expect { fixed_charge_service.call }.to change(Fee, :count)
+        end
+
+        context "with preview context" do
+          let(:context) { :invoice_preview }
+
+          it "does not persist fee" do
+            expect { fixed_charge_service.call }.not_to change(Fee, :count)
+          end
+        end
+
+        context "with prorated fixed_charge" do
+          let(:fixed_charge) do
+            create(:fixed_charge, plan: subscription.plan, charge_model: "standard", prorated: true, properties: {amount: "20"})
+          end
+
+          it "creates a fee" do
+            result = fixed_charge_service.call
+            expect(result).to be_success
+            prorated_units = (10 * 3.0 / 31).round(6)
+            expect(result.fee).to have_attributes(
+              id: String,
+              invoice_id: invoice.id,
+              fixed_charge_id: fixed_charge.id,
+              amount_cents: 1935,
+              precise_amount_cents: 2000 * prorated_units,
+              taxes_precise_amount_cents: 0.0,
+              amount_currency: "EUR",
+              units: prorated_units,
+              unit_amount_cents: 2000,
+              precise_unit_amount: 20,
+              events_count: nil,
+              payment_status: "pending"
+            )
+          end
+        end
+      end
+    end
+
+    context "with graduated charge model " do
+      let(:fixed_charge) do
+        create(
+          :fixed_charge,
+          plan: subscription.plan,
+          charge_model: "graduated",
+          prorated: false,
+          properties: {
+            graduated_ranges: [
+              {
+                from_value: 0,
+                to_value: 5,
+                per_unit_amount: "0.1",
+                flat_amount: "10"
+              },
+              {
+                from_value: 6,
+                to_value: nil,
+                per_unit_amount: "2",
+                flat_amount: "20"
+              }
+            ]
+          }
+        )
+      end
+
+      before do
+        create(:fixed_charge_event, fixed_charge:, subscription:, timestamp: boundaries.from_datetime + 5.days, units: 31, created_at: boundaries.from_datetime + 5.days)
+        create(:fixed_charge_event, fixed_charge:, subscription:, timestamp: boundaries.from_datetime + 10.days, units: 3.1, created_at: boundaries.from_datetime + 10.days)
+      end
+
+      # this is not prorated result!
+      it "creates a fee" do
+        result = fixed_charge_service.call
+        expect(result).to be_success
+        expect(result.fee).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          fixed_charge_id: fixed_charge.id,
+          amount_cents: 1031,
+          precise_amount_cents: 1031.0,
+          taxes_precise_amount_cents: 0.0,
+          amount_currency: "EUR",
+          units: 3.1,
+          unit_amount_cents: 332,
+          precise_unit_amount: (10.31 / 3.1),
+          events_count: nil
+        )
+      end
+
+      context "with prorated fixed_charge" do
+        let(:fixed_charge) do
+          create(
+            :fixed_charge,
+            plan: subscription.plan,
+            charge_model: "graduated",
+            prorated: true,
+            properties: {
+              graduated_ranges: [
+                {
+                  from_value: 0,
+                  to_value: 5,
+                  per_unit_amount: "0.1",
+                  flat_amount: "10"
+                },
+                {
+                  from_value: 6,
+                  to_value: nil,
+                  per_unit_amount: "2",
+                  flat_amount: "20"
+                }
+              ]
+            }
+          )
+        end
+
+        it "creates a fee" do
+          result = fixed_charge_service.call
+          expect(result).to be_success
+          prorated_units = (31 * 5 / 31.0 + 3.1 * 5 / 31.0).round(6)
+          expect(result.fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            fixed_charge_id: fixed_charge.id,
+            amount_cents: 1050 + (2000 + 100),
+            precise_amount_cents: 3150.0,
+            taxes_precise_amount_cents: 0.0,
+            amount_currency: "EUR",
+            units: prorated_units,
+            unit_amount_cents: 572,
+            events_count: nil
+          )
+        end
+      end
+    end
+
+    context "with volume charge model" do
+      let(:fixed_charge) do
+        create(:fixed_charge,
+          plan: subscription.plan,
+          charge_model: "volume",
+          prorated: false,
+          properties: {
+            volume_ranges: [
+              {
+                from_value: 0,
+                to_value: 10,
+                per_unit_amount: "0.1",
+                flat_amount: "10"
+              },
+              {
+                from_value: 11,
+                to_value: nil,
+                per_unit_amount: "2",
+                flat_amount: "20"
+              }
+            ]
+          })
+      end
+
+      before do
+        create(:fixed_charge_event, fixed_charge:, subscription:, timestamp: boundaries.from_datetime + 5.days, units: 31, created_at: boundaries.from_datetime + 5.days)
+        create(:fixed_charge_event, fixed_charge:, subscription:, timestamp: boundaries.from_datetime + 10.days, units: 3.1, created_at: boundaries.from_datetime + 10.days)
+      end
+
+      it "creates a fee" do
+        result = fixed_charge_service.call
+        expect(result).to be_success
+        expect(result.fee).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          fixed_charge_id: fixed_charge.id,
+          amount_cents: 1031,
+          precise_amount_cents: 1031.0,
+          taxes_precise_amount_cents: 0.0,
+          amount_currency: "EUR",
+          units: 3.1,
+          unit_amount_cents: 332,
+          precise_unit_amount: 10.31 / 3.1,
+          events_count: nil
+        )
+      end
+
+      context "with prorated fixed_charge" do
+        let(:fixed_charge) do
+          create(:fixed_charge,
+            plan: subscription.plan,
+            charge_model: "volume",
+            prorated: true,
+            properties: {
+              volume_ranges: [
+                {
+                  from_value: 0,
+                  to_value: 10,
+                  per_unit_amount: "0.1",
+                  flat_amount: "10"
+                },
+                {
+                  from_value: 11,
+                  to_value: nil,
+                  per_unit_amount: "2",
+                  flat_amount: "20"
+                }
+              ]
+            })
+        end
+
+        it "creates a fee" do
+          result = fixed_charge_service.call
+          expect(result).to be_success
+          prorated_units = (31 * 5 / 31.0 + 3.1 * 5 / 31.0).round(6)
+          expect(result.fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            fixed_charge_id: fixed_charge.id,
+            amount_cents: 1000 + (10 * 5.5),
+            precise_amount_cents: 1055.0,
+            taxes_precise_amount_cents: 0.0,
+            amount_currency: "EUR",
+            units: prorated_units,
+            unit_amount_cents: 191,
+            precise_unit_amount: 10.55 / 5.5,
+            events_count: nil
+          )
+        end
+      end
+    end
+
+    context "when fee already exists on the period" do
+      before do
+        create(:fee, fixed_charge:, subscription:, invoice:)
+      end
+
+      it "does not create a new fee" do
+        expect { fixed_charge_service.call }.not_to change(Fee, :count)
+      end
+    end
+
+    context "when billing a new upgraded subscription" do
+      let(:previous_plan) { create(:plan, amount_cents: subscription.plan.amount_cents - 20) }
+      let(:previous_subscription) do
+        create(:subscription, plan: previous_plan, status: :terminated)
+      end
+
+      let(:event) do
+        create(
+          :fixed_charge_event,
+          organization: invoice.organization,
+          subscription:,
+          fixed_charge:,
+          timestamp: Time.zone.parse("10 Apr 2022 00:01:00"),
+          units: 10
+        )
+      end
+
+      let(:boundaries) do
+        BillingPeriodBoundaries.new(
+          from_datetime: Time.zone.parse("15 Apr 2022 00:01:00"),
+          to_datetime: Time.zone.parse("30 Apr 2022 00:01:00"),
+          charges_from_datetime: subscription.started_at,
+          charges_to_datetime: Time.zone.parse("30 Apr 2022 00:01:00"),
+          fixed_charges_from_datetime: subscription.started_at,
+          fixed_charges_to_datetime: Time.zone.parse("30 Apr 2022 00:01:00"),
+          charges_duration: 30,
+          fixed_charges_duration: 30,
+          timestamp: Time.zone.parse("2022-05-01T00:01:00")
+        )
+      end
+
+      before do
+        subscription.update!(previous_subscription:)
+        event
+      end
+
+      it "creates a new fee for the complete period" do
+        result = fixed_charge_service.call
+        expect(result).to be_success
+        expect(result.fee).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          fixed_charge_id: fixed_charge.id,
+          amount_cents: 20000,
+          precise_amount_cents: 20_000.0,
+          taxes_precise_amount_cents: 0.0,
+          amount_currency: "EUR",
+          units: 10
+        )
+      end
+    end
+
+    context "when applying taxes" do
+      let(:apply_taxes) { true }
+      let(:event) do
+        create(
+          :fixed_charge_event,
+          organization: subscription.organization,
+          subscription:,
+          fixed_charge:,
+          timestamp: boundaries.charges_to_datetime - 2.days,
+          units: 10
+        )
+      end
+
+      before do
+        event
+        fixed_charge_tax
+      end
+
+      it "creates a fee with taxes" do
+        result = fixed_charge_service.call
+        expect(result).to be_success
+        expect(result.fee).to have_attributes(
+          taxes_precise_amount_cents: 20000 * fixed_charge_tax.tax.rate / 100
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Add a service that generates fees for a fixed_charge. It uses calls aggregation to see how much units should be billed, and then applies charge model on the aggregation result, and then creates fee. By default it does not apply taxes, but a flag can be passed to apply taxes

## Description

- added `Fees::FixedChargeService`