### PR TITLE
fix(billing): Use customer snapshot in invoices templates

### DIFF
--- a/app/views/templates/credit_notes/self_billed.slim
+++ b/app/views/templates/credit_notes/self_billed.slim
@@ -35,24 +35,24 @@ html
       .mb-24.overflow-auto
         .billing-information-column
           .body-1 = I18n.t('credit_note.credit_from')
-          .body-2 = customer.display_name
-          - if customer.legal_number.present?
-            .body-2 #{customer.legal_number}
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
+          .body-2 = customer_snapshot.display_name
+          - if customer_snapshot.legal_number.present?
+            .body-2 #{customer_snapshot.legal_number}
+          .body-2 = customer_snapshot.address_line1
+          .body-2 = customer_snapshot.address_line2
           .body-2
             span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
+              = customer_snapshot.zipcode
+            - if customer_snapshot.zipcode.present? && customer_snapshot.city.present?
               span
                 | , &nbsp;
             span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
-          .body-2 = customer.email
-          - if customer.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)
+              = customer_snapshot.city
+          .body-2 = customer_snapshot.state
+          .body-2 = ISO3166::Country.new(customer_snapshot.country)&.common_name
+          .body-2 = customer_snapshot.email
+          - if customer_snapshot.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer_snapshot.tax_identification_number)
 
         .billing-information-column
           .body-1 = I18n.t('credit_note.credit_to')

--- a/app/views/templates/invoices/v1.slim
+++ b/app/views/templates/invoices/v1.slim
@@ -411,20 +411,20 @@ html
           .body-2 = billing_entity.email
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2 = customer.display_name
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
+          .body-2 = customer_snapshot.display_name
+          .body-2 = customer_snapshot.address_line1
+          .body-2 = customer_snapshot.address_line2
           .body-2
             span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
+              = customer_snapshot.zipcode
+            - if customer_snapshot.zipcode.present? && customer_snapshot.city.present?
               span
                 | , &nbsp;
             span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
-          .body-2 = customer.email
+              = customer_snapshot.city
+          .body-2 = customer_snapshot.state
+          .body-2 = ISO3166::Country.new(customer_snapshot.country)&.common_name
+          .body-2 = customer_snapshot.email
 
       .mb-24
         h2.title-2.mb-8 = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))

--- a/app/views/templates/invoices/v2.slim
+++ b/app/views/templates/invoices/v2.slim
@@ -411,20 +411,20 @@ html
           .body-2 = billing_entity.email
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2 = customer.display_name
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
+          .body-2 = customer_snapshot.display_name
+          .body-2 = customer_snapshot.address_line1
+          .body-2 = customer_snapshot.address_line2
           .body-2
             span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
+              = customer_snapshot.zipcode
+            - if customer_snapshot.zipcode.present? && customer_snapshot.city.present?
               span
                 | , &nbsp;
             span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
-          .body-2 = customer.email
+              = customer_snapshot.city
+          .body-2 = customer_snapshot.state
+          .body-2 = ISO3166::Country.new(customer_snapshot.country)&.common_name
+          .body-2 = customer_snapshot.email
 
       .mb-24
         h2.title-2.mb-8 = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))

--- a/app/views/templates/invoices/v3.slim
+++ b/app/views/templates/invoices/v3.slim
@@ -394,24 +394,24 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2 = customer.display_name
-          - if customer.legal_number.present?
-            .body-2 #{customer.legal_number}
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
+          .body-2 = customer_snapshot.display_name
+          - if customer_snapshot.legal_number.present?
+            .body-2 #{customer_snapshot.legal_number}
+          .body-2 = customer_snapshot.address_line1
+          .body-2 = customer_snapshot.address_line2
           .body-2
             span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
+              = customer_snapshot.zipcode
+            - if customer_snapshot.zipcode.present? && customer_snapshot.city.present?
               span
                 | , &nbsp;
             span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
-          .body-2 = customer.email
-          - if customer.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)
+              = customer_snapshot.city
+          .body-2 = customer_snapshot.state
+          .body-2 = ISO3166::Country.new(customer_snapshot.country)&.common_name
+          .body-2 = customer_snapshot.email
+          - if customer_snapshot.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer_snapshot.tax_identification_number)
 
       .mb-24
         h2.title-2.mb-4 = MoneyHelper.format(total_amount)

--- a/app/views/templates/invoices/v3/charge.slim
+++ b/app/views/templates/invoices/v3/charge.slim
@@ -388,24 +388,24 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2 = customer.display_name
-          - if customer.legal_number.present?
-            .body-2 #{customer.legal_number}
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
+          .body-2 = customer_snapshot.display_name
+          - if customer_snapshot.legal_number.present?
+            .body-2 #{customer_snapshot.legal_number}
+          .body-2 = customer_snapshot.address_line1
+          .body-2 = customer_snapshot.address_line2
           .body-2
             span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
