### PR TITLE
test(commitment): Fix flaky test

### DIFF
--- a/spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb
+++ b/spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService, type: :service d
   let(:customer) { create(:customer, organization:) }
   let(:subscription_at) { DateTime.parse("2024-01-01T00:00:00") }
   let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:, pay_in_advance:, interval: [:semiannual, :yearly].sample) }
+  let(:plan) { create(:plan, organization:, pay_in_advance:, interval: :yearly) }
   let(:billing_time) { :calendar }
   let(:bill_charges_monthly) { false }
   let(:pay_in_advance) { false }


### PR DESCRIPTION
## Context

The `Commitments::Minimum::CalculateTrueUpFeeService` had a test with a random plan interval between `:semiannual` and `:yearly`.

Unfortunately, the `:semiannual` interval always results in an error resulting in a flaky test:

```sh
Commitments::Minimum::CalculateTrueUpFeeService
  #call
    when plan is paid in arrears
      when plan has minimum commitment
        when there are no fees
          returns result with amount cents (FAILED - 1)

Failures:

  1) Commitments::Minimum::CalculateTrueUpFeeService#call when plan is paid in arrears when plan has minimum commitment when there are no fees returns result with amount cents
     Failure/Error: all_invoice_subscriptions.first.from_datetime,

     NoMethodError:
       undefined method 'from_datetime' for nil
     # ./app/services/commitments/calculate_prorated_coefficient_service.rb:44:in 'Commitments::CalculateProratedCoefficientService#calculate_proration_coefficient'
     # ./app/services/commitments/calculate_prorated_coefficient_service.rb:13:in 'Commitments::CalculateProratedCoefficientService#proration_coefficient'
     # ./app/services/commitments/calculate_amount_service.rb:26:in 'Commitments::CalculateAmountService#commitment_amount_cents'
     # ./app/services/commitments/calculate_amount_service.rb:13:in 'Commitments::CalculateAmountService#call'
     # ./app/services/base_service.rb:163:in 'block in BaseService.call'
     # ./app/services/base_service.rb:157:in 'BaseService.call'
     # ./app/services/commitments/minimum/calculate_true_up_fee_service.rb:62:in 'Commitments::Minimum::CalculateTrueUpFeeService#commitment_amount_cents'
     # ./app/services/commitments/minimum/calculate_true_up_fee_service.rb:36:in 'Commitments::Minimum::CalculateTrueUpFeeService#amount_cents'
     # ./app/services/commitments/minimum/calculate_true_up_fee_service.rb:24:in 'Commitments::Minimum::CalculateTrueUpFeeService#call'
     # ./spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb:35:in 'block (3 levels) in <top (required)>'
     # ./spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb:59:in 'block (6 levels) in <top (required)>'

Finished in 0.42983 seconds (files took 3.19 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb:58 # Commitments::Minimum::CalculateTrueUpFeeService#call when plan is paid in arrears when plan has minimum commitment when there are no fees returns result with amount cents
```

## Description

This simply fixes the interval to `:yearly`.