### PR TITLE
feat(ai-agent): Add MISTRAL_AGENT_ID env variable

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -61,6 +61,7 @@ jobs:
       KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
       KNAPSACK_PRO_LOG_LEVEL: info
       MISTRAL_API_KEY: ""
+      MISTRAL_AGENT_ID: ""
 
     steps:
       - name: Checkout code

--- a/app/services/ai_conversations/stream_service.rb
+++ b/app/services/ai_conversations/stream_service.rb
@@ -4,7 +4,6 @@ module AiConversations
   class StreamService < BaseService
     Result = BaseResult[:ai_conversation]
 
-    MISTRAL_AGENT_ID = "ag:60070909:20250806:lago-billing-assistant:56aead9d"
     MISTRAL_CONVERSATIONS_API_URL = "https://api.mistral.ai/v1/conversations"
 
     def initialize(ai_conversation:, message:)
@@ -59,7 +58,7 @@ module AiConversations
         stream: true,
         store: true
       }.tap do |body|
-        body[:agent_id] = MISTRAL_AGENT_ID if ai_conversation.mistral_conversation_id.blank?
+        body[:agent_id] = ENV["MISTRAL_AGENT_ID"] if ai_conversation.mistral_conversation_id.blank?
       end
     end
   end

--- a/spec/services/ai_conversations/stream_service_spec.rb
+++ b/spec/services/ai_conversations/stream_service_spec.rb
@@ -64,5 +64,23 @@ RSpec.describe AiConversations::StreamService do
         {chunk: nil, done: true}
       )
     end
+
+    it "sends the agent id if the conversation id is blank" do
+      allow(http_client).to receive(:post_with_stream)
+
+      service.call
+
+      expect(http_client).to have_received(:post_with_stream).with(
+        {
+          inputs: "Hello world",
+          stream: true,
+          store: true,
+          agent_id: ENV["MISTRAL_AGENT_ID"]
+        },
+        {
+          "Authorization" => "Bearer #{ENV["MISTRAL_API_KEY"]}"
+        }
+      )
+    end
   end
 end


### PR DESCRIPTION
## Context

We want the AI agent to assist users in running common actions (e.g., API queries) or accessing product knowledge without requiring engineering support.

## Description

The goal of this PR is to introduce a new environment variable: `MISTRAL_AGENT_ID`.