### PR TITLE
chore(integration): Remove unused code related to integration mapping update

### DIFF
--- a/app/graphql/types/integration_mappings/update_input.rb
+++ b/app/graphql/types/integration_mappings/update_input.rb
@@ -9,6 +9,9 @@ module Types
       argument :external_id, String, required: false
       argument :external_name, String, required: false
       argument :id, ID, required: true
+
+      # DEPRECATED: These fields are not used anymore and will be removed in a future release once the frontend is
+      #             updated to not use them anymore.
       argument :integration_id, ID, required: false
       argument :mappable_id, ID, required: false
       argument :mappable_type, Types::IntegrationMappings::MappableTypeEnum, required: false

--- a/app/services/integration_mappings/update_service.rb
+++ b/app/services/integration_mappings/update_service.rb
@@ -12,9 +12,6 @@ module IntegrationMappings
     def call
       return result.not_found_failure!(resource: "integration_mapping") unless integration_mapping
 
-      integration_mapping.integration_id = params[:integration_id] if params.key?(:integration_id)
-      integration_mapping.mappable_id = params[:mappable_id] if params.key?(:mappable_id)
-      integration_mapping.mappable_type = params[:mappable_type] if params.key?(:mappable_type)
       integration_mapping.external_id = params[:external_id] if params.key?(:external_id)
       integration_mapping.external_account_code = params[:external_account_code] if params.key?(:external_account_code)
       integration_mapping.external_name = params[:external_name] if params.key?(:external_name)

--- a/spec/graphql/mutations/integration_mappings/update_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/update_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mutations::IntegrationMappings::Update do
   let(:required_permission) { "organization:integrations:update" }
   let(:integration_mapping) { create(:netsuite_mapping, integration:) }
   let(:integration) { create(:netsuite_integration, organization:) }
-  let(:mappable) { create(:add_on, organization:) }
+  let(:mappable) { integration_mapping.mappable }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }
   let(:external_account_code) { Faker::Barcode.ean }

--- a/spec/graphql/types/integration_mappings/update_input_spec.rb
+++ b/spec/graphql/types/integration_mappings/update_input_spec.rb
@@ -7,9 +7,6 @@ RSpec.describe Types::IntegrationMappings::UpdateInput do
 
   it do
     expect(subject).to accept_argument(:id).of_type("ID!")
-    expect(subject).to accept_argument(:integration_id).of_type("ID")
-    expect(subject).to accept_argument(:mappable_id).of_type("ID")
-    expect(subject).to accept_argument(:mappable_type).of_type("MappableTypeEnum")
     expect(subject).to accept_argument(:external_account_code).of_type("String")
     expect(subject).to accept_argument(:external_id).of_type("String")
     expect(subject).to accept_argument(:external_name).of_type("String")

--- a/spec/services/integration_mappings/update_service_spec.rb
+++ b/spec/services/integration_mappings/update_service_spec.rb
@@ -27,33 +27,15 @@ RSpec.describe IntegrationMappings::UpdateService do
 
         integration_mapping = IntegrationMappings::NetsuiteMapping.order(:updated_at).last
 
-        aggregate_failures do
-          expect(integration_mapping.external_id).to eq("456")
-          expect(integration_mapping.external_name).to eq("Name1")
-          expect(integration_mapping.external_account_code).to eq("code-2")
-        end
+        expect(integration_mapping.external_id).to eq("456")
+        expect(integration_mapping.external_name).to eq("Name1")
+        expect(integration_mapping.external_account_code).to eq("code-2")
       end
 
       it "returns an integration mapping in result object" do
         result = service_call
 
         expect(result.integration_mapping).to be_a(IntegrationMappings::NetsuiteMapping)
-      end
-    end
-
-    context "with validation error" do
-      let(:update_args) do
-        {integration_id: nil}
-      end
-
-      it "returns an error" do
-        result = service_call
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:integration]).to eq(["relation_must_exist"])
-        end
       end
     end
   end


### PR DESCRIPTION
## Context

When updating a integration mapping, it doesn't really make sense to update the `mappable_id`, `mappable_type` and `integration_id` as this mapping is intrinsically bound to the `integration` and `mappable`. For instance, one would never "move" a mapping from one integration to the other.

Also when updating an integration mapping, [the frontend is currently resending the same data as it received](https://github.com/getlago/lago-front/blob/2c4967927a0c7bb34af7c48784f1f32fd457113d/src/components/settings/integrations/NetsuiteIntegrationMapItemDialog.tsx#L304-L306). 

Therefore the `integration_id`, `mappable_id`, `mappable_type` arguments of the `update_integration_mapping` GraphQL query are currently unnecessary. 

## Description

This PR removes the code related these field update for the sake of simplifying this integration mapping code. We still needed to keep the GraphQL fields in the schema (although unused) to avoid a breaking change.

