### PR TITLE
test(scenario): Infer metadata for scenario tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,6 +87,10 @@ RSpec/NestedGroups:
 RSpec/NamedSubject:
   Enabled: false
 
+RSpec/DescribeClass:
+  Exclude:
+    - "spec/scenarios/**/*"
+
 # GraphQL
 
 GraphQL/ArgumentDescription:

--- a/spec/integration/stripe/simple_payment_integration_spec.rb
+++ b/spec/integration/stripe/simple_payment_integration_spec.rb
@@ -8,7 +8,7 @@ require "rails_helper"
 # things still work when upgrading the API version.
 # This also creates logs on Stripe so you can copy past them to update the fixtures.
 
-describe "Stripe Payment Integration Test", :scenarios, type: :request do
+describe "Stripe Payment Integration Test", :with_pdf_generation_stub, type: :request do
   let(:api_key) { ENV["STRIPE_API_KEY"] }
 
   let(:organization) { create(:organization, :premium, name: "Stripe IRL") }

--- a/spec/scenarios/billable_metrics/custom_aggregation_spec.rb
+++ b/spec/scenarios/billable_metrics/custom_aggregation_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Aggregation - Custom Aggregation Scenarios", :scenarios, type: :request, transaction: false do
+RSpec.describe "Aggregation - Custom Aggregation Scenarios", transaction: false do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/scenarios/billable_metrics/sum_spec.rb
+++ b/spec/scenarios/billable_metrics/sum_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Aggregation - Sum Scenarios", :scenarios, type: :request, transaction: false do
+describe "Aggregation - Sum Scenarios", transaction: false do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/scenarios/billable_metrics/unique_count_spec.rb
+++ b/spec/scenarios/billable_metrics/unique_count_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Aggregation - Unique Count Scenarios", :scenarios, type: :request, transaction: false do
+describe "Aggregation - Unique Count Scenarios", transaction: false do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/scenarios/billable_metrics/weighted_sum_spec.rb
+++ b/spec/scenarios/billable_metrics/weighted_sum_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Aggregation - Weighted Sum Scenarios", :scenarios, type: :request, transaction: false do
+describe "Aggregation - Weighted Sum Scenarios", transaction: false do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/scenarios/charge_models/clickhouse/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/clickhouse/prorated_graduated_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Charge Models - Prorated Graduated Scenarios", :scenarios, type: :request, transaction: false, clickhouse: true do
+describe "Charge Models - Prorated Graduated Scenarios", transaction: false, clickhouse: true do
   let(:organization) { create(:organization, webhook_url: nil, clickhouse_events_store: true) }
   let(:customer) { create(:customer, organization:, name: "aaaaaabcd") }
   let(:tax) { create(:tax, organization:, rate: 0) }

--- a/spec/scenarios/charge_models/dynamic_spec.rb
+++ b/spec/scenarios/charge_models/dynamic_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Charge Models - Dynamic Pricing Scenarios", :scenarios, type: :request, transaction: false do
+describe "Charge Models - Dynamic Pricing Scenarios", transaction: false do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/scenarios/charge_models/edit_with_filter_spec.rb
+++ b/spec/scenarios/charge_models/edit_with_filter_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Change charge model with filters", :scenarios, type: :request do
+describe "Change charge model with filters" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/scenarios/charge_models/percentage_spec.rb
+++ b/spec/scenarios/charge_models/percentage_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Charge Models - Percentage Scenarios", :scenarios, type: :request do
+describe "Charge Models - Percentage Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Charge Models - Prorated Graduated Scenarios", :scenarios, type: :request, transaction: false do
+describe "Charge Models - Prorated Graduated Scenarios", transaction: false do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:, name: "aaaaaabcd") }
   let(:tax) { create(:tax, organization:, rate: 0) }

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/monthly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/quarterly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/weekly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/yearly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/monthly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/quarterly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/weekly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/yearly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_advance_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Advance Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Advance Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:, currency: "EUR") }

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/monthly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/quarterly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/weekly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/yearly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/monthly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/quarterly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/weekly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/yearly_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:) }

--- a/spec/scenarios/commitments/minimum/in_arrears_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Minimum Commitments In Arrears Scenario", :scenarios, type: :request do
+describe "Billing Minimum Commitments In Arrears Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { "UTC" }
   let(:customer) { create(:customer, organization:, timezone:, currency: "EUR") }

