### PR TITLE
fix(invoice-pdf): Display prepaid credits for progressive billing invoices

### DIFF
--- a/app/views/templates/invoices/v4/_progressive_billing_details.slim
+++ b/app/views/templates/invoices/v4/_progressive_billing_details.slim
@@ -82,7 +82,7 @@
         td.body-2
         td.body-2 = I18n.t('invoice.credit_notes')
         td.body-2 = '-' +  MoneyHelper.format(credit_notes_amount)
-    - if subscription? && wallet_transactions.exists?
+    - if wallet_transactions.exists?
       tr
         td.body-2
         td.body-2 = I18n.t('invoice.prepaid_credits')


### PR DESCRIPTION
## Description

We enter this template only with invoices having type `progressive_billing`. Progressive invoice can never be subscription type leading to never showing prepaid credits line in the pdf.
