### PR TITLE
test(wallet): Add scenario test for wallet transaction name

### DIFF
--- a/spec/scenarios/wallets/__snapshots__/Wallet_Transaction_with_name/when_the_transaction_name_is_not_provided/when_the_wallet_has_a_name/renders_the_wallet_name_on_the_invoice.html.snap
+++ b/spec/scenarios/wallets/__snapshots__/Wallet_Transaction_with_name/when_the_transaction_name_is_not_provided/when_the_wallet_has_a_name/renders_the_wallet_name_on_the_invoice.html.snap
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">Advance invoice</h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">Invoice Number</td>
+              <td class="body-2">ACM-8924-001-001</td>
+            </tr>
+            <tr>
+              <td class="body-1">Issue Date</td>
+              <td class="body-2">Jan 02, 2025</td>
+            </tr>
+            <tr>
+              <td class="body-1">Payment term</td>
+              <td class="body-2">0 days</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table"></table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">From</div>
+          <div class="body-2">ACME Corporation</div>
+          <div class="body-2">123 Business St</div>
+          <div class="body-2">Suite 100</div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">CA</div>
+          <div class="body-2">United States</div>
+          <div class="body-2">billing@acme.com</div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">Bill to</div>
+          <div class="body-2">Doe Corp - John Doe</div>
+          <div class="body-2">1234567890</div>
+          <div class="body-2">456 Customer Ave</div>
+          <div class="body-2">Apt 202</div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">NY</div>
+          <div class="body-2">United States</div>
+          <div class="body-2">john.doe@example.com</div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-4">€100.00</h2>
+        <div class="body-1">Due Jan 02, 2025</div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td class="body-2">Item</td>
+            <td class="body-2">Units</td>
+            <td class="body-2">Unit price</td>
+            <td class="body-2">Amount</td>
+          </tr>
+          <tr>
+            <td class="body-1">Prepaid credits - My wallet</td>
+            <td class="body-2">100.0</td>
+            <td class="body-2">1.0</td>
+            <td class="body-2">€100.00</td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2"></td>
+            <td class="body-1">Total</td>
+            <td class="body-1">€100.00</td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24"></p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/scenarios/wallets/__snapshots__/Wallet_Transaction_with_name/when_the_transaction_name_is_not_provided/when_the_wallet_has_no_name/renders_the_default_name_on_the_invoice.html.snap
+++ b/spec/scenarios/wallets/__snapshots__/Wallet_Transaction_with_name/when_the_transaction_name_is_not_provided/when_the_wallet_has_no_name/renders_the_default_name_on_the_invoice.html.snap
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">Advance invoice</h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">Invoice Number</td>
+              <td class="body-2">ACM-8924-001-001</td>
+            </tr>
+            <tr>
+              <td class="body-1">Issue Date</td>
+              <td class="body-2">Jan 02, 2025</td>
+            </tr>
+            <tr>
+              <td class="body-1">Payment term</td>
+              <td class="body-2">0 days</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table"></table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">From</div>
+          <div class="body-2">ACME Corporation</div>
+          <div class="body-2">123 Business St</div>
+          <div class="body-2">Suite 100</div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">CA</div>
+          <div class="body-2">United States</div>
+          <div class="body-2">billing@acme.com</div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">Bill to</div>
+          <div class="body-2">Doe Corp - John Doe</div>
+          <div class="body-2">1234567890</div>
+          <div class="body-2">456 Customer Ave</div>
+          <div class="body-2">Apt 202</div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">NY</div>
+          <div class="body-2">United States</div>
+          <div class="body-2">john.doe@example.com</div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-4">€100.00</h2>
+        <div class="body-1">Due Jan 02, 2025</div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td class="body-2">Item</td>
+            <td class="body-2">Units</td>
+            <td class="body-2">Unit price</td>
+            <td class="body-2">Amount</td>
+          </tr>
+          <tr>
+            <td class="body-1">Prepaid credits</td>
+            <td class="body-2">100.0</td>
+            <td class="body-2">1.0</td>
+            <td class="body-2">€100.00</td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2"></td>
+            <td class="body-1">Total</td>
+            <td class="body-1">€100.00</td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24"></p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/scenarios/wallets/__snapshots__/Wallet_Transaction_with_name/when_the_transaction_name_is_provided/renders_the_transaction_name_on_the_invoice/Initial_top-up.html.snap
+++ b/spec/scenarios/wallets/__snapshots__/Wallet_Transaction_with_name/when_the_transaction_name_is_provided/renders_the_transaction_name_on_the_invoice/Initial_top-up.html.snap
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">Advance invoice</h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">Invoice Number</td>
+              <td class="body-2">ACM-8924-001-001</td>
+            </tr>
+            <tr>
+              <td class="body-1">Issue Date</td>
+              <td class="body-2">Jan 02, 2025</td>
+            </tr>
+            <tr>
+              <td class="body-1">Payment term</td>
+              <td class="body-2">0 days</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table"></table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">From</div>
+          <div class="body-2">ACME Corporation</div>
+          <div class="body-2">123 Business St</div>
+          <div class="body-2">Suite 100</div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">CA</div>
+          <div class="body-2">United States</div>
+          <div class="body-2">billing@acme.com</div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">Bill to</div>
+          <div class="body-2">Doe Corp - John Doe</div>
+          <div class="body-2">1234567890</div>
+          <div class="body-2">456 Customer Ave</div>
+          <div class="body-2">Apt 202</div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">NY</div>
+          <div class="body-2">United States</div>
+          <div class="body-2">john.doe@example.com</div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-4">€100.00</h2>
+        <div class="body-1">Due Jan 02, 2025</div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td class="body-2">Item</td>
+            <td class="body-2">Units</td>
+            <td class="body-2">Unit price</td>
+            <td class="body-2">Amount</td>
+          </tr>
+          <tr>
+            <td class="body-1">Initial top-up</td>
+            <td class="body-2">100.0</td>
+            <td class="body-2">1.0</td>
+            <td class="body-2">€100.00</td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2"></td>
+            <td class="body-1">Total</td>
+            <td class="body-1">€100.00</td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24"></p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/scenarios/wallets/__snapshots__/Wallet_Transaction_with_name/when_the_transaction_name_is_provided/renders_the_transaction_name_on_the_invoice/Top-up.html.snap
+++ b/spec/scenarios/wallets/__snapshots__/Wallet_Transaction_with_name/when_the_transaction_name_is_provided/renders_the_transaction_name_on_the_invoice/Top-up.html.snap
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div class="wrapper">
+      <div class="mb-24">
+        <h1 class="invoice-title">Advance invoice</h1>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="invoice-information-column">
+          <table class="invoice-information-table">
+            <tr>
+              <td class="body-1">Invoice Number</td>
+              <td class="body-2">ACM-8924-001-002</td>
+            </tr>
+            <tr>
+              <td class="body-1">Issue Date</td>
+              <td class="body-2">Jan 03, 2025</td>
+            </tr>
+            <tr>
+              <td class="body-1">Payment term</td>
+              <td class="body-2">0 days</td>
+            </tr>
+          </table>
+        </div>
+        <div class="invoice-information-column">
+          <table class="invoice-information-table"></table>
+        </div>
+      </div>
+      <div class="mb-24 overflow-auto">
+        <div class="billing-information-column">
+          <div class="body-1">From</div>
+          <div class="body-2">ACME Corporation</div>
+          <div class="body-2">123 Business St</div>
+          <div class="body-2">Suite 100</div>
+          <div class="body-2">
+            <span>94105</span>
+            <span>, &nbsp;</span>
+            <span>San Francisco</span>
+          </div>
+          <div class="body-2">CA</div>
+          <div class="body-2">United States</div>
+          <div class="body-2">billing@acme.com</div>
+        </div>
+        <div class="billing-information-column">
+          <div class="body-1">Bill to</div>
+          <div class="body-2">Doe Corp - John Doe</div>
+          <div class="body-2">1234567890</div>
+          <div class="body-2">456 Customer Ave</div>
+          <div class="body-2">Apt 202</div>
+          <div class="body-2">
+            <span>10001</span>
+            <span>, &nbsp;</span>
+            <span>New York</span>
+          </div>
+          <div class="body-2">NY</div>
+          <div class="body-2">United States</div>
+          <div class="body-2">john.doe@example.com</div>
+        </div>
+      </div>
+      <div class="mb-24">
+        <h2 class="title-2 mb-4">€200.00</h2>
+        <div class="body-1">Due Jan 03, 2025</div>
+      </div>
+      <div class="invoice-resume mb-24 overflow-auto">
+        <table class="invoice-resume-table" width="100%">
+          <tr>
+            <td class="body-2">Item</td>
+            <td class="body-2">Units</td>
+            <td class="body-2">Unit price</td>
+            <td class="body-2">Amount</td>
+          </tr>
+          <tr>
+            <td class="body-1">Top-up</td>
+            <td class="body-2">200.0</td>
+            <td class="body-2">1.0</td>
+            <td class="body-2">€200.00</td>
+          </tr>
+        </table>
+        <table class="total-table" width="100%">
+          <tr>
+            <td class="body-2"></td>
+            <td class="body-1">Total</td>
+            <td class="body-1">€200.00</td>
+          </tr>
+        </table>
+      </div>
+      <p class="body-3 mb-24"></p>
+      <div class="powered-by">
+        <span class="body-2">Powered by &nbsp;</span>
+        <img alt="Lago Logo" src="lago-logo-invoice.png" />
+      </div>
+    </div>
+  </body>
+</html>

