### PR TITLE
chore(cache): Use Redis as development cache store

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,16 +26,7 @@ Rails.application.configure do
   config.server_timing = true
 
   config.cache_store = :redis_cache_store, {url: ENV["LAGO_REDIS_CACHE_URL"], db: 3}
-
-  if Rails.root.join("tmp/caching-dev.txt").exist?
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
-    }
-  else
-    config.action_controller.perform_caching = false
-    config.cache_store = :null_store
-  end
+  config.action_controller.perform_caching = false
 
   config.active_storage.service = if ENV["LAGO_USE_AWS_S3"].present? && ENV["LAGO_USE_AWS_S3"] == "true"
     if ENV["LAGO_AWS_S3_ENDPOINT"].present?


### PR DESCRIPTION
## Context

The default cache store in development is currently the `ActiveSupport::Cache::NullStore` instead of Redis. I believe this might be due to an unwanted change during a Rails upgrade.

## Description

This updates the cache store to use Redis.

