### PR TITLE
chore(stripe): rename `setup_future_usage`

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -134,7 +134,7 @@ module Invoices
           expires_at: payment_intent.expires_at.to_i,
           payment_intent_data: {
             description:,
-            setup_future_usage: off_session? ? "off_session" : nil, # save payment method for future use
+            setup_future_usage: setup_future_usage? ? "off_session" : nil,
             metadata: {
               lago_customer_id: customer.id,
               lago_invoice_id: invoice.id,
@@ -202,10 +202,9 @@ module Invoices
         result
       end
 
-      # NOTE: Due to RBI limitation, all indians payment should be off_session
-      # to permit 3D secure authentication
-      # https://docs.stripe.com/india-recurring-payments
-      def off_session?
+      # NOTE: Due to RBI limitation, all indians payment should be "on session". See: https://docs.stripe.com/india-recurring-payments
+      # crypto payments don't support 'off_session'
+      def setup_future_usage?
         return false if customer.country == "IN"
         return false if customer.stripe_customer.provider_payment_methods.include?("crypto")
 

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       expect(::Stripe::Checkout::Session).to have_received(:create)
     end
 
-    context "with #payment_url_payload" do
+    describe "#payment_url_payload" do
       let(:payment_url_payload) { stripe_service.__send__(:payment_url_payload, payment_intent) }
 
       let(:payload) do
@@ -89,6 +89,22 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       context "when paid amount is zero" do
         it "returns the payload" do
           expect(payment_url_payload).to eq(payload)
+        end
+      end
+
+      context "when customer is from India" do
+        let(:customer) { create(:customer, payment_provider_code: code, country: "IN") }
+
+        it "does not save the card" do
+          expect(payment_url_payload[:payment_intent_data][:setup_future_usage]).to be_nil
+        end
+      end
+
+      context "when customer can use crypto" do
+        it "does not save the card" do
+          stripe_customer.provider_payment_methods << "crypto"
+          stripe_customer.save!
+          expect(payment_url_payload[:payment_intent_data][:setup_future_usage]).to be_nil
         end
       end
     end


### PR DESCRIPTION
## Context

I'm adding 3DS support for all Stripe customers. This is extracted from #4336 to keep last PR more manageable.

## Description

`error_on_requires_action?` was introduced in #2690, but #2959 refactored the payment, this function was left here unused.

`setup_future_usage` was added between the 2 PR mentioned above so I reused the `off_session?` method. Since the method is extracted, it's best to rename it. Soon, `off_session?` will be for all customers but `setup_future_usage: "off_session"` should still be only for customer in India.
