### PR TITLE
fix(wallet-update): Removing a wallet scope limitation doesn't work

### DIFF
--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -33,6 +33,8 @@ module Wallets
         end
         if params.key?(:applies_to)
           wallet.allowed_fee_types = params[:applies_to][:fee_types] if params[:applies_to].key?(:fee_types)
+        else
+          wallet.allowed_fee_types = []
         end
 
         process_billable_metrics

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -484,5 +484,17 @@ RSpec.describe Wallets::UpdateService do
         end
       end
     end
+
+    context "when wallet has existing allowed_fee_types and applies_to is not provided" do
+      let(:wallet) { create(:wallet, customer:, allowed_fee_types: %w[charge]) }
+
+      it "clears the allowed_fee_types" do
+        result = update_service.call
+
+        expect(result).to be_success
+        expect(result.wallet.reload.allowed_fee_types).to eq([])
+        expect(SendWebhookJob).to have_been_enqueued.with("wallet.updated", Wallet)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

If you add a wallet scope limitation to a wallet (charge fees, commitment fees, or subscription fees) and save the wallet, then edit the wallet again to remove the limitation, the limitation does not get removed. 

## Description

When the param `applies_to` is not sent, we update the `wallet` `allowed_fee_types` to empty.