### PR TITLE
fix(netsuite): Add trandate param to invoice payload

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -41,22 +41,14 @@ module Integrations
             result = {
               "tranid" => invoice.number,
               "custbody_ava_disable_tax_calculation" => true,
-              "custbody_lago_invoice_link" => invoice_url
+              "custbody_lago_invoice_link" => invoice_url,
+              "trandate" => issuing_date,
+              "duedate" => due_date,
+              "taxdetailsoverride" => true,
+              "custbody_lago_id" => invoice.id,
+              "entity" => integration_customer.external_customer_id,
+              "lago_plan_codes" => invoice.invoice_subscriptions.map(&:subscription).map(&:plan).map(&:code).join(",")
             }
-
-            unless tax_item_complete?
-              result["trandate"] = issuing_date
-            end
-
-            result = result.merge(
-              {
-                "duedate" => due_date,
-                "taxdetailsoverride" => true,
-                "custbody_lago_id" => invoice.id,
-                "entity" => integration_customer.external_customer_id,
-                "lago_plan_codes" => invoice.invoice_subscriptions.map(&:subscription).map(&:plan).map(&:code).join(",")
-              }
-            )
 
             if tax_item&.tax_nexus.present?
               result["nexus"] = tax_item.tax_nexus

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -255,6 +255,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
         "tranid",
         "custbody_ava_disable_tax_calculation",
         "custbody_lago_invoice_link",
+        "trandate",
         "duedate",
         "taxdetailsoverride",
         "custbody_lago_id",
@@ -268,12 +269,8 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
       column_keys_with_taxes.insert(7, "nexus")
     end
 
-    let(:column_keys_without_taxes) do
-      column_keys_with_taxes.insert(3, "trandate")
-    end
-
     let(:column_keys_without_taxes_with_nexus) do
-      column_keys_without_taxes.insert(8, "nexus")
+      column_keys_with_taxes.insert(8, "nexus")
     end
 
     before do
@@ -318,7 +315,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
         end
 
         it "has the columns keys in order" do
-          expect(subject["columns"].keys).to match_array(column_keys_without_taxes)
+          expect(subject["columns"].keys).to match_array(column_keys_with_taxes)
         end
       end
 
@@ -408,6 +405,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
               "custbody_lago_id" => invoice.id,
               "custbody_ava_disable_tax_calculation" => true,
               "custbody_lago_invoice_link" => invoice_link,
+              "trandate" => issuing_date,
               "duedate" => due_date,
               "nexus" => "some_nexus",
               "lago_plan_codes" => invoice.invoice_subscriptions.map(&:subscription).map(&:plan).map(&:code).join(",")
@@ -474,7 +472,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
       end
 
       it "has the columns keys in order" do
-        expect(subject["columns"].keys).to match_array(column_keys_without_taxes)
+        expect(subject["columns"].keys).to match_array(column_keys_with_taxes)
       end
     end
   end


### PR DESCRIPTION
## Context

Netsuite invoice param `trandate` was only added unless tax nexus was configured.

## Description

This PR fixes the Netsuite invoice payload - `trandate` is now present in all cases.