### PR TITLE
test(invoice): Refactor invoice tests with `match_html_snapshot` matcher

### DIFF
--- a/spec/support/matchers/snapshot_matcher.rb
+++ b/spec/support/matchers/snapshot_matcher.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# This matcher allows to match an HTML snapshot with the same logic as the `match_snapshot` matcher.
+#
+# The main difference is that it will add the test context and a `.html` extension to the snapshot name. For instance, if the test is:
+#
+# ```ruby
+# context "when the customer is a company" do
+#   let(:customer) { create(:customer, :company) }
+#
+#   it "renders the invoice" do
+#     expect(rendered_template).to match_html_snapshot
+#   end
+# end
+# ```
+#
+# The snapshot name will be `when_the_customer_is_a_company/renders_the_invoice.html.snap`.
+#
+# Usage example:
+#
+# ```
+# it "renders the invoice" do
+#   expect(rendered_template).to match_html_snapshot
+# end
+# ```
+RSpec::Matchers.define :match_html_snapshot do |name = nil|
+  match(notify_expectation_failures: true) do |html|
+    name = [snapshot_name(RSpec.current_example.metadata), name].compact.join("/")
+    name += ".html"
+    html = beautify(html)
+    expect(html).to match_snapshot(name)
+  end
+
+  private
+
+  def snapshot_name(metadata)
+    description = metadata[:description].empty? ? metadata[:scoped_id] : metadata[:description]
+    example_group = metadata.key?(:example_group) ? metadata[:example_group] : metadata[:parent_example_group]
+
+    description = description.tr("/", "_").tr(" ", "_")
+    if example_group
+      [snapshot_name(example_group), description].join("/")
+    else
+      description
+    end
+  end
+
+  def beautify(html)
+    # Ensure the HTML string is properly encoded as UTF-8, otherwise we won't be able to write the snapshot
+    html = html.force_encoding("UTF-8") if html.encoding != Encoding::UTF_8
+    HtmlBeautifier.beautify(html, stop_on_errors: true)
+  end
+end

--- a/spec/views/app/views/templates/invoices/v4.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4.slim_spec.rb
@@ -9,10 +9,7 @@ require "rails_helper"
 
 RSpec.describe "templates/invoices/v4.slim", type: :view do
   subject(:rendered_template) do
-    # We have to use both `pretty: true` and `HtmlBeautifier.beautify` to ensure proper formatting which eases the
-    # snapshot diff review.
-    html = Slim::Template.new(template, 1, pretty: true).render(invoice)
-    HtmlBeautifier.beautify(html, stop_on_errors: true)
+    Slim::Template.new(template, 1, pretty: true).render(invoice)
   end
 
   let(:template) { Rails.root.join("app/views/templates/invoices/v4.slim") }
@@ -120,40 +117,12 @@ RSpec.describe "templates/invoices/v4.slim", type: :view do
     I18n.locale = :en
   end
 
-  def snapshot_name(metadata)
-    description =
-      if metadata[:description].empty?
-        # we have an "it { is_expected.to be something }" block
-        metadata[:scoped_id]
-      else
-        metadata[:description]
-      end
-    example_group =
-      if metadata.key?(:example_group)
-        metadata[:example_group]
-      else
-        metadata[:parent_example_group]
-      end
-
-    description = description.tr("/", "_").tr(" ", "_")
-    if example_group
-      [snapshot_name(example_group), description].join("/")
-    else
-      description
-    end
-  end
-
-  def expect_to_match_snapshot
-    snapshot_name = self.snapshot_name(RSpec.current_example.metadata)
-    expect(rendered_template).to match_snapshot("#{snapshot_name}.html")
-  end
-
   context "when invoice_type is credit" do
     context "when wallet transaction has a name" do
       let(:wallet_transaction_name) { "Wallet Transaction Name" }
 
       it "renders correctly" do
-        expect_to_match_snapshot
+        expect(rendered_template).to match_html_snapshot
       end
     end
 
@@ -164,7 +133,7 @@ RSpec.describe "templates/invoices/v4.slim", type: :view do
         let(:wallet_name) { nil }
 
         it "renders correctly" do
-          expect_to_match_snapshot
+          expect(rendered_template).to match_html_snapshot
         end
       end
 
@@ -172,7 +141,7 @@ RSpec.describe "templates/invoices/v4.slim", type: :view do
         let(:wallet_name) { "Premium Wallet" }
 
         it "renders correctly" do
-          expect_to_match_snapshot
+          expect(rendered_template).to match_html_snapshot
         end
       end
     end


### PR DESCRIPTION
## Context

Today, we have some tests that rely on snapshot testing to test the rendering of the invoice. It was an ad-hoc solution that was not made re-usable or flexible.

## Description

In order to be able to re-use the same testing strategy in other tests, I have extracted the snapshot logic into a `match_html_snapshot` matcher.