--- a/spec/scenarios/coupons_breakdown_spec.rb
+++ b/spec/scenarios/coupons_breakdown_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Coupons breakdown Spec", :scenarios, type: :request do
+describe "Coupons breakdown Spec" do
   let(:organization) { create(:organization, webhook_url: nil) }
 
   before do

--- a/spec/scenarios/create_event_spec.rb
+++ b/spec/scenarios/create_event_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Create Event Scenarios", :scenarios, type: :request do
+describe "Create Event Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
   let(:billable_metric) { create(:billable_metric, organization:) }

--- a/spec/scenarios/credit_note_spec.rb
+++ b/spec/scenarios/credit_note_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Create credit note Scenarios", :scenarios, type: :request do
+describe "Create credit note Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/scenarios/customer_usage_spec.rb
+++ b/spec/scenarios/customer_usage_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Customer usage Scenario", :scenarios, type: :request do
+describe "Customer usage Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
 
   let(:timezone) { "UTC" }

--- a/spec/scenarios/customers/create_partner_and_run_billing_spec.rb
+++ b/spec/scenarios/customers/create_partner_and_run_billing_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Create partner and run billing Scenarios", :scenarios, type: :request do
+describe "Create partner and run billing Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil, document_numbering: "per_organization", premium_integrations: ["revenue_share"]) }
   let(:billing_entity) { organization.default_billing_entity }
   let(:partner) { create(:customer, organization:, billing_entity:) }

--- a/spec/scenarios/customers/customer_eu_taxes_spec.rb
+++ b/spec/scenarios/customers/customer_eu_taxes_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Add customer-specific taxes", :scenarios, type: :request do
+describe "Add customer-specific taxes" do
   let(:organization) { create(:organization, country: "FR", eu_tax_management: false, billing_entities: [create(:billing_entity, country: "FR")]) }
   let(:plan) { create(:plan, organization:, pay_in_advance: true, amount_cents: 149_00) }
 

--- a/spec/scenarios/customers/update_invoice_grace_period_spec.rb
+++ b/spec/scenarios/customers/update_invoice_grace_period_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Update Customer Invoice Grace Period Scenarios", :scenarios, type: :request do
+describe "Update Customer Invoice Grace Period Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
   let(:plan) { create(:plan, pay_in_advance: true, organization:) }

--- a/spec/scenarios/daily_usages/fill_history_spec.rb
+++ b/spec/scenarios/daily_usages/fill_history_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Daily Usages: Fill History", :time_travel, :scenarios, type: :request, transaction: false do
+describe "Daily Usages: Fill History", :time_travel, transaction: false do
   around { |test| lago_premium!(&test) }
 
   let(:organization) { create(:organization, webhook_url: nil, email_settings: [], premium_integrations: ["revenue_analytics"]) }

--- a/spec/scenarios/delete_customer_spec.rb
+++ b/spec/scenarios/delete_customer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Delete Customer Scenarios", :scenarios, type: :request do
+describe "Delete Customer Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
   let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 1000) }

--- a/spec/scenarios/delete_plan_spec.rb
+++ b/spec/scenarios/delete_plan_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Delete Plan Scenarios", :scenarios, type: :request do
+describe "Delete Plan Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
   let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 1000) }

--- a/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
+++ b/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Dunning Campaign v1", :scenarios, type: :request do
+describe "Dunning Campaign v1" do
   let(:organization) do
     create(:organization, name: "JC AI", premium_integrations: %w[auto_dunning])
   end

--- a/spec/scenarios/fees/recurring_fee_downgrade_spec.rb
+++ b/spec/scenarios/fees/recurring_fee_downgrade_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Recurring Fees Subscription Downgrade", :scenarios, type: :request do
+describe "Recurring Fees Subscription Downgrade" do
   let(:organization) { create(:organization, webhook_url: "http://fees.test/wh") }
   let(:customer) { create(:customer, organization:) }
   let(:billable_metric) { create(:unique_count_billable_metric, :recurring, organization:, code: "seats") }

