### PR TITLE
fix(clickhouse): Limit 1 with raw SQL

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -34,12 +34,11 @@ module Events
 
         query = query.where(arel_table[:timestamp].gteq(from_datetime)) if force_from || use_from_boundary
         query = query.where(arel_table[:timestamp].lteq(to_datetime)) if to_datetime
-        query = query.limit_by(1, "events_enriched.transaction_id")
 
         query = apply_arel_grouped_by_values(query) if grouped_by_values?
         query = arel_filters_scope(query)
 
-        query.project(select).to_sql
+        "#{query.project(select).to_sql} LIMIT 1 by events_enriched.transaction_id"
       end
 
       def distinct_codes


### PR DESCRIPTION
## Description

This PR makes sure that the `limit 1 by events_enriched.transaction_id` responsible for the events deduplication in clickhouse is added when calling the `events_sql` method.

The logic was missing since the merge of https://github.com/getlago/lago-api/pull/3858
