### PR TITLE
fix(event-aggregation): the query should group prorated units by day

### DIFF
--- a/app/services/events/stores/clickhouse/unique_count_query.rb
+++ b/app/services/events/stores/clickhouse/unique_count_query.rb
@@ -34,9 +34,38 @@ module Events
           SQL
         end
 
+        # NOTE: current implementation of clickhouse's query is different from postgres's one:
+        # IN POSTGRES we do not ignore Add events at all (they will be handled by adjusted value)
+        # remove events are ignored if there is an Add event later on the save day. This query is done using
+        # next_event.operation_type != event.operation_type, which is not supported in current verison of
+        # Clickhouse we have on production, while this approach is more effective as it only queries one row and does not use
+        # window function.
+        # IN CLICKHOUSE we do not ignore Add events at all (they will be handled by adjusted value)
+        # remove events are not ignored only if they are the last event of the day
+        # this way we're not using not supported by clickhouse join on !=, but we use window function, which is less
+        # performant than the postgres approach.
+        # TODO: we should use the postgres approach in clickhouse as well, but it requires update CLickhouse
         def prorated_query
           <<-SQL
             #{events_cte_sql},
+            same_day_ignored AS (
+              SELECT
+                property,
+                operation_type,
+                timestamp,
+                #{ignore_remove_events_sql} AS is_ignored
+              FROM (
+                SELECT
+                  timestamp,
+                  property,
+                  operation_type,
+                  -- Check if this is the last event of the day for this property
+                  timestamp = MAX(timestamp) OVER (PARTITION BY property, toDate(timestamp, :timezone)) AS is_last_event_of_day
+                FROM events_data
+                ORDER BY timestamp ASC
+              ) as e
+            ),
+            -- Check if the operation type is the same as previous, so it nullifies this one
             event_values AS (
               SELECT
                 property,
@@ -48,11 +77,12 @@ module Events
                   property,
                   operation_type,
                   #{operation_value_sql} AS adjusted_value
-                FROM events_data
+                FROM same_day_ignored
+                WHERE is_ignored = false
                 ORDER BY timestamp ASC
               ) adjusted_event_values
               WHERE adjusted_value != 0 -- adjusted_value = 0 does not impact the total
-              GROUP BY property, timestamp, operation_type
+              GROUP BY property, operation_type, timestamp
             )
 
             SELECT coalesce(SUM(period_ratio), 0) as aggregation
@@ -96,7 +126,27 @@ module Events
         def grouped_prorated_query
           <<-SQL
             #{grouped_events_cte_sql},
-
+            -- Only ignore remove events if they are NOT the last event of the day
+            same_day_ignored AS (
+              SELECT
+                #{group_names},
+                property,
+                operation_type,
+                timestamp,
+                #{ignore_remove_events_sql} AS is_ignored
+              FROM (
+                SELECT
+                  timestamp,
+                  property,
+                  operation_type,
+                  #{group_names},
+                  -- Check if this is the last event of the day for this property and group
+                  timestamp = MAX(timestamp) OVER (PARTITION BY #{group_names}, property, toDate(timestamp, :timezone)) AS is_last_event_of_day
+                FROM events_data
+                ORDER BY timestamp ASC
+              ) as e
+            ),
+            -- Check if the operation type is the same as previous, so it nullifies this one
             event_values AS (
               SELECT
                 #{group_names},
@@ -110,7 +160,8 @@ module Events
                   operation_type,
                   #{group_names},
                   #{grouped_operation_value_sql} AS adjusted_value
-                FROM events_data
+                FROM same_day_ignored
+                WHERE is_ignored = false
                 ORDER BY timestamp ASC
               ) adjusted_event_values
               WHERE adjusted_value != 0 -- adjusted_value = 0 does not impact the total
@@ -158,6 +209,24 @@ module Events
         def prorated_breakdown_query(with_remove: false)
           <<-SQL
             #{events_cte_sql},
+            -- Only ignore remove events if they are NOT the last event of the day
+            same_day_ignored AS (
+              SELECT
+                property,
+                operation_type,
+                timestamp,
+                #{ignore_remove_events_sql} AS is_ignored
+              FROM (
+                SELECT
+                  timestamp,
+                  property,
+                  operation_type,
+                  -- Check if this is the last event of the day for this property
+                  timestamp = MAX(timestamp) OVER (PARTITION BY property, toDate(timestamp, :timezone)) AS is_last_event_of_day
+                FROM events_data
+                ORDER BY timestamp ASC
+              ) as e
+            ),
             event_values AS (
               SELECT
                 property,
@@ -169,11 +238,12 @@ module Events
                   property,
                   operation_type,
                   #{operation_value_sql} AS adjusted_value
-                FROM events_data
+                FROM same_day_ignored
+                WHERE is_ignored = false
                 ORDER BY timestamp ASC
               ) adjusted_event_values
               WHERE adjusted_value != 0 -- adjusted_value = 0 does not impact the total
-              GROUP BY property, operation_type, timestamp
+              GROUP BY property, timestamp, operation_type
             )
 
             SELECT
