### PR TITLE
fix(daily_usage): Fix backfill max timestamp with pro-ration

### DIFF
--- a/app/models/billing_period_boundaries.rb
+++ b/app/models/billing_period_boundaries.rb
@@ -10,7 +10,9 @@ class BillingPeriodBoundaries
     :fixed_charges_from_datetime,
     :fixed_charges_to_datetime,
     :fixed_charges_duration
-  attr_accessor :charges_to_datetime
+
+  attr_accessor :charges_to_datetime,
+    :max_timestamp # Used to limit event timestamp when filling the daily usage
 
   def self.from_fee(fee)
     props = fee&.properties || {}
@@ -39,7 +41,8 @@ class BillingPeriodBoundaries
     fixed_charges_from_datetime: nil,
     fixed_charges_to_datetime: nil,
     fixed_charges_duration: nil,
-    issuing_date: nil
+    issuing_date: nil,
+    max_timestamp: nil
   )
     @from_datetime = from_datetime
     @to_datetime = to_datetime
@@ -51,6 +54,7 @@ class BillingPeriodBoundaries
     @fixed_charges_from_datetime = fixed_charges_from_datetime
     @fixed_charges_to_datetime = fixed_charges_to_datetime
     @fixed_charges_duration = fixed_charges_duration
+    @max_timestamp = max_timestamp
   end
 
   def to_h
@@ -66,6 +70,7 @@ class BillingPeriodBoundaries
       "fixed_charges_duration" => fixed_charges_duration
     }.with_indifferent_access
     h["issuing_date"] = issuing_date if issuing_date.present?
+    h["max_timestamp"] = max_timestamp if max_timestamp.present?
     h
   end
 end

--- a/app/services/daily_usages/fill_history_service.rb
+++ b/app/services/daily_usages/fill_history_service.rb
@@ -30,7 +30,7 @@ module DailyUsages
             subscription: subscription,
             apply_taxes: false,
             with_cache: false,
-            max_to_datetime: time_to_freeze,
+            max_timestamp: time_to_freeze,
             with_zero_units_filters: false
           ).raise_if_error!.usage
           next if sandbox

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -126,6 +126,10 @@ module Events
         boundaries[:charges_duration]
       end
 
+      def applicable_to_datetime
+        boundaries[:max_timestamp] || to_datetime
+      end
+
       def sanitize_colon(query)
         # NOTE: escape ':' to avoid ActiveRecord::PreparedStatementInvalid,
         query.gsub("'#{code}'", "'#{code.gsub(":", "\\:")}'")

--- a/app/services/events/stores/clickhouse/weighted_sum_query.rb
+++ b/app/services/events/stores/clickhouse/weighted_sum_query.rb
@@ -46,7 +46,7 @@ module Events
               timestamp,
               difference,
               SUM(difference) OVER (ORDER BY timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS cumul,
-              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) AS second_duration,
+              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:applicable_to_datetime, 5, 'UTC')) OVER (ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) AS second_duration,
               (#{period_ratio_sql}) AS period_ratio
             FROM events_data
             ORDER BY timestamp ASC
@@ -99,13 +99,13 @@ module Events
           <<-SQL
             if(
               -- NOTE: duration in seconds between current event and next one
-              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) > 0,
+              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:applicable_to_datetime, 5, 'UTC')) OVER (ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) > 0,
 
               -- NOTE: cumulative sum from previous events in the period
               (SUM(difference) OVER (ORDER BY timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))
               *
               -- NOTE: duration in seconds between current event and next one - using end of period as final boundaries
-              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING))
+              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:applicable_to_datetime, 5, 'UTC')) OVER (ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING))
               /
               -- NOTE: full duration of the period
               #{charges_duration.days.to_i}