+              = customer_snapshot.zipcode
+            - if customer_snapshot.zipcode.present? && customer_snapshot.city.present?
               span
                 | , &nbsp;
             span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
-          .body-2 = customer.email
-          - if customer.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)
+              = customer_snapshot.city
+          .body-2 = customer_snapshot.state
+          .body-2 = ISO3166::Country.new(customer_snapshot.country)&.common_name
+          .body-2 = customer_snapshot.email
+          - if customer_snapshot.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer_snapshot.tax_identification_number)
 
       .mb-24
         h2.title-2.mb-4 = MoneyHelper.format(total_amount)

--- a/app/views/templates/invoices/v3/one_off.slim
+++ b/app/views/templates/invoices/v3/one_off.slim
@@ -389,24 +389,24 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2 = customer.display_name
-          - if customer.legal_number.present?
-            .body-2 #{customer.legal_number}
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
+          .body-2 = customer_snapshot.display_name
+          - if customer_snapshot.legal_number.present?
+            .body-2 #{customer_snapshot.legal_number}
+          .body-2 = customer_snapshot.address_line1
+          .body-2 = customer_snapshot.address_line2
           .body-2
             span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
+              = customer_snapshot.zipcode
+            - if customer_snapshot.zipcode.present? && customer_snapshot.city.present?
               span
                 | , &nbsp;
             span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
-          .body-2 = customer.email
-          - if customer.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)
+              = customer_snapshot.city
+          .body-2 = customer_snapshot.state
+          .body-2 = ISO3166::Country.new(customer_snapshot.country)&.common_name
+          .body-2 = customer_snapshot.email
+          - if customer_snapshot.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer_snapshot.tax_identification_number)
 
       .mb-24
         h2.title-2.mb-4 = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))

--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -446,24 +446,24 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2 = customer.display_name
-          - if customer.legal_number.present?
-            .body-2 #{customer.legal_number}
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
+          .body-2 = customer_snapshot.display_name
+          - if customer_snapshot.legal_number.present?
+            .body-2 #{customer_snapshot.legal_number}
+          .body-2 = customer_snapshot.address_line1
+          .body-2 = customer_snapshot.address_line2
           .body-2
             span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
+              = customer_snapshot.zipcode
+            - if customer_snapshot.zipcode.present? && customer_snapshot.city.present?
               span
                 | , &nbsp;
             span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
-          .body-2 = customer.email&.gsub(/,\s*/, ', ')
-          - if customer.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)
+              = customer_snapshot.city
+          .body-2 = customer_snapshot.state
+          .body-2 = ISO3166::Country.new(customer_snapshot.country)&.common_name
+          .body-2 = customer_snapshot.email&.gsub(/,\s*/, ', ')
+          - if customer_snapshot.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer_snapshot.tax_identification_number)
 
       .mb-24
         h2.title-2.mb-4 = MoneyHelper.format(total_amount)

--- a/app/views/templates/invoices/v4/_charge.slim
+++ b/app/views/templates/invoices/v4/_charge.slim
@@ -42,7 +42,7 @@ table.invoice-resume-table width="100%"
               = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
               - if fee.charge_filter_id?
                 = ' • ' + fee.filter_display_name(separator: ' • ')
-            - succeeded_at_date = fee.succeeded_at&.in_time_zone(customer.applicable_timezone)&.to_date
+            - succeeded_at_date = fee.succeeded_at&.in_time_zone(customer_snapshot.applicable_timezone)&.to_date
             - if succeeded_at_date
               .body-3 = I18n.l(succeeded_at_date, format: :default)
         - elsif fee.charge.prorated?

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -443,24 +443,24 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2 = customer.display_name
-          - if customer.legal_number.present?
-            .body-2 #{customer.legal_number}
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
+          .body-2 = customer_snapshot.display_name
+          - if customer_snapshot.legal_number.present?
+            .body-2 #{customer_snapshot.legal_number}
+          .body-2 = customer_snapshot.address_line1
+          .body-2 = customer_snapshot.address_line2
           .body-2
             span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
+              = customer_snapshot.zipcode
+            - if customer_snapshot.zipcode.present? && customer_snapshot.city.present?
               span
                 | , &nbsp;
             span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
-          .body-2 = customer.email
-          - if customer.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)
+              = customer_snapshot.city
+          .body-2 = customer_snapshot.state
+          .body-2 = ISO3166::Country.new(customer_snapshot.country)&.common_name
+          .body-2 = customer_snapshot.email
+          - if customer_snapshot.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer_snapshot.tax_identification_number)
 
       .mb-24
         h2.title-2.mb-4 = MoneyHelper.format(total_amount)