@@ -388,6 +458,19 @@ module Events
               ),
               :decimal_scale
             )
+          SQL
+        end
+
+        def ignore_remove_events_sql
+          # NOTE: Only NOT ignore remove events if they are the last event of the day
+          <<-SQL
+            CASE
+              -- Never ignore add events
+              WHEN operation_type = 'add' THEN false
+              -- Only ignore remove events if they are NOT the last event of the day
+              WHEN operation_type = 'remove' AND NOT is_last_event_of_day THEN true
+              ELSE false
+            END
           SQL
         end
 

--- a/app/services/events/stores/postgres/unique_count_query.rb
+++ b/app/services/events/stores/postgres/unique_count_query.rb
@@ -37,6 +37,16 @@ module Events
         def prorated_query
           <<-SQL
             #{events_cte_sql},
+            -- ignore if for remove event there is a following add event the same day that nullifies this one
+            same_day_ignored AS (
+              SELECT
+                property,
+                operation_type,
+                timestamp,
+                #{ignore_remove_events_sql} AS is_ignored
+              FROM events_data as e
+            ),
+            -- Check if the operation type is the same as previous, so it nullifies this one
             event_values AS (
               SELECT
                 property,
@@ -48,7 +58,8 @@ module Events
                   property,
                   operation_type,
                   #{operation_value_sql} AS adjusted_value
-                FROM events_data
+                FROM same_day_ignored
+                WHERE is_ignored = false
                 ORDER BY timestamp ASC
               ) adjusted_event_values
               WHERE adjusted_value != 0 -- adjusted_value = 0 does not impact the total
@@ -69,7 +80,7 @@ module Events
 
             event_values AS (
               SELECT
-                #{group_names},
+                #{group_names.join(", ")},
                 property,
                 SUM(adjusted_value) AS sum_adjusted_value
               FROM (
@@ -77,29 +88,47 @@ module Events
                   timestamp,
                   property,
                   operation_type,
-                  #{group_names},
+                  #{group_names.join(", ")},
                   #{grouped_operation_value_sql} AS adjusted_value
                 FROM events_data
                 ORDER BY timestamp ASC
               ) adjusted_event_values
-              GROUP BY #{group_names}, property
+              GROUP BY #{group_names.join(", ")}, property
             )
 
             SELECT
-              #{group_names},
+              #{group_names.join(", ")},
               COALESCE(SUM(sum_adjusted_value), 0) as aggregation
             FROM event_values
-            GROUP BY #{group_names}
+            GROUP BY #{group_names.join(", ")}
           SQL
         end
 
         def grouped_prorated_query
           <<-SQL
             #{grouped_events_cte_sql},
-
+            -- ignore if for remove event there is a following add event the same day (for grouped events) that nullifies this one
+            same_day_ignored AS (
+              SELECT
+                #{group_names.join(", ")},
+                property,
+                operation_type,
+                timestamp,
+                #{ignore_remove_grouped_events_sql} AS is_ignored
+              FROM (
+                SELECT
+                  #{group_names.join(", ")},
+                  property,
+                  operation_type,
+                  timestamp
+                FROM events_data
+                ORDER BY timestamp ASC
+              ) as e
+            ),
+            -- Check if the operation type is the same as previous, so it nullifies this one
             event_values AS (
               SELECT
-                #{group_names},
+                #{group_names.join(", ")},
                 property,
                 operation_type,
                 timestamp
@@ -108,25 +137,27 @@ module Events
                   timestamp,
                   property,
                   operation_type,
-                  #{group_names},
+                  #{group_names.join(", ")},
                   #{grouped_operation_value_sql} AS adjusted_value
-                FROM events_data
+                FROM same_day_ignored
+                WHERE is_ignored = false
                 ORDER BY timestamp ASC
               ) adjusted_event_values
               WHERE adjusted_value != 0 -- adjusted_value = 0 does not impact the total
