### PR TITLE
test(job): Remove unnecessary `type` spec metadata

### DIFF
--- a/spec/jobs/ai_conversations/stream_job_spec.rb
+++ b/spec/jobs/ai_conversations/stream_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AiConversations::StreamJob, type: :job do
+RSpec.describe AiConversations::StreamJob do
   let(:ai_conversation) { create(:ai_conversation) }
   let(:message) { Faker::Lorem.word }
 

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ApplicationJob, type: :job do
+RSpec.describe ApplicationJob do
   let(:job_class) do
     Class.new(ApplicationJob) do
       def perform(arg1, arg2, option: "default")

--- a/spec/jobs/bill_add_on_job_spec.rb
+++ b/spec/jobs/bill_add_on_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillAddOnJob, type: :job do
+RSpec.describe BillAddOnJob do
   let(:applied_add_on) { create(:applied_add_on) }
   let(:datetime) { Time.current.round }
 

--- a/spec/jobs/bill_paid_credit_job_spec.rb
+++ b/spec/jobs/bill_paid_credit_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillPaidCreditJob, type: :job do
+RSpec.describe BillPaidCreditJob do
   let(:wallet_transaction) { create(:wallet_transaction) }
   let(:timestamp) { Time.current.to_i }
 

--- a/spec/jobs/bill_subscription_job_spec.rb
+++ b/spec/jobs/bill_subscription_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillSubscriptionJob, type: :job do
+RSpec.describe BillSubscriptionJob do
   let(:subscriptions) { [create(:subscription)] }
   let(:timestamp) { Time.zone.now.to_i }
 

--- a/spec/jobs/billable_metric_filters/destroy_all_job_spec.rb
+++ b/spec/jobs/billable_metric_filters/destroy_all_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe BillableMetricFilters::DestroyAllJob, type: :job do
+RSpec.describe BillableMetricFilters::DestroyAllJob do
   let(:billable_metric) { create(:billable_metric, :discarded) }
 
   it "destroys all filters and filter values" do

--- a/spec/jobs/billable_metrics/delete_events_job_spec.rb
+++ b/spec/jobs/billable_metrics/delete_events_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::DeleteEventsJob, type: :job, transaction: false, clickhouse: true do
+RSpec.describe BillableMetrics::DeleteEventsJob, transaction: false, clickhouse: true do
   let(:billable_metric) { create(:billable_metric, :deleted) }
   let(:subscription) { create(:subscription) }
 

--- a/spec/jobs/charges/create_children_batch_job_spec.rb
+++ b/spec/jobs/charges/create_children_batch_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::CreateChildrenBatchJob, type: :job do
+RSpec.describe Charges::CreateChildrenBatchJob do
   let(:billable_metric) { create(:billable_metric) }
   let(:plan) { create(:plan, organization: billable_metric.organization) }
   let(:child_plan) { create(:plan, organization: billable_metric.organization, parent_id: plan.id) }

--- a/spec/jobs/charges/create_children_job_spec.rb
+++ b/spec/jobs/charges/create_children_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::CreateChildrenJob, type: :job do
+RSpec.describe Charges::CreateChildrenJob do
   let(:billable_metric) { create(:billable_metric) }
   let(:plan) { create(:plan, organization: billable_metric.organization) }
   let(:subscription) { create(:subscription, plan: child_plan) }

--- a/spec/jobs/charges/destroy_children_job_spec.rb
+++ b/spec/jobs/charges/destroy_children_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::DestroyChildrenJob, type: :job do
+RSpec.describe Charges::DestroyChildrenJob do
   let(:charge) { create(:standard_charge, :deleted) }
 
   before do

--- a/spec/jobs/charges/update_children_batch_job_spec.rb
+++ b/spec/jobs/charges/update_children_batch_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::UpdateChildrenBatchJob, type: :job do
+RSpec.describe Charges::UpdateChildrenBatchJob do
   let(:charge) { create(:standard_charge) }
   let(:child_charge) { create(:standard_charge, parent_id: charge.id) }
   let(:child_charge2) { create(:standard_charge, parent_id: charge.id) }

--- a/spec/jobs/charges/update_children_job_spec.rb
+++ b/spec/jobs/charges/update_children_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::UpdateChildrenJob, type: :job do
+RSpec.describe Charges::UpdateChildrenJob do
   let(:charge) { create(:standard_charge) }
   let(:child_plan1) { create(:plan, parent_id: charge.plan.id) }
   let(:child_plan2) { create(:plan, parent_id: charge.plan.id) }

--- a/spec/jobs/clock/compute_all_daily_usages_job_spec.rb
+++ b/spec/jobs/clock/compute_all_daily_usages_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Clock::ComputeAllDailyUsagesJob, type: :job do
+RSpec.describe Clock::ComputeAllDailyUsagesJob do
   subject(:compute_job) { described_class }
 
   describe ".perform" do

--- a/spec/jobs/clock/consume_subscription_refreshed_queue_job_spec.rb
+++ b/spec/jobs/clock/consume_subscription_refreshed_queue_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Clock::ConsumeSubscriptionRefreshedQueueJob, type: :job do
+RSpec.describe Clock::ConsumeSubscriptionRefreshedQueueJob do
   subject(:refresh_jobs) { described_class }
 
   describe "#perform" do

