### PR TITLE
test(wallet): Test invoice rendering in wallet top-up scenarios tests

### DIFF
--- a/spec/scenarios/wallets/__snapshots__/Wallet_Transaction_with_rounding/rounds_the_amount_field_when_handling_paid_credits.html.snap
+++ b/spec/scenarios/wallets/__snapshots__/Wallet_Transaction_with_rounding/rounds_the_amount_field_when_handling_paid_credits.html.snap
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">Advance invoice</h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">Invoice Number</td>
+              <td class="body-2">ACM-8924-001-001</td>
+            </tr>
+            <tr>
+              <td class="body-1">Issue Date</td>
+              <td class="body-2">Jan 01, 2025</td>
+            </tr>
+            <tr>
+              <td class="body-1">Payment term</td>
+              <td class="body-2">0 days</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table"></table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">From</div>
+          <div class="body-2">ACME Corporation</div>
+          <div class="body-2">123 Business St</div>
+          <div class="body-2">Suite 100</div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">CA</div>
+          <div class="body-2">United States</div>
+          <div class="body-2">billing@acme.com</div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">Bill to</div>
+          <div class="body-2">Doe Corp - John Doe</div>
+          <div class="body-2">1234567890</div>
+          <div class="body-2">456 Customer Ave</div>
+          <div class="body-2">Apt 202</div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">NY</div>
+          <div class="body-2">United States</div>
+          <div class="body-2">john.doe@example.com</div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-4">€17.97</h2>
+        <div class="body-1">Due Jan 01, 2025</div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td class="body-2">Item</td>
+            <td class="body-2">Units</td>
+            <td class="body-2">Unit price</td>
+            <td class="body-2">Amount</td>
+          </tr>
+          <tr>
+            <td class="body-1">Prepaid credits - Wallet1</td>
+            <td class="body-2">17.97</td>
+            <td class="body-2">1.0</td>
+            <td class="body-2">€17.97</td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2"></td>
+            <td class="body-1">Total</td>
+            <td class="body-1">€17.97</td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24"></p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/support/pdf_helper.rb
+++ b/spec/support/pdf_helper.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
 module PdfHelper
-  def stub_pdf_generation(response_body = nil, status = 200)
-    response_body ||= File.read(Rails.root.join("spec/fixtures/blank.pdf"))
-
+  # This helper stubs the PDF generation request to return the input HTML as response so that it can be used in the tests.
+  def stub_pdf_generation
     stub_request(:post, "#{ENV["LAGO_PDF_URL"]}/forms/chromium/convert/html")
-      .to_return(body: response_body, status: status)
+      .to_return do |request|
+        env = {
+          "CONTENT_TYPE" => request.headers["Content-Type"],
+          "CONTENT_LENGTH" => request.headers["Content-Length"],
+          "rack.input" => StringIO.new(request.body)
+        }
+        params = Rack::Multipart.parse_multipart(env)
+        html = params["file1"][:tempfile].read
+        {body: html, status: 200}
+      end
   end
 end


### PR DESCRIPTION
## Context

We currently have some scenario tests related to wallet top-up but they don't actually test the impact on the generated PDF.

## Description

This adds an assertion on the wallet top-up scenario test to render and test the invoice via snapshot testing.

In order to do that, I had to modify the `stub_pdf_generation` to use the rendered HTML instead of a blank PDF in the mocked response. This way, the invoice file will contain the rendered HTML which we can test using `expect(invoice.file.download).to match_html_snapshot`. Note that the mocked response is currently not used and has no impact the test suite.