### PR TITLE
test(factory): Add `with_static_values` trait to some factories

### DIFF
--- a/spec/factories/billing_entities.rb
+++ b/spec/factories/billing_entities.rb
@@ -17,5 +17,17 @@ FactoryBot.define do
     trait :archived do
       archived_at { Time.current }
     end
+
+    trait :with_static_values do
+      name { "ACME Corporation" }
+      email { "billing@acme.com" }
+      address_line1 { "123 Business St" }
+      address_line2 { "Suite 100" }
+      city { "San Francisco" }
+      state { "CA" }
+      zipcode { "94105" }
+      country { "US" }
+      document_number_prefix { "ACM-8924" }
+    end
   end
 end

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -77,5 +77,24 @@ FactoryBot.define do
         create(:stripe_customer, customer:, payment_provider:)
       end
     end
+
+    trait :with_static_values do
+      with_same_billing_and_shipping_address
+
+      firstname { "John" }
+      lastname { "Doe" }
+      name { "John Doe" }
+      legal_name { "Doe Corp" }
+      legal_number { "1234567890" }
+      external_id { "customer_123" }
+      email { "john.doe@example.com" }
+      address_line1 { "456 Customer Ave" }
+      address_line2 { "Apt 202" }
+      city { "New York" }
+      state { "NY" }
+      zipcode { "10001" }
+      country { "US" }
+      phone { "+1-555-123-4567" }
+    end
   end
 end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -2,6 +2,10 @@
 
 FactoryBot.define do
   factory :organization do
+    transient do
+      with_static_values { false }
+    end
+
     name { Faker::Company.name }
     default_currency { "USD" }
 
@@ -9,7 +13,15 @@ FactoryBot.define do
     email_settings { ["invoice.finalized", "credit_note.created"] }
 
     api_keys { [association(:api_key, organization: instance)] }
-    billing_entities { [association(:billing_entity, organization: instance)] }
+    billing_entities do
+      [
+        association(
+          :billing_entity,
+          *(with_static_values ? [:with_static_values] : []),
+          organization: instance
+        )
+      ]
+    end
 
     transient do
       webhook_url { Faker::Internet.url }
@@ -38,6 +50,14 @@ FactoryBot.define do
       after :create do |org|
         create(:dunning_campaign, organization: org, applied_to_organization: true)
       end
+    end
+
+    trait :with_static_values do
+      with_static_values { true }
+
+      name { "ACME Corporation" }
+      default_currency { "USD" }
+      country { "US" }
     end
   end
 end

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_credit/when_wallet_transaction_has_a_name/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_credit/when_wallet_transaction_has_a_name/renders_correctly.html.snap
@@ -464,7 +464,7 @@
             Bill to
           </div>
           <div class="body-2">
-            John Doe
+            Doe Corp - John Doe
           </div>
           <div class="body-2">
             1234567890

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_credit/when_wallet_transaction_has_no_name/when_wallet_has_a_name/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_credit/when_wallet_transaction_has_no_name/when_wallet_has_a_name/renders_correctly.html.snap
@@ -464,7 +464,7 @@
             Bill to
           </div>
           <div class="body-2">
-            John Doe
+            Doe Corp - John Doe
           </div>
           <div class="body-2">
             1234567890

--- a/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_credit/when_wallet_transaction_has_no_name/when_wallet_has_no_name/renders_correctly.html.snap
+++ b/spec/views/app/views/templates/invoices/__snapshots__/templates_invoices_v4.slim/when_invoice_type_is_credit/when_wallet_transaction_has_no_name/when_wallet_has_no_name/renders_correctly.html.snap
@@ -464,7 +464,7 @@
             Bill to
           </div>
           <div class="body-2">
-            John Doe
+            Doe Corp - John Doe
           </div>
           <div class="body-2">
             1234567890

--- a/spec/views/app/views/templates/invoices/v4.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4.slim_spec.rb
@@ -33,49 +33,16 @@ RSpec.describe "templates/invoices/v4.slim", type: :view do
   end
   # Static organization data for consistent rendering
   let(:organization) do
-    build_stubbed(
-      :organization,
-      name: "ACME Corporation",
-      default_currency: "USD",
-      country: "US"
-    )
+    build_stubbed(:organization, :with_static_values)
   end
 
   # Static billing entity data for consistent rendering
   let(:billing_entity) do
-    build_stubbed(
-      :billing_entity,
-      organization: organization,
-      name: "ACME Corporation",
-      email: "billing@acme.com",
-      address_line1: "123 Business St",
-      address_line2: "Suite 100",
-      city: "San Francisco",
-      state: "CA",
-      zipcode: "94105",
-      country: "US"
-    )
+    build_stubbed(:billing_entity, :with_static_values, organization: organization)
   end
   # Static customer data
   let(:customer) do
-    build_stubbed(
-      :customer,
-      organization: organization,
-      firstname: nil,
-      lastname: nil,
-      name: "John Doe",
-      legal_name: "John Doe",
-      legal_number: "1234567890",
-      external_id: "customer_123",
-      email: "john.doe@example.com",
-      address_line1: "456 Customer Ave",
-      address_line2: "Apt 202",
-      city: "New York",
-      state: "NY",
-      zipcode: "10001",
-      country: "US",
-      phone: "+1-555-123-4567"
-    )
+    build_stubbed(:customer, :with_static_values, organization: organization)
   end
 
   # Static wallet data


### PR DESCRIPTION
## Context

In order to test invoice rendering, we are using static values for customer, organization and billing entities. These values are not really re-usable as is. If we want to add more invoice rendering tests, we'd have to copy-paste those values.

## Description

This adds a `with_static_values` trait to the customer, organization and billing entity factories which sets fixed values for attributes used in the invoice rendering. We can then easily re-use those factories with:

```ruby
let(:customer) { create(:customer, :with_static_values) }
```
