### PR TITLE
fix(clickhouse): Rollback applicable_to_datetime in weighted sum

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -500,7 +500,6 @@ module Events
               {
                 from_datetime:,
                 to_datetime: to_datetime.ceil,
-                applicable_to_datetime: applicable_to_datetime.ceil,
                 decimal_scale: DECIMAL_SCALE,
                 initial_value: initial_value || 0
               }
@@ -539,7 +538,6 @@ module Events
               {
                 from_datetime:,
                 to_datetime: to_datetime.ceil,
-                applicable_to_datetime: applicable_to_datetime.ceil,
                 decimal_scale: DECIMAL_SCALE
               }
             ]
@@ -561,7 +559,6 @@ module Events
                 {
                   from_datetime:,
                   to_datetime: to_datetime.ceil,
-                  applicable_to_datetime: applicable_to_datetime.ceil,
                   decimal_scale: DECIMAL_SCALE,
                   initial_value: initial_value || 0
                 }

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -283,7 +283,6 @@ module Events
             {
               from_datetime:,
               to_datetime: to_datetime.ceil,
-              applicable_to_datetime: applicable_to_datetime.ceil,
               initial_value: initial_value || 0
             }
           ]
@@ -318,8 +317,7 @@ module Events
             sanitize_colon(query.grouped_query(initial_values: formated_initial_values)),
             {
               from_datetime:,
-              to_datetime: to_datetime.ceil,
-              applicable_to_datetime: applicable_to_datetime.ceil
+              to_datetime: to_datetime.ceil
             }
           ]
         )
@@ -337,7 +335,6 @@ module Events
               {
                 from_datetime:,
                 to_datetime: to_datetime.ceil,
-                applicable_to_datetime: applicable_to_datetime.ceil,
                 initial_value: initial_value || 0
               }
             ]


### PR DESCRIPTION
## Description

This PR follows https://github.com/getlago/lago-api/pull/4435, it removes the use of `applicable_to_datetime` in weighted sum query whem computing period ratios.
The query should keep using the end of period value when computing those ratios.
