### PR TITLE
feat(webhook): Reduce HTTP write timeout from 60s to 30s

### DIFF
--- a/app/services/webhooks/send_http_service.rb
+++ b/app/services/webhooks/send_http_service.rb
@@ -13,7 +13,7 @@ module Webhooks
     def call
       webhook.endpoint = webhook.webhook_endpoint.webhook_url
 
-      http_client = LagoHttpClient::Client.new(webhook.webhook_endpoint.webhook_url)
+      http_client = LagoHttpClient::Client.new(webhook.webhook_endpoint.webhook_url, write_timeout: 30)
       response = http_client.post_with_response(webhook.payload, webhook.generate_headers)
 
       mark_webhook_as_succeeded(response)

--- a/lib/lago_http_client/lago_http_client/client.rb
+++ b/lib/lago_http_client/lago_http_client/client.rb
@@ -10,10 +10,11 @@ module LagoHttpClient
 
     attr_reader :uri, :retries_on
 
-    def initialize(url, read_timeout: nil, retries_on: [])
+    def initialize(url, read_timeout: nil, write_timeout: nil, retries_on: [])
       @uri = URI(url)
       @http_client = Net::HTTP.new(uri.host, uri.port)
       @http_client.read_timeout = read_timeout if read_timeout.present?
+      @http_client.write_timeout = write_timeout if write_timeout.present?
       @http_client.use_ssl = true if uri.scheme == "https"
       @retries_on = retries_on
     end

--- a/spec/lib/lago_http_client/client_spec.rb
+++ b/spec/lib/lago_http_client/client_spec.rb
@@ -7,6 +7,19 @@ RSpec.describe LagoHttpClient::Client do
 
   let(:url) { "http://example.com/api/v1/example" }
 
+  describe "#initialize" do
+    it "use default timeouts from Net::HTTP" do
+      expect(client.send(:http_client).write_timeout).to eq 60
+      expect(client.send(:http_client).read_timeout).to eq 60
+    end
+
+    it "can override timeouts" do
+      client = described_class.new(url, read_timeout: 8, write_timeout: 12)
+      expect(client.send(:http_client).write_timeout).to eq 12
+      expect(client.send(:http_client).read_timeout).to eq 8
+    end
+  end
+
   describe "#post" do
     context "when response status code is 2xx" do
       let(:response) do

--- a/spec/services/webhooks/send_http_service_spec.rb
+++ b/spec/services/webhooks/send_http_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Webhooks::SendHttpService do
     end
 
     before do
-      allow(LagoHttpClient::Client).to receive(:new).with(webhook.webhook_endpoint.webhook_url).and_return(lago_client)
+      allow(LagoHttpClient::Client).to receive(:new).with(webhook.webhook_endpoint.webhook_url, write_timeout: 30).and_return(lago_client)
       allow(lago_client).to receive(:post_with_response).and_raise(
         LagoHttpClient::HttpError.new(403, error_body.to_json, "")
       )


### PR DESCRIPTION
Lago sends a lot of webhooks. Reducing write timeout would help in case some customer infra does not respond.
Default is 60 seconds, I propose to reduce it to 10 seconds.

Any other opinion on what value would be best? Maybe we could start with 30s.