### PR TITLE
fix(alerts): Add validation for duplicated threshold

### DIFF
--- a/app/services/usage_monitoring/create_alert_service.rb
+++ b/app/services/usage_monitoring/create_alert_service.rb
@@ -26,6 +26,11 @@ module UsageMonitoring
         return result.single_validation_failure!(field: :thresholds, error_code: "too_many_thresholds")
       end
 
+      threshold_values = params[:thresholds].map { |t| t[:value] }.compact
+      if threshold_values.size != threshold_values.uniq.size
+        return result.single_validation_failure!(field: :thresholds, error_code: "duplicate_threshold_values")
+      end
+
       billable_metric = find_billable_metric_from_params!
       return result unless result.success?
 

--- a/app/services/usage_monitoring/update_alert_service.rb
+++ b/app/services/usage_monitoring/update_alert_service.rb
@@ -19,6 +19,13 @@ module UsageMonitoring
         return result.single_validation_failure!(field: :thresholds, error_code: "too_many_thresholds")
       end
 
+      if params[:thresholds].present?
+        threshold_values = params[:thresholds].map { |t| t[:value] }.compact
+        if threshold_values.size != threshold_values.uniq.size
+          return result.single_validation_failure!(field: :thresholds, error_code: "duplicate_threshold_values")
+        end
+      end
+
       result.alert = alert
 
       billable_metric = find_billable_metric_from_params!

--- a/spec/services/usage_monitoring/create_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/create_alert_service_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe UsageMonitoring::CreateAlertService do
     end
 
     context "when code is blank" do
-      let(:params) { {alert_type: "current_usage_amount", code: nil, thresholds: [{ value: nil }]} }
+      let(:params) { {alert_type: "current_usage_amount", code: nil, thresholds: [{value: nil}]} }
 
       it "returns a validation failure result" do
         expect(result).to be_failure
@@ -100,7 +100,7 @@ RSpec.describe UsageMonitoring::CreateAlertService do
     end
 
     context "when alert_type is blank" do
-      let(:params) { {alert_type: nil, code: "ok", thresholds: [{ value: nil }]} }
+      let(:params) { {alert_type: nil, code: "ok", thresholds: [{value: nil}]} }
 
       it "returns a validation failure result" do
         expect(result).to be_failure

--- a/spec/services/usage_monitoring/create_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/create_alert_service_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe UsageMonitoring::CreateAlertService do
     end
 
     context "when code is blank" do
-      let(:params) { {alert_type: "current_usage_amount", code: nil, thresholds: [1]} }
+      let(:params) { {alert_type: "current_usage_amount", code: nil, thresholds: [{ value: nil }]} }
 
       it "returns a validation failure result" do
         expect(result).to be_failure
@@ -100,7 +100,7 @@ RSpec.describe UsageMonitoring::CreateAlertService do
     end
 
     context "when alert_type is blank" do
-      let(:params) { {alert_type: nil, code: "ok", thresholds: [1]} }
+      let(:params) { {alert_type: nil, code: "ok", thresholds: [{ value: nil }]} }
 
       it "returns a validation failure result" do
         expect(result).to be_failure
@@ -114,6 +114,15 @@ RSpec.describe UsageMonitoring::CreateAlertService do
       it "returns a validation failure result" do
         expect(result).to be_failure
         expect(result.error.messages[:thresholds]).to include("value_is_mandatory")
+      end
+    end
+
+    context "when thresholds have duplicate values" do
+      let(:params) { {alert_type: "current_usage_amount", code: "ok", thresholds: [{value: 1}, {value: 1}]} }
+
+      it "returns a validation failure result" do
+        expect(result).to be_failure
+        expect(result.error.messages[:thresholds]).to include("duplicate_threshold_values")
       end
     end
 

--- a/spec/services/usage_monitoring/update_alert_service_spec.rb
+++ b/spec/services/usage_monitoring/update_alert_service_spec.rb
@@ -84,5 +84,14 @@ RSpec.describe UsageMonitoring::UpdateAlertService do
         expect(result.error.message).to include("too_many_thresholds")
       end
     end
+
+    context "when thresholds have duplicate values" do
+      let(:params) { {thresholds: [{value: 1}, {value: 1}]} }
+
+      it "returns a validation failure result" do
+        expect(result).to be_failure
+        expect(result.error.messages[:thresholds]).to include("duplicate_threshold_values")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

We validated the threshold values only in the UI, not on the API side.

## Description

Added the validation for duplicated threshold values.