### PR TITLE
fix(integrations): Fix create credit note service

### DIFF
--- a/app/services/integrations/aggregator/credit_notes/create_service.rb
+++ b/app/services/integrations/aggregator/credit_notes/create_service.rb
@@ -56,6 +56,7 @@ module Integrations
           raise e
         rescue Integrations::Aggregator::BasePayload::Failure => e
           deliver_error_webhook(customer:, code: e.code, message: e.code.humanize)
+          result
         end
 
         def call_async

--- a/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
@@ -416,6 +416,10 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
         expect { service_call }.to have_enqueued_job(SendWebhookJob)
       end
 
+      it "returns result" do
+        expect(service_call).to be_a(BaseService::Result)
+      end
+
       it_behaves_like "throttles!", :anrok, :netsuite, :xero
     end
   end


### PR DESCRIPTION
## Context

There was an issue when creating credit note via integrations aggregator:

```
NoMethodError
undefined method 'raise_if_error!' for an instance of SendWebhookJob (NoMethodError)
```

Instead of returning a result object an instance of `SendWebhookJob` was returned.

## Description

Return result object in case the payload is not correct.