--- a/app/views/templates/invoices/v4/one_off.slim
+++ b/app/views/templates/invoices/v4/one_off.slim
@@ -391,24 +391,24 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2 = customer.display_name
-          - if customer.legal_number.present?
-            .body-2 #{customer.legal_number}
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
+          .body-2 = customer_snapshot.display_name
+          - if customer_snapshot.legal_number.present?
+            .body-2 #{customer_snapshot.legal_number}
+          .body-2 = customer_snapshot.address_line1
+          .body-2 = customer_snapshot.address_line2
           .body-2
             span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
+              = customer_snapshot.zipcode
+            - if customer_snapshot.zipcode.present? && customer_snapshot.city.present?
               span
                 | , &nbsp;
             span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
-          .body-2 = customer.email
-          - if customer.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)
+              = customer_snapshot.city
+          .body-2 = customer_snapshot.state
+          .body-2 = ISO3166::Country.new(customer_snapshot.country)&.common_name
+          .body-2 = customer_snapshot.email
+          - if customer_snapshot.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer_snapshot.tax_identification_number)
 
       .mb-24
         h2.title-2.mb-4 = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))

--- a/app/views/templates/invoices/v4/self_billed.slim
+++ b/app/views/templates/invoices/v4/self_billed.slim
@@ -400,24 +400,24 @@ html
         // Issuer (partner) information
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_from')
-          .body-2 = customer.display_name
-          - if customer.legal_number.present?
-            .body-2 #{customer.legal_number}
-          .body-2 = customer.address_line1
-          .body-2 = customer.address_line2
+          .body-2 = customer_snapshot.display_name
+          - if customer_snapshot.legal_number.present?
+            .body-2 #{customer_snapshot.legal_number}
+          .body-2 = customer_snapshot.address_line1
+          .body-2 = customer_snapshot.address_line2
           .body-2
             span
-              = customer.zipcode
-            - if customer.zipcode.present? && customer.city.present?
+              = customer_snapshot.zipcode
+            - if customer_snapshot.zipcode.present? && customer_snapshot.city.present?
               span
                 | , &nbsp;
             span
-              = customer.city
-          .body-2 = customer.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
-          .body-2 = customer.email&.gsub(/,\s*/, ', ')
-          - if customer.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)
+              = customer_snapshot.city
+          .body-2 = customer_snapshot.state
+          .body-2 = ISO3166::Country.new(customer_snapshot.country)&.common_name
+          .body-2 = customer_snapshot.email&.gsub(/,\s*/, ', ')
+          - if customer_snapshot.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer_snapshot.tax_identification_number)
 
         // Recipient (billing_entity) information
         .billing-information-column

--- a/app/views/templates/payment_receipts/v1.slim
+++ b/app/views/templates/payment_receipts/v1.slim
@@ -72,24 +72,24 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: @billing_entity.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2 = @customer.display_name
-          - if @customer.legal_number.present?
-            .body-2 #{@customer.legal_number}
-          .body-2 = @customer.address_line1
-          .body-2 = @customer.address_line2
+          .body-2 = @customer_snapshot.display_name
+          - if @customer_snapshot.legal_number.present?
+            .body-2 #{@customer_snapshot.legal_number}
+          .body-2 = @customer_snapshot.address_line1
+          .body-2 = @customer_snapshot.address_line2
           .body-2
             span
-              = @customer.zipcode
-            - if @customer.zipcode.present? && @customer.city.present?
+              = @customer_snapshot.zipcode
+            - if @customer_snapshot.zipcode.present? && @customer_snapshot.city.present?
               span
                 | , &nbsp;
             span
-              = @customer.city
-          .body-2 = @customer.state
-          .body-2 = ISO3166::Country.new(@customer.country)&.common_name
-          .body-2 = @customer.email&.gsub(/,\s*/, ', ')
-          - if @customer.tax_identification_number.present?
-            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: @customer.tax_identification_number)
+              = @customer_snapshot.city
+          .body-2 = @customer_snapshot.state
+          .body-2 = ISO3166::Country.new(@customer_snapshot.country)&.common_name
+          .body-2 = @customer_snapshot.email&.gsub(/,\s*/, ', ')
+          - if @customer_snapshot.tax_identification_number.present?
+            .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: @customer_snapshot.tax_identification_number)
 
       .mb-24
         h2.title-2.mb-4 = MoneyHelper.format(payment.amount)


### PR DESCRIPTION
Invoice templates uses customer snapshotted data instead of live data to ensure invoice PDFs are immutable once finalized.