### PR TITLE
fix(customer): Use proper metadata index for `CustomersQuery`

### DIFF
--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -72,6 +72,7 @@ class CustomersQuery < BaseQuery
     if presence_filters.any?
       tuples = presence_filters.map { "(?, ?)" }.join(", ")
       subquery = Metadata::CustomerMetadata
+        .where(organization_id: organization.id)
         .where("(key, value) IN (#{tuples})", *presence_filters.flatten)
         .group("customer_id")
         .having("COUNT(DISTINCT key) = ?", presence_filters.size)
@@ -82,7 +83,7 @@ class CustomersQuery < BaseQuery
 
     if absence_filters.any?
       keys = absence_filters.map { |k, _v| k }
-      subquery = Metadata::CustomerMetadata.where(key: keys).select(:customer_id)
+      subquery = Metadata::CustomerMetadata.where(organization_id: organization.id).where(key: keys).select(:customer_id)
       scope = scope.where.not(id: subquery)
     end
 


### PR DESCRIPTION
## Context

`customer_metadata` currently has indexes on `organization_id` and `(customer_id, key)` but no index on `key` as the primary column.

Therefore the metadata sub-queries present in the `CustomersQuery` are not actually relying on any index:

```sql
EXPLAIN ANALYZE
SELECT "customers".*
FROM "customers"
WHERE "customers"."deleted_at" IS NULL
  AND "customers"."organization_id" = '466aec29-ff0b-4f9e-a69f-ec69ba84067f'
  AND "customers"."id" IN (
    SELECT "customer_metadata"."customer_id"
    FROM "customer_metadata"
    WHERE ((key, value) IN (('coin', 'bitcoin')))
    GROUP BY "customer_metadata"."customer_id"
    HAVING (COUNT(DISTINCT key) = 1)
  )
ORDER BY "customers"."created_at" DESC,
  "customers"."id" ASC
LIMIT 25;

                                                                               QUERY PLAN                                                                                
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=123983.78..123983.84 rows=25 width=847) (actual time=2938.525..2938.585 rows=25 loops=1)
   ->  Sort  (cost=123983.78..123984.01 rows=91 width=847) (actual time=2925.085..2925.143 rows=25 loops=1)
         Sort Key: customers.created_at DESC, customers.id
         Sort Method: top-N heapsort  Memory: 47kB
         ->  Nested Loop  (cost=80089.46..123981.21 rows=91 width=847) (actual time=289.755..2908.223 rows=49923 loops=1)
               ->  GroupAggregate  (cost=80089.04..114247.07 rows=1185 width=16) (actual time=289.438..661.494 rows=634543 loops=1)
                     Group Key: customer_metadata.customer_id
                     Filter: (count(DISTINCT customer_metadata.key) = 1)
                     ->  Gather Merge  (cost=80089.04..109999.37 rows=256815 width=22) (actual time=289.394..360.664 rows=634543 loops=1)
                           Workers Planned: 2
                           Workers Launched: 2
                           ->  Sort  (cost=79089.01..79356.53 rows=107006 width=22) (actual time=269.755..281.599 rows=211514 loops=3)
                                 Sort Key: customer_metadata.customer_id
                                 Sort Method: external merge  Disk: 7656kB
                                 Worker 0:  Sort Method: external merge  Disk: 5784kB
                                 Worker 1:  Sort Method: external merge  Disk: 5848kB
                                 ->  Parallel Seq Scan on customer_metadata  (cost=0.00..67955.59 rows=107006 width=22) (actual time=2.104..225.869 rows=211514 loops=3)
                                       Filter: (((key)::text = 'coin'::text) AND ((value)::text = 'bitcoin'::text))
                                       Rows Removed by Filter: 847171
               ->  Index Scan using customers_pkey on customers  (cost=0.43..8.20 rows=1 width=847) (actual time=0.003..0.003 rows=0 loops=634543)
                     Index Cond: (id = customer_metadata.customer_id)
                     Filter: ((deleted_at IS NULL) AND (organization_id = '466aec29-ff0b-4f9e-a69f-ec69ba84067f'::uuid))
                     Rows Removed by Filter: 1
 Planning Time: 0.402 ms
 JIT:    
   Functions: 24
   Options: Inlining false, Optimization false, Expressions true, Deforming true
   Timing: Generation 4.734 ms, Inlining 0.000 ms, Optimization 2.167 ms, Emission 16.528 ms, Total 23.429 ms
 Execution Time: 2942.034 ms
(29 rows)
```