--- a/spec/scenarios/fees/recurring_fee_upgrade_spec.rb
+++ b/spec/scenarios/fees/recurring_fee_upgrade_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Recurring Fees Subscription Upgrade", :scenarios, type: :request do
+describe "Recurring Fees Subscription Upgrade" do
   let(:organization) { create(:organization, webhook_url: "http://fees.test/wh") }
   let(:customer) { create(:customer, organization:) }
   let(:billable_metric) { create(:unique_count_billable_metric, :recurring, organization:, code: "seats") }

--- a/spec/scenarios/fees/recurring_fees_spec.rb
+++ b/spec/scenarios/fees/recurring_fees_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Recurring Non Invoiceable Fees", :scenarios, type: :request do
+describe "Recurring Non Invoiceable Fees" do
   let(:organization) { create(:organization, webhook_url: "http://fees.test/wh") }
   let(:billing_entity) { create(:billing_entity, organization:) }
   let(:customer) { create(:customer, organization:, billing_entity:) }

--- a/spec/scenarios/invoices/adjusted_charge_fees_spec.rb
+++ b/spec/scenarios/invoices/adjusted_charge_fees_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Adjusted Charge Fees Scenario", :scenarios, type: :request, transaction: false do
+describe "Adjusted Charge Fees Scenario", transaction: false do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: "") }
 
   let(:customer) { create(:customer, organization:, invoice_grace_period: 5) }

--- a/spec/scenarios/invoices/adjusted_subscription_fees_spec.rb
+++ b/spec/scenarios/invoices/adjusted_subscription_fees_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Adjusted Subscription Fees Scenario", :scenarios, type: :request, transaction: false do
+describe "Adjusted Subscription Fees Scenario", transaction: false do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: "") }
 
   let(:customer) { create(:customer, organization:, invoice_grace_period: 5) }

--- a/spec/scenarios/invoices/advance_charges_dates_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_dates_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
+describe "Advance Charges Invoices Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
   let(:tax_rate) { 20 }

--- a/spec/scenarios/invoices/advance_charges_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Advance Charges Invoices Scenarios", :scenarios, type: :request, transaction: false do
+describe "Advance Charges Invoices Scenarios", transaction: false do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
   let(:tax_rate) { 20 }

--- a/spec/scenarios/invoices/advance_charges_taxes_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_taxes_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Advance Charges Invoices Scenarios", :scenarios, type: :request do
+describe "Advance Charges Invoices Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
   let(:tax_rate_1) { 9.3 }

--- a/spec/scenarios/invoices/filters_and_grouped_by_spec.rb
+++ b/spec/scenarios/invoices/filters_and_grouped_by_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Invoices for charges with filters and grouped by", :scenarios, type: :request do
+RSpec.describe "Invoices for charges with filters and grouped by" do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
 
   let(:customer) { create(:customer, organization:) }

--- a/spec/scenarios/invoices/invoice_numbering_spec.rb
+++ b/spec/scenarios/invoices/invoice_numbering_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Invoice Numbering Scenario", :scenarios, type: :request, transaction: false do
+describe "Invoice Numbering Scenario", transaction: false do
   let(:customer_first) { create(:customer, organization:, billing_entity: billing_entity_first) }
   let(:customer_second) { create(:customer, organization:, billing_entity: billing_entity_first) }
   let(:customer_third) { create(:customer, organization:, billing_entity: billing_entity_first) }

--- a/spec/scenarios/invoices/invoice_payments_spec.rb
+++ b/spec/scenarios/invoices/invoice_payments_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Invoice Payments Scenarios", :scenarios, type: :request do
+describe "Invoice Payments Scenarios" do
   let(:webhook_url) { "https://test.co/lago" }
   let(:organization) do
     create(:organization,

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Invoices Scenarios", :scenarios, type: :request do
+describe "Invoices Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
 

--- a/spec/scenarios/invoices/progressive_billing_spec.rb
+++ b/spec/scenarios/invoices/progressive_billing_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Progressive billing invoices", :scenarios, type: :request, transaction: false do
+describe "Progressive billing invoices", transaction: false do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: [], premium_integrations: ["progressive_billing"]) }
   let(:billing_entity) { create(:billing_entity, organization:) }
   let(:plan) { create(:plan, organization: organization, interval: "monthly", amount_cents: 31_00, pay_in_advance: false) }

