### PR TITLE
chore(integration): Remove unused `integration_collection_mappings` code

### DIFF
--- a/app/graphql/resolvers/integration_collection_mappings_resolver.rb
+++ b/app/graphql/resolvers/integration_collection_mappings_resolver.rb
@@ -9,18 +9,14 @@ module Resolvers
 
     description "Query integration collection mappings"
 
-    argument :integration_id, ID, required: false
-    argument :limit, Integer, required: false
-    argument :mapping_type, Types::IntegrationCollectionMappings::MappingTypeEnum, required: false
-    argument :page, Integer, required: false
+    argument :integration_id, ID, required: true
 
     type Types::IntegrationCollectionMappings::Object.collection_type, null: true
 
-    def resolve(page: nil, limit: nil, integration_id: nil, mapping_type: nil)
+    def resolve(integration_id:)
       result = ::IntegrationCollectionMappingsQuery.call(
         organization: current_organization,
-        pagination: {page:, limit:},
-        filters: {integration_id:, mapping_type:}
+        filters: {integration_id:}
       )
 
       result.integration_collection_mappings

--- a/app/queries/integration_collection_mappings_query.rb
+++ b/app/queries/integration_collection_mappings_query.rb
@@ -2,14 +2,13 @@
 
 class IntegrationCollectionMappingsQuery < BaseQuery
   Result = BaseResult[:integration_collection_mappings]
-  Filters = BaseFilters[:integration_id, :mapping_type]
+  Filters = BaseFilters[:integration_id]
 
   def call
     integration_collection_mappings = paginate(base_scope)
     integration_collection_mappings = apply_consistent_ordering(integration_collection_mappings)
 
     integration_collection_mappings = with_integration_id(integration_collection_mappings) if filters.integration_id
-    integration_collection_mappings = with_mapping_type(integration_collection_mappings) if filters.mapping_type
 
     result.integration_collection_mappings = integration_collection_mappings
     result
@@ -24,9 +23,5 @@ class IntegrationCollectionMappingsQuery < BaseQuery
 
   def with_integration_id(scope)
     scope.where(integration_id: filters.integration_id)
