### PR TITLE
fix(wallet): Fix behavior when `invoice_requires_successful_payment` is nil

### DIFF
--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -24,6 +24,7 @@ class Wallet < ApplicationRecord
 
   validates :rate_amount, numericality: {greater_than: 0}
   validates :currency, inclusion: {in: currency_list}
+  validates :invoice_requires_successful_payment, exclusion: [nil]
   validates :paid_top_up_min_amount_cents, numericality: {greater_than: 0}, allow_nil: true
   validates :paid_top_up_max_amount_cents, numericality: {greater_than: 0}, allow_nil: true
   validate :paid_top_up_max_greater_than_or_equal_min

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -41,6 +41,7 @@ class WalletTransaction < ApplicationRecord
 
   validates :priority, presence: true, inclusion: {in: 1..50}
   validates :name, length: {minimum: 1, maximum: 255}, allow_nil: true
+  validates :invoice_requires_successful_payment, exclusion: [nil]
 
   delegate :customer, to: :wallet
 

--- a/app/services/wallet_transactions/create_from_params_service.rb
+++ b/app/services/wallet_transactions/create_from_params_service.rb
@@ -28,9 +28,8 @@ module WalletTransactions
       @priority = params[:priority] || 50
       invoice_requires_successful_payment = if params.key?(:invoice_requires_successful_payment)
         ActiveModel::Type::Boolean.new.cast(params[:invoice_requires_successful_payment])
-      else
-        result.current_wallet.invoice_requires_successful_payment
       end
+      invoice_requires_successful_payment ||= result.current_wallet.invoice_requires_successful_payment
       wallet = result.current_wallet
 
       ActiveRecord::Base.transaction do

--- a/app/services/wallet_transactions/create_from_params_service.rb
+++ b/app/services/wallet_transactions/create_from_params_service.rb
@@ -29,7 +29,7 @@ module WalletTransactions
       invoice_requires_successful_payment = if params.key?(:invoice_requires_successful_payment)
         ActiveModel::Type::Boolean.new.cast(params[:invoice_requires_successful_payment])
       end
-      invoice_requires_successful_payment ||= result.current_wallet.invoice_requires_successful_payment
+      invoice_requires_successful_payment = result.current_wallet.invoice_requires_successful_payment if invoice_requires_successful_payment.nil?
       wallet = result.current_wallet
 
       ActiveRecord::Base.transaction do

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -30,7 +30,7 @@ module Wallets
       }
 
       if params.key?(:invoice_requires_successful_payment)
-        attributes[:invoice_requires_successful_payment] = ActiveModel::Type::Boolean.new.cast(params[:invoice_requires_successful_payment])
+        attributes[:invoice_requires_successful_payment] = ActiveModel::Type::Boolean.new.cast(params[:invoice_requires_successful_payment]) || false
       end
 
       if params.key?(:applies_to)

--- a/spec/factories/wallet_transactions.rb
+++ b/spec/factories/wallet_transactions.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     credit_amount { "1.00" }
     settled_at { Time.zone.now }
     name { "Custom Transaction Name" }
+    invoice_requires_successful_payment { false }
 
     trait :failed do
       status { "failed" }

--- a/spec/factories/wallets.rb
+++ b/spec/factories/wallets.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     credits_balance { 0 }
     balance_cents { 0 }
     consumed_credits { 0 }
+    invoice_requires_successful_payment { false }
 
     trait :terminated do
       status { "terminated" }

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Wallet do
 
   describe "validations" do
     it { is_expected.to validate_numericality_of(:rate_amount).is_greater_than(0) }
+    it { is_expected.to validate_inclusion_of(:currency).in_array(described_class.currency_list) }
+    it { is_expected.to validate_exclusion_of(:invoice_requires_successful_payment).in_array([nil]) }
     it { is_expected.to validate_numericality_of(:paid_top_up_min_amount_cents).is_greater_than(0).allow_nil }
     it { is_expected.to validate_numericality_of(:paid_top_up_max_amount_cents).is_greater_than(0).allow_nil }
 

--- a/spec/models/wallet_transaction_spec.rb
+++ b/spec/models/wallet_transaction_spec.rb
@@ -3,9 +3,12 @@
 require "rails_helper"
 
 RSpec.describe WalletTransaction do
-  it { is_expected.to validate_presence_of(:priority) }
-  it { is_expected.to validate_inclusion_of(:priority).in_range(1..50) }
-  it { is_expected.to validate_length_of(:name).is_at_most(255).is_at_least(1).allow_nil }
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:priority) }
+    it { is_expected.to validate_inclusion_of(:priority).in_range(1..50) }
+    it { is_expected.to validate_length_of(:name).is_at_most(255).is_at_least(1).allow_nil }
+    it { is_expected.to validate_exclusion_of(:invoice_requires_successful_payment).in_array([nil]) }
+  end
 
   describe "associations" do
     it { is_expected.to belong_to(:wallet) }

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -16,9 +16,11 @@ RSpec.describe WalletTransactions::CreateFromParamsService do
       balance_cents: 1000,
       credits_balance: 10.0,
       ongoing_balance_cents: 1000,