-              GROUP BY #{group_names}, property, operation_type, timestamp
+              GROUP BY #{group_names.join(", ")}, property, operation_type, timestamp
+              ORDER BY timestamp ASC
             )
 
             SELECT
-              #{group_names},
+              #{group_names.join(", ")},
               COALESCE(SUM(period_ratio), 0) as aggregation
             FROM (
               SELECT
                 (#{grouped_period_ratio_sql}) AS period_ratio,
-                #{group_names}
+                #{group_names.join(", ")}
               FROM event_values
             ) cumulated_ratios
-            GROUP BY #{group_names}
+            GROUP BY #{group_names.join(", ")}
           SQL
         end
 
@@ -157,6 +188,16 @@ module Events
         def prorated_breakdown_query(with_remove: false)
           <<-SQL
             #{events_cte_sql},
+            -- ignore if for remove event there is a following add event the same day that nullifies this one
+            same_day_ignored AS (
+              SELECT
+                property,
+                operation_type,
+                timestamp,
+                #{ignore_remove_events_sql} AS is_ignored
+              FROM events_data as e
+            ),
+            -- Check if the operation type is repeated, so it nullifies this one at the same day
             event_values AS (
               SELECT
                 property,
@@ -168,7 +209,8 @@ module Events
                   property,
                   operation_type,
                   #{operation_value_sql} AS adjusted_value
-                FROM events_data
+                FROM same_day_ignored
+                WHERE is_ignored = false
                 ORDER BY timestamp ASC
               ) adjusted_event_values
               WHERE adjusted_value != 0 -- adjusted_value = 0 does not impact the total
@@ -236,17 +278,10 @@ module Events
           # If property already added, another addition returns 0 ; it returns 1 otherwise
           # If property already removed or not yet present, another removal returns 0 ; it returns -1 otherwise
           <<-SQL
-            CASE WHEN operation_type = 'add'
-            THEN
-              CASE WHEN LAG(operation_type, 1) OVER (PARTITION BY property ORDER BY timestamp) = 'add'
-              THEN 0
-              ELSE 1
-              END
-            ELSE
-              CASE LAG(operation_type, 1, 'remove') OVER (PARTITION BY property ORDER BY timestamp)
-                WHEN 'remove' THEN 0
-                ELSE -1
-              END
+            CASE
+            WHEN LAG(operation_type, 1, 'remove') OVER (PARTITION BY property ORDER BY timestamp) = operation_type
+            THEN 0 -- NOTE: if the first ever operation is a remove, it's not relevant; note that it's "remove" if not found, so we ignore "empty" remove
+            ELSE CASE WHEN operation_type = 'add' THEN 1 ELSE -1 END
             END
           SQL
         end
@@ -256,17 +291,10 @@ module Events
           # If property already added, another addition returns 0 ; it returns 1 otherwise
           # If property already removed or not yet present, another removal returns 0 ; it returns -1 otherwise
           <<-SQL
-            CASE WHEN operation_type = 'add'
-            THEN
-              CASE WHEN LAG(operation_type, 1) OVER (PARTITION BY #{group_names}, property ORDER BY timestamp) = 'add'
-              THEN 0
-              ELSE 1
-              END
-            ELSE
-              CASE LAG(operation_type, 1, 'remove') OVER (PARTITION BY #{group_names}, property ORDER BY timestamp)
-                WHEN 'remove' THEN 0
-                ELSE -1
-              END
+            CASE
+            WHEN LAG(operation_type, 1, 'remove') OVER (PARTITION BY #{group_names.join(", ")}, property ORDER BY timestamp) = operation_type
+            THEN 0 -- NOTE: if the first ever operation is a remove, it's not relevant; note that it's "remove" if not found, so we ignore "empty" remove
+            ELSE CASE WHEN operation_type = 'add' THEN 1 ELSE -1 END
             END
           SQL
         end
@@ -309,9 +337,9 @@ module Events
                 (
                   DATE((
                     -- NOTE: if following event is older than the start of the period, we use the start of the period as the reference
-                    CASE WHEN (LEAD(timestamp, 1, :to_datetime) OVER (PARTITION BY #{group_names}, property ORDER BY timestamp)) < :from_datetime
+                    CASE WHEN (LEAD(timestamp, 1, :to_datetime) OVER (PARTITION BY #{group_names.join(", ")}, property ORDER BY timestamp)) < :from_datetime
                     THEN :from_datetime
-                    ELSE LEAD(timestamp, 1, :to_datetime) OVER (PARTITION BY #{group_names}, property ORDER BY timestamp)
+                    ELSE LEAD(timestamp, 1, :to_datetime) OVER (PARTITION BY #{group_names.join(", ")}, property ORDER BY timestamp)
                     END
                   )::timestamptz AT TIME ZONE :timezone)
                   - DATE((
@@ -330,8 +358,84 @@ module Events
           SQL
         end
 
+        def ignore_remove_events_sql
+          <<-SQL
+            CASE
+              -- we do not ignore ADDs, if they are duplicated they'll be cleaned by adjusted value calculation
+              WHEN operation_type = 'add' THEN false
+              -- if there is a next event the same day is the opposite operation type, this should be ignored
+              WHEN #{existing_event_opposite_operation_type_sql} THEN true
+              ELSE false
+            END
+          SQL
+        end
+
+        def ignore_remove_grouped_events_sql
+          <<-SQL
+            CASE
+              -- we do not ignore ADDs, if they are duplicated they'll be cleaned by adjusted value calculation
+              WHEN operation_type = 'add' THEN false
+              -- if the next event the same day is the opposite operation type, it should be ignored
+              WHEN #{existing_grouped_event_opposite_operation_type_sql} THEN true
+              ELSE false
+            END
+          SQL
+        end
+
+        # IS_IGNORED logic for prorated aggregation desired behaviour is:
+        # 27th property add
+        # 27th property remove
+        # 27th property add
+
+        # 28th property add (operation is 0, so it's already filtered by previous query)
+        # 28th property remove
+        # --- end of unit 0, prorated 2 days
+        # 30th property add
+        # --the result of 30 is 1 -> prorated 1 day
+        # for this we want to have only 2 events: 27th-28th and 30th to 30th
+
+        # summary table:
+        # 27th property add not_ignore
+        # 27th property remove ignore
+        # 27th property add ignore
+        # 28th property remove not_ignore
+        # 30th property add not_ignore
+        # So the rule is:
+        # -- for the same day, we look at next event. if it's opposite of current, current can be ignored
+        # -- we look at previous not ignored event. if the operation type matches. we can ignore current
+        def existing_event_opposite_operation_type_sql
+          <<-SQL
+            (
+              SELECT
+                1
+              FROM events_data next_event
+              WHERE next_event.property = e.property
+                AND DATE((next_event.timestamp)::timestamptz AT TIME ZONE :timezone) = DATE((e.timestamp)::timestamptz AT TIME ZONE :timezone)
+                AND next_event.operation_type <> e.operation_type
+                AND next_event.timestamp > e.timestamp
+              LIMIT 1
+            ) = 1
+          SQL
+        end
+
+        def existing_grouped_event_opposite_operation_type_sql
+          <<-SQL
+            (
+              SELECT
+                1
+              FROM events_data next_event
+              WHERE next_event.property = e.property
+                AND #{group_names.map { |name| "next_event.#{name} = e.#{name}" }.join(" AND ")}
+                AND DATE((next_event.timestamp)::timestamptz AT TIME ZONE :timezone) = DATE((e.timestamp)::timestamptz AT TIME ZONE :timezone)
+                AND next_event.operation_type <> e.operation_type
+                AND next_event.timestamp > e.timestamp
+              LIMIT 1
+            ) = 1
+          SQL
+        end
+
         def group_names
-          @group_names ||= store.grouped_by.map.with_index { |_, index| "g_#{index}" }.join(", ")
+          @group_names ||= store.grouped_by.map.with_index { |_, index| "g_#{index}" }
         end
       end
     end

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -137,7 +137,6 @@ module Events
             }
           ]
         )
-
         ActiveRecord::Base.connection.select_all(sql).to_a
       end
 

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -275,8 +275,8 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
         expect(result.aggregation).to eq(29.fdiv(31).ceil(5))
       end
 
-      context "when added and removed the same day" do
-        let(:added_at) { from_datetime + 1.day }
+      context "when added and removed the same day multiple times" do
+        let(:added_at) { from_datetime + 1.hour }
 
         it "returns a 1 day duration" do
           create(
@@ -284,7 +284,31 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
             organization_id: organization.id,
             code: billable_metric.code,
             external_subscription_id: subscription.external_id,
-            timestamp: added_at.end_of_day,
+            timestamp: added_at + 1.hour,
+            properties: {
+              unique_id: event.properties["unique_id"],
+              operation_type: "remove"
+            }
+          )
+
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            external_subscription_id: subscription.external_id,
+            timestamp: added_at + 2.hours,
+            properties: {
+              unique_id: event.properties["unique_id"],
+              operation_type: "add"
+            }
+          )
+
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            external_subscription_id: subscription.external_id,
+            timestamp: added_at + 3.hours,
             properties: {
               unique_id: event.properties["unique_id"],
               operation_type: "remove"
@@ -292,6 +316,31 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
           )
 
           expect(result.aggregation).to eq(1.fdiv(31).ceil(5))
+        end
+
+        context "when added and removed the same day multiple days" do
+          it "returns the correct number" do
+            events_params = [
+              {timestamp: added_at, id: event.properties["unique_id"], operation_type: "add"},
+              {timestamp: added_at + 1.hour, id: event.properties["unique_id"], operation_type: "remove"},
+              {timestamp: added_at + 5.days, id: event.properties["unique_id"], operation_type: "add"},
+              {timestamp: added_at + 5.days + 1.hour, id: event.properties["unique_id"], operation_type: "remove"},
+              {timestamp: added_at + 10.days, id: event.properties["unique_id"], operation_type: "add"},
+              {timestamp: added_at + 10.days + 1.hour, id: event.properties["unique_id"], operation_type: "remove"}
+            ]
+
+            events_params.each do |event_params|
+              create(
+                :event,
+                organization_id: organization.id,
+                code: billable_metric.code,
+                external_subscription_id: subscription.external_id,
+                timestamp: event_params[:timestamp],
+                properties: {unique_id: event_params[:id], operation_type: event_params[:operation_type]}
+              )
+            end
+            expect(result.aggregation).to eq(3.fdiv(31).ceil(5))
+          end
         end
       end
     end
@@ -313,6 +362,67 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
 
         expect(result.aggregation).to eq((1 + 21.fdiv(31)).ceil(5))
         expect(result.current_usage_units).to eq(2)
+      end
+
+      context "when added and removed several times a day during multiple days" do
+        it "returns the correct result" do
+          # 0 day: add (month ago - 1 day)
+          # 1st day: add, add, remove, add
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            external_subscription_id: subscription.external_id,
+            timestamp: from_datetime + 1.day,
+            properties: {unique_id: event.properties["unique_id"]}
+          )
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            external_subscription_id: subscription.external_id,
+            timestamp: from_datetime + 1.day + 1.hour,
+            properties: {unique_id: event.properties["unique_id"]}
+          )
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            external_subscription_id: subscription.external_id,
+            timestamp: from_datetime + 1.day + 2.hours,
+            properties: {unique_id: event.properties["unique_id"], operation_type: "remove"}
+          )
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            external_subscription_id: subscription.external_id,
+            timestamp: from_datetime + 1.day + 3.hours,
+            properties: {unique_id: event.properties["unique_id"]}
+          )
+
+          # 3rd day: add, remove
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            external_subscription_id: subscription.external_id,
+            timestamp: from_datetime + 3.days + 1.hour,
+            properties: {unique_id: event.properties["unique_id"]}
+          )
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            external_subscription_id: subscription.external_id,
+            timestamp: from_datetime + 3.days + 2.hours,
+            properties: {unique_id: event.properties["unique_id"], operation_type: "remove"}
+          )
+
+          expect(result.aggregation).to eq(4.fdiv(31).ceil(5))
+          # NOTE: current_usage_units is 0 because there are no "active" events in the period
+          expect(result.current_usage_units).to eq(0)
+        end
       end
     end
 
@@ -612,6 +722,61 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
           end
         end
       end
+
+      context "when added and removed the same day multiple times" do
+        it "does not count the same day multiple times" do
+          times_and_actions = [
+            [from_datetime + 1.day, "add"],
+            [from_datetime + 1.day + 1.hour, "remove"],
+            [from_datetime + 1.day + 2.hours, "add"],
+            [from_datetime + 1.day + 2.hours + 1.second, "remove"],
+            [from_datetime + 1.day + 3.hours, "add"],
+            [from_datetime + 2.days, "remove"],
+            [from_datetime + 2.days + 1.hour, "add"],
+            [from_datetime + 2.days + 2.hours, "remove"] # 2022-07-11
+          ]
+          agent_names.each do |agent_name|
+            times_and_actions.each do |timestamp, action|
+              create(
+                :event,
+                organization_id: organization.id,
+                code: billable_metric.code,
+                external_subscription_id: subscription.external_id,
+                timestamp:,
+                properties: {unique_id: "000", agent_name:, operation_type: action}
+              )
+            end
+          end
+
+          # aggregated by agents
+          expect(result.aggregations.count).to eq(2)
+
+          # As result of all merged events we have this table:
+          # [
+          #   {"g_0" => "aragorn", "property" => "000", "timestamp" => "2022-06-09T00:00:00.000Z", "operation_type" => "add", "rn" => 1, "is_ignored" => false, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "frodo",   "property" => "000", "timestamp" => "2022-06-09T00:00:00.000Z", "operation_type" => "add", "rn" => 1, "is_ignored" => false, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "aragorn", "property" => "000", "timestamp" => "2022-07-10T01:00:00.000Z", "operation_type" => "remove", "rn" => 2, "is_ignored" => true, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "frodo",   "property" => "000", "timestamp" => "2022-07-10T01:00:00.000Z", "operation_type" => "remove", "rn" => 2, "is_ignored" => true, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "aragorn", "property" => "000", "timestamp" => "2022-07-10T02:00:00.000Z", "operation_type" => "add", "rn" => 3, "is_ignored" => true, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "frodo",   "property" => "000", "timestamp" => "2022-07-10T02:00:00.000Z", "operation_type" => "add", "rn" => 3, "is_ignored" => true, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "aragorn", "property" => "000", "timestamp" => "2022-07-10T02:00:01.000Z", "operation_type" => "remove", "rn" => 4, "is_ignored" => true, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "frodo",   "property" => "000", "timestamp" => "2022-07-10T02:00:01.000Z", "operation_type" => "remove", "rn" => 4, "is_ignored" => true, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "aragorn", "property" => "000", "timestamp" => "2022-07-10T03:00:00.000Z", "operation_type" => "add", "rn" => 5, "is_ignored" => true, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "frodo",   "property" => "000", "timestamp" => "2022-07-10T03:00:00.000Z", "operation_type" => "add", "rn" => 5, "is_ignored" => true, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "aragorn", "property" => "000", "timestamp" => "2022-07-11T00:00:00.000Z", "operation_type" => "remove", "rn" => 6, "is_ignored" => true, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "frodo",   "property" => "000", "timestamp" => "2022-07-11T00:00:00.000Z", "operation_type" => "remove", "rn" => 6, "is_ignored" => true, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "aragorn", "property" => "000", "timestamp" => "2022-07-11T01:00:00.000Z", "operation_type" => "add", "rn" => 7, "is_ignored" => true, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "frodo",   "property" => "000", "timestamp" => "2022-07-11T01:00:00.000Z", "operation_type" => "add", "rn" => 7, "is_ignored" => true, "previous_not_ignored_operation_type" => "add"},
+          #   {"g_0" => "aragorn", "property" => "000", "timestamp" => "2022-07-11T02:00:00.000Z", "operation_type" => "remove", "rn" => 8, "is_ignored" => false, "previous_not_ignored_operation_type" => "remove"},
+          #   {"g_0" => "frodo",   "property" => "000", "timestamp" => "2022-07-11T02:00:00.000Z", "operation_type" => "remove", "rn" => 8, "is_ignored" => false, "previous_not_ignored_operation_type" => "remove"}
+          # ]
+          result.aggregations.each do |aggregation|
+            expect(aggregation.grouped_by.keys).to include("agent_name")
+            expect(aggregation.grouped_by["agent_name"]).to eq("frodo").or eq("aragorn")
+            expect(aggregation.aggregation).to eq(3.fdiv(31).ceil(5)) # subscription starts on 9th, so we have 3 days of usage
+          end
+        end
+      end
     end
 
     context "with persisted metrics added and terminated in the period" do
@@ -804,6 +969,115 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, transa
 
           expect(result.event_aggregation).to eq([1])
           expect(result.event_prorated_aggregation.map { |el| el.ceil(5) }).to eq([21.fdiv(31).ceil(5)])
+        end
+
+        context "when sending multiple events per day" do
+          let(:event) do
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at,
+              properties: {unique_id: "property_1"}
+            )
+          end
+
+          it "aggregates per events" do
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at,
+              properties: {unique_id: "property_1", scheme: "visa"}
+            )
+
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at,
+              properties: {unique_id: "property_1", scheme: "visa"}
+            )
+
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at + 1.hour,
+              properties: {unique_id: "property_1", scheme: "visa", operation_type: "remove"}
+            )
+
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at + 2.hours,
+              properties: {unique_id: "property_1", scheme: "visa", operation_type: "remove"}
+            )
+
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at + 3.hours,
+              properties: {unique_id: "property_1", scheme: "visa", operation_type: "add"}
+            )
+
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at + 1.day,
+              properties: {unique_id: "property_1", scheme: "visa", operation_type: "add"}
+            )
+
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at + 1.day + 1.hour,
+              properties: {unique_id: "property_1", scheme: "visa", operation_type: "remove"}
+            )
+
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              external_subscription_id: subscription.external_id,
+              timestamp: added_at + 1.day + 2.hours,
+              properties: {unique_id: "property_1", scheme: "visa", operation_type: "add"}
+            )
+
+            result = unique_count_service.per_event_aggregation(grouped_by_values: {"scheme" => "visa"})
+
+            # as result of this events we have:
+            # 1. timestamp: added_at, operation_type: add, property: SecureRandom.uuid, scheme: visa
+            # 2. timestamp: from_datetime + 20.days, operation_type: add, property: '1111'
+            # 3. timestamp: added_at, operation_type: add, property: property_1
+            # 4. timestamp: added_at, operation_type: add, property: property_1, scheme: visa
+            # 5. timestamp: added_at, operation_type: add, property: property_1, scheme: visa (ignored)
+            # 6. timestamp: added_at + 1.hour, operation_type: remove, property: property_1, scheme: visa (ignored)
+            # 7. timestamp: added_at + 2.hours, operation_type: remove, property: property_1, scheme: visa (ignored)
+            # 8. timestamp: added_at + 3.hours, operation_type: add, property: property_1, scheme: visa (ignored)
+            # 9. timestamp: added_at + 1.day, operation_type: add, property: property_1, scheme: visa (ignored)
+            # 10. timestamp: added_at + 1.day, operation_type: remove, property: property_1, scheme: visa (ignored)
+            # 11. timestamp: added_at + 1.day, operation_type: add, property: property_1, scheme: visa (ignored)
+            # when grouping by scheme Visa + taking into account minimal length of proration (1 day), some events are ignored,
+            # so we have 2 uniq properties: property_1, SecureRandom.uuid; '1111' doesn't have scheme visa, so it's excluded
+            # length of proration is 21 days for property_1, 21 days for SecureRandom.uuid (becuase random is just added once, property_1
+            # is added and removed multiple times, but the last action is add, so we merge all the events into one add)
+
+            expect(result.event_aggregation).to eq([1, 1])
+            expect(result.event_prorated_aggregation.map { |el| el.ceil(5) }).to eq([21.fdiv(31).ceil(5), 21.fdiv(31).ceil(5)])
+          end
         end
       end
     end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: true do
         organization_id: organization.id,
         external_subscription_id: subscription.external_id,
         code:,
