### PR TITLE
test: Remove unnecessary `type` RSpec metadata

### DIFF
--- a/spec/contracts/queries/billable_metrics_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/billable_metrics_query_filters_contract_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Queries::BillableMetricsQueryFiltersContract, type: :contract do
+RSpec.describe Queries::BillableMetricsQueryFiltersContract do
   subject(:result) { described_class.new.call(filters:, search_term:) }
 
   let(:filters) { {} }

--- a/spec/contracts/queries/customers_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/customers_query_filters_contract_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Queries::CustomersQueryFiltersContract, type: :contract do
+RSpec.describe Queries::CustomersQueryFiltersContract do
   subject(:result) { described_class.new.call(filters:, search_term:) }
 
   let(:filters) { {} }

--- a/spec/contracts/queries/invoices_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/invoices_query_filters_contract_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Queries::InvoicesQueryFiltersContract, type: :contract do
+RSpec.describe Queries::InvoicesQueryFiltersContract do
   subject(:result) { described_class.new.call(filters:, search_term:) }
 
   let(:filters) { {} }

--- a/spec/contracts/queries/payment_receipts_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/payment_receipts_query_filters_contract_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Queries::PaymentReceiptsQueryFiltersContract, type: :contract do
+RSpec.describe Queries::PaymentReceiptsQueryFiltersContract do
   subject(:result) { described_class.new.call(filters:) }
 
   let(:filters) { {} }

--- a/spec/contracts/queries/payments_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/payments_query_filters_contract_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Queries::PaymentsQueryFiltersContract, type: :contract do
+RSpec.describe Queries::PaymentsQueryFiltersContract do
   subject(:result) { described_class.new.call(filters:) }
 
   let(:filters) { {} }

--- a/spec/controllers/concerns/api_loggable_spec.rb
+++ b/spec/controllers/concerns/api_loggable_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ApiLoggable, type: :controller do
+RSpec.describe ApiLoggable do
   # rubocop:disable RSpec/DescribedClass
   controller(ApplicationController) do
     include ApiLoggable

--- a/spec/controllers/concerns/premium_feature_only_spec.rb
+++ b/spec/controllers/concerns/premium_feature_only_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PremiumFeatureOnly, type: :controller do
+RSpec.describe PremiumFeatureOnly do
   include ApiHelper
 
   # rubocop:disable RSpec/DescribedClass

--- a/spec/serializers/v1/billing_entity_serializer_spec.rb
+++ b/spec/serializers/v1/billing_entity_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe V1::BillingEntitySerializer, type: :serializer do
+RSpec.describe V1::BillingEntitySerializer do
   subject(:serializer) { described_class.new(billing_entity, root_name: "billing_entity", includes: includes_options) }
 
   let(:organization) { create(:organization) }

--- a/spec/serializers/v1/credit_note_serializer_spec.rb
+++ b/spec/serializers/v1/credit_note_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe V1::CreditNoteSerializer, type: :serializer do
+RSpec.describe V1::CreditNoteSerializer do
   subject(:serializer) do
     described_class.new(credit_note, root_name: "credit_note", includes: %i[customer items error_details])
   end

--- a/spec/serializers/v1/entitlement/feature_serializer_spec.rb
+++ b/spec/serializers/v1/entitlement/feature_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe V1::Entitlement::FeatureSerializer, type: :serializer do
+RSpec.describe V1::Entitlement::FeatureSerializer do
   subject { described_class.new(feature) }
 
   let(:organization) { create(:organization) }

--- a/spec/serializers/v1/entitlement/subscription_entitlement_serializer_spec.rb
+++ b/spec/serializers/v1/entitlement/subscription_entitlement_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe V1::Entitlement::SubscriptionEntitlementSerializer, type: :serializer do
+RSpec.describe V1::Entitlement::SubscriptionEntitlementSerializer do
   subject(:serializer) do
     ::CollectionSerializer.new(
       collection,

--- a/spec/serializers/v1/invoices/applied_invoice_custom_section_serializer_spec.rb
+++ b/spec/serializers/v1/invoices/applied_invoice_custom_section_serializer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe V1::Invoices::AppliedInvoiceCustomSectionSerializer, type: :serializer do
+RSpec.describe V1::Invoices::AppliedInvoiceCustomSectionSerializer do
   subject(:serializer) { described_class.new(applied_invoice_custom_section) }
 
   let(:invoice) { create(:invoice) }

--- a/spec/services/validators/metadata_validator_spec.rb
+++ b/spec/services/validators/metadata_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Validators::MetadataValidator, type: :validator do
+RSpec.describe Validators::MetadataValidator do
   subject(:metadata_validator) { described_class.new(metadata) }
 
   let(:max_keys) { Validators::MetadataValidator::DEFAULT_CONFIG[:max_keys] }

--- a/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
+++ b/spec/services/validators/wallet_transaction_amount_limits_validator_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Validators::WalletTransactionAmountLimitsValidator, type: :validator do
+RSpec.describe Validators::WalletTransactionAmountLimitsValidator do
   let(:result) { BaseService::LegacyResult.new }
   let(:wallet) { create(:wallet, paid_top_up_min_amount_cents:, paid_top_up_max_amount_cents:) }
   let(:paid_top_up_min_amount_cents) { 5_00 }


### PR DESCRIPTION
## Context

All controller tests have the `type: :controller` RSpec metadata but this metadata is already infered due to the `config.infer_spec_type_from_file_location!` setting.

Also the `contract`, `serializer` and `validator` type metadata are not actually used.

## Description

This removes the redundant and unnecessary metadata.

