### PR TITLE
feat(customer): Add more filters to `customers` GraphQL query

### DIFF
--- a/app/graphql/resolvers/customers_resolver.rb
+++ b/app/graphql/resolvers/customers_resolver.rb
@@ -18,25 +18,30 @@ module Resolvers
     argument :active_subscriptions_count_from, Integer, required: false
     argument :active_subscriptions_count_to, Integer, required: false
     argument :billing_entity_ids, [ID], required: false
+    argument :countries, [Types::CountryCodeEnum], required: false
+    argument :currencies, [Types::CurrencyEnum], required: false
+    argument :customer_type, Types::Customers::CustomerTypeEnum, required: false
+    argument :has_customer_type, Boolean, required: false
+    argument :has_tax_identification_number, Boolean, required: false
+    argument :metadata, [Types::Customers::Metadata::Filter], required: false
+    argument :states, [String], required: false
     argument :with_deleted, Boolean, required: false
+    argument :zipcodes, [String], required: false
 
     type Types::Customers::Object.collection_type, null: false
 
-    def resolve(**args)
+    def resolve(search_term: nil, page: nil, limit: nil, metadata: nil, **filters)
+      if metadata.present?
+        filters[:metadata] = metadata.to_h { |m| [m[:key], m[:value]] }
+      end
       result = CustomersQuery.call(
         organization: current_organization,
-        search_term: args[:search_term],
+        search_term:,
         pagination: {
-          page: args[:page],
-          limit: args[:limit]
+          page:,
+          limit:
         },
-        filters: args.slice(
-          :account_type,
-          :billing_entity_ids,
-          :with_deleted,
-          :active_subscriptions_count_from,
-          :active_subscriptions_count_to
-        )
+        filters:
       )
 
       result.customers

--- a/app/graphql/types/customers/metadata/filter.rb
+++ b/app/graphql/types/customers/metadata/filter.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  module Customers
+    module Metadata
+      class Filter < Types::BaseInputObject
+        graphql_name "CustomerMetadataFilter"
+
+        argument :key, String, required: true
+        argument :value, String, required: true
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4147,6 +4147,11 @@ type CustomerMetadata {
   value: String!
 }
 
