### PR TITLE
fix(progressive_billing): Avoid parallel processing

### DIFF
--- a/app/jobs/lifetime_usages/recalculate_and_check_job.rb
+++ b/app/jobs/lifetime_usages/recalculate_and_check_job.rb
@@ -12,9 +12,17 @@ module LifetimeUsages
 
     unique :until_executed, on_conflict: :log, lock_ttl: 12.hours
 
-    def perform(lifetime_usage)
-      LifetimeUsages::CalculateService.call!(lifetime_usage:)
-      LifetimeUsages::CheckThresholdsService.call(lifetime_usage:)
+    # NOTE: do not pass current usage with perform_later as it will be a huge JSON
+    def perform(lifetime_usage, current_usage: nil)
+      LifetimeUsages::CalculateService.call!(lifetime_usage:, current_usage:)
+
+      if lifetime_usage.organization.progressive_billing_enabled?
+        LifetimeUsages::CheckThresholdsService.call!(lifetime_usage:)
+      end
+    end
+
+    def lock_key_arguments
+      [arguments.first]
     end
   end
 end

--- a/app/services/lifetime_usages/check_thresholds_service.rb
+++ b/app/services/lifetime_usages/check_thresholds_service.rb
@@ -25,6 +25,7 @@ module LifetimeUsages
           SendWebhookJob.perform_later("subscription.usage_threshold_reached", subscription, usage_threshold:)
         end
       end
+
       result
     end
 

--- a/app/services/usage_monitoring/process_subscription_activity_service.rb
+++ b/app/services/usage_monitoring/process_subscription_activity_service.rb
@@ -21,12 +21,9 @@ module UsageMonitoring
       #       We believe it's a good tradeoff because they should rarely raise but this can change in the future
 
       begin
+        # Note we rely on the jobs rather than on the services to take advantage of the job's uniqueness strategy
         if organization.using_lifetime_usage?
-          LifetimeUsages::CalculateService.call!(lifetime_usage:, current_usage:)
-        end
-
-        if organization.progressive_billing_enabled?
-          LifetimeUsages::CheckThresholdsService.call(lifetime_usage:)
+          LifetimeUsages::RecalculateAndCheckJob.perform_now(lifetime_usage, current_usage:)
         end
       rescue => e
         exception_to_raise = e

--- a/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
+++ b/spec/jobs/lifetime_usages/recalculate_and_check_job_spec.rb
@@ -3,13 +3,38 @@
 require "rails_helper"
 
 RSpec.describe LifetimeUsages::RecalculateAndCheckJob do
-  let(:lifetime_usage) { create(:lifetime_usage) }
+  let(:organization) { create(:organization, :premium, premium_integrations:) }
+  let(:lifetime_usage) { create(:lifetime_usage, organization:) }
 
-  it "delegates to the RecalculateAndCheck service" do
+  let(:premium_integrations) { ["progressive_billing"] }
+
+  it "delegates to the Calculate service" do
     allow(LifetimeUsages::CalculateService).to receive(:call!)
-    allow(LifetimeUsages::CheckThresholdsService).to receive(:call)
+    allow(LifetimeUsages::CheckThresholdsService).to receive(:call!)
     described_class.perform_now(lifetime_usage)
-    expect(LifetimeUsages::CalculateService).to have_received(:call!).with(lifetime_usage:)
-    expect(LifetimeUsages::CheckThresholdsService).to have_received(:call).with(lifetime_usage:)
+    expect(LifetimeUsages::CalculateService).to have_received(:call!).with(lifetime_usage:, current_usage: nil)
+    expect(LifetimeUsages::CheckThresholdsService).not_to have_received(:call!)
+  end
+
+  context "when premium", :premium do
+    it "delegates to the RecalculateAndCheck service" do
+      allow(LifetimeUsages::CalculateService).to receive(:call!)
+      allow(LifetimeUsages::CheckThresholdsService).to receive(:call!)
+      described_class.perform_now(lifetime_usage)
+      expect(LifetimeUsages::CalculateService).to have_received(:call!).with(lifetime_usage:, current_usage: nil)
+      expect(LifetimeUsages::CheckThresholdsService).to have_received(:call!).with(lifetime_usage:)
+    end
+
+    context "when progressive billing is disabled" do
+      let(:premium_integrations) { [] }
+
+      it "delegates to the RecalculateAndCheck service" do
+        allow(LifetimeUsages::CalculateService).to receive(:call!)
+        allow(LifetimeUsages::CheckThresholdsService).to receive(:call!)
+        described_class.perform_now(lifetime_usage)
+        expect(LifetimeUsages::CalculateService).to have_received(:call!).with(lifetime_usage:, current_usage: nil)
+        expect(LifetimeUsages::CheckThresholdsService).not_to have_received(:call!)
+      end
+    end
   end
 end

