### PR TITLE
fix: add guard clause when applying prog billing credits on fee

### DIFF
--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -69,6 +69,7 @@ module Credits
         next unless fee
 
         fee.precise_coupons_amount_cents += progressive_fee.amount_cents
+        fee.precise_coupons_amount_cents = fee.amount_cents if fee.amount_cents < fee.precise_coupons_amount_cents
         fee.save!
       end
     end

--- a/spec/services/credits/progressive_billing_service_spec.rb
+++ b/spec/services/credits/progressive_billing_service_spec.rb
@@ -83,6 +83,20 @@ Rspec.describe Credits::ProgressiveBillingService do
         expect(subscription_fee2.reload.precise_coupons_amount_cents).to eq(0)
       end
 
+      context "when progressive billing credits are greater that amount cents" do
+        let(:subscription_fee1) { create(:charge_fee, invoice:, subscription:, amount_cents: 19) }
+
+        it "applies correctly one credit to the invoice" do
+          result = credit_service.call
+          expect(result.credits.size).to eq(1)
+          credit = result.credits.sole
+          expect(credit.amount_cents).to eq(20)
+          expect(invoice.progressive_billing_credit_amount_cents).to eq(20)
+          expect(subscription_fee1.reload.precise_coupons_amount_cents).to eq(19)
+          expect(subscription_fee2.reload.precise_coupons_amount_cents).to eq(0)
+        end
+      end
+
       context "with additional subscription fee" do
         let(:subscription_fees) { [subscription_fee1, subscription_fee2, subscription_fee3] }
         let(:subscription_fee1) { create(:charge_fee, invoice:, subscription:, amount_cents: 300) }


### PR DESCRIPTION
## Context

We need to ensure that fee amount_cents are never less than credits applied on that fee

## Description

This PR fixes described case