### PR TITLE
feat(customer): Add `search_term` filters to `GET /api/v1/customers`

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -35,7 +35,8 @@ module Api
       end
 
       def index
-        filter_params = params.permit(billing_entity_codes: [], account_type: [])
+        filter_params = params.permit(:search_term, billing_entity_codes: [], account_type: [])
+        search_term = filter_params.delete(:search_term)
         billing_entity_codes = filter_params.delete(:billing_entity_codes)
         if billing_entity_codes.present?
           billing_entities = current_organization.all_billing_entities.where(code: billing_entity_codes)
@@ -48,6 +49,7 @@ module Api
             page: params[:page],
             limit: params[:per_page] || PER_PAGE
           },
+          search_term:,
           filters: filter_params.merge(billing_entity_ids: billing_entities&.ids)
         )
 

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -118,47 +118,53 @@ RSpec.describe CustomersQuery, type: :query do
     end
   end
 
-  context "when searching for /de/ term" do
-    let(:search_term) { "de" }
+  context "with search_term" do
+    context "when searching for name 'de'" do
+      let(:search_term) { "de" }
 
-    it "returns only two customers" do
-      expect(returned_ids.count).to eq(2)
-      expect(returned_ids).to include(customer_first.id)
-      expect(returned_ids).to include(customer_second.id)
-      expect(returned_ids).not_to include(customer_third.id)
+      it "returns only two customers" do
+        expect(returned_ids).to match_array([customer_first.id, customer_second.id])
+      end
     end
-  end
 
-  context "when searching for firstname 'Jane'" do
-    let(:search_term) { "Jane" }
+    context "when searching for firstname 'Jane'" do
+      let(:search_term) { "Jane" }
 
-    it "returns only one customer" do
-      expect(returned_ids.count).to eq(1)
-      expect(returned_ids).to include(customer_second.id)
-      expect(returned_ids).not_to include(customer_first.id)
-      expect(returned_ids).not_to include(customer_third.id)
+      it "returns only one customer" do
+        expect(returned_ids).to eq([customer_second.id])
+      end
     end
-  end
 
-  context "when searching for lastname 'Johnson'" do
-    let(:search_term) { "Johnson" }
+    context "when searching for lastname 'Johnson'" do
+      let(:search_term) { "Johnson" }
 
-    it "returns only one customer" do
-      expect(returned_ids.count).to eq(1)
-      expect(returned_ids).not_to include(customer_first.id)
-      expect(returned_ids).not_to include(customer_second.id)
-      expect(returned_ids).to include(customer_third.id)
+      it "returns only one customer" do
+        expect(returned_ids).to eq([customer_third.id])
+      end
     end
-  end
 
-  context "when searching for legalname 'Company'" do
-    let(:search_term) { "Company" }
+    context "when searching for legalname 'Company'" do
+      let(:search_term) { "Company" }
 
-    it "returns only one customer" do
-      expect(returned_ids.count).to eq(1)
-      expect(returned_ids).not_to include(customer_first.id)
-      expect(returned_ids).not_to include(customer_second.id)
-      expect(returned_ids).to include(customer_third.id)
+      it "returns only one customer" do
+        expect(returned_ids).to eq([customer_third.id])
+      end
+    end
+
+    context "when searching for external_id '11'" do
+      let(:search_term) { "11" }
+
+      it "returns only one customer" do
+        expect(returned_ids).to eq([customer_first.id])
+      end
+    end
+
+    context "when searching for email '1@e'" do
+      let(:search_term) { "1@e" }
+
+      it "returns only one customer" do
+        expect(returned_ids).to eq([customer_first.id])
+      end
     end
   end
 

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -477,6 +477,20 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         end
       end
     end
+
+    context "when filtering by search_term" do
+      let(:params) { {search_term: "oo b"} }
+      let!(:customer) { create(:customer, organization:, name: "Foo Bar") }
+
+      it "returns customers for the specified search_term" do
+        subject
+
+        expect(response).to have_http_status(:ok)
+
+        expect(json[:customers].count).to eq(1)
+        expect(json[:customers].first[:lago_id]).to eq(customer.id)
+      end
+    end
   end
 
   describe "GET /api/v1/customers/:customer_id" do


### PR DESCRIPTION
## Context

The filtering on the `GET /api/v1/customers` endpoint is too limited.

## Description

This adds a `search_term` filter to be able to search by `name`, `firstname`, `lastname`, `legalname`, `external_id` or `email`.
