### PR TITLE
test(model): Remove redundant `type: :model` metadata from model tests

### DIFF
--- a/spec/models/add_on_spec.rb
+++ b/spec/models/add_on_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AddOn, type: :model do
+RSpec.describe AddOn do
   subject { build(:add_on) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/ai_conversation_spec.rb
+++ b/spec/models/ai_conversation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe AiConversation, type: :model do
+RSpec.describe AiConversation do
   subject { build(:ai_conversation) }
 
   describe "associations" do

--- a/spec/models/analytics/gross_revenue_spec.rb
+++ b/spec/models/analytics/gross_revenue_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Analytics::GrossRevenue, type: :model do
+RSpec.describe Analytics::GrossRevenue do
   describe ".cache_key" do
     subject(:gross_revenue_cache_key) { described_class.cache_key(organization_id, **args) }
 

--- a/spec/models/analytics/invoice_collection_spec.rb
+++ b/spec/models/analytics/invoice_collection_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Analytics::InvoiceCollection, type: :model do
+RSpec.describe Analytics::InvoiceCollection do
   describe ".cache_key" do
     subject(:invoice_collection_cache_key) { described_class.cache_key(organization_id, **args) }
 

--- a/spec/models/analytics/invoiced_usage_spec.rb
+++ b/spec/models/analytics/invoiced_usage_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Analytics::InvoicedUsage, type: :model do
+RSpec.describe Analytics::InvoicedUsage do
   describe ".cache_key" do
     subject(:invoiced_usage_cache_key) { described_class.cache_key(organization_id, **args) }
 

--- a/spec/models/analytics/mrr_spec.rb
+++ b/spec/models/analytics/mrr_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Analytics::Mrr, type: :model do
+RSpec.describe Analytics::Mrr do
   describe ".cache_key" do
     subject(:mrr_cache_key) { described_class.cache_key(organization_id, **args) }
 

--- a/spec/models/analytics/overdue_balance_spec.rb
+++ b/spec/models/analytics/overdue_balance_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Analytics::OverdueBalance, type: :model do
+RSpec.describe Analytics::OverdueBalance do
   describe ".cache_key" do
     subject(:overdue_balance_cache_key) { described_class.cache_key(organization_id, **args) }
 

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ApiKey, type: :model do
+RSpec.describe ApiKey do
   subject { build(:api_key, expires_at:) }
 
   let(:expires_at) { nil }

--- a/spec/models/applied_add_on_spec.rb
+++ b/spec/models/applied_add_on_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedAddOn, type: :model do
+RSpec.describe AppliedAddOn do
   subject { build(:applied_add_on) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/applied_coupon_spec.rb
+++ b/spec/models/applied_coupon_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedCoupon, type: :model do
+RSpec.describe AppliedCoupon do
   subject(:applied_coupon) { create(:applied_coupon) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/applied_invoice_custom_section_spec.rb
+++ b/spec/models/applied_invoice_custom_section_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedInvoiceCustomSection, type: :model do
+RSpec.describe AppliedInvoiceCustomSection do
   subject(:applied_invoice_custom_section) { build(:applied_invoice_custom_section) }
 
   it { is_expected.to belong_to(:invoice) }

--- a/spec/models/applied_pricing_unit_spec.rb
+++ b/spec/models/applied_pricing_unit_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedPricingUnit, type: :model do
+RSpec.describe AppliedPricingUnit do
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:pricing_unit) }
   it { is_expected.to belong_to(:pricing_unitable) }

--- a/spec/models/applied_usage_threshold_spec.rb
+++ b/spec/models/applied_usage_threshold_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedUsageThreshold, type: :model do
+RSpec.describe AppliedUsageThreshold do
   subject(:applied_usage_threshold) { build(:applied_usage_threshold) }
 
   it { is_expected.to belong_to(:usage_threshold) }

--- a/spec/models/billable_metric_filter_spec.rb
+++ b/spec/models/billable_metric_filter_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetricFilter, type: :model do
+RSpec.describe BillableMetricFilter do
   subject(:billable_metric_filter) { build(:billable_metric_filter) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/billable_metric_spec.rb
+++ b/spec/models/billable_metric_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetric, type: :model do
+RSpec.describe BillableMetric do
   subject(:billable_metric) { create(:billable_metric) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/billing_entity/applied_invoice_custom_section_spec.rb
+++ b/spec/models/billing_entity/applied_invoice_custom_section_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillingEntity::AppliedInvoiceCustomSection, type: :model do
+RSpec.describe BillingEntity::AppliedInvoiceCustomSection do
   subject(:applied_invoice_custom_section) do
     create(:billing_entity_applied_invoice_custom_section)
   end

--- a/spec/models/billing_entity/applied_tax_spec.rb
+++ b/spec/models/billing_entity/applied_tax_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillingEntity::AppliedTax, type: :model do
+RSpec.describe BillingEntity::AppliedTax do
   subject(:billing_entity_applied_tax) { create(:billing_entity_applied_tax) }
 
   it { is_expected.to belong_to(:billing_entity) }

--- a/spec/models/billing_entity_spec.rb
+++ b/spec/models/billing_entity_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillingEntity, type: :model do
+RSpec.describe BillingEntity do
   subject(:billing_entity) { build(:billing_entity) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/billing_period_boundaries_spec.rb
+++ b/spec/models/billing_period_boundaries_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillingPeriodBoundaries, type: :model do
+RSpec.describe BillingPeriodBoundaries do
   subject(:boundaries) do
     described_class.new(
       from_datetime:,

--- a/spec/models/charge/applied_tax_spec.rb
+++ b/spec/models/charge/applied_tax_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Charge::AppliedTax, type: :model do
+RSpec.describe Charge::AppliedTax do
   subject(:charge_applied_tax) { create(:charge_applied_tax) }
 
   it { is_expected.to belong_to(:charge) }

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeFilter, type: :model do
+RSpec.describe ChargeFilter do
   subject(:charge_filter) { build(:charge_filter) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/charge_filter_value_spec.rb
+++ b/spec/models/charge_filter_value_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeFilterValue, type: :model do
+RSpec.describe ChargeFilterValue do
   subject { build(:charge_filter_value) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charge, type: :model do
+RSpec.describe Charge do
   subject(:charge) { create(:standard_charge) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/clickhouse/activity_log_spec.rb
+++ b/spec/models/clickhouse/activity_log_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Clickhouse::ActivityLog, type: :model, clickhouse: true do
+RSpec.describe Clickhouse::ActivityLog, clickhouse: true do
   subject(:activity_log) { create(:clickhouse_activity_log) }
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/clickhouse/api_log_spec.rb
+++ b/spec/models/clickhouse/api_log_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Clickhouse::ApiLog, type: :model, clickhouse: true do
+RSpec.describe Clickhouse::ApiLog, clickhouse: true do
   subject(:api_log) { create(:clickhouse_api_log) }
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/commitment/applied_tax_spec.rb
+++ b/spec/models/commitment/applied_tax_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Commitment::AppliedTax, type: :model do
+RSpec.describe Commitment::AppliedTax do
   it { is_expected.to belong_to(:commitment) }
   it { is_expected.to belong_to(:tax) }
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/commitment_spec.rb
+++ b/spec/models/commitment_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Commitment, type: :model do
+RSpec.describe Commitment do
   it { is_expected.to belong_to(:plan) }
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to have_many(:applied_taxes).dependent(:destroy) }

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Coupon, type: :model do
+RSpec.describe Coupon do
   subject(:coupon) { build(:coupon) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/coupon_target_spec.rb
+++ b/spec/models/coupon_target_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe CouponTarget, type: :model do
+RSpec.describe CouponTarget do
   subject(:coupon_target) { build(:coupon_plan) }
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/credit_note/applied_tax_spec.rb
+++ b/spec/models/credit_note/applied_tax_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNote::AppliedTax, type: :model do
+RSpec.describe CreditNote::AppliedTax do
   subject(:applied_tax) { create(:credit_note_applied_tax) }
 
   describe "associations" do

--- a/spec/models/credit_note_item_spec.rb
+++ b/spec/models/credit_note_item_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNoteItem, type: :model do
+RSpec.describe CreditNoteItem do
   subject(:credit_note_item) { create(:credit_note_item) }
 
   it { is_expected.to belong_to(:credit_note) }

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNote, type: :model do
+RSpec.describe CreditNote do
   subject(:credit_note) do
     create :credit_note, credit_amount_cents: 11000, total_amount_cents: 11000, taxes_amount_cents: 1000,
       taxes_rate: 10.0, precise_taxes_amount_cents: 1000

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Credit, type: :model do
+RSpec.describe Credit do
   subject(:credit) { create(:credit) }
 
   describe "associations" do

--- a/spec/models/customer/applied_invoice_custom_section_spec.rb
+++ b/spec/models/customer/applied_invoice_custom_section_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customer::AppliedInvoiceCustomSection, type: :model do
+RSpec.describe Customer::AppliedInvoiceCustomSection do
   subject(:applied_invoice_custom_section) do
     create(:customer_applied_invoice_custom_section)
   end

--- a/spec/models/customer/applied_tax_spec.rb
+++ b/spec/models/customer/applied_tax_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customer::AppliedTax, type: :model do
+RSpec.describe Customer::AppliedTax do
   subject(:applied_tax) { create(:customer_applied_tax) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customer, type: :model do
+RSpec.describe Customer do
   subject(:customer) { create(:customer) }
 
   let(:organization) { create(:organization) }

--- a/spec/models/daily_usage_spec.rb
+++ b/spec/models/daily_usage_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DailyUsage, type: :model do
+RSpec.describe DailyUsage do
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:customer) }
   it { is_expected.to belong_to(:subscription) }

--- a/spec/models/data_export_part_spec.rb
+++ b/spec/models/data_export_part_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataExportPart, type: :model do
+RSpec.describe DataExportPart do
   it { is_expected.to belong_to(:data_export) }
   it { is_expected.to belong_to(:organization) }
 end

--- a/spec/models/data_export_spec.rb
+++ b/spec/models/data_export_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataExport, type: :model do
+RSpec.describe DataExport do
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:membership) }
   it { is_expected.to have_one(:user).through(:membership) }

--- a/spec/models/deprecation_spec.rb
+++ b/spec/models/deprecation_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Deprecation, type: :model, cache: :redis do
+RSpec.describe Deprecation, cache: :redis do
   let(:organization) { create(:organization) }
   let(:feature_name) { "event_legacy" }
 

--- a/spec/models/dunning_campaign_spec.rb
+++ b/spec/models/dunning_campaign_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DunningCampaign, type: :model do
+RSpec.describe DunningCampaign do
   subject(:dunning_campaign) { create(:dunning_campaign) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/dunning_campaign_threshold_spec.rb
+++ b/spec/models/dunning_campaign_threshold_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DunningCampaignThreshold, type: :model do
+RSpec.describe DunningCampaignThreshold do
   subject(:dunning_campaign_threshold) { create(:dunning_campaign_threshold) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/entitlement/entitlement_spec.rb
+++ b/spec/models/entitlement/entitlement_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::Entitlement, type: :model do
+RSpec.describe Entitlement::Entitlement do
   subject { build(:entitlement) }
 
   it { expect(described_class).to be_soft_deletable }

--- a/spec/models/entitlement/entitlement_value_spec.rb
+++ b/spec/models/entitlement/entitlement_value_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::EntitlementValue, type: :model do
+RSpec.describe Entitlement::EntitlementValue do
   subject { create(:entitlement_value) }
 
   it { expect(described_class).to be_soft_deletable }

--- a/spec/models/entitlement/feature_spec.rb
+++ b/spec/models/entitlement/feature_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::Feature, type: :model do
+RSpec.describe Entitlement::Feature do
   subject { build(:feature) }
 
   it { expect(described_class).to be_soft_deletable }

--- a/spec/models/entitlement/privilege_spec.rb
+++ b/spec/models/entitlement/privilege_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::Privilege, type: :model do
+RSpec.describe Entitlement::Privilege do
   subject { build(:privilege) }
 
   it { expect(described_class).to be_soft_deletable }

--- a/spec/models/entitlement/subscription_entitlement_privilege_spec.rb
+++ b/spec/models/entitlement/subscription_entitlement_privilege_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::SubscriptionEntitlementPrivilege, type: :model do
+RSpec.describe Entitlement::SubscriptionEntitlementPrivilege do
   describe "initialization" do
     it "creates an instance with no attributes" do
       privilege = described_class.new

--- a/spec/models/entitlement/subscription_entitlement_spec.rb
+++ b/spec/models/entitlement/subscription_entitlement_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::SubscriptionEntitlement, type: :model do
+RSpec.describe Entitlement::SubscriptionEntitlement do
   describe "initialization" do
     it "creates an instance with no attributes" do
       entitlement = described_class.new

--- a/spec/models/entitlement/subscription_feature_removal_spec.rb
+++ b/spec/models/entitlement/subscription_feature_removal_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::SubscriptionFeatureRemoval, type: :model do
+RSpec.describe Entitlement::SubscriptionFeatureRemoval do
   subject { build(:subscription_feature_removal) }
 
   it { expect(described_class).to be_soft_deletable }

--- a/spec/models/error_detail_spec.rb
+++ b/spec/models/error_detail_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ErrorDetail, type: :model do
+RSpec.describe ErrorDetail do
   it { is_expected.to belong_to(:owner) }
   it { is_expected.to belong_to(:organization) }
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Event, type: :model do
+RSpec.describe Event do
   describe "#customer" do
     let(:organization) { create(:organization) }
     let(:customer) { create(:customer, organization:) }

--- a/spec/models/fee/applied_tax_spec.rb
+++ b/spec/models/fee/applied_tax_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Fee::AppliedTax, type: :model do
+RSpec.describe Fee::AppliedTax do
   subject(:applied_tax) { create(:fee_applied_tax) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Fee, type: :model do
+RSpec.describe Fee do
   subject { build(:fee) }
 
   it { is_expected.to belong_to(:add_on).optional }

--- a/spec/models/fixed_charge/applied_tax_spec.rb
+++ b/spec/models/fixed_charge/applied_tax_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharge::AppliedTax, type: :model do
+RSpec.describe FixedCharge::AppliedTax do
   it { is_expected.to belong_to(:fixed_charge) }
   it { is_expected.to belong_to(:tax) }
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/fixed_charge_event_spec.rb
+++ b/spec/models/fixed_charge_event_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedChargeEvent, type: :model do
+RSpec.describe FixedChargeEvent do
   subject { build(:fixed_charge_event) }
 
   it { expect(described_class).to be_soft_deletable }

--- a/spec/models/fixed_charge_spec.rb
+++ b/spec/models/fixed_charge_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharge, type: :model do
+RSpec.describe FixedCharge do
   subject { build(:fixed_charge) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/inbound_webhook_spec.rb
+++ b/spec/models/inbound_webhook_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe InboundWebhook, type: :model do
+RSpec.describe InboundWebhook do
   subject(:inbound_webhook) { build(:inbound_webhook) }
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/integration_collection_mappings/base_collection_mapping_spec.rb
+++ b/spec/models/integration_collection_mappings/base_collection_mapping_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCollectionMappings::BaseCollectionMapping, type: :model do
+RSpec.describe IntegrationCollectionMappings::BaseCollectionMapping do
   subject(:mapping) { build(:netsuite_collection_mapping, settings: {}) }
 
   let(:mapping_types) do

--- a/spec/models/integration_collection_mappings/netsuite_collection_mapping_spec.rb
+++ b/spec/models/integration_collection_mappings/netsuite_collection_mapping_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCollectionMappings::NetsuiteCollectionMapping, type: :model do
+RSpec.describe IntegrationCollectionMappings::NetsuiteCollectionMapping do
   subject(:mapping) { build(:netsuite_collection_mapping) }
 
   describe "#external_id" do

--- a/spec/models/integration_collection_mappings/xero_collection_mapping_spec.rb
+++ b/spec/models/integration_collection_mappings/xero_collection_mapping_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCollectionMappings::XeroCollectionMapping, type: :model do
+RSpec.describe IntegrationCollectionMappings::XeroCollectionMapping do
   subject(:mapping) { build(:xero_collection_mapping) }
 
   describe "#external_id" do

--- a/spec/models/integration_customers/base_customer_spec.rb
+++ b/spec/models/integration_customers/base_customer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::BaseCustomer, type: :model do
+RSpec.describe IntegrationCustomers::BaseCustomer do
   subject(:integration_customer) { described_class.new(integration:, customer:, type:, external_customer_id:, organization:) }
 
   let(:integration) { create(:netsuite_integration) }

--- a/spec/models/integration_customers/hubspot_customer_spec.rb
+++ b/spec/models/integration_customers/hubspot_customer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::HubspotCustomer, type: :model do
+RSpec.describe IntegrationCustomers::HubspotCustomer do
   subject(:hubspot_customer) { build(:hubspot_customer) }
 
   describe "#targeted_object" do

--- a/spec/models/integration_customers/netsuite_customer_spec.rb
+++ b/spec/models/integration_customers/netsuite_customer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::NetsuiteCustomer, type: :model do
+RSpec.describe IntegrationCustomers::NetsuiteCustomer do
   subject(:netsuite_customer) { build(:netsuite_customer) }
 
   describe "#subsidiary_id" do

--- a/spec/models/integration_item_spec.rb
+++ b/spec/models/integration_item_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationItem, type: :model do
+RSpec.describe IntegrationItem do
   subject(:integration_item) { build(:integration_item) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/integration_mappings/base_mapping_spec.rb
+++ b/spec/models/integration_mappings/base_mapping_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationMappings::BaseMapping, type: :model do
+RSpec.describe IntegrationMappings::BaseMapping do
   subject(:mapping) { build(:netsuite_mapping, settings: {}) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/integration_mappings/netsuite_mapping_spec.rb
+++ b/spec/models/integration_mappings/netsuite_mapping_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationMappings::NetsuiteMapping, type: :model do
+RSpec.describe IntegrationMappings::NetsuiteMapping do
   subject(:mapping) { build(:netsuite_mapping) }
 
   describe "#external_id" do

--- a/spec/models/integration_mappings/xero_mapping_spec.rb
+++ b/spec/models/integration_mappings/xero_mapping_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationMappings::XeroMapping, type: :model do
+RSpec.describe IntegrationMappings::XeroMapping do
   subject(:mapping) { build(:xero_mapping) }
 
   describe "#external_id" do

--- a/spec/models/integration_resource_spec.rb
+++ b/spec/models/integration_resource_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationResource, type: :model do
+RSpec.describe IntegrationResource do
   subject(:integration_resource) { build(:integration_resource) }
 
   let(:resource_types) do

--- a/spec/models/integrations/anrok_integration_spec.rb
+++ b/spec/models/integrations/anrok_integration_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::AnrokIntegration, type: :model do
+RSpec.describe Integrations::AnrokIntegration do
   subject(:anrok_integration) { build(:anrok_integration) }
 
   it { is_expected.to validate_presence_of(:name) }

--- a/spec/models/integrations/avalara_integration_spec.rb
+++ b/spec/models/integrations/avalara_integration_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::AvalaraIntegration, type: :model do
+RSpec.describe Integrations::AvalaraIntegration do
   subject(:avalara_integration) { build(:avalara_integration) }
 
   it { is_expected.to validate_presence_of(:name) }

--- a/spec/models/integrations/base_integration_spec.rb
+++ b/spec/models/integrations/base_integration_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::BaseIntegration, type: :model do
+RSpec.describe Integrations::BaseIntegration do
   subject(:integration) { described_class.new(attributes) }
 
   it_behaves_like "paper_trail traceable" do

--- a/spec/models/integrations/hubspot_integration_spec.rb
+++ b/spec/models/integrations/hubspot_integration_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::HubspotIntegration, type: :model do
+RSpec.describe Integrations::HubspotIntegration do
   subject(:hubspot_integration) { build(:hubspot_integration) }
 
   it { is_expected.to validate_presence_of(:name) }

--- a/spec/models/integrations/netsuite_integration_spec.rb
+++ b/spec/models/integrations/netsuite_integration_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::NetsuiteIntegration, type: :model do
+RSpec.describe Integrations::NetsuiteIntegration do
   subject(:netsuite_integration) { build(:netsuite_integration) }
 
   it { is_expected.to validate_presence_of(:name) }

--- a/spec/models/integrations/okta_integration_spec.rb
+++ b/spec/models/integrations/okta_integration_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::OktaIntegration, type: :model do
+RSpec.describe Integrations::OktaIntegration do
   subject(:okta_integration) { build(:okta_integration) }
 
   it { is_expected.to validate_presence_of(:domain) }

--- a/spec/models/integrations/salesforce_integration_spec.rb
+++ b/spec/models/integrations/salesforce_integration_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::SalesforceIntegration, type: :model do
+RSpec.describe Integrations::SalesforceIntegration do
   subject(:salesforce_integration) { build(:salesforce_integration) }
 
   it { is_expected.to validate_presence_of(:code) }

--- a/spec/models/integrations/xero_integration_spec.rb
+++ b/spec/models/integrations/xero_integration_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::XeroIntegration, type: :model do
+RSpec.describe Integrations::XeroIntegration do
   subject(:xero_integration) { build(:xero_integration) }
 
   it { is_expected.to validate_presence_of(:name) }

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invite, type: :model do
+RSpec.describe Invite do
   subject(:invite) { create(:invite) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/invoice/applied_tax_spec.rb
+++ b/spec/models/invoice/applied_tax_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoice::AppliedTax, type: :model do
+RSpec.describe Invoice::AppliedTax do
   subject(:applied_tax) { create(:invoice_applied_tax) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/invoice_custom_section_spec.rb
+++ b/spec/models/invoice_custom_section_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe InvoiceCustomSection, type: :model do
+RSpec.describe InvoiceCustomSection do
   subject(:invoice_custom_section) { create(:invoice_custom_section) }
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoice, type: :model do
+RSpec.describe Invoice do
   subject(:invoice) { create(:invoice, organization:) }
 
   let(:organization) { create(:organization) }

--- a/spec/models/invoice_subscription_spec.rb
+++ b/spec/models/invoice_subscription_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe InvoiceSubscription, type: :model do
+RSpec.describe InvoiceSubscription do
   subject(:invoice_subscription) do
     create(
       :invoice_subscription,

--- a/spec/models/lifetime_usage_spec.rb
+++ b/spec/models/lifetime_usage_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe LifetimeUsage, type: :model do
+RSpec.describe LifetimeUsage do
   subject(:lifetime_usage) { create(:lifetime_usage) }
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Membership, type: :model do
+RSpec.describe Membership do
   subject(:membership) { create(:membership) }
 
   it { is_expected.to have_many(:data_exports) }

--- a/spec/models/metadata/customer_metadata_spec.rb
+++ b/spec/models/metadata/customer_metadata_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Metadata::CustomerMetadata, type: :model do
+RSpec.describe Metadata::CustomerMetadata do
   subject(:metadata) { described_class.new(attributes) }
 
   let(:customer) { create(:customer) }

--- a/spec/models/metadata/invoice_metadata_spec.rb
+++ b/spec/models/metadata/invoice_metadata_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Metadata::InvoiceMetadata, type: :model do
+RSpec.describe Metadata::InvoiceMetadata do
   subject(:metadata) { described_class.new(attributes) }
 
   let(:invoice) { create(:invoice) }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Organization, type: :model do
+RSpec.describe Organization do
   subject(:organization) do
     described_class.new(
       name: "PiedPiper",

--- a/spec/models/password_reset_spec.rb
+++ b/spec/models/password_reset_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PasswordReset, type: :model do
+RSpec.describe PasswordReset do
   subject(:password_reset) do
     described_class.new(
       user: create(:user),

--- a/spec/models/payment_intent_spec.rb
+++ b/spec/models/payment_intent_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentIntent, type: :model do
+RSpec.describe PaymentIntent do
   it { is_expected.to define_enum_for(:status).with_values(described_class::STATUSES) }
 
   it { is_expected.to belong_to(:invoice) }

--- a/spec/models/payment_provider_customers/adyen_customer_spec.rb
+++ b/spec/models/payment_provider_customers/adyen_customer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::AdyenCustomer, type: :model do
+RSpec.describe PaymentProviderCustomers::AdyenCustomer do
   subject(:adyen_customer) { described_class.new(attributes) }
 
   let(:attributes) {}

--- a/spec/models/payment_provider_customers/base_customer_spec.rb
+++ b/spec/models/payment_provider_customers/base_customer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe PaymentProviderCustomers::BaseCustomer, type: :model do
+RSpec.describe PaymentProviderCustomers::BaseCustomer do
   subject(:integration_customer) { described_class.new(attributes) }
 
   let(:attributes) { {} }

--- a/spec/models/payment_provider_customers/cashfree_customer_spec.rb
+++ b/spec/models/payment_provider_customers/cashfree_customer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::CashfreeCustomer, type: :model do
+RSpec.describe PaymentProviderCustomers::CashfreeCustomer do
   subject(:cashfree_customer) { described_class.new(attributes) }
 
   let(:attributes) {}

--- a/spec/models/payment_provider_customers/gocardless_customer_spec.rb
+++ b/spec/models/payment_provider_customers/gocardless_customer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::GocardlessCustomer, type: :model do
+RSpec.describe PaymentProviderCustomers::GocardlessCustomer do
   subject(:gocardless_customer) { described_class.new(attributes) }
 
   let(:attributes) {}

--- a/spec/models/payment_provider_customers/moneyhash_customer_spec.rb
+++ b/spec/models/payment_provider_customers/moneyhash_customer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::MoneyhashCustomer, type: :model do
+RSpec.describe PaymentProviderCustomers::MoneyhashCustomer do
   subject(:moneyhash_customer) { described_class.new(attributes) }
 
   let(:attributes) {}

--- a/spec/models/payment_provider_customers/stripe_customer_spec.rb
+++ b/spec/models/payment_provider_customers/stripe_customer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::StripeCustomer, type: :model do
+RSpec.describe PaymentProviderCustomers::StripeCustomer do
   subject(:stripe_customer) { described_class.new(attributes) }
 
   let(:attributes) {}

--- a/spec/models/payment_providers/adyen_provider_spec.rb
+++ b/spec/models/payment_providers/adyen_provider_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::AdyenProvider, type: :model do
+RSpec.describe PaymentProviders::AdyenProvider do
   subject(:provider) { build(:adyen_provider) }
 
   it { is_expected.to validate_length_of(:success_redirect_url).is_at_most(1024).allow_nil }

--- a/spec/models/payment_providers/base_provider_spec.rb
+++ b/spec/models/payment_providers/base_provider_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::BaseProvider, type: :model do
+RSpec.describe PaymentProviders::BaseProvider do
   subject(:provider) { described_class.new(attributes) }
 
   let(:secrets) { {"api_key" => api_key, "api_secret" => api_secret} }

--- a/spec/models/payment_providers/flutterwave_provider_spec.rb
+++ b/spec/models/payment_providers/flutterwave_provider_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::FlutterwaveProvider, type: :model do
+RSpec.describe PaymentProviders::FlutterwaveProvider do
   subject(:flutterwave_provider) { build(:flutterwave_provider) }
 
   describe "validations" do

--- a/spec/models/payment_providers/gocardless_provider_spec.rb
+++ b/spec/models/payment_providers/gocardless_provider_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::GocardlessProvider, type: :model do
+RSpec.describe PaymentProviders::GocardlessProvider do
   subject(:gocardless_provider) { build(:gocardless_provider, attributes) }
 
   let(:attributes) {}

--- a/spec/models/payment_providers/moneyhash_provider_spec.rb
+++ b/spec/models/payment_providers/moneyhash_provider_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::MoneyhashProvider, type: :model do
+RSpec.describe PaymentProviders::MoneyhashProvider do
   subject(:moneyhash_provider) { build(:moneyhash_provider, attributes) }
 
   let(:attributes) {}

--- a/spec/models/payment_providers/stripe_provider_spec.rb
+++ b/spec/models/payment_providers/stripe_provider_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::StripeProvider, type: :model do
+RSpec.describe PaymentProviders::StripeProvider do
   subject(:stripe_provider) { build(:stripe_provider, attributes) }
 
   let(:attributes) {}

--- a/spec/models/payment_receipt_spec.rb
+++ b/spec/models/payment_receipt_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentReceipt, type: :model do
+RSpec.describe PaymentReceipt do
   subject(:payment_receipt) { build(:payment_receipt) }
 
   it do

--- a/spec/models/payment_request/applied_invoice_spec.rb
+++ b/spec/models/payment_request/applied_invoice_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe PaymentRequest::AppliedInvoice, type: :model do
+RSpec.describe PaymentRequest::AppliedInvoice do
   subject(:applied_invoice) { build(:payment_request_applied_invoice) }
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/payment_request_spec.rb
+++ b/spec/models/payment_request_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequest, type: :model do
+RSpec.describe PaymentRequest do
   subject(:payment_request) do
     described_class.new(
       organization:,

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Payment, type: :model do
+RSpec.describe Payment do
   subject(:payment) { build(:payment, payable:, payment_type:, provider_payment_id:, reference:, amount_cents:) }
 
   let(:payable) { create(:invoice, invoice_type:, total_amount_cents: 10000) }

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Permission, type: :model do
+RSpec.describe Permission do
   it "defines permission hashes" do
     names = %w[DEFAULT_PERMISSIONS_HASH ADMIN_PERMISSIONS_HASH MANAGER_PERMISSIONS_HASH FINANCE_PERMISSIONS_HASH]
 

--- a/spec/models/plan/applied_tax_spec.rb
+++ b/spec/models/plan/applied_tax_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Plan::AppliedTax, type: :model do
+RSpec.describe Plan::AppliedTax do
   subject(:plan_applied_tax) { create(:plan_applied_tax) }
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Plan, type: :model do
+RSpec.describe Plan do
   subject(:plan) { build(:plan, trial_period: 3) }
 
   it { expect(described_class).to be_soft_deletable }

--- a/spec/models/pricing_unit_spec.rb
+++ b/spec/models/pricing_unit_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PricingUnit, type: :model do
+RSpec.describe PricingUnit do
   subject { build(:pricing_unit) }
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/pricing_unit_usage_spec.rb
+++ b/spec/models/pricing_unit_usage_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PricingUnitUsage, type: :model do
+RSpec.describe PricingUnitUsage do
   subject { build(:pricing_unit_usage) }
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/recurring_transaction_rule_spec.rb
+++ b/spec/models/recurring_transaction_rule_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe RecurringTransactionRule, type: :model do
+RSpec.describe RecurringTransactionRule do
   describe "associations" do
     it { is_expected.to belong_to(:wallet) }
     it { is_expected.to belong_to(:organization) }

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Refund, type: :model do
+RSpec.describe Refund do
   subject(:refund) { build(:refund) }
 
   describe "associations" do

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscription, type: :model do
+RSpec.describe Subscription do
   subject(:subscription) { create(:subscription, plan:) }
 
   let(:plan) { create(:plan) }

--- a/spec/models/tax_spec.rb
+++ b/spec/models/tax_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Tax, type: :model do
+RSpec.describe Tax do
   subject(:tax) { create(:tax, applied_to_organization:) }
 
   let(:applied_to_organization) { false }

--- a/spec/models/usage_monitoring/alert_spec.rb
+++ b/spec/models/usage_monitoring/alert_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::Alert, type: :model do
+RSpec.describe UsageMonitoring::Alert do
   let(:alert) { create(:alert, code: "my-code", thresholds: [10, 30, 50], recurring_threshold: 100) }
 
   describe "associations" do

--- a/spec/models/usage_monitoring/billable_metric_current_usage_amount_alert_spec.rb
+++ b/spec/models/usage_monitoring/billable_metric_current_usage_amount_alert_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::BillableMetricCurrentUsageAmountAlert, type: :model do
+RSpec.describe UsageMonitoring::BillableMetricCurrentUsageAmountAlert do
   subject { alert.find_value(current_usage) }
 
   let(:alert) { create(:billable_metric_current_usage_amount_alert, subscription_external_id: "test") }

--- a/spec/models/usage_monitoring/billable_metric_current_usage_units_alert_spec.rb
+++ b/spec/models/usage_monitoring/billable_metric_current_usage_units_alert_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::BillableMetricCurrentUsageUnitsAlert, type: :model do
+RSpec.describe UsageMonitoring::BillableMetricCurrentUsageUnitsAlert do
   subject { alert.find_value(current_usage) }
 
   let(:alert) { create(:billable_metric_current_usage_units_alert, subscription_external_id: "test") }

--- a/spec/models/usage_monitoring/current_usage_amount_alert_spec.rb
+++ b/spec/models/usage_monitoring/current_usage_amount_alert_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::CurrentUsageAmountAlert, type: :model do
+RSpec.describe UsageMonitoring::CurrentUsageAmountAlert do
   let(:alert) { create(:usage_current_amount_alert) }
   let(:subscription) { create(:subscription) }
 

--- a/spec/models/usage_monitoring/lifetime_usage_amount_alert_spec.rb
+++ b/spec/models/usage_monitoring/lifetime_usage_amount_alert_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::LifetimeUsageAmountAlert, type: :model do
+RSpec.describe UsageMonitoring::LifetimeUsageAmountAlert do
   describe "#find_value" do
     subject { alert.find_value(lifetime_usage) }
 

--- a/spec/models/usage_monitoring/subscription_activity_spec.rb
+++ b/spec/models/usage_monitoring/subscription_activity_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::SubscriptionActivity, type: :model do
+RSpec.describe UsageMonitoring::SubscriptionActivity do
   it do
     expect(subject).to belong_to(:organization)
     expect(subject).to belong_to(:subscription)

--- a/spec/models/usage_monitoring/triggered_alert_spec.rb
+++ b/spec/models/usage_monitoring/triggered_alert_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::TriggeredAlert, type: :model do
+RSpec.describe UsageMonitoring::TriggeredAlert do
   let(:triggered_alert) { create(:triggered_alert) }
 
   describe "associations" do

--- a/spec/models/usage_threshold_spec.rb
+++ b/spec/models/usage_threshold_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageThreshold, type: :model do
+RSpec.describe UsageThreshold do
   subject(:usage_threshold) { build(:usage_threshold) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe User, type: :model do
+RSpec.describe User do
   subject { described_class.new(email: "gavin@hooli.com", password: "f**k_piedpiper") }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallet, type: :model do
+RSpec.describe Wallet do
   subject(:wallet) { build(:wallet) }
 
   it_behaves_like "paper_trail traceable"

--- a/spec/models/wallet_target_spec.rb
+++ b/spec/models/wallet_target_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe WalletTarget, type: :model do
+RSpec.describe WalletTarget do
   subject(:wallet_target) { build(:wallet_target) }
 
   it { is_expected.to belong_to(:organization) }

--- a/spec/models/wallet_transaction_spec.rb
+++ b/spec/models/wallet_transaction_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WalletTransaction, type: :model do
+RSpec.describe WalletTransaction do
   it { is_expected.to validate_presence_of(:priority) }
   it { is_expected.to validate_inclusion_of(:priority).in_range(1..50) }
   it { is_expected.to validate_length_of(:name).is_at_most(255).is_at_least(1).allow_nil }

--- a/spec/models/webhook_endpoint_spec.rb
+++ b/spec/models/webhook_endpoint_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WebhookEndpoint, type: :model do
+RSpec.describe WebhookEndpoint do
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to have_many(:webhooks).dependent(:delete_all) }
 

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Webhook, type: :model do
+RSpec.describe Webhook do
   subject(:webhook) { build(:webhook) }
 
   it { is_expected.to belong_to(:webhook_endpoint) }


### PR DESCRIPTION
## Context

All model tests have the `type: :model` RSpec metadata but this metadata is already infered due to the `config.infer_spec_type_from_file_location!` setting.

## Description

This removes the redundant metadata.
