### PR TITLE
test: Fix failing `spec/services/daily_usages/compute_service_spec.rb` test

### DIFF
--- a/spec/services/daily_usages/compute_service_spec.rb
+++ b/spec/services/daily_usages/compute_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DailyUsages::ComputeService do
   let(:charge) { create(:standard_charge, plan:, billable_metric:) }
   let(:plan) { create(:plan, organization:) }
   let(:subscription) do
-    create(:subscription, :calendar, customer:, plan:, started_at: 1.year.ago, subscription_at: 1.year.ago)
+    create(:subscription, :calendar, customer:, plan:, started_at: timestamp - 1.year, subscription_at: timestamp - 1.year)
   end
 
   let(:timestamp) { Time.zone.parse("2024-10-22 00:05:00") }


### PR DESCRIPTION
## Context

As the subscription `started_at/subscription_at` were set to 1 year ago relative to the current date, the charges `from_datetime` would be set the current time instead of beginning of the month.

## Description

This fix the spec.
