### PR TITLE
test(graphql): Infer `type: :graphql` spec metadata

### DIFF
--- a/spec/graphql/concerns/authenticable_api_user_spec.rb
+++ b/spec/graphql/concerns/authenticable_api_user_spec.rb
@@ -29,7 +29,7 @@ module AuthenticableApiUserSpec
   end
 end
 
-RSpec.describe AuthenticableApiUser, type: :graphql do
+RSpec.describe AuthenticableApiUser do
   let(:mutation) do
     <<-GQL
       mutation($input: RenameThingInput!) {

--- a/spec/graphql/concerns/authenticable_customer_portal_user_spec.rb
+++ b/spec/graphql/concerns/authenticable_customer_portal_user_spec.rb
@@ -26,7 +26,7 @@ module AuthenticableCustomerPortalUserSpec
   end
 end
 
-RSpec.describe AuthenticableCustomerPortalUser, type: :graphql do
+RSpec.describe AuthenticableCustomerPortalUser do
   let(:resolver) do
     <<~GQL
       query {

--- a/spec/graphql/concerns/can_require_permissions_spec.rb
+++ b/spec/graphql/concerns/can_require_permissions_spec.rb
@@ -31,7 +31,7 @@ module CanRequirePermissionsSpec
   end
 end
 
-RSpec.describe CanRequirePermissions, type: :graphql do
+RSpec.describe CanRequirePermissions do
   let(:mutation) do
     <<-GQL
       mutation($input: RenameThingInput!) {

--- a/spec/graphql/concerns/required_organization_spec.rb
+++ b/spec/graphql/concerns/required_organization_spec.rb
@@ -29,7 +29,7 @@ module RequiredOrganizationSpec
   end
 end
 
-RSpec.describe RequiredOrganization, type: :graphql do
+RSpec.describe RequiredOrganization do
   let(:mutation) do
     <<-GQL
       mutation($input: RenameThingInput!) {

--- a/spec/graphql/mutations/add_ons/create_spec.rb
+++ b/spec/graphql/mutations/add_ons/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::AddOns::Create, type: :graphql do
+RSpec.describe Mutations::AddOns::Create do
   let(:required_permission) { "addons:create" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/add_ons/destroy_spec.rb
+++ b/spec/graphql/mutations/add_ons/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::AddOns::Destroy, type: :graphql do
+RSpec.describe Mutations::AddOns::Destroy do
   let(:required_permission) { "addons:delete" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/add_ons/update_spec.rb
+++ b/spec/graphql/mutations/add_ons/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::AddOns::Update, type: :graphql do
+RSpec.describe Mutations::AddOns::Update do
   let(:required_permission) { "addons:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/adjusted_fees/create_spec.rb
+++ b/spec/graphql/mutations/adjusted_fees/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::AdjustedFees::Create, type: :graphql do
+RSpec.describe Mutations::AdjustedFees::Create do
   let(:required_permission) { "invoices:update" }
   let(:organization) { create(:organization) }
   let(:membership) { create(:membership, organization:) }

--- a/spec/graphql/mutations/adjusted_fees/destroy_spec.rb
+++ b/spec/graphql/mutations/adjusted_fees/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::AdjustedFees::Destroy, type: :graphql do
+RSpec.describe Mutations::AdjustedFees::Destroy do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/adjusted_fees/preview_spec.rb
+++ b/spec/graphql/mutations/adjusted_fees/preview_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::AdjustedFees::Preview, type: :graphql do
+RSpec.describe Mutations::AdjustedFees::Preview do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/api_keys/create_spec.rb
+++ b/spec/graphql/mutations/api_keys/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::ApiKeys::Create, type: :graphql do
+RSpec.describe Mutations::ApiKeys::Create do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/api_keys/destroy_spec.rb
+++ b/spec/graphql/mutations/api_keys/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::ApiKeys::Destroy, type: :graphql do
+RSpec.describe Mutations::ApiKeys::Destroy do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/api_keys/rotate_spec.rb
+++ b/spec/graphql/mutations/api_keys/rotate_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::ApiKeys::Rotate, type: :graphql do
+RSpec.describe Mutations::ApiKeys::Rotate do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/api_keys/update_spec.rb
+++ b/spec/graphql/mutations/api_keys/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::ApiKeys::Update, type: :graphql do
+RSpec.describe Mutations::ApiKeys::Update do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/applied_coupons/create_spec.rb
+++ b/spec/graphql/mutations/applied_coupons/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::AppliedCoupons::Create, type: :graphql do
+RSpec.describe Mutations::AppliedCoupons::Create do
   let(:required_permission) { "coupons:attach" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/applied_coupons/terminate_spec.rb
+++ b/spec/graphql/mutations/applied_coupons/terminate_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::AppliedCoupons::Terminate, type: :graphql do
+RSpec.describe Mutations::AppliedCoupons::Terminate do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:coupon) { create(:coupon, organization:) }

--- a/spec/graphql/mutations/auth/google/accept_invite_spec.rb
+++ b/spec/graphql/mutations/auth/google/accept_invite_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Auth::Google::AcceptInvite, type: :graphql do
+RSpec.describe Mutations::Auth::Google::AcceptInvite do
   let(:google_service) { instance_double(Auth::GoogleService) }
   let(:user) { create(:user) }
   let(:invite) { create(:invite) }

--- a/spec/graphql/mutations/auth/google/login_user_spec.rb
+++ b/spec/graphql/mutations/auth/google/login_user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Auth::Google::LoginUser, type: :graphql do
+RSpec.describe Mutations::Auth::Google::LoginUser do
   let(:membership) { create(:membership) }
   let(:user) { membership.user }
   let(:google_service) { instance_double(Auth::GoogleService) }

--- a/spec/graphql/mutations/auth/google/register_user_spec.rb
+++ b/spec/graphql/mutations/auth/google/register_user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Auth::Google::RegisterUser, type: :graphql do
+RSpec.describe Mutations::Auth::Google::RegisterUser do
   let(:google_service) { instance_double(Auth::GoogleService) }
   let(:user) { create(:user) }
 

--- a/spec/graphql/mutations/auth/okta/accept_invite_spec.rb
+++ b/spec/graphql/mutations/auth/okta/accept_invite_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Auth::Okta::AcceptInvite, type: :graphql, cache: :memory do
+RSpec.describe Mutations::Auth::Okta::AcceptInvite, cache: :memory do
   let(:organization) { create(:organization, premium_integrations: ["okta"]) }
   let(:invite) { create(:invite, email: "foo@bar.com", organization:) }
   let(:okta_integration) { create(:okta_integration, domain: "bar.com", organization_name: "foo", organization:) }

--- a/spec/graphql/mutations/auth/okta/authorize_spec.rb
+++ b/spec/graphql/mutations/auth/okta/authorize_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Auth::Okta::Authorize, type: :graphql do
+RSpec.describe Mutations::Auth::Okta::Authorize do
   let(:user) { create(:user) }
   let(:okta_integration) { create(:okta_integration) }
 

--- a/spec/graphql/mutations/auth/okta/login_spec.rb
+++ b/spec/graphql/mutations/auth/okta/login_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Auth::Okta::Login, type: :graphql, cache: :memory do
+RSpec.describe Mutations::Auth::Okta::Login, cache: :memory do
   let(:okta_integration) { create(:okta_integration, domain: "bar.com", organization_name: "foo") }
   let(:lago_http_client) { instance_double(LagoHttpClient::Client) }
   let(:okta_token_response) { OpenStruct.new(body: {access_token: "access_token"}) }

--- a/spec/graphql/mutations/billable_metrics/create_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::BillableMetrics::Create, type: :graphql do
+RSpec.describe Mutations::BillableMetrics::Create do
   let(:required_permission) { "billable_metrics:create" }
   let(:membership) { create(:membership) }
   let(:mutation) do

--- a/spec/graphql/mutations/billable_metrics/destroy_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::BillableMetrics::Destroy, type: :graphql do
+RSpec.describe Mutations::BillableMetrics::Destroy do
   let(:required_permission) { "billable_metrics:delete" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/billable_metrics/update_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::BillableMetrics::Update, type: :graphql do
+RSpec.describe Mutations::BillableMetrics::Update do
   let(:required_permission) { "billable_metrics:update" }
   let(:membership) { create(:membership) }
   let(:billable_metric) { create(:weighted_sum_billable_metric, organization: membership.organization) }

--- a/spec/graphql/mutations/billing_entities/apply_taxes_spec.rb
+++ b/spec/graphql/mutations/billing_entities/apply_taxes_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::BillingEntities::ApplyTaxes, type: :graphql do
+RSpec.describe Mutations::BillingEntities::ApplyTaxes do
   let(:required_permission) { "billing_entities:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/billing_entities/create_spec.rb
+++ b/spec/graphql/mutations/billing_entities/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::BillingEntities::Create, type: :graphql do
+RSpec.describe Mutations::BillingEntities::Create do
   let(:required_permission) { "billing_entities:create" }
   let(:membership) { create(:membership, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/graphql/mutations/billing_entities/destroy_spec.rb
+++ b/spec/graphql/mutations/billing_entities/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::BillingEntities::Destroy, type: :graphql do
+RSpec.describe Mutations::BillingEntities::Destroy do
   let(:required_permission) { "billing_entities:delete" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/billing_entities/remove_taxes_spec.rb
+++ b/spec/graphql/mutations/billing_entities/remove_taxes_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::BillingEntities::RemoveTaxes, type: :graphql do
+RSpec.describe Mutations::BillingEntities::RemoveTaxes do
   let(:required_permission) { "billing_entities:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/billing_entities/update_applied_dunning_campaign_spec.rb
+++ b/spec/graphql/mutations/billing_entities/update_applied_dunning_campaign_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::BillingEntities::UpdateAppliedDunningCampaign, type: :graphql do
+RSpec.describe Mutations::BillingEntities::UpdateAppliedDunningCampaign do
   let(:required_permission) { "billing_entities:dunning_campaigns:update" }
   let(:membership) { create(:membership, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/graphql/mutations/billing_entities/update_spec.rb
+++ b/spec/graphql/mutations/billing_entities/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::BillingEntities::Update, type: :graphql do
+RSpec.describe Mutations::BillingEntities::Update do
   let(:required_permission) { "billing_entities:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/coupons/create_spec.rb
+++ b/spec/graphql/mutations/coupons/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Coupons::Create, type: :graphql do
+RSpec.describe Mutations::Coupons::Create do
   let(:required_permission) { "coupons:create" }
   let(:membership) { create(:membership) }
   let(:expiration_at) { Time.current + 3.days }

--- a/spec/graphql/mutations/coupons/destroy_spec.rb
+++ b/spec/graphql/mutations/coupons/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Coupons::Destroy, type: :graphql do
+RSpec.describe Mutations::Coupons::Destroy do
   let(:required_permission) { "coupons:delete" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/coupons/terminate_spec.rb
+++ b/spec/graphql/mutations/coupons/terminate_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Coupons::Terminate, type: :graphql do
+RSpec.describe Mutations::Coupons::Terminate do
   let(:required_permission) { "coupons:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/coupons/update_spec.rb
+++ b/spec/graphql/mutations/coupons/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Coupons::Update, type: :graphql do
+RSpec.describe Mutations::Coupons::Update do
   let(:required_permission) { "coupons:update" }
   let(:membership) { create(:membership) }
   let(:coupon) { create(:coupon, organization: membership.organization) }

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
+RSpec.describe Mutations::CreditNotes::Create do
   let(:required_permission) { "credit_notes:create" }
   let(:organization) { create(:organization) }
   let(:membership) { create(:membership, organization:) }

--- a/spec/graphql/mutations/credit_notes/download_spec.rb
+++ b/spec/graphql/mutations/credit_notes/download_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::CreditNotes::Download, type: :graphql do
+RSpec.describe Mutations::CreditNotes::Download do
   let(:required_permission) { "credit_notes:view" }
   let(:credit_note) { create(:credit_note) }
   let(:organization) { credit_note.organization }

--- a/spec/graphql/mutations/credit_notes/retry_tax_reporting_spec.rb
+++ b/spec/graphql/mutations/credit_notes/retry_tax_reporting_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::CreditNotes::RetryTaxReporting, type: :graphql do
+RSpec.describe Mutations::CreditNotes::RetryTaxReporting do
   let(:required_permission) { "credit_notes:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/credit_notes/update_spec.rb
+++ b/spec/graphql/mutations/credit_notes/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::CreditNotes::Update, type: :graphql do
+RSpec.describe Mutations::CreditNotes::Update do
   let(:required_permission) { "credit_notes:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/credit_notes/void_spec.rb
+++ b/spec/graphql/mutations/credit_notes/void_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::CreditNotes::Void, type: :graphql do
+RSpec.describe Mutations::CreditNotes::Void do
   let(:required_permission) { "credit_notes:void" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/customer_portal/download_invoice_spec.rb
+++ b/spec/graphql/mutations/customer_portal/download_invoice_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::CustomerPortal::DownloadInvoice, type: :graphql do
+RSpec.describe Mutations::CustomerPortal::DownloadInvoice do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }

--- a/spec/graphql/mutations/customer_portal/generate_url_spec.rb
+++ b/spec/graphql/mutations/customer_portal/generate_url_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::CustomerPortal::GenerateUrl, type: :graphql do
+RSpec.describe Mutations::CustomerPortal::GenerateUrl do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }

--- a/spec/graphql/mutations/customer_portal/update_customer_spec.rb
+++ b/spec/graphql/mutations/customer_portal/update_customer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::CustomerPortal::UpdateCustomer, type: :graphql do
+RSpec.describe Mutations::CustomerPortal::UpdateCustomer do
   subject(:result) do
     execute_graphql(
       customer_portal_user: customer,

--- a/spec/graphql/mutations/customer_portal/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/customer_portal/wallet_transactions/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::CustomerPortal::WalletTransactions::Create, type: :graphql do
+RSpec.describe Mutations::CustomerPortal::WalletTransactions::Create do
   let(:wallet) { create(:wallet, balance: 10.0, credits_balance: 10.0) }
 
   let(:mutation) do

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Customers::Create, type: :graphql do
+RSpec.describe Mutations::Customers::Create do
   let(:required_permissions) { "customers:create" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/customers/destroy_spec.rb
+++ b/spec/graphql/mutations/customers/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Customers::Destroy, type: :graphql do
+RSpec.describe Mutations::Customers::Destroy do
   let(:required_permissions) { "customers:delete" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/customers/update_invoice_grace_period_spec.rb
+++ b/spec/graphql/mutations/customers/update_invoice_grace_period_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Customers::UpdateInvoiceGracePeriod, type: :graphql do
+RSpec.describe Mutations::Customers::UpdateInvoiceGracePeriod do
   let(:required_permissions) { "customer_settings:update:grace_period" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Customers::Update, type: :graphql do
+RSpec.describe Mutations::Customers::Update do
   let(:required_permissions) { "customers:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/data_exports/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/data_exports/credit_notes/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::DataExports::CreditNotes::Create, type: :graphql do
+RSpec.describe Mutations::DataExports::CreditNotes::Create do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/data_exports/invoices/create_spec.rb
+++ b/spec/graphql/mutations/data_exports/invoices/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::DataExports::Invoices::Create, type: :graphql do
+RSpec.describe Mutations::DataExports::Invoices::Create do
   let(:required_permission) { "invoices:export" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/dunning_campaigns/create_spec.rb
+++ b/spec/graphql/mutations/dunning_campaigns/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::DunningCampaigns::Create, type: :graphql do
+RSpec.describe Mutations::DunningCampaigns::Create do
   let(:required_permission) { "dunning_campaigns:create" }
   let(:organization) { create(:organization, premium_integrations: ["auto_dunning"]) }
   let(:membership) { create(:membership, organization:) }

--- a/spec/graphql/mutations/dunning_campaigns/destroy_spec.rb
+++ b/spec/graphql/mutations/dunning_campaigns/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::DunningCampaigns::Destroy, type: :graphql do
+RSpec.describe Mutations::DunningCampaigns::Destroy do
   let(:required_permissions) { "dunning_campaigns:delete" }
   let(:membership) { create(:membership, organization:) }
   let(:organization) { create(:organization, premium_integrations: ["auto_dunning"]) }

--- a/spec/graphql/mutations/dunning_campaigns/update_spec.rb
+++ b/spec/graphql/mutations/dunning_campaigns/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::DunningCampaigns::Update, type: :graphql do
+RSpec.describe Mutations::DunningCampaigns::Update do
   let(:required_permission) { "dunning_campaigns:update" }
   let(:organization) { create(:organization, premium_integrations: ["auto_dunning"]) }
   let(:membership) { create(:membership, organization:) }

--- a/spec/graphql/mutations/entitlement/create_feature_spec.rb
+++ b/spec/graphql/mutations/entitlement/create_feature_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Entitlement::CreateFeature, type: :graphql do
+RSpec.describe Mutations::Entitlement::CreateFeature do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "features:create" }

--- a/spec/graphql/mutations/entitlement/create_or_update_subscription_entitlement_spec.rb
+++ b/spec/graphql/mutations/entitlement/create_or_update_subscription_entitlement_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Entitlement::CreateOrUpdateSubscriptionEntitlement, type: :graphql do
+RSpec.describe Mutations::Entitlement::CreateOrUpdateSubscriptionEntitlement do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "subscriptions:update" }

--- a/spec/graphql/mutations/entitlement/destroy_feature_spec.rb
+++ b/spec/graphql/mutations/entitlement/destroy_feature_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Entitlement::DestroyFeature, type: :graphql do
+RSpec.describe Mutations::Entitlement::DestroyFeature do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "features:delete" }

--- a/spec/graphql/mutations/entitlement/remove_subscription_entitlement_spec.rb
+++ b/spec/graphql/mutations/entitlement/remove_subscription_entitlement_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Entitlement::RemoveSubscriptionEntitlement, type: :graphql do
+RSpec.describe Mutations::Entitlement::RemoveSubscriptionEntitlement do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "subscriptions:update" }

--- a/spec/graphql/mutations/entitlement/update_feature_spec.rb
+++ b/spec/graphql/mutations/entitlement/update_feature_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Entitlement::UpdateFeature, type: :graphql do
+RSpec.describe Mutations::Entitlement::UpdateFeature do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "features:update" }

--- a/spec/graphql/mutations/integration_collection_mappings/create_spec.rb
+++ b/spec/graphql/mutations/integration_collection_mappings/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::IntegrationCollectionMappings::Create, type: :graphql do
+RSpec.describe Mutations::IntegrationCollectionMappings::Create do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:mapping_type) { %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit].sample.to_s }

--- a/spec/graphql/mutations/integration_collection_mappings/destroy_spec.rb
+++ b/spec/graphql/mutations/integration_collection_mappings/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::IntegrationCollectionMappings::Destroy, type: :graphql do
+RSpec.describe Mutations::IntegrationCollectionMappings::Destroy do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration_collection_mapping) { create(:netsuite_collection_mapping, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }

--- a/spec/graphql/mutations/integration_collection_mappings/update_spec.rb
+++ b/spec/graphql/mutations/integration_collection_mappings/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::IntegrationCollectionMappings::Update, type: :graphql do
+RSpec.describe Mutations::IntegrationCollectionMappings::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration_collection_mapping) { create(:netsuite_collection_mapping, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }

--- a/spec/graphql/mutations/integration_items/fetch_accounts_spec.rb
+++ b/spec/graphql/mutations/integration_items/fetch_accounts_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::IntegrationItems::FetchAccounts, type: :graphql do
+RSpec.describe Mutations::IntegrationItems::FetchAccounts do
   let(:required_permission) { "organization:integrations:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/integration_items/fetch_items_spec.rb
+++ b/spec/graphql/mutations/integration_items/fetch_items_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::IntegrationItems::FetchItems, type: :graphql do
+RSpec.describe Mutations::IntegrationItems::FetchItems do
   let(:required_permission) { "organization:integrations:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/integration_mappings/create_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::IntegrationMappings::Create, type: :graphql do
+RSpec.describe Mutations::IntegrationMappings::Create do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:mappable) { create(:add_on, organization:) }

--- a/spec/graphql/mutations/integration_mappings/destroy_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::IntegrationMappings::Destroy, type: :graphql do
+RSpec.describe Mutations::IntegrationMappings::Destroy do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration_mapping) { create(:netsuite_mapping, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }

--- a/spec/graphql/mutations/integration_mappings/update_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::IntegrationMappings::Update, type: :graphql do
+RSpec.describe Mutations::IntegrationMappings::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration_mapping) { create(:netsuite_mapping, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }

--- a/spec/graphql/mutations/integrations/anrok/create_spec.rb
+++ b/spec/graphql/mutations/integrations/anrok/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Anrok::Create, type: :graphql do
+RSpec.describe Mutations::Integrations::Anrok::Create do
   let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
   let(:code) { "anrok1" }

--- a/spec/graphql/mutations/integrations/anrok/update_spec.rb
+++ b/spec/graphql/mutations/integrations/anrok/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Anrok::Update, type: :graphql do
+RSpec.describe Mutations::Integrations::Anrok::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration) { create(:anrok_integration, organization:) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/integrations/avalara/create_spec.rb
+++ b/spec/graphql/mutations/integrations/avalara/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Avalara::Create, type: :graphql do
+RSpec.describe Mutations::Integrations::Avalara::Create do
   let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
   let(:code) { "avalara1" }

--- a/spec/graphql/mutations/integrations/avalara/update_spec.rb
+++ b/spec/graphql/mutations/integrations/avalara/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Avalara::Update, type: :graphql do
+RSpec.describe Mutations::Integrations::Avalara::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration) { create(:avalara_integration, organization:) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/integrations/destroy_spec.rb
+++ b/spec/graphql/mutations/integrations/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Destroy, type: :graphql do
+RSpec.describe Mutations::Integrations::Destroy do
   let(:required_permission) { "organization:integrations:delete" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/integrations/fetch_draft_invoice_taxes_spec.rb
+++ b/spec/graphql/mutations/integrations/fetch_draft_invoice_taxes_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::FetchDraftInvoiceTaxes, type: :graphql do
+RSpec.describe Mutations::Integrations::FetchDraftInvoiceTaxes do
   let(:required_permission) { "invoices:create" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/integrations/hubspot/create_spec.rb
+++ b/spec/graphql/mutations/integrations/hubspot/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Hubspot::Create, type: :graphql do
+RSpec.describe Mutations::Integrations::Hubspot::Create do
   let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
   let(:code) { "hubspot1" }

--- a/spec/graphql/mutations/integrations/hubspot/sync_invoice_spec.rb
+++ b/spec/graphql/mutations/integrations/hubspot/sync_invoice_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Hubspot::SyncInvoice, type: :graphql do
+RSpec.describe Mutations::Integrations::Hubspot::SyncInvoice do
   subject(:execute_graphql_call) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/integrations/hubspot/update_spec.rb
+++ b/spec/graphql/mutations/integrations/hubspot/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Hubspot::Update, type: :graphql do
+RSpec.describe Mutations::Integrations::Hubspot::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration) { create(:hubspot_integration, organization:) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/integrations/netsuite/create_spec.rb
+++ b/spec/graphql/mutations/integrations/netsuite/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Netsuite::Create, type: :graphql do
+RSpec.describe Mutations::Integrations::Netsuite::Create do
   let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
   let(:code) { "netsuite1" }

--- a/spec/graphql/mutations/integrations/netsuite/update_spec.rb
+++ b/spec/graphql/mutations/integrations/netsuite/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Netsuite::Update, type: :graphql do
+RSpec.describe Mutations::Integrations::Netsuite::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/integrations/okta/create_spec.rb
+++ b/spec/graphql/mutations/integrations/okta/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Okta::Create, type: :graphql do
+RSpec.describe Mutations::Integrations::Okta::Create do
   let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
 

--- a/spec/graphql/mutations/integrations/okta/update_spec.rb
+++ b/spec/graphql/mutations/integrations/okta/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Okta::Update, type: :graphql do
+RSpec.describe Mutations::Integrations::Okta::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration) { create(:okta_integration, organization:) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/integrations/salesforce/create_spec.rb
+++ b/spec/graphql/mutations/integrations/salesforce/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Salesforce::Create, type: :graphql do
+RSpec.describe Mutations::Integrations::Salesforce::Create do
   let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
   let(:name) { "Salesforce 1" }

--- a/spec/graphql/mutations/integrations/salesforce/sync_invoice_spec.rb
+++ b/spec/graphql/mutations/integrations/salesforce/sync_invoice_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Salesforce::SyncInvoice, type: :graphql do
+RSpec.describe Mutations::Integrations::Salesforce::SyncInvoice do
   subject(:execute_graphql_call) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/integrations/salesforce/update_spec.rb
+++ b/spec/graphql/mutations/integrations/salesforce/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Salesforce::Update, type: :graphql do
+RSpec.describe Mutations::Integrations::Salesforce::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration) { create(:salesforce_integration, organization:) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/integrations/sync_credit_note_spec.rb
+++ b/spec/graphql/mutations/integrations/sync_credit_note_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::SyncCreditNote, type: :graphql do
+RSpec.describe Mutations::Integrations::SyncCreditNote do
   subject(:execute_graphql_call) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/integrations/sync_invoice_spec.rb
+++ b/spec/graphql/mutations/integrations/sync_invoice_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::SyncInvoice, type: :graphql do
+RSpec.describe Mutations::Integrations::SyncInvoice do
   subject(:execute_graphql_call) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/integrations/xero/create_spec.rb
+++ b/spec/graphql/mutations/integrations/xero/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Xero::Create, type: :graphql do
+RSpec.describe Mutations::Integrations::Xero::Create do
   let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
   let(:code) { "xero1" }

--- a/spec/graphql/mutations/integrations/xero/update_spec.rb
+++ b/spec/graphql/mutations/integrations/xero/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Integrations::Xero::Update, type: :graphql do
+RSpec.describe Mutations::Integrations::Xero::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration) { create(:xero_integration, organization:) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invites/accept_spec.rb
+++ b/spec/graphql/mutations/invites/accept_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invites::Accept, type: :graphql do
+RSpec.describe Mutations::Invites::Accept do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:password) { Faker::Internet.password }

--- a/spec/graphql/mutations/invites/create_spec.rb
+++ b/spec/graphql/mutations/invites/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invites::Create, type: :graphql do
+RSpec.describe Mutations::Invites::Create do
   let(:required_permission) { "organization:members:create" }
   let(:membership) { create(:membership) }
   let(:revoked_membership) do

--- a/spec/graphql/mutations/invites/revoke_spec.rb
+++ b/spec/graphql/mutations/invites/revoke_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invites::Revoke, type: :graphql do
+RSpec.describe Mutations::Invites::Revoke do
   let(:required_permission) { "organization:members:delete" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invites/update_spec.rb
+++ b/spec/graphql/mutations/invites/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invites::Update, type: :graphql do
+RSpec.describe Mutations::Invites::Update do
   let(:required_permission) { "organization:members:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoice_custom_sections/create_spec.rb
+++ b/spec/graphql/mutations/invoice_custom_sections/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::InvoiceCustomSections::Create, type: :graphql do
+RSpec.describe Mutations::InvoiceCustomSections::Create do
   let(:required_permission) { "invoice_custom_sections:create" }
   let(:membership) { create(:membership) }
 

--- a/spec/graphql/mutations/invoice_custom_sections/destroy_spec.rb
+++ b/spec/graphql/mutations/invoice_custom_sections/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::InvoiceCustomSections::Destroy, type: :graphql do
+RSpec.describe Mutations::InvoiceCustomSections::Destroy do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/invoice_custom_sections/update_spec.rb
+++ b/spec/graphql/mutations/invoice_custom_sections/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::InvoiceCustomSections::Update, type: :graphql do
+RSpec.describe Mutations::InvoiceCustomSections::Update do
   let(:required_permission) { "invoice_custom_sections:update" }
   let(:membership) { create(:membership) }
 

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::Create, type: :graphql do
+RSpec.describe Mutations::Invoices::Create do
   let(:required_permission) { "invoices:create" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/download_spec.rb
+++ b/spec/graphql/mutations/invoices/download_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::Download, type: :graphql do
+RSpec.describe Mutations::Invoices::Download do
   let(:required_permission) { "invoices:view" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/finalize_all_spec.rb
+++ b/spec/graphql/mutations/invoices/finalize_all_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::FinalizeAll, type: :graphql do
+RSpec.describe Mutations::Invoices::FinalizeAll do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/finalize_spec.rb
+++ b/spec/graphql/mutations/invoices/finalize_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::Finalize, type: :graphql do
+RSpec.describe Mutations::Invoices::Finalize do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/generate_payment_url_spec.rb
+++ b/spec/graphql/mutations/invoices/generate_payment_url_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::GeneratePaymentUrl, type: :graphql do
+RSpec.describe Mutations::Invoices::GeneratePaymentUrl do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/lose_dispute_spec.rb
+++ b/spec/graphql/mutations/invoices/lose_dispute_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::LoseDispute, type: :graphql do
+RSpec.describe Mutations::Invoices::LoseDispute do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/refresh_spec.rb
+++ b/spec/graphql/mutations/invoices/refresh_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::Refresh, type: :graphql do
+RSpec.describe Mutations::Invoices::Refresh do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/regenerate_from_voided_spec.rb
+++ b/spec/graphql/mutations/invoices/regenerate_from_voided_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::RegenerateFromVoided, type: :graphql do
+RSpec.describe Mutations::Invoices::RegenerateFromVoided do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/retry_all_payments_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_all_payments_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::RetryAllPayments, type: :graphql do
+RSpec.describe Mutations::Invoices::RetryAllPayments do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/retry_all_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_all_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::RetryAll, type: :graphql do
+RSpec.describe Mutations::Invoices::RetryAll do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/retry_payment_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_payment_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::RetryPayment, type: :graphql do
+RSpec.describe Mutations::Invoices::RetryPayment do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/retry_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::Retry, type: :graphql do
+RSpec.describe Mutations::Invoices::Retry do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/retry_tax_provider_voiding_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_tax_provider_voiding_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::RetryTaxProviderVoiding, type: :graphql do
+RSpec.describe Mutations::Invoices::RetryTaxProviderVoiding do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/update_spec.rb
+++ b/spec/graphql/mutations/invoices/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::Update, type: :graphql do
+RSpec.describe Mutations::Invoices::Update do
   let(:required_permission) { "invoices:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/invoices/void_spec.rb
+++ b/spec/graphql/mutations/invoices/void_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::Void, type: :graphql do
+RSpec.describe Mutations::Invoices::Void do
   let(:required_permission) { "invoices:void" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/login_user_spec.rb
+++ b/spec/graphql/mutations/login_user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::LoginUser, type: :graphql do
+RSpec.describe Mutations::LoginUser do
   let(:membership) { create(:membership) }
   let(:user) { membership.user }
   let(:mutation) do

--- a/spec/graphql/mutations/memberships/revoke_spec.rb
+++ b/spec/graphql/mutations/memberships/revoke_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Memberships::Revoke, type: :graphql do
+RSpec.describe Mutations::Memberships::Revoke do
   let(:required_permission) { "organization:members:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/memberships/update_spec.rb
+++ b/spec/graphql/mutations/memberships/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Memberships::Update, type: :graphql do
+RSpec.describe Mutations::Memberships::Update do
   let(:required_permission) { "organization:members:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Organizations::Update, type: :graphql do
+RSpec.describe Mutations::Organizations::Update do
   let(:membership) { create(:membership) }
   let(:mutation) do
     <<~GQL

--- a/spec/graphql/mutations/password_resets/create_spec.rb
+++ b/spec/graphql/mutations/password_resets/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PasswordResets::Create, type: :graphql do
+RSpec.describe Mutations::PasswordResets::Create do
   let(:user) { create(:user) }
   let(:email) { user.email }
 

--- a/spec/graphql/mutations/password_resets/reset_spec.rb
+++ b/spec/graphql/mutations/password_resets/reset_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PasswordResets::Reset, type: :graphql do
+RSpec.describe Mutations::PasswordResets::Reset do
   let(:membership) { create(:membership, user: create(:user, password: "HelloLago!1")) }
   let(:password_reset) { create(:password_reset, user: membership.user) }
 

--- a/spec/graphql/mutations/payment_providers/adyen/create_spec.rb
+++ b/spec/graphql/mutations/payment_providers/adyen/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentProviders::Adyen::Create, type: :graphql do
+RSpec.describe Mutations::PaymentProviders::Adyen::Create do
   let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
   let(:api_key) { "api_key_123456_abc" }

--- a/spec/graphql/mutations/payment_providers/adyen/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/adyen/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentProviders::Adyen::Update, type: :graphql do
+RSpec.describe Mutations::PaymentProviders::Adyen::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:membership) { create(:membership) }
   let(:adyen_provider) { create(:adyen_provider, organization: membership.organization) }

--- a/spec/graphql/mutations/payment_providers/cashfree/create_spec.rb
+++ b/spec/graphql/mutations/payment_providers/cashfree/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentProviders::Cashfree::Create, type: :graphql do
+RSpec.describe Mutations::PaymentProviders::Cashfree::Create do
   let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
   let(:client_id) { "123456_abc" }

--- a/spec/graphql/mutations/payment_providers/cashfree/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/cashfree/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentProviders::Cashfree::Update, type: :graphql do
+RSpec.describe Mutations::PaymentProviders::Cashfree::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:membership) { create(:membership) }
   let(:cashfree_provider) { create(:cashfree_provider, organization: membership.organization) }

--- a/spec/graphql/mutations/payment_providers/destroy_spec.rb
+++ b/spec/graphql/mutations/payment_providers/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentProviders::Destroy, type: :graphql do
+RSpec.describe Mutations::PaymentProviders::Destroy do
   let(:required_permission) { "organization:integrations:delete" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/payment_providers/flutterwave/create_spec.rb
+++ b/spec/graphql/mutations/payment_providers/flutterwave/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentProviders::Flutterwave::Create, type: :graphql do
+RSpec.describe Mutations::PaymentProviders::Flutterwave::Create do
   let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
   let(:secret_key) { "FLWSECK-xxxxxxxxx-X" }

--- a/spec/graphql/mutations/payment_providers/flutterwave/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/flutterwave/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentProviders::Flutterwave::Update, type: :graphql do
+RSpec.describe Mutations::PaymentProviders::Flutterwave::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:membership) { create(:membership) }
   let(:flutterwave_provider) { create(:flutterwave_provider, organization: membership.organization) }

--- a/spec/graphql/mutations/payment_providers/gocardless/create_spec.rb
+++ b/spec/graphql/mutations/payment_providers/gocardless/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentProviders::Gocardless::Create, type: :graphql do
+RSpec.describe Mutations::PaymentProviders::Gocardless::Create do
   let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
   let(:access_code) { "ert_123456_abc" }

--- a/spec/graphql/mutations/payment_providers/gocardless/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/gocardless/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentProviders::Gocardless::Update, type: :graphql do
+RSpec.describe Mutations::PaymentProviders::Gocardless::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:oauth_client) { instance_double(OAuth2::Client) }
   let(:auth_code_strategy) { instance_double(OAuth2::Strategy::AuthCode) }

--- a/spec/graphql/mutations/payment_providers/stripe/create_spec.rb
+++ b/spec/graphql/mutations/payment_providers/stripe/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentProviders::Stripe::Create, type: :graphql do
+RSpec.describe Mutations::PaymentProviders::Stripe::Create do
   let(:required_permission) { "organization:integrations:create" }
   let(:membership) { create(:membership) }
 

--- a/spec/graphql/mutations/payment_providers/stripe/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/stripe/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentProviders::Stripe::Update, type: :graphql do
+RSpec.describe Mutations::PaymentProviders::Stripe::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:membership) { create(:membership) }
   let(:stripe_provider) { create(:stripe_provider, organization: membership.organization) }

--- a/spec/graphql/mutations/payment_receipts/download_spec.rb
+++ b/spec/graphql/mutations/payment_receipts/download_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentReceipts::Download, type: :graphql do
+RSpec.describe Mutations::PaymentReceipts::Download do
   let(:required_permission) { "invoices:view" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/payment_requests/create_spec.rb
+++ b/spec/graphql/mutations/payment_requests/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PaymentRequests::Create, type: :graphql do
+RSpec.describe Mutations::PaymentRequests::Create do
   let(:required_permission) { "payment_requests:create" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/payments/create_spec.rb
+++ b/spec/graphql/mutations/payments/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Payments::Create, type: :graphql do
+RSpec.describe Mutations::Payments::Create do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Plans::Create, type: :graphql do
+RSpec.describe Mutations::Plans::Create do
   let(:required_permission) { "plans:create" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/plans/destroy_spec.rb
+++ b/spec/graphql/mutations/plans/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Plans::Destroy, type: :graphql do
+RSpec.describe Mutations::Plans::Destroy do
   subject(:graphql_request) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Plans::Update, type: :graphql do
+RSpec.describe Mutations::Plans::Update do
   let(:required_permission) { "plans:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/pricing_units/create_spec.rb
+++ b/spec/graphql/mutations/pricing_units/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PricingUnits::Create, type: :graphql do
+RSpec.describe Mutations::PricingUnits::Create do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/pricing_units/update_spec.rb
+++ b/spec/graphql/mutations/pricing_units/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::PricingUnits::Update, type: :graphql do
+RSpec.describe Mutations::PricingUnits::Update do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/register_user_spec.rb
+++ b/spec/graphql/mutations/register_user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::RegisterUser, type: :graphql do
+RSpec.describe Mutations::RegisterUser do
   let(:mutation) do
     <<~GQL
       mutation($input: RegisterUserInput!) {

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
+RSpec.describe Mutations::Subscriptions::Create do
   let(:required_permission) { "subscriptions:create" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/subscriptions/terminate_spec.rb
+++ b/spec/graphql/mutations/subscriptions/terminate_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Subscriptions::Terminate, type: :graphql do
+RSpec.describe Mutations::Subscriptions::Terminate do
   subject(:result) do
     execute_query(
       query: mutation,

--- a/spec/graphql/mutations/subscriptions/update_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
+RSpec.describe Mutations::Subscriptions::Update do
   subject { execute_query(query:, input:) }
 
   let(:required_permission) { "subscriptions:update" }

--- a/spec/graphql/mutations/taxes/create_spec.rb
+++ b/spec/graphql/mutations/taxes/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Taxes::Create, type: :graphql do
+RSpec.describe Mutations::Taxes::Create do
   let(:membership) { create(:membership) }
   let(:input) do
     {

--- a/spec/graphql/mutations/taxes/destroy_spec.rb
+++ b/spec/graphql/mutations/taxes/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Taxes::Destroy, type: :graphql do
+RSpec.describe Mutations::Taxes::Destroy do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:tax) { create(:tax, organization:) }

--- a/spec/graphql/mutations/taxes/update_spec.rb
+++ b/spec/graphql/mutations/taxes/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Taxes::Update, type: :graphql do
+RSpec.describe Mutations::Taxes::Update do
   let(:membership) { create(:membership) }
   let(:tax) { create(:tax, organization: membership.organization) }
   let(:input) do

--- a/spec/graphql/mutations/usage_monitoring/alerts/create_spec.rb
+++ b/spec/graphql/mutations/usage_monitoring/alerts/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::UsageMonitoring::Alerts::Create, type: :graphql do
+RSpec.describe Mutations::UsageMonitoring::Alerts::Create do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/usage_monitoring/alerts/destroy_spec.rb
+++ b/spec/graphql/mutations/usage_monitoring/alerts/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::UsageMonitoring::Alerts::Destroy, type: :graphql do
+RSpec.describe Mutations::UsageMonitoring::Alerts::Destroy do
   let(:required_permission) { "subscriptions:update" }
   let(:membership) { create(:membership) }
   let(:customer) { create(:customer, organization: membership.organization) }

--- a/spec/graphql/mutations/usage_monitoring/alerts/update_spec.rb
+++ b/spec/graphql/mutations/usage_monitoring/alerts/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::UsageMonitoring::Alerts::Update, type: :graphql do
+RSpec.describe Mutations::UsageMonitoring::Alerts::Update do
   let(:required_permission) { "subscriptions:update" }
   let(:membership) { create(:membership) }
   let(:customer) { create(:customer, organization: membership.organization) }

--- a/spec/graphql/mutations/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/wallet_transactions/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
+RSpec.describe Mutations::WalletTransactions::Create do
   subject(:result) { execute_query(query:, input:) }
 
   let(:required_permission) { "wallets:top_up" }

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Wallets::Create, type: :graphql do
+RSpec.describe Mutations::Wallets::Create do
   let(:required_permission) { "wallets:create" }
   let(:membership) { create(:membership) }
   let(:customer) { create(:customer, organization: membership.organization, currency: "EUR") }

--- a/spec/graphql/mutations/wallets/terminate_spec.rb
+++ b/spec/graphql/mutations/wallets/terminate_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Wallets::Terminate, type: :graphql do
+RSpec.describe Mutations::Wallets::Terminate do
   let(:required_permission) { "wallets:terminate" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Wallets::Update, type: :graphql do
+RSpec.describe Mutations::Wallets::Update do
   let(:required_permission) { "wallets:update" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/webhook_endpoints/create_spec.rb
+++ b/spec/graphql/mutations/webhook_endpoints/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::WebhookEndpoints::Create, type: :graphql do
+RSpec.describe Mutations::WebhookEndpoints::Create do
   let(:required_permission) { "developers:manage" }
   let(:membership) { create(:membership) }
   let(:webhook_url) { Faker::Internet.url }

--- a/spec/graphql/mutations/webhook_endpoints/destroy_spec.rb
+++ b/spec/graphql/mutations/webhook_endpoints/destroy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::WebhookEndpoints::Destroy, type: :graphql do
+RSpec.describe Mutations::WebhookEndpoints::Destroy do
   let(:required_permission) { "developers:manage" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/mutations/webhook_endpoints/update_spec.rb
+++ b/spec/graphql/mutations/webhook_endpoints/update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::WebhookEndpoints::Update, type: :graphql do
+RSpec.describe Mutations::WebhookEndpoints::Update do
   let(:required_permission) { "developers:manage" }
   let(:membership) { create(:membership) }
   let(:webhook_url) { Faker::Internet.url }

--- a/spec/graphql/mutations/webhooks/retry_spec.rb
+++ b/spec/graphql/mutations/webhooks/retry_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Webhooks::Retry, type: :graphql do
+RSpec.describe Mutations::Webhooks::Retry do
   let(:required_permission) { "developers:manage" }
   let(:webhook) { create(:webhook, :failed, webhook_endpoint:) }
   let(:webhook_endpoint) { create(:webhook_endpoint) }

--- a/spec/graphql/resolvers/activity_log_resolver_spec.rb
+++ b/spec/graphql/resolvers/activity_log_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::ActivityLogResolver, type: :graphql, clickhouse: true do
+RSpec.describe Resolvers::ActivityLogResolver, clickhouse: true do
   let(:required_permission) { "audit_logs:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/activity_logs_resolver_spec.rb
+++ b/spec/graphql/resolvers/activity_logs_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::ActivityLogsResolver, type: :graphql, clickhouse: true do
+RSpec.describe Resolvers::ActivityLogsResolver, clickhouse: true do
   let(:required_permission) { "audit_logs:view" }
   let(:query) { build_query(limit: 5) }
 

--- a/spec/graphql/resolvers/add_on_resolver_spec.rb
+++ b/spec/graphql/resolvers/add_on_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::AddOnResolver, type: :graphql do
+RSpec.describe Resolvers::AddOnResolver do
   let(:required_permission) { "addons:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/add_ons_resolver_spec.rb
+++ b/spec/graphql/resolvers/add_ons_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::AddOnsResolver, type: :graphql do
+RSpec.describe Resolvers::AddOnsResolver do
   let(:required_permission) { "addons:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/analytics/gross_revenues_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/gross_revenues_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Analytics::GrossRevenuesResolver, type: :graphql do
+RSpec.describe Resolvers::Analytics::GrossRevenuesResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver, type: :graphql do
+RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver, type: :graphql do
+RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Analytics::MrrsResolver, type: :graphql do
+RSpec.describe Resolvers::Analytics::MrrsResolver do
   let(:required_permission) { "analytics:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Analytics::OverdueBalancesResolver, type: :graphql do
+RSpec.describe Resolvers::Analytics::OverdueBalancesResolver do
   let(:required_permission) { "analytics:overdue_balances:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/api_key_resolver_spec.rb
+++ b/spec/graphql/resolvers/api_key_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::ApiKeyResolver, type: :graphql do
+RSpec.describe Resolvers::ApiKeyResolver do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/resolvers/api_keys_resolver_spec.rb
+++ b/spec/graphql/resolvers/api_keys_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::ApiKeysResolver, type: :graphql do
+RSpec.describe Resolvers::ApiKeysResolver do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/resolvers/api_log_resolver_spec.rb
+++ b/spec/graphql/resolvers/api_log_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::ApiLogResolver, type: :graphql, clickhouse: true do
+RSpec.describe Resolvers::ApiLogResolver, clickhouse: true do
   let(:required_permission) { "audit_logs:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/api_logs_resolver_spec.rb
+++ b/spec/graphql/resolvers/api_logs_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::ApiLogsResolver, type: :graphql, clickhouse: true do
+RSpec.describe Resolvers::ApiLogsResolver, clickhouse: true do
   let(:required_permission) { "audit_logs:view" }
   let(:query) { build_query(limit: 5) }
 

--- a/spec/graphql/resolvers/auth/google/auth_url_resolver_spec.rb
+++ b/spec/graphql/resolvers/auth/google/auth_url_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Auth::Google::AuthUrlResolver, type: :graphql do
+RSpec.describe Resolvers::Auth::Google::AuthUrlResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/billable_metric_resolver_spec.rb
+++ b/spec/graphql/resolvers/billable_metric_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
+RSpec.describe Resolvers::BillableMetricResolver do
   subject(:graphql_request) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/resolvers/billable_metrics_resolver_spec.rb
+++ b/spec/graphql/resolvers/billable_metrics_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::BillableMetricsResolver, type: :graphql do
+RSpec.describe Resolvers::BillableMetricsResolver do
   let(:required_permission) { "billable_metrics:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/billing_entities_resolver_spec.rb
+++ b/spec/graphql/resolvers/billing_entities_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::BillingEntitiesResolver, type: :graphql do
+RSpec.describe Resolvers::BillingEntitiesResolver do
   let(:required_permission) { "billing_entities:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/billing_entity_resolver_spec.rb
+++ b/spec/graphql/resolvers/billing_entity_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::BillingEntityResolver, type: :graphql do
+RSpec.describe Resolvers::BillingEntityResolver do
   subject(:graphql_request) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/resolvers/billing_entity_taxes_resolver_spec.rb
+++ b/spec/graphql/resolvers/billing_entity_taxes_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::BillingEntityTaxesResolver, type: :graphql do
+RSpec.describe Resolvers::BillingEntityTaxesResolver do
   let(:query) do
     <<~GQL
       query($billing_entity_id: ID!) {

--- a/spec/graphql/resolvers/coupon_resolver_spec.rb
+++ b/spec/graphql/resolvers/coupon_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CouponResolver, type: :graphql do
+RSpec.describe Resolvers::CouponResolver do
   let(:required_permission) { "coupons:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/coupons_resolver_spec.rb
+++ b/spec/graphql/resolvers/coupons_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CouponsResolver, type: :graphql do
+RSpec.describe Resolvers::CouponsResolver do
   let(:required_permission) { "coupons:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/credit_note_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_note_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CreditNoteResolver, type: :graphql do
+RSpec.describe Resolvers::CreditNoteResolver do
   let(:required_permission) { "credit_notes:view" }
   let(:query) do
     <<-GQL

--- a/spec/graphql/resolvers/credit_notes/estimate_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes/estimate_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CreditNotes::EstimateResolver, type: :graphql do
+RSpec.describe Resolvers::CreditNotes::EstimateResolver do
   let(:query) do
     <<~GQL
       query($invoiceId: ID!, $items: [CreditNoteItemInput!]!) {

--- a/spec/graphql/resolvers/credit_notes_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CreditNotesResolver, type: :graphql do
+RSpec.describe Resolvers::CreditNotesResolver do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/resolvers/current_user_resolver_spec.rb
+++ b/spec/graphql/resolvers/current_user_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CurrentUserResolver, type: :graphql do
+RSpec.describe Resolvers::CurrentUserResolver do
   let(:query) do
     <<~GRAPHQL
       query {

--- a/spec/graphql/resolvers/customer_portal/analytics/invoice_collections_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/analytics/invoice_collections_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomerPortal::Analytics::InvoiceCollectionsResolver, type: :graphql do
+RSpec.describe Resolvers::CustomerPortal::Analytics::InvoiceCollectionsResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/customer_portal/analytics/overdue_balances_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/analytics/overdue_balances_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomerPortal::Analytics::OverdueBalancesResolver, type: :graphql do
+RSpec.describe Resolvers::CustomerPortal::Analytics::OverdueBalancesResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/customer_portal/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customer_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomerPortal::CustomerResolver, type: :graphql do
+RSpec.describe Resolvers::CustomerPortal::CustomerResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/projected_usage_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver, type: :graphql do
+RSpec.describe Resolvers::CustomerPortal::Customers::ProjectedUsageResolver do
   let(:query) do
     <<~GQL
       query($subscriptionId: ID!) {

--- a/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/customers/usage_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver, type: :graphql do
+RSpec.describe Resolvers::CustomerPortal::Customers::UsageResolver do
   let(:now) { Time.zone.parse("2025-06-15").in_time_zone }
   let(:timestamp) { now }
   let(:query) do

--- a/spec/graphql/resolvers/customer_portal/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/invoices_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomerPortal::InvoicesResolver, type: :graphql do
+RSpec.describe Resolvers::CustomerPortal::InvoicesResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/customer_portal/organization_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/organization_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomerPortal::OrganizationResolver, type: :graphql do
+RSpec.describe Resolvers::CustomerPortal::OrganizationResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/customer_portal/subscription_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/subscription_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomerPortal::SubscriptionResolver, type: :graphql do
+RSpec.describe Resolvers::CustomerPortal::SubscriptionResolver do
   let(:query) do
     <<~GQL
       query($subscriptionId: ID!) {

--- a/spec/graphql/resolvers/customer_portal/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/subscriptions_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomerPortal::SubscriptionsResolver, type: :graphql do
+RSpec.describe Resolvers::CustomerPortal::SubscriptionsResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/customer_portal/wallets_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/wallets_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomerPortal::WalletsResolver, type: :graphql do
+RSpec.describe Resolvers::CustomerPortal::WalletsResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomerResolver, type: :graphql do
+RSpec.describe Resolvers::CustomerResolver do
   let(:required_permission) { "customers:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Customers::InvoicesResolver, type: :graphql do
+RSpec.describe Resolvers::Customers::InvoicesResolver do
   let(:required_permission) { "invoices:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/customers/projected_usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/projected_usage_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Customers::ProjectedUsageResolver, type: :graphql do
+RSpec.describe Resolvers::Customers::ProjectedUsageResolver do
   let(:required_permission) { "customers:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/customers/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/subscriptions_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Customers::SubscriptionsResolver, type: :graphql do
+RSpec.describe Resolvers::Customers::SubscriptionsResolver do
   let(:required_permission) { "customers:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
+RSpec.describe Resolvers::Customers::UsageResolver do
   let(:required_permission) { "customers:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomersResolver, type: :graphql do
+RSpec.describe Resolvers::CustomersResolver do
   let(:required_permission) { "customers:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/data_api/mrrs/plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/mrrs/plans_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::DataApi::Mrrs::PlansResolver, type: :graphql do
+RSpec.describe Resolvers::DataApi::Mrrs::PlansResolver do
   let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/data_api/mrrs_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/mrrs_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::DataApi::MrrsResolver, type: :graphql do
+RSpec.describe Resolvers::DataApi::MrrsResolver do
   let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/data_api/prepaid_credits_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/prepaid_credits_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::DataApi::PrepaidCreditsResolver, type: :graphql do
+RSpec.describe Resolvers::DataApi::PrepaidCreditsResolver do
   let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/data_api/revenue_streams/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams/customers_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::DataApi::RevenueStreams::CustomersResolver, type: :graphql do
+RSpec.describe Resolvers::DataApi::RevenueStreams::CustomersResolver do
   let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/data_api/revenue_streams/plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams/plans_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::DataApi::RevenueStreams::PlansResolver, type: :graphql do
+RSpec.describe Resolvers::DataApi::RevenueStreams::PlansResolver do
   let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/data_api/revenue_streams_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/revenue_streams_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::DataApi::RevenueStreamsResolver, type: :graphql do
+RSpec.describe Resolvers::DataApi::RevenueStreamsResolver do
   let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/data_api/usages/aggregated_amounts_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/usages/aggregated_amounts_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::DataApi::Usages::AggregatedAmountsResolver, type: :graphql do
+RSpec.describe Resolvers::DataApi::Usages::AggregatedAmountsResolver do
   let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/data_api/usages/invoiced_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/usages/invoiced_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::DataApi::Usages::InvoicedResolver, type: :graphql do
+RSpec.describe Resolvers::DataApi::Usages::InvoicedResolver do
   let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/data_api/usages_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/usages_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::DataApi::UsagesResolver, type: :graphql do
+RSpec.describe Resolvers::DataApi::UsagesResolver do
   let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/dunning_campaign_resolver_spec.rb
+++ b/spec/graphql/resolvers/dunning_campaign_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::DunningCampaignResolver, type: :graphql do
+RSpec.describe Resolvers::DunningCampaignResolver do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/resolvers/dunning_campaigns_resolver_spec.rb
+++ b/spec/graphql/resolvers/dunning_campaigns_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::DunningCampaignsResolver, type: :graphql do
+RSpec.describe Resolvers::DunningCampaignsResolver do
   let(:required_permission) { "dunning_campaigns:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/entitlement/feature_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/feature_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Entitlement::FeatureResolver, type: :graphql do
+RSpec.describe Resolvers::Entitlement::FeatureResolver do
   subject { execute_query(query:, variables:) }
 
   let(:organization) { create(:organization) }

--- a/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/features_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Entitlement::FeaturesResolver, type: :graphql do
+RSpec.describe Resolvers::Entitlement::FeaturesResolver do
   subject { execute_query(query:) }
 
   let(:organization) { create(:organization) }

--- a/spec/graphql/resolvers/entitlement/subscription_entitlement_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/subscription_entitlement_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Entitlement::SubscriptionEntitlementResolver, type: :graphql do
+RSpec.describe Resolvers::Entitlement::SubscriptionEntitlementResolver do
   subject { execute_query(query:, variables:) }
 
   let(:organization) { create(:organization) }

--- a/spec/graphql/resolvers/entitlement/subscription_entitlements_resolver_spec.rb
+++ b/spec/graphql/resolvers/entitlement/subscription_entitlements_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Entitlement::SubscriptionEntitlementsResolver, type: :graphql do
+RSpec.describe Resolvers::Entitlement::SubscriptionEntitlementsResolver do
   subject { execute_query(query:, variables:) }
 
   let(:organization) { create(:organization) }

--- a/spec/graphql/resolvers/event_resolver_spec.rb
+++ b/spec/graphql/resolvers/event_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::EventResolver, type: :graphql, transaction: false do
+RSpec.describe Resolvers::EventResolver, transaction: false do
   let(:query) do
     <<~GQL
       query($eventTransactionId: ID!) {

--- a/spec/graphql/resolvers/events_resolver_spec.rb
+++ b/spec/graphql/resolvers/events_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::EventsResolver, type: :graphql, transaction: false, clickhouse: true do
+RSpec.describe Resolvers::EventsResolver, transaction: false, clickhouse: true do
   let(:query) do
     <<~GQL
       query($page: Int) {

--- a/spec/graphql/resolvers/integration_collection_mapping_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_collection_mapping_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::IntegrationCollectionMappingResolver, type: :graphql do
+RSpec.describe Resolvers::IntegrationCollectionMappingResolver do
   let(:required_permission) { "organization:integrations:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/integration_collection_mappings_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_collection_mappings_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::IntegrationCollectionMappingsResolver, type: :graphql do
+RSpec.describe Resolvers::IntegrationCollectionMappingsResolver do
   let(:required_permission) { "organization:integrations:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/integration_items_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_items_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::IntegrationItemsResolver, type: :graphql do
+RSpec.describe Resolvers::IntegrationItemsResolver do
   let(:required_permission) { "organization:integrations:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/integration_mapping_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_mapping_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::IntegrationMappingResolver, type: :graphql do
+RSpec.describe Resolvers::IntegrationMappingResolver do
   let(:required_permission) { "organization:integrations:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/integration_mappings_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_mappings_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::IntegrationMappingsResolver, type: :graphql do
+RSpec.describe Resolvers::IntegrationMappingsResolver do
   let(:required_permission) { "organization:integrations:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/integration_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::IntegrationResolver, type: :graphql do
+RSpec.describe Resolvers::IntegrationResolver do
   let(:required_permission) { "organization:integrations:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/integrations/subsidiaries_resolver_spec.rb
+++ b/spec/graphql/resolvers/integrations/subsidiaries_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::Integrations::SubsidiariesResolver, type: :graphql do
+RSpec.describe Resolvers::Integrations::SubsidiariesResolver do
   let(:required_permission) { "organization:integrations:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/integrations_resolver_spec.rb
+++ b/spec/graphql/resolvers/integrations_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::IntegrationsResolver, type: :graphql do
+RSpec.describe Resolvers::IntegrationsResolver do
   let(:required_permission) { "customers:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/invite_resolver_spec.rb
+++ b/spec/graphql/resolvers/invite_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::InviteResolver, type: :graphql do
+RSpec.describe Resolvers::InviteResolver do
   let(:query) do
     <<~GQL
       query($token: String!) {

--- a/spec/graphql/resolvers/invites_resolver_spec.rb
+++ b/spec/graphql/resolvers/invites_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::InvitesResolver, type: :graphql do
+RSpec.describe Resolvers::InvitesResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/invoice_credit_notes_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_credit_notes_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::InvoiceCreditNotesResolver, type: :graphql do
+RSpec.describe Resolvers::InvoiceCreditNotesResolver do
   let(:required_permission) { "credit_notes:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/invoice_custom_section_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_custom_section_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::InvoiceCustomSectionResolver, type: :graphql do
+RSpec.describe Resolvers::InvoiceCustomSectionResolver do
   let(:query) do
     <<~GQL
       query($invoiceCustomSectionId: ID!) {

--- a/spec/graphql/resolvers/invoice_custom_sections_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_custom_sections_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::InvoiceCustomSectionsResolver, type: :graphql do
+RSpec.describe Resolvers::InvoiceCustomSectionsResolver do
   let(:required_permission) { "invoice_custom_sections:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
+RSpec.describe Resolvers::InvoiceResolver do
   let(:required_permission) { "invoices:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
+RSpec.describe Resolvers::InvoicesResolver do
   let(:required_permission) { "invoices:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/memberships_resolver_spec.rb
+++ b/spec/graphql/resolvers/memberships_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::MembershipsResolver, type: :graphql do
+RSpec.describe Resolvers::MembershipsResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/organization_resolver_spec.rb
+++ b/spec/graphql/resolvers/organization_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::OrganizationResolver, type: :graphql do
+RSpec.describe Resolvers::OrganizationResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/password_reset_resolver_spec.rb
+++ b/spec/graphql/resolvers/password_reset_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::PasswordResetResolver, type: :graphql do
+RSpec.describe Resolvers::PasswordResetResolver do
   let(:query) do
     <<~GQL
       query($token: String!) {

--- a/spec/graphql/resolvers/payment_provider_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_provider_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::PaymentProviderResolver, type: :graphql do
+RSpec.describe Resolvers::PaymentProviderResolver do
   let(:required_permission) { "organization:integrations:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/payment_providers_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_providers_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::PaymentProvidersResolver, type: :graphql do
+RSpec.describe Resolvers::PaymentProvidersResolver do
   let(:required_permission) { "customers:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/payment_requests_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_requests_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::PaymentRequestsResolver, type: :graphql do
+RSpec.describe Resolvers::PaymentRequestsResolver do
   let(:required_permission) { "payment_requests:view" }
   let(:filters) { "limit: 5" }
   let(:query) do

--- a/spec/graphql/resolvers/payment_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::PaymentResolver, type: :graphql do
+RSpec.describe Resolvers::PaymentResolver do
   let(:required_permission) { "payments:view" }
 
   let(:query) do

--- a/spec/graphql/resolvers/payments_resolver_spec.rb
+++ b/spec/graphql/resolvers/payments_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::PaymentsResolver, type: :graphql do
+RSpec.describe Resolvers::PaymentsResolver do
   let(:required_permission) { "payments:view" }
   let(:query) {}
 

--- a/spec/graphql/resolvers/plan_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::PlanResolver, type: :graphql do
+RSpec.describe Resolvers::PlanResolver do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/resolvers/plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/plans_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::PlansResolver, type: :graphql do
+RSpec.describe Resolvers::PlansResolver do
   let(:required_permission) { "plans:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/pricing_unit_resolver_spec.rb
+++ b/spec/graphql/resolvers/pricing_unit_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::PricingUnitResolver, type: :graphql do
+RSpec.describe Resolvers::PricingUnitResolver do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/resolvers/pricing_units_resolver_spec.rb
+++ b/spec/graphql/resolvers/pricing_units_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::PricingUnitsResolver, type: :graphql do
+RSpec.describe Resolvers::PricingUnitsResolver do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/resolvers/subscription_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscription_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::SubscriptionResolver, type: :graphql do
+RSpec.describe Resolvers::SubscriptionResolver do
   let(:required_permission) { "subscriptions:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscriptions_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::SubscriptionsResolver, type: :graphql do
+RSpec.describe Resolvers::SubscriptionsResolver do
   let(:required_permission) { "subscriptions:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/tax_resolver_spec.rb
+++ b/spec/graphql/resolvers/tax_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::TaxResolver, type: :graphql do
+RSpec.describe Resolvers::TaxResolver do
   let(:query) do
     <<~GQL
       query($taxId: ID!) {

--- a/spec/graphql/resolvers/taxes_resolver_spec.rb
+++ b/spec/graphql/resolvers/taxes_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::TaxesResolver, type: :graphql do
+RSpec.describe Resolvers::TaxesResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/usage_monitoring/alert_resolver_spec.rb
+++ b/spec/graphql/resolvers/usage_monitoring/alert_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::UsageMonitoring::AlertResolver, type: :graphql do
+RSpec.describe Resolvers::UsageMonitoring::AlertResolver do
   let(:required_permission) { "subscriptions:view" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/usage_monitoring/subscription_alerts_resolver_spec.rb
+++ b/spec/graphql/resolvers/usage_monitoring/subscription_alerts_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::UsageMonitoring::SubscriptionAlertsResolver, type: :graphql do
+RSpec.describe Resolvers::UsageMonitoring::SubscriptionAlertsResolver do
   let(:required_permission) { "subscriptions:view" }
 
   let(:membership) { create(:membership) }

--- a/spec/graphql/resolvers/version_resolver_spec.rb
+++ b/spec/graphql/resolvers/version_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::VersionResolver, type: :graphql do
+RSpec.describe Resolvers::VersionResolver do
   let(:query) do
     <<~GQL
       query {

--- a/spec/graphql/resolvers/wallet_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::WalletResolver, type: :graphql do
+RSpec.describe Resolvers::WalletResolver do
   let(:query) do
     <<~GQL
       query($id: ID!) {

--- a/spec/graphql/resolvers/wallet_transaction_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_transaction_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::WalletTransactionResolver, type: :graphql do
+RSpec.describe Resolvers::WalletTransactionResolver do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/resolvers/wallets_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallets_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::WalletsResolver, type: :graphql do
+RSpec.describe Resolvers::WalletsResolver do
   let(:query) do
     <<~GQL
       query($customerId: ID!) {

--- a/spec/graphql/resolvers/wallets_resolver_transactions_spec.rb
+++ b/spec/graphql/resolvers/wallets_resolver_transactions_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::WalletsResolver, type: :graphql do
+RSpec.describe Resolvers::WalletsResolver do
   let(:query) do
     <<~GQL
       query($walletId: ID!) {

--- a/spec/graphql/resolvers/webhook_endpoint_resolver_spec.rb
+++ b/spec/graphql/resolvers/webhook_endpoint_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::WebhookEndpointResolver, type: :graphql do
+RSpec.describe Resolvers::WebhookEndpointResolver do
   let(:required_permission) { "developers:manage" }
   let(:query) do
     <<-GQL

--- a/spec/graphql/resolvers/webhook_endpoints_resolver_spec.rb
+++ b/spec/graphql/resolvers/webhook_endpoints_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::WebhookEndpointsResolver, type: :graphql do
+RSpec.describe Resolvers::WebhookEndpointsResolver do
   let(:required_permission) { "developers:manage" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/webhook_resolver_spec.rb
+++ b/spec/graphql/resolvers/webhook_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::WebhookResolver, type: :graphql do
+RSpec.describe Resolvers::WebhookResolver do
   let(:required_permission) { "developers:manage" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/resolvers/webhooks_resolver_spec.rb
+++ b/spec/graphql/resolvers/webhooks_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::WebhooksResolver, type: :graphql do
+RSpec.describe Resolvers::WebhooksResolver do
   let(:required_permission) { "developers:manage" }
   let(:query) do
     <<~GQL

--- a/spec/graphql/types/subscriptions/billing_time_enum_spec.rb
+++ b/spec/graphql/types/subscriptions/billing_time_enum_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Types::Subscriptions::BillingTimeEnum, type: :graphql do
+RSpec.describe Types::Subscriptions::BillingTimeEnum do
   it "exposes all enum values" do
     expect(described_class.values.keys).to match_array(%w[calendar anniversary])
   end

--- a/spec/graphql/types/subscriptions/next_subscription_type_enum_spec.rb
+++ b/spec/graphql/types/subscriptions/next_subscription_type_enum_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Types::Subscriptions::NextSubscriptionTypeEnum, type: :graphql do
+RSpec.describe Types::Subscriptions::NextSubscriptionTypeEnum do
   it "exposes all enum values" do
     expect(described_class.values.keys).to match_array(%w[upgrade downgrade])
   end

--- a/spec/graphql/types/subscriptions/on_termination_invoice_enum_spec.rb
+++ b/spec/graphql/types/subscriptions/on_termination_invoice_enum_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Types::Subscriptions::OnTerminationInvoiceEnum, type: :graphql do
+RSpec.describe Types::Subscriptions::OnTerminationInvoiceEnum do
   it "exposes all enum values" do
     expect(described_class.values.keys).to match_array(%w[generate skip])
   end

--- a/spec/graphql/types/subscriptions/status_type_enum_spec.rb
+++ b/spec/graphql/types/subscriptions/status_type_enum_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Types::Subscriptions::StatusTypeEnum, type: :graphql do
+RSpec.describe Types::Subscriptions::StatusTypeEnum do
   it "exposes all enum values" do
     expect(described_class.values.keys).to match_array(%w[pending active terminated canceled])
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,6 +86,9 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.infer_spec_type_from_file_location!
+  config.define_derived_metadata(file_path: Regexp.new("/spec/graphql/")) do |metadata|
+    metadata[:type] = :graphql
+  end
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
## Context

All GraphQL tests currently require the `type: :graphql` RSpec metadata. This can be inferred from the file path and do not need to be set manually.

## Description

This changes the RSpec configuration to infer the type of GraphQL tests.
