### PR TITLE
feat(customer): Add `has_tax_identification_number` filter to `GET /api/v1/customers`

### DIFF
--- a/app/contracts/queries/customers_query_filters_contract.rb
+++ b/app/contracts/queries/customers_query_filters_contract.rb
@@ -10,6 +10,7 @@ module Queries
         optional(:states).array(:string)
         optional(:zipcodes).array(:string)
         optional(:currencies).array(:string, included_in?: Customer.currency_list)
+        optional(:has_tax_identification_number).value(:"coercible.string", included_in?: %w[true false])
       end
 
       optional(:search_term).maybe(:string)

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -37,6 +37,7 @@ module Api
       def index
         filter_params = params.permit(
           :search_term,
+          :has_tax_identification_number,
           currencies: [],
           countries: [],
           states: [],

--- a/app/queries/base_filters.rb
+++ b/app/queries/base_filters.rb
@@ -16,7 +16,7 @@ class BaseFilters
 
   attr_reader :filters
 
-  delegate :[], to: :filters
+  delegate :[], :key?, to: :filters
 
   def to_h
     filters

--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -12,7 +12,8 @@ class CustomersQuery < BaseQuery
     :countries,
     :states,
     :zipcodes,
-    :currencies
+    :currencies,
+    :has_tax_identification_number
   ]
 
   def call
@@ -27,6 +28,7 @@ class CustomersQuery < BaseQuery
     customers = with_active_subscriptions_range(customers) if filters.active_subscriptions_count_from.present? || filters.active_subscriptions_count_to.present?
     customers = with_billing_address_filter(customers) if billing_address_filter?
     customers = with_currencies(customers) if filters.currencies.present?
+    customers = with_has_tax_identification_number(customers) if filters.key?(:has_tax_identification_number)
 
     customers = customers.with_discarded if filters.with_deleted
 
@@ -71,6 +73,14 @@ class CustomersQuery < BaseQuery
       external_id_cont: search_term,
       email_cont: search_term
     }
+  end
+
+  def with_has_tax_identification_number(scope)
+    if ActiveModel::Type::Boolean.new.cast(filters.has_tax_identification_number)
+      scope.where.not(tax_identification_number: nil)
+    else
+      scope.where(tax_identification_number: nil)
+    end
   end
 
   def with_account_type(scope)

--- a/spec/contracts/queries/customers_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/customers_query_filters_contract_spec.rb
@@ -56,6 +56,21 @@ RSpec.describe Queries::CustomersQueryFiltersContract do
     end
   end
 
+  context "when filtering by has_tax_identification_number" do
+    [
+      "true",
+      "false",
+      true,
+      false
+    ].each do |value|
+      let(:filters) { {has_tax_identification_number: value} }
+
+      it "is valid" do
+        expect(result.success?).to be(true)
+      end
+    end
+  end
+
   context "when search_term is provided and valid" do
     let(:search_term) { "valid_search_term" }
 
@@ -91,5 +106,10 @@ RSpec.describe Queries::CustomersQueryFiltersContract do
     it_behaves_like "an invalid filter", :countries, %w[random], {0 => [/^must be one of: AD, .*XK$/]}
     it_behaves_like "an invalid filter", :states, SecureRandom.uuid, ["must be an array"]
     it_behaves_like "an invalid filter", :zipcodes, SecureRandom.uuid, ["must be an array"]
+    it_behaves_like "an invalid filter", :has_tax_identification_number, SecureRandom.uuid, ["must be one of: true, false"]
+    it_behaves_like "an invalid filter", :has_tax_identification_number, "t", ["must be one of: true, false"]
+    it_behaves_like "an invalid filter", :has_tax_identification_number, "f", ["must be one of: true, false"]
+    it_behaves_like "an invalid filter", :has_tax_identification_number, 1, ["must be one of: true, false"]
+    it_behaves_like "an invalid filter", :has_tax_identification_number, 0, ["must be one of: true, false"]
   end
 end

--- a/spec/queries/base_filters_spec.rb
+++ b/spec/queries/base_filters_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe BaseFilters do
     end
   end
 
+  describe "key?" do
+    it "returns whether the filter exists" do
+      expect(filters.key?(:value)).to be(true)
+      expect(filters.key?(:name)).to be(true)
+      expect(filters.key?(:unexpected)).to be(false)
+      expect(filters.key?(:not_defined)).to be(false)
+    end
+  end
+
   describe "[]" do
     it "returns the value of the filter" do
       expect(filters[:value]).to eq("test")

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe CustomersQuery, type: :query do
       state: "CA",
       zipcode: "90001",
       billing_entity: billing_entity1,
-      currency: "USD"
+      currency: "USD",
+      tax_identification_number: "US123456789"
     )
   end
   let(:customer_second) do
@@ -337,6 +338,24 @@ RSpec.describe CustomersQuery, type: :query do
       it "returns no customers" do
         expect(result).not_to be_success
         expect(result.error.messages[:filters][:currencies]).to match({0 => [/^must be one of: AED, AFN.*ZMW$/]})
+      end
+    end
+  end
+
+  context "when filtering by has_tax_identification_number" do
+    context "when filtering by true" do
+      let(:filters) { {has_tax_identification_number: true} }
+
+      it "returns only the customer with a tax identification number" do
+        expect(returned_ids).to match_array([customer_first.id])
+      end
+    end
+
+    context "when filtering by false" do
+      let(:filters) { {has_tax_identification_number: false} }
+
+      it "returns only the customers without a tax identification number" do
+        expect(returned_ids).to match_array([customer_second.id, customer_third.id])
       end
     end
   end


### PR DESCRIPTION
## Context

The filtering on the `GET /api/v1/customers` endpoint is too limited.

## Description

This adds a `has_tax_identification_number` filter to this endpoint.