### PR TITLE
feat(customer): Add `metadata[key]` filter to `GET /api/v1/customers`

### DIFF
--- a/app/contracts/queries/customers_query_filters_contract.rb
+++ b/app/contracts/queries/customers_query_filters_contract.rb
@@ -11,9 +11,19 @@ module Queries
         optional(:zipcodes).array(:string)
         optional(:currencies).array(:string, included_in?: Customer.currency_list)
         optional(:has_tax_identification_number).value(:"coercible.string", included_in?: %w[true false])
+        optional(:metadata).value(:hash)
       end
 
       optional(:search_term).maybe(:string)
+    end
+
+    rule("filters.metadata") do
+      if key? && value.is_a?(Hash)
+        value.each_with_index do |(k, v), index|
+          key([:filters, :metadata]).failure("keys must be string") unless k.is_a?(String)
+          key([:filters, :metadata, k]).failure("must be a string") unless v.is_a?(String)
+        end
+      end
     end
   end
 end

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -43,7 +43,8 @@ module Api
           states: [],
           zipcodes: [],
           billing_entity_codes: [],
-          account_type: []
+          account_type: [],
+          metadata: {}
         )
         search_term = filter_params.delete(:search_term)
         billing_entity_codes = filter_params.delete(:billing_entity_codes)

--- a/spec/contracts/queries/customers_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/customers_query_filters_contract_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe Queries::CustomersQueryFiltersContract do
     end
   end
 
+  context "when filtering by metadata" do
+    let(:filters) { {metadata: {"key" => "value"}} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
   context "when search_term is provided and valid" do
     let(:search_term) { "valid_search_term" }
 
@@ -111,5 +119,8 @@ RSpec.describe Queries::CustomersQueryFiltersContract do
     it_behaves_like "an invalid filter", :has_tax_identification_number, "f", ["must be one of: true, false"]
     it_behaves_like "an invalid filter", :has_tax_identification_number, 1, ["must be one of: true, false"]
     it_behaves_like "an invalid filter", :has_tax_identification_number, 0, ["must be one of: true, false"]
+    it_behaves_like "an invalid filter", :metadata, SecureRandom.uuid, ["must be a hash"]
+    it_behaves_like "an invalid filter", :metadata, {0 => "integer key"}, ["keys must be string"]
+    it_behaves_like "an invalid filter", :metadata, {"key" => ["must be a string"]}, {"key" => ["must be a string"]}
   end
 end

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe CustomersQuery, type: :query do
     customer_first
     customer_second
     customer_third
+
+    create(:customer_metadata, customer: customer_first, key: "id", value: "1")
+    create(:customer_metadata, customer: customer_first, key: "name", value: "John Doe")
+    create(:customer_metadata, customer: customer_second, key: "id", value: "2")
   end
 
   it "returns all customers" do
@@ -356,6 +360,48 @@ RSpec.describe CustomersQuery, type: :query do
 
       it "returns only the customers without a tax identification number" do
         expect(returned_ids).to match_array([customer_second.id, customer_third.id])
+      end
+    end
+  end
+
+  context "when filtering by metadata" do
+    context "when filtering by presence" do
+      let(:filters) { {metadata: {id: "1"}} }
+
+      it "returns only the customers with the metadata" do
+        expect(returned_ids).to match_array([customer_first.id])
+      end
+    end
+
+    context "when filtering by absence" do
+      let(:filters) { {metadata: {name: ""}} }
+
+      it "returns only the customers without the metadata" do
+        expect(returned_ids).to match_array([customer_second.id, customer_third.id])
+      end
+    end
+
+    context "when matching multiple metadata" do
+      let(:filters) { {metadata: {id: "1", name: "John Doe"}} }
+
+      it "returns only the customers with the metadata" do
+        expect(returned_ids).to match_array([customer_first.id])
+      end
+    end
+
+    context "when matching one but not the other" do
+      let(:filters) { {metadata: {id: "1", name: "Jane Smith"}} }
+
+      it "returns only the customers with the metadata" do
+        expect(returned_ids).to match_array([])
+      end
+    end
+
+    context "when filtering by presence and absence" do
+      let(:filters) { {metadata: {id: "2", name: ""}} }
+
+      it "returns only the customers with the metadata" do
+        expect(returned_ids).to match_array([customer_second.id])
       end
     end
   end


### PR DESCRIPTION
## Context

The filtering on the `GET /api/v1/customers` endpoint is too limited.

## Description

This adds a `metadata[key]` filter to this endpoint.