--- a/spec/scenarios/wallets/topup_with_name_spec.rb
+++ b/spec/scenarios/wallets/topup_with_name_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Wallet Transaction with name", :premium do
+  let(:organization) { create(:organization, :with_static_values, webhook_url: nil) }
+  let(:customer) { create(:customer, :with_static_values, organization:) }
+
+  def within_first_day(&block)
+    travel_to Time.zone.local(2025, 1, 2, 0, 0, 0) do
+      yield
+    end
+  end
+
+  def within_second_day(&block)
+    travel_to Time.zone.local(2025, 1, 3, 0, 0, 0) do
+      yield
+    end
+  end
+
+  def test_invoice_on_wallet_creation(attrs: {}, snapshot_name: nil)
+    wallet = within_first_day do
+      create_wallet({
+        external_customer_id: customer.external_id,
+        rate_amount: "1",
+        currency: "EUR",
+        paid_credits: "100",
+        **attrs
+      }, as: :model)
+    end
+
+    expect(wallet.rate_amount).to eq(1)
+
+    wallet_transactions = wallet.wallet_transactions
+    expect(wallet_transactions.count).to eq(1)
+    expect(wallet_transactions.first.name).to eq(attrs[:transaction_name])
+
+    invoice = customer.invoices.credit.sole
+    expect(invoice.file.download).to match_html_snapshot(name: snapshot_name)
+
+    wallet
+  end
+
+  context "when the transaction name is provided" do
+    it "renders the transaction name on the invoice" do
+      wallet = test_invoice_on_wallet_creation(
+        attrs: {transaction_name: "Initial top-up"},
+        snapshot_name: "Initial top-up"
+      )
+
+      wt = within_second_day do
+        create_wallet_transaction({
+          wallet_id: wallet.id,
+          paid_credits: "200",
+          metadata: [{key: "transaction_id", value: "123"}],
+          name: "Top-up"
+        }, as: :model).first
+      end
+
+      expect(wt.status).to eq "pending"
+      expect(wt.transaction_status).to eq "purchased"
+      expect(wt.invoice_requires_successful_payment).to be false
+      expect(wt.credit_amount).to eq(200)
+      expect(wt.amount).to eq(200)
+      expect(wt.name).to eq("Top-up")
+      expect(wt.metadata).to eq([{"key" => "transaction_id", "value" => "123"}])
+
+      top_up_invoice = customer.invoices.credit.order(:created_at).last
+      expect(top_up_invoice.file.download).to match_html_snapshot(name: "Top-up")
+    end
+  end
+
+  context "when the transaction name is not provided" do
+    context "when the wallet has a name" do
+      it "renders the wallet name on the invoice" do
+        test_invoice_on_wallet_creation(attrs: {name: "My wallet"})
+      end
+    end
+
+    context "when the wallet has no name" do
+      it "renders the default name on the invoice" do
+        test_invoice_on_wallet_creation
+      end
+    end
+  end
+end

