### PR TITLE
feat(customer): Add `currencies[]` filter to `GET /api/v1/customers`

### DIFF
--- a/app/contracts/queries/customers_query_filters_contract.rb
+++ b/app/contracts/queries/customers_query_filters_contract.rb
@@ -6,6 +6,10 @@ module Queries
       required(:filters).hash do
         optional(:account_type).array(:string, included_in?: Customer::ACCOUNT_TYPES.values)
         optional(:billing_entity_ids).maybe { array(:string, format?: Regex::UUID) }
+        optional(:countries).array(:string, included_in?: ISO3166::Country.codes)
+        optional(:states).array(:string)
+        optional(:zipcodes).array(:string)
+        optional(:currencies).array(:string, included_in?: Customer.currency_list)
       end
 
       optional(:search_term).maybe(:string)

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -37,6 +37,7 @@ module Api
       def index
         filter_params = params.permit(
           :search_term,
+          currencies: [],
           countries: [],
           states: [],
           zipcodes: [],

--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -11,7 +11,8 @@ class CustomersQuery < BaseQuery
     :active_subscriptions_count_to,
     :countries,
     :states,
-    :zipcodes
+    :zipcodes,
+    :currencies
   ]
 
   def call
@@ -24,8 +25,9 @@ class CustomersQuery < BaseQuery
     customers = with_account_type(customers) if filters.account_type.present?
     customers = with_billing_entity_ids(customers) if filters.billing_entity_ids.present?
     customers = with_active_subscriptions_range(customers) if filters.active_subscriptions_count_from.present? || filters.active_subscriptions_count_to.present?
-
     customers = with_billing_address_filter(customers) if billing_address_filter?
+    customers = with_currencies(customers) if filters.currencies.present?
+
     customers = customers.with_discarded if filters.with_deleted
 
     result.customers = customers
@@ -44,6 +46,10 @@ class CustomersQuery < BaseQuery
 
   def base_scope
     Customer.where(organization:).ransack(search_params)
+  end
+
+  def with_currencies(scope)
+    scope.where(currency: filters.currencies)
   end
 
   def with_billing_address_filter(scope)

--- a/spec/contracts/queries/customers_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/customers_query_filters_contract_spec.rb
@@ -24,6 +24,38 @@ RSpec.describe Queries::CustomersQueryFiltersContract, type: :contract do
     end
   end
 
+  context "when filtering by currencies" do
+    let(:filters) { {currencies: ["USD"]} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filtering by countries" do
+    let(:filters) { {countries: ["US"]} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filtering by states" do
+    let(:filters) { {states: ["CA"]} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filtering by zipcodes" do
+    let(:filters) { {zipcodes: ["10115"]} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
   context "when search_term is provided and valid" do
     let(:search_term) { "valid_search_term" }
 
@@ -47,7 +79,7 @@ RSpec.describe Queries::CustomersQueryFiltersContract, type: :contract do
 
       it "is invalid when #{filter} is set to #{value.inspect}" do
         expect(result.success?).to be(false)
-        expect(result.errors.to_h).to include(filters: {filter => error_message})
+        expect(result.errors.to_h).to match(filters: {filter => error_message})
       end
     end
 
@@ -55,5 +87,9 @@ RSpec.describe Queries::CustomersQueryFiltersContract, type: :contract do
     it_behaves_like "an invalid filter", :account_type, %w[random], {0 => ["must be one of: customer, partner"]}
     it_behaves_like "an invalid filter", :billing_entity_ids, SecureRandom.uuid, ["must be an array"]
     it_behaves_like "an invalid filter", :billing_entity_ids, %w[random], {0 => ["is in invalid format"]}
+    it_behaves_like "an invalid filter", :currencies, %w[random], {0 => [/^must be one of: AED,.*ZMW$/]}
+    it_behaves_like "an invalid filter", :countries, %w[random], {0 => [/^must be one of: AD, .*XK$/]}
+    it_behaves_like "an invalid filter", :states, SecureRandom.uuid, ["must be an array"]
+    it_behaves_like "an invalid filter", :zipcodes, SecureRandom.uuid, ["must be an array"]
   end
 end

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe CustomersQuery, type: :query do
       country: "US",
       state: "CA",
       zipcode: "90001",
-      billing_entity: billing_entity1
+      billing_entity: billing_entity1,
+      currency: "USD"
     )
   end
   let(:customer_second) do
@@ -44,7 +45,8 @@ RSpec.describe CustomersQuery, type: :query do
       country: "FR",
       state: "Paris",
       zipcode: "75001",
-      billing_entity: billing_entity1
+      billing_entity: billing_entity1,
+      currency: "EUR"
     )
   end
   let(:customer_third) do
@@ -61,7 +63,8 @@ RSpec.describe CustomersQuery, type: :query do
       country: "DE",
       state: "Berlin",
       zipcode: "10115",
-      billing_entity: billing_entity2
+      billing_entity: billing_entity2,
+      currency: "EUR"
     )
   end
 
@@ -203,6 +206,15 @@ RSpec.describe CustomersQuery, type: :query do
     it "returns only two customers" do
       expect(returned_ids).to match_array([customer_first.id, customer_second.id])
     end
+
+    context "when filtering by invalid country" do
+      let(:filters) { {countries: ["INVALID"]} }
+
+      it "returns no customers" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:filters][:countries]).to match({0 => [/^must be one of: AD, AE.*XK$/]})
+      end
+    end
   end
 
   context "when filtering by states" do
@@ -211,6 +223,15 @@ RSpec.describe CustomersQuery, type: :query do
     it "returns only two customers" do
       expect(returned_ids).to match_array([customer_first.id, customer_second.id])
     end
+
+    context "when filtering by invalid state" do
+      let(:filters) { {states: "INVALID"} }
+
+      it "returns no customers" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:filters][:states]).to eq(["must be an array"])
+      end
+    end
   end
 
   context "when filtering by zipcodes" do
@@ -218,6 +239,15 @@ RSpec.describe CustomersQuery, type: :query do
 
     it "returns only two customers" do
       expect(returned_ids).to match_array([customer_third.id, customer_second.id])
+    end
+
+    context "when filtering by invalid zipcode" do
+      let(:filters) { {zipcodes: "INVALID"} }
+
+      it "returns no customers" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:filters][:zipcodes]).to eq(["must be an array"])
+      end
     end
   end
 
@@ -290,6 +320,23 @@ RSpec.describe CustomersQuery, type: :query do
         expect(returned_ids.count).to eq(2)
         expect(returned_ids).to include(customer_first.id)
         expect(returned_ids).to include(subscriptionless_customer.id)
+      end
+    end
+  end
+
+  context "when filtering by currencies" do
+    let(:filters) { {currencies: ["USD"]} }
+
+    it "returns only two customers" do
+      expect(returned_ids).to match_array([customer_first.id])
+    end
+
+    context "when filtering by invalid currency" do
+      let(:filters) { {currencies: ["INVALID"]} }
+
+      it "returns no customers" do
+        expect(result).not_to be_success
+        expect(result.error.messages[:filters][:currencies]).to match({0 => [/^must be one of: AED, AFN.*ZMW$/]})
       end
     end
   end


### PR DESCRIPTION
## Context

The filtering on the `GET /api/v1/customers` endpoint is too limited.

## Description

This adds a `currencies[]` filter to this endpoint.

Also, some of the existing filters were not properly validated. They are now validated.