-        timestamp: boundaries[:from_datetime] + 1.day,
+        timestamp: boundaries[:from_datetime] + 0.days,
         properties: {
           billable_metric.field_name => 2
         },
@@ -374,7 +374,7 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: true do
         organization_id: organization.id,
         external_subscription_id: subscription.external_id,
         code:,
-        timestamp: (boundaries[:from_datetime] + 1.day).end_of_day,
+        timestamp: (boundaries[:from_datetime] + 0.days).end_of_day,
         properties: {
           billable_metric.field_name => 2,
           :operation_type => "remove"
@@ -382,11 +382,56 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: true do
         value: "2",
         decimal_value: 2
       )
-
       event_store.aggregation_property = billable_metric.field_name
 
       # NOTE: Events calculation: 16/31 + 1/31 + + 15/31 + 14/31 + 13/31 + 12/31
+      # Events:
+      # 1 => added on 0 day, never removed => 16/31
+      # 2 => added on 0 day, removed on 0 day => 1/31
+      # 2 => added on 1 day, never removed => 15/31
+      # 3 => added on 2 day, never removed => 14/31
+      # 4 => added on 3 day, never removed => 13/31
+      # 5 => added on 4 day, never removed => 12/31
       expect(event_store.prorated_unique_count.round(3)).to eq(2.29)
