### PR TITLE
feat(customer): Add `customer_type` filters to `GET /api/v1/customers`

### DIFF
--- a/app/contracts/queries/customers_query_filters_contract.rb
+++ b/app/contracts/queries/customers_query_filters_contract.rb
@@ -12,6 +12,8 @@ module Queries
         optional(:currencies).array(:string, included_in?: Customer.currency_list)
         optional(:has_tax_identification_number).value(:"coercible.string", included_in?: %w[true false])
         optional(:metadata).value(:hash)
+        optional(:has_customer_type).value(:"coercible.string", included_in?: %w[true false])
+        optional(:customer_type).value(:string, included_in?: Customer::CUSTOMER_TYPES.values)
       end
 
       optional(:search_term).maybe(:string)
@@ -23,6 +25,12 @@ module Queries
           key([:filters, :metadata]).failure("keys must be string") unless k.is_a?(String)
           key([:filters, :metadata, k]).failure("must be a string") unless v.is_a?(String)
         end
+      end
+    end
+
+    rule("filters.has_customer_type", "filters.customer_type") do
+      if values["filters.has_customer_type"] == "false" && values["filters.customer_type"].present?
+        key([:filters, :customer_type]).failure("must be nil when has_customer_type is false")
       end
     end
   end

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -38,6 +38,8 @@ module Api
         filter_params = params.permit(
           :search_term,
           :has_tax_identification_number,
+          :has_customer_type,
+          :customer_type,
           currencies: [],
           countries: [],
           states: [],

--- a/spec/contracts/queries/customers_query_filters_contract_spec.rb
+++ b/spec/contracts/queries/customers_query_filters_contract_spec.rb
@@ -96,6 +96,49 @@ RSpec.describe Queries::CustomersQueryFiltersContract do
     end
   end
 
+  context "when filtering by customer_type" do
+    let(:filters) { {customer_type: "company"} }
+
+    it "is valid" do
+      expect(result.success?).to be(true)
+    end
+  end
+
+  context "when filtering by has_customer_type" do
+    context "when filtering by true" do
+      let(:filters) { {has_customer_type: true} }
+
+      it "is valid" do
+        expect(result.success?).to be(true)
+      end
+
+      context "when customer_type is provided" do
+        let(:filters) { {has_customer_type: true, customer_type: "company"} }
+
+        it "is valid" do
+          expect(result.success?).to be(true)
+        end
+      end
+    end
+
+    context "when filtering by false" do
+      let(:filters) { {has_customer_type: false} }
+
+      it "is valid" do
+        expect(result.success?).to be(true)
+      end
+
+      context "when customer_type is provided" do
+        let(:filters) { {has_customer_type: false, customer_type: "company"} }
+
+        it "is invalid" do
+          expect(result.success?).to be(false)
+          expect(result.errors.to_h).to include(filters: {customer_type: ["must be nil when has_customer_type is false"]})
+        end
+      end
+    end
+  end
+
   context "when filters are invalid" do
     shared_examples "an invalid filter" do |filter, value, error_message|
       let(:filters) { {filter => value} }
@@ -122,5 +165,11 @@ RSpec.describe Queries::CustomersQueryFiltersContract do
     it_behaves_like "an invalid filter", :metadata, SecureRandom.uuid, ["must be a hash"]
     it_behaves_like "an invalid filter", :metadata, {0 => "integer key"}, ["keys must be string"]
     it_behaves_like "an invalid filter", :metadata, {"key" => ["must be a string"]}, {"key" => ["must be a string"]}
+    it_behaves_like "an invalid filter", :customer_type, "random", ["must be one of: company, individual"]
+    it_behaves_like "an invalid filter", :has_customer_type, SecureRandom.uuid, ["must be one of: true, false"]
+    it_behaves_like "an invalid filter", :has_customer_type, "t", ["must be one of: true, false"]
+    it_behaves_like "an invalid filter", :has_customer_type, "f", ["must be one of: true, false"]
+    it_behaves_like "an invalid filter", :has_customer_type, 1, ["must be one of: true, false"]
+    it_behaves_like "an invalid filter", :has_customer_type, 0, ["must be one of: true, false"]
   end
 end

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe CustomersQuery, type: :query do
       zipcode: "90001",
       billing_entity: billing_entity1,
       currency: "USD",
-      tax_identification_number: "US123456789"
+      tax_identification_number: "US123456789",
+      customer_type: "company"
     )
   end
   let(:customer_second) do
@@ -47,7 +48,8 @@ RSpec.describe CustomersQuery, type: :query do
       state: "Paris",
       zipcode: "75001",
       billing_entity: billing_entity1,
-      currency: "EUR"
+      currency: "EUR",
+      customer_type: "individual"
     )
   end
   let(:customer_third) do
@@ -65,7 +67,8 @@ RSpec.describe CustomersQuery, type: :query do
       state: "Berlin",
       zipcode: "10115",
       billing_entity: billing_entity2,
-      currency: "EUR"
+      currency: "EUR",
+      customer_type: nil
     )
   end
 
@@ -85,6 +88,51 @@ RSpec.describe CustomersQuery, type: :query do
     expect(returned_ids).to include(customer_first.id)
     expect(returned_ids).to include(customer_second.id)
     expect(returned_ids).to include(customer_third.id)
+  end
+
+  context "when filtering by customer_type" do
+    context "when filtering by company" do
+      let(:filters) { {customer_type: "company"} }
+
+      it "returns company customers" do
+        expect(returned_ids.count).to eq(1)
+        expect(returned_ids).to eq [customer_first.id]
+      end
+    end
+
+    context "when filtering by individual" do
+      let(:filters) { {customer_type: "individual"} }
+
+      it "returns the customers with nil customer_type" do
+        expect(returned_ids).to eq([customer_second.id])
+      end
+    end
+
+    context "when filtering with invalid customer_type" do
+      let(:filters) { {customer_types: %w[invalid]} }
+
+      it "returns the customers with nil customer_type" do
+        expect(returned_ids.count).to eq(3)
+      end
+    end
+  end
+
+  context "when filtering by has_customer_type" do
+    context "when filtering by true" do
+      let(:filters) { {has_customer_type: true} }
+
+      it "returns the customers with customer_type" do
+        expect(returned_ids).to match_array([customer_first.id, customer_second.id])
+      end
+    end
+
+    context "when filtering by false" do
+      let(:filters) { {has_customer_type: false} }
+
+      it "returns the customers with nil customer_type" do
+        expect(returned_ids).to eq([customer_third.id])
+      end
+    end
   end
 
   context "when filtering by partner account_type" do


### PR DESCRIPTION
## Context

The filtering on the `GET /api/v1/customers` endpoint is too limited.

## Description

This adds a `customer_type` and `has_customer_type` filters to this endpoint.