### PR TITLE
chore(stripe): Remove "beta" for Stripe pre-auth feature

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -20,18 +20,6 @@ module Api
         )
         customer.billing_entity ||= billing_entity
 
-        if params[:authorization] && !current_organization.beta_payment_authorization_enabled?
-          return render(
-            json: {
-              status: 403,
-              error: "Forbidden",
-              code: "feature_not_available",
-              message: "Payment authorization (beta_payment_authorization) is not available for this organization"
-            },
-            status: :forbidden
-          )
-        end
-
         if params[:authorization]
           unless customer.payment_provider&.to_sym == :stripe
             return render(

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -92,12 +92,15 @@ class Organization < ApplicationRecord
     :per_organization
   ].freeze
 
+  REMOVED_INTEGRATIONS = %w[
+    beta_payment_authorization
+  ]
+
   NON_PREMIUM_INTEGRATIONS = %w[
     anrok
   ].freeze
 
   PREMIUM_INTEGRATIONS = %w[
-    beta_payment_authorization
     netsuite
     okta
     avalara
@@ -247,7 +250,7 @@ class Organization < ApplicationRecord
   end
 
   def validate_premium_integrations
-    return if premium_integrations.all? { |v| PREMIUM_INTEGRATIONS.include?(v) }
+    return if (premium_integrations - REMOVED_INTEGRATIONS).all? { |v| PREMIUM_INTEGRATIONS.include?(v) }
 
     errors.add(:premium_integrations, :inclusion, value: premium_integrations)
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -5674,7 +5674,6 @@ enum IntegrationTypeEnum {
   api_permissions
   auto_dunning
   avalara
-  beta_payment_authorization
   from_email
   hubspot
   issue_receipts
@@ -8100,7 +8099,6 @@ enum PremiumIntegrationTypeEnum {
   api_permissions
   auto_dunning
   avalara
-  beta_payment_authorization
   from_email
   hubspot
   issue_receipts

--- a/schema.json
+++ b/schema.json
@@ -28183,12 +28183,6 @@
               "deprecationReason": null
             },
             {
-              "name": "beta_payment_authorization",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "netsuite",
               "description": null,
               "isDeprecated": false,
@@ -40737,12 +40731,6 @@
           "fields": null,
           "inputFields": null,
           "enumValues": [
-            {
-              "name": "beta_payment_authorization",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
             {
               "name": "netsuite",
               "description": null,

--- a/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
+++ b/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 RSpec.describe Types::Integrations::PremiumIntegrationTypeEnum do
   let(:premium_integration_types) do
     %w[
-      beta_payment_authorization
       api_permissions
       auto_dunning
       hubspot

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -210,6 +210,12 @@ RSpec.describe Organization do
 
         it { is_expected.to be_valid }
       end
+
+      context "when it includes a removed integration" do
+        subject(:organization) { build(:organization, premium_integrations: ["beta_payment_authorization"]) }
+
+        it { is_expected.to be_valid }
+      end
     end
   end
 


### PR DESCRIPTION
## Context

This feature was introduced in March in #3262 as a _beta_ feature.

## Description

The _beta_ aspect was handled by a premium integration. I'm removing the premium integration to release the feature in _GA_.

Note that "removing" integration isn't something too common, all apps with this integration would be considered invalid. 
I propose to introduce a list of previous integrations. 

Another way is a db migration to remove the data but it creates "down time" where the feature is removed from DB but the code still rely on this flag. I think this can be done later, if the list grows.