--- a/spec/scenarios/invoices/recurring_fees_spec.rb
+++ b/spec/scenarios/invoices/recurring_fees_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Recurring fee invoice inclusion after upgrade", :scenarios, type: :request do
+describe "Recurring fee invoice inclusion after upgrade" do
   let(:organization) { create(:organization, webhook_url: "http://lago.test/wh") }
   let(:customer) { create(:customer, organization:) }
   let(:billable_metric) { create(:sum_billable_metric, :recurring, organization:) }

--- a/spec/scenarios/invoices/void_invoice_spec.rb
+++ b/spec/scenarios/invoices/void_invoice_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Void Invoice Scenarios", :scenarios, type: :request do
+describe "Void Invoice Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
   let(:customer) { create(:customer, organization:) }

--- a/spec/scenarios/lifetime_usages/without_progressive_billing_spec.rb
+++ b/spec/scenarios/lifetime_usages/without_progressive_billing_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Lifetime usage without progressive billing", :time_travel, :scenarios, type: :request do
+describe "Lifetime usage without progressive billing", :time_travel do
   around { |test| lago_premium!(&test) }
 
   let(:organization) { create(:organization, webhook_url: nil, email_settings: [], premium_integrations: ["lifetime_usage", "progressive_billing"]) }

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Pay in advance charges Scenarios", :scenarios, type: :request, transaction: false do
+describe "Pay in advance charges Scenarios", transaction: false do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/scenarios/plans/create_and_update_filters_spec.rb
+++ b/spec/scenarios/plans/create_and_update_filters_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Create and edit plans with charge filters", :scenarios, type: :request do
+RSpec.describe "Create and edit plans with charge filters" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
   let(:billable_metric) { create(:sum_billable_metric, organization:, field_name: "value") }

--- a/spec/scenarios/spending_minimum_spec.rb
+++ b/spec/scenarios/spending_minimum_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Spending Minimum Scenarios", :scenarios, type: :request do
+describe "Spending Minimum Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }

--- a/spec/scenarios/subscriptions/activation_spec.rb
+++ b/spec/scenarios/subscriptions/activation_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Subscriptions Activation Scenario", :scenarios, type: :request do
+describe "Subscriptions Activation Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
 
   let(:timezone) { "America/Bogota" }

--- a/spec/scenarios/subscriptions/billing_boundaries_spec.rb
+++ b/spec/scenarios/subscriptions/billing_boundaries_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Boundaries Scenario", :scenarios, type: :request do
+describe "Billing Boundaries Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
 
   let(:timezone) { "UTC" }

--- a/spec/scenarios/subscriptions/billing_spec.rb
+++ b/spec/scenarios/subscriptions/billing_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Billing Subscriptions Scenario", :scenarios, type: :request do
+describe "Billing Subscriptions Scenario" do
   let(:organization) { create(:organization, webhook_url: nil) }
 
   let(:timezone) { "UTC" }

--- a/spec/scenarios/subscriptions/downgrade_spec.rb
+++ b/spec/scenarios/subscriptions/downgrade_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Subscription Downgrade Scenario", :scenarios, type: :request, transaction: false do
+describe "Subscription Downgrade Scenario", transaction: false do
   let(:organization) { create(:organization, webhook_url: false) }
 
   let(:customer) { create(:customer, organization:) }

--- a/spec/scenarios/subscriptions/free_trial_billing_spec.rb
+++ b/spec/scenarios/subscriptions/free_trial_billing_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Free Trial Billing Subscriptions Scenario", :scenarios, type: :request do
+describe "Free Trial Billing Subscriptions Scenario" do
   let(:timezone) { "UTC" }
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:billable_metric) { create(:billable_metric, organization:) }

--- a/spec/scenarios/subscriptions/multiple_upgrade_spec.rb
+++ b/spec/scenarios/subscriptions/multiple_upgrade_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Multiple Subscription Upgrade Scenario", :scenarios, type: :request do
+describe "Multiple Subscription Upgrade Scenario" do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
 
   let(:customer) { create(:customer, organization:) }