-  end
-
-  def with_mapping_type(scope)
-    scope.where(mapping_type: filters.mapping_type)
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -8735,7 +8735,7 @@ type Query {
   """
   Query integration collection mappings
   """
-  integrationCollectionMappings(integrationId: ID, limit: Int, mappingType: MappingTypeEnum, page: Int): CollectionMappingCollection
+  integrationCollectionMappings(integrationId: ID!): CollectionMappingCollection
 
   """
   Query integration items of an integration

--- a/schema.json
+++ b/schema.json
@@ -46813,45 +46813,13 @@
                   "name": "integrationId",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "limit",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "mappingType",
-                  "description": null,
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "MappingTypeEnum",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "page",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/spec/graphql/resolvers/integration_collection_mappings_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_collection_mappings_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::IntegrationCollectionMappingsResolver do
   let(:required_permission) { "organization:integrations:view" }
   let(:query) do
     <<~GQL
-      query {
-        integrationCollectionMappings(limit: 5) {
+      query($integrationId: ID!) {
+        integrationCollectionMappings(integrationId: $integrationId) {
           collection { id }
           metadata { currentPage, totalCount }
         }
@@ -27,21 +27,33 @@ RSpec.describe Resolvers::IntegrationCollectionMappingsResolver do
   it_behaves_like "requires permission", "organization:integrations:view"
 
   it "returns a list of mappings" do
-    result = execute_graphql(
-      current_user: membership.user,
-      current_organization: organization,
-      permissions: required_permission,
-      query:
-    )
+    result = execute_query(query:, variables: {integrationId: integration.id})
 
     integration_collection_mappings_response = result["data"]["integrationCollectionMappings"]
 
-    aggregate_failures do
-      expect(integration_collection_mappings_response["collection"].count).to eq(1)
-      expect(integration_collection_mappings_response["collection"].first["id"]).to eq(netsuite_collection_mapping.id)
+    expect(integration_collection_mappings_response["collection"].count).to eq(1)
+    expect(integration_collection_mappings_response["collection"].first["id"]).to eq(netsuite_collection_mapping.id)
 
-      expect(integration_collection_mappings_response["metadata"]["currentPage"]).to eq(1)
-      expect(integration_collection_mappings_response["metadata"]["totalCount"]).to eq(1)
+    expect(integration_collection_mappings_response["metadata"]["currentPage"]).to eq(1)
+    expect(integration_collection_mappings_response["metadata"]["totalCount"]).to eq(1)
+  end
+
+  context "when the integration id is not provided" do
+    it "returns an error" do
+      result = execute_query(query:)
+      expect(result["errors"]).to eq([
+        {
+          "extensions" => {
+            "problems" =>
+             [
+               {"explanation" => "Expected value to not be null", "path" => []}
+             ],
+            "value" => nil
+          },
+          "locations" => [{"column" => 7, "line" => 1}],
+          "message" => "Variable $integrationId of type ID! was provided invalid value"
+        }
+      ])
     end
   end
 end

--- a/spec/queries/integration_collection_mappings_query_spec.rb
+++ b/spec/queries/integration_collection_mappings_query_spec.rb
@@ -77,16 +77,4 @@ RSpec.describe IntegrationCollectionMappingsQuery, type: :query do
       expect(returned_ids).not_to include(netsuite_collection_mapping_fourth.id)
     end
   end
-
-  context "when filtering by mapping type" do
-    let(:filters) { {mapping_type: "fallback_item"} }
-
-    it "returns one netsuite mappings" do
-      expect(result.integration_collection_mappings.count).to eq(1)
-      expect(returned_ids).to include(netsuite_collection_mapping_first.id)
-      expect(returned_ids).not_to include(netsuite_collection_mapping_second.id)
-      expect(returned_ids).not_to include(netsuite_collection_mapping_third.id)
-      expect(returned_ids).not_to include(netsuite_collection_mapping_fourth.id)
-    end
-  end
 end


### PR DESCRIPTION
## Context

The frontend is currently not using the `mappingType`, `page` and `limit` attributes of the `integrationCollectionMappings` query:

```sh
⋊> rg -B 1 'integrationCollectionMappings\('
src/generated/graphql.tsx
24722-    query getAnrokIntegrationCollectionMappings($integrationId: ID!) {
24723:  integrationCollectionMappings(integrationId: $integrationId) {
--
25155-    query getAvalaraIntegrationCollectionMappings($integrationId: ID!) {
25156:  integrationCollectionMappings(integrationId: $integrationId) {
--
25852-    query getNetsuiteIntegrationCollectionMappings($integrationId: ID!) {
25853:  integrationCollectionMappings(integrationId: $integrationId) {
--
26251-    query getXeroIntegrationCollectionMappings($integrationId: ID!) {
26252:  integrationCollectionMappings(integrationId: $integrationId) {

src/components/settings/integrations/AvalaraIntegrationItemsList.tsx
45-  query getAvalaraIntegrationCollectionMappings($integrationId: ID!) {
46:    integrationCollectionMappings(integrationId: $integrationId) {

src/components/settings/integrations/XeroIntegrationItemsList.tsx
46-  query getXeroIntegrationCollectionMappings($integrationId: ID!) {
47:    integrationCollectionMappings(integrationId: $integrationId) {

src/components/settings/integrations/AnrokIntegrationItemsList.tsx
46-  query getAnrokIntegrationCollectionMappings($integrationId: ID!) {
47:    integrationCollectionMappings(integrationId: $integrationId) {

src/components/settings/integrations/NetsuiteIntegrationItemsList.tsx
46-  query getNetsuiteIntegrationCollectionMappings($integrationId: ID!) {
47:    integrationCollectionMappings(integrationId: $integrationId) {
```

## Description

This removes the `limit`, `mapping_type` and `page` arguments.

The `integration_id` is now required because:
1. We never actually fetch the mappings without specifying the integration. It doesn't really makes sense as it is to retrieve mappings across different integration. This might change in the future though.
2.  Removing the pagination arguments will cause the `IntegrationCollectionMappingsQuery` to skip pagination and returns all data matching the filters. It we don't make the filter mandatory, it might returns ALL mappings for an organization.
3. The frontend always send the `integration_id` as a `ID!` which makes it already compatible with the new schema.
