### PR TITLE
feat(customer): Add billing address filters to `GET /api/v1/customers`

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -35,7 +35,14 @@ module Api
       end
 
       def index
-        filter_params = params.permit(:search_term, billing_entity_codes: [], account_type: [])
+        filter_params = params.permit(
+          :search_term,
+          countries: [],
+          states: [],
+          zipcodes: [],
+          billing_entity_codes: [],
+          account_type: []
+        )
         search_term = filter_params.delete(:search_term)
         billing_entity_codes = filter_params.delete(:billing_entity_codes)
         if billing_entity_codes.present?

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -16,10 +16,36 @@ RSpec.describe CustomersQuery, type: :query do
   let(:billing_entity2) { create(:billing_entity, organization:) }
 
   let(:customer_first) do
-    create(:customer, organization:, name: "defgh", firstname: "John", lastname: "Doe", legal_name: "Legalname", external_id: "11", email: "1@example.com", billing_entity: billing_entity1)
+    create(
+      :customer,
+      organization:,
+      name: "defgh",
+      firstname: "John",
+      lastname: "Doe",
+      legal_name: "Legalname",
+      external_id: "11",
+      email: "1@example.com",
+      country: "US",
+      state: "CA",
+      zipcode: "90001",
+      billing_entity: billing_entity1
+    )
   end
   let(:customer_second) do
-    create(:customer, organization:, name: "abcde", firstname: "Jane", lastname: "Smith", legal_name: "other name", external_id: "22", email: "2@example.com", billing_entity: billing_entity1)
+    create(
+      :customer,
+      organization:,
+      name: "abcde",
+      firstname: "Jane",
+      lastname: "Smith",
+      legal_name: "other name",
+      external_id: "22",
+      email: "2@example.com",
+      country: "FR",
+      state: "Paris",
+      zipcode: "75001",
+      billing_entity: billing_entity1
+    )
   end
   let(:customer_third) do
     create(
@@ -32,6 +58,9 @@ RSpec.describe CustomersQuery, type: :query do
       lastname: "Johnson",
       legal_name: "Company name",
       name: "presuv",
+      country: "DE",
+      state: "Berlin",
+      zipcode: "10115",
       billing_entity: billing_entity2
     )
   end
@@ -165,6 +194,30 @@ RSpec.describe CustomersQuery, type: :query do
       it "returns only one customer" do
         expect(returned_ids).to eq([customer_first.id])
       end
+    end
+  end
+
+  context "when filtering by countries" do
+    let(:filters) { {countries: ["US", "FR"]} }
+
+    it "returns only two customers" do
+      expect(returned_ids).to match_array([customer_first.id, customer_second.id])
+    end
+  end
+
+  context "when filtering by states" do
+    let(:filters) { {states: ["CA", "Paris"]} }
+
+    it "returns only two customers" do
+      expect(returned_ids).to match_array([customer_first.id, customer_second.id])
+    end
+  end
+
+  context "when filtering by zipcodes" do
+    let(:filters) { {zipcodes: ["10115", "75001"]} }
+
+    it "returns only two customers" do
+      expect(returned_ids).to match_array([customer_third.id, customer_second.id])
     end
   end
 

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -478,6 +478,46 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       end
     end
 
+    context "when filtering by countries" do
+      let(:params) { {countries: ["US", "FR"]} }
+
+      let!(:customer) { create(:customer, organization:, country: "US") }
+      let!(:customer2) { create(:customer, organization:, country: "FR") }
+
+      it "returns only two customers" do
+        subject
+        expect(response).to have_http_status(:success)
+        expect(json[:customers].count).to eq(2)
+        expect(json[:customers].map { |customer| customer[:lago_id] }).to match_array([customer.id, customer2.id])
+      end
+    end
+
+    context "when filtering by states" do
+      let(:params) { {states: ["CA", "Paris"]} }
+      let!(:customer) { create(:customer, organization:, state: "CA") }
+      let!(:customer2) { create(:customer, organization:, state: "Paris") }
+
+      it "returns only two customers" do
+        subject
+        expect(response).to have_http_status(:success)
+        expect(json[:customers].count).to eq(2)
+        expect(json[:customers].map { |customer| customer[:lago_id] }).to match_array([customer.id, customer2.id])
+      end
+    end
+
+    context "when filtering by zipcodes" do
+      let(:params) { {zipcodes: ["10115", "75001"]} }
+      let!(:customer) { create(:customer, organization:, zipcode: "10115") }
+      let!(:customer2) { create(:customer, organization:, zipcode: "75001") }
+
+      it "returns only two customers" do
+        subject
+        expect(response).to have_http_status(:success)
+        expect(json[:customers].count).to eq(2)
+        expect(json[:customers].map { |customer| customer[:lago_id] }).to match_array([customer.id, customer2.id])
+      end
+    end
+
     context "when filtering by search_term" do
       let(:params) { {search_term: "oo b"} }
       let!(:customer) { create(:customer, organization:, name: "Foo Bar") }


### PR DESCRIPTION
## Context

The filtering on the `GET /api/v1/customers` endpoint is too limited.

## Description

This adds a `countries[]`, `states[]` and `zip_codes[]` filters to this endpoint.
