### PR TITLE
fix: Ability to update a subscription without passing bm_id

### DIFF
--- a/app/services/charges/create_service.rb
+++ b/app/services/charges/create_service.rb
@@ -11,6 +11,7 @@ module Charges
 
     def call
       return result.not_found_failure!(resource: "plan") unless plan
+      return result.not_found_failure!(resource: "billable_metric") unless billable_metric
 
       ActiveRecord::Base.transaction do
         charge = plan.charges.new(
@@ -66,5 +67,9 @@ module Charges
     private
 
     attr_reader :plan, :params
+
+    def billable_metric
+      @billable_metric ||= plan.organization.billable_metrics.find_by(id: params[:billable_metric_id])
+    end
   end
 end

--- a/app/services/plans/chargeables_validation_service.rb
+++ b/app/services/plans/chargeables_validation_service.rb
@@ -31,7 +31,7 @@ module Plans
     def validate_billable_metrics
       return if charges.blank?
 
-      metric_ids = charges.map { |c| c[:billable_metric_id] }.uniq
+      metric_ids = charges.map { |c| c[:billable_metric_id] }.compact.uniq
       return if metric_ids.blank?
 
       if organization.billable_metrics.where(id: metric_ids).count != metric_ids.count

--- a/spec/services/charges/create_service_spec.rb
+++ b/spec/services/charges/create_service_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe Charges::CreateService, type: :service do
       end
     end
 
+    context "when billable metric is not found" do
+      let(:params) { {billable_metric_id: "non-existing-id"} }
+
+      it "returns an error" do
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq("billable_metric_not_found")
+      end
+    end
+
     context "when plan exists" do
       let(:sum_billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
 


### PR DESCRIPTION
## Description

Updating a subscription payload is not aligned with creating one.

Creating one only requires an `id` for charge override. However, the update one requires both the `id` **AND** the `billable_metric_id`.

The goal of this PR is to be able to update an existing subscription by passing a charge without its `billable_metric_id`.