## Description

This fixes it by adding `AND organization_id = ?` in the sub-queries:

```sql
EXPLAIN ANALYZE
SELECT "customers".*
FROM "customers"
WHERE "customers"."deleted_at" IS NULL
  AND "customers"."organization_id" = '466aec29-ff0b-4f9e-a69f-ec69ba84067f'
  AND "customers"."id" IN (
    SELECT "customer_metadata"."customer_id"
    FROM "customer_metadata"
    WHERE "customer_metadata"."organization_id" = '466aec29-ff0b-4f9e-a69f-ec69ba84067f'
      AND ((key, value) IN (('coin', 'bitcoin')))
    GROUP BY "customer_metadata"."customer_id"
    HAVING (COUNT(DISTINCT key) = 1)
  )
ORDER BY "customers"."created_at" DESC,
  "customers"."id" ASC
LIMIT 25;
                                                                                              QUERY PLAN                                                                                              
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=57671.81..57671.83 rows=8 width=847) (actual time=1180.213..1180.625 rows=25 loops=1)
   ->  Sort  (cost=57671.81..57671.83 rows=8 width=847) (actual time=1180.212..1180.622 rows=25 loops=1)
         Sort Key: customers.created_at DESC, customers.id
         Sort Method: top-N heapsort  Memory: 47kB
         ->  Nested Loop  (cost=54135.19..57671.69 rows=8 width=847) (actual time=539.823..1164.935 rows=49923 loops=1)
               ->  GroupAggregate  (cost=54134.76..56825.94 rows=100 width=16) (actual time=539.500..576.489 rows=49923 loops=1)
                     Group Key: customer_metadata.customer_id
                     Filter: (count(DISTINCT customer_metadata.key) = 1)
                     ->  Gather Merge  (cost=54134.76..56475.74 rows=20100 width=22) (actual time=539.458..547.193 rows=49923 loops=1)
                           Workers Planned: 2
                           Workers Launched: 2
                           ->  Sort  (cost=53134.74..53155.67 rows=8375 width=22) (actual time=513.928..514.605 rows=16641 loops=3)
                                 Sort Key: customer_metadata.customer_id
                                 Sort Method: quicksort  Memory: 2192kB
                                 Worker 0:  Sort Method: quicksort  Memory: 1633kB
                                 Worker 1:  Sort Method: quicksort  Memory: 1613kB
                                 ->  Parallel Bitmap Heap Scan on customer_metadata  (cost=2669.63..52589.03 rows=8375 width=22) (actual time=16.680..508.387 rows=16641 loops=3)
                                       Recheck Cond: (organization_id = '466aec29-ff0b-4f9e-a69f-ec69ba84067f'::uuid)
                                       Filter: (((key)::text = 'coin'::text) AND ((value)::text = 'bitcoin'::text))
                                       Rows Removed by Filter: 66656
                                       Heap Blocks: exact=16470
                                       ->  Bitmap Index Scan on index_customer_metadata_on_organization_id  (cost=0.00..2664.61 rows=248557 width=0) (actual time=37.953..37.953 rows=249892 loops=1)
                                             Index Cond: (organization_id = '466aec29-ff0b-4f9e-a69f-ec69ba84067f'::uuid)
               ->  Index Scan using customers_pkey on customers  (cost=0.43..8.45 rows=1 width=847) (actual time=0.012..0.012 rows=1 loops=49923)
                     Index Cond: (id = customer_metadata.customer_id)
                     Filter: ((deleted_at IS NULL) AND (organization_id = '466aec29-ff0b-4f9e-a69f-ec69ba84067f'::uuid))
 Planning Time: 0.475 ms
 Execution Time: 1180.850 ms
(28 rows)
```

Note that a better fix might be to use a more efficient index but that will come in another iteration.
