### PR TITLE
test(credit-note): Fix flaky `Invoices::ApplyTaxesService` test

### DIFF
--- a/spec/services/credit_notes/apply_taxes_service_spec.rb
+++ b/spec/services/credit_notes/apply_taxes_service_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe CreditNotes::ApplyTaxesService do
   end
 
   context "when local taxes are applied" do
-    let(:tax1) { create(:tax, organization:, rate: 12) }
-    let(:tax2) { create(:tax, organization:, rate: 8) }
+    let(:tax1) { create(:tax, organization:, code: "tax1", rate: 12) }
+    let(:tax2) { create(:tax, organization:, code: "tax2", rate: 8) }
 
     let(:fee_applied_tax11) do
       create(
@@ -119,40 +119,36 @@ RSpec.describe CreditNotes::ApplyTaxesService do
       it "creates applied taxes" do
         result = apply_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
+        expect(result).to be_success
 
-          aggregate_failures do
-            applied_taxes = result.applied_taxes
-            expect(applied_taxes.count).to eq(2)
+        applied_taxes = result.applied_taxes.sort_by(&:tax_code)
+        expect(applied_taxes.count).to eq(2)
 
-            expect(applied_taxes[0]).to have_attributes(
-              credit_note: nil,
-              tax: tax1,
-              tax_description: tax1.description,
-              tax_code: tax1.code,
-              tax_name: tax1.name,
-              tax_rate: 12,
-              amount_currency: invoice.currency,
-              amount_cents: 7
-            )
+        expect(applied_taxes[0]).to have_attributes(
+          credit_note: nil,
+          tax: tax1,
+          tax_description: tax1.description,
+          tax_code: tax1.code,
+          tax_name: tax1.name,
+          tax_rate: 12,
+          amount_currency: invoice.currency,
+          amount_cents: 7
+        )
 
-            expect(applied_taxes[1]).to have_attributes(
-              credit_note: nil,
-              tax: tax2,
-              tax_description: tax2.description,
-              tax_code: tax2.code,
-              tax_name: tax2.name,
-              tax_rate: 8,
-              amount_currency: invoice.currency,
-              amount_cents: 3
-            )
+        expect(applied_taxes[1]).to have_attributes(
+          credit_note: nil,
+          tax: tax2,
+          tax_description: tax2.description,
+          tax_code: tax2.code,
+          tax_name: tax2.name,
+          tax_rate: 8,
+          amount_currency: invoice.currency,
+          amount_cents: 3
+        )
 
-            expect(result.taxes_amount_cents.round).to eq(10)
-            expect(result.taxes_rate).to eq(17.71429)
-            expect(result.coupons_adjustment_amount_cents.round).to eq(12)
-          end
-        end
+        expect(result.taxes_amount_cents.round).to eq(10)
+        expect(result.taxes_rate).to eq(17.71429)
+        expect(result.coupons_adjustment_amount_cents.round).to eq(12)
       end
     end
   end
@@ -210,40 +206,36 @@ RSpec.describe CreditNotes::ApplyTaxesService do
         it "creates applied taxes" do
           result = apply_service.call
 
-          aggregate_failures do
-            expect(result).to be_success
+          expect(result).to be_success
 
-            aggregate_failures do
-              applied_taxes = result.applied_taxes
-              expect(applied_taxes.count).to eq(2)
+          applied_taxes = result.applied_taxes.sort_by(&:tax_code)
+          expect(applied_taxes.count).to eq(2)
 
-              expect(applied_taxes[0]).to have_attributes(
-                credit_note: nil,
-                tax: nil,
-                tax_description: provider_tax_1.type,
-                tax_code: provider_tax_1.code,
-                tax_name: provider_tax_1.name,
-                tax_rate: provider_tax_1.rate,
-                amount_currency: invoice.currency,
-                amount_cents: 7
-              )
+          expect(applied_taxes[0]).to have_attributes(
+            credit_note: nil,
+            tax: nil,
+            tax_description: provider_tax_1.type,
+            tax_code: provider_tax_1.code,
+            tax_name: provider_tax_1.name,
+            tax_rate: provider_tax_1.rate,
+            amount_currency: invoice.currency,
+            amount_cents: 7
+          )
 
-              expect(applied_taxes[1]).to have_attributes(
-                credit_note: nil,
-                tax: nil,
-                tax_description: provider_tax_2.type,
-                tax_code: provider_tax_2.code,
-                tax_name: provider_tax_2.name,
-                tax_rate: provider_tax_2.rate,
-                amount_currency: invoice.currency,
-                amount_cents: 3
-              )
+          expect(applied_taxes[1]).to have_attributes(
+            credit_note: nil,
+            tax: nil,
+            tax_description: provider_tax_2.type,
+            tax_code: provider_tax_2.code,
+            tax_name: provider_tax_2.name,
+            tax_rate: provider_tax_2.rate,
+            amount_currency: invoice.currency,
+            amount_cents: 3
+          )
 
-              expect(result.taxes_amount_cents.round).to eq(10)
-              expect(result.taxes_rate).to eq(17.71429)
-              expect(result.coupons_adjustment_amount_cents.round).to eq(12)
-            end
-          end
+          expect(result.taxes_amount_cents.round).to eq(10)
+          expect(result.taxes_rate).to eq(17.71429)
+          expect(result.coupons_adjustment_amount_cents.round).to eq(12)
         end
       end
     end
@@ -278,40 +270,36 @@ RSpec.describe CreditNotes::ApplyTaxesService do
         it "creates applied taxes" do
           result = apply_service.call
 
-          aggregate_failures do
-            expect(result).to be_success
+          expect(result).to be_success
 
-            aggregate_failures do
-              applied_taxes = result.applied_taxes
-              expect(applied_taxes.count).to eq(2)
+          applied_taxes = result.applied_taxes.sort_by(&:tax_code)
+          expect(applied_taxes.count).to eq(2)
 
-              expect(applied_taxes[0]).to have_attributes(
-                credit_note: nil,
-                tax: nil,
-                tax_description: provider_tax_1.type,
-                tax_code: provider_tax_1.code,
-                tax_name: provider_tax_1.name,
-                tax_rate: provider_tax_1.rate,
-                amount_currency: invoice.currency,
-                amount_cents: 14
-              )
+          expect(applied_taxes[0]).to have_attributes(
+            credit_note: nil,
+            tax: nil,
+            tax_description: provider_tax_1.type,
+            tax_code: provider_tax_1.code,
+            tax_name: provider_tax_1.name,
+            tax_rate: provider_tax_1.rate,
+            amount_currency: invoice.currency,
+            amount_cents: 14
+          )
 
-              expect(applied_taxes[1]).to have_attributes(
-                credit_note: nil,
-                tax: nil,
-                tax_description: provider_tax_2.type,
-                tax_code: provider_tax_2.code,
-                tax_name: provider_tax_2.name,
-                tax_rate: provider_tax_2.rate,
-                amount_currency: invoice.currency,
-                amount_cents: 5
-              )
+          expect(applied_taxes[1]).to have_attributes(
+            credit_note: nil,
+            tax: nil,
+            tax_description: provider_tax_2.type,
+            tax_code: provider_tax_2.code,
+            tax_name: provider_tax_2.name,
+            tax_rate: provider_tax_2.rate,
+            amount_currency: invoice.currency,
+            amount_cents: 5
+          )
 
-              expect(result.taxes_amount_cents.round).to eq(19)
-              expect(result.taxes_rate).to eq(27.14286)
-              expect(result.coupons_adjustment_amount_cents.round).to eq(0)
-            end
-          end
+          expect(result.taxes_amount_cents.round).to eq(19)
+          expect(result.taxes_rate).to eq(27.14286)
+          expect(result.coupons_adjustment_amount_cents.round).to eq(0)
         end
       end
     end
@@ -322,13 +310,11 @@ RSpec.describe CreditNotes::ApplyTaxesService do
       it "succeeds" do
         result = apply_service.call
         expect(result).to be_success
-        aggregate_failures do
-          applied_taxes = result.applied_taxes
-          expect(applied_taxes.count).to eq(0)
-          expect(result.taxes_amount_cents.round).to eq(0)
-          expect(result.taxes_rate).to eq(0)
-          expect(result.coupons_adjustment_amount_cents.round).to eq(12)
-        end
+        applied_taxes = result.applied_taxes
+        expect(applied_taxes.count).to eq(0)
+        expect(result.taxes_amount_cents.round).to eq(0)
+        expect(result.taxes_rate).to eq(0)
+        expect(result.coupons_adjustment_amount_cents.round).to eq(12)
       end
     end
   end


### PR DESCRIPTION
## Context

The `spec/services/credit_notes/apply_taxes_service_spec.rb` is currently flaky due to random ordering:

```ruby
  1) Invoices::ApplyTaxesService call with non zero fees amount creates applied taxes
     Got 2 failures from failure aggregation block.
     # ./spec/services/invoices/apply_taxes_service_spec.rb:41:in 'block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:217:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:209:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:208:in 'block (2 levels) in <top (required)>'

     1.1) Failure/Error:
            expect(applied_taxes[0]).to have_attributes(
              invoice:,
              tax: tax1,
              tax_description: tax1.description,
              tax_code: tax1.code,
              tax_name: tax1.name,
              tax_rate: 10,
              amount_currency: invoice.currency,
              amount_cents: 300,
              fees_amount_cents: 3000

            expected #<Invoice::AppliedTax id: "8efb5b4f-fb17-4fac-9280-d40d838f32ae", invoice_id: "334c60fe-0000-4c60-b9b..._cents: 2000, taxable_base_amount_cents: 0, organization_id: "47bc267d-93ad-4986-84b5-770ce8dca04c"> to have attributes {:amount_cents => 300, :amount_currency => "EUR", :fees_amount_cents => 3000, :invoice => #<Invoice i...-b4c5-3131e75f58d5", :tax_description => "French Standard VAT", :tax_name => "VAT", :tax_rate => 10} but had attributes {:amount_cents => 240, :amount_currency => "EUR", :fees_amount_cents => 2000, :invoice => #<Invoice i...04a-de4160214ad3", :tax_description => "French Standard VAT", :tax_name => "VAT", :tax_rate => 12.0}
            Diff:



            @@ -1,10 +1,10 @@
            -:amount_cents => 300,
            +:amount_cents => 240,
             :amount_currency => "EUR",
            -:fees_amount_cents => 3000,
            +:fees_amount_cents => 2000,
             :invoice => #<Invoice id: "334c60fe-0000-4c60-b9be-a93780d605ab", created_at: "2025-09-23 09:53:11.612069000 +0000", updated_at: "2025-09-23 09:53:11.612069000 +0000", issuing_date: "2025-09-22", taxes_amount_cents: 540, total_amount_cents: 0, invoice_type: "subscription", payment_status: "pending", number: "SHI-AB79-DRAFT", sequential_id: nil, file: nil, customer_id: "b3eb90a5-fa1a-4877-8176-46b4afbcbb6a", taxes_rate: 18.0, status: "finalized", timezone: "UTC", payment_attempts: 0, ready_for_payment_processing: true, organization_id: "47bc267d-93ad-4986-84b5-770ce8dca04c", version_number: 4, currency: "EUR", fees_amount_cents: 3000, coupons_amount_cents: 0, credit_notes_amount_cents: 0, prepaid_credit_amount_cents: 0, sub_total_excluding_taxes_amount_cents: 3000, sub_total_including_taxes_amount_cents: 0, payment_due_date: "2025-09-22", net_payment_term: 0, voided_at: nil, organization_sequential_id: 786298, ready_to_be_refreshed: false, payment_dispute_lost_at: nil, skip_charges: false, payment_overdue: false, progressive_billing_credit_amount_cents: 0, tax_status: nil, total_paid_amount_cents: 0, self_billed: false, applied_grace_period: nil, billing_entity_id: "4ef67cff-a4eb-4072-96bc-6be71864ab79", billing_entity_sequential_id: nil, finalized_at: nil, voided_invoice_id: nil>,
            -:tax => #<Tax id: "38554ceb-1852-4a1b-a396-c3199213ec56", organization_id: "47bc267d-93ad-4986-84b5-770ce8dca04c", description: "French Standard VAT", code: "vat-fede6ece-0742-4bc0-b4c5-3131e75f58d5", name: "VAT", rate: 10.0, created_at: "2025-09-23 09:53:11.741812000 +0000", updated_at: "2025-09-23 09:53:11.741812000 +0000", applied_to_organization: false, auto_generated: false, deleted_at: nil>,
            -:tax_code => "vat-fede6ece-0742-4bc0-b4c5-3131e75f58d5",
            +:tax => #<Tax id: "ebdce5cc-649d-4d83-abd9-88a4ca921fcd", organization_id: "47bc267d-93ad-4986-84b5-770ce8dca04c", description: "French Standard VAT", code: "vat-f4ccd295-b149-43f0-b04a-de4160214ad3", name: "VAT", rate: 12.0, created_at: "2025-09-23 09:53:11.814194000 +0000", updated_at: "2025-09-23 09:53:11.814194000 +0000", applied_to_organization: false, auto_generated: false, deleted_at: nil>,
            +:tax_code => "vat-f4ccd295-b149-43f0-b04a-de4160214ad3",
             :tax_description => "French Standard VAT",
             :tax_name => "VAT",
            -:tax_rate => 10,
            +:tax_rate => 12.0,
          # ./spec/services/invoices/apply_taxes_service_spec.rb:47:in 'block (5 levels) in <top (required)>'

     1.2) Failure/Error:
            expect(applied_taxes[1]).to have_attributes(
              invoice:,
              tax: tax2,
              tax_description: tax2.description,
              tax_code: tax2.code,
              tax_name: tax2.name,
              tax_rate: 12,
              amount_currency: invoice.currency,
              amount_cents: 240,
              fees_amount_cents: 2000

            expected #<Invoice::AppliedTax id: "182896a4-765f-4957-88be-c4acd19431e0", invoice_id: "334c60fe-0000-4c60-b9b..._cents: 3000, taxable_base_amount_cents: 0, organization_id: "47bc267d-93ad-4986-84b5-770ce8dca04c"> to have attributes {:amount_cents => 240, :amount_currency => "EUR", :fees_amount_cents => 2000, :invoice => #<Invoice i...-b04a-de4160214ad3", :tax_description => "French Standard VAT", :tax_name => "VAT", :tax_rate => 12} but had attributes {:amount_cents => 300, :amount_currency => "EUR", :fees_amount_cents => 3000, :invoice => #<Invoice i...4c5-3131e75f58d5", :tax_description => "French Standard VAT", :tax_name => "VAT", :tax_rate => 10.0}
            Diff:



            @@ -1,10 +1,10 @@
            -:amount_cents => 240,
            +:amount_cents => 300,
             :amount_currency => "EUR",
            -:fees_amount_cents => 2000,
            +:fees_amount_cents => 3000,
             :invoice => #<Invoice id: "334c60fe-0000-4c60-b9be-a93780d605ab", created_at: "2025-09-23 09:53:11.612069000 +0000", updated_at: "2025-09-23 09:53:11.612069000 +0000", issuing_date: "2025-09-22", taxes_amount_cents: 540, total_amount_cents: 0, invoice_type: "subscription", payment_status: "pending", number: "SHI-AB79-DRAFT", sequential_id: nil, file: nil, customer_id: "b3eb90a5-fa1a-4877-8176-46b4afbcbb6a", taxes_rate: 18.0, status: "finalized", timezone: "UTC", payment_attempts: 0, ready_for_payment_processing: true, organization_id: "47bc267d-93ad-4986-84b5-770ce8dca04c", version_number: 4, currency: "EUR", fees_amount_cents: 3000, coupons_amount_cents: 0, credit_notes_amount_cents: 0, prepaid_credit_amount_cents: 0, sub_total_excluding_taxes_amount_cents: 3000, sub_total_including_taxes_amount_cents: 0, payment_due_date: "2025-09-22", net_payment_term: 0, voided_at: nil, organization_sequential_id: 786298, ready_to_be_refreshed: false, payment_dispute_lost_at: nil, skip_charges: false, payment_overdue: false, progressive_billing_credit_amount_cents: 0, tax_status: nil, total_paid_amount_cents: 0, self_billed: false, applied_grace_period: nil, billing_entity_id: "4ef67cff-a4eb-4072-96bc-6be71864ab79", billing_entity_sequential_id: nil, finalized_at: nil, voided_invoice_id: nil>,
            -:tax => #<Tax id: "ebdce5cc-649d-4d83-abd9-88a4ca921fcd", organization_id: "47bc267d-93ad-4986-84b5-770ce8dca04c", description: "French Standard VAT", code: "vat-f4ccd295-b149-43f0-b04a-de4160214ad3", name: "VAT", rate: 12.0, created_at: "2025-09-23 09:53:11.814194000 +0000", updated_at: "2025-09-23 09:53:11.814194000 +0000", applied_to_organization: false, auto_generated: false, deleted_at: nil>,
            -:tax_code => "vat-f4ccd295-b149-43f0-b04a-de4160214ad3",
            +:tax => #<Tax id: "38554ceb-1852-4a1b-a396-c3199213ec56", organization_id: "47bc267d-93ad-4986-84b5-770ce8dca04c", description: "French Standard VAT", code: "vat-fede6ece-0742-4bc0-b4c5-3131e75f58d5", name: "VAT", rate: 10.0, created_at: "2025-09-23 09:53:11.741812000 +0000", updated_at: "2025-09-23 09:53:11.741812000 +0000", applied_to_organization: false, auto_generated: false, deleted_at: nil>,
            +:tax_code => "vat-fede6ece-0742-4bc0-b4c5-3131e75f58d5",
             :tax_description => "French Standard VAT",
             :tax_name => "VAT",
            -:tax_rate => 12,
            +:tax_rate => 10.0,
          # ./spec/services/invoices/apply_taxes_service_spec.rb:59:in 'block (5 levels) in <top (required)>'

  2) Invoices::ApplyTaxesService call with coupon applied to invoice taxes the coupon at pro-rata of each fees
     Got 2 failures from failure aggregation block.
     # ./spec/services/invoices/apply_taxes_service_spec.rb:149:in 'block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:217:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:209:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:208:in 'block (2 levels) in <top (required)>'

     2.1) Failure/Error:
            expect(applied_taxes[0]).to have_attributes(
              invoice:,
              tax: tax1,
              tax_description: tax1.description,
              tax_code: tax1.code,
              tax_name: tax1.name,
              tax_rate: 10,
              amount_currency: invoice.currency,
              amount_cents: 200,
              fees_amount_cents: 2000

            expected #<Invoice::AppliedTax id: "fc40869b-efe0-4a1f-b1e1-b88f1fdda4bb", invoice_id: "70f8c9ee-9789-4f74-9d3..._cents: 1333, taxable_base_amount_cents: 0, organization_id: "f27d622e-2228-4394-a4a3-e802b208a3ae"> to have attributes {:amount_cents => 200, :amount_currency => "EUR", :fees_amount_cents => 2000, :invoice => #<Invoice i...-bb68-81600724095a", :tax_description => "French Standard VAT", :tax_name => "VAT", :tax_rate => 10} but had attributes {:amount_cents => 160, :amount_currency => "EUR", :fees_amount_cents => 1333, :invoice => #<Invoice i...de8-ea71408780d0", :tax_description => "French Standard VAT", :tax_name => "VAT", :tax_rate => 12.0}
            Diff:



            @@ -1,10 +1,10 @@
            -:amount_cents => 200,
            +:amount_cents => 160,
             :amount_currency => "EUR",
            -:fees_amount_cents => 2000,
            +:fees_amount_cents => 1333,
             :invoice => #<Invoice id: "70f8c9ee-9789-4f74-9d33-c9aa93c5d88a", created_at: "2025-09-23 09:53:12.124214000 +0000", updated_at: "2025-09-23 09:53:12.124214000 +0000", issuing_date: "2025-09-22", taxes_amount_cents: 360, total_amount_cents: 0, invoice_type: "subscription", payment_status: "pending", number: "NIT-D4F5-DRAFT", sequential_id: nil, file: nil, customer_id: "885e87b5-1de2-4fa5-92bd-ad4c0d70dc8a", taxes_rate: 18.0, status: "finalized", timezone: "UTC", payment_attempts: 0, ready_for_payment_processing: true, organization_id: "f27d622e-2228-4394-a4a3-e802b208a3ae", version_number: 4, currency: "EUR", fees_amount_cents: 3000, coupons_amount_cents: 1000, credit_notes_amount_cents: 0, prepaid_credit_amount_cents: 0, sub_total_excluding_taxes_amount_cents: 2000, sub_total_including_taxes_amount_cents: 0, payment_due_date: "2025-09-22", net_payment_term: 0, voided_at: nil, organization_sequential_id: 185318, ready_to_be_refreshed: false, payment_dispute_lost_at: nil, skip_charges: false, payment_overdue: false, progressive_billing_credit_amount_cents: 0, tax_status: nil, total_paid_amount_cents: 0, self_billed: false, applied_grace_period: nil, billing_entity_id: "d666b74d-ef26-40d7-992d-7eb5b138d4f5", billing_entity_sequential_id: nil, finalized_at: nil, voided_invoice_id: nil>,
            -:tax => #<Tax id: "47a8de5e-8353-44cb-9219-a0717c84f47e", organization_id: "f27d622e-2228-4394-a4a3-e802b208a3ae", description: "French Standard VAT", code: "vat-4c2c6078-09f7-4217-bb68-81600724095a", name: "VAT", rate: 10.0, created_at: "2025-09-23 09:53:12.180402000 +0000", updated_at: "2025-09-23 09:53:12.180402000 +0000", applied_to_organization: false, auto_generated: false, deleted_at: nil>,
            -:tax_code => "vat-4c2c6078-09f7-4217-bb68-81600724095a",
            +:tax => #<Tax id: "b5c8a34f-4c66-43de-8575-f2f8c19a0dd4", organization_id: "f27d622e-2228-4394-a4a3-e802b208a3ae", description: "French Standard VAT", code: "vat-140ec3ce-0c98-453a-8de8-ea71408780d0", name: "VAT", rate: 12.0, created_at: "2025-09-23 09:53:12.240966000 +0000", updated_at: "2025-09-23 09:53:12.240966000 +0000", applied_to_organization: false, auto_generated: false, deleted_at: nil>,
            +:tax_code => "vat-140ec3ce-0c98-453a-8de8-ea71408780d0",
             :tax_description => "French Standard VAT",
             :tax_name => "VAT",
            -:tax_rate => 10,
            +:tax_rate => 12.0,
          # ./spec/services/invoices/apply_taxes_service_spec.rb:155:in 'block (5 levels) in <top (required)>'

     2.2) Failure/Error:
            expect(applied_taxes[1]).to have_attributes(
              invoice:,
              tax: tax2,
              tax_description: tax2.description,
              tax_code: tax2.code,
              tax_name: tax2.name,
              tax_rate: 12,
              amount_currency: invoice.currency,
              amount_cents: 160,
              fees_amount_cents: 1333

            expected #<Invoice::AppliedTax id: "52a98dc3-63e6-41e3-959e-c04be73b439d", invoice_id: "70f8c9ee-9789-4f74-9d3..._cents: 2000, taxable_base_amount_cents: 0, organization_id: "f27d622e-2228-4394-a4a3-e802b208a3ae"> to have attributes {:amount_cents => 160, :amount_currency => "EUR", :fees_amount_cents => 1333, :invoice => #<Invoice i...-8de8-ea71408780d0", :tax_description => "French Standard VAT", :tax_name => "VAT", :tax_rate => 12} but had attributes {:amount_cents => 200, :amount_currency => "EUR", :fees_amount_cents => 2000, :invoice => #<Invoice i...b68-81600724095a", :tax_description => "French Standard VAT", :tax_name => "VAT", :tax_rate => 10.0}
            Diff:



            @@ -1,10 +1,10 @@
            -:amount_cents => 160,
            +:amount_cents => 200,
             :amount_currency => "EUR",
            -:fees_amount_cents => 1333,
            +:fees_amount_cents => 2000,
             :invoice => #<Invoice id: "70f8c9ee-9789-4f74-9d33-c9aa93c5d88a", created_at: "2025-09-23 09:53:12.124214000 +0000", updated_at: "2025-09-23 09:53:12.124214000 +0000", issuing_date: "2025-09-22", taxes_amount_cents: 360, total_amount_cents: 0, invoice_type: "subscription", payment_status: "pending", number: "NIT-D4F5-DRAFT", sequential_id: nil, file: nil, customer_id: "885e87b5-1de2-4fa5-92bd-ad4c0d70dc8a", taxes_rate: 18.0, status: "finalized", timezone: "UTC", payment_attempts: 0, ready_for_payment_processing: true, organization_id: "f27d622e-2228-4394-a4a3-e802b208a3ae", version_number: 4, currency: "EUR", fees_amount_cents: 3000, coupons_amount_cents: 1000, credit_notes_amount_cents: 0, prepaid_credit_amount_cents: 0, sub_total_excluding_taxes_amount_cents: 2000, sub_total_including_taxes_amount_cents: 0, payment_due_date: "2025-09-22", net_payment_term: 0, voided_at: nil, organization_sequential_id: 185318, ready_to_be_refreshed: false, payment_dispute_lost_at: nil, skip_charges: false, payment_overdue: false, progressive_billing_credit_amount_cents: 0, tax_status: nil, total_paid_amount_cents: 0, self_billed: false, applied_grace_period: nil, billing_entity_id: "d666b74d-ef26-40d7-992d-7eb5b138d4f5", billing_entity_sequential_id: nil, finalized_at: nil, voided_invoice_id: nil>,
            -:tax => #<Tax id: "b5c8a34f-4c66-43de-8575-f2f8c19a0dd4", organization_id: "f27d622e-2228-4394-a4a3-e802b208a3ae", description: "French Standard VAT", code: "vat-140ec3ce-0c98-453a-8de8-ea71408780d0", name: "VAT", rate: 12.0, created_at: "2025-09-23 09:53:12.240966000 +0000", updated_at: "2025-09-23 09:53:12.240966000 +0000", applied_to_organization: false, auto_generated: false, deleted_at: nil>,
            -:tax_code => "vat-140ec3ce-0c98-453a-8de8-ea71408780d0",
            +:tax => #<Tax id: "47a8de5e-8353-44cb-9219-a0717c84f47e", organization_id: "f27d622e-2228-4394-a4a3-e802b208a3ae", description: "French Standard VAT", code: "vat-4c2c6078-09f7-4217-bb68-81600724095a", name: "VAT", rate: 10.0, created_at: "2025-09-23 09:53:12.180402000 +0000", updated_at: "2025-09-23 09:53:12.180402000 +0000", applied_to_organization: false, auto_generated: false, deleted_at: nil>,
            +:tax_code => "vat-4c2c6078-09f7-4217-bb68-81600724095a",
             :tax_description => "French Standard VAT",
             :tax_name => "VAT",
            -:tax_rate => 12,
            +:tax_rate => 10.0,
          # ./spec/services/invoices/apply_taxes_service_spec.rb:167:in 'block (5 levels) in <top (required)>'

Finished in 1.01 seconds (files took 4.86 seconds to load)
3 examples, 2 failures

Failed examples:

rspec ./spec/services/invoices/apply_taxes_service_spec.rb:38 # Invoices::ApplyTaxesService call with non zero fees amount creates applied taxes
rspec ./spec/services/invoices/apply_taxes_service_spec.rb:146 # Invoices::ApplyTaxesService call with coupon applied to invoice taxes the coupon at pro-rata of each fees
```

## Description

This fixes those tests by ordering the taxes by `code`.