### PR TITLE
test(subscription): Fix flaky subscription test

### DIFF
--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -879,8 +879,9 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
               ]
             }
           )
-          charges = plan_json[:charges]
+          charges = plan_json[:charges].sort_by { |charge| charge[:invoice_display_name] }
           expect(charges.length).to eq(2)
+
           first_charge = charges.first
           second_charge = charges.second
           expect(first_charge).to match(


### PR DESCRIPTION
## Context

I got the following flaky test on one of my CI run:

```sh
  1) Api::V1::SubscriptionsController PUT /api/v1/subscriptions/:external_id when the plan has already been overriden when progressive billing premium integration is present updates a subscription
     Got 2 failures:

     1.1) Failure/Error:
            expect(first_charge).to match(
              {
                lago_id: Regex::UUID,
                lago_billable_metric_id: overriden_package_charge.billable_metric.id,
                invoice_display_name: "Setup",
                billable_metric_code: overriden_package_charge.billable_metric.code,
                created_at: Regex::ISO8601_DATETIME,
                charge_model: "package",
                invoiceable: true,
                regroup_paid_fees: nil,

            expected {:applied_pricing_unit => {:code => "ETH", :conversion_rate => "40.0"}, :billable_metric_code => "ufq...go_id => "f8f752f8-a464-4a24-aa96-9d5e52acd51f", :name => "VAT", :plans_count => 0, :rate => 20.0}]} to match {lago_id: /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/, lago_billable_metric_id: "5f73cc93-12b2-4c85-94d9-992bb4c983aa", invoice_display_name: "Setup", billable_metric_code: "e17k6586rd", created_at: /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\z/, charge_model: "package", invoiceable: true, regroup_paid_fees: nil, pay_in_advance: false, prorated: false, min_amount_cents: 0, properties: {amount: "60", free_units: 200, package_size: 2000}, applied_pricing_unit: nil, filters: [], taxes: [{lago_id: /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/, name: "VAT", code: (a kind of String), rate: 20.0, description: "French Standard VAT", applied_to_organization: false, add_ons_count: 0, customers_count: 0, plans_count: 0, charges_count: 0, commitments_count: 0, created_at: /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\z/}]}
            Diff:

            @@ -1,16 +1,16 @@
            -:applied_pricing_unit => nil,
            -:billable_metric_code => "e17k6586rd",
            +:applied_pricing_unit => {:code => "ETH", :conversion_rate => "40.0"},
            +:billable_metric_code => "ufqzhf20ur",
             :charge_model => "package",
            -:created_at => /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\z/,
            +:created_at => "2025-09-18T07:41:28Z",
             :filters => [],
            -:invoice_display_name => "Setup",
            +:invoice_display_name => "Setup 2",
             :invoiceable => true,
            -:lago_billable_metric_id => "5f73cc93-12b2-4c85-94d9-992bb4c983aa",
            -:lago_id => /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/,
            -:min_amount_cents => 0,
            +:lago_billable_metric_id => "205f4cd9-b438-431a-8ff2-461bf8d1e6ce",
            +:lago_id => "deada7a7-152b-412c-afe4-dec5e6c5eaf4",
            +:min_amount_cents => 6000,
             :pay_in_advance => false,
             :properties => {:amount => "60", :free_units => 200, :package_size => 2000},
             :prorated => false,
             :regroup_paid_fees => nil,
            -:taxes => [{:add_ons_count => 0, :applied_to_organization => false, :charges_count => 0, :code => (a kind of String), :commitments_count => 0, :created_at => /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\z/, :customers_count => 0, :description => "French Standard VAT", :lago_id => /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/, :name => "VAT", :plans_count => 0, :rate => 20.0}],
            +:taxes => [{:add_ons_count => 0, :applied_to_organization => false, :charges_count => 0, :code => "vat-61a49fb6-0995-4e6e-bbf7-bd6492e7c9b1", :commitments_count => 0, :created_at => "2025-09-18T07:41:28Z", :customers_count => 0, :description => "French Standard VAT", :lago_id => "f8f752f8-a464-4a24-aa96-9d5e52acd51f", :name => "VAT", :plans_count => 0, :rate => 20.0}],
          # ./spec/requests/api/v1/subscriptions_controller_spec.rb:886:in 'block (5 levels) in <top (required)>'
          # ./spec/support/license_helper.rb:6:in 'LicenseHelper#lago_premium!'
          # ./spec/requests/api/v1/subscriptions_controller_spec.rb:816:in 'block (5 levels) in <top (required)>'
          # ./spec/support/license_helper.rb:6:in 'LicenseHelper#lago_premium!'
          # ./spec/requests/api/v1/subscriptions_controller_spec.rb:12:in 'block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:214:in 'block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:206:in 'block (3 levels) in <top (required)>'
          # ./spec/spec_helper.rb:205:in 'block (2 levels) in <top (required)>'

     1.2) Failure/Error:
            expect(second_charge).to match(
              {
                lago_id: Regex::UUID,
                lago_billable_metric_id: other_billable_metric.id,
                invoice_display_name: "Setup 2",
                billable_metric_code: other_billable_metric.code,
                created_at: Regex::ISO8601_DATETIME,
                charge_model: "package",
                invoiceable: true,
                regroup_paid_fees: nil,

            expected {:applied_pricing_unit => nil, :billable_metric_code => "e17k6586rd", :charge_model => "package", :cr...go_id => "f8f752f8-a464-4a24-aa96-9d5e52acd51f", :name => "VAT", :plans_count => 0, :rate => 20.0}]} to match {lago_id: /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/, lago_billable_metric_id: "205f4cd9-b438-431a-8ff2-461bf8d1e6ce", invoice_display_name: "Setup 2", billable_metric_code: "ufqzhf20ur", created_at: /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\z/, charge_model: "package", invoiceable: true, regroup_paid_fees: nil, pay_in_advance: false, prorated: false, min_amount_cents: 6000, applied_pricing_unit: {conversion_rate: "40.0", code: "ETH"}, properties: {amount: "60", free_units: 200, package_size: 2000}, filters: [], taxes: [{lago_id: /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/, name: "VAT", code: (a kind of String), rate: 20.0, description: "French Standard VAT", applied_to_organization: false, add_ons_count: 0, customers_count: 0, plans_count: 0, charges_count: 0, commitments_count: 0, created_at: /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\z/}]}
            Diff:

            @@ -1,16 +1,16 @@
            -:applied_pricing_unit => {:code => "ETH", :conversion_rate => "40.0"},
            -:billable_metric_code => "ufqzhf20ur",
            +:applied_pricing_unit => nil,
            +:billable_metric_code => "e17k6586rd",
             :charge_model => "package",
            -:created_at => /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\z/,
            +:created_at => "2025-09-18T07:41:28Z",
             :filters => [],
            -:invoice_display_name => "Setup 2",
            +:invoice_display_name => "Setup",
             :invoiceable => true,
            -:lago_billable_metric_id => "205f4cd9-b438-431a-8ff2-461bf8d1e6ce",
            -:lago_id => /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/,
            -:min_amount_cents => 6000,
            +:lago_billable_metric_id => "5f73cc93-12b2-4c85-94d9-992bb4c983aa",
            +:lago_id => "3ef98848-2eda-4aa5-a32f-bbcea1dd8e74",
            +:min_amount_cents => 0,
             :pay_in_advance => false,
             :properties => {:amount => "60", :free_units => 200, :package_size => 2000},
             :prorated => false,
             :regroup_paid_fees => nil,
            -:taxes => [{:add_ons_count => 0, :applied_to_organization => false, :charges_count => 0, :code => (a kind of String), :commitments_count => 0, :created_at => /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\z/, :customers_count => 0, :description => "French Standard VAT", :lago_id => /\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/, :name => "VAT", :plans_count => 0, :rate => 20.0}],
            +:taxes => [{:add_ons_count => 0, :applied_to_organization => false, :charges_count => 0, :code => "vat-61a49fb6-0995-4e6e-bbf7-bd6492e7c9b1", :commitments_count => 0, :created_at => "2025-09-18T07:41:28Z", :customers_count => 0, :description => "French Standard VAT", :lago_id => "f8f752f8-a464-4a24-aa96-9d5e52acd51f", :name => "VAT", :plans_count => 0, :rate => 20.0}],
          # ./spec/requests/api/v1/subscriptions_controller_spec.rb:920:in 'block (5 levels) in <top (required)>'
          # ./spec/support/license_helper.rb:6:in 'LicenseHelper#lago_premium!'
          # ./spec/requests/api/v1/subscriptions_controller_spec.rb:816:in 'block (5 levels) in <top (required)>'
          # ./spec/support/license_helper.rb:6:in 'LicenseHelper#lago_premium!'
          # ./spec/requests/api/v1/subscriptions_controller_spec.rb:12:in 'block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:214:in 'block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:206:in 'block (3 levels) in <top (required)>'
          # ./spec/spec_helper.rb:205:in 'block (2 levels) in <top (required)>'

Finished in 0.78766 seconds (files took 4.97 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/requests/api/v1/subscriptions_controller_spec.rb:822 # Api::V1::SubscriptionsController PUT /api/v1/subscriptions/:external_id when the plan has already been overriden when progressive billing premium integration is present updates a subscription
```

## Description

This fixes it by sorting the charges by invoice display name.