+    end
+
+    context "with multiple events at the same day" do
+      it "returns the number of unique active event properties merged within one day" do
+        event_params = [
+          {timestamp: boundaries[:from_datetime], operation_type: "remove"},
+          {timestamp: boundaries[:from_datetime] + 1.hour, operation_type: "add"},
+          {timestamp: boundaries[:from_datetime] + 2.hours, operation_type: "remove"},
+          {timestamp: boundaries[:from_datetime] + 3.hours, operation_type: "add"},
+          {timestamp: boundaries[:from_datetime] + 1.day, operation_type: "remove"},
+          {timestamp: boundaries[:from_datetime] + 1.day + 1.hour, operation_type: "add"},
+          {timestamp: boundaries[:from_datetime] + 2.days + 1.hour, operation_type: "remove"}
+        ]
+
+        event_params.each do |params|
+          Clickhouse::EventsEnriched.create!(
+            transaction_id: SecureRandom.uuid,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            code:,
+            timestamp: params[:timestamp],
+            properties: {
+              billable_metric.field_name => 2,
+              :operation_type => params[:operation_type]
+            },
+            value: "2",
+            decimal_value: 2
+          )
+        end
+
+        # NOTE: Events calculation: 3/31
+        # Events:
+        # 1 => added on 0 day, never removed => 16/31
+        # 2 => added on 0 day, removed on 2 day => 3/31
+        # 3 => added on 2 day, never removed => 14/31
+        # 4 => added on 3 day, never removed => 13/31
+        # 5 => added on 4 day, never removed => 12/31
+        expect(event_store.prorated_unique_count.round(3)).to eq(1.871) # 16/31 + 3/31 + 14/31 + 13/31 + 12/31
+      end
     end
   end
 

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -322,6 +322,45 @@ RSpec.describe Events::Stores::PostgresStore do
       # NOTE: Events calculation: 16/31 + 1/31 + + 15/31 + 14/31 + 13/31 + 12/31
       expect(event_store.prorated_unique_count.round(3)).to eq(2.29)
     end
