### PR TITLE
chore(stripe): Remove "beta" for Stripe pre-auth feature [2]

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -20,18 +20,6 @@ module Api
         )
         customer.billing_entity ||= billing_entity
 
-        if params[:authorization] && !current_organization.beta_payment_authorization_enabled?
-          return render(
-            json: {
-              status: 403,
-              error: "Forbidden",
-              code: "feature_not_available",
-              message: "Payment authorization (beta_payment_authorization) is not available for this organization"
-            },
-            status: :forbidden
-          )
-        end
-
         if params[:authorization]
           unless customer.payment_provider&.to_sym == :stripe
             return render(

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -163,6 +163,10 @@ class Organization < ApplicationRecord
     end
   end
 
+  def premium_integrations
+    super & INTEGRATIONS
+  end
+
   def using_lifetime_usage?
     lifetime_usage_enabled? || progressive_billing_enabled?
   end
@@ -250,7 +254,7 @@ class Organization < ApplicationRecord
   end
 
   def validate_premium_integrations
-    return if (premium_integrations - REMOVED_INTEGRATIONS).all? { |v| PREMIUM_INTEGRATIONS.include?(v) }
+    return if (self[:premium_integrations] - REMOVED_INTEGRATIONS).all? { |v| PREMIUM_INTEGRATIONS.include?(v) }
 
     errors.add(:premium_integrations, :inclusion, value: premium_integrations)
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -92,12 +92,15 @@ class Organization < ApplicationRecord
     :per_organization
   ].freeze
 
+  REMOVED_INTEGRATIONS = %w[
+    beta_payment_authorization
+  ]
+
   NON_PREMIUM_INTEGRATIONS = %w[
     anrok
   ].freeze
 
   PREMIUM_INTEGRATIONS = %w[
-    beta_payment_authorization
     netsuite
     okta
     avalara
@@ -247,7 +250,7 @@ class Organization < ApplicationRecord
   end
 
   def validate_premium_integrations
-    return if premium_integrations.all? { |v| PREMIUM_INTEGRATIONS.include?(v) }
+    return if (premium_integrations - REMOVED_INTEGRATIONS).all? { |v| PREMIUM_INTEGRATIONS.include?(v) }
 
     errors.add(:premium_integrations, :inclusion, value: premium_integrations)
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -5674,7 +5674,6 @@ enum IntegrationTypeEnum {
   api_permissions
   auto_dunning
   avalara
-  beta_payment_authorization
   from_email
   hubspot
   issue_receipts
@@ -8100,7 +8099,6 @@ enum PremiumIntegrationTypeEnum {
   api_permissions
   auto_dunning
   avalara
-  beta_payment_authorization
   from_email
   hubspot
   issue_receipts

--- a/schema.json
+++ b/schema.json
@@ -28183,12 +28183,6 @@
               "deprecationReason": null
             },
             {
-              "name": "beta_payment_authorization",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "netsuite",
               "description": null,
               "isDeprecated": false,
@@ -40737,12 +40731,6 @@
           "fields": null,
           "inputFields": null,
           "enumValues": [
-            {
-              "name": "beta_payment_authorization",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
             {
               "name": "netsuite",
               "description": null,

--- a/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
+++ b/spec/graphql/types/integrations/premium_integration_type_enum_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 RSpec.describe Types::Integrations::PremiumIntegrationTypeEnum do
   let(:premium_integration_types) do
     %w[
-      beta_payment_authorization
       api_permissions
       auto_dunning
       hubspot

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -293,6 +293,13 @@ RSpec.describe Organization do
     end
   end
 
+  describe "#premium_integrations" do
+    it "returns the premium integrations without removed integration or invalid integrations" do
+      organization.update!(premium_integrations: %w[okta invalid_integration beta_payment_authorization progressive_billing])
+      expect(organization.premium_integrations).to eq(%w[okta progressive_billing])
+    end
+  end
+
   describe "#can_create_billing_entity?" do
     subject { organization.can_create_billing_entity? }
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -210,6 +210,12 @@ RSpec.describe Organization do
 
         it { is_expected.to be_valid }
       end
+
+      context "when it includes a removed integration" do
+        subject(:organization) { build(:organization, premium_integrations: ["beta_payment_authorization"]) }
+
+        it { is_expected.to be_valid }
+      end
     end
   end
 


### PR DESCRIPTION
Re-apply https://github.com/getlago/lago-api/pull/4387

I believe this is the first time we remove an integration. Unfortunately, this created a bug where data in the database was being serialized in the GraphQL but this was invalid beacuse the value wasn't found in the enum.

The second commit is the fix of the first PR. Basically, whatever is in the DB, we return the intersection of db value and valid integrations.

<img width="1224" height="2932" alt="CleanShot 2025-09-25 at 12 08 48@2x" src="https://github.com/user-attachments/assets/eaad5668-0d27-43bf-9b33-5f576021b964" />