@@ -187,13 +187,13 @@ module Events
           <<-SQL
             if(
               -- NOTE: duration in seconds between current event and next one
-              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (PARTITION BY #{group_names} ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) > 0,
+              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:applicable_to_datetime, 5, 'UTC')) OVER (PARTITION BY #{group_names} ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) > 0,
 
               -- NOTE: cumulative sum from previous events in the period
               (SUM(difference) OVER (PARTITION BY #{group_names} ORDER BY timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))
               *
               -- NOTE: duration in seconds between current event and next one - using end of period as final boundaries
-              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (PARTITION BY #{group_names} ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING))
+              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:applicable_to_datetime, 5, 'UTC')) OVER (PARTITION BY #{group_names} ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING))
               /
               -- NOTE: full duration of the period
               #{charges_duration.days.to_i}

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -14,7 +14,7 @@ module Events
           scope = scope.order(timestamp: :asc) if ordered
 
           scope = scope.where("events_enriched.timestamp >= ?", from_datetime) if force_from || use_from_boundary
-          scope = scope.where("events_enriched.timestamp <= ?", to_datetime) if to_datetime
+          scope = scope.where("events_enriched.timestamp <= ?", applicable_to_datetime) if applicable_to_datetime
           scope = scope.limit_by(1, "events_enriched.transaction_id")
 
           scope = apply_grouped_by_values(scope) if grouped_by_values?
@@ -32,7 +32,7 @@ module Events
         query = query.order(arel_table[:timestamp].desc) if ordered
 
         query = query.where(arel_table[:timestamp].gteq(from_datetime)) if force_from || use_from_boundary
-        query = query.where(arel_table[:timestamp].lteq(to_datetime)) if to_datetime
+        query = query.where(arel_table[:timestamp].lteq(applicable_to_datetime)) if applicable_to_datetime
         query = query.limit_by(1, "events_enriched.transaction_id")
 
         query = apply_arel_grouped_by_values(query) if grouped_by_values?
@@ -47,7 +47,7 @@ module Events
             .where(external_subscription_id: subscription.external_id)
             .where(organization_id: subscription.organization.id)
             .where("events_enriched.timestamp >= ?", from_datetime)
-            .where("events_enriched.timestamp <= ?", to_datetime)
+            .where("events_enriched.timestamp <= ?", applicable_to_datetime)
             .pluck("DISTINCT(code)")
         end
       end
@@ -500,6 +500,7 @@ module Events
               {
                 from_datetime:,
                 to_datetime: to_datetime.ceil,
+                applicable_to_datetime: applicable_to_datetime.ceil,
                 decimal_scale: DECIMAL_SCALE,
                 initial_value: initial_value || 0
               }
@@ -538,6 +539,7 @@ module Events
               {
                 from_datetime:,
                 to_datetime: to_datetime.ceil,
+                applicable_to_datetime: applicable_to_datetime.ceil,
                 decimal_scale: DECIMAL_SCALE
               }
             ]
@@ -559,6 +561,7 @@ module Events
                 {
                   from_datetime:,
                   to_datetime: to_datetime.ceil,
+                  applicable_to_datetime: applicable_to_datetime.ceil,
                   decimal_scale: DECIMAL_SCALE,
                   initial_value: initial_value || 0
                 }

--- a/app/services/events/stores/postgres/weighted_sum_query.rb
+++ b/app/services/events/stores/postgres/weighted_sum_query.rb
@@ -46,7 +46,7 @@ module Events
               timestamp,
               difference,
               SUM(difference) OVER (ORDER BY timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS cumul,
-              EXTRACT(epoch FROM lead(timestamp, 1, :to_datetime) OVER (ORDER BY timestamp) - timestamp) AS second_duration,
+              EXTRACT(epoch FROM lead(timestamp, 1, :applicable_to_datetime) OVER (ORDER BY timestamp) - timestamp) AS second_duration,
               (#{period_ratio_sql}) AS period_ratio
             FROM events_data
             ORDER BY timestamp ASC
@@ -96,7 +96,7 @@ module Events
         def period_ratio_sql
           <<-SQL
             -- NOTE: duration in seconds between current event and next one
-            CASE WHEN EXTRACT(EPOCH FROM LEAD(timestamp, 1, :to_datetime) OVER (ORDER BY timestamp) - timestamp) = 0
+            CASE WHEN EXTRACT(EPOCH FROM LEAD(timestamp, 1, :applicable_to_datetime) OVER (ORDER BY timestamp) - timestamp) = 0
             THEN
               0 -- NOTE: duration was null so usage is null
             ELSE
@@ -104,7 +104,7 @@ module Events
               (SUM(difference) OVER (ORDER BY timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))
               *
               -- NOTE: duration in seconds between current event and next one - using end of period as final boundaries
-              EXTRACT(EPOCH FROM LEAD(timestamp, 1, :to_datetime) OVER (ORDER BY timestamp) - timestamp)
+              EXTRACT(EPOCH FROM LEAD(timestamp, 1, :applicable_to_datetime) OVER (ORDER BY timestamp) - timestamp)
               /
               -- NOTE: full duration of the period
               #{charges_duration.days.to_i}
@@ -187,7 +187,7 @@ module Events
         def grouped_period_ratio_sql
           <<-SQL
             -- NOTE: duration in seconds between current event and next one
-            CASE WHEN EXTRACT(EPOCH FROM LEAD(timestamp, 1, :to_datetime) OVER (PARTITION BY #{group_names} ORDER BY timestamp) - timestamp) = 0
+            CASE WHEN EXTRACT(EPOCH FROM LEAD(timestamp, 1, :applicable_to_datetime) OVER (PARTITION BY #{group_names} ORDER BY timestamp) - timestamp) = 0
             THEN
               0 -- NOTE: duration was null so usage is null
             ELSE
@@ -195,7 +195,7 @@ module Events
               (SUM(difference) OVER (PARTITION BY #{group_names} ORDER BY timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))
               *
               -- NOTE: duration in seconds between current event and next one - using end of period as final boundaries
-              EXTRACT(EPOCH FROM LEAD(timestamp, 1, :to_datetime) OVER (PARTITION BY #{group_names} ORDER BY timestamp) - timestamp)
+              EXTRACT(EPOCH FROM LEAD(timestamp, 1, :applicable_to_datetime) OVER (PARTITION BY #{group_names} ORDER BY timestamp) - timestamp)
               /
               -- NOTE: full duration of the period
               #{charges_duration.days.to_i}

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -11,7 +11,7 @@ module Events
         scope = scope.order(timestamp: :asc) if ordered
 
         scope = scope.from_datetime(from_datetime) if force_from || use_from_boundary
-        scope = scope.to_datetime(to_datetime) if to_datetime
+        scope = scope.to_datetime(applicable_to_datetime) if applicable_to_datetime
 
         if numeric_property
           scope = scope.where(presence_condition)
@@ -26,7 +26,7 @@ module Events
         Event.where(external_subscription_id: subscription.external_id)
           .where(organization_id: subscription.organization.id)
           .from_datetime(from_datetime)
-          .to_datetime(to_datetime)
+          .to_datetime(applicable_to_datetime)
           .pluck("DISTINCT(code)")
       end
 
@@ -283,6 +283,7 @@ module Events
             {
               from_datetime:,
               to_datetime: to_datetime.ceil,
+              applicable_to_datetime: applicable_to_datetime.ceil,
               initial_value: initial_value || 0
             }
           ]
@@ -317,7 +318,8 @@ module Events
             sanitize_colon(query.grouped_query(initial_values: formated_initial_values)),
             {
               from_datetime:,
-              to_datetime: to_datetime.ceil
+              to_datetime: to_datetime.ceil,
+              applicable_to_datetime: applicable_to_datetime.ceil
             }
           ]
         )
@@ -335,6 +337,7 @@ module Events
               {
                 from_datetime:,
                 to_datetime: to_datetime.ceil,
+                applicable_to_datetime: applicable_to_datetime.ceil,
                 initial_value: initial_value || 0
               }
             ]

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -311,7 +311,8 @@ module Fees
         boundaries: {
           from_datetime: boundaries.charges_from_datetime,
           to_datetime: boundaries.charges_to_datetime,
-          charges_duration: boundaries.charges_duration
+          charges_duration: boundaries.charges_duration,
+          max_timestamp: boundaries.max_timestamp
         },
         filters: aggregation_filters(charge_filter:),
         bypass_aggregation:

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -8,7 +8,7 @@ module Invoices
       timestamp: Time.current,
       apply_taxes: true,
       with_cache: true,
-      max_to_datetime: nil,
+      max_timestamp: nil,
       calculate_projected_usage: false,
       with_zero_units_filters: true
     )
@@ -23,7 +23,7 @@ module Invoices
       @with_zero_units_filters = with_zero_units_filters
 
       # NOTE: used to force charges_to_datetime boundary
-      @max_to_datetime = max_to_datetime
+      @max_timestamp = max_timestamp
     end
 
     def self.with_external_ids(customer_external_id:, external_subscription_id:, organization_id:, apply_taxes: true, calculate_projected_usage: false)
@@ -55,7 +55,7 @@ module Invoices
 
     private
 
-    attr_reader :customer, :invoice, :subscription, :timestamp, :apply_taxes, :with_cache, :max_to_datetime, :calculate_projected_usage, :with_zero_units_filters
+    attr_reader :customer, :invoice, :subscription, :timestamp, :apply_taxes, :with_cache, :max_timestamp, :calculate_projected_usage, :with_zero_units_filters
 
     delegate :plan, to: :subscription
     delegate :organization, to: :subscription
@@ -115,7 +115,7 @@ module Invoices
       )
 
       applied_boundaries = boundaries
-      applied_boundaries = boundaries.dup.tap { it.charges_to_datetime = max_to_datetime } if max_to_datetime
+      applied_boundaries = boundaries.dup.tap { it.max_timestamp = max_timestamp } if max_timestamp
 
       Fees::ChargeService
         .call(

--- a/spec/scenarios/daily_usages/fill_history_spec.rb
+++ b/spec/scenarios/daily_usages/fill_history_spec.rb
@@ -150,11 +150,7 @@ describe "Daily Usages: Fill History", :time_travel, transaction: false do
 
       usages = DailyUsage.where(usage_date: from.to_date..to.to_date)
       expect(usages.count).to eq(31)
-
-      # NOTE: The last usage of the month should be 100 and the usage diff should not be 0.
-      last_daily_usage = DailyUsage.find_by(usage_date: to.to_date)
-      expect(last_daily_usage.usage["amount_cents"]).to eq(100)
-      expect(last_daily_usage.usage_diff["amount_cents"]).not_to eq(0)
+      expect(usages.pluck(Arel.sql("usage['amount_cents']")).uniq).to eq([100])
     end
   end
 

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -123,6 +123,21 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: true do
         expect(event_store.count).to eq(2) # 1st event is ignored
       end
     end
+
+    context "with max timestamp" do
+      let(:boundaries) do
+        {
+          from_datetime: subscription.started_at.beginning_of_day,
+          to_datetime: subscription.started_at.end_of_month.end_of_day,
+          max_timestamp: subscription.started_at.beginning_of_day.end_of_day + 2.days,
+          charges_duration: 31
+        }
+      end
+
+      it "returns a list of events" do
+        expect(event_store.count).to eq(2)
+      end
+    end
   end
 
   describe "#with_grouped_by_values" do

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -116,6 +116,21 @@ RSpec.describe Events::Stores::PostgresStore do
         expect(event_store.events.count).to eq(2) # 1st event is ignored
       end
     end
+
+    context "with max timestamp" do
+      let(:boundaries) do
+        {
+          from_datetime: subscription.started_at.beginning_of_day,
+          to_datetime: subscription.started_at.end_of_month.end_of_day,
+          max_timestamp: subscription.started_at.beginning_of_day.end_of_day + 2.days,
+          charges_duration: 31
+        }
+      end
+
+      it "returns a list of events" do
+        expect(event_store.count).to eq(2)
+      end
+    end
   end
 
   describe "#with_grouped_by_values" do


### PR DESCRIPTION
## Context

This PR fixes the logic to back-fill the daily usage history. 

The existing implementation was forcing the `to_datetime` boundary in the event stores to the day it was backfilling for. It was working fine for standard metrics, but it was failling for all metrics relying on proration as it was virtually reducing the duration of the period.

## Description

This PR introduces a new `max_timestamp` attribute in the event stores and use it only for event filtering. It keeps relying on the `to_datetime` attribute for all pro-rated computation making sure the period duration is consistent on all consecutive daily usages 