--- a/spec/scenarios/subscriptions/progressive_billing_enablement_spec.rb
+++ b/spec/scenarios/subscriptions/progressive_billing_enablement_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Progressive Billing enablement", :scenarios, type: :request, transaction: false do
+describe "Progressive Billing enablement", transaction: false do
   let(:timezone) { "UTC" }
   let(:organization) { create(:organization, webhook_url: nil, premium_integrations: ["progressive_billing"]) }
   let(:billable_metric) { create(:sum_billable_metric, organization:) }

--- a/spec/scenarios/subscriptions/terminate_ended_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Subscriptions Termination Scenario", :scenarios, type: :request do
+describe "Subscriptions Termination Scenario" do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: "") }
 
   let(:timezone) { "Europe/Paris" }

--- a/spec/scenarios/subscriptions/terminate_manually_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_manually_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Subscription manual termination", :scenarios, type: :request do
+describe "Subscription manual termination" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:, timezone: "UTC") }
   let(:billable_metric) { create(:sum_billable_metric, organization:, field_name: "item_count") }

--- a/spec/scenarios/subscriptions/upgrade_spec.rb
+++ b/spec/scenarios/subscriptions/upgrade_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Subscription Upgrade Scenario", :scenarios, type: :request, transaction: false do
+describe "Subscription Upgrade Scenario", transaction: false do
   let(:organization) { create(:organization, webhook_url: false, email_settings: []) }
 
   let(:customer) { create(:customer, organization:) }

--- a/spec/scenarios/taxes_on_invoice_spec.rb
+++ b/spec/scenarios/taxes_on_invoice_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Taxes on Invoice Scenarios", :scenarios, type: :request do
+describe "Taxes on Invoice Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
 
   before do

--- a/spec/scenarios/terminate_pay_in_advance_spec.rb
+++ b/spec/scenarios/terminate_pay_in_advance_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Terminate Pay in Advance Scenarios", :scenarios, type: :request do
+describe "Terminate Pay in Advance Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }

--- a/spec/scenarios/usage_monitoring/subscription_alerts_spec.rb
+++ b/spec/scenarios/usage_monitoring/subscription_alerts_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Subscriptions Alerting Scenario", :scenarios, type: :request, cache: :redis do
+describe "Subscriptions Alerting Scenario", cache: :redis do
   let(:organization) { create(:organization, premium_integrations:) }
   let(:premium_integrations) { [] }
   let(:plan) { create(:plan, organization:, name: "Premium Plan", code: "premium_plan", amount_cents: 49_00) }

--- a/spec/scenarios/wallets/balance_spec.rb
+++ b/spec/scenarios/wallets/balance_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Use wallet's credits and recalculate balances", :scenarios, type: :request, transaction: false do
+describe "Use wallet's credits and recalculate balances", transaction: false do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: [], premium_integrations: ["progressive_billing"]) }
   let(:billing_entity) { create(:billing_entity, organization:, invoice_grace_period: 10) }
   let(:plan) { create(:plan, organization: organization, interval: "monthly", amount_cents: 1_00, pay_in_advance: false) }

--- a/spec/scenarios/wallets/topup_with_open_invoices_spec.rb
+++ b/spec/scenarios/wallets/topup_with_open_invoices_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Wallet Transaction with invoice after payment", :scenarios, type: :request do
+describe "Wallet Transaction with invoice after payment" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/scenarios/wallets/topup_with_rounding_spec.rb
+++ b/spec/scenarios/wallets/topup_with_rounding_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Wallet Transaction with rounding", :scenarios, type: :request do
+describe "Wallet Transaction with rounding" do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/services/invoices/regenerate_from_voided_service_spec.rb
+++ b/spec/services/invoices/regenerate_from_voided_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Regenerate From Voided Invoice Scenarios", :scenarios, type: :request do
+describe "Regenerate From Voided Invoice Scenarios", :with_pdf_generation_stub, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
   let(:customer) { create(:customer, organization:) }


### PR DESCRIPTION
## Context

All scenario tests currently require the `:scenarios, type: :request` RSpec metadata. Those can be inferred from the file path and do not need to be set manually.

## Description

This change the RSpec configuration to infer the `type: :request` metadata for `spec/scenarios` folder.

The `scenarios` metadata was also replaced by a more explicit `:with_pdf_generation_stub` metadata. This metadata defines a before hook that calls `stub_pdf_generation`. Note that `stub_pdf_generation` is called in multiple places which can re-use this metadata but I'll handle this in another PR.