--- a/spec/services/usage_monitoring/process_subscription_activity_service_spec.rb
+++ b/spec/services/usage_monitoring/process_subscription_activity_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe UsageMonitoring::ProcessSubscriptionActivityService, type: :servi
     allow(::Invoices::CustomerUsageService).to receive(:call)
       .and_return(double(usage: mocked_current_usage)) # rubocop:disable RSpec/VerifiedDoubles
     allow(LifetimeUsages::CalculateService).to receive(:call!)
-    allow(LifetimeUsages::CheckThresholdsService).to receive(:call)
+    allow(LifetimeUsages::CheckThresholdsService).to receive(:call!)
   end
 
   around { |test| lago_premium!(&test) }
@@ -30,7 +30,7 @@ RSpec.describe UsageMonitoring::ProcessSubscriptionActivityService, type: :servi
         lifetime_usage: subscription.lifetime_usage || an_instance_of(LifetimeUsage),
         current_usage: mocked_current_usage
       )
-      expect(LifetimeUsages::CheckThresholdsService).to have_received(:call).with(
+      expect(LifetimeUsages::CheckThresholdsService).to have_received(:call!).with(
         lifetime_usage: subscription.lifetime_usage || an_instance_of(LifetimeUsage)
       )
 
@@ -46,7 +46,7 @@ RSpec.describe UsageMonitoring::ProcessSubscriptionActivityService, type: :servi
       result = service.call
 
       expect(LifetimeUsages::CalculateService).not_to have_received(:call!)
-      expect(LifetimeUsages::CheckThresholdsService).not_to have_received(:call)
+      expect(LifetimeUsages::CheckThresholdsService).not_to have_received(:call!)
 
       expect(result).to be_success
       expect { subscription_activity.reload }.to raise_error(ActiveRecord::RecordNotFound) # deleted
@@ -68,7 +68,7 @@ RSpec.describe UsageMonitoring::ProcessSubscriptionActivityService, type: :servi
         lifetime_usage: subscription.lifetime_usage || an_instance_of(LifetimeUsage),
         current_usage: mocked_current_usage
       )
-      expect(LifetimeUsages::CheckThresholdsService).not_to have_received(:call)
+      expect(LifetimeUsages::CheckThresholdsService).not_to have_received(:call!)
 
       expect(result).to be_success
       expect { subscription_activity.reload }.to raise_error(ActiveRecord::RecordNotFound)
@@ -85,7 +85,7 @@ RSpec.describe UsageMonitoring::ProcessSubscriptionActivityService, type: :servi
         lifetime_usage: subscription.lifetime_usage || an_instance_of(LifetimeUsage),
         current_usage: mocked_current_usage
       )
-      expect(LifetimeUsages::CheckThresholdsService).to have_received(:call).with(
+      expect(LifetimeUsages::CheckThresholdsService).to have_received(:call!).with(
         lifetime_usage: subscription.lifetime_usage || an_instance_of(LifetimeUsage)
       )
 
@@ -141,7 +141,7 @@ RSpec.describe UsageMonitoring::ProcessSubscriptionActivityService, type: :servi
       let(:premium_integrations) { %w[lifetime_usage progressive_billing] }
 
       it "processes alert and then raise" do
-        allow(LifetimeUsages::CheckThresholdsService).to receive(:call).and_raise(StandardError, "boom")
+        allow(LifetimeUsages::CheckThresholdsService).to receive(:call!).and_raise(StandardError, "boom")
         expect { service.call }.to raise_error(StandardError, "boom")
         expect(::UsageMonitoring::ProcessAlertService).to have_received(:call).with(alert:, subscription:, current_metrics: mocked_current_usage)
         expect { subscription_activity.reload }.to raise_error(ActiveRecord::RecordNotFound)


### PR DESCRIPTION
## Context

Sometimes `UsageMonitoring::ProcessSubscriptionActivityService` and `LifetimeUsages::RecalculateAndCheckJob` are performed at the same time.

This leads to a lot of `Idempotency::IdempotencyError` as a logic to avoid duplicating invoices is in place to prevent the same usage threshold from being billed twice.
In some rare situtation (when we are out of luck) it could lead to a double invoicing of the same thresold, with the amount of the first invoice immediately re-credited on the second one. This situation is related to a race condition appearing when the `LifetimeUsages::CalculateService` start to process just before the commit of the Idempotent transaction.

It appears that the `Idempotent.transaction` is not enough to mitigate this situation as it does not cover the full computation leading to a Progressive Billing invoice.

## Description

This PR re-use the existing `LifetimeUsages::RecalculateAndCheckJob` in the `UsageMonitoring::ProcessSubscriptionActivityService` in order to take advantage of the `active_job_uniqueness`  making sure that we cannot process multiple check for the same lifetime usage record in parallel.

The job is enqueued using `perform_now` because it takes the current_usage as an input parameter and we don't want to add new load with serialization/deserialization of huge JSON objects to this pipeline.
