### PR TITLE
test(mailer): Remove unnecessary type spec metadata

### DIFF
--- a/spec/mailers/api_key_mailer_spec.rb
+++ b/spec/mailers/api_key_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ApiKeyMailer, type: :mailer do
+RSpec.describe ApiKeyMailer do
   describe "#rotated" do
     let(:mail) { described_class.with(api_key:).rotated }
     let(:api_key) { create(:api_key) }

--- a/spec/mailers/credit_note_mailer_spec.rb
+++ b/spec/mailers/credit_note_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNoteMailer, type: :mailer do
+RSpec.describe CreditNoteMailer do
   subject(:credit_note_mailer) { described_class }
 
   let(:credit_note) { create(:credit_note) }

--- a/spec/mailers/data_export_mailer_spec.rb
+++ b/spec/mailers/data_export_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataExportMailer, type: :mailer do
+RSpec.describe DataExportMailer do
   let(:data_export) { create(:data_export, :completed) }
 
   describe "#completed" do

--- a/spec/mailers/invoice_mailer_spec.rb
+++ b/spec/mailers/invoice_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe InvoiceMailer, type: :mailer do
+RSpec.describe InvoiceMailer do
   subject(:invoice_mailer) { described_class }
 
   let(:invoice) { create(:invoice, organization:, billing_entity:, fees_amount_cents: 100) }

--- a/spec/mailers/organization_mailer_spec.rb
+++ b/spec/mailers/organization_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe OrganizationMailer, type: :mailer do
+RSpec.describe OrganizationMailer do
   subject(:organization_mailer) do
     described_class.with(organization:, user: admin0, additions:, deletions:).authentication_methods_updated
   end

--- a/spec/mailers/password_reset_mailer_spec.rb
+++ b/spec/mailers/password_reset_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PasswordResetMailer, type: :mailer do
+RSpec.describe PasswordResetMailer do
   subject(:password_reset_mailer) { described_class }
 
   let(:password_reset) { create(:password_reset) }

--- a/spec/mailers/payment_receipt_mailer_spec.rb
+++ b/spec/mailers/payment_receipt_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentReceiptMailer, type: :mailer do
+RSpec.describe PaymentReceiptMailer do
   subject(:payment_receipt_mailer) { described_class }
 
   let(:payment_receipt) { create(:payment_receipt) }

--- a/spec/mailers/payment_request_mailer_spec.rb
+++ b/spec/mailers/payment_request_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequestMailer, type: :mailer do
+RSpec.describe PaymentRequestMailer do
   subject(:mailer) { described_class.with(payment_request:).requested }
 
   let(:organization) { create(:organization, document_number_prefix: "ORG-123B") }


### PR DESCRIPTION
## Context

All model tests have the `type: :mailer` RSpec metadata but this metadata is already inferred due to the `config.infer_spec_type_from_file_location!` setting (see the doc [here](https://rspec.info/features/8-0/rspec-rails/directory-structure/)).

## Description

This removes the redundant metadata.