+
+    context "with multiple events at the same day" do
+      it "returns the number of unique active event properties merged within one day", transaction: false do
+        event_params = [
+          {timestamp: boundaries[:from_datetime], operation_type: "remove"},
+          {timestamp: boundaries[:from_datetime] + 1.hour, operation_type: "add"},
+          {timestamp: boundaries[:from_datetime] + 2.hours, operation_type: "remove"},
+          {timestamp: boundaries[:from_datetime] + 3.hours, operation_type: "add"},
+          {timestamp: boundaries[:from_datetime] + 1.day, operation_type: "remove"},
+          {timestamp: boundaries[:from_datetime] + 1.day + 1.hour, operation_type: "add"},
+          {timestamp: boundaries[:from_datetime] + 2.days + 1.hour, operation_type: "remove"}
+        ]
+
+        event_params.each do |params|
+          create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
+            code:,
+            timestamp: params[:timestamp],
+            properties: {
+              billable_metric.field_name => 2,
+              :operation_type => params[:operation_type]
+            }
+          )
+        end
+
+        # NOTE: Events calculation: 3/31
+        # Events:
+        # 1 => added on 0 day, never removed => 16/31
+        # 2 => added on 0 day, removed on 2 day => 3/31
+        # 3 => added on 2 day, never removed => 14/31
+        # 4 => added on 3 day, never removed => 13/31
+        # 5 => added on 4 day, never removed => 12/31
+        event_store.aggregation_property = billable_metric.field_name
+        expect(event_store.prorated_unique_count.round(3)).to eq(1.871) # 16/31 + 3/31 + 14/31 + 13/31 + 12/31
+      end
+    end
   end
 
   describe "#grouped_unique_count" do