--- a/spec/jobs/clock/subscriptions_biller_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_biller_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Clock::SubscriptionsBillerJob, type: :job do
+RSpec.describe Clock::SubscriptionsBillerJob do
   subject { described_class }
 
   describe ".perform" do

--- a/spec/jobs/credit_notes/generate_pdf_job_spec.rb
+++ b/spec/jobs/credit_notes/generate_pdf_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::GeneratePdfJob, type: :job do
+RSpec.describe CreditNotes::GeneratePdfJob do
   let(:credit_note) { create(:credit_note) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/jobs/credit_notes/provider_taxes/report_job_spec.rb
+++ b/spec/jobs/credit_notes/provider_taxes/report_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::ProviderTaxes::ReportJob, type: :job do
+RSpec.describe CreditNotes::ProviderTaxes::ReportJob do
   let(:organization) { create(:organization) }
   let(:credit_note) { create(:credit_note, customer:) }
   let(:customer) { create(:customer, organization:) }

--- a/spec/jobs/credit_notes/refunds/adyen_create_job_spec.rb
+++ b/spec/jobs/credit_notes/refunds/adyen_create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::Refunds::AdyenCreateJob, type: :job do
+RSpec.describe CreditNotes::Refunds::AdyenCreateJob do
   let(:credit_note) { create(:credit_note) }
 
   let(:refund_service) do

--- a/spec/jobs/credit_notes/refunds/gocardless_create_job_spec.rb
+++ b/spec/jobs/credit_notes/refunds/gocardless_create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::Refunds::GocardlessCreateJob, type: :job do
+RSpec.describe CreditNotes::Refunds::GocardlessCreateJob do
   let(:credit_note) { create(:credit_note) }
 
   let(:refund_service) do

--- a/spec/jobs/credit_notes/refunds/stripe_create_job_spec.rb
+++ b/spec/jobs/credit_notes/refunds/stripe_create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::Refunds::StripeCreateJob, type: :job do
+RSpec.describe CreditNotes::Refunds::StripeCreateJob do
   let(:credit_note) { create(:credit_note) }
 
   let(:refund_service) do

--- a/spec/jobs/customers/retry_vies_check_job_spec.rb
+++ b/spec/jobs/customers/retry_vies_check_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customers::RetryViesCheckJob, type: :job do
+RSpec.describe Customers::RetryViesCheckJob do
   let(:customer) { create(:customer, tax_identification_number: "IE6388047V") }
   let(:vies_response) do
     {

--- a/spec/jobs/customers/terminate_relations_job_spec.rb
+++ b/spec/jobs/customers/terminate_relations_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customers::TerminateRelationsJob, type: :job do
+RSpec.describe Customers::TerminateRelationsJob do
   let(:customer) { create(:customer, :deleted) }
 
   it "calls the service" do

--- a/spec/jobs/daily_usages/compute_job_spec.rb
+++ b/spec/jobs/daily_usages/compute_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DailyUsages::ComputeJob, type: :job do
+RSpec.describe DailyUsages::ComputeJob do
   subject(:compute_job) { described_class }
 
   let(:subscription) { create(:subscription) }

--- a/spec/jobs/daily_usages/fill_from_invoice_job_spec.rb
+++ b/spec/jobs/daily_usages/fill_from_invoice_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DailyUsages::FillFromInvoiceJob, type: :job do
+RSpec.describe DailyUsages::FillFromInvoiceJob do
   subject(:compute_job) { described_class }
 
   let(:subscription) { create(:subscription) }

--- a/spec/jobs/data_exports/combine_parts_job_spec.rb
+++ b/spec/jobs/data_exports/combine_parts_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataExports::CombinePartsJob, type: :job do
+RSpec.describe DataExports::CombinePartsJob do
   let(:data_export) { create(:data_export) }
   let(:result) { BaseService::Result.new }
 

--- a/spec/jobs/data_exports/export_resources_job_spec.rb
+++ b/spec/jobs/data_exports/export_resources_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataExports::ExportResourcesJob, type: :job do
+RSpec.describe DataExports::ExportResourcesJob do
   let(:data_export) { create(:data_export) }
   let(:result) { BaseService::Result.new }
 

--- a/spec/jobs/data_exports/process_part_job_spec.rb
+++ b/spec/jobs/data_exports/process_part_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataExports::ProcessPartJob, type: :job do
+RSpec.describe DataExports::ProcessPartJob do
   let(:data_export_part) { create(:data_export_part) }
   let(:result) { BaseService::Result.new }
 

--- a/spec/jobs/dunning_campaigns/bulk_process_job_spec.rb
+++ b/spec/jobs/dunning_campaigns/bulk_process_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DunningCampaigns::BulkProcessJob, type: :job do
+RSpec.describe DunningCampaigns::BulkProcessJob do
   let(:result) { BaseService::Result.new }
 
   before do

--- a/spec/jobs/dunning_campaigns/process_attempt_job_spec.rb
+++ b/spec/jobs/dunning_campaigns/process_attempt_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DunningCampaigns::ProcessAttemptJob, type: :job do
+RSpec.describe DunningCampaigns::ProcessAttemptJob do
   let(:result) { BaseService::Result.new }
   let(:customer) { build :customer }
   let(:dunning_campaign_threshold) { build :dunning_campaign_threshold }

--- a/spec/jobs/events/pay_in_advance_job_spec.rb
+++ b/spec/jobs/events/pay_in_advance_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Events::PayInAdvanceJob, type: :job do
+RSpec.describe Events::PayInAdvanceJob do
   let(:pay_in_advance_service) { instance_double(Events::PayInAdvanceService) }
   let(:result) { BaseService::Result.new }
 

--- a/spec/jobs/events/post_process_job_spec.rb
+++ b/spec/jobs/events/post_process_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Events::PostProcessJob, type: :job do
+RSpec.describe Events::PostProcessJob do
   let(:process_service) { instance_double(Events::PostProcessService) }
   let(:result) { BaseService::Result.new }
 

--- a/spec/jobs/fees/create_pay_in_advance_job_spec.rb
+++ b/spec/jobs/fees/create_pay_in_advance_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Fees::CreatePayInAdvanceJob, type: :job do
+RSpec.describe Fees::CreatePayInAdvanceJob do
   let(:charge) { create(:standard_charge, :pay_in_advance) }
   let(:event) { create(:event) }
 

--- a/spec/jobs/fixed_charges/create_children_batch_job_spec.rb
+++ b/spec/jobs/fixed_charges/create_children_batch_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::CreateChildrenBatchJob, type: :job do
+RSpec.describe FixedCharges::CreateChildrenBatchJob do
   let(:organization) { create(:organization) }
   let(:plan) { create(:plan, organization:) }
   let(:add_on) { create(:add_on, organization:) }

--- a/spec/jobs/fixed_charges/create_children_job_spec.rb
+++ b/spec/jobs/fixed_charges/create_children_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::CreateChildrenJob, type: :job do
+RSpec.describe FixedCharges::CreateChildrenJob do
   let(:add_on) { create(:add_on) }
   let(:plan) { create(:plan, organization: add_on.organization) }
   let(:subscription) { create(:subscription, plan: child_plan) }

--- a/spec/jobs/fixed_charges/destroy_children_job_spec.rb
+++ b/spec/jobs/fixed_charges/destroy_children_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::DestroyChildrenJob, type: :job do
+RSpec.describe FixedCharges::DestroyChildrenJob do
   let(:fixed_charge) { create(:fixed_charge, :deleted) }
 
   before do

--- a/spec/jobs/fixed_charges/update_children_batch_job_spec.rb
+++ b/spec/jobs/fixed_charges/update_children_batch_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::UpdateChildrenBatchJob, type: :job do
+RSpec.describe FixedCharges::UpdateChildrenBatchJob do
   let(:organization) { create(:organization) }
   let(:plan) { create(:plan, organization:) }
   let(:add_on) { create(:add_on, organization:) }

--- a/spec/jobs/fixed_charges/update_children_job_spec.rb
+++ b/spec/jobs/fixed_charges/update_children_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::UpdateChildrenJob, type: :job do
+RSpec.describe FixedCharges::UpdateChildrenJob do
   let(:organization) { create(:organization) }
   let(:plan) { create(:plan, organization:) }
   let(:add_on) { create(:add_on, organization:) }

--- a/spec/jobs/inbound_webhooks/process_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/process_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe InboundWebhooks::ProcessJob, type: :job do
+RSpec.describe InboundWebhooks::ProcessJob do
   subject(:process_job) { described_class }
 
   let(:inbound_webhook) { create :inbound_webhook }

--- a/spec/jobs/integration_customers/create_job_spec.rb
+++ b/spec/jobs/integration_customers/create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::CreateJob, type: :job do
+RSpec.describe IntegrationCustomers::CreateJob do
   subject(:create_job) { described_class }
 
   let(:create_service) { instance_double(IntegrationCustomers::CreateService) }

--- a/spec/jobs/integration_customers/update_job_spec.rb
+++ b/spec/jobs/integration_customers/update_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::UpdateJob, type: :job do
+RSpec.describe IntegrationCustomers::UpdateJob do
   subject(:create_job) { described_class }
 
   let(:update_service) { instance_double(IntegrationCustomers::UpdateService) }

--- a/spec/jobs/integrations/aggregator/credit_notes/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/credit_notes/create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::CreditNotes::CreateJob, type: :job do
+RSpec.describe Integrations::Aggregator::CreditNotes::CreateJob do
   subject(:create_job) { described_class }
 
   let(:service) { instance_double(Integrations::Aggregator::CreditNotes::CreateService) }

--- a/spec/jobs/integrations/aggregator/fetch_items_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/fetch_items_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::FetchItemsJob, type: :job do
+RSpec.describe Integrations::Aggregator::FetchItemsJob do
   subject(:fetch_items_job) { described_class }
 
   let(:items_service) { instance_double(Integrations::Aggregator::ItemsService) }

--- a/spec/jobs/integrations/aggregator/invoices/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Invoices::CreateJob, type: :job do
+RSpec.describe Integrations::Aggregator::Invoices::CreateJob do
   subject(:create_job) { described_class }
 
   let(:service) { instance_double(Integrations::Aggregator::Invoices::CreateService) }

--- a/spec/jobs/integrations/aggregator/invoices/hubspot/create_customer_association_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/hubspot/create_customer_association_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssociationJob, type: :job do
+RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssociationJob do
   subject(:create_job) { described_class }
 
   let(:service) { instance_double(Integrations::Aggregator::Invoices::Hubspot::CreateCustomerAssociationService) }

--- a/spec/jobs/integrations/aggregator/invoices/hubspot/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/hubspot/create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateJob, type: :job do
+RSpec.describe Integrations::Aggregator::Invoices::Hubspot::CreateJob do
   subject(:create_job) { described_class }
 
   let(:service) { instance_double(Integrations::Aggregator::Invoices::Hubspot::CreateService) }

--- a/spec/jobs/integrations/aggregator/invoices/hubspot/update_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/invoices/hubspot/update_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateJob, type: :job do
+RSpec.describe Integrations::Aggregator::Invoices::Hubspot::UpdateJob do
   subject(:create_job) { described_class }
 
   let(:service) { instance_double(Integrations::Aggregator::Invoices::Hubspot::UpdateService) }

--- a/spec/jobs/integrations/aggregator/payments/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/payments/create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Payments::CreateJob, type: :job do
+RSpec.describe Integrations::Aggregator::Payments::CreateJob do
   subject(:create_job) { described_class }
 
   let(:service) { instance_double(Integrations::Aggregator::Payments::CreateService) }

--- a/spec/jobs/integrations/aggregator/perform_sync_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/perform_sync_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::PerformSyncJob, type: :job do
+RSpec.describe Integrations::Aggregator::PerformSyncJob do
   subject(:perform_sync_job) { described_class.perform_now(integration:, sync_items:) }
 
   let(:sync_service) { instance_double(Integrations::Aggregator::SyncService) }

--- a/spec/jobs/integrations/aggregator/send_restlet_endpoint_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/send_restlet_endpoint_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::SendRestletEndpointJob, type: :job do
+RSpec.describe Integrations::Aggregator::SendRestletEndpointJob do
   subject(:send_endpoint_job) { described_class }
 
   let(:send_endpoint_service) { instance_double(Integrations::Aggregator::SendRestletEndpointService) }

--- a/spec/jobs/integrations/aggregator/subscriptions/hubspot/create_customer_association_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/subscriptions/hubspot/create_customer_association_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateCustomerAssociationJob, type: :job do
+RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateCustomerAssociationJob do
   subject(:create_job) { described_class }
 
   let(:service) { instance_double(Integrations::Aggregator::Subscriptions::Hubspot::CreateCustomerAssociationService) }

--- a/spec/jobs/integrations/aggregator/subscriptions/hubspot/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/subscriptions/hubspot/create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateJob, type: :job do
+RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::CreateJob do
   subject(:create_job) { described_class }
 
   let(:service) { instance_double(Integrations::Aggregator::Subscriptions::Hubspot::CreateService) }

--- a/spec/jobs/integrations/aggregator/subscriptions/hubspot/update_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/subscriptions/hubspot/update_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob, type: :job do
+RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::UpdateJob do
   subject(:create_job) { described_class }
 
   let(:service) { instance_double(Integrations::Aggregator::Subscriptions::Hubspot::UpdateService) }

--- a/spec/jobs/integrations/aggregator/sync_custom_objects_and_properties_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/sync_custom_objects_and_properties_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::SyncCustomObjectsAndPropertiesJob, type: :job do
+RSpec.describe Integrations::Aggregator::SyncCustomObjectsAndPropertiesJob do
   describe "#perform" do
     subject(:sync_job) { described_class }
 

--- a/spec/jobs/integrations/avalara/fetch_company_id_job_spec.rb
+++ b/spec/jobs/integrations/avalara/fetch_company_id_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Avalara::FetchCompanyIdJob, type: :job do
+RSpec.describe Integrations::Avalara::FetchCompanyIdJob do
   describe "#perform" do
     subject(:job) { described_class }
 

--- a/spec/jobs/integrations/hubspot/companies/deploy_properties_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/companies/deploy_properties_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Hubspot::Companies::DeployPropertiesJob, type: :job do
+RSpec.describe Integrations::Hubspot::Companies::DeployPropertiesJob do
   describe "#perform" do
     subject(:deploy_properties_job) { described_class }
 

--- a/spec/jobs/integrations/hubspot/contacts/deploy_properties_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/contacts/deploy_properties_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Hubspot::Contacts::DeployPropertiesJob, type: :job do
+RSpec.describe Integrations::Hubspot::Contacts::DeployPropertiesJob do
   describe "#perform" do
     subject(:deploy_properties_job) { described_class }
 

--- a/spec/jobs/integrations/hubspot/invoices/deploy_object_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/invoices/deploy_object_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Hubspot::Invoices::DeployObjectJob, type: :job do
+RSpec.describe Integrations::Hubspot::Invoices::DeployObjectJob do
   describe "#perform" do
     subject(:deploy_object_job) { described_class }
 

--- a/spec/jobs/integrations/hubspot/save_portal_id_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/save_portal_id_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Hubspot::SavePortalIdJob, type: :job do
+RSpec.describe Integrations::Hubspot::SavePortalIdJob do
   describe "#perform" do
     subject(:job) { described_class }
 

--- a/spec/jobs/integrations/hubspot/subscriptions/deploy_object_job_spec.rb
+++ b/spec/jobs/integrations/hubspot/subscriptions/deploy_object_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Hubspot::Subscriptions::DeployObjectJob, type: :job do
+RSpec.describe Integrations::Hubspot::Subscriptions::DeployObjectJob do
   describe "#perform" do
     subject(:deploy_object_job) { described_class }
 

--- a/spec/jobs/invoices/create_pay_in_advance_charge_job_spec.rb
+++ b/spec/jobs/invoices/create_pay_in_advance_charge_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::CreatePayInAdvanceChargeJob, type: :job do
+RSpec.describe Invoices::CreatePayInAdvanceChargeJob do
   let(:charge) { create(:standard_charge, :pay_in_advance, invoiceable: true) }
   let(:event) { create(:event) }
   let(:timestamp) { Time.current.to_i }

--- a/spec/jobs/invoices/finalize_all_job_spec.rb
+++ b/spec/jobs/invoices/finalize_all_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::FinalizeAllJob, type: :job do
+RSpec.describe Invoices::FinalizeAllJob do
   subject(:finalize_all_job) { described_class }
 
   let(:finalize_batch_service) { instance_double(Invoices::FinalizeBatchService) }

--- a/spec/jobs/invoices/finalize_job_spec.rb
+++ b/spec/jobs/invoices/finalize_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::FinalizeJob, type: :job do
+RSpec.describe Invoices::FinalizeJob do
   let(:invoice) { create(:invoice) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/jobs/invoices/generate_pdf_job_spec.rb
+++ b/spec/jobs/invoices/generate_pdf_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::GeneratePdfJob, type: :job do
+RSpec.describe Invoices::GeneratePdfJob do
   let(:invoice) { create(:invoice) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/jobs/invoices/payments/adyen_create_job_spec.rb
+++ b/spec/jobs/invoices/payments/adyen_create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::AdyenCreateJob, type: :job do
+RSpec.describe Invoices::Payments::AdyenCreateJob do
   let(:invoice) { create(:invoice) }
 
   it "calls the stripe create service" do

--- a/spec/jobs/invoices/payments/create_job_spec.rb
+++ b/spec/jobs/invoices/payments/create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::CreateJob, type: :job do
+RSpec.describe Invoices::Payments::CreateJob do
   let(:invoice) { create(:invoice) }
   let(:payment_provider) { "stripe" }
 

--- a/spec/jobs/invoices/payments/gocardless_create_job_spec.rb
+++ b/spec/jobs/invoices/payments/gocardless_create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::GocardlessCreateJob, type: :job do
+RSpec.describe Invoices::Payments::GocardlessCreateJob do
   let(:invoice) { create(:invoice) }
 
   it "calls the stripe create service" do

--- a/spec/jobs/invoices/payments/retry_all_job_spec.rb
+++ b/spec/jobs/invoices/payments/retry_all_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::RetryAllJob, type: :job do
+RSpec.describe Invoices::Payments::RetryAllJob do
   subject(:retry_all_job) { described_class }
 
   let(:retry_batch_service) { instance_double(Invoices::Payments::RetryBatchService) }

--- a/spec/jobs/invoices/payments/stripe_create_job_spec.rb
+++ b/spec/jobs/invoices/payments/stripe_create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::StripeCreateJob, type: :job do
+RSpec.describe Invoices::Payments::StripeCreateJob do
   let(:invoice) { create(:invoice) }
 
   it "calls the stripe create service" do

--- a/spec/jobs/invoices/prepaid_credit_job_spec.rb
+++ b/spec/jobs/invoices/prepaid_credit_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::PrepaidCreditJob, type: :job do
+RSpec.describe Invoices::PrepaidCreditJob do
   let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
   let(:customer) { create(:customer) }
   let(:subscription) { create(:subscription, customer:) }

--- a/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
+++ b/spec/jobs/invoices/provider_taxes/pull_taxes_and_apply_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyJob, type: :job do
+RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyJob do
   let(:organization) { create(:organization) }
   let(:invoice) { create(:invoice, customer:) }
   let(:customer) { create(:customer, organization:) }

--- a/spec/jobs/invoices/provider_taxes/void_job_spec.rb
+++ b/spec/jobs/invoices/provider_taxes/void_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::ProviderTaxes::VoidJob, type: :job do
+RSpec.describe Invoices::ProviderTaxes::VoidJob do
   let(:organization) { create(:organization) }
   let(:invoice) { create(:invoice, customer:) }
   let(:customer) { create(:customer, organization:) }

--- a/spec/jobs/invoices/refresh_draft_job_spec.rb
+++ b/spec/jobs/invoices/refresh_draft_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::RefreshDraftJob, type: :job do
+RSpec.describe Invoices::RefreshDraftJob do
   let(:invoice) { create(:invoice, ready_to_be_refreshed: true) }
   let(:result) { BaseService::Result.new }
 

--- a/spec/jobs/invoices/retry_all_job_spec.rb
+++ b/spec/jobs/invoices/retry_all_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::RetryAllJob, type: :job do
+RSpec.describe Invoices::RetryAllJob do
   subject(:retry_all_job) { described_class }
 
   let(:retry_batch_service) { instance_double(Invoices::RetryBatchService) }

--- a/spec/jobs/invoices/update_all_invoice_grace_period_from_billing_entity_job_spec.rb
+++ b/spec/jobs/invoices/update_all_invoice_grace_period_from_billing_entity_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::UpdateAllInvoiceGracePeriodFromBillingEntityJob, type: :job do
+RSpec.describe Invoices::UpdateAllInvoiceGracePeriodFromBillingEntityJob do
   subject { described_class.perform_now(billing_entity, old_grace_period) }
 
   let(:billing_entity) { create(:billing_entity) }

--- a/spec/jobs/invoices/update_fees_payment_status_job_spec.rb
+++ b/spec/jobs/invoices/update_fees_payment_status_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::UpdateFeesPaymentStatusJob, type: :job do
+RSpec.describe Invoices::UpdateFeesPaymentStatusJob do
   let(:invoice) { create(:invoice, payment_status: :succeeded) }
   let(:fee) { create(:fee, invoice:) }
 

--- a/spec/jobs/invoices/update_grace_period_from_billing_entity_job_spec.rb
+++ b/spec/jobs/invoices/update_grace_period_from_billing_entity_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::UpdateGracePeriodFromBillingEntityJob, type: :job do
+RSpec.describe Invoices::UpdateGracePeriodFromBillingEntityJob do
   subject { described_class.perform_now(invoice, old_grace_period) }
 
   let(:invoice) { create(:invoice) }

--- a/spec/jobs/lifetime_usages/flag_refresh_from_plan_update_job_spec.rb
+++ b/spec/jobs/lifetime_usages/flag_refresh_from_plan_update_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe LifetimeUsages::FlagRefreshFromPlanUpdateJob, type: :job do
+RSpec.describe LifetimeUsages::FlagRefreshFromPlanUpdateJob do
   let(:plan) { create(:plan) }
 
   it "delegates to the FlagRefreshFromPlanUpdate service" do

--- a/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
+++ b/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe LifetimeUsages::RecalculateAndCheckJob, type: :job do
+RSpec.describe LifetimeUsages::RecalculateAndCheckJob do
   let(:lifetime_usage) { create(:lifetime_usage) }
 
   it "delegates to the RecalculateAndCheck service" do

--- a/spec/jobs/payment_provider_customers/gocardless_checkout_url_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/gocardless_checkout_url_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::GocardlessCheckoutUrlJob, type: :job do
+RSpec.describe PaymentProviderCustomers::GocardlessCheckoutUrlJob do
   subject(:gocardless_checkout_job) { described_class }
 
   let(:gocardless_customer) { create(:gocardless_customer) }

--- a/spec/jobs/payment_provider_customers/gocardless_create_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/gocardless_create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::GocardlessCreateJob, type: :job do
+RSpec.describe PaymentProviderCustomers::GocardlessCreateJob do
   let(:gocardless_customer) { create(:gocardless_customer) }
 
   let(:gocardless_service) { instance_double(PaymentProviderCustomers::GocardlessService) }

--- a/spec/jobs/payment_provider_customers/stripe_checkout_url_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/stripe_checkout_url_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::StripeCheckoutUrlJob, type: :job do
+RSpec.describe PaymentProviderCustomers::StripeCheckoutUrlJob do
   subject(:stripe_checkout_job) { described_class }
 
   let(:stripe_customer) { create(:stripe_customer) }

--- a/spec/jobs/payment_provider_customers/stripe_create_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/stripe_create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::StripeCreateJob, type: :job do
+RSpec.describe PaymentProviderCustomers::StripeCreateJob do
   let(:stripe_customer) { create(:stripe_customer) }
 
   let(:stripe_service) { instance_double(PaymentProviderCustomers::StripeService) }

--- a/spec/jobs/payment_provider_customers/stripe_sync_funding_instructions_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/stripe_sync_funding_instructions_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::StripeSyncFundingInstructionsJob, type: :job do
+RSpec.describe PaymentProviderCustomers::StripeSyncFundingInstructionsJob do
   subject(:stripe_sync_funding_instructions_job) { described_class }
 
   let(:stripe_customer) { create(:stripe_customer) }

--- a/spec/jobs/payment_providers/adyen/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/adyen/handle_event_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Adyen::HandleEventJob, type: :job do
+RSpec.describe PaymentProviders::Adyen::HandleEventJob do
   subject(:handle_event_job) { described_class }
 
   let(:result) { BaseService::Result.new }

--- a/spec/jobs/payment_providers/cancel_payment_authorization_job_spec.rb
+++ b/spec/jobs/payment_providers/cancel_payment_authorization_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::CancelPaymentAuthorizationJob, type: :job do
+RSpec.describe PaymentProviders::CancelPaymentAuthorizationJob do
   it "calls the Stripe API" do
     payment_provider = create(:stripe_provider)
     stub_request(:post, %r{stripe}).and_return(status: 200, body: "{}")

--- a/spec/jobs/payment_providers/cashfree/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/cashfree/handle_event_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Cashfree::HandleEventJob, type: :job do
+RSpec.describe PaymentProviders::Cashfree::HandleEventJob do
   let(:result) { BaseService::Result.new }
   let(:organization) { create(:organization) }
 

--- a/spec/jobs/payment_providers/gocardless/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/gocardless/handle_event_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Gocardless::HandleEventJob, type: :job do
+RSpec.describe PaymentProviders::Gocardless::HandleEventJob do
   subject(:handle_event_job) { described_class }
 
   let(:gocardless_service) { instance_double(PaymentProviders::GocardlessService) }

--- a/spec/jobs/payment_providers/stripe/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/stripe/handle_event_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Stripe::HandleEventJob, type: :job do
+RSpec.describe PaymentProviders::Stripe::HandleEventJob do
   let(:result) { BaseService::Result.new }
   let(:organization) { create(:organization) }
 

--- a/spec/jobs/payment_providers/stripe/refresh_webhook_job_spec.rb
+++ b/spec/jobs/payment_providers/stripe/refresh_webhook_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Stripe::RefreshWebhookJob, type: :job do
+RSpec.describe PaymentProviders::Stripe::RefreshWebhookJob do
   it "calls the refresh webhook service" do
     allow(PaymentProviders::Stripe::RefreshWebhookService).to receive(:call!)
 

--- a/spec/jobs/payment_providers/stripe/register_webhook_job_spec.rb
+++ b/spec/jobs/payment_providers/stripe/register_webhook_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Stripe::RegisterWebhookJob, type: :job do
+RSpec.describe PaymentProviders::Stripe::RegisterWebhookJob do
   it "calls the register webhook service" do
     allow(PaymentProviders::Stripe::RegisterWebhookService).to receive(:call!)
 

--- a/spec/jobs/payment_receipts/create_job_spec.rb
+++ b/spec/jobs/payment_receipts/create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentReceipts::CreateJob, type: :job do
+RSpec.describe PaymentReceipts::CreateJob do
   let(:payment) { create(:payment) }
 
   it "calls the create service" do

--- a/spec/jobs/payment_receipts/generate_pdf_and_notify_job_spec.rb
+++ b/spec/jobs/payment_receipts/generate_pdf_and_notify_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentReceipts::GeneratePdfAndNotifyJob, type: :job do
+RSpec.describe PaymentReceipts::GeneratePdfAndNotifyJob do
   let(:payment_receipt) { create(:payment_receipt) }
   let(:result) { BaseService::Result.new }
   let(:generate_service) { instance_double(PaymentReceipts::GeneratePdfService) }

--- a/spec/jobs/payment_receipts/generate_pdf_job_spec.rb
+++ b/spec/jobs/payment_receipts/generate_pdf_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentReceipts::GeneratePdfJob, type: :job do
+RSpec.describe PaymentReceipts::GeneratePdfJob do
   let(:payment_receipt) { create(:payment_receipt) }
   let(:result) { BaseService::Result.new }
   let(:generate_service) { instance_double(PaymentReceipts::GeneratePdfService) }

--- a/spec/jobs/payment_requests/payments/adyen_create_job_spec.rb
+++ b/spec/jobs/payment_requests/payments/adyen_create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::Payments::AdyenCreateJob, type: :job do
+RSpec.describe PaymentRequests::Payments::AdyenCreateJob do
   let(:payment_request) { create(:payment_request) }
 
   let(:service_result) { BaseService::Result.new }

--- a/spec/jobs/payment_requests/payments/create_job_spec.rb
+++ b/spec/jobs/payment_requests/payments/create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::Payments::CreateJob, type: :job do
+RSpec.describe PaymentRequests::Payments::CreateJob do
   let(:payment_request) { create(:payment_request) }
 
   let(:service_result) { BaseService::Result.new }

--- a/spec/jobs/payment_requests/payments/gocardless_create_job_spec.rb
+++ b/spec/jobs/payment_requests/payments/gocardless_create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::Payments::GocardlessCreateJob, type: :job do
+RSpec.describe PaymentRequests::Payments::GocardlessCreateJob do
   let(:payment_request) { create(:payment_request) }
 
   let(:service_result) { BaseService::Result.new }

--- a/spec/jobs/payment_requests/payments/stripe_create_job_spec.rb
+++ b/spec/jobs/payment_requests/payments/stripe_create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::Payments::StripeCreateJob, type: :job do
+RSpec.describe PaymentRequests::Payments::StripeCreateJob do
   let(:payment_request) { create(:payment_request) }
 
   let(:service_result) { BaseService::Result.new }

--- a/spec/jobs/payments/manual_create_job_spec.rb
+++ b/spec/jobs/payments/manual_create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Payments::ManualCreateJob, type: :job do
+RSpec.describe Payments::ManualCreateJob do
   let(:organization) { invoice.customer.organization }
   let(:invoice) { create(:invoice) }
   let(:params) { {invoice_id: invoice.id, amount_cents: invoice.total_amount_cents, reference: "ref1"} }

--- a/spec/jobs/payments/set_payment_method_and_create_receipt_job_spec.rb
+++ b/spec/jobs/payments/set_payment_method_and_create_receipt_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Payments::SetPaymentMethodAndCreateReceiptJob, type: :job do
+RSpec.describe Payments::SetPaymentMethodAndCreateReceiptJob do
   let(:payment) { create(:payment) }
   let(:provider_payment_method_id) { "pm_001" }
 

--- a/spec/jobs/plans/destroy_job_spec.rb
+++ b/spec/jobs/plans/destroy_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Plans::DestroyJob, type: :job do
+RSpec.describe Plans::DestroyJob do
   include ActiveJob::TestHelper
 
   let(:plan) { create(:plan) }

--- a/spec/jobs/plans/update_amount_job_spec.rb
+++ b/spec/jobs/plans/update_amount_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Plans::UpdateAmountJob, type: :job do
+RSpec.describe Plans::UpdateAmountJob do
   let(:plan) { create(:plan) }
   let(:amount_cents) { 200 }
   let(:expected_amount_cents) { 100 }

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe SendWebhookJob, type: :job do
+RSpec.describe SendWebhookJob do
   subject(:send_webhook_job) { described_class }
 
   let(:organization) { create(:organization, webhook_url: "http://foo.bar") }

--- a/spec/jobs/subscriptions/flag_refreshed_job_spec.rb
+++ b/spec/jobs/subscriptions/flag_refreshed_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::FlagRefreshedJob, type: :job do
+RSpec.describe Subscriptions::FlagRefreshedJob do
   describe "#perform" do
     let(:subscription_id) { SecureRandom.uuid }
 

--- a/spec/jobs/subscriptions/organization_billing_job_spec.rb
+++ b/spec/jobs/subscriptions/organization_billing_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::OrganizationBillingJob, type: :job do
+RSpec.describe Subscriptions::OrganizationBillingJob do
   subject { described_class }
 
   describe ".perform" do

--- a/spec/jobs/subscriptions/terminate_job_spec.rb
+++ b/spec/jobs/subscriptions/terminate_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::TerminateJob, type: :job do
+RSpec.describe Subscriptions::TerminateJob do
   let(:subscription) { create(:subscription) }
   let(:timestamp) { Time.zone.now.to_i }
 

--- a/spec/jobs/taxes/update_all_eu_taxes_job_spec.rb
+++ b/spec/jobs/taxes/update_all_eu_taxes_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Taxes::UpdateAllEuTaxesJob, type: :job do
+RSpec.describe Taxes::UpdateAllEuTaxesJob do
   subject { described_class.perform_now }
 
   let(:organization) { create(:organization, eu_tax_management: true) }

--- a/spec/jobs/taxes/update_organization_eu_taxes_job_spec.rb
+++ b/spec/jobs/taxes/update_organization_eu_taxes_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Taxes::UpdateOrganizationEuTaxesJob, type: :job do
+RSpec.describe Taxes::UpdateOrganizationEuTaxesJob do
   let(:organization) { create(:organization) }
 
   describe ".perform" do

--- a/spec/jobs/usage_monitoring/process_organization_subscription_activities_job_spec.rb
+++ b/spec/jobs/usage_monitoring/process_organization_subscription_activities_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob, type: :job do
+RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesJob do
   let(:organization) { create(:organization) }
 
   before do

--- a/spec/jobs/usage_monitoring/process_subscription_activity_job_spec.rb
+++ b/spec/jobs/usage_monitoring/process_subscription_activity_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::ProcessSubscriptionActivityJob, type: :job do
+RSpec.describe UsageMonitoring::ProcessSubscriptionActivityJob do
   describe "#perform" do
     let(:subscription_activity) { create(:subscription_activity) }
     let(:subscription_activity_id) { subscription_activity.id }

--- a/spec/jobs/wallet_transactions/create_job_spec.rb
+++ b/spec/jobs/wallet_transactions/create_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WalletTransactions::CreateJob, type: :job do
+RSpec.describe WalletTransactions::CreateJob do
   subject(:create_job) { described_class }
 
   let(:organization) { create(:organization) }

--- a/spec/jobs/wallets/refresh_ongoing_balance_job_spec.rb
+++ b/spec/jobs/wallets/refresh_ongoing_balance_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::RefreshOngoingBalanceJob, type: :job do
+RSpec.describe Wallets::RefreshOngoingBalanceJob do
   let(:wallet) { create(:wallet, ready_to_be_refreshed: true) }
   let(:result) { BaseService::Result.new }
 


### PR DESCRIPTION
## Context

All model tests have the `type: :job` RSpec metadata but this metadata is already infered due to the `config.infer_spec_type_from_file_location!` setting (see the doc [here](https://rspec.info/features/8-0/rspec-rails/directory-structure/)).

## Description

This removes the redundant metadata.