+input CustomerMetadataFilter {
+  key: String!
+  value: String!
+}
+
 input CustomerMetadataInput {
   displayInInvoice: Boolean!
   id: ID
@@ -8600,7 +8605,7 @@ type Query {
   """
   Query customers of an organization
   """
-  customers(accountType: [CustomerAccountTypeEnum!], activeSubscriptionsCountFrom: Int, activeSubscriptionsCountTo: Int, billingEntityIds: [ID!], limit: Int, page: Int, searchTerm: String, withDeleted: Boolean): CustomerCollection!
+  customers(accountType: [CustomerAccountTypeEnum!], activeSubscriptionsCountFrom: Int, activeSubscriptionsCountTo: Int, billingEntityIds: [ID!], countries: [CountryCode!], currencies: [CurrencyEnum!], customerType: CustomerTypeEnum, hasCustomerType: Boolean, hasTaxIdentificationNumber: Boolean, limit: Int, metadata: [CustomerMetadataFilter!], page: Int, searchTerm: String, states: [String!], withDeleted: Boolean, zipcodes: [String!]): CustomerCollection!
 
   """
   Query monthly recurring revenues of an organization

--- a/schema.json
+++ b/schema.json
@@ -17923,6 +17923,49 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "CustomerMetadataFilter",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "key",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "CustomerMetadataInput",
           "description": null,
           "interfaces": null,
@@ -44834,12 +44877,148 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "countries",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CountryCode",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "currencies",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "CurrencyEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "customerType",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CustomerTypeEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "hasCustomerType",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "hasTaxIdentificationNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "metadata",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "CustomerMetadataFilter",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "states",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "withDeleted",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
                     "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "zipcodes",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/spec/graphql/resolvers/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers_resolver_spec.rb
@@ -4,10 +4,48 @@ require "rails_helper"
 
 RSpec.describe Resolvers::CustomersResolver do
   let(:required_permission) { "customers:view" }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:billing_entity1) { organization.default_billing_entity }
+  let(:billing_entity2) { create(:billing_entity, organization:) }
   let(:query) do
     <<~GQL
-      query {
-        customers(limit: 5) {
+      query(
+        $searchTerm: String,
+        $page: Int,
+        $limit: Int,
+        $accountType: [CustomerAccountTypeEnum!],
+        $billingEntityIds: [ID!],
+        $activeSubscriptionsCountFrom: Int,
+        $activeSubscriptionsCountTo: Int,
+        $customerType: CustomerTypeEnum,
+        $hasCustomerType: Boolean,
+        $hasTaxIdentificationNumber: Boolean,
+        $countries: [CountryCode!],
+        $states: [String!],
+        $zipcodes: [String!],
+        $currencies: [CurrencyEnum!],
+        $withDeleted: Boolean,
+        $metadata: [CustomerMetadataFilter!]
+      ) {
+        customers(
+          limit: $limit,
+          searchTerm: $searchTerm,
+          page: $page,
+          accountType: $accountType,
+          billingEntityIds: $billingEntityIds,
+          activeSubscriptionsCountFrom: $activeSubscriptionsCountFrom,
+          activeSubscriptionsCountTo: $activeSubscriptionsCountTo,
+          customerType: $customerType,
+          hasCustomerType: $hasCustomerType,
+          hasTaxIdentificationNumber: $hasTaxIdentificationNumber,
+          countries: $countries,
+          states: $states,
+          zipcodes: $zipcodes,
+          currencies: $currencies,
+          withDeleted: $withDeleted,
+          metadata: $metadata
+        ) {
           collection { id externalId name }
           metadata { currentPage, totalCount }
         }
@@ -15,44 +53,37 @@ RSpec.describe Resolvers::CustomersResolver do
     GQL
   end
 
-  let(:membership) { create(:membership) }
-  let(:organization) { membership.organization }
-  let(:billing_entity1) { organization.default_billing_entity }
-  let(:billing_entity2) { create(:billing_entity, organization:) }
+  def test_customers_resolver(expected_customers, variables: {})
+    variables = {page: 1, limit: 5}.merge(variables)
+    result = execute_query(query:, variables: variables)
+
+    customers_response = result["data"]["customers"]
+
+    expected_customers = Array.wrap(expected_customers)
+
+    expect(customers_response["collection"].count).to eq(expected_customers.count)
+    expect(customers_response["collection"].pluck("id")).to match_array(expected_customers.pluck(:id))
+
+    expect(customers_response["metadata"]["currentPage"]).to eq(1)
+    expect(customers_response["metadata"]["totalCount"]).to eq(expected_customers.count)
+  end
 
   it_behaves_like "requires current user"
   it_behaves_like "requires current organization"
   it_behaves_like "requires permission", "customers:view"
 
   it "returns a list of customers" do
-    customer = create(:customer, organization:)
+    customer_1 = create(:customer, organization:)
+    customer_2 = create(:customer, organization:)
 
-    result = execute_graphql(
-      current_user: membership.user,
-      current_organization: organization,
-      permissions: required_permission,
-      query:
-    )
-
-    customers_response = result["data"]["customers"]
-
-    aggregate_failures do
-      expect(customers_response["collection"].count).to eq(organization.customers.count)
-      expect(customers_response["collection"].first["id"]).to eq(customer.id)
-
-      expect(customers_response["metadata"]["currentPage"]).to eq(1)
-      expect(customers_response["metadata"]["totalCount"]).to eq(1)
-    end
+    test_customers_resolver([customer_1, customer_2])
   end
 
   context "without current organization" do
     it "returns an error" do
       result = execute_graphql(current_user: membership.user, query:)
 
-      expect_graphql_error(
-        result:,
-        message: "Missing organization id"
-      )
+      expect_graphql_error(result:, message: "Missing organization id")
     end
   end
 
@@ -60,38 +91,13 @@ RSpec.describe Resolvers::CustomersResolver do
     let(:customer) { create(:customer, organization:) }
     let(:partner) { create(:customer, organization:, account_type: "partner") }
 
-    let(:query) do
-      <<~GQL
-        query($accountType: [CustomerAccountTypeEnum!]) {
-          customers(limit: 5, accountType: $accountType) {
-            collection { id }
-            metadata { currentPage, totalCount }
-          }
-        }
-      GQL
-    end
-
     before do
       customer
       partner
     end
 
     it "returns all customers with account_type partner" do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        permissions: required_permission,
-        query:,
-        variables: {accountType: "partner"}
-      )
-
-      invoices_response = result["data"]["customers"]
-
-      expect(invoices_response["collection"].count).to eq(1)
-      expect(invoices_response["collection"].first["id"]).to eq(partner.id)
-
-      expect(invoices_response["metadata"]["currentPage"]).to eq(1)
-      expect(invoices_response["metadata"]["totalCount"]).to eq(1)
+      test_customers_resolver(partner, variables: {accountType: ["partner"]})
     end
   end
 
@@ -99,38 +105,13 @@ RSpec.describe Resolvers::CustomersResolver do
     let(:customer) { create(:customer, organization:, billing_entity: billing_entity1) }
     let(:customer2) { create(:customer, organization:, billing_entity: billing_entity2) }
 
-    let(:query) do
-      <<~GQL
-        query($billingEntityIds: [ID!]) {
-          customers(limit: 5, billingEntityIds: $billingEntityIds) {
-            collection { id }
-            metadata { currentPage, totalCount }
-          }
-        }
-      GQL
-    end
-
     before do
       customer
       customer2
     end
 
     it "returns all customers for the specified billing entity" do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        permissions: required_permission,
-        query:,
-        variables: {billingEntityIds: [billing_entity2.id]}
-      )
-
-      customers_response = result["data"]["customers"]
-
-      expect(customers_response["collection"].count).to eq(1)
-      expect(customers_response["collection"].first["id"]).to eq(customer2.id)
-
-      expect(customers_response["metadata"]["currentPage"]).to eq(1)
-      expect(customers_response["metadata"]["totalCount"]).to eq(1)
+      test_customers_resolver(customer2, variables: {billingEntityIds: [billing_entity2.id]})
     end
   end
 
@@ -138,78 +119,155 @@ RSpec.describe Resolvers::CustomersResolver do
     let(:customer) { create(:customer, organization:) }
     let(:deleted_customer) { create(:customer, organization:, deleted_at: Time.current) }
 
-    let(:query) do
-      <<~GQL
-        query($withDeleted: Boolean) {
-          customers(limit: 5, withDeleted: $withDeleted) {
-            collection { id }
-            metadata { currentPage, totalCount }
-          }
-        }
-      GQL
-    end
-
     before do
       customer
       deleted_customer
     end
 
     it "returns all customers including deleted ones" do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        permissions: required_permission,
-        query:,
-        variables: {withDeleted: true}
-      )
-
-      customers_response = result["data"]["customers"]
-
-      expect(customers_response["collection"].count).to eq(2)
-      expect(customers_response["collection"].map { |c| c["id"] }).to include(customer.id, deleted_customer.id)
-
-      expect(customers_response["metadata"]["currentPage"]).to eq(1)
-      expect(customers_response["metadata"]["totalCount"]).to eq(2)
+      test_customers_resolver([customer, deleted_customer], variables: {withDeleted: true})
     end
   end
 
   context "when filtering by active subscriptions" do
-    let(:customer) { create(:customer, organization:) }
-
-    let(:query) do
-      <<~GQL
-        query($activeSubscriptionsCountFrom: Int, $activeSubscriptionsCountTo: Int) {
-          customers(limit: 5, activeSubscriptionsCountFrom: $activeSubscriptionsCountFrom, activeSubscriptionsCountTo: $activeSubscriptionsCountTo) {
-            collection { id }
-            metadata { currentPage, totalCount }
-          }
-        }
-      GQL
-    end
+    let(:active_subscription_customer) { create(:customer, organization:) }
 
     before do
-      create(:customer, organization:)
+      other_customer = create(:customer, organization:)
+      create(:subscription, customer: other_customer)
       2.times do
-        create(:subscription, customer:)
+        create(:subscription, customer: active_subscription_customer)
       end
     end
 
     it "returns all customers with 2 active subscriptions" do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        permissions: required_permission,
-        query:,
-        variables: {activeSubscriptionsCountFrom: 2, activeSubscriptionsCountTo: 2}
+      test_customers_resolver(active_subscription_customer, variables: {activeSubscriptionsCountFrom: 2, activeSubscriptionsCountTo: 2})
+    end
+  end
+
+  context "when filtering by customer_type" do
+    let!(:company_customer) { create(:customer, organization:, customer_type: "company") }
+
+    before do
+      create(:customer, organization:, customer_type: "individual")
+    end
+
+    it "returns all customers with customer_type company" do
+      test_customers_resolver(company_customer, variables: {customerType: "company"})
+    end
+  end
+
+  context "when filtering by has_customer_type" do
+    let!(:company_customer) { create(:customer, organization:, customer_type: "company") }
+
+    before do
+      create(:customer, organization:, customer_type: nil)
+    end
+
+    it "returns all customers with customer_type company" do
+      test_customers_resolver(company_customer, variables: {hasCustomerType: true})
+    end
+  end
+
+  context "when filtering by has_tax_identification_number" do
+    let!(:customer_with_tax_identification_number) { create(:customer, organization:, tax_identification_number: "1234567890") }
+
+    before do
+      create(:customer, organization:, tax_identification_number: nil)
+    end
+
+    it "returns all customers with tax_identification_number" do
+      test_customers_resolver(customer_with_tax_identification_number, variables: {hasTaxIdentificationNumber: true})
+    end
+  end
+
+  context "when filtering by countries" do
+    let!(:customer_in_france) { create(:customer, organization:, country: "FR") }
+
+    before do
+      create(:customer, organization:, country: "US")
+    end
+
+    it "returns all customers in France" do
+      test_customers_resolver(customer_in_france, variables: {countries: ["FR"]})
+    end
+  end
+
+  context "when filtering by states" do
+    let!(:customer_in_new_york) { create(:customer, organization:, state: "NY") }
+
+    before do
+      create(:customer, organization:, state: "CA")
+    end
+
+    it "returns all customers in New York" do
+      test_customers_resolver(customer_in_new_york, variables: {states: ["NY"]})
+    end
+  end
+
+  context "when filtering by zipcodes" do
+    let!(:customer_in_new_york) { create(:customer, organization:, zipcode: "10001") }
+
+    before do
+      create(:customer, organization:, zipcode: "90001")
+    end
+
+    it "returns all customers in New York" do
+      test_customers_resolver(customer_in_new_york, variables: {zipcodes: ["10001"]})
+    end
+  end
+
+  context "when filtering by currencies" do
+    let!(:customer_in_usd) { create(:customer, organization:, currency: "USD") }
+
+    before do
+      create(:customer, organization:, currency: "EUR")
+    end
+
+    it "returns all customers in USD" do
+      test_customers_resolver(customer_in_usd, variables: {currencies: ["USD"]})
+    end
+  end
+
+  context "when filtering by search_term" do
+    let!(:john_doe) { create(:customer, organization:, name: "John, Doe", email: "john@doe.com", legal_name: "John-Doe", firstname: "Johnnas", lastname: "Doefe", external_id: "1234567890") }
+
+    before do
+      create(:customer, organization:, name: "Jane Doe", email: "jane@doe.com", legal_name: "Jane-Doe", firstname: "Janenas", lastname: "Doefae", external_id: "1234567891")
+    end
+
+    [
+      ["John,", :name],
+      ["ohn@doe.com", :email],
+      ["hn-d", :legal_name],
+      ["nnas", :firstname],
+      ["doefe", :lastname],
+      ["1234567890", :external_id]
+    ].each do |search_term, field|
+      context "when search_term matches #{field}" do
+        it "returns the matching customer" do
+          test_customers_resolver(john_doe, variables: {searchTerm: search_term})
+        end
+      end
+    end
+  end
+
+  context "when filtering by metadata" do
+    let!(:customer_with_metadata) { create(:customer, organization:) }
+
+    before do
+      create(:customer_metadata, customer: customer_with_metadata, key: "key_1", value: "value_1")
+
+      second_customer = create(:customer, organization:)
+      create(:customer_metadata, customer: second_customer, key: "key_1", value: "value_1")
+      create(:customer_metadata, customer: second_customer, key: "key_2", value: "value_2")
+    end
+
+    it "returns all customers with metadata" do
+      test_customers_resolver(
+        customer_with_metadata,
+        variables: {metadata: [{key: "key_1", value: "value_1"}, {key: "key_2", value: ""}]}
       )
-
-      customers_response = result["data"]["customers"]
-
-      expect(customers_response["collection"].count).to eq(1)
-      expect(customers_response["collection"].map { |c| c["id"] }).to include(customer.id)
-
-      expect(customers_response["metadata"]["currentPage"]).to eq(1)
-      expect(customers_response["metadata"]["totalCount"]).to eq(1)
     end
   end
 end

--- a/spec/graphql/types/customers/metadata/filter_spec.rb
+++ b/spec/graphql/types/customers/metadata/filter_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::Customers::Metadata::Filter do
+  subject { described_class }
+
+  it do
+    expect(subject).to accept_argument(:key).of_type("String!")
+    expect(subject).to accept_argument(:value).of_type("String!")
+  end
+end


### PR DESCRIPTION
## Context

The filtering on the `GET /api/v1/customers` endpoint was too limited so we added a few filters:

- https://github.com/getlago/lago-api/pull/4377
- https://github.com/getlago/lago-api/pull/4378
- https://github.com/getlago/lago-api/pull/4383
- https://github.com/getlago/lago-api/pull/4386
- https://github.com/getlago/lago-api/pull/4392
- https://github.com/getlago/lago-api/pull/4393

## Description

This adds those filters to the `customers` GraphQL query as well.

Note that GraphQL doesn't allow arbitrary map/hash as type so I had to create a specific type for the `metadata` filter.