### PR DESCRIPTION
## Context

when for uniq count we post several events per day like:
27th June - 10:00 - property - Add
27th June - 11:00 - property - Remove
27th June - 12:00 - property - Add
27th June - 13:00 - property - Remove

current logic will count it as two events with minimal length of
proration 1 day, so the customer will be charged for 2 prorated days of
usage.

Instead, we want to group events by day, because we prorate them through
day, and for one day record only one event

another scenario:
27th June - 10:00 - property - Add
28th June - 10:00 - property - Remove
28th June - 11:00 - property - Add

if we "end" usage on 28th, the first Add event will "cover" usage on
28th. The event received on 28th will not do the double charge on 28th,
and will "start" on 29th, but: as result anyway we'll charge for the
usage on 27th, 28, 29.. so we can just ignore the remove event, and
aggregate all this as as one event started on 27th

## Description

Updated prorated uniq_count_queries for postgresql and clickhouse
Algorithm:
1) prepare events table
2) ignore only REMOVE events that will be "cancelled" by the following
Add event at the same day
3) using adjusted value logic nullify not needed Adds (if previous row
has the same operation_type, current has adjusted value 0; otherwise
it's 1 for Add; -1 for Remove)


this pr is a pure pain.
especially clickhouse - it can't do recursion, LAG and LOG are very
heavy there and tests were killing the db... so I needed to write a
completely different approach from postgres, thenI rewrote couple of
approaches on both stores, finally found a bug in clickhouse proration,
and here is the result