-      credits_ongoing_balance: 10.0
+      credits_ongoing_balance: 10.0,
+      invoice_requires_successful_payment: wallet_invoice_requires_successful_payment
     )
   end
+  let(:wallet_invoice_requires_successful_payment) { false }
   let(:rate_amount) { 1 }
 
   before do
@@ -163,6 +165,40 @@ RSpec.describe WalletTransactions::CreateFromParamsService do
 
         it "creates wallet transactions with nil name" do
           expect(result.wallet_transactions).to all(have_attributes(name: nil))
+        end
+      end
+    end
+
+    context "with invoice_requires_successful_payment parameter" do
+      let(:params) do
+        {
+          wallet_id: wallet.id,
+          paid_credits:,
+          invoice_requires_successful_payment:
+        }
+      end
+
+      let(:invoice_requires_successful_payment) { true }
+
+      it "creates wallet transactions with specified invoice_requires_successful_payment" do
+        expect(result.wallet_transactions).to all(have_attributes(invoice_requires_successful_payment:))
+      end
+
+      context "when invoice_requires_successful_payment parameter is null" do
+        let(:invoice_requires_successful_payment) { nil }
+
+        context "when wallet's invoice_requires_successful_payment is true" do
+          let(:wallet_invoice_requires_successful_payment) { true }
+
+          it "creates wallet transactions with specified invoice_requires_successful_payment" do
+            expect(result.wallet_transactions).to all(have_attributes(invoice_requires_successful_payment: true))
+          end
+        end
+
+        context "when wallet's invoice_requires_successful_payment is false" do
+          it "creates wallet transactions with specified invoice_requires_successful_payment" do
+            expect(result.wallet_transactions).to all(have_attributes(invoice_requires_successful_payment: false))
+          end
         end
       end
     end

--- a/spec/services/wallet_transactions/create_from_params_service_spec.rb
+++ b/spec/services/wallet_transactions/create_from_params_service_spec.rb
@@ -184,6 +184,18 @@ RSpec.describe WalletTransactions::CreateFromParamsService do
         expect(result.wallet_transactions).to all(have_attributes(invoice_requires_successful_payment:))
       end
 
+      context "when invoice_requires_successful_payment parameter is false" do
+        let(:invoice_requires_successful_payment) { false }
+
+        context "when wallet's invoice_requires_successful_payment is true" do
+          let(:wallet_invoice_requires_successful_payment) { true }
+
+          it "creates wallet transactions with specified invoice_requires_successful_payment" do
+            expect(result.wallet_transactions).to all(have_attributes(invoice_requires_successful_payment: false))
+          end
+        end
+      end
+
       context "when invoice_requires_successful_payment parameter is null" do
         let(:invoice_requires_successful_payment) { nil }
 

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Wallets::CreateService do
       end
     end
 
-    context "when invoice_requires_successful_payment is set " do
+    context "when invoice_requires_successful_payment is set" do
       let(:params) do
         {
           name: "New Wallet",
@@ -95,18 +95,30 @@ RSpec.describe Wallets::CreateService do
           currency: "EUR",
           rate_amount: "1.00",
           paid_credits:,
-          invoice_requires_successful_payment: true
+          invoice_requires_successful_payment:
         }
       end
+      let(:invoice_requires_successful_payment) { true }
 
       it "follows the value" do
-        aggregate_failures do
+        expect { service_result }.to change(Wallet, :count).by(1)
+
+        expect(service_result).to be_success
+
+        wallet = service_result.wallet
+        expect(wallet.invoice_requires_successful_payment).to eq(true)
+      end
+
+      context "when invoice_requires_successful_payment is null" do
+        let(:invoice_requires_successful_payment) { nil }
+
+        it "defaults to false" do
           expect { service_result }.to change(Wallet, :count).by(1)
 
           expect(service_result).to be_success
 
           wallet = service_result.wallet
-          expect(wallet.invoice_requires_successful_payment).to eq(true)
+          expect(wallet.invoice_requires_successful_payment).to eq(false)
         end
       end
     end


### PR DESCRIPTION
## Context

Because `ActiveModel::Type::Boolean.new.cast(nil)` returns `nil` and the `invoice_requires_successful_payment` has a `NOT NULL` db constraint, we fail to create a wallet or wallet transaction when `invoice_requires_successful_payment` is set to `nil`.

## Description

This fixes this behavior by defaulting to `false` when creating a wallet and defaulting to the wallet's value when creating a transaction. Validations were also added on the model to ensure saving such value will fail.