--- a/spec/support/matchers/snapshot_matcher.rb
+++ b/spec/support/matchers/snapshot_matcher.rb
@@ -23,9 +23,9 @@
 #   expect(rendered_template).to match_html_snapshot
 # end
 # ```
-RSpec::Matchers.define :match_html_snapshot do |name = nil, strip_style: true, strip_head: true|
+RSpec::Matchers.define :match_html_snapshot do |name: nil, strip_style: true, strip_head: true|
   match(notify_expectation_failures: true) do |html|
-    name = [snapshot_name(RSpec.current_example.metadata), name].compact.join("/")
+    name = [snapshot_name(RSpec.current_example.metadata), sanitize_fragment(name)].compact.join("/")
     name += ".html"
     html = beautify(html, strip_style: strip_style, strip_head: strip_head)
     expect(html).to match_snapshot(name)
@@ -33,11 +33,17 @@ RSpec::Matchers.define :match_html_snapshot do |name = nil, strip_style: true, s
 
   private
 
+  def sanitize_fragment(fragment)
+    return nil if fragment.nil?
+
+    fragment.tr("/", "_").tr(" ", "_")
+  end
+
   def snapshot_name(metadata)
     description = metadata[:description].empty? ? metadata[:scoped_id] : metadata[:description]
     example_group = metadata.key?(:example_group) ? metadata[:example_group] : metadata[:parent_example_group]
 
-    description = description.tr("/", "_").tr(" ", "_")
+    description = sanitize_fragment(description)
     if example_group
       [snapshot_name(example_group), description].join("/")
     else


### PR DESCRIPTION
## Context

There is currently no scenario test that ensures the behavior of the displayed name of a wallet transaction on an invoice PDF.

## Description

This tests those behaviors.

It also improves the `match_html_snapshot` to properly format the `name` parameter by replace spaces and `/` with `_`.