### PR TITLE
test(service): Remove unused `type: :service` spec metadata

### DIFF
--- a/spec/queries/entitlement/features_query_spec.rb
+++ b/spec/queries/entitlement/features_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::FeaturesQuery, type: :service do
+RSpec.describe Entitlement::FeaturesQuery do
   let(:organization) { create(:organization) }
   let!(:feature1) { create(:feature, organization:, code: "seats", name: "Number of seats") }
   let!(:feature2) { create(:feature, organization:, code: "storage", name: "Storage") }

--- a/spec/queries/entitlement/subscription_entitlement_query_spec.rb
+++ b/spec/queries/entitlement/subscription_entitlement_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::SubscriptionEntitlementQuery, type: :service do
+RSpec.describe Entitlement::SubscriptionEntitlementQuery do
   subject do
     described_class.call(
       organization:,

--- a/spec/services/add_ons/apply_taxes_service_spec.rb
+++ b/spec/services/add_ons/apply_taxes_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AddOns::ApplyTaxesService, type: :service do
+RSpec.describe AddOns::ApplyTaxesService do
   subject(:apply_service) { described_class.new(add_on:, tax_codes:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/add_ons/create_service_spec.rb
+++ b/spec/services/add_ons/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AddOns::CreateService, type: :service do
+RSpec.describe AddOns::CreateService do
   subject(:create_service) { described_class.new(create_args) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/add_ons/destroy_service_spec.rb
+++ b/spec/services/add_ons/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AddOns::DestroyService, type: :service do
+RSpec.describe AddOns::DestroyService do
   subject(:destroy_service) { described_class.new(add_on:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/add_ons/update_service_spec.rb
+++ b/spec/services/add_ons/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AddOns::UpdateService, type: :service do
+RSpec.describe AddOns::UpdateService do
   subject(:add_ons_service) { described_class.new(add_on:, params: update_args) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/adjusted_fees/create_service_spec.rb
+++ b/spec/services/adjusted_fees/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AdjustedFees::CreateService, type: :service do
+RSpec.describe AdjustedFees::CreateService do
   subject(:create_service) { described_class.new(invoice:, params:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/adjusted_fees/destroy_service_spec.rb
+++ b/spec/services/adjusted_fees/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AdjustedFees::DestroyService, type: :service do
+RSpec.describe AdjustedFees::DestroyService do
   subject(:destroy_service) { described_class.new(fee:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/adjusted_fees/estimate_service_spec.rb
+++ b/spec/services/adjusted_fees/estimate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AdjustedFees::EstimateService, type: :service do
+RSpec.describe AdjustedFees::EstimateService do
   subject(:estimate_service) { described_class.new(invoice:, params:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/ai_conversations/stream_service_spec.rb
+++ b/spec/services/ai_conversations/stream_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AiConversations::StreamService, type: :service do
+RSpec.describe AiConversations::StreamService do
   subject(:service) { described_class.new(ai_conversation:, message:) }
 
   let(:ai_conversation) { create(:ai_conversation, mistral_conversation_id: nil) }

--- a/spec/services/analytics/gross_revenues_service_spec.rb
+++ b/spec/services/analytics/gross_revenues_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Analytics::GrossRevenuesService, type: :service do
+RSpec.describe Analytics::GrossRevenuesService do
   let(:service) { described_class.new(organization) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/analytics/invoice_collections_service_spec.rb
+++ b/spec/services/analytics/invoice_collections_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Analytics::InvoiceCollectionsService, type: :service do
+RSpec.describe Analytics::InvoiceCollectionsService do
   let(:service) { described_class.new(organization) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/analytics/invoiced_usages_service_spec.rb
+++ b/spec/services/analytics/invoiced_usages_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Analytics::InvoicedUsagesService, type: :service do
+RSpec.describe Analytics::InvoicedUsagesService do
   let(:service) { described_class.new(organization) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/analytics/mrrs_service_spec.rb
+++ b/spec/services/analytics/mrrs_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Analytics::MrrsService, type: :service do
+RSpec.describe Analytics::MrrsService do
   let(:service) { described_class.new(organization) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/analytics/overdue_balances_service_spec.rb
+++ b/spec/services/analytics/overdue_balances_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Analytics::OverdueBalancesService, type: :service do
+RSpec.describe Analytics::OverdueBalancesService do
   let(:service) { described_class.new(organization) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/api_keys/cache_service_spec.rb
+++ b/spec/services/api_keys/cache_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ApiKeys::CacheService, type: :service, cache: :redis do
+RSpec.describe ApiKeys::CacheService, cache: :redis do
   subject(:cache_service) { described_class.new(auth_token, with_cache:) }
 
   let(:auth_token) { "token" }

--- a/spec/services/api_keys/create_service_spec.rb
+++ b/spec/services/api_keys/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ApiKeys::CreateService, type: :service do
+RSpec.describe ApiKeys::CreateService do
   describe "#call" do
     subject(:service_result) { described_class.call(params) }
 

--- a/spec/services/api_keys/destroy_service_spec.rb
+++ b/spec/services/api_keys/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ApiKeys::DestroyService, type: :service do
+RSpec.describe ApiKeys::DestroyService do
   describe "#call" do
     subject(:service_result) { described_class.call(api_key) }
 

--- a/spec/services/api_keys/rotate_service_spec.rb
+++ b/spec/services/api_keys/rotate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ApiKeys::RotateService, type: :service do
+RSpec.describe ApiKeys::RotateService do
   describe "#call" do
     subject(:service_result) { described_class.call(api_key:, params:) }
 

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedCoupons::CreateService, type: :service do
+RSpec.describe AppliedCoupons::CreateService do
   subject(:create_service) do
     described_class.new(customer:, coupon:, params:)
   end

--- a/spec/services/applied_coupons/lock_service_spec.rb
+++ b/spec/services/applied_coupons/lock_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedCoupons::LockService, type: :service do
+RSpec.describe AppliedCoupons::LockService do
   subject(:lock_service) { described_class.new(customer:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/applied_coupons/recredit_service_spec.rb
+++ b/spec/services/applied_coupons/recredit_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedCoupons::RecreditService, type: :service do
+RSpec.describe AppliedCoupons::RecreditService do
   subject(:recredit_service) { described_class.new(credit:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/applied_coupons/terminate_service_spec.rb
+++ b/spec/services/applied_coupons/terminate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedCoupons::TerminateService, type: :service do
+RSpec.describe AppliedCoupons::TerminateService do
   subject(:terminate_service) { described_class.new(applied_coupon:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/applied_pricing_units/create_service_spec.rb
+++ b/spec/services/applied_pricing_units/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedPricingUnits::CreateService, type: :service do
+RSpec.describe AppliedPricingUnits::CreateService do
   let(:create_service) { described_class.new(charge:, params:) }
 
   describe "#create_applied_pricing_unit?" do

--- a/spec/services/applied_pricing_units/update_service_spec.rb
+++ b/spec/services/applied_pricing_units/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedPricingUnits::UpdateService, type: :service do
+RSpec.describe AppliedPricingUnits::UpdateService do
   let(:update_service) { described_class.new(charge:, cascade_options:, params:) }
 
   describe ".call" do

--- a/spec/services/base_service_spec.rb
+++ b/spec/services/base_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ::BaseService, type: :service do
+RSpec.describe ::BaseService do
   subject(:service) { described_class.new }
 
   it { is_expected.to be_kind_of(AfterCommitEverywhere) }

--- a/spec/services/billable_metric_filters/destroy_all_service_spec.rb
+++ b/spec/services/billable_metric_filters/destroy_all_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe BillableMetricFilters::DestroyAllService, type: :service do
+RSpec.describe BillableMetricFilters::DestroyAllService do
   subject(:destroy_service) { described_class.new(billable_metric) }
 
   let(:billable_metric) { create(:billable_metric, :deleted) }

--- a/spec/services/billable_metrics/aggregation_factory_spec.rb
+++ b/spec/services/billable_metrics/aggregation_factory_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::AggregationFactory, type: :service do
+RSpec.describe BillableMetrics::AggregationFactory do
   subject(:factory) { described_class }
 
   let(:billable_metric) { create(billable_aggregation, recurring:) }

--- a/spec/services/billable_metrics/aggregations/apply_rounding_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/apply_rounding_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::Aggregations::ApplyRoundingService, type: :service do
+RSpec.describe BillableMetrics::Aggregations::ApplyRoundingService do
   subject(:rounding_service) { described_class.new(billable_metric:, units:) }
 
   let(:rounding_function) { "round" }

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
+RSpec.describe BillableMetrics::Aggregations::CountService do
   subject(:count_service) do
     described_class.new(
       event_store_class:,

--- a/spec/services/billable_metrics/aggregations/custom_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/custom_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::Aggregations::CustomService, type: :service do
+RSpec.describe BillableMetrics::Aggregations::CustomService do
   subject(:custom_service) do
     described_class.new(
       event_store_class:,

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
+RSpec.describe BillableMetrics::Aggregations::LatestService do
   subject(:latest_service) do
     described_class.new(
       event_store_class:,

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
+RSpec.describe BillableMetrics::Aggregations::MaxService do
   subject(:max_service) do
     described_class.new(
       event_store_class:,

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transaction: false do
+RSpec.describe BillableMetrics::Aggregations::SumService, transaction: false do
   subject(:sum_service) do
     described_class.new(
       event_store_class:,

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service, transaction: false do
+RSpec.describe BillableMetrics::Aggregations::UniqueCountService, transaction: false do
   subject(:count_service) do
     described_class.new(
       event_store_class:,

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service, transaction: false do
+RSpec.describe BillableMetrics::Aggregations::WeightedSumService, transaction: false do
   subject(:aggregator) do
     described_class.new(
       event_store_class:,

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transaction: false do
+RSpec.describe BillableMetrics::Breakdown::SumService, transaction: false do
   subject(:service) do
     described_class.new(
       event_store_class:,

--- a/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service, transaction: false do
+RSpec.describe BillableMetrics::Breakdown::UniqueCountService, transaction: false do
   subject(:service) do
     described_class.new(
       event_store_class:,

--- a/spec/services/billable_metrics/create_service_spec.rb
+++ b/spec/services/billable_metrics/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::CreateService, type: :service do
+RSpec.describe BillableMetrics::CreateService do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::DestroyService, type: :service do
+RSpec.describe BillableMetrics::DestroyService do
   subject(:destroy_service) { described_class.new(metric: billable_metric) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/billable_metrics/evaluate_expression_service_spec.rb
+++ b/spec/services/billable_metrics/evaluate_expression_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::EvaluateExpressionService, type: :service do
+RSpec.describe BillableMetrics::EvaluateExpressionService do
   subject(:evaluate_service) { described_class.new(expression:, event:) }
 
   let(:expression) { "round(event.properties.value * event.properties.units)" }

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service, transaction: false do
+RSpec.describe BillableMetrics::ProratedAggregations::SumService, transaction: false do
   subject(:sum_service) do
     described_class.new(
       event_store_class:,

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: :service, transaction: false do
+RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transaction: false do
   subject(:unique_count_service) do
     described_class.new(
       event_store_class:,

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetrics::UpdateService, type: :service do
+RSpec.describe BillableMetrics::UpdateService do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 

--- a/spec/services/billing_entities/change_eu_tax_management_service_spec.rb
+++ b/spec/services/billing_entities/change_eu_tax_management_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillingEntities::ChangeEuTaxManagementService, type: :service do
+RSpec.describe BillingEntities::ChangeEuTaxManagementService do
   subject(:service) { described_class.new(billing_entity:, eu_tax_management:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/billing_entities/change_invoice_numbering_service_spec.rb
+++ b/spec/services/billing_entities/change_invoice_numbering_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillingEntities::ChangeInvoiceNumberingService, type: :service do
+RSpec.describe BillingEntities::ChangeInvoiceNumberingService do
   subject(:result) { described_class.call(billing_entity:, document_numbering:) }
 
   let(:billing_entity) { create(:billing_entity, document_numbering: "per_customer") }

--- a/spec/services/billing_entities/create_service_spec.rb
+++ b/spec/services/billing_entities/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillingEntities::CreateService, type: :service do
+RSpec.describe BillingEntities::CreateService do
   subject(:result) { described_class.call(organization:, params:) }
 
   let(:organization) { create :organization }

--- a/spec/services/billing_entities/update_applied_dunning_campaign_service_spec.rb
+++ b/spec/services/billing_entities/update_applied_dunning_campaign_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillingEntities::UpdateAppliedDunningCampaignService, type: :service do
+RSpec.describe BillingEntities::UpdateAppliedDunningCampaignService do
   subject(:update_service) { described_class.new(billing_entity:, applied_dunning_campaign_id:) }
 
   let(:billing_entity) { create(:billing_entity) }

--- a/spec/services/billing_entities/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/billing_entities/update_invoice_grace_period_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillingEntities::UpdateInvoiceGracePeriodService, type: :service do
+RSpec.describe BillingEntities::UpdateInvoiceGracePeriodService do
   include ActiveJob::TestHelper
 
   subject(:update_service) { described_class.new(billing_entity:, grace_period:) }

--- a/spec/services/billing_entities/update_invoice_payment_due_date_service_spec.rb
+++ b/spec/services/billing_entities/update_invoice_payment_due_date_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillingEntities::UpdateInvoicePaymentDueDateService, type: :service do
+RSpec.describe BillingEntities::UpdateInvoicePaymentDueDateService do
   subject(:update_service) { described_class.new(billing_entity:, net_payment_term:) }
 
   let(:billing_entity) { create(:billing_entity) }

--- a/spec/services/charge_filters/event_matching_service_spec.rb
+++ b/spec/services/charge_filters/event_matching_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeFilters::EventMatchingService, type: :service do
+RSpec.describe ChargeFilters::EventMatchingService do
   subject(:service_result) { described_class.call(charge:, event:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/charge_models/amount_details/range_graduated_percentage_service_spec.rb
+++ b/spec/services/charge_models/amount_details/range_graduated_percentage_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::AmountDetails::RangeGraduatedPercentageService, type: :service do
+RSpec.describe ChargeModels::AmountDetails::RangeGraduatedPercentageService do
   subject(:service) { described_class.new(range:, total_units:) }
 
   let(:total_units) { 15 }

--- a/spec/services/charge_models/amount_details/range_graduated_service_spec.rb
+++ b/spec/services/charge_models/amount_details/range_graduated_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::AmountDetails::RangeGraduatedService, type: :service do
+RSpec.describe ChargeModels::AmountDetails::RangeGraduatedService do
   subject(:service) { described_class.new(range:, total_units:) }
 
   let(:total_units) { 15 }

--- a/spec/services/charge_models/build_default_properties_service_spec.rb
+++ b/spec/services/charge_models/build_default_properties_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::BuildDefaultPropertiesService, type: :service do
+RSpec.describe ChargeModels::BuildDefaultPropertiesService do
   subject(:service) { described_class.new(charge_model) }
 
   describe "call" do

--- a/spec/services/charge_models/custom_service_spec.rb
+++ b/spec/services/charge_models/custom_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-Rspec.describe ChargeModels::CustomService, type: :service do
+Rspec.describe ChargeModels::CustomService do
   subject(:apply_custom_service) do
     described_class.apply(
       charge:,

--- a/spec/services/charge_models/dynamic_service_spec.rb
+++ b/spec/services/charge_models/dynamic_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::DynamicService, type: :service do
+RSpec.describe ChargeModels::DynamicService do
   subject(:apply_dynamic_service) do
     described_class.apply(
       charge:,

--- a/spec/services/charge_models/filter_properties/charge_service_spec.rb
+++ b/spec/services/charge_models/filter_properties/charge_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::FilterProperties::ChargeService, type: :service do
+RSpec.describe ChargeModels::FilterProperties::ChargeService do
   subject(:filter_service) { described_class.new(chargeable:, properties:) }
 
   let(:charge_model) { nil }

--- a/spec/services/charge_models/filter_properties/fixed_charge_service_spec.rb
+++ b/spec/services/charge_models/filter_properties/fixed_charge_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::FilterProperties::FixedChargeService, type: :service do
+RSpec.describe ChargeModels::FilterProperties::FixedChargeService do
   subject(:filter_service) { described_class.new(chargeable:, properties:) }
 
   let(:charge_model) { nil }

--- a/spec/services/charge_models/filter_properties_service_spec.rb
+++ b/spec/services/charge_models/filter_properties_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::FilterPropertiesService, type: :service do
+RSpec.describe ChargeModels::FilterPropertiesService do
   subject(:filter_service) { described_class.new(chargeable:, properties:) }
 
   let(:properties) { {"amount" => 100} }

--- a/spec/services/charge_models/graduated_percentage_service_spec.rb
+++ b/spec/services/charge_models/graduated_percentage_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::GraduatedPercentageService, type: :service do
+RSpec.describe ChargeModels::GraduatedPercentageService do
   subject(:apply_graduated_percentage_service) do
     described_class.apply(
       charge:,

--- a/spec/services/charge_models/graduated_service_spec.rb
+++ b/spec/services/charge_models/graduated_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::GraduatedService, type: :service do
+RSpec.describe ChargeModels::GraduatedService do
   subject(:apply_graduated_service) do
     described_class.apply(
       charge:,

--- a/spec/services/charge_models/package_service_spec.rb
+++ b/spec/services/charge_models/package_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::PackageService, type: :service do
+RSpec.describe ChargeModels::PackageService do
   subject(:apply_package_service) do
     described_class.apply(
       charge:,

--- a/spec/services/charge_models/percentage_service_spec.rb
+++ b/spec/services/charge_models/percentage_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::PercentageService, type: :service do
+RSpec.describe ChargeModels::PercentageService do
   subject(:apply_percentage_service) do
     described_class.apply(
       charge:,

--- a/spec/services/charge_models/prorated_graduated_service_spec.rb
+++ b/spec/services/charge_models/prorated_graduated_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::ProratedGraduatedService, type: :service do
+RSpec.describe ChargeModels::ProratedGraduatedService do
   subject(:apply_graduated_service) do
     described_class.apply(
       charge:,

--- a/spec/services/charge_models/standard_service_spec.rb
+++ b/spec/services/charge_models/standard_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::StandardService, type: :service do
+RSpec.describe ChargeModels::StandardService do
   subject(:apply_standard_service) do
     described_class.apply(
       charge:,

--- a/spec/services/charge_models/volume_service_spec.rb
+++ b/spec/services/charge_models/volume_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ChargeModels::VolumeService, type: :service do
+RSpec.describe ChargeModels::VolumeService do
   subject(:apply_volume_service) do
     described_class.apply(
       charge:,

--- a/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::ApplyPayInAdvanceChargeModelService, type: :service do
+RSpec.describe Charges::ApplyPayInAdvanceChargeModelService do
   let(:charge_service) { described_class.new(charge:, aggregation_result:, properties:) }
 
   let(:charge) { create(:standard_charge, :pay_in_advance) }

--- a/spec/services/charges/apply_taxes_service_spec.rb
+++ b/spec/services/charges/apply_taxes_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::ApplyTaxesService, type: :service do
+RSpec.describe Charges::ApplyTaxesService do
   subject(:apply_service) { described_class.new(charge:, tax_codes:) }
 
   let(:plan) { create(:plan) }

--- a/spec/services/charges/charge_model_factory_spec.rb
+++ b/spec/services/charges/charge_model_factory_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::ChargeModelFactory, type: :service do
+RSpec.describe Charges::ChargeModelFactory do
   subject(:factory) { described_class }
 
   let(:charge) { build(:standard_charge) }

--- a/spec/services/charges/create_children_service_spec.rb
+++ b/spec/services/charges/create_children_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::CreateChildrenService, type: :service do
+RSpec.describe Charges::CreateChildrenService do
   subject(:create_service) { described_class.new(child_ids:, charge:, payload:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/charges/create_service_spec.rb
+++ b/spec/services/charges/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::CreateService, type: :service do
+RSpec.describe Charges::CreateService do
   let(:create_service) { described_class.new(plan:, params:) }
 
   let(:plan) { create(:plan) }

--- a/spec/services/charges/destroy_children_service_spec.rb
+++ b/spec/services/charges/destroy_children_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::DestroyChildrenService, type: :service do
+RSpec.describe Charges::DestroyChildrenService do
   subject(:destroy_service) { described_class.new(charge) }
 
   let(:billable_metric) { create(:billable_metric) }

--- a/spec/services/charges/destroy_service_spec.rb
+++ b/spec/services/charges/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::DestroyService, type: :service do
+RSpec.describe Charges::DestroyService do
   subject(:destroy_service) { described_class.new(charge:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/charges/estimate_instant/percentage_service_spec.rb
+++ b/spec/services/charges/estimate_instant/percentage_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::EstimateInstant::PercentageService, type: :service do
+RSpec.describe Charges::EstimateInstant::PercentageService do
   subject { described_class.new(properties:, units:) }
 
   let(:properties) do

--- a/spec/services/charges/estimate_instant/standard_service_spec.rb
+++ b/spec/services/charges/estimate_instant/standard_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::EstimateInstant::StandardService, type: :service do
+RSpec.describe Charges::EstimateInstant::StandardService do
   subject { described_class.new(properties:, units:) }
 
   let(:properties) do

--- a/spec/services/charges/override_service_spec.rb
+++ b/spec/services/charges/override_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::OverrideService, type: :service do
+RSpec.describe Charges::OverrideService do
   subject(:override_service) { described_class.new(charge:, params:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/charges/pay_in_advance/amount_details_calculator_spec.rb
+++ b/spec/services/charges/pay_in_advance/amount_details_calculator_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::PayInAdvance::AmountDetailsCalculator, type: :service do
+RSpec.describe Charges::PayInAdvance::AmountDetailsCalculator do
   let(:amount_details_calculator) { described_class.new(charge:, applied_charge_model:, applied_charge_model_excluding_event:) }
 
   let(:charge) { create(:standard_charge, :pay_in_advance) }

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
+RSpec.describe Charges::PayInAdvanceAggregationService do
   subject(:agg_service) do
     described_class.new(charge:, boundaries:, properties:, event:, charge_filter:)
   end

--- a/spec/services/charges/update_children_service_spec.rb
+++ b/spec/services/charges/update_children_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::UpdateChildrenService, type: :service do
+RSpec.describe Charges::UpdateChildrenService do
   subject(:update_service) do
     described_class.new(
       charge:,

--- a/spec/services/charges/update_service_spec.rb
+++ b/spec/services/charges/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::UpdateService, type: :service do
+RSpec.describe Charges::UpdateService do
   let(:update_service) { described_class.new(charge:, params:, cascade_options:) }
 
   let(:plan) { create(:plan) }

--- a/spec/services/charges/validators/graduated_percentage_service_spec.rb
+++ b/spec/services/charges/validators/graduated_percentage_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service do
+RSpec.describe Charges::Validators::GraduatedPercentageService do
   subject(:validation_service) { described_class.new(charge:) }
 
   let(:charge) { build(:graduated_percentage_charge, properties:) }

--- a/spec/services/charges/validators/graduated_service_spec.rb
+++ b/spec/services/charges/validators/graduated_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::Validators::GraduatedService, type: :service do
+RSpec.describe Charges::Validators::GraduatedService do
   subject(:validation_service) { described_class.new(charge:) }
 
   let(:charge) { build(:graduated_charge, properties:) }

--- a/spec/services/charges/validators/package_service_spec.rb
+++ b/spec/services/charges/validators/package_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::Validators::PackageService, type: :service do
+RSpec.describe Charges::Validators::PackageService do
   subject(:validation_service) { described_class.new(charge:) }
 
   let(:charge) { build(:package_charge, properties: package_properties) }

--- a/spec/services/charges/validators/percentage_service_spec.rb
+++ b/spec/services/charges/validators/percentage_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::Validators::PercentageService, type: :service do
+RSpec.describe Charges::Validators::PercentageService do
   subject(:validation_service) { described_class.new(charge:) }
 
   let(:charge) { build(:percentage_charge, properties: percentage_properties) }

--- a/spec/services/charges/validators/standard_service_spec.rb
+++ b/spec/services/charges/validators/standard_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::Validators::StandardService, type: :service do
+RSpec.describe Charges::Validators::StandardService do
   subject(:validation_service) { described_class.new(charge:) }
 
   let(:charge) { build(:standard_charge, properties:) }

--- a/spec/services/charges/validators/volume_service_spec.rb
+++ b/spec/services/charges/validators/volume_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::Validators::VolumeService, type: :service do
+RSpec.describe Charges::Validators::VolumeService do
   subject(:validation_service) { described_class.new(charge:) }
 
   let(:charge) { build(:volume_charge, properties:) }

--- a/spec/services/commitments/apply_taxes_service_spec.rb
+++ b/spec/services/commitments/apply_taxes_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Commitments::ApplyTaxesService, type: :service do
+RSpec.describe Commitments::ApplyTaxesService do
   subject(:apply_service) { described_class.new(commitment:, tax_codes:) }
 
   let(:commitment) { create(:commitment, plan:) }

--- a/spec/services/commitments/calculate_amount_service_spec.rb
+++ b/spec/services/commitments/calculate_amount_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Commitments::CalculateAmountService, type: :service do
+RSpec.describe Commitments::CalculateAmountService do
   subject(:apply_service) { described_class.new(commitment:, invoice_subscription:) }
 
   let(:invoice_subscription) do

--- a/spec/services/commitments/calculate_prorated_coefficient_service_spec.rb
+++ b/spec/services/commitments/calculate_prorated_coefficient_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Commitments::CalculateProratedCoefficientService, type: :service do
+RSpec.describe Commitments::CalculateProratedCoefficientService do
   let(:service) { described_class.new(commitment:, invoice_subscription:) }
   let(:commitment) { create(:commitment, plan:) }
   let(:plan) { create(:plan, organization:) }

--- a/spec/services/commitments/dates_service_spec.rb
+++ b/spec/services/commitments/dates_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Commitments::DatesService, type: :service do
+RSpec.describe Commitments::DatesService do
   let(:commitment) { create(:commitment) }
   let(:invoice_subscription) { create(:invoice_subscription, subscription:) }
   let(:subscription) { create(:subscription, customer:, plan:) }

--- a/spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb
+++ b/spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService, type: :service do
+RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
   subject(:service) { described_class.new_instance(invoice_subscription:) }
 
   let(:invoice_subscription) do
@@ -26,7 +26,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService, type: :service d
   let(:customer) { create(:customer, organization:) }
   let(:subscription_at) { DateTime.parse("2024-01-01T00:00:00") }
   let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:, pay_in_advance:, interval: :yearly) }
+  let(:plan) { create(:plan, organization:, pay_in_advance:, interval: [:semiannual, :yearly].sample) }
   let(:billing_time) { :calendar }
   let(:bill_charges_monthly) { false }
   let(:pay_in_advance) { false }

--- a/spec/services/commitments/override_service_spec.rb
+++ b/spec/services/commitments/override_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Commitments::OverrideService, type: :service do
+RSpec.describe Commitments::OverrideService do
   subject(:override_service) { described_class.new(commitment:, params:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Coupons::CreateService, type: :service do
+RSpec.describe Coupons::CreateService do
   subject(:create_service) { described_class.new(create_args) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/coupons/destroy_service_spec.rb
+++ b/spec/services/coupons/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Coupons::DestroyService, type: :service do
+RSpec.describe Coupons::DestroyService do
   subject(:destroy_service) { described_class.new(coupon:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/coupons/terminate_service_spec.rb
+++ b/spec/services/coupons/terminate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Coupons::TerminateService, type: :service do
+RSpec.describe Coupons::TerminateService do
   subject(:terminate_service) { described_class.new(coupon) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/coupons/update_service_spec.rb
+++ b/spec/services/coupons/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Coupons::UpdateService, type: :service do
+RSpec.describe Coupons::UpdateService do
   subject(:update_service) { described_class.new(coupon:, params:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/coupons/validate_service_spec.rb
+++ b/spec/services/coupons/validate_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-RSpec.describe Coupons::ValidateService, type: :service do
+RSpec.describe Coupons::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/services/credit_notes/apply_taxes_service_spec.rb
+++ b/spec/services/credit_notes/apply_taxes_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
+RSpec.describe CreditNotes::ApplyTaxesService do
   subject(:apply_service) { described_class.new(invoice:, items:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/credit_notes/create_from_progressive_billing_invoice_spec.rb
+++ b/spec/services/credit_notes/create_from_progressive_billing_invoice_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::CreateFromProgressiveBillingInvoice, type: :service do
+RSpec.describe CreditNotes::CreateFromProgressiveBillingInvoice do
   subject(:credit_service) { described_class.new(progressive_billing_invoice:, amount:, reason:) }
 
   let(:reason) { :other }

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::CreateFromTermination, type: :service do
+RSpec.describe CreditNotes::CreateFromTermination do
   subject(:create_service) { described_class.new(subscription:, context:, **kwargs) }
 
   let(:kwargs) { {} }

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::CreateService, type: :service do
+RSpec.describe CreditNotes::CreateService do
   subject(:create_service) do
     described_class.new(
       invoice:,

--- a/spec/services/credit_notes/estimate_service_spec.rb
+++ b/spec/services/credit_notes/estimate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::EstimateService, type: :service do
+RSpec.describe CreditNotes::EstimateService do
   subject(:estimate_service) { described_class.new(invoice: invoice&.reload, items:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/credit_notes/generate_service_spec.rb
+++ b/spec/services/credit_notes/generate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::GenerateService, type: :service do
+RSpec.describe CreditNotes::GenerateService do
   subject(:credit_note_generate_service) { described_class.new(credit_note:, context:) }
 
   let(:organization) { create(:organization, name: "LAGO") }

--- a/spec/services/credit_notes/provider_taxes/report_service_spec.rb
+++ b/spec/services/credit_notes/provider_taxes/report_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::ProviderTaxes::ReportService, type: :service do
+RSpec.describe CreditNotes::ProviderTaxes::ReportService do
   subject(:report_service) { described_class.new(credit_note:) }
 
   describe "#call" do

--- a/spec/services/credit_notes/recredit_service_spec.rb
+++ b/spec/services/credit_notes/recredit_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::RecreditService, type: :service do
+RSpec.describe CreditNotes::RecreditService do
   subject(:service) { described_class.new(credit:) }
 
   let(:credit_note) { credit.credit_note }

--- a/spec/services/credit_notes/refresh_draft_service_spec.rb
+++ b/spec/services/credit_notes/refresh_draft_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::RefreshDraftService, type: :service do
+RSpec.describe CreditNotes::RefreshDraftService do
   subject(:refresh_service) { described_class.new(credit_note:, fee:, old_fee_values:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/credit_notes/refunds/adyen_service_spec.rb
+++ b/spec/services/credit_notes/refunds/adyen_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
+RSpec.describe CreditNotes::Refunds::AdyenService do
   subject(:adyen_service) { described_class.new(credit_note) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/credit_notes/refunds/gocardless_service_spec.rb
+++ b/spec/services/credit_notes/refunds/gocardless_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::Refunds::GocardlessService, type: :service do
+RSpec.describe CreditNotes::Refunds::GocardlessService do
   subject(:gocardless_service) { described_class.new(credit_note) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
+RSpec.describe CreditNotes::Refunds::StripeService do
   subject(:stripe_service) { described_class.new(credit_note) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/credit_notes/update_service_spec.rb
+++ b/spec/services/credit_notes/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::UpdateService, type: :service do
+RSpec.describe CreditNotes::UpdateService do
   subject(:credit_note_service) { described_class.new(credit_note:, **params) }
 
   let(:credit_note) { create(:credit_note) }

--- a/spec/services/credit_notes/validate_item_service_spec.rb
+++ b/spec/services/credit_notes/validate_item_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::ValidateItemService, type: :service do
+RSpec.describe CreditNotes::ValidateItemService do
   subject(:validator) { described_class.new(result, item:) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/services/credit_notes/validate_service_spec.rb
+++ b/spec/services/credit_notes/validate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::ValidateService, type: :service do
+RSpec.describe CreditNotes::ValidateService do
   subject(:validator) { described_class.new(result, item: credit_note) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/services/credit_notes/void_service_spec.rb
+++ b/spec/services/credit_notes/void_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotes::VoidService, type: :service do
+RSpec.describe CreditNotes::VoidService do
   subject(:void_service) { described_class.new(credit_note:) }
 
   let(:credit_note) { create(:credit_note) }

--- a/spec/services/credits/progressive_billing_service_spec.rb
+++ b/spec/services/credits/progressive_billing_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-Rspec.describe Credits::ProgressiveBillingService, type: :service do
+Rspec.describe Credits::ProgressiveBillingService do
   subject(:credit_service) { described_class.new(invoice:) }
 
   let(:subscription) { create(:subscription, customer_id: customer.id) }

--- a/spec/services/customer_portal/customer_update_service_spec.rb
+++ b/spec/services/customer_portal/customer_update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CustomerPortal::CustomerUpdateService, type: :service do
+RSpec.describe CustomerPortal::CustomerUpdateService do
   subject(:result) { described_class.call(customer:, args: update_args) }
 
   let(:customer) { create :customer }

--- a/spec/services/customer_portal/generate_url_service_spec.rb
+++ b/spec/services/customer_portal/generate_url_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CustomerPortal::GenerateUrlService, type: :service do
+RSpec.describe CustomerPortal::GenerateUrlService do
   subject(:generate_url_service) { described_class.new(customer:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/customers/apply_taxes_service_spec.rb
+++ b/spec/services/customers/apply_taxes_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customers::ApplyTaxesService, type: :service do
+RSpec.describe Customers::ApplyTaxesService do
   subject(:apply_service) { described_class.new(customer:, tax_codes:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customers::CreateService, type: :service do
+RSpec.describe Customers::CreateService do
   subject(:result) { described_class.call(**create_args) }
 
   let(:billing_entity) { create(:billing_entity) }

--- a/spec/services/customers/destroy_service_spec.rb
+++ b/spec/services/customers/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customers::DestroyService, type: :service do
+RSpec.describe Customers::DestroyService do
   subject(:destroy_service) { described_class.new(customer:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/customers/eu_auto_taxes_service_spec.rb
+++ b/spec/services/customers/eu_auto_taxes_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customers::EuAutoTaxesService, type: :service do
+RSpec.describe Customers::EuAutoTaxesService do
   subject(:eu_tax_service) { described_class.new(customer:, new_record:, tax_attributes_changed:) }
 
   let(:organization) { create(:organization, country: "IT", eu_tax_management: true) }

--- a/spec/services/customers/generate_checkout_url_service_spec.rb
+++ b/spec/services/customers/generate_checkout_url_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customers::GenerateCheckoutUrlService, type: :service do
+RSpec.describe Customers::GenerateCheckoutUrlService do
   subject(:generate_checkout_url_service) { described_class.new(customer:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/customers/terminate_relations_service_spec.rb
+++ b/spec/services/customers/terminate_relations_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customers::TerminateRelationsService, type: :service do
+RSpec.describe Customers::TerminateRelationsService do
   subject(:terminate_service) { described_class.new(customer:) }
 
   let(:customer) { create(:customer, :deleted) }

--- a/spec/services/customers/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/customers/update_invoice_grace_period_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customers::UpdateInvoiceGracePeriodService, type: :service do
+RSpec.describe Customers::UpdateInvoiceGracePeriodService do
   subject(:update_service) { described_class.new(customer:, grace_period:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/customers/update_invoice_payment_due_date_service_spec.rb
+++ b/spec/services/customers/update_invoice_payment_due_date_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customers::UpdateInvoicePaymentDueDateService, type: :service do
+RSpec.describe Customers::UpdateInvoicePaymentDueDateService do
   subject(:update_service) { described_class.new(customer:, net_payment_term:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customers::UpdateService, type: :service do
+RSpec.describe Customers::UpdateService do
   subject(:customers_service) { described_class.new(customer:, args: update_args) }
 
   let(:billing_entity) { create(:billing_entity) }

--- a/spec/services/customers/upsert_from_api_service_spec.rb
+++ b/spec/services/customers/upsert_from_api_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Customers::UpsertFromApiService, type: :service do
+RSpec.describe Customers::UpsertFromApiService do
   subject(:result) { described_class.call(organization:, params: create_args) }
 
   let(:billing_entity) { create :billing_entity }

--- a/spec/services/daily_usages/compute_all_service_spec.rb
+++ b/spec/services/daily_usages/compute_all_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DailyUsages::ComputeAllService, type: :service do
+RSpec.describe DailyUsages::ComputeAllService do
   subject(:compute_service) { described_class.new(timestamp:) }
 
   let(:timestamp) { Time.zone.parse("2024-10-22 00:05:00") }

--- a/spec/services/daily_usages/compute_diff_service_spec.rb
+++ b/spec/services/daily_usages/compute_diff_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DailyUsages::ComputeDiffService, type: :service do
+RSpec.describe DailyUsages::ComputeDiffService do
   subject(:diff_service) { described_class.new(daily_usage:, previous_daily_usage:) }
 
   let(:daily_usage) { create(:daily_usage, usage:) }

--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DailyUsages::ComputeService, type: :service do
+RSpec.describe DailyUsages::ComputeService do
   subject(:compute_service) { described_class.new(subscription:, timestamp:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/daily_usages/fill_from_invoice_service_spec.rb
+++ b/spec/services/daily_usages/fill_from_invoice_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DailyUsages::FillFromInvoiceService, type: :service do
+RSpec.describe DailyUsages::FillFromInvoiceService do
   subject(:fill_service) { described_class.new(invoice:, subscriptions:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/data_api/mrrs/plans_service_spec.rb
+++ b/spec/services/data_api/mrrs/plans_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::Mrrs::PlansService, type: :service do
+RSpec.describe DataApi::Mrrs::PlansService do
   let(:service) { described_class.new(organization, **params) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/data_api/mrrs_service_spec.rb
+++ b/spec/services/data_api/mrrs_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::MrrsService, type: :service do
+RSpec.describe DataApi::MrrsService do
   let(:service) { described_class.new(organization, **params) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/data_api/prepaid_credits_service_spec.rb
+++ b/spec/services/data_api/prepaid_credits_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::PrepaidCreditsService, type: :service do
+RSpec.describe DataApi::PrepaidCreditsService do
   let(:service) { described_class.new(organization, **params) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/data_api/revenue_streams/customers_service_spec.rb
+++ b/spec/services/data_api/revenue_streams/customers_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::RevenueStreams::CustomersService, type: :service do
+RSpec.describe DataApi::RevenueStreams::CustomersService do
   let(:service) { described_class.new(organization, **params) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/data_api/revenue_streams/plans_service_spec.rb
+++ b/spec/services/data_api/revenue_streams/plans_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::RevenueStreams::PlansService, type: :service do
+RSpec.describe DataApi::RevenueStreams::PlansService do
   let(:service) { described_class.new(organization, **params) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/data_api/revenue_streams_service_spec.rb
+++ b/spec/services/data_api/revenue_streams_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::RevenueStreamsService, type: :service do
+RSpec.describe DataApi::RevenueStreamsService do
   let(:service) { described_class.new(organization, **params) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/data_api/usages/aggregated_amounts_service_spec.rb
+++ b/spec/services/data_api/usages/aggregated_amounts_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::Usages::AggregatedAmountsService, type: :service do
+RSpec.describe DataApi::Usages::AggregatedAmountsService do
   let(:service) { described_class.new(organization, **params) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/data_api/usages/invoiced_service_spec.rb
+++ b/spec/services/data_api/usages/invoiced_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::Usages::InvoicedService, type: :service do
+RSpec.describe DataApi::Usages::InvoicedService do
   let(:service) { described_class.new(organization, **params) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/data_api/usages_service_spec.rb
+++ b/spec/services/data_api/usages_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::UsagesService, type: :service do
+RSpec.describe DataApi::UsagesService do
   let(:service) { described_class.new(organization, **params) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/data_exports/combine_parts_service_spec.rb
+++ b/spec/services/data_exports/combine_parts_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataExports::CombinePartsService, type: :service do
+RSpec.describe DataExports::CombinePartsService do
   subject(:result) { described_class.call(data_export:) }
 
   let(:data_export) { create :data_export, :processing, resource_type: "invoice_fees" }

--- a/spec/services/data_exports/create_part_service_spec.rb
+++ b/spec/services/data_exports/create_part_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataExports::CreatePartService, type: :service do
+RSpec.describe DataExports::CreatePartService do
   subject(:result) { described_class.call(data_export:, object_ids:, index:) }
 
   let(:data_export) { create :data_export, resource_type: "invoices", format: "csv" }

--- a/spec/services/data_exports/create_service_spec.rb
+++ b/spec/services/data_exports/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataExports::CreateService, type: :service do
+RSpec.describe DataExports::CreateService do
   subject(:result) do
     described_class.call(organization:, user:, format:, resource_type:, resource_query:)
   end

--- a/spec/services/data_exports/export_resources_service_spec.rb
+++ b/spec/services/data_exports/export_resources_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataExports::ExportResourcesService, type: :service do
+RSpec.describe DataExports::ExportResourcesService do
   subject(:result) { described_class.call(data_export:, batch_size:) }
 
   let(:organization) { data_export.organization }

--- a/spec/services/data_exports/process_part_service_spec.rb
+++ b/spec/services/data_exports/process_part_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataExports::ProcessPartService, type: :service do
+RSpec.describe DataExports::ProcessPartService do
   subject(:result) { described_class.call(data_export_part:) }
 
   let(:data_export) { create :data_export, resource_type: "invoices", format: "csv" }

--- a/spec/services/dunning_campaigns/bulk_process_service_spec.rb
+++ b/spec/services/dunning_campaigns/bulk_process_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DunningCampaigns::BulkProcessService, type: :service, aggregate_failures: true do
+RSpec.describe DunningCampaigns::BulkProcessService, aggregate_failures: true do
   subject(:result) { described_class.call }
 
   let(:currency) { "EUR" }

--- a/spec/services/dunning_campaigns/create_service_spec.rb
+++ b/spec/services/dunning_campaigns/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DunningCampaigns::CreateService, type: :service do
+RSpec.describe DunningCampaigns::CreateService do
   subject(:create_service) { described_class.new(organization:, params:) }
 
   let(:organization) { create :organization }

--- a/spec/services/dunning_campaigns/destroy_service_spec.rb
+++ b/spec/services/dunning_campaigns/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DunningCampaigns::DestroyService, type: :service do
+RSpec.describe DunningCampaigns::DestroyService do
   subject(:destroy_service) { described_class.new(dunning_campaign:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/dunning_campaigns/process_attempt_service_spec.rb
+++ b/spec/services/dunning_campaigns/process_attempt_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DunningCampaigns::ProcessAttemptService, type: :service, aggregate_failures: true do
+RSpec.describe DunningCampaigns::ProcessAttemptService, aggregate_failures: true do
   subject(:result) { described_class.call(customer:, dunning_campaign_threshold:) }
 
   let(:customer) { create :customer, organization:, currency: }

--- a/spec/services/dunning_campaigns/update_service_spec.rb
+++ b/spec/services/dunning_campaigns/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DunningCampaigns::UpdateService, type: :service do
+RSpec.describe DunningCampaigns::UpdateService do
   subject(:update_service) { described_class.new(organization:, dunning_campaign:, params:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/feature_create_service_spec.rb
+++ b/spec/services/entitlement/feature_create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::FeatureCreateService, type: :service do
+RSpec.describe Entitlement::FeatureCreateService do
   subject { described_class.call(organization:, params:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/feature_destroy_service_spec.rb
+++ b/spec/services/entitlement/feature_destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::FeatureDestroyService, type: :service do
+RSpec.describe Entitlement::FeatureDestroyService do
   subject { described_class.call(feature:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/feature_update_service_spec.rb
+++ b/spec/services/entitlement/feature_update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::FeatureUpdateService, type: :service do
+RSpec.describe Entitlement::FeatureUpdateService do
   subject { described_class.call(feature:, params:, partial:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/plan_entitlement_destroy_service_spec.rb
+++ b/spec/services/entitlement/plan_entitlement_destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::PlanEntitlementDestroyService, type: :service do
+RSpec.describe Entitlement::PlanEntitlementDestroyService do
   subject(:result) { described_class.call(entitlement:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/plan_entitlement_privilege_destroy_service_spec.rb
+++ b/spec/services/entitlement/plan_entitlement_privilege_destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::PlanEntitlementPrivilegeDestroyService, type: :service do
+RSpec.describe Entitlement::PlanEntitlementPrivilegeDestroyService do
   subject(:result) { described_class.call(entitlement:, privilege_code:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-full_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::PlanEntitlementsUpdateService, type: :service do
+RSpec.describe Entitlement::PlanEntitlementsUpdateService do
   subject(:result) { described_class.call(organization:, plan:, entitlements_params:, partial: false) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/plan_entitlements_update_service-partial_spec.rb
+++ b/spec/services/entitlement/plan_entitlements_update_service-partial_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::PlanEntitlementsUpdateService, type: :service do
+RSpec.describe Entitlement::PlanEntitlementsUpdateService do
   subject(:result) { described_class.call(organization:, plan:, entitlements_params:, partial: true) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/privilege_destroy_service_spec.rb
+++ b/spec/services/entitlement/privilege_destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::PrivilegeDestroyService, type: :service do
+RSpec.describe Entitlement::PrivilegeDestroyService do
   subject { described_class.call(privilege:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/subscription_entitlement_core_update_service_spec.rb
+++ b/spec/services/entitlement/subscription_entitlement_core_update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::SubscriptionEntitlementCoreUpdateService, type: :service do
+RSpec.describe Entitlement::SubscriptionEntitlementCoreUpdateService do
   subject(:result) { described_class.call(subscription:, plan:, feature: seats, privilege_params:, partial:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/subscription_entitlement_update_service_spec.rb
+++ b/spec/services/entitlement/subscription_entitlement_update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::SubscriptionEntitlementUpdateService, type: :service do
+RSpec.describe Entitlement::SubscriptionEntitlementUpdateService do
   subject(:result) do
     described_class.call(
       subscription:,

--- a/spec/services/entitlement/subscription_entitlements_update_service-full_spec.rb
+++ b/spec/services/entitlement/subscription_entitlements_update_service-full_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::SubscriptionEntitlementsUpdateService, type: :service do
+RSpec.describe Entitlement::SubscriptionEntitlementsUpdateService do
   subject(:result) { described_class.call(subscription:, entitlements_params:, partial: false) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/subscription_entitlements_update_service-partial_spec.rb
+++ b/spec/services/entitlement/subscription_entitlements_update_service-partial_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::SubscriptionEntitlementsUpdateService, type: :service do
+RSpec.describe Entitlement::SubscriptionEntitlementsUpdateService do
   subject(:result) { described_class.call(subscription:, entitlements_params:, partial: true) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/subscription_feature_privilege_remove_service_spec.rb
+++ b/spec/services/entitlement/subscription_feature_privilege_remove_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::SubscriptionFeaturePrivilegeRemoveService, type: :service do
+RSpec.describe Entitlement::SubscriptionFeaturePrivilegeRemoveService do
   subject(:result) { described_class.call(subscription:, feature_code:, privilege_code:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/entitlement/subscription_feature_remove_service_spec.rb
+++ b/spec/services/entitlement/subscription_feature_remove_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Entitlement::SubscriptionFeatureRemoveService, type: :service do
+RSpec.describe Entitlement::SubscriptionFeatureRemoveService do
   subject(:result) { described_class.call(subscription:, feature_code:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/error_details/create_service_spec.rb
+++ b/spec/services/error_details/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ErrorDetails::CreateService, type: :service do
+RSpec.describe ErrorDetails::CreateService do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }

--- a/spec/services/events/calculate_expression_service_spec.rb
+++ b/spec/services/events/calculate_expression_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Events::CalculateExpressionService, type: :service do
+RSpec.describe Events::CalculateExpressionService do
   describe "#call" do
     subject(:service_call) { described_class.new(organization: organization, event: event).call }
 

--- a/spec/services/events/create_batch_service_spec.rb
+++ b/spec/services/events/create_batch_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Events::CreateBatchService, type: :service do
+RSpec.describe Events::CreateBatchService do
   subject(:create_batch_service) do
     described_class.new(
       organization:,

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Events::CreateService, type: :service do
+RSpec.describe Events::CreateService do
   subject(:create_service) do
     described_class.new(
       organization:,

--- a/spec/services/events/kafka_producer_service_spec.rb
+++ b/spec/services/events/kafka_producer_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Events::KafkaProducerService, type: :service do
+RSpec.describe Events::KafkaProducerService do
   subject(:producer_service) { described_class.new(event: event, organization: organization) }
 
   let(:event) { create(:event, organization:) }

--- a/spec/services/events/pay_in_advance_service_spec.rb
+++ b/spec/services/events/pay_in_advance_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Events::PayInAdvanceService, type: :service do
+RSpec.describe Events::PayInAdvanceService do
   let(:in_advance_service) { described_class.new(event:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/events/post_process_service_spec.rb
+++ b/spec/services/events/post_process_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Events::PostProcessService, type: :service do
+RSpec.describe Events::PostProcessService do
   subject(:process_service) { described_class.new(event:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/events/post_validation_service_spec.rb
+++ b/spec/services/events/post_validation_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Events::PostValidationService, type: :service, transaction: false do
+RSpec.describe Events::PostValidationService, transaction: false do
   subject(:validation_service) { described_class.new(organization:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
+++ b/spec/services/events/stores/aggregated_clickhouse_store_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Events::Stores::AggregatedClickhouseStore, type: :service, clickhouse: true do
+RSpec.describe Events::Stores::AggregatedClickhouseStore, clickhouse: true do
   group_values = {
     cloud: %w[aws azure gcp],
     region: %w[eu me us]

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true do
+RSpec.describe Events::Stores::ClickhouseStore, clickhouse: true do
   subject(:event_store) do
     described_class.new(
       code:,

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Events::Stores::PostgresStore, type: :service do
+RSpec.describe Events::Stores::PostgresStore do
   subject(:event_store) do
     described_class.new(
       code:,

--- a/spec/services/events/validate_creation_service_spec.rb
+++ b/spec/services/events/validate_creation_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Events::ValidateCreationService, type: :service do
+RSpec.describe Events::ValidateCreationService do
   subject(:validate_event) do
     described_class.call(
       organization:,

--- a/spec/services/fees/apply_provider_taxes_service_spec.rb
+++ b/spec/services/fees/apply_provider_taxes_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Fees::ApplyProviderTaxesService, type: :service do
+RSpec.describe Fees::ApplyProviderTaxesService do
   subject(:apply_service) { described_class.new(fee:, fee_taxes:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/fees/apply_taxes_service_spec.rb
+++ b/spec/services/fees/apply_taxes_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Fees::ApplyTaxesService, type: :service do
+RSpec.describe Fees::ApplyTaxesService do
   subject(:apply_service) { described_class.new(fee:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
+RSpec.describe Fees::CreatePayInAdvanceService do
   subject(:fee_service) { described_class.new(charge:, event:, billing_at: event.timestamp, estimate:) }
 
   let(:billing_entity) { create(:billing_entity) }

--- a/spec/services/fees/create_true_up_service_spec.rb
+++ b/spec/services/fees/create_true_up_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Fees::CreateTrueUpService, type: :service do
+RSpec.describe Fees::CreateTrueUpService do
   let(:create_service) { described_class.new(fee:, used_amount_cents:, used_precise_amount_cents:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
+++ b/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Fees::InitFromAdjustedChargeFeeService, type: :service do
+RSpec.describe Fees::InitFromAdjustedChargeFeeService do
   subject(:init_service) { described_class.new(adjusted_fee:, boundaries:, properties:) }
 
   let(:subscription) do

--- a/spec/services/fees/update_service_spec.rb
+++ b/spec/services/fees/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Fees::UpdateService, type: :service do
+RSpec.describe Fees::UpdateService do
   subject(:update_service) { described_class.new(fee:, params:) }
 
   let(:charge) { create(:standard_charge, invoiceable: false) }

--- a/spec/services/fixed_charge_events/create_service_spec.rb
+++ b/spec/services/fixed_charge_events/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedChargeEvents::CreateService, type: :service do
+RSpec.describe FixedChargeEvents::CreateService do
   subject(:create_service) do
     described_class.new(
       subscription:,

--- a/spec/services/fixed_charges/apply_taxes_service_spec.rb
+++ b/spec/services/fixed_charges/apply_taxes_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::ApplyTaxesService, type: :service do
+RSpec.describe FixedCharges::ApplyTaxesService do
   subject(:apply_service) { described_class.new(fixed_charge:, tax_codes:) }
 
   let(:plan) { create(:plan) }

--- a/spec/services/fixed_charges/create_children_service_spec.rb
+++ b/spec/services/fixed_charges/create_children_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::CreateChildrenService, type: :service do
+RSpec.describe FixedCharges::CreateChildrenService do
   subject(:create_service) { described_class.new(child_ids:, fixed_charge:, payload:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/fixed_charges/create_service_spec.rb
+++ b/spec/services/fixed_charges/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::CreateService, type: :service do
+RSpec.describe FixedCharges::CreateService do
   subject(:create_service) { described_class.new(plan:, params:) }
 
   let(:plan) { create(:plan) }

--- a/spec/services/fixed_charges/destroy_children_service_spec.rb
+++ b/spec/services/fixed_charges/destroy_children_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::DestroyChildrenService, type: :service do
+RSpec.describe FixedCharges::DestroyChildrenService do
   subject(:destroy_service) { described_class.new(fixed_charge) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/fixed_charges/destroy_service_spec.rb
+++ b/spec/services/fixed_charges/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::DestroyService, type: :service do
+RSpec.describe FixedCharges::DestroyService do
   subject(:destroy_service) { described_class.new(fixed_charge:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/fixed_charges/override_service_spec.rb
+++ b/spec/services/fixed_charges/override_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::OverrideService, type: :service do
+RSpec.describe FixedCharges::OverrideService do
   subject(:override_service) { described_class.new(fixed_charge:, params:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/fixed_charges/update_children_service_spec.rb
+++ b/spec/services/fixed_charges/update_children_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::UpdateChildrenService, type: :service do
+RSpec.describe FixedCharges::UpdateChildrenService do
   subject(:update_service) do
     described_class.new(fixed_charge:, params:, old_parent_attrs:, child_ids:)
   end

--- a/spec/services/fixed_charges/update_service_spec.rb
+++ b/spec/services/fixed_charges/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::UpdateService, type: :service do
+RSpec.describe FixedCharges::UpdateService do
   subject(:update_service) { described_class.new(fixed_charge:, params:, cascade_options:) }
 
   let(:plan) { create(:plan) }

--- a/spec/services/idempotency_records/create_service_spec.rb
+++ b/spec/services/idempotency_records/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IdempotencyRecords::CreateService, type: :service do
+RSpec.describe IdempotencyRecords::CreateService do
   subject(:result) { described_class.call(idempotency_key:, resource:) }
 
   let(:idempotency_key) { SecureRandom.uuid }

--- a/spec/services/idempotency_records/key_service_spec.rb
+++ b/spec/services/idempotency_records/key_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IdempotencyRecords::KeyService, type: :service do
+RSpec.describe IdempotencyRecords::KeyService do
   subject(:result) { described_class.call(**key_parts) }
 
   let(:key_parts) { {} }

--- a/spec/services/inbound_webhooks/create_service_spec.rb
+++ b/spec/services/inbound_webhooks/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe InboundWebhooks::CreateService, type: :service do
+RSpec.describe InboundWebhooks::CreateService do
   subject(:result) do
     described_class.call(
       organization_id: organization.id,

--- a/spec/services/inbound_webhooks/process_service_spec.rb
+++ b/spec/services/inbound_webhooks/process_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe InboundWebhooks::ProcessService, type: :service do
+RSpec.describe InboundWebhooks::ProcessService do
   subject(:result) { described_class.call(inbound_webhook:) }
 
   let(:inbound_webhook) { create :inbound_webhook, source: webhook_source }

--- a/spec/services/inbound_webhooks/validate_payload_service_spec.rb
+++ b/spec/services/inbound_webhooks/validate_payload_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe InboundWebhooks::ValidatePayloadService, type: :service do
+RSpec.describe InboundWebhooks::ValidatePayloadService do
   subject(:result) do
     described_class.call(
       organization_id: organization.id,

--- a/spec/services/integration_collection_mappings/create_service_spec.rb
+++ b/spec/services/integration_collection_mappings/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCollectionMappings::CreateService, type: :service do
+RSpec.describe IntegrationCollectionMappings::CreateService do
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integration_collection_mappings/destroy_service_spec.rb
+++ b/spec/services/integration_collection_mappings/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCollectionMappings::DestroyService, type: :service do
+RSpec.describe IntegrationCollectionMappings::DestroyService do
   subject(:destroy_service) { described_class.new(integration_collection_mapping:) }
 
   let(:integration) { create(:netsuite_integration, organization:) }

--- a/spec/services/integration_collection_mappings/update_service_spec.rb
+++ b/spec/services/integration_collection_mappings/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCollectionMappings::UpdateService, type: :service do
+RSpec.describe IntegrationCollectionMappings::UpdateService do
   let(:integration_collection_mapping) { create(:netsuite_collection_mapping, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:organization) { membership.organization }

--- a/spec/services/integration_customers/anrok_service_spec.rb
+++ b/spec/services/integration_customers/anrok_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::AnrokService, type: :service do
+RSpec.describe IntegrationCustomers::AnrokService do
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integration_customers/avalara_service_spec.rb
+++ b/spec/services/integration_customers/avalara_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::AvalaraService, type: :service do
+RSpec.describe IntegrationCustomers::AvalaraService do
   let(:integration) { create(:avalara_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integration_customers/create_or_update_service_spec.rb
+++ b/spec/services/integration_customers/create_or_update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::CreateOrUpdateService, type: :service do
+RSpec.describe IntegrationCustomers::CreateOrUpdateService do
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integration_customers/create_service_spec.rb
+++ b/spec/services/integration_customers/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::CreateService, type: :service do
+RSpec.describe IntegrationCustomers::CreateService do
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integration_customers/hubspot_service_spec.rb
+++ b/spec/services/integration_customers/hubspot_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::HubspotService, type: :service do
+RSpec.describe IntegrationCustomers::HubspotService do
   let(:integration) { create(:hubspot_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integration_customers/netsuite_service_spec.rb
+++ b/spec/services/integration_customers/netsuite_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::NetsuiteService, type: :service do
+RSpec.describe IntegrationCustomers::NetsuiteService do
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integration_customers/salesforce_service_spec.rb
+++ b/spec/services/integration_customers/salesforce_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::SalesforceService, type: :service do
+RSpec.describe IntegrationCustomers::SalesforceService do
   let(:integration) { create(:salesforce_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integration_customers/update_service_spec.rb
+++ b/spec/services/integration_customers/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::UpdateService, type: :service do
+RSpec.describe IntegrationCustomers::UpdateService do
   let(:integration) { create(:netsuite_integration, organization:) }
 
   let(:organization) { membership.organization }

--- a/spec/services/integration_customers/xero_service_spec.rb
+++ b/spec/services/integration_customers/xero_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCustomers::XeroService, type: :service do
+RSpec.describe IntegrationCustomers::XeroService do
   let(:integration) { create(:xero_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integration_mappings/create_service_spec.rb
+++ b/spec/services/integration_mappings/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationMappings::CreateService, type: :service do
+RSpec.describe IntegrationMappings::CreateService do
   let(:service) { described_class.new(membership.user) }
 
   let(:integration) { create(:netsuite_integration, organization:) }

--- a/spec/services/integration_mappings/destroy_service_spec.rb
+++ b/spec/services/integration_mappings/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationMappings::DestroyService, type: :service do
+RSpec.describe IntegrationMappings::DestroyService do
   subject(:destroy_service) { described_class.new(integration_mapping:) }
 
   let(:integration) { create(:netsuite_integration, organization:) }

--- a/spec/services/integration_mappings/update_service_spec.rb
+++ b/spec/services/integration_mappings/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationMappings::UpdateService, type: :service do
+RSpec.describe IntegrationMappings::UpdateService do
   let(:integration_mapping) { create(:netsuite_mapping, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:organization) { membership.organization }

--- a/spec/services/integrations/aggregator/invoices/hubspot/base_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/hubspot/base_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Invoices::Hubspot::BaseService, type: :service do
+RSpec.describe Integrations::Aggregator::Invoices::Hubspot::BaseService do
   let(:service) { described_class.new(invoice:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
   let(:integration) { create(:hubspot_integration, organization:) }

--- a/spec/services/integrations/aggregator/payments/payloads/base_payload_spec.rb
+++ b/spec/services/integrations/aggregator/payments/payloads/base_payload_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Payments::Payloads::BasePayload, type: :service do
+RSpec.describe Integrations::Aggregator::Payments::Payloads::BasePayload do
   let(:payload) { described_class.new(integration:, payment:) }
   let(:payment) { create(:payment, payable: invoice) }
   let(:invoice) { create(:invoice, customer:, organization:) }

--- a/spec/services/integrations/aggregator/subscriptions/hubspot/base_service_spec.rb
+++ b/spec/services/integrations/aggregator/subscriptions/hubspot/base_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::BaseService, type: :service do
+RSpec.describe Integrations::Aggregator::Subscriptions::Hubspot::BaseService do
   let(:service) { described_class.new(subscription:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:plan) { create(:plan, organization:) }

--- a/spec/services/integrations/anrok/create_service_spec.rb
+++ b/spec/services/integrations/anrok/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Anrok::CreateService, type: :service do
+RSpec.describe Integrations::Anrok::CreateService do
   let(:service) { described_class.new(membership.user) }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/services/integrations/anrok/update_service_spec.rb
+++ b/spec/services/integrations/anrok/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Anrok::UpdateService, type: :service do
+RSpec.describe Integrations::Anrok::UpdateService do
   let(:integration) { create(:anrok_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integrations/avalara/create_service_spec.rb
+++ b/spec/services/integrations/avalara/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Avalara::CreateService, type: :service do
+RSpec.describe Integrations::Avalara::CreateService do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 

--- a/spec/services/integrations/avalara/update_service_spec.rb
+++ b/spec/services/integrations/avalara/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Avalara::UpdateService, type: :service do
+RSpec.describe Integrations::Avalara::UpdateService do
   let(:integration) { create(:avalara_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integrations/destroy_service_spec.rb
+++ b/spec/services/integrations/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::DestroyService, type: :service do
+RSpec.describe Integrations::DestroyService do
   subject(:destroy_service) { described_class.new(integration:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/integrations/hubspot/create_service_spec.rb
+++ b/spec/services/integrations/hubspot/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Hubspot::CreateService, type: :service do
+RSpec.describe Integrations::Hubspot::CreateService do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 

--- a/spec/services/integrations/hubspot/update_service_spec.rb
+++ b/spec/services/integrations/hubspot/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Hubspot::UpdateService, type: :service do
+RSpec.describe Integrations::Hubspot::UpdateService do
   let(:integration) { create(:hubspot_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integrations/netsuite/create_service_spec.rb
+++ b/spec/services/integrations/netsuite/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Netsuite::CreateService, type: :service do
+RSpec.describe Integrations::Netsuite::CreateService do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 

--- a/spec/services/integrations/netsuite/update_service_spec.rb
+++ b/spec/services/integrations/netsuite/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Netsuite::UpdateService, type: :service do
+RSpec.describe Integrations::Netsuite::UpdateService do
   let(:integration) { create(:netsuite_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integrations/okta/create_service_spec.rb
+++ b/spec/services/integrations/okta/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Okta::CreateService, type: :service do
+RSpec.describe Integrations::Okta::CreateService do
   let(:service) { described_class.new(membership.user) }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/services/integrations/okta/destroy_service_spec.rb
+++ b/spec/services/integrations/okta/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Okta::DestroyService, type: :service do
+RSpec.describe Integrations::Okta::DestroyService do
   subject(:destroy_service) { described_class.new(integration:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/integrations/okta/update_service_spec.rb
+++ b/spec/services/integrations/okta/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Okta::UpdateService, type: :service do
+RSpec.describe Integrations::Okta::UpdateService do
   let(:integration) { create(:okta_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integrations/salesforce/create_service_spec.rb
+++ b/spec/services/integrations/salesforce/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Salesforce::CreateService, type: :service do
+RSpec.describe Integrations::Salesforce::CreateService do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 

--- a/spec/services/integrations/salesforce/update_service_spec.rb
+++ b/spec/services/integrations/salesforce/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Salesforce::UpdateService, type: :service do
+RSpec.describe Integrations::Salesforce::UpdateService do
   let(:integration) { create(:salesforce_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/integrations/xero/create_service_spec.rb
+++ b/spec/services/integrations/xero/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Xero::CreateService, type: :service do
+RSpec.describe Integrations::Xero::CreateService do
   let(:service) { described_class.new(membership.user) }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/services/integrations/xero/update_service_spec.rb
+++ b/spec/services/integrations/xero/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Integrations::Xero::UpdateService, type: :service do
+RSpec.describe Integrations::Xero::UpdateService do
   let(:integration) { create(:xero_integration, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }

--- a/spec/services/invites/accept_service_spec.rb
+++ b/spec/services/invites/accept_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invites::AcceptService, type: :service do
+RSpec.describe Invites::AcceptService do
   subject(:accept_service) { described_class.new }
 
   let(:membership) { create(:membership) }

--- a/spec/services/invites/create_service_spec.rb
+++ b/spec/services/invites/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invites::CreateService, type: :service do
+RSpec.describe Invites::CreateService do
   subject(:create_service) { described_class.new(create_args) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/invites/revoke_service_spec.rb
+++ b/spec/services/invites/revoke_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invites::RevokeService, type: :service do
+RSpec.describe Invites::RevokeService do
   subject(:revoke_service) { described_class.new(invite) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/invites/update_service_spec.rb
+++ b/spec/services/invites/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invites::UpdateService, type: :service do
+RSpec.describe Invites::UpdateService do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:invite) { create(:invite, organization:) }

--- a/spec/services/invites/validate_service_spec.rb
+++ b/spec/services/invites/validate_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-RSpec.describe Invites::ValidateService, type: :service do
+RSpec.describe Invites::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/services/invoice_custom_sections/create_service_spec.rb
+++ b/spec/services/invoice_custom_sections/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe InvoiceCustomSections::CreateService, type: :service do
+RSpec.describe InvoiceCustomSections::CreateService do
   describe "#call" do
     subject(:service_result) { described_class.call(organization:, create_params:) }
 

--- a/spec/services/invoice_custom_sections/deselect_all_service_spec.rb
+++ b/spec/services/invoice_custom_sections/deselect_all_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe InvoiceCustomSections::DeselectAllService, type: :service do
+RSpec.describe InvoiceCustomSections::DeselectAllService do
   describe "#call" do
     subject(:service_result) { described_class.call(section:) }
 

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::AddOnService, type: :service do
+RSpec.describe Invoices::AddOnService do
   subject(:invoice_service) do
     described_class.new(applied_add_on:, datetime:)
   end

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::AdvanceChargesService, type: :service do
+RSpec.describe Invoices::AdvanceChargesService do
   subject(:invoice_service) do
     described_class.new(initial_subscriptions: subscriptions, billing_at:)
   end

--- a/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
+++ b/spec/services/invoices/aggregate_amounts_and_taxes_from_fees_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::AggregateAmountsAndTaxesFromFees, type: :service do
+RSpec.describe Invoices::AggregateAmountsAndTaxesFromFees do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, invoice_type: :advance_charges, customer:) }

--- a/spec/services/invoices/apply_invoice_custom_sections_service_spec.rb
+++ b/spec/services/invoices/apply_invoice_custom_sections_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::ApplyInvoiceCustomSectionsService, type: :service do
+RSpec.describe Invoices::ApplyInvoiceCustomSectionsService do
   subject(:invoice_service) { described_class.new(invoice:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/invoices/apply_provider_taxes_service_spec.rb
+++ b/spec/services/invoices/apply_provider_taxes_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::ApplyProviderTaxesService, type: :service do
+RSpec.describe Invoices::ApplyProviderTaxesService do
   subject(:apply_service) { described_class.new(invoice:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/invoices/apply_taxes_service_spec.rb
+++ b/spec/services/invoices/apply_taxes_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::ApplyTaxesService, type: :service do
+RSpec.describe Invoices::ApplyTaxesService do
   subject(:apply_service) { described_class.new(invoice:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::CalculateFeesService, type: :service do
+RSpec.describe Invoices::CalculateFeesService do
   subject(:invoice_service) do
     described_class.new(
       invoice:,

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::ComputeAmountsFromFees, type: :service do
+RSpec.describe Invoices::ComputeAmountsFromFees do
   subject(:compute_amounts) { described_class.new(invoice:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
+++ b/spec/services/invoices/compute_taxes_and_totals_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::ComputeTaxesAndTotalsService, type: :service do
+RSpec.describe Invoices::ComputeTaxesAndTotalsService do
   subject(:totals_service) { described_class.new(invoice:) }
 
   describe "#call" do

--- a/spec/services/invoices/create_generating_service_spec.rb
+++ b/spec/services/invoices/create_generating_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::CreateGeneratingService, type: :service do
+RSpec.describe Invoices::CreateGeneratingService do
   subject(:create_service) do
     described_class.new(customer:, invoice_type:, currency:, datetime:, charge_in_advance:)
   end

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::CreateOneOffService, type: :service do
+RSpec.describe Invoices::CreateOneOffService do
   let(:args) { {customer:, timestamp: timestamp.to_i, fees:, currency:} }
   let(:timestamp) { Time.zone.now.beginning_of_month }
   let(:organization) { create(:organization) }

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
+RSpec.describe Invoices::CreatePayInAdvanceChargeService do
   subject(:invoice_service) do
     described_class.new(charge:, event:, timestamp: timestamp.to_i)
   end

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
+RSpec.describe Invoices::CustomerUsageService, cache: :memory do
   subject(:usage_service) do
     described_class.with_ids(
       organization_id: membership.organization_id,

--- a/spec/services/invoices/finalize_batch_service_spec.rb
+++ b/spec/services/invoices/finalize_batch_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::FinalizeBatchService, type: :service do
+RSpec.describe Invoices::FinalizeBatchService do
   subject(:finalize_batch_service) { described_class.new(organization:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/invoices/finalize_open_credit_service_spec.rb
+++ b/spec/services/invoices/finalize_open_credit_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::FinalizeOpenCreditService, type: :service do
+RSpec.describe Invoices::FinalizeOpenCreditService do
   let(:service) { described_class.new(invoice:) }
 
   let(:organization) { create(:organization, email_settings: Organization::EMAIL_SETTINGS) }

--- a/spec/services/invoices/generate_pdf_service_spec.rb
+++ b/spec/services/invoices/generate_pdf_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::GeneratePdfService, type: :service do
+RSpec.describe Invoices::GeneratePdfService do
   let(:context) { "graphql" }
   let(:organization) { create(:organization, name: "LAGO") }
   let(:customer) { create(:customer, organization:) }

--- a/spec/services/invoices/lose_dispute_service_spec.rb
+++ b/spec/services/invoices/lose_dispute_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::LoseDisputeService, type: :service do
+RSpec.describe Invoices::LoseDisputeService do
   subject(:lose_dispute_service) { described_class.new(invoice:) }
 
   describe "#call" do

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::PaidCreditService, type: :service do
+RSpec.describe Invoices::PaidCreditService do
   subject(:invoice_service) do
     described_class.new(wallet_transaction:, timestamp:, invoice:)
   end

--- a/spec/services/invoices/payments/adyen_service_spec.rb
+++ b/spec/services/invoices/payments/adyen_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::AdyenService, type: :service do
+RSpec.describe Invoices::Payments::AdyenService do
   subject(:adyen_service) { described_class.new(invoice) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/invoices/payments/cashfree_service_spec.rb
+++ b/spec/services/invoices/payments/cashfree_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::CashfreeService, type: :service do
+RSpec.describe Invoices::Payments::CashfreeService do
   subject(:cashfree_service) { described_class.new(invoice) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::CreateService, type: :service do
+RSpec.describe Invoices::Payments::CreateService do
   subject(:create_service) { described_class.new(invoice:, payment_provider: provider) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/invoices/payments/deliver_error_webhook_service_spec.rb
+++ b/spec/services/invoices/payments/deliver_error_webhook_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::DeliverErrorWebhookService, type: :service do
+RSpec.describe Invoices::Payments::DeliverErrorWebhookService do
   subject(:webhook_service) { described_class.new(invoice, params) }
 
   let(:params) do

--- a/spec/services/invoices/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/invoices/payments/generate_payment_url_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::GeneratePaymentUrlService, type: :service do
+RSpec.describe Invoices::Payments::GeneratePaymentUrlService do
   subject(:generate_payment_url_service) { described_class.new(invoice:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/invoices/payments/gocardless_service_spec.rb
+++ b/spec/services/invoices/payments/gocardless_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::GocardlessService, type: :service do
+RSpec.describe Invoices::Payments::GocardlessService do
   subject(:gocardless_service) { described_class.new(argument) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/invoices/payments/mark_overdue_service_spec.rb
+++ b/spec/services/invoices/payments/mark_overdue_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::MarkOverdueService, type: :service do
+RSpec.describe Invoices::Payments::MarkOverdueService do
   let(:result) { described_class.call(invoice:) }
 
   let(:invoice) do

--- a/spec/services/invoices/payments/payment_providers/factory_spec.rb
+++ b/spec/services/invoices/payments/payment_providers/factory_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::PaymentProviders::Factory, type: :service do
+RSpec.describe Invoices::Payments::PaymentProviders::Factory do
   subject(:factory_service) { described_class.new_instance(invoice:) }
 
   let(:payment_provider) { "stripe" }

--- a/spec/services/invoices/payments/retry_batch_service_spec.rb
+++ b/spec/services/invoices/payments/retry_batch_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::RetryBatchService, type: :service do
+RSpec.describe Invoices::Payments::RetryBatchService do
   subject(:retry_batch_service) { described_class.new(organization_id: organization.id) }
 
   let(:customer) { create(:customer, payment_provider: "stripe") }

--- a/spec/services/invoices/payments/retry_service_spec.rb
+++ b/spec/services/invoices/payments/retry_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::RetryService, type: :service do
+RSpec.describe Invoices::Payments::RetryService do
   subject(:retry_service) { described_class.new(invoice:) }
 
   let(:invoice) { create(:invoice, customer:, status: "finalized", organization: customer.organization) }

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Payments::StripeService, type: :service do
+RSpec.describe Invoices::Payments::StripeService do
   subject(:stripe_service) { described_class.new(invoice) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/invoices/preview/build_subscription_service_spec.rb
+++ b/spec/services/invoices/preview/build_subscription_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Preview::BuildSubscriptionService, type: :service do
+RSpec.describe Invoices::Preview::BuildSubscriptionService do
   describe ".call" do
     subject(:result) { described_class.call(customer:, params:) }
 

--- a/spec/services/invoices/preview/credits_service_spec.rb
+++ b/spec/services/invoices/preview/credits_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Preview::CreditsService, type: :service do
+RSpec.describe Invoices::Preview::CreditsService do
   describe ".call" do
     subject(:result) { described_class.call(invoice:, terminated_subscription:) }
 

--- a/spec/services/invoices/preview/find_subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/find_subscriptions_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Preview::FindSubscriptionsService, type: :service do
+RSpec.describe Invoices::Preview::FindSubscriptionsService do
   describe ".call" do
     subject(:result) { described_class.call(subscriptions:) }
 

--- a/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_plan_change_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Preview::SubscriptionPlanChangeService, type: :service do
+RSpec.describe Invoices::Preview::SubscriptionPlanChangeService do
   describe ".call" do
     subject(:result) { described_class.call(current_subscription:, target_plan_code:) }
 

--- a/spec/services/invoices/preview/subscription_termination_service_spec.rb
+++ b/spec/services/invoices/preview/subscription_termination_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::Preview::SubscriptionTerminationService, type: :service do
+RSpec.describe Invoices::Preview::SubscriptionTerminationService do
   describe ".call" do
     subject(:result) do
       described_class.call(current_subscription:, terminated_at: terminated_at&.to_s)

--- a/spec/services/invoices/preview/subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/subscriptions_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Invoices::Preview::SubscriptionsService, type: :service do
+RSpec.describe Invoices::Preview::SubscriptionsService do
   let(:result) { described_class.call(organization:, customer:, params:) }
 
   describe ".call" do

--- a/spec/services/invoices/preview_context_service_spec.rb
+++ b/spec/services/invoices/preview_context_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::PreviewContextService, type: :service do
+RSpec.describe Invoices::PreviewContextService do
   let(:result) { described_class.call(organization:, params:, billing_entity:) }
 
   describe "#call" do

--- a/spec/services/invoices/preview_service_spec.rb
+++ b/spec/services/invoices/preview_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::PreviewService, type: :service, cache: :memory do
+RSpec.describe Invoices::PreviewService, cache: :memory do
   subject(:preview_service) { described_class.new(customer:, subscriptions:) }
 
   describe "#call" do

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::ProgressiveBillingService, type: :service, transaction: false do
+RSpec.describe Invoices::ProgressiveBillingService, transaction: false do
   subject(:create_service) { described_class.new(sorted_usage_thresholds:, lifetime_usage:, timestamp:) }
 
   let(:sorted_usage_thresholds) { [create(:usage_threshold, plan:)] }

--- a/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/pull_taxes_and_apply_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService, type: :service do
+RSpec.describe Invoices::ProviderTaxes::PullTaxesAndApplyService do
   subject(:pull_taxes_service) { described_class.new(invoice:) }
 
   describe "#call" do

--- a/spec/services/invoices/provider_taxes/void_service_spec.rb
+++ b/spec/services/invoices/provider_taxes/void_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::ProviderTaxes::VoidService, type: :service do
+RSpec.describe Invoices::ProviderTaxes::VoidService do
   subject(:void_service) { described_class.new(invoice:) }
 
   describe "#call" do

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
+RSpec.describe Invoices::RefreshDraftAndFinalizeService do
   subject(:finalize_service) { described_class.new(invoice:) }
 
   describe "#call" do

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::RefreshDraftService, type: :service do
+RSpec.describe Invoices::RefreshDraftService do
   subject(:refresh_service) { described_class.new(invoice:) }
 
   describe "#call" do

--- a/spec/services/invoices/retry_batch_service_spec.rb
+++ b/spec/services/invoices/retry_batch_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::RetryBatchService, type: :service do
+RSpec.describe Invoices::RetryBatchService do
   subject(:retry_batch_service) { described_class.new(organization:) }
 
   let(:customer) { create(:customer, payment_provider: "stripe") }

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::RetryService, type: :service do
+RSpec.describe Invoices::RetryService do
   subject(:retry_service) { described_class.new(invoice:) }
 
   describe "#call" do

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::SubscriptionService, type: :service do
+RSpec.describe Invoices::SubscriptionService do
   subject(:invoice_service) do
     described_class.new(
       subscriptions:,

--- a/spec/services/invoices/sync_salesforce_id_service_spec.rb
+++ b/spec/services/invoices/sync_salesforce_id_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::SyncSalesforceIdService, type: :service do
+RSpec.describe Invoices::SyncSalesforceIdService do
   subject(:service_call) { sync_salesforce_id_service.call }
 
   let(:sync_salesforce_id_service) { described_class.new(invoice:, params:) }

--- a/spec/services/invoices/transition_to_final_status_service_spec.rb
+++ b/spec/services/invoices/transition_to_final_status_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::TransitionToFinalStatusService, type: :service do
+RSpec.describe Invoices::TransitionToFinalStatusService do
   subject { described_class.new(invoice: invoice) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/invoices/void_service_spec.rb
+++ b/spec/services/invoices/void_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::VoidService, type: :service do
+RSpec.describe Invoices::VoidService do
   subject(:void_service) { described_class.new(invoice:, params:) }
 
   let(:params) { {} }

--- a/spec/services/lifetime_usages/calculate_service_spec.rb
+++ b/spec/services/lifetime_usages/calculate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe LifetimeUsages::CalculateService, type: :service do
+RSpec.describe LifetimeUsages::CalculateService do
   subject(:service) { described_class.new(lifetime_usage: lifetime_usage) }
 
   let(:lifetime_usage) { create(:lifetime_usage, organization:, subscription:, recalculate_current_usage:, recalculate_invoiced_usage:) }

--- a/spec/services/lifetime_usages/check_thresholds_service_spec.rb
+++ b/spec/services/lifetime_usages/check_thresholds_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe LifetimeUsages::CheckThresholdsService, type: :service, transaction: false do
+RSpec.describe LifetimeUsages::CheckThresholdsService, transaction: false do
   subject(:service) { described_class.new(lifetime_usage:) }
 
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, recalculate_current_usage: true, recalculate_invoiced_usage: true, current_usage_amount_cents:) }

--- a/spec/services/lifetime_usages/find_last_and_next_thresholds_service_spec.rb
+++ b/spec/services/lifetime_usages/find_last_and_next_thresholds_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe LifetimeUsages::FindLastAndNextThresholdsService, type: :service do
+RSpec.describe LifetimeUsages::FindLastAndNextThresholdsService do
   subject(:lifetime_usage_result) { described_class.call(lifetime_usage:) }
 
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, organization:, current_usage_amount_cents:) }

--- a/spec/services/lifetime_usages/flag_refresh_from_invoice_service_spec.rb
+++ b/spec/services/lifetime_usages/flag_refresh_from_invoice_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe LifetimeUsages::FlagRefreshFromInvoiceService, type: :service do
+RSpec.describe LifetimeUsages::FlagRefreshFromInvoiceService do
   subject(:flag_service) { described_class.new(invoice:) }
 
   around { |test| lago_premium!(&test) }

--- a/spec/services/lifetime_usages/flag_refresh_from_plan_update_service_spec.rb
+++ b/spec/services/lifetime_usages/flag_refresh_from_plan_update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe LifetimeUsages::FlagRefreshFromPlanUpdateService, type: :service do
+RSpec.describe LifetimeUsages::FlagRefreshFromPlanUpdateService do
   subject { described_class.call(plan:) }
 
   let(:plan) { create(:plan) }

--- a/spec/services/lifetime_usages/update_service_spec.rb
+++ b/spec/services/lifetime_usages/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe LifetimeUsages::UpdateService, type: :service do
+RSpec.describe LifetimeUsages::UpdateService do
   subject(:update_service) { described_class.new(lifetime_usage:, params:) }
 
   let(:lifetime_usage) { create(:lifetime_usage) }

--- a/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
+++ b/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe LifetimeUsages::UsageThresholds::CheckService, type: :service do
+RSpec.describe LifetimeUsages::UsageThresholds::CheckService do
   subject(:service) { described_class.new(lifetime_usage:, progressive_billed_amount:) }
 
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, historical_usage_amount_cents:, recalculate_current_usage:, recalculate_invoiced_usage:) }

--- a/spec/services/lifetime_usages/usage_thresholds_completion_service_spec.rb
+++ b/spec/services/lifetime_usages/usage_thresholds_completion_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe LifetimeUsages::UsageThresholdsCompletionService, type: :service do
+RSpec.describe LifetimeUsages::UsageThresholdsCompletionService do
   subject(:result) { described_class.call(lifetime_usage:) }
 
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, organization:, current_usage_amount_cents:) }

--- a/spec/services/memberships/create_service_spec.rb
+++ b/spec/services/memberships/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Memberships::CreateService, type: :service do
+RSpec.describe Memberships::CreateService do
   subject(:create_service) { described_class.new(user:, organization:) }
 
   let(:user) { create(:user) }

--- a/spec/services/memberships/revoke_service_spec.rb
+++ b/spec/services/memberships/revoke_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Memberships::RevokeService, type: :service do
+RSpec.describe Memberships::RevokeService do
   subject(:revoke_service) { described_class.new(user:, membership:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/memberships/update_service_spec.rb
+++ b/spec/services/memberships/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Memberships::UpdateService, type: :service do
+RSpec.describe Memberships::UpdateService do
   let(:membership) { create(:membership, role: "admin") }
   let(:organization) { membership.organization }
   let(:params) { {role: "manager"} }

--- a/spec/services/organizations/create_service_spec.rb
+++ b/spec/services/organizations/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Organizations::CreateService, type: :service do
+RSpec.describe Organizations::CreateService do
   describe "#call" do
     subject(:service_result) { described_class.call(params) }
 

--- a/spec/services/password_resets/create_service_spec.rb
+++ b/spec/services/password_resets/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PasswordResets::CreateService, type: :service do
+RSpec.describe PasswordResets::CreateService do
   subject(:create_service) { described_class }
 
   describe "#call" do

--- a/spec/services/password_resets/reset_service_spec.rb
+++ b/spec/services/password_resets/reset_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PasswordResets::ResetService, type: :service do
+RSpec.describe PasswordResets::ResetService do
   subject(:reset_service) { described_class }
 
   describe "#call" do

--- a/spec/services/payment_provider_customers/adyen_service_spec.rb
+++ b/spec/services/payment_provider_customers/adyen_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::AdyenService, type: :service do
+RSpec.describe PaymentProviderCustomers::AdyenService do
   let(:adyen_service) { described_class.new(adyen_customer) }
   let(:customer) { create(:customer, organization:) }
   let(:adyen_provider) { create(:adyen_provider) }

--- a/spec/services/payment_provider_customers/gocardless_service_spec.rb
+++ b/spec/services/payment_provider_customers/gocardless_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::GocardlessService, type: :service do
+RSpec.describe PaymentProviderCustomers::GocardlessService do
   subject(:gocardless_service) { described_class.new(gocardless_customer) }
 
   let(:customer) { create(:customer, organization:) }

--- a/spec/services/payment_provider_customers/moneyhash_service_spec.rb
+++ b/spec/services/payment_provider_customers/moneyhash_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::MoneyhashService, type: :service do
+RSpec.describe PaymentProviderCustomers::MoneyhashService do
   subject(:moneyhash_service) { described_class.new(moneyhash_customer) }
 
   let(:customer) { create(:customer, name: customer_name, organization:) }

--- a/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/check_payment_method_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::Stripe::CheckPaymentMethodService, type: :service do
+RSpec.describe PaymentProviderCustomers::Stripe::CheckPaymentMethodService do
   subject(:check_service) { described_class.new(stripe_customer:, payment_method_id:) }
 
   let(:customer) { create(:customer, organization:) }

--- a/spec/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/retrieve_latest_payment_method_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::Stripe::RetrieveLatestPaymentMethodService, type: :service do
+RSpec.describe PaymentProviderCustomers::Stripe::RetrieveLatestPaymentMethodService do
   subject { described_class.new(provider_customer:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe/update_payment_method_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::Stripe::UpdatePaymentMethodService, type: :service do
+RSpec.describe PaymentProviderCustomers::Stripe::UpdatePaymentMethodService do
   subject(:update_service) { described_class.new(stripe_customer:, payment_method_id:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
+RSpec.describe PaymentProviderCustomers::StripeService do
   subject(:stripe_service) { described_class.new(stripe_customer) }
 
   let(:customer) { create(:customer, name: customer_name, organization:) }

--- a/spec/services/payment_provider_customers/update_service_spec.rb
+++ b/spec/services/payment_provider_customers/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviderCustomers::UpdateService, type: :service do
+RSpec.describe PaymentProviderCustomers::UpdateService do
   let(:customer) { create(:customer, payment_provider: provider_name.downcase) }
   let(:payment_provider) { create(:stripe_provider, organization: customer.organization) }
   let(:provider_name) { "Stripe" }

--- a/spec/services/payment_providers/adyen/customers/create_service_spec.rb
+++ b/spec/services/payment_providers/adyen/customers/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Adyen::Customers::CreateService, type: :service do
+RSpec.describe PaymentProviders::Adyen::Customers::CreateService do
   let(:create_service) { described_class.new(customer:, payment_provider_id:, params:, async:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/payment_providers/adyen/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/adyen/handle_incoming_webhook_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Adyen::HandleIncomingWebhookService, type: :service do
+RSpec.describe PaymentProviders::Adyen::HandleIncomingWebhookService do
   let(:webhook_service) { described_class.new(organization_id:, body:, code:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/payment_providers/adyen/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/adyen/payments/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Adyen::Payments::CreateService, type: :service do
+RSpec.describe PaymentProviders::Adyen::Payments::CreateService do
   subject(:create_service) { described_class.new(payment:, reference:, metadata:) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/payment_providers/adyen/webhooks/chargeback_service_spec.rb
+++ b/spec/services/payment_providers/adyen/webhooks/chargeback_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Adyen::Webhooks::ChargebackService, type: :service do
+RSpec.describe PaymentProviders::Adyen::Webhooks::ChargebackService do
   subject(:service) { described_class.new(organization_id:, event_json:) }
 
   let(:organization_id) { organization.id }

--- a/spec/services/payment_providers/adyen_service_spec.rb
+++ b/spec/services/payment_providers/adyen_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::AdyenService, type: :service do
+RSpec.describe PaymentProviders::AdyenService do
   subject(:adyen_service) { described_class.new(membership.user) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/payment_providers/cashfree/customers/create_service_spec.rb
+++ b/spec/services/payment_providers/cashfree/customers/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Cashfree::Customers::CreateService, type: :service do
+RSpec.describe PaymentProviders::Cashfree::Customers::CreateService do
   let(:create_service) { described_class.new(customer:, payment_provider_id:, params:, async:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/payment_providers/cashfree/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/cashfree/handle_incoming_webhook_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Cashfree::HandleIncomingWebhookService, type: :service do
+RSpec.describe PaymentProviders::Cashfree::HandleIncomingWebhookService do
   let(:webhook_service) { described_class.new(organization_id:, body:, code:, timestamp:, signature:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/payment_providers/cashfree/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/cashfree/payments/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Cashfree::Payments::CreateService, type: :service do
+RSpec.describe PaymentProviders::Cashfree::Payments::CreateService do
   subject(:create_service) { described_class.new(payment:) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/payment_providers/cashfree/webhooks/payment_link_event_service_spec.rb
+++ b/spec/services/payment_providers/cashfree/webhooks/payment_link_event_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Cashfree::Webhooks::PaymentLinkEventService, type: :service do
+RSpec.describe PaymentProviders::Cashfree::Webhooks::PaymentLinkEventService do
   subject(:webhook_service) { described_class.new(organization_id: organization.id, event_json:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/payment_providers/cashfree_service_spec.rb
+++ b/spec/services/payment_providers/cashfree_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::CashfreeService, type: :service do
+RSpec.describe PaymentProviders::CashfreeService do
   subject(:cashfree_service) { described_class.new(membership.user) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/payment_providers/create_customer_factory_spec.rb
+++ b/spec/services/payment_providers/create_customer_factory_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::CreateCustomerFactory, type: :service do
+RSpec.describe PaymentProviders::CreateCustomerFactory do
   subject(:new_instance) { described_class.new_instance(provider:, customer:, payment_provider_id:, params:, async:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/payment_providers/create_payment_factory_spec.rb
+++ b/spec/services/payment_providers/create_payment_factory_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::CreatePaymentFactory, type: :service do
+RSpec.describe PaymentProviders::CreatePaymentFactory do
   subject(:new_instance) { described_class.new_instance(provider:, payment:, reference: "", metadata: {}) }
 
   let(:provider) { "stripe" }

--- a/spec/services/payment_providers/destroy_service_spec.rb
+++ b/spec/services/payment_providers/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::DestroyService, type: :service do
+RSpec.describe PaymentProviders::DestroyService do
   subject(:destroy_service) { described_class.new(payment_provider) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/payment_providers/find_service_spec.rb
+++ b/spec/services/payment_providers/find_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::FindService, type: :service do
+RSpec.describe PaymentProviders::FindService do
   let(:service) { described_class.new(organization_id:, code:, id:) }
   let(:payment_provider) { create(:adyen_provider, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/payment_providers/gocardless/customers/create_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/customers/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Gocardless::Customers::CreateService, type: :service do
+RSpec.describe PaymentProviders::Gocardless::Customers::CreateService do
   let(:create_service) { described_class.new(customer:, payment_provider_id:, params:, async:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/payment_providers/gocardless/handle_event_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/handle_event_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Gocardless::HandleEventService, type: :service do
+RSpec.describe PaymentProviders::Gocardless::HandleEventService do
   subject(:event_service) { described_class.new(event_json:) }
 
   let(:event_json) do

--- a/spec/services/payment_providers/gocardless/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/handle_incoming_webhook_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Gocardless::HandleIncomingWebhookService, type: :service do
+RSpec.describe PaymentProviders::Gocardless::HandleIncomingWebhookService do
   let(:webhook_service) { described_class.new(organization_id: organization.id, body:, signature:, code:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/payment_providers/gocardless/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/gocardless/payments/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Gocardless::Payments::CreateService, type: :service do
+RSpec.describe PaymentProviders::Gocardless::Payments::CreateService do
   subject(:create_service) { described_class.new(payment:, reference:, metadata:) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/payment_providers/gocardless_service_spec.rb
+++ b/spec/services/payment_providers/gocardless_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::GocardlessService, type: :service do
+RSpec.describe PaymentProviders::GocardlessService do
   subject(:gocardless_service) { described_class.new(membership.user) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/payment_providers/moneyhash/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/handle_incoming_webhook_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Moneyhash::HandleIncomingWebhookService, type: :service do
+RSpec.describe PaymentProviders::Moneyhash::HandleIncomingWebhookService do
   subject(:result) { described_class.call(inbound_webhook:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/payment_providers/moneyhash/validate_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash/validate_incoming_webhook_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Moneyhash::ValidateIncomingWebhookService, type: :service do
+RSpec.describe PaymentProviders::Moneyhash::ValidateIncomingWebhookService do
   subject(:result) do
     described_class.call(payload:, signature:, payment_provider:)
   end

--- a/spec/services/payment_providers/moneyhash_service_spec.rb
+++ b/spec/services/payment_providers/moneyhash_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::MoneyhashService, type: :service do
+RSpec.describe PaymentProviders::MoneyhashService do
   let(:organization) { create(:organization) }
   let(:moneyhash_provider) { create(:moneyhash_provider, organization:) }
   let(:customer) { create(:customer, organization:) }

--- a/spec/services/payment_providers/stripe/customers/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/customers/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Stripe::Customers::CreateService, type: :service do
+RSpec.describe PaymentProviders::Stripe::Customers::CreateService do
   let(:create_service) { described_class.new(customer:, payment_provider_id:, params:, async:) }
 
   let(:customer) { create(:customer) }

--- a/spec/services/payment_providers/stripe/handle_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/handle_incoming_webhook_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Stripe::HandleIncomingWebhookService, type: :service do
+RSpec.describe PaymentProviders::Stripe::HandleIncomingWebhookService do
   subject(:result) { described_class.call(inbound_webhook:) }
 
   let(:inbound_webhook) { create :inbound_webhook }

--- a/spec/services/payment_providers/stripe/payments/create_service_spec.rb
+++ b/spec/services/payment_providers/stripe/payments/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Stripe::Payments::CreateService, type: :service do
+RSpec.describe PaymentProviders::Stripe::Payments::CreateService do
   subject(:create_service) { described_class.new(payment:, reference:, metadata:) }
 
   let(:customer) { create(:customer, payment_provider_code: code, country:) }

--- a/spec/services/payment_providers/stripe/validate_incoming_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/validate_incoming_webhook_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Stripe::ValidateIncomingWebhookService, type: :service do
+RSpec.describe PaymentProviders::Stripe::ValidateIncomingWebhookService do
   subject(:result) do
     described_class.call(payload:, signature:, payment_provider:)
   end

--- a/spec/services/payment_providers/stripe/webhooks/charge_dispute_closed_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/charge_dispute_closed_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Stripe::Webhooks::ChargeDisputeClosedService, type: :service do
+RSpec.describe PaymentProviders::Stripe::Webhooks::ChargeDisputeClosedService do
   subject(:service) { described_class.new(organization_id:, event:) }
 
   let(:organization_id) { organization.id }

--- a/spec/services/payment_providers/stripe/webhooks/customer_updated_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/customer_updated_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerUpdatedService, type: :service do
+RSpec.describe PaymentProviders::Stripe::Webhooks::CustomerUpdatedService do
   subject(:webhook_service) { described_class.new(organization_id: organization.id, event:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/payment_intent_succeeded_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService, type: :service do
+RSpec.describe PaymentProviders::Stripe::Webhooks::PaymentIntentSucceededService do
   subject(:event_service) { described_class.new(organization_id: organization.id, event:) }
 
   let(:event) { ::Stripe::Event.construct_from(JSON.parse(event_json)) }

--- a/spec/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service_spec.rb
+++ b/spec/services/payment_providers/stripe/webhooks/setup_intent_succeeded_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::Stripe::Webhooks::SetupIntentSucceededService, type: :service do
+RSpec.describe PaymentProviders::Stripe::Webhooks::SetupIntentSucceededService do
   subject(:webhook_service) { described_class.new(organization_id: organization.id, event:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/payment_providers/stripe_service_spec.rb
+++ b/spec/services/payment_providers/stripe_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentProviders::StripeService, type: :service do
+RSpec.describe PaymentProviders::StripeService do
   subject(:stripe_service) { described_class.new(membership.user) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/payment_receipts/create_service_spec.rb
+++ b/spec/services/payment_receipts/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentReceipts::CreateService, type: :service do
+RSpec.describe PaymentReceipts::CreateService do
   let(:invoice) { create(:invoice, customer:, organization:, total_amount_cents: 10000, status: :finalized) }
   let(:organization) { create(:organization) }
   let(:billing_entity) { organization.default_billing_entity }

--- a/spec/services/payment_receipts/generate_pdf_service_spec.rb
+++ b/spec/services/payment_receipts/generate_pdf_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentReceipts::GeneratePdfService, type: :service do
+RSpec.describe PaymentReceipts::GeneratePdfService do
   subject(:payment_receipt_generate_service) { described_class.new(payment_receipt:, context:) }
 
   let(:context) { "graphql" }

--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::CreateService, type: :service do
+RSpec.describe PaymentRequests::CreateService do
   subject(:create_service) { described_class.new(organization:, params:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/payment_requests/payments/adyen_service_spec.rb
+++ b/spec/services/payment_requests/payments/adyen_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::Payments::AdyenService, type: :service do
+RSpec.describe PaymentRequests::Payments::AdyenService do
   subject(:adyen_service) { described_class.new(payment_request) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/payment_requests/payments/cashfree_service_spec.rb
+++ b/spec/services/payment_requests/payments/cashfree_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::Payments::CashfreeService, type: :service do
+RSpec.describe PaymentRequests::Payments::CashfreeService do
   subject(:cashfree_service) { described_class.new(payment_request) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/payment_requests/payments/create_service_spec.rb
+++ b/spec/services/payment_requests/payments/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::Payments::CreateService, type: :service do
+RSpec.describe PaymentRequests::Payments::CreateService do
   subject(:create_service) { described_class.new(payable: payment_request, payment_provider: provider) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/payment_requests/payments/deliver_error_webhook_service_spec.rb
+++ b/spec/services/payment_requests/payments/deliver_error_webhook_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::Payments::DeliverErrorWebhookService, type: :service do
+RSpec.describe PaymentRequests::Payments::DeliverErrorWebhookService do
   subject(:webhook_service) { described_class.new(payment_request, params) }
 
   let(:payment_request) { create(:payment_request) }

--- a/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService, type: :service do
+RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService do
   subject(:generate_payment_url_service) { described_class.new(payable: payment_request) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/payment_requests/payments/gocardless_service_spec.rb
+++ b/spec/services/payment_requests/payments/gocardless_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::Payments::GocardlessService, type: :service do
+RSpec.describe PaymentRequests::Payments::GocardlessService do
   subject(:gocardless_service) { described_class.new(payment_request) }
 
   let(:organization) { create(:organization, webhook_url: "https://webhook.com") }

--- a/spec/services/payment_requests/payments/payment_providers/factory_spec.rb
+++ b/spec/services/payment_requests/payments/payment_providers/factory_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::Payments::PaymentProviders::Factory, type: :service do
+RSpec.describe PaymentRequests::Payments::PaymentProviders::Factory do
   subject(:factory_service) { described_class.new_instance(payable:) }
 
   let(:payment_provider) { "stripe" }

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
+RSpec.describe PaymentRequests::Payments::StripeService do
   subject(:stripe_service) { described_class.new(payment_request) }
 
   let(:customer) { create(:customer, payment_provider_code: code) }

--- a/spec/services/payments/lose_dispute_service_spec.rb
+++ b/spec/services/payments/lose_dispute_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Payments::LoseDisputeService, type: :service do
+RSpec.describe Payments::LoseDisputeService do
   subject(:lose_dispute_service) { described_class.new(payment:) }
 
   describe "#call" do

--- a/spec/services/payments/manual_create_service_spec.rb
+++ b/spec/services/payments/manual_create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Payments::ManualCreateService, type: :service do
+RSpec.describe Payments::ManualCreateService do
   subject(:service) { described_class.new(organization:, params:) }
 
   let(:invoice) { create(:invoice, customer:, organization:, total_amount_cents: 10000, status: :finalized) }

--- a/spec/services/payments/set_payment_method_data_service_spec.rb
+++ b/spec/services/payments/set_payment_method_data_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Payments::SetPaymentMethodDataService, type: :service do
+RSpec.describe Payments::SetPaymentMethodDataService do
   subject(:service) { described_class.new(payment:, provider_payment_method_id:) }
 
   let(:provider_payment_method_id) { "pm_1R2DFsQ8iJWBZFaMw3LLbR0r" }

--- a/spec/services/plans/apply_taxes_service_spec.rb
+++ b/spec/services/plans/apply_taxes_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Plans::ApplyTaxesService, type: :service do
+RSpec.describe Plans::ApplyTaxesService do
   subject(:apply_service) { described_class.new(plan:, tax_codes:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Plans::CreateService, type: :service do
+RSpec.describe Plans::CreateService do
   let(:plans_service) { described_class.new(create_args) }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Plans::DestroyService, type: :service do
+RSpec.describe Plans::DestroyService do
   subject(:destroy_service) { described_class.new(plan:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/plans/override_service_spec.rb
+++ b/spec/services/plans/override_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Plans::OverrideService, type: :service do
+RSpec.describe Plans::OverrideService do
   subject(:override_service) { described_class.new(plan: parent_plan, params:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/plans/prepare_destroy_service_spec.rb
+++ b/spec/services/plans/prepare_destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Plans::PrepareDestroyService, type: :service do
+RSpec.describe Plans::PrepareDestroyService do
   subject(:prepare_destroy_service) { described_class.new(plan:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/plans/update_amount_service_spec.rb
+++ b/spec/services/plans/update_amount_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Plans::UpdateAmountService, type: :service do
+RSpec.describe Plans::UpdateAmountService do
   subject(:update_service) { described_class.new(plan:, amount_cents:, expected_amount_cents:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Plans::UpdateService, type: :service do
+RSpec.describe Plans::UpdateService do
   subject(:plans_service) { described_class.new(plan:, params: update_args) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/plans/update_usage_thresholds_service_spec.rb
+++ b/spec/services/plans/update_usage_thresholds_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Plans::UpdateUsageThresholdsService, type: :service do
+RSpec.describe Plans::UpdateUsageThresholdsService do
   subject { described_class.call(plan:, usage_thresholds_params:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/pricing_units/create_service_spec.rb
+++ b/spec/services/pricing_units/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PricingUnits::CreateService, type: :service do
+RSpec.describe PricingUnits::CreateService do
   describe "#call" do
     subject(:result) { described_class.call(params) }
 

--- a/spec/services/pricing_units/update_service_spec.rb
+++ b/spec/services/pricing_units/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PricingUnits::UpdateService, type: :service do
+RSpec.describe PricingUnits::UpdateService do
   describe "#call" do
     subject(:result) { described_class.call(pricing_unit:, params:) }
 

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::ActivateService, type: :service, clickhouse: true do
+RSpec.describe Subscriptions::ActivateService, clickhouse: true do
   subject(:activate_service) { described_class.new(timestamp: timestamp.to_i) }
 
   let(:timestamp) { Time.current }

--- a/spec/services/subscriptions/charge_cache_service_spec.rb
+++ b/spec/services/subscriptions/charge_cache_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::ChargeCacheService, type: :service do
+RSpec.describe Subscriptions::ChargeCacheService do
   subject(:cache_service) { described_class.new(subscription:, charge:, charge_filter:) }
 
   let(:subscription) { create(:subscription) }

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::CreateService, type: :service do
+RSpec.describe Subscriptions::CreateService do
   subject(:create_service) { described_class.new(customer:, plan:, params:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
+RSpec.describe Subscriptions::Dates::MonthlyService do
   subject(:date_service) { described_class.new(subscription, billing_at, false) }
 
   let(:subscription) do

--- a/spec/services/subscriptions/dates/quarterly_service_spec.rb
+++ b/spec/services/subscriptions/dates/quarterly_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
+RSpec.describe Subscriptions::Dates::QuarterlyService do
   subject(:date_service) { described_class.new(subscription, billing_at, current_usage) }
 
   let(:subscription) do

--- a/spec/services/subscriptions/dates/semiannual_service_spec.rb
+++ b/spec/services/subscriptions/dates/semiannual_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::Dates::SemiannualService, type: :service do
+RSpec.describe Subscriptions::Dates::SemiannualService do
   subject(:date_service) { described_class.new(subscription, billing_at, current_usage) }
 
   let(:subscription) do

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
+RSpec.describe Subscriptions::Dates::WeeklyService do
   subject(:date_service) { described_class.new(subscription, billing_at, false) }
 
   let(:subscription) do

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
+RSpec.describe Subscriptions::Dates::YearlyService do
   subject(:date_service) { described_class.new(subscription, billing_at, current_usage) }
 
   let(:subscription) do

--- a/spec/services/subscriptions/dates_service_spec.rb
+++ b/spec/services/subscriptions/dates_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::DatesService, type: :service do
+RSpec.describe Subscriptions::DatesService do
   subject(:date_service) { described_class.new(subscription, billing_date, false) }
 
   let(:subscription) do

--- a/spec/services/subscriptions/flag_refreshed_service_spec.rb
+++ b/spec/services/subscriptions/flag_refreshed_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::FlagRefreshedService, type: :service do
+RSpec.describe Subscriptions::FlagRefreshedService do
   subject(:flag_service) { described_class.new(subscription.id) }
 
   let(:organization) { create(:organization, premium_integrations: %w[lifetime_usage]) }

--- a/spec/services/subscriptions/free_trial_billing_service_spec.rb
+++ b/spec/services/subscriptions/free_trial_billing_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::FreeTrialBillingService, type: :service do
+RSpec.describe Subscriptions::FreeTrialBillingService do
   subject(:service) { described_class.new(timestamp:) }
 
   let(:timestamp) { Time.zone.now }

--- a/spec/services/subscriptions/organization_billing_service_spec.rb
+++ b/spec/services/subscriptions/organization_billing_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::OrganizationBillingService, type: :service do
+RSpec.describe Subscriptions::OrganizationBillingService do
   subject(:billing_service) { described_class.new(organization:, billing_at:) }
 
   describe ".call" do

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::PlanUpgradeService, type: :service do
+RSpec.describe Subscriptions::PlanUpgradeService do
   subject(:result) do
     described_class.call(current_subscription: subscription, plan:, params:)
   end

--- a/spec/services/subscriptions/progressive_billed_amount_spec.rb
+++ b/spec/services/subscriptions/progressive_billed_amount_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::ProgressiveBilledAmount, type: :service do
+RSpec.describe Subscriptions::ProgressiveBilledAmount do
   subject(:service) { described_class.new(subscription:, timestamp:) }
 
   let(:timestamp) { Time.current }

--- a/spec/services/subscriptions/terminated_dates_service_spec.rb
+++ b/spec/services/subscriptions/terminated_dates_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::TerminatedDatesService, type: :service do
+RSpec.describe Subscriptions::TerminatedDatesService do
   subject(:terminated_date_service) { described_class.new(subscription:, invoice:, date_service:, match_invoice_subscription:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::UpdateService, type: :service do
+RSpec.describe Subscriptions::UpdateService do
   subject(:update_service) { described_class.new(subscription:, params:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::ValidateService, type: :service do
+RSpec.describe Subscriptions::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/services/taxes/auto_generate_service_spec.rb
+++ b/spec/services/taxes/auto_generate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Taxes::AutoGenerateService, type: :service do
+RSpec.describe Taxes::AutoGenerateService do
   subject(:auto_generate_service) { described_class.new(organization:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/taxes/create_service_spec.rb
+++ b/spec/services/taxes/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Taxes::CreateService, type: :service do
+RSpec.describe Taxes::CreateService do
   subject(:create_service) { described_class.new(organization:, params:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/taxes/destroy_service_spec.rb
+++ b/spec/services/taxes/destroy_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Taxes::DestroyService, type: :service do
+RSpec.describe Taxes::DestroyService do
   subject(:destroy_service) { described_class.new(tax:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/taxes/update_service_spec.rb
+++ b/spec/services/taxes/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Taxes::UpdateService, type: :service do
+RSpec.describe Taxes::UpdateService do
   subject(:update_service) { described_class.new(tax:, params:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/usage_monitoring/process_all_subscription_activities_service_spec.rb
+++ b/spec/services/usage_monitoring/process_all_subscription_activities_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::ProcessAllSubscriptionActivitiesService, type: :service do
+RSpec.describe UsageMonitoring::ProcessAllSubscriptionActivitiesService do
   describe "#call" do
     subject(:service) { described_class.new }
 

--- a/spec/services/usage_monitoring/process_organization_subscription_activities_service_spec.rb
+++ b/spec/services/usage_monitoring/process_organization_subscription_activities_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService, type: :service do
+RSpec.describe UsageMonitoring::ProcessOrganizationSubscriptionActivitiesService do
   describe "#call" do
     let(:organization) { create(:organization) }
     let(:service) { described_class.new(organization:) }

--- a/spec/services/usage_monitoring/process_subscription_activity_service_spec.rb
+++ b/spec/services/usage_monitoring/process_subscription_activity_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::ProcessSubscriptionActivityService, type: :service do
+RSpec.describe UsageMonitoring::ProcessSubscriptionActivityService do
   subject(:service) { described_class.new(subscription_activity:) }
 
   let(:organization) { create(:organization, premium_integrations:) }

--- a/spec/services/usage_monitoring/track_subscription_activity_service_spec.rb
+++ b/spec/services/usage_monitoring/track_subscription_activity_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::TrackSubscriptionActivityService, type: :service do
+RSpec.describe UsageMonitoring::TrackSubscriptionActivityService do
   subject { described_class.new(organization:, subscription:) }
 
   let(:organization) { create(:organization, premium_integrations: %w[lifetime_usage]) }

--- a/spec/services/usage_thresholds/override_service_spec.rb
+++ b/spec/services/usage_thresholds/override_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageThresholds::OverrideService, type: :service do
+RSpec.describe UsageThresholds::OverrideService do
   subject(:override_service) { described_class.new(usage_thresholds_params:, new_plan: plan) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsersService, type: :service do
+RSpec.describe UsersService do
   subject(:user_service) { described_class.new }
 
   describe "register" do

--- a/spec/services/utils/activity_log_spec.rb
+++ b/spec/services/utils/activity_log_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Utils::ActivityLog, type: :service do
+RSpec.describe Utils::ActivityLog do
   subject(:activity_log) { described_class }
 
   let(:membership) { create(:membership) }

--- a/spec/services/utils/api_log_spec.rb
+++ b/spec/services/utils/api_log_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Utils::ApiLog, type: :service do
+RSpec.describe Utils::ApiLog do
   subject(:api_log) { described_class }
 
   let(:api_key) { create(:api_key) }

--- a/spec/services/utils/datetime_spec.rb
+++ b/spec/services/utils/datetime_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Utils::Datetime, type: :service do
+RSpec.describe Utils::Datetime do
   subject(:datetime) { described_class }
 
   describe ".valid_format?" do

--- a/spec/services/utils/pdf_generator_spec.rb
+++ b/spec/services/utils/pdf_generator_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Utils::PdfGenerator, type: :service do
+RSpec.describe Utils::PdfGenerator do
   subject(:pdf_generator_service) { described_class.new(template: "invoices/v2", context: invoice) }
 
   let(:invoice) { create(:invoice) }

--- a/spec/services/validators/decimal_amount_service_spec.rb
+++ b/spec/services/validators/decimal_amount_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Validators::DecimalAmountService, type: :service do
+RSpec.describe Validators::DecimalAmountService do
   subject(:decimal_amount_service) { described_class.new(amount) }
 
   describe ".valid_amount?" do

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WalletTransactions::CreateFromParamsService, type: :service do
+RSpec.describe WalletTransactions::CreateFromParamsService do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:, currency:) }
   let(:currency) { "EUR" }

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WalletTransactions::CreateService, type: :service do
+RSpec.describe WalletTransactions::CreateService do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:, currency:) }
   let(:currency) { "EUR" }

--- a/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
+++ b/spec/services/wallet_transactions/mark_as_failed_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WalletTransactions::MarkAsFailedService, type: :service do
+RSpec.describe WalletTransactions::MarkAsFailedService do
   subject(:service) { described_class.new(wallet_transaction:) }
 
   let(:wallet_transaction) { create(:wallet_transaction, status: "pending") }

--- a/spec/services/wallet_transactions/recredit_service_spec.rb
+++ b/spec/services/wallet_transactions/recredit_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WalletTransactions::RecreditService, type: :service do
+RSpec.describe WalletTransactions::RecreditService do
   subject(:service) { described_class.new(wallet_transaction:) }
 
   let(:wallet_transaction) { create(:wallet_transaction, wallet:) }

--- a/spec/services/wallet_transactions/settle_service_spec.rb
+++ b/spec/services/wallet_transactions/settle_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WalletTransactions::SettleService, type: :service do
+RSpec.describe WalletTransactions::SettleService do
   subject(:service) { described_class.new(wallet_transaction:) }
 
   let(:wallet_transaction) { create(:wallet_transaction, status: "pending", settled_at: nil) }

--- a/spec/services/wallet_transactions/validate_service_spec.rb
+++ b/spec/services/wallet_transactions/validate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WalletTransactions::ValidateService, type: :service do
+RSpec.describe WalletTransactions::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/services/wallet_transactions/void_service_spec.rb
+++ b/spec/services/wallet_transactions/void_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WalletTransactions::VoidService, type: :service do
+RSpec.describe WalletTransactions::VoidService do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }

--- a/spec/services/wallets/apply_paid_credits_service_spec.rb
+++ b/spec/services/wallets/apply_paid_credits_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::ApplyPaidCreditsService, type: :service do
+RSpec.describe Wallets::ApplyPaidCreditsService do
   subject(:service) { described_class.new(wallet_transaction:) }
 
   describe ".call" do

--- a/spec/services/wallets/balance/decrease_service_spec.rb
+++ b/spec/services/wallets/balance/decrease_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::Balance::DecreaseService, type: :service do
+RSpec.describe Wallets::Balance::DecreaseService do
   subject(:create_service) { described_class.new(wallet:, wallet_transaction:) }
 
   let(:wallet) do

--- a/spec/services/wallets/balance/increase_service_spec.rb
+++ b/spec/services/wallets/balance/increase_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::Balance::IncreaseService, type: :service do
+RSpec.describe Wallets::Balance::IncreaseService do
   subject(:create_service) { described_class.new(wallet:, wallet_transaction:) }
 
   let(:credits_amount) { BigDecimal("4.5") }

--- a/spec/services/wallets/balance/refresh_ongoing_service_spec.rb
+++ b/spec/services/wallets/balance/refresh_ongoing_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::Balance::RefreshOngoingService, type: :service do
+RSpec.describe Wallets::Balance::RefreshOngoingService do
   subject(:refresh_service) { described_class.new(wallet:) }
 
   let(:wallet) do

--- a/spec/services/wallets/balance/update_ongoing_service_spec.rb
+++ b/spec/services/wallets/balance/update_ongoing_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::Balance::UpdateOngoingService, type: :service do
+RSpec.describe Wallets::Balance::UpdateOngoingService do
   subject(:update_service) { described_class.new(wallet:, update_params:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service do
+RSpec.describe Wallets::CreateIntervalWalletTransactionsService do
   subject(:create_interval_transactions_service) { described_class.new }
 
   describe ".call" do

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::CreateService, type: :service do
+RSpec.describe Wallets::CreateService do
   subject(:create_service) { described_class.new(params:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/wallets/recurring_transaction_rules/terminate_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/terminate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::RecurringTransactionRules::TerminateService, type: :service do
+RSpec.describe Wallets::RecurringTransactionRules::TerminateService do
   subject(:terminate_service) { described_class.new(recurring_transaction_rule:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/wallets/terminate_service_spec.rb
+++ b/spec/services/wallets/terminate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::TerminateService, type: :service do
+RSpec.describe Wallets::TerminateService do
   subject(:terminate_service) { described_class.new(wallet:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::ThresholdTopUpService, type: :service do
+RSpec.describe Wallets::ThresholdTopUpService do
   subject(:top_up_service) { described_class.new(wallet:) }
 
   let(:wallet) do

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::UpdateService, type: :service do
+RSpec.describe Wallets::UpdateService do
   subject(:update_service) { described_class.new(wallet:, params:) }
 
   let(:membership) { create(:membership) }

--- a/spec/services/wallets/validate_limitations_service_spec.rb
+++ b/spec/services/wallets/validate_limitations_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::ValidateLimitationsService, type: :service do
+RSpec.describe Wallets::ValidateLimitationsService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/services/wallets/validate_recurring_transaction_rules_service_spec.rb
+++ b/spec/services/wallets/validate_recurring_transaction_rules_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::ValidateRecurringTransactionRulesService, type: :service do
+RSpec.describe Wallets::ValidateRecurringTransactionRulesService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Wallets::ValidateService, type: :service do
+RSpec.describe Wallets::ValidateService do
   subject(:validate_service) { described_class.new(result, **args) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/services/webhook_endpoints/update_service_spec.rb
+++ b/spec/services/webhook_endpoints/update_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WebhookEndpoints::UpdateService, type: :service do
+RSpec.describe WebhookEndpoints::UpdateService do
   subject(:update_service) { described_class.new(id: webhook_endpoint.id, organization:, params: update_params) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/webhooks/base_service_spec.rb
+++ b/spec/services/webhooks/base_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Webhooks::BaseService, type: :service do
+RSpec.describe Webhooks::BaseService do
   subject(:webhook_service) { WebhooksSpec::DummyClass.new(object:) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/webhooks/retry_service_spec.rb
+++ b/spec/services/webhooks/retry_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Webhooks::RetryService, type: :service do
+RSpec.describe Webhooks::RetryService do
   subject(:retry_service) { described_class.new(webhook:) }
 
   let(:webhook) { create(:webhook, :failed) }

--- a/spec/services/webhooks/send_http_service_spec.rb
+++ b/spec/services/webhooks/send_http_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Webhooks::SendHttpService, type: :service do
+RSpec.describe Webhooks::SendHttpService do
   subject(:service) { described_class.new(webhook:) }
 
   let(:webhook_endpoint) { create(:webhook_endpoint, webhook_url: "https://wh.test.com") }


### PR DESCRIPTION
## Context

All service tests include the `type: :service` RSpec metadata but this metadata isn't actually used. This make the metadata more confusing than helpful.

## Description

This removes the unnecessary metadata.
