### PR TITLE
test(event): Use a `shared_example` for Postgres and Clickhouse event stores

### DIFF
--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -95,7 +95,7 @@ module Events
       def unique_count
         query = Events::Stores::Postgres::UniqueCountQuery.new(store: self)
         sql = ActiveRecord::Base.sanitize_sql_for_conditions([query.query])
-        result = ActiveRecord::Base.connection.select_one(sql)
+        result = Event.connection.select_one(sql)
 
         result["aggregation"]
       end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -2,346 +2,40 @@
 
 require "rails_helper"
 
-RSpec.describe Events::Stores::ClickhouseStore, clickhouse: true do
-  subject(:event_store) do
-    described_class.new(
-      code:,
-      subscription:,
-      boundaries:,
-      filters: {
-        grouped_by:,
-        grouped_by_values:,
-        matching_filters:,
-        ignored_filters:
-      }
-    )
-  end
+require_relative "shared_examples/an_event_store"
 
-  let(:billable_metric) { create(:billable_metric, field_name: "value", code: "bm:code") }
-  let(:organization) { billable_metric.organization }
-
-  let(:customer) { create(:customer, organization:) }
-  let(:subscription) { create(:subscription, customer:, started_at:) }
-
-  let(:started_at) { DateTime.parse("2023-03-15") }
-  let(:code) { billable_metric.code }
-
-  let(:boundaries) do
-    {
-      from_datetime: subscription.started_at.beginning_of_day,
-      to_datetime: subscription.started_at.end_of_month.end_of_day,
-      charges_duration: 31
-    }
-  end
-
-  let(:grouped_by) { nil }
-  let(:grouped_by_values) { nil }
-  let(:with_grouped_by_values) { nil }
-  let(:matching_filters) { {} }
-  let(:ignored_filters) { [] }
-
-  let(:events) do
-    events = []
-
-    5.times do |i|
-      properties = {billable_metric.field_name => i + 1}
-
-      if i.even?
-        matching_filters.each { |key, values| properties[key] = values.first }
-
-        applied_grouped_by_values = grouped_by_values || with_grouped_by_values
-
-        if applied_grouped_by_values.present?
-          applied_grouped_by_values.each { |grouped_by, value| properties[grouped_by] = value }
-        elsif grouped_by.present?
-          grouped_by.each do |group|
-            properties[group] = "#{Faker::Fantasy::Tolkien.character.delete("'")}_#{i}"
-          end
-        end
-      end
-
-      (ignored_filters.first || {}).each { |key, values| properties[key] = values.first } if i.zero?
-
-      events << Clickhouse::EventsEnriched.create!(
-        transaction_id: SecureRandom.uuid,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        code:,
-        timestamp: boundaries[:from_datetime] + (i + 1).days,
-        properties:,
-        value: (i + 1).to_s,
-        decimal_value: (i + 1).to_d,
-        precise_total_amount_cents: i + 1
-      )
-    end
-
-    events
-  end
-
-  # NOTE: this does not include test with real values yet as we have to figure out
-  #       how to add factories of fixtures in spec env and to setup clickhouse on the CI
-  before do
-    if ENV["LAGO_CLICKHOUSE_ENABLED"].blank?
-      skip
-    else
-      events
-    end
-  end
-
-  after do
-    next if ENV["LAGO_CLICKHOUSE_ENABLED"].blank?
-
-    Clickhouse::EventsEnriched.connection.execute("TRUNCATE TABLE events_enriched")
-  end
-
-  describe ".events" do
-    it "returns a list of events" do
-      expect(event_store.count).to eq(5)
-    end
-
-    context "with grouped_by_values" do
-      let(:grouped_by_values) { {"region" => "europe"} }
-
-      it "returns a list of events" do
-        expect(event_store.count).to eq(3)
-      end
-
-      context "when grouped_by_values value is nil" do
-        let(:grouped_by_values) { {"region" => nil} }
-
-        it "returns a list of events" do
-          expect(event_store.count).to eq(5)
-        end
-      end
-    end
-
-    context "with filters" do
-      let(:matching_filters) { {"region" => ["europe"], "country" => ["france"]} }
-      let(:ignored_filters) { [{"city" => ["paris"]}, {"city" => ["londons"], "country" => ["united kingdom"]}] }
-
-      it "returns a list of events" do
-        expect(event_store.count).to eq(2) # 1st event is ignored
-      end
-    end
-
-    context "with max timestamp" do
-      let(:boundaries) do
-        {
-          from_datetime: subscription.started_at.beginning_of_day,
-          to_datetime: subscription.started_at.end_of_month.end_of_day,
-          max_timestamp: subscription.started_at.beginning_of_day.end_of_day + 2.days,
-          charges_duration: 31
-        }
-      end
-
-      it "returns a list of events" do
-        expect(event_store.count).to eq(2)
-      end
-    end
-  end
-
-  describe "#with_grouped_by_values" do
-    let(:with_grouped_by_values) { {"region" => "europe"} }
-
-    it "applies the grouped_by_values in the block" do
-      event_store.with_grouped_by_values(with_grouped_by_values) do
-        expect(event_store.count).to eq(3)
-      end
-    end
-  end
-
-  describe "#distinct_codes" do
-    before do
+RSpec.describe Events::Stores::ClickhouseStore, clickhouse: {clean_before: true} do
+  it_behaves_like "an event store" do
+    def create_event(timestamp:, value:, properties: {}, transaction_id: SecureRandom.uuid, code: billable_metric.code)
       Clickhouse::EventsEnriched.create!(
-        transaction_id: SecureRandom.uuid,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        code: "other_code",
-        timestamp: boundaries[:from_datetime] + (1..10).to_a.sample.days,
-        value: "value",
-        decimal_value: 0,
-        precise_total_amount_cents: 0
-      )
-    end
-
-    it "returns the distinct event codes" do
-      expect(event_store.distinct_codes).to match_array([code, "other_code"])
-    end
-  end
-
-  describe ".count" do
-    it "returns the number of unique events" do
-      expect(event_store.count).to eq(5)
-    end
-
-    context "with duplicated transaction_id" do
-      before do
-        event = events.first
-
-        Clickhouse::EventsEnriched.create!(
-          transaction_id: event.transaction_id,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          timestamp: boundaries[:from_datetime] + 5.days,
-          properties: {},
-          value: 1.to_s,
-          decimal_value: 1.0,
-          precise_total_amount_cents: 1.0
-        )
-
-        # Force clickhouse deduplication
-        Clickhouse::EventsEnriched.connection.execute("OPTIMIZE TABLE events_enriched FINAL")
-      end
-
-      it "takes the event into account" do
-        expect(event_store.count).to eq(6)
-      end
-    end
-
-    context "with duplicated transaction_id and timestamp" do
-      before do
-        event = events.first
-
-        Clickhouse::EventsEnriched.create!(
-          transaction_id: event.transaction_id,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          timestamp: event.timestamp,
-          properties: {},
-          value: 1.to_s,
-          decimal_value: 1.0,
-          precise_total_amount_cents: 1.0
-        )
-
-        # Force clickhouse deduplication
-        Clickhouse::EventsEnriched.connection.execute("OPTIMIZE TABLE events_enriched FINAL")
-      end
-
-      it "deduplicates the events" do
-        expect(event_store.count).to eq(5)
-      end
-    end
-  end
-
-  describe ".grouped_count" do
-    let(:grouped_by) { %w[cloud] }
-
-    it "returns the number of unique events grouped by the provided group" do
-      result = event_store.grouped_count
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |v| v[:groups]["cloud"].nil? }
-      expect(null_group[:value]).to eq(2)
-
-      result.each do |row|
-        next if row[:groups]["cloud"].nil?
-
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).to eq(1)
-      end
-    end
-
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
-
-      it "returns the number of unique events grouped by the provided groups" do
-        result = event_store.grouped_count
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |v| v[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value]).to eq(2)
-
-        result[...-1].each do |row|
-          next if row[:groups]["cloud"].nil?
-
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).to eq(1)
-        end
-      end
-    end
-  end
-
-  describe "#sum_precise_total_amount_cents" do
-    it "returns the sum of precise_total_amount_cent values" do
-      expect(event_store.sum_precise_total_amount_cents).to eq(15)
-    end
-  end
-
-  describe "#grouped_sum_precise_total_amount_cents" do
-    let(:grouped_by) { %w[cloud] }
-
-    it "returns the sum of values grouped by the provided group" do
-      result = event_store.grouped_sum_precise_total_amount_cents
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |v| v[:groups]["cloud"].nil? }
-      expect(null_group[:value]).to eq(6)
-
-      result[...-1].each do |row|
-        next if row[:groups]["cloud"].nil?
-
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).not_to be_nil
-      end
-    end
-
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
-
-      it "returns the sum of values grouped by the provided groups" do
-        result = event_store.grouped_sum_precise_total_amount_cents
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |v| v[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value]).to eq(6)
-
-        result[...-1].each do |row|
-          next if row[:groups]["cloud"].nil?
-
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
-        end
-      end
-    end
-  end
-
-  describe "#active_unique_property?" do
-    before { event_store.aggregation_property = billable_metric.field_name }
-
-    it "returns false when no previous events exist" do
-      bm_value = SecureRandom.uuid
-
-      event = ::Clickhouse::EventsEnriched.create!(
+        transaction_id: transaction_id,
         organization_id: organization.id,
         external_subscription_id: subscription.external_id,
         code:,
-        timestamp: (boundaries[:from_datetime] + 2.days).end_of_day,
-        properties: {
-          billable_metric.field_name => bm_value
-        },
-        value: bm_value
+        timestamp: timestamp,
+        properties: properties.merge(billable_metric.field_name => value).compact,
+        value: value,
+        decimal_value: value&.to_i&.to_d,
+        precise_total_amount_cents: value
       )
-
-      expect(event_store).not_to be_active_unique_property(event)
     end
 
-    context "when event is already active" do
-      it "returns true if the event property is active" do
-        ::Clickhouse::EventsEnriched.create!(
+    def format_timestamp(timestamp)
+      Time.zone.parse(timestamp).strftime("%Y-%m-%d %H:%M:%S.%L")
+    end
+
+    def force_deduplication
+      Clickhouse::EventsEnriched.connection.execute("OPTIMIZE TABLE events_enriched FINAL")
+    end
+
+    describe "#prorated_unique_count" do
+      it "returns the number of unique active event properties" do
+        Clickhouse::EventsEnriched.create!(
+          transaction_id: SecureRandom.uuid,
           organization_id: organization.id,
           external_subscription_id: subscription.external_id,
           code:,
-          timestamp: (boundaries[:from_datetime] + 2.days).end_of_day,
+          timestamp: boundaries[:from_datetime] + 0.days,
           properties: {
             billable_metric.field_name => 2
           },
@@ -349,29 +43,12 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: true do
           decimal_value: 2
         )
 
-        event = ::Clickhouse::EventsEnriched.create!(
+        Clickhouse::EventsEnriched.create!(
+          transaction_id: SecureRandom.uuid,
           organization_id: organization.id,
           external_subscription_id: subscription.external_id,
           code:,
-          timestamp: (boundaries[:from_datetime] + 3.days).end_of_day,
-          properties: {
-            billable_metric.field_name => 2
-          },
-          value: "2",
-          decimal_value: 2
-        )
-
-        expect(event_store).to be_active_unique_property(event)
-      end
-    end
-
-    context "with a previous removed event" do
-      it "returns false" do
-        ::Clickhouse::EventsEnriched.create!(
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          timestamp: (boundaries[:from_datetime] + 2.days).end_of_day,
+          timestamp: (boundaries[:from_datetime] + 0.days).end_of_day,
           properties: {
             billable_metric.field_name => 2,
             :operation_type => "remove"
@@ -379,1038 +56,501 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: true do
           value: "2",
           decimal_value: 2
         )
+        event_store.aggregation_property = billable_metric.field_name
 
-        event = ::Clickhouse::EventsEnriched.create!(
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          timestamp: (boundaries[:from_datetime] + 3.days).end_of_day,
-          properties: {
-            billable_metric.field_name => 2
-          },
-          value: "2",
-          decimal_value: 2
-        )
-
-        expect(event_store).not_to be_active_unique_property(event)
-      end
-    end
-  end
-
-  describe "#unique_count" do
-    it "returns the number of unique active event properties" do
-      Clickhouse::EventsEnriched.create!(
-        transaction_id: SecureRandom.uuid,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        code:,
-        timestamp: boundaries[:from_datetime] + 3.days,
-        properties: {
-          billable_metric.field_name => 2,
-          :operation_type => "remove"
-        },
-        value: "2",
-        decimal_value: 2
-      )
-
-      event_store.aggregation_property = billable_metric.field_name
-
-      expect(event_store.unique_count).to eq(4) # 5 events added / 1 removed
-    end
-  end
-
-  describe "#prorated_unique_count" do
-    it "returns the number of unique active event properties" do
-      Clickhouse::EventsEnriched.create!(
-        transaction_id: SecureRandom.uuid,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        code:,
-        timestamp: boundaries[:from_datetime] + 0.days,
-        properties: {
-          billable_metric.field_name => 2
-        },
-        value: "2",
-        decimal_value: 2
-      )
-
-      Clickhouse::EventsEnriched.create!(
-        transaction_id: SecureRandom.uuid,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        code:,
-        timestamp: (boundaries[:from_datetime] + 0.days).end_of_day,
-        properties: {
-          billable_metric.field_name => 2,
-          :operation_type => "remove"
-        },
-        value: "2",
-        decimal_value: 2
-      )
-      event_store.aggregation_property = billable_metric.field_name
-
-      # NOTE: Events calculation: 16/31 + 1/31 + + 15/31 + 14/31 + 13/31 + 12/31
-      # Events:
-      # 1 => added on 0 day, never removed => 16/31
-      # 2 => added on 0 day, removed on 0 day => 1/31
-      # 2 => added on 1 day, never removed => 15/31
-      # 3 => added on 2 day, never removed => 14/31
-      # 4 => added on 3 day, never removed => 13/31
-      # 5 => added on 4 day, never removed => 12/31
-      expect(event_store.prorated_unique_count.round(3)).to eq(2.29)
-    end
-
-    context "with multiple events at the same day" do
-      it "returns the number of unique active event properties merged within one day" do
-        event_params = [
-          {timestamp: boundaries[:from_datetime], operation_type: "remove"},
-          {timestamp: boundaries[:from_datetime] + 1.hour, operation_type: "add"},
-          {timestamp: boundaries[:from_datetime] + 2.hours, operation_type: "remove"},
-          {timestamp: boundaries[:from_datetime] + 3.hours, operation_type: "add"},
-          {timestamp: boundaries[:from_datetime] + 1.day, operation_type: "remove"},
-          {timestamp: boundaries[:from_datetime] + 1.day + 1.hour, operation_type: "add"},
-          {timestamp: boundaries[:from_datetime] + 2.days + 1.hour, operation_type: "remove"}
-        ]
-
-        event_params.each do |params|
-          Clickhouse::EventsEnriched.create!(
-            transaction_id: SecureRandom.uuid,
-            organization_id: organization.id,
-            external_subscription_id: subscription.external_id,
-            code:,
-            timestamp: params[:timestamp],
-            properties: {
-              billable_metric.field_name => 2,
-              :operation_type => params[:operation_type]
-            },
-            value: "2",
-            decimal_value: 2
-          )
-        end
-
-        # NOTE: Events calculation: 3/31
+        # NOTE: Events calculation: 16/31 + 1/31 + + 15/31 + 14/31 + 13/31 + 12/31
         # Events:
         # 1 => added on 0 day, never removed => 16/31
-        # 2 => added on 0 day, removed on 2 day => 3/31
+        # 2 => added on 0 day, removed on 0 day => 1/31
+        # 2 => added on 1 day, never removed => 15/31
         # 3 => added on 2 day, never removed => 14/31
         # 4 => added on 3 day, never removed => 13/31
         # 5 => added on 4 day, never removed => 12/31
-        expect(event_store.prorated_unique_count.round(3)).to eq(1.871) # 16/31 + 3/31 + 14/31 + 13/31 + 12/31
+        expect(event_store.prorated_unique_count.round(3)).to eq(2.29)
+      end
+
+      context "with multiple events at the same day" do
+        it "returns the number of unique active event properties merged within one day" do
+          event_params = [
+            {timestamp: boundaries[:from_datetime], operation_type: "remove"},
+            {timestamp: boundaries[:from_datetime] + 1.hour, operation_type: "add"},
+            {timestamp: boundaries[:from_datetime] + 2.hours, operation_type: "remove"},
+            {timestamp: boundaries[:from_datetime] + 3.hours, operation_type: "add"},
+            {timestamp: boundaries[:from_datetime] + 1.day, operation_type: "remove"},
+            {timestamp: boundaries[:from_datetime] + 1.day + 1.hour, operation_type: "add"},
+            {timestamp: boundaries[:from_datetime] + 2.days + 1.hour, operation_type: "remove"}
+          ]
+
+          event_params.each do |params|
+            Clickhouse::EventsEnriched.create!(
+              transaction_id: SecureRandom.uuid,
+              organization_id: organization.id,
+              external_subscription_id: subscription.external_id,
+              code:,
+              timestamp: params[:timestamp],
+              properties: {
+                billable_metric.field_name => 2,
+                :operation_type => params[:operation_type]
+              },
+              value: "2",
+              decimal_value: 2
+            )
+          end
+
+          # NOTE: Events calculation: 3/31
+          # Events:
+          # 1 => added on 0 day, never removed => 16/31
+          # 2 => added on 0 day, removed on 2 day => 3/31
+          # 3 => added on 2 day, never removed => 14/31
+          # 4 => added on 3 day, never removed => 13/31
+          # 5 => added on 4 day, never removed => 12/31
+          expect(event_store.prorated_unique_count.round(3)).to eq(1.871) # 16/31 + 3/31 + 14/31 + 13/31 + 12/31
+        end
       end
     end
-  end
 
-  describe "#grouped_unique_count" do
-    let(:grouped_by) { %w[agent_name other] }
-    let(:started_at) { Time.zone.parse("2023-03-01") }
+    describe "#grouped_prorated_unique_count" do
+      let(:grouped_by) { %w[agent_name other] }
+      let(:started_at) { Time.zone.parse("2023-03-01") }
 
-    let(:events) do
-      [
-        Clickhouse::EventsEnriched.create!(
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          transaction_id: SecureRandom.uuid,
-          timestamp: boundaries[:from_datetime] + 1.hour,
-          properties: {
-            billable_metric.field_name => 2,
-            :agent_name => "frodo"
-          },
-          value: "2",
-          decimal_value: 2
-        ),
-        Clickhouse::EventsEnriched.create!(
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          transaction_id: SecureRandom.uuid,
-          timestamp: boundaries[:from_datetime] + 1.day,
-          properties: {
-            billable_metric.field_name => 2,
-            :agent_name => "aragorn"
-          },
-          value: "2",
-          decimal_value: 2
-        ),
-        Clickhouse::EventsEnriched.create!(
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          transaction_id: SecureRandom.uuid,
-          timestamp: boundaries[:from_datetime] + 2.days,
-          properties: {
-            billable_metric.field_name => 2,
-            :agent_name => "aragorn",
-            :operation_type => "remove"
-          },
-          value: "2",
-          decimal_value: 2
-        ),
-        Clickhouse::EventsEnriched.create!(
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          transaction_id: SecureRandom.uuid,
-          timestamp: boundaries[:from_datetime] + 2.days,
-          properties: {billable_metric.field_name => 2},
-          value: "2",
-          decimal_value: 2
-        )
-      ]
-    end
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-    end
-
-    it "returns the unique count of event properties" do
-      result = event_store.grouped_unique_count
-
-      expect(result.count).to eq(3)
-
-      null_group = result.find { |v| v[:groups]["agent_name"].nil? }
-      expect(null_group[:groups]["other"]).to be_nil
-      expect(null_group[:value]).to eq(1)
-
-      expect((result - [null_group]).map { |r| r[:value] }).to contain_exactly(1, 0)
-    end
-
-    context "with no events" do
-      let(:events) { [] }
-
-      it "returns the unique count of event properties" do
-        result = event_store.grouped_unique_count
-        expect(result.count).to eq(0)
+      let(:events) do
+        [
+          Clickhouse::EventsEnriched.create!(
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            code:,
+            transaction_id: SecureRandom.uuid,
+            timestamp: boundaries[:from_datetime] + 1.day,
+            properties: {
+              billable_metric.field_name => 2,
+              :agent_name => "frodo"
+            },
+            value: "2",
+            decimal_value: 2
+          ),
+          Clickhouse::EventsEnriched.create!(
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            code:,
+            transaction_id: SecureRandom.uuid,
+            timestamp: boundaries[:from_datetime] + 1.day,
+            properties: {
+              billable_metric.field_name => 2,
+              :agent_name => "aragorn"
+            },
+            value: "2",
+            decimal_value: 2
+          ),
+          Clickhouse::EventsEnriched.create!(
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            code:,
+            transaction_id: SecureRandom.uuid,
+            timestamp: (boundaries[:from_datetime] + 1.day).end_of_day,
+            properties: {
+              billable_metric.field_name => 2,
+              :agent_name => "aragorn",
+              :operation_type => "remove"
+            },
+            value: "2",
+            decimal_value: 2
+          ),
+          Clickhouse::EventsEnriched.create!(
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            code:,
+            transaction_id: SecureRandom.uuid,
+            timestamp: boundaries[:from_datetime] + 2.days,
+            properties: {billable_metric.field_name => 2},
+            value: "2",
+            decimal_value: 2
+          )
+        ]
       end
-    end
-  end
 
-  describe "#grouped_prorated_unique_count" do
-    let(:grouped_by) { %w[agent_name other] }
-    let(:started_at) { Time.zone.parse("2023-03-01") }
-
-    let(:events) do
-      [
-        Clickhouse::EventsEnriched.create!(
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          transaction_id: SecureRandom.uuid,
-          timestamp: boundaries[:from_datetime] + 1.day,
-          properties: {
-            billable_metric.field_name => 2,
-            :agent_name => "frodo"
-          },
-          value: "2",
-          decimal_value: 2
-        ),
-        Clickhouse::EventsEnriched.create!(
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          transaction_id: SecureRandom.uuid,
-          timestamp: boundaries[:from_datetime] + 1.day,
-          properties: {
-            billable_metric.field_name => 2,
-            :agent_name => "aragorn"
-          },
-          value: "2",
-          decimal_value: 2
-        ),
-        Clickhouse::EventsEnriched.create!(
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          transaction_id: SecureRandom.uuid,
-          timestamp: (boundaries[:from_datetime] + 1.day).end_of_day,
-          properties: {
-            billable_metric.field_name => 2,
-            :agent_name => "aragorn",
-            :operation_type => "remove"
-          },
-          value: "2",
-          decimal_value: 2
-        ),
-        Clickhouse::EventsEnriched.create!(
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          transaction_id: SecureRandom.uuid,
-          timestamp: boundaries[:from_datetime] + 2.days,
-          properties: {billable_metric.field_name => 2},
-          value: "2",
-          decimal_value: 2
-        )
-      ]
-    end
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-    end
-
-    it "returns the unique count of event properties" do
-      result = event_store.grouped_prorated_unique_count
-
-      expect(result.count).to eq(3)
-
-      null_group = result.find { |v| v[:groups]["agent_name"].nil? }
-      expect(null_group[:groups]["other"]).to be_nil
-      expect(null_group[:value].round(3)).to eq(0.935) # 29/31
-
-      # NOTE: Events calculation: [1/31, 30/31]
-      expect((result - [null_group]).map { |r| r[:value].round(3) }).to contain_exactly(0.032, 0.968)
-    end
-
-    context "with no events" do
-      let(:events) { [] }
+      before do
+        event_store.aggregation_property = billable_metric.field_name
+      end
 
       it "returns the unique count of event properties" do
         result = event_store.grouped_prorated_unique_count
-        expect(result.count).to eq(0)
-      end
-    end
-  end
 
-  describe "#prorated_unique_count_breakdown" do
-    it "returns the breakdown of add and remove of unique event properties" do
-      Clickhouse::EventsEnriched.create!(
-        transaction_id: SecureRandom.uuid,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        code:,
-        timestamp: boundaries[:from_datetime] + 1.day,
-        properties: {
-          billable_metric.field_name => 2
-        },
-        value: "2",
-        decimal_value: 2
-      )
+        expect(result.count).to eq(3)
 
-      Clickhouse::EventsEnriched.create!(
-        transaction_id: SecureRandom.uuid,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        code:,
-        timestamp: boundaries[:from_datetime] + 1.day,
-        properties: {
-          billable_metric.field_name => 3
-        },
-        value: "30",
-        decimal_value: 30
-      )
+        null_group = result.find { |v| v[:groups]["agent_name"].nil? }
+        expect(null_group[:groups]["other"]).to be_nil
+        expect(null_group[:value].round(3)).to eq(0.935) # 29/31
 
-      Clickhouse::EventsEnriched.create!(
-        transaction_id: SecureRandom.uuid,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        code:,
-        timestamp: (boundaries[:from_datetime] + 1.day).end_of_day,
-        properties: {
-          billable_metric.field_name => 2,
-          :operation_type => "remove"
-        },
-        value: "2",
-        decimal_value: 2
-      )
-
-      event_store.aggregation_property = billable_metric.field_name
-
-      result = event_store.prorated_unique_count_breakdown
-      expect(result.count).to eq(7)
-
-      # Ensure consistent ordering with 2 events with the same timestamp
-      expect(result.map { it["property"] }).to eq(%w[1 2 30 2 3 4 5])
-
-      grouped_result = result.group_by { |r| r["property"] }
-
-      # NOTE: group with property 1
-      group = grouped_result["1"]
-      expect(group.count).to eq(1)
-      expect(group.first["prorated_value"].round(3)).to eq(0.516) # 16/31
-      expect(group.first["operation_type"]).to eq("add")
-
-      # NOTE: group with property 2 (added and removed)
-      group = grouped_result["2"]
-      expect(group.first["prorated_value"].round(3)).to eq(0.032) # 1/31
-      expect(group.last["prorated_value"].round(3)).to eq(0.484) # 15/31
-      expect(group.count).to eq(2)
-
-      # NOTE: group with property 3
-      group = grouped_result["3"]
-      expect(group.count).to eq(1)
-      expect(group.first["prorated_value"].round(3)).to eq(0.452) # 14/31
-      expect(group.first["operation_type"]).to eq("add")
-
-      # NOTE: group with property 4
-      group = grouped_result["4"]
-      expect(group.count).to eq(1)
-      expect(group.first["prorated_value"].round(3)).to eq(0.419) # 13/31
-      expect(group.first["operation_type"]).to eq("add")
-
-      # NOTE: group with property 5
-      group = grouped_result["5"]
-      expect(group.count).to eq(1)
-      expect(group.first["prorated_value"].round(3)).to eq(0.387) # 12/31
-      expect(group.first["operation_type"]).to eq("add")
-    end
-  end
-
-  describe ".events_values" do
-    it "returns the value attached to each event" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.events_values).to eq([1, 2, 3, 4, 5])
-    end
-
-    context "when exclude_event is true" do
-      subject(:event_store) do
-        described_class.new(
-          code:,
-          subscription:,
-          boundaries:,
-          filters: {
-            grouped_by:,
-            grouped_by_values:,
-            matching_filters:,
-            ignored_filters:,
-            event:
-          }
-        )
+        # NOTE: Events calculation: [1/31, 30/31]
+        expect((result - [null_group]).map { |r| r[:value].round(3) }).to contain_exactly(0.032, 0.968)
       end
 
-      let(:event) do
+      context "with no events" do
+        let(:events) { [] }
+
+        it "returns the unique count of event properties" do
+          result = event_store.grouped_prorated_unique_count
+          expect(result.count).to eq(0)
+        end
+      end
+    end
+
+    describe "#prorated_unique_count_breakdown" do
+      it "returns the breakdown of add and remove of unique event properties" do
         Clickhouse::EventsEnriched.create!(
           transaction_id: SecureRandom.uuid,
           organization_id: organization.id,
           external_subscription_id: subscription.external_id,
           code:,
           timestamp: boundaries[:from_datetime] + 1.day,
-          properties: {billable_metric.field_name => 6},
-          value: "6",
-          decimal_value: 6
+          properties: {
+            billable_metric.field_name => 2
+          },
+          value: "2",
+          decimal_value: 2
         )
-      end
 
-      it "excludes current event but returns the value attached to other events" do
-        event
+        Clickhouse::EventsEnriched.create!(
+          transaction_id: SecureRandom.uuid,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          code:,
+          timestamp: (boundaries[:from_datetime] + 1.day).end_of_day,
+          properties: {
+            billable_metric.field_name => 2,
+            :operation_type => "remove"
+          },
+          value: "2",
+          decimal_value: 2
+        )
+
+        event_store.aggregation_property = billable_metric.field_name
+
+        result = event_store.prorated_unique_count_breakdown
+        expect(result.count).to eq(6)
+
+        grouped_result = result.group_by { |r| r["property"] }
+
+        # NOTE: group with property 1
+        group = grouped_result["1"]
+        expect(group.count).to eq(1)
+        expect(group.first["prorated_value"].round(3)).to eq(0.516) # 16/31
+        expect(group.first["operation_type"]).to eq("add")
+
+        # NOTE: group with property 2 (added and removed)
+        group = grouped_result["2"]
+        expect(group.first["prorated_value"].round(3)).to eq(0.032) # 1/31
+        expect(group.last["prorated_value"].round(3)).to eq(0.484) # 15/31
+        expect(group.count).to eq(2)
+
+        # NOTE: group with property 3
+        group = grouped_result["3"]
+        expect(group.count).to eq(1)
+        expect(group.first["prorated_value"].round(3)).to eq(0.452) # 14/31
+        expect(group.first["operation_type"]).to eq("add")
+
+        # NOTE: group with property 4
+        group = grouped_result["4"]
+        expect(group.count).to eq(1)
+        expect(group.first["prorated_value"].round(3)).to eq(0.419) # 13/31
+        expect(group.first["operation_type"]).to eq("add")
+
+        # NOTE: group with property 5
+        group = grouped_result["5"]
+        expect(group.count).to eq(1)
+        expect(group.first["prorated_value"].round(3)).to eq(0.387) # 12/31
+        expect(group.first["operation_type"]).to eq("add")
+      end
+    end
+
+    describe "#prorated_events_values" do
+      it "returns the values attached to each event with prorata on period duration" do
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
 
-        expect(event_store.events_values(exclude_event: true)).to eq([1, 2, 3, 4, 5])
-      end
-    end
-  end
-
-  describe ".last_event" do
-    it "returns the last event" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.last_event.transaction_id).to eq(events.last.transaction_id)
-    end
-  end
-
-  describe ".grouped_last_event" do
-    let(:grouped_by) { %w[cloud] }
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
-
-    it "returns the last events grouped by the provided group" do
-      result = event_store.grouped_last_event
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |v| v[:groups]["cloud"].nil? }
-      expect(null_group[:groups]["cloud"]).to be_nil
-      expect(null_group[:value]).to eq(4)
-      expect(null_group[:timestamp]).not_to be_nil
-
-      (result - [null_group]).each do |row|
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).not_to be_nil
-        expect(row[:timestamp]).not_to be_nil
-      end
-    end
-
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
-
-      it "returns the last events grouped by the provided groups" do
-        result = event_store.grouped_last_event
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |v| v[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["cloud"]).to be_nil
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value]).to eq(4)
-        expect(null_group[:timestamp]).not_to be_nil
-
-        (result - [null_group]).each do |row|
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
-          expect(row[:timestamp]).not_to be_nil
-        end
-      end
-    end
-  end
-
-  describe ".prorated_events_values" do
-    it "returns the values attached to each event with prorata on period duration" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.prorated_events_values(31).map { |v| v.round(3) }).to eq(
-        [0.516, 0.968, 1.355, 1.677, 1.935]
-      )
-    end
-  end
-
-  describe ".max" do
-    it "returns the max value" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.max).to eq(5)
-    end
-  end
-
-  describe ".grouped_max" do
-    let(:grouped_by) { %w[cloud] }
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
-
-    it "returns the max values grouped by the provided group" do
-      result = event_store.grouped_max
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |v| v[:groups]["cloud"].nil? }
-      expect(null_group[:value]).to eq(4)
-
-      result[...-1].each do |row|
-        next if row[:groups]["cloud"].nil?
-
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).not_to be_nil
-      end
-    end
-
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
-
-      it "returns the max values grouped by the provided groups" do
-        result = event_store.grouped_max
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |v| v[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value]).to eq(4)
-
-        result[...-1].each do |row|
-          next if row[:groups]["cloud"].nil?
-
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
-        end
-      end
-    end
-  end
-
-  describe ".last" do
-    it "returns the last event" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.last).to eq(5)
-    end
-  end
-
-  describe ".grouped_last" do
-    let(:grouped_by) { %w[cloud] }
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
-
-    it "returns the value attached to each event prorated on the provided duration" do
-      result = event_store.grouped_last
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |v| v[:groups]["cloud"].nil? }
-      expect(null_group[:value]).to eq(4)
-
-      result[...-1].each do |row|
-        next if row[:groups]["cloud"].nil?
-
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).not_to be_nil
-      end
-    end
-
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
-
-      it "returns the last value for each provided groups" do
-        result = event_store.grouped_last
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |v| v[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value]).to eq(4)
-
-        result[...-1].each do |row|
-          next if row[:groups]["cloud"].nil?
-
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
-        end
-      end
-    end
-  end
-
-  describe ".sum" do
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
-
-    it "returns the sum of event properties" do
-      expect(event_store.sum).to eq(15)
-    end
-
-    context "with duplicated transaction_id" do
-      before do
-        event = events.first
-
-        Clickhouse::EventsEnriched.create!(
-          transaction_id: event.transaction_id,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          timestamp: boundaries[:from_datetime] + 5.days,
-          properties: {billable_metric.field_name => 100},
-          value: 100.to_s,
-          decimal_value: 100.0,
-          precise_total_amount_cents: 100.0
+        expect(event_store.prorated_events_values(31).map { |v| v.round(3) }).to eq(
+          [0.516, 0.968, 1.355, 1.677, 1.935]
         )
-
-        # Force clickhouse deduplication
-        Clickhouse::EventsEnriched.connection.execute("OPTIMIZE TABLE events_enriched FINAL")
-      end
-
-      it "takes the event into account" do
-        expect(event_store.sum).to eq(115) # New event value was added
       end
     end
 
-    context "with duplicated transaction_id and timestamp" do
-      before do
-        event = events.first
-
-        Clickhouse::EventsEnriched.create!(
-          transaction_id: event.transaction_id,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          timestamp: event.timestamp,
-          properties: {billable_metric.field_name => 100},
-          value: 100.to_s,
-          decimal_value: 100.0,
-          precise_total_amount_cents: 100.0
-        )
-
-        # Force clickhouse deduplication
-        Clickhouse::EventsEnriched.connection.execute("OPTIMIZE TABLE events_enriched FINAL")
-      end
-
-      it "deduplicates the events" do
-        expect(event_store.sum).to eq(114) # First event value was changed from 1 to 100
-      end
-    end
-  end
-
-  describe ".grouped_sum" do
-    let(:grouped_by) { %w[cloud] }
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
-
-    it "returns the sum of values grouped by the provided group" do
-      result = event_store.grouped_sum
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |v| v[:groups]["cloud"].nil? }
-      expect(null_group[:value]).to eq(6)
-
-      result[...-1].each do |row|
-        next if row[:groups]["cloud"].nil?
-
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).not_to be_nil
-      end
-    end
-
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
-
-      it "returns the sum of values grouped by the provided groups" do
-        result = event_store.grouped_sum
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |v| v[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value]).to eq(6)
-
-        result[...-1].each do |row|
-          next if row[:groups]["cloud"].nil?
-
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
-        end
-      end
-    end
-  end
-
-  describe ".prorated_sum" do
-    it "returns the prorated sum of event properties" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.prorated_sum(period_duration: 31).round(5)).to eq(6.45161)
-    end
-
-    context "with persisted_duration" do
+    describe "#prorated_sum" do
       it "returns the prorated sum of event properties" do
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
 
-        expect(event_store.prorated_sum(period_duration: 31, persisted_duration: 10).round(5)).to eq(4.83871)
+        expect(event_store.prorated_sum(period_duration: 31).round(5)).to eq(6.45161)
       end
-    end
-  end
 
-  describe ".grouped_prorated_sum" do
-    let(:grouped_by) { %w[cloud] }
+      context "with persisted_duration" do
+        it "returns the prorated sum of event properties" do
+          event_store.aggregation_property = billable_metric.field_name
+          event_store.numeric_property = true
 
-    it "returns the prorated sum of event properties" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      result = event_store.grouped_prorated_sum(period_duration: 31)
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |v| v[:groups]["cloud"].nil? }
-      expect(null_group[:groups]["cloud"]).to be_nil
-      expect(null_group[:value].round(5)).to eq(2.64516)
-
-      (result - [null_group]).each do |row|
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).not_to be_nil
-      end
-    end
-
-    context "with persisted_duration" do
-      it "returns the prorated sum of event properties" do
-        event_store.aggregation_property = billable_metric.field_name
-        event_store.numeric_property = true
-
-        result = event_store.grouped_prorated_sum(period_duration: 31, persisted_duration: 10)
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |v| v[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["cloud"]).to be_nil
-        expect(null_group[:value].round(5)).to eq(1.93548)
-
-        (result - [null_group]).each do |row|
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
+          expect(event_store.prorated_sum(period_duration: 31, persisted_duration: 10).round(5)).to eq(4.83871)
         end
       end
     end
 
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
+    describe "#grouped_prorated_sum" do
+      let(:grouped_by) { %w[region] }
 
-      it "returns the sum of values grouped by the provided groups" do
+      it "returns the prorated sum of event properties" do
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
 
         result = event_store.grouped_prorated_sum(period_duration: 31)
 
-        expect(result.count).to eq(4)
+        expect(result).to match_array([
+          {groups: {"region" => nil}, value: within(0.00001).of(2.64516)},
+          {groups: {"region" => "europe"}, value: within(0.00001).of(3.80645)}
+        ])
+      end
 
-        null_group = result.find { |v| v[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["cloud"]).to be_nil
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value].round(5)).to eq(2.64516)
+      context "with persisted_duration" do
+        it "returns the prorated sum of event properties" do
+          event_store.aggregation_property = billable_metric.field_name
+          event_store.numeric_property = true
 
-        (result - [null_group]).each do |row|
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
+          result = event_store.grouped_prorated_sum(period_duration: 31, persisted_duration: 10)
+
+          expect(result).to match_array([
+            {groups: {"region" => nil}, value: within(0.00001).of(1.93548)},
+            {groups: {"region" => "europe"}, value: within(0.00001).of(2.90322)}
+          ])
+        end
+      end
+
+      context "with multiple groups" do
+        let(:grouped_by) { %w[region country] }
+
+        it "returns the sum of values grouped by the provided groups" do
+          event_store.aggregation_property = billable_metric.field_name
+          event_store.numeric_property = true
+
+          result = event_store.grouped_prorated_sum(period_duration: 31)
+
+          expect(result).to match_array(
+            [
+              {
+                groups: {"country" => "united kingdom", "region" => "europe"},
+                value: within(0.00001).of(1.93548)
+              },
+              {
+                groups: {"country" => nil, "region" => nil},
+                value: within(0.00001).of(2.64516)
+              },
+              {
+                groups: {"country" => "france", "region" => "europe"},
+                value: within(0.00001).of(1.87096)
+              }
+            ]
+          )
         end
       end
     end
-  end
 
-  describe ".sum_date_breakdown" do
-    it "returns the sum grouped by day" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
+    describe "#weighted_sum" do
+      let(:started_at) { Time.zone.parse("2023-03-01") }
 
-      expect(event_store.sum_date_breakdown).to eq(
-        events.map do |e|
-          {
-            date: e.timestamp.to_date,
-            value: e.decimal_value
-          }
+      let(:events_values) do
+        [
+          {timestamp: Time.zone.parse("2023-03-05 00:00:00.000"), value: 2},
+          {timestamp: Time.zone.parse("2023-03-05 01:00:00"), value: 3},
+          {timestamp: Time.zone.parse("2023-03-05 01:30:00"), value: 1},
+          {timestamp: Time.zone.parse("2023-03-05 02:00:00"), value: -4},
+          {timestamp: Time.zone.parse("2023-03-05 04:00:00"), value: -2},
+          {timestamp: Time.zone.parse("2023-03-05 05:00:00"), value: 10},
+          {timestamp: Time.zone.parse("2023-03-05 05:30:00"), value: -10}
+        ]
+      end
+
+      let(:events) do
+        events_values.map do |values|
+          properties = {value: values[:value]}
+          properties[:region] = values[:region] if values[:region]
+
+          Clickhouse::EventsEnriched.create!(
+            transaction_id: SecureRandom.uuid,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            code:,
+            timestamp: values[:timestamp],
+            properties:,
+            value: values[:value].to_s,
+            decimal_value: values[:value].to_d
+          )
         end
-      )
-    end
-  end
-
-  describe ".weighted_sum" do
-    let(:started_at) { Time.zone.parse("2023-03-01") }
-
-    let(:events_values) do
-      [
-        {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2},
-        {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3},
-        {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1},
-        {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4},
-        {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2},
-        {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10},
-        {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10}
-      ]
-    end
-
-    let(:events) do
-      events_values.map do |values|
-        properties = {value: values[:value]}
-        properties[:region] = values[:region] if values[:region]
-
-        Clickhouse::EventsEnriched.create!(
-          transaction_id: SecureRandom.uuid,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          timestamp: values[:timestamp],
-          properties:,
-          value: values[:value].to_s,
-          decimal_value: values[:value].to_d
-        )
       end
-    end
 
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
-
-    it "returns the weighted sum of event properties" do
-      expect(event_store.weighted_sum.round(5)).to eq(0.02218)
-    end
-
-    context "with a single event" do
-      let(:events_values) do
-        [
-          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 1000}
-        ]
+      before do
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
       end
 
       it "returns the weighted sum of event properties" do
-        expect(event_store.weighted_sum.round(5)).to eq(1000.0)
-      end
-    end
-
-    context "with no events" do
-      let(:events_values) { [] }
-
-      it "returns the weighted sum of event properties" do
-        expect(event_store.weighted_sum.round(5)).to eq(0.0)
-      end
-    end
-
-    context "with events with the same timestamp" do
-      let(:events_values) do
-        [
-          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 3},
-          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 3}
-        ]
+        expect(event_store.weighted_sum.round(5)).to eq(0.02218)
       end
 
-      it "returns the weighted sum of event properties" do
-        expect(event_store.weighted_sum.round(5)).to eq(6.0)
+      context "with a single event" do
+        let(:events_values) do
+          [
+            {timestamp: Time.zone.parse("2023-03-05 00:00:00.000"), value: 1000}
+          ]
+        end
+
+        it "returns the weighted sum of event properties" do
+          expect(event_store.weighted_sum.round(5)).to eq(870.96774) # 4 / 31 * 0 + 27 / 31 * 1000
+        end
       end
-    end
 
-    context "with initial value" do
-      let(:initial_value) { 1000 }
-
-      it "uses the initial value in the aggregation" do
-        expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.02218)
-      end
-
-      context "without events" do
+      context "with no events" do
         let(:events_values) { [] }
 
-        it "uses only the initial value in the aggregation" do
-          expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.0)
+        it "returns the weighted sum of event properties" do
+          expect(event_store.weighted_sum.round(5)).to eq(0.0)
+        end
+      end
+
+      context "with events with the same timestamp" do
+        let(:events_values) do
+          [
+            {timestamp: Time.zone.parse("2023-03-05 00:00:00.000"), value: 3},
+            {timestamp: Time.zone.parse("2023-03-05 00:00:00.000"), value: 3}
+          ]
+        end
+
+        it "returns the weighted sum of event properties" do
+          expect(event_store.weighted_sum.round(5)).to eq(5.22581) # 4 / 31 * 0 + 27 / 31 * 6
+        end
+      end
+
+      context "with initial value" do
+        let(:initial_value) { 1000 }
+
+        it "uses the initial value in the aggregation" do
+          expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.02218)
+        end
+
+        context "without events" do
+          let(:events_values) { [] }
+
+          it "uses only the initial value in the aggregation" do
+            expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.0)
+          end
+        end
+      end
+
+      context "with filters" do
+        let(:matching_filters) { {region: ["europe"]} }
+
+        let(:events_values) do
+          [
+            {timestamp: Time.zone.parse("2023-03-04 00:00:00.000"), value: 1000, region: "us"},
+            {timestamp: Time.zone.parse("2023-03-05 00:00:00.000"), value: 1000, region: "europe"}
+          ]
+        end
+
+        it "returns the weighted sum of event properties scoped to the group" do
+          expect(event_store.weighted_sum.round(5)).to eq(870.96774) # 4 / 31 * 0 + 27 / 31 * 1000
         end
       end
     end
 
-    context "with filters" do
-      let(:matching_filters) { {region: ["europe"]} }
+    describe "#grouped_weighted_sum" do
+      let(:grouped_by) { %w[agent_name other] }
+
+      let(:started_at) { Time.zone.parse("2023-03-01") }
 
       let(:events_values) do
         [
-          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 1000, region: "europe"}
+          {timestamp: Time.zone.parse("2023-03-05 00:00:00.000"), value: 2, agent_name: "frodo"},
+          {timestamp: Time.zone.parse("2023-03-05 01:00:00"), value: 3, agent_name: "frodo"},
+          {timestamp: Time.zone.parse("2023-03-05 01:30:00"), value: 1, agent_name: "frodo"},
+          {timestamp: Time.zone.parse("2023-03-05 02:00:00"), value: -4, agent_name: "frodo"},
+          {timestamp: Time.zone.parse("2023-03-05 04:00:00"), value: -2, agent_name: "frodo"},
+          {timestamp: Time.zone.parse("2023-03-05 05:00:00"), value: 10, agent_name: "frodo"},
+          {timestamp: Time.zone.parse("2023-03-05 05:30:00"), value: -10, agent_name: "frodo"},
+
+          {timestamp: Time.zone.parse("2023-03-05 00:00:00.000"), value: 2, agent_name: "aragorn"},
+          {timestamp: Time.zone.parse("2023-03-05 01:00:00"), value: 3, agent_name: "aragorn"},
+          {timestamp: Time.zone.parse("2023-03-05 01:30:00"), value: 1, agent_name: "aragorn"},
+          {timestamp: Time.zone.parse("2023-03-05 02:00:00"), value: -4, agent_name: "aragorn"},
+          {timestamp: Time.zone.parse("2023-03-05 04:00:00"), value: -2, agent_name: "aragorn"},
+          {timestamp: Time.zone.parse("2023-03-05 05:00:00"), value: 10, agent_name: "aragorn"},
+          {timestamp: Time.zone.parse("2023-03-05 05:30:00"), value: -10, agent_name: "aragorn"},
+
+          {timestamp: Time.zone.parse("2023-03-05 00:00:00.000"), value: 2},
+          {timestamp: Time.zone.parse("2023-03-05 01:00:00"), value: 3},
+          {timestamp: Time.zone.parse("2023-03-05 01:30:00"), value: 1},
+          {timestamp: Time.zone.parse("2023-03-05 02:00:00"), value: -4},
+          {timestamp: Time.zone.parse("2023-03-05 04:00:00"), value: -2},
+          {timestamp: Time.zone.parse("2023-03-05 05:00:00"), value: 10},
+          {timestamp: Time.zone.parse("2023-03-05 05:30:00"), value: -10}
         ]
       end
 
-      it "returns the weighted sum of event properties scoped to the group" do
-        expect(event_store.weighted_sum.round(5)).to eq(1000.0)
+      let(:events) do
+        events_values.map do |values|
+          properties = {value: values[:value]}
+          properties[:region] = values[:region] if values[:region]
+          properties[:agent_name] = values[:agent_name] if values[:agent_name]
+
+          Clickhouse::EventsEnriched.create!(
+            transaction_id: SecureRandom.uuid,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            code:,
+            timestamp: values[:timestamp],
+            properties:,
+            value: values[:value].to_s,
+            decimal_value: values[:value].to_d
+          )
+        end
       end
-    end
-  end
 
-  describe ".grouped_weighted_sum" do
-    let(:grouped_by) { %w[agent_name other] }
-
-    let(:started_at) { Time.zone.parse("2023-03-01") }
-
-    let(:events_values) do
-      [
-        {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2, agent_name: "frodo"},
-        {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3, agent_name: "frodo"},
-        {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1, agent_name: "frodo"},
-        {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4, agent_name: "frodo"},
-        {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2, agent_name: "frodo"},
-        {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10, agent_name: "frodo"},
-        {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10, agent_name: "frodo"},
-
-        {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2, agent_name: "aragorn"},
-        {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3, agent_name: "aragorn"},
-        {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1, agent_name: "aragorn"},
-        {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4, agent_name: "aragorn"},
-        {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2, agent_name: "aragorn"},
-        {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10, agent_name: "aragorn"},
-        {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10, agent_name: "aragorn"},
-
-        {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2},
-        {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3},
-        {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1},
-        {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4},
-        {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2},
-        {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10},
-        {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10}
-      ]
-    end
-
-    let(:events) do
-      events_values.map do |values|
-        properties = {value: values[:value]}
-        properties[:region] = values[:region] if values[:region]
-        properties[:agent_name] = values[:agent_name] if values[:agent_name]
-
-        Clickhouse::EventsEnriched.create!(
-          transaction_id: SecureRandom.uuid,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          code:,
-          timestamp: values[:timestamp],
-          properties:,
-          value: values[:value].to_s,
-          decimal_value: values[:value].to_d
-        )
+      before do
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
       end
-    end
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
-
-    it "returns the weighted sum of event properties" do
-      result = event_store.grouped_weighted_sum
-
-      expect(result.count).to eq(3)
-
-      null_group = result.find { |v| v[:groups]["agent_name"].nil? }
-      expect(null_group[:groups]["agent_name"]).to be_nil
-      expect(null_group[:groups]["other"]).to be_nil
-      expect(null_group[:value].round(5)).to eq(0.02218)
-
-      (result - [null_group]).each do |row|
-        expect(row[:groups]["agent_name"]).not_to be_nil
-        expect(row[:groups]["other"]).to be_nil
-        expect(row[:value].round(5)).to eq(0.02218)
-      end
-    end
-
-    context "with no events" do
-      let(:events_values) { [] }
 
       it "returns the weighted sum of event properties" do
         result = event_store.grouped_weighted_sum
-
-        expect(result.count).to eq(0)
-      end
-    end
-
-    context "with initial values" do
-      let(:initial_values) do
-        [
-          {groups: {"agent_name" => "frodo", "other" => nil}, value: 1000},
-          {groups: {"agent_name" => "aragorn", "other" => nil}, value: 1000},
-          {groups: {"agent_name" => nil, "other" => nil}, value: 1000}
-        ]
-      end
-
-      it "uses the initial value in the aggregation" do
-        result = event_store.grouped_weighted_sum(initial_values:)
 
         expect(result.count).to eq(3)
 
         null_group = result.find { |v| v[:groups]["agent_name"].nil? }
         expect(null_group[:groups]["agent_name"]).to be_nil
         expect(null_group[:groups]["other"]).to be_nil
-        expect(null_group[:value].round(5)).to eq(1000.02218)
+        expect(null_group[:value].round(5)).to eq(0.02218)
 
         (result - [null_group]).each do |row|
           expect(row[:groups]["agent_name"]).not_to be_nil
           expect(row[:groups]["other"]).to be_nil
-          expect(row[:value].round(5)).to eq(1000.02218)
+          expect(row[:value].round(5)).to eq(0.02218)
         end
       end
 
-      context "without events" do
+      context "with no events" do
         let(:events_values) { [] }
 
-        it "uses only the initial value in the aggregation" do
+        it "returns the weighted sum of event properties" do
+          result = event_store.grouped_weighted_sum
+
+          expect(result.count).to eq(0)
+        end
+      end
+
+      context "with initial values" do
+        let(:initial_values) do
+          [
+            {groups: {"agent_name" => "frodo", "other" => nil}, value: 1000},
+            {groups: {"agent_name" => "aragorn", "other" => nil}, value: 1000},
+            {groups: {"agent_name" => nil, "other" => nil}, value: 1000}
+          ]
+        end
+
+        it "uses the initial value in the aggregation" do
           result = event_store.grouped_weighted_sum(initial_values:)
 
           expect(result.count).to eq(3)
@@ -1418,12 +558,33 @@ RSpec.describe Events::Stores::ClickhouseStore, clickhouse: true do
           null_group = result.find { |v| v[:groups]["agent_name"].nil? }
           expect(null_group[:groups]["agent_name"]).to be_nil
           expect(null_group[:groups]["other"]).to be_nil
-          expect(null_group[:value].round(5)).to eq(1000)
+          expect(null_group[:value].round(5)).to eq(1000.02218)
 
           (result - [null_group]).each do |row|
             expect(row[:groups]["agent_name"]).not_to be_nil
             expect(row[:groups]["other"]).to be_nil
-            expect(row[:value].round(5)).to eq(1000)
+            expect(row[:value].round(5)).to eq(1000.02218)
+          end
+        end
+
+        context "without events" do
+          let(:events_values) { [] }
+
+          it "uses only the initial value in the aggregation" do
+            result = event_store.grouped_weighted_sum(initial_values:)
+
+            expect(result.count).to eq(3)
+
+            null_group = result.find { |v| v[:groups]["agent_name"].nil? }
+            expect(null_group[:groups]["agent_name"]).to be_nil
+            expect(null_group[:groups]["other"]).to be_nil
+            expect(null_group[:value].round(5)).to eq(1000)
+
+            (result - [null_group]).each do |row|
+              expect(row[:groups]["agent_name"]).not_to be_nil
+              expect(row[:groups]["other"]).to be_nil
+              expect(row[:value].round(5)).to eq(1000)
+            end
           end
         end
       end

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -2,496 +2,280 @@
 
 require "rails_helper"
 
+require_relative "shared_examples/an_event_store"
+
 RSpec.describe Events::Stores::PostgresStore do
-  subject(:event_store) do
-    described_class.new(
-      code:,
-      subscription:,
-      boundaries:,
-      filters: {
-        grouped_by:,
-        grouped_by_values:,
-        matching_filters:,
-        ignored_filters:
-      }
-    )
-  end
-
-  let(:billable_metric) { create(:billable_metric, field_name: "value", code: "bm:code") }
-  let(:organization) { billable_metric.organization }
-
-  let(:customer) { create(:customer, organization:) }
-  let(:started_at) { Time.zone.parse("2023-03-15") }
-  let(:subscription) { create(:subscription, customer:, started_at:) }
-
-  let(:code) { billable_metric.code }
-
-  let(:boundaries) do
-    {
-      from_datetime: started_at.beginning_of_day,
-      to_datetime: started_at.end_of_month.end_of_day,
-      charges_duration: 31
-    }
-  end
-
-  let(:grouped_by) { nil }
-  let(:grouped_by_values) { nil }
-  let(:with_grouped_by_values) { nil }
-  let(:matching_filters) { {} }
-  let(:ignored_filters) { [] }
-
-  let(:events) do
-    events = []
-
-    5.times do |i|
-      event = build(
-        :event,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        external_customer_id: customer.external_id,
-        code:,
-        timestamp: boundaries[:from_datetime] + (i + 1).days,
-        properties: {
-          billable_metric.field_name => i + 1
-        },
-        precise_total_amount_cents: i + 1
-      )
-
-      if i.even?
-        matching_filters.each { |key, values| event.properties[key] = values.first }
-
-        applied_grouped_by_values = grouped_by_values || with_grouped_by_values
-
-        if applied_grouped_by_values.present?
-          applied_grouped_by_values.each { |grouped_by, value| event.properties[grouped_by] = value }
-        elsif grouped_by.present?
-          grouped_by.each do |group|
-            event.properties[group] = "#{Faker::Fantasy::Tolkien.character}_#{i}"
-          end
-        end
-      end
-
-      event.save!
-
-      events << event
-    end
-
-    first_event = events.first
-    (ignored_filters.first || {}).each do |key, values|
-      first_event.properties[key] = values.first
-      first_event.save!
-    end
-
-    events
-  end
-
-  before { events }
-
-  describe "#events" do
-    it "returns a list of events" do
-      expect(event_store.events.count).to eq(5)
-    end
-
-    context "with grouped_by_values" do
-      let(:grouped_by_values) { {"region" => "europe"} }
-
-      it "returns a list of events" do
-        expect(event_store.events.count).to eq(3)
-      end
-
-      context "when grouped_by_values value is nil" do
-        let(:grouped_by_values) { {"region" => nil} }
-
-        it "returns a list of events" do
-          expect(event_store.events.count).to eq(5)
-        end
-      end
-    end
-
-    context "with filters" do
-      let(:matching_filters) { {"region" => ["europe"], "country" => %w[france germany]} }
-      let(:ignored_filters) { [{"city" => ["paris"]}, {"city" => ["londons"], "country" => ["united kingdom"]}] }
-
-      it "returns a list of events" do
-        expect(event_store.events.count).to eq(2) # 1st event is ignored
-      end
-    end
-
-    context "with max timestamp" do
-      let(:boundaries) do
-        {
-          from_datetime: subscription.started_at.beginning_of_day,
-          to_datetime: subscription.started_at.end_of_month.end_of_day,
-          max_timestamp: subscription.started_at.beginning_of_day.end_of_day + 2.days,
-          charges_duration: 31
-        }
-      end
-
-      it "returns a list of events" do
-        expect(event_store.count).to eq(2)
-      end
-    end
-  end
-
-  describe "#with_grouped_by_values" do
-    let(:with_grouped_by_values) { {"region" => "europe"} }
-
-    it "applies the grouped_by_values in the block" do
-      event_store.with_grouped_by_values(with_grouped_by_values) do
-        expect(event_store.count).to eq(3)
-      end
-    end
-  end
-
-  describe "#distinct_codes" do
-    before do
+  it_behaves_like "an event store", with_event_duplication: false do
+    def create_event(timestamp:, value:, properties: {}, transaction_id: SecureRandom.uuid, code: billable_metric.code)
       create(
         :event,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        code: "other_code",
-        timestamp: boundaries[:from_datetime] + (1..10).to_a.sample.days
-      )
-    end
-
-    it "returns the distinct event codes" do
-      expect(event_store.distinct_codes).to match_array([code, "other_code"])
-    end
-  end
-
-  describe "#count" do
-    it "returns the number of unique events" do
-      expect(event_store.count).to eq(5)
-    end
-  end
-
-  describe "#grouped_count" do
-    let(:grouped_by) { %w[cloud] }
-
-    it "returns the number of unique events grouped by the provided group" do
-      result = event_store.grouped_count
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |r| r[:groups]["cloud"].nil? }
-      expect(null_group[:groups]["cloud"]).to be_nil
-      expect(null_group[:value]).to eq(2)
-
-      result.without(null_group).each do |row|
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).to eq(1)
-      end
-    end
-
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
-
-      it "returns the number of unique events grouped by the provided groups" do
-        result = event_store.grouped_count
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |r| r[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["cloud"]).to be_nil
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value]).to eq(2)
-
-        result.without(null_group).each do |row|
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).to eq(1)
-        end
-      end
-    end
-  end
-
-  describe "#active_unique_property?" do
-    before { event_store.aggregation_property = billable_metric.field_name }
-
-    it "returns false when no previous events exist" do
-      event = create(
-        :event,
+        transaction_id: transaction_id,
         organization_id: organization.id,
         external_subscription_id: subscription.external_id,
         external_customer_id: customer.external_id,
         code:,
-        timestamp: (boundaries[:from_datetime] + 2.days).end_of_day,
-        properties: {
-          billable_metric.field_name => SecureRandom.uuid
-        }
+        timestamp: timestamp,
+        properties: properties.merge(billable_metric.field_name => value),
+        precise_total_amount_cents: value
       )
-
-      expect(event_store).not_to be_active_unique_property(event)
     end
 
-    context "when event is already active" do
-      it "returns true if the event property is active" do
+    def format_timestamp(timestamp)
+      Time.zone.parse(timestamp)
+    end
+
+    describe "#prorated_unique_count" do
+      it "returns the number of unique active event properties", transaction: false do
         create(
           :event,
           organization_id: organization.id,
           external_subscription_id: subscription.external_id,
           external_customer_id: customer.external_id,
           code:,
-          timestamp: (boundaries[:from_datetime] + 2.days).end_of_day,
-          properties: {
-            billable_metric.field_name => 2
-          }
+          timestamp: boundaries[:from_datetime] + 1.day,
+          properties: {billable_metric.field_name => 2}
         )
 
-        event = create(
-          :event,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          external_customer_id: customer.external_id,
-          code:,
-          timestamp: (boundaries[:from_datetime] + 3.days).end_of_day,
-          properties: {
-            billable_metric.field_name => 2
-          }
-        )
-
-        expect(event_store).to be_active_unique_property(event)
-      end
-    end
-
-    context "with a previous removed event" do
-      it "returns false" do
         create(
           :event,
           organization_id: organization.id,
           external_subscription_id: subscription.external_id,
           external_customer_id: customer.external_id,
           code:,
-          timestamp: (boundaries[:from_datetime] + 2.days).end_of_day,
+          timestamp: boundaries[:from_datetime] + 2.days - 1.second,
           properties: {
             billable_metric.field_name => 2,
             :operation_type => "remove"
           }
         )
 
-        event = create(
-          :event,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          external_customer_id: customer.external_id,
-          code:,
-          timestamp: (boundaries[:from_datetime] + 3.days).end_of_day,
-          properties: {
-            billable_metric.field_name => 2
-          }
-        )
+        event_store.aggregation_property = billable_metric.field_name
 
-        expect(event_store).not_to be_active_unique_property(event)
+        # NOTE: Events calculation: 16/31 + 1/31 + + 15/31 + 14/31 + 13/31 + 12/31
+        expect(event_store.prorated_unique_count.round(3)).to eq(2.29)
+      end
+
+      context "with multiple events at the same day" do
+        it "returns the number of unique active event properties merged within one day", transaction: false do
+          event_params = [
+            {timestamp: boundaries[:from_datetime], operation_type: "remove"},
+            {timestamp: boundaries[:from_datetime] + 1.hour, operation_type: "add"},
+            {timestamp: boundaries[:from_datetime] + 2.hours, operation_type: "remove"},
+            {timestamp: boundaries[:from_datetime] + 3.hours, operation_type: "add"},
+            {timestamp: boundaries[:from_datetime] + 1.day, operation_type: "remove"},
+            {timestamp: boundaries[:from_datetime] + 1.day + 1.hour, operation_type: "add"},
+            {timestamp: boundaries[:from_datetime] + 2.days + 1.hour, operation_type: "remove"}
+          ]
+
+          event_params.each do |params|
+            create(
+              :event,
+              organization_id: organization.id,
+              external_subscription_id: subscription.external_id,
+              external_customer_id: customer.external_id,
+              code:,
+              timestamp: params[:timestamp],
+              properties: {
+                billable_metric.field_name => 2,
+                :operation_type => params[:operation_type]
+              }
+            )
+          end
+
+          # NOTE: Events calculation: 3/31
+          # Events:
+          # 1 => added on 0 day, never removed => 16/31
+          # 2 => added on 0 day, removed on 2 day => 3/31
+          # 3 => added on 2 day, never removed => 14/31
+          # 4 => added on 3 day, never removed => 13/31
+          # 5 => added on 4 day, never removed => 12/31
+          event_store.aggregation_property = billable_metric.field_name
+          expect(event_store.prorated_unique_count.round(3)).to eq(1.871) # 16/31 + 3/31 + 14/31 + 13/31 + 12/31
+        end
       end
     end
-  end
 
-  describe "#unique_count" do
-    it "returns the number of unique active event properties", transaction: false do
-      create(
-        :event,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        external_customer_id: customer.external_id,
-        code:,
-        timestamp: (boundaries[:from_datetime] + 2.days).end_of_day,
-        properties: {
-          billable_metric.field_name => 2,
-          :operation_type => "remove"
-        }
-      )
+    describe "#grouped_unique_count" do
+      let(:grouped_by) { %w[agent_name other] }
+      let(:started_at) { Time.zone.parse("2023-03-01") }
 
-      event_store.aggregation_property = billable_metric.field_name
-
-      expect(event_store.unique_count).to eq(4) # 5 events added / 1 removed
-    end
-  end
-
-  describe "#prorated_unique_count" do
-    it "returns the number of unique active event properties", transaction: false do
-      create(
-        :event,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        external_customer_id: customer.external_id,
-        code:,
-        timestamp: boundaries[:from_datetime] + 1.day,
-        properties: {billable_metric.field_name => 2}
-      )
-
-      create(
-        :event,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        external_customer_id: customer.external_id,
-        code:,
-        timestamp: boundaries[:from_datetime] + 2.days - 1.second,
-        properties: {
-          billable_metric.field_name => 2,
-          :operation_type => "remove"
-        }
-      )
-
-      event_store.aggregation_property = billable_metric.field_name
-
-      # NOTE: Events calculation: 16/31 + 1/31 + + 15/31 + 14/31 + 13/31 + 12/31
-      expect(event_store.prorated_unique_count.round(3)).to eq(2.29)
-    end
-
-    context "with multiple events at the same day" do
-      it "returns the number of unique active event properties merged within one day", transaction: false do
-        event_params = [
-          {timestamp: boundaries[:from_datetime], operation_type: "remove"},
-          {timestamp: boundaries[:from_datetime] + 1.hour, operation_type: "add"},
-          {timestamp: boundaries[:from_datetime] + 2.hours, operation_type: "remove"},
-          {timestamp: boundaries[:from_datetime] + 3.hours, operation_type: "add"},
-          {timestamp: boundaries[:from_datetime] + 1.day, operation_type: "remove"},
-          {timestamp: boundaries[:from_datetime] + 1.day + 1.hour, operation_type: "add"},
-          {timestamp: boundaries[:from_datetime] + 2.days + 1.hour, operation_type: "remove"}
-        ]
-
-        event_params.each do |params|
+      let(:events) do
+        [
           create(
             :event,
             organization_id: organization.id,
             external_subscription_id: subscription.external_id,
             external_customer_id: customer.external_id,
             code:,
-            timestamp: params[:timestamp],
+            timestamp: boundaries[:from_datetime] + 1.hour,
             properties: {
               billable_metric.field_name => 2,
-              :operation_type => params[:operation_type]
+              :agent_name => "frodo"
             }
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
+            code:,
+            timestamp: boundaries[:from_datetime] + 1.day,
+            properties: {
+              billable_metric.field_name => 2,
+              :agent_name => "aragorn"
+            }
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
+            code:,
+            timestamp: boundaries[:from_datetime] + 2.days,
+            properties: {
+              billable_metric.field_name => 2,
+              :agent_name => "aragorn",
+              :operation_type => "remove"
+            }
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
+            code:,
+            timestamp: boundaries[:from_datetime] + 2.days,
+            properties: {billable_metric.field_name => 2}
           )
-        end
-
-        # NOTE: Events calculation: 3/31
-        # Events:
-        # 1 => added on 0 day, never removed => 16/31
-        # 2 => added on 0 day, removed on 2 day => 3/31
-        # 3 => added on 2 day, never removed => 14/31
-        # 4 => added on 3 day, never removed => 13/31
-        # 5 => added on 4 day, never removed => 12/31
-        event_store.aggregation_property = billable_metric.field_name
-        expect(event_store.prorated_unique_count.round(3)).to eq(1.871) # 16/31 + 3/31 + 14/31 + 13/31 + 12/31
+        ]
       end
-    end
-  end
 
-  describe "#grouped_unique_count" do
-    let(:grouped_by) { %w[agent_name other] }
-    let(:started_at) { Time.zone.parse("2023-03-01") }
-
-    let(:events) do
-      [
-        create(
-          :event,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          external_customer_id: customer.external_id,
-          code:,
-          timestamp: boundaries[:from_datetime] + 1.hour,
-          properties: {
-            billable_metric.field_name => 2,
-            :agent_name => "frodo"
-          }
-        ),
-        create(
-          :event,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          external_customer_id: customer.external_id,
-          code:,
-          timestamp: boundaries[:from_datetime] + 1.day,
-          properties: {
-            billable_metric.field_name => 2,
-            :agent_name => "aragorn"
-          }
-        ),
-        create(
-          :event,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          external_customer_id: customer.external_id,
-          code:,
-          timestamp: boundaries[:from_datetime] + 2.days,
-          properties: {
-            billable_metric.field_name => 2,
-            :agent_name => "aragorn",
-            :operation_type => "remove"
-          }
-        ),
-        create(
-          :event,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          external_customer_id: customer.external_id,
-          code:,
-          timestamp: boundaries[:from_datetime] + 2.days,
-          properties: {billable_metric.field_name => 2}
-        )
-      ]
-    end
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-    end
-
-    it "returns the unique count of event properties" do
-      result = event_store.grouped_unique_count
-
-      expect(result.count).to eq(3)
-
-      null_group = result.find { |r| r[:groups]["agent_name"].nil? }
-      expect(null_group[:groups]["agent_name"]).to be_nil
-      expect(null_group[:groups]["other"]).to be_nil
-      expect(null_group[:value]).to eq(1)
-
-      expect(result.without(null_group).map { |r| r[:value] }).to contain_exactly(1, 0)
-    end
-
-    context "with no events" do
-      let(:events) { [] }
+      before do
+        event_store.aggregation_property = billable_metric.field_name
+      end
 
       it "returns the unique count of event properties" do
         result = event_store.grouped_unique_count
-        expect(result.count).to eq(0)
+
+        expect(result.count).to eq(3)
+
+        null_group = result.find { |r| r[:groups]["agent_name"].nil? }
+        expect(null_group[:groups]["agent_name"]).to be_nil
+        expect(null_group[:groups]["other"]).to be_nil
+        expect(null_group[:value]).to eq(1)
+
+        expect(result.without(null_group).map { |r| r[:value] }).to contain_exactly(1, 0)
+      end
+
+      context "with no events" do
+        let(:events) { [] }
+
+        it "returns the unique count of event properties" do
+          result = event_store.grouped_unique_count
+          expect(result.count).to eq(0)
+        end
       end
     end
-  end
 
-  describe "#grouped_prorated_unique_count" do
-    let(:grouped_by) { %w[agent_name other] }
-    let(:started_at) { Time.zone.parse("2023-03-01") }
+    describe "#grouped_prorated_unique_count" do
+      let(:grouped_by) { %w[agent_name other] }
+      let(:started_at) { Time.zone.parse("2023-03-01") }
 
-    let(:events) do
-      [
-        create(
-          :event,
+      let(:events) do
+        [
+          create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
+            code:,
+            timestamp: boundaries[:from_datetime] + 1.day,
+            properties: {
+              billable_metric.field_name => 2,
+              :agent_name => "frodo"
+            }
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
+            code:,
+            timestamp: boundaries[:from_datetime] + 1.day,
+            properties: {
+              billable_metric.field_name => 2,
+              :agent_name => "aragorn"
+            }
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
+            code:,
+            timestamp: (boundaries[:from_datetime] + 1.day).end_of_day,
+            properties: {
+              billable_metric.field_name => 2,
+              :agent_name => "aragorn",
+              :operation_type => "remove"
+            }
+          ),
+          create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
+            code:,
+            timestamp: boundaries[:from_datetime] + 2.days,
+            properties: {billable_metric.field_name => 2}
+          )
+        ]
+      end
+
+      before do
+        event_store.aggregation_property = billable_metric.field_name
+      end
+
+      it "returns the unique count of event properties" do
+        result = event_store.grouped_prorated_unique_count
+
+        expect(result.count).to eq(3)
+
+        null_group = result.find { |r| r[:groups]["agent_name"].nil? }
+        expect(null_group[:groups]["agent_name"]).to be_nil
+        expect(null_group[:groups]["other"]).to be_nil
+        expect(null_group[:value].round(3)).to eq(0.935) # 29/31
+
+        # NOTE: Events calculation: [1/31, 30/31]
+        expect(result.without(null_group).map { |r| r[:value].round(3) }).to contain_exactly(0.032, 0.968)
+      end
+
+      context "with no events" do
+        let(:events) { [] }
+
+        it "returns the unique count of event properties" do
+          result = event_store.grouped_prorated_unique_count
+          expect(result.count).to eq(0)
+        end
+      end
+    end
+
+    describe "#prorated_unique_count_breakdown" do
+      it "returns the breakdown of add and remove of unique event properties", transaction: false do
+        Event.create!(
+          transaction_id: SecureRandom.uuid,
           organization_id: organization.id,
           external_subscription_id: subscription.external_id,
           external_customer_id: customer.external_id,
           code:,
           timestamp: boundaries[:from_datetime] + 1.day,
           properties: {
-            billable_metric.field_name => 2,
-            :agent_name => "frodo"
+            billable_metric.field_name => 2
           }
-        ),
-        create(
-          :event,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          external_customer_id: customer.external_id,
-          code:,
-          timestamp: boundaries[:from_datetime] + 1.day,
-          properties: {
-            billable_metric.field_name => 2,
-            :agent_name => "aragorn"
-          }
-        ),
-        create(
-          :event,
+        )
+
+        Event.create!(
+          transaction_id: SecureRandom.uuid,
           organization_id: organization.id,
           external_subscription_id: subscription.external_id,
           external_customer_id: customer.external_id,
@@ -499,502 +283,130 @@ RSpec.describe Events::Stores::PostgresStore do
           timestamp: (boundaries[:from_datetime] + 1.day).end_of_day,
           properties: {
             billable_metric.field_name => 2,
-            :agent_name => "aragorn",
             :operation_type => "remove"
           }
-        ),
-        create(
-          :event,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          external_customer_id: customer.external_id,
-          code:,
-          timestamp: boundaries[:from_datetime] + 2.days,
-          properties: {billable_metric.field_name => 2}
         )
-      ]
-    end
 
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-    end
+        event_store.aggregation_property = billable_metric.field_name
 
-    it "returns the unique count of event properties" do
-      result = event_store.grouped_prorated_unique_count
+        result = event_store.prorated_unique_count_breakdown
+        expect(result.count).to eq(6)
 
-      expect(result.count).to eq(3)
+        grouped_result = result.group_by { |r| r["property"] }
 
-      null_group = result.find { |r| r[:groups]["agent_name"].nil? }
-      expect(null_group[:groups]["agent_name"]).to be_nil
-      expect(null_group[:groups]["other"]).to be_nil
-      expect(null_group[:value].round(3)).to eq(0.935) # 29/31
+        # NOTE: group with property 1
+        group = grouped_result["1"]
+        expect(group.count).to eq(1)
+        expect(group.first["prorated_value"].round(3)).to eq(0.516) # 16/31
+        expect(group.first["operation_type"]).to eq("add")
 
-      # NOTE: Events calculation: [1/31, 30/31]
-      expect(result.without(null_group).map { |r| r[:value].round(3) }).to contain_exactly(0.032, 0.968)
-    end
+        # NOTE: group with property 2 (added and removed)
+        group = grouped_result["2"]
+        expect(group.first["prorated_value"].round(3)).to eq(0.032) # 1/31
+        expect(group.last["prorated_value"].round(3)).to eq(0.484) # 15/31
+        expect(group.count).to eq(2)
 
-    context "with no events" do
-      let(:events) { [] }
+        # NOTE: group with property 3
+        group = grouped_result["3"]
+        expect(group.count).to eq(1)
+        expect(group.first["prorated_value"].round(3)).to eq(0.452) # 14/31
+        expect(group.first["operation_type"]).to eq("add")
 
-      it "returns the unique count of event properties" do
-        result = event_store.grouped_prorated_unique_count
-        expect(result.count).to eq(0)
+        # NOTE: group with property 4
+        group = grouped_result["4"]
+        expect(group.count).to eq(1)
+        expect(group.first["prorated_value"].round(3)).to eq(0.419) # 13/31
+        expect(group.first["operation_type"]).to eq("add")
+
+        # NOTE: group with property 5
+        group = grouped_result["5"]
+        expect(group.count).to eq(1)
+        expect(group.first["prorated_value"].round(3)).to eq(0.387) # 12/31
+        expect(group.first["operation_type"]).to eq("add")
       end
     end
-  end
 
-  describe "#prorated_unique_count_breakdown" do
-    it "returns the breakdown of add and remove of unique event properties", transaction: false do
-      Event.create!(
-        transaction_id: SecureRandom.uuid,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        external_customer_id: customer.external_id,
-        code:,
-        timestamp: boundaries[:from_datetime] + 1.day,
-        properties: {
-          billable_metric.field_name => 2
-        }
-      )
-
-      Event.create!(
-        transaction_id: SecureRandom.uuid,
-        organization_id: organization.id,
-        external_subscription_id: subscription.external_id,
-        external_customer_id: customer.external_id,
-        code:,
-        timestamp: (boundaries[:from_datetime] + 1.day).end_of_day,
-        properties: {
-          billable_metric.field_name => 2,
-          :operation_type => "remove"
-        }
-      )
-
-      event_store.aggregation_property = billable_metric.field_name
-
-      result = event_store.prorated_unique_count_breakdown
-      expect(result.count).to eq(6)
-
-      grouped_result = result.group_by { |r| r["property"] }
-
-      # NOTE: group with property 1
-      group = grouped_result["1"]
-      expect(group.count).to eq(1)
-      expect(group.first["prorated_value"].round(3)).to eq(0.516) # 16/31
-      expect(group.first["operation_type"]).to eq("add")
-
-      # NOTE: group with property 2 (added and removed)
-      group = grouped_result["2"]
-      expect(group.first["prorated_value"].round(3)).to eq(0.032) # 1/31
-      expect(group.last["prorated_value"].round(3)).to eq(0.484) # 15/31
-      expect(group.count).to eq(2)
-
-      # NOTE: group with property 3
-      group = grouped_result["3"]
-      expect(group.count).to eq(1)
-      expect(group.first["prorated_value"].round(3)).to eq(0.452) # 14/31
-      expect(group.first["operation_type"]).to eq("add")
-
-      # NOTE: group with property 4
-      group = grouped_result["4"]
-      expect(group.count).to eq(1)
-      expect(group.first["prorated_value"].round(3)).to eq(0.419) # 13/31
-      expect(group.first["operation_type"]).to eq("add")
-
-      # NOTE: group with property 5
-      group = grouped_result["5"]
-      expect(group.count).to eq(1)
-      expect(group.first["prorated_value"].round(3)).to eq(0.387) # 12/31
-      expect(group.first["operation_type"]).to eq("add")
-    end
-  end
-
-  describe "#events_values" do
-    it "returns the value attached to each event" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.events_values).to eq([1, 2, 3, 4, 5])
-    end
-
-    context "when exclude_event is true" do
-      subject(:event_store) do
-        described_class.new(
-          code:,
-          subscription:,
-          boundaries:,
-          filters: {
-            grouped_by:,
-            grouped_by_values:,
-            matching_filters:,
-            ignored_filters:,
-            event:
-          }
-        )
-      end
-
-      let(:event) do
-        create(
-          :event,
-          organization:,
-          external_subscription_id: subscription.external_id,
-          code:,
-          timestamp: boundaries[:from_datetime] + 1.day,
-          properties: {billable_metric.field_name => 6}
-        )
-      end
-
-      it "excludes current event but returns the value attached to other events" do
-        event
+    describe "#prorated_events_values" do
+      it "returns the value attached to each event prorated on the provided duration" do
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
 
-        expect(event_store.events_values(exclude_event: true)).to eq([1, 2, 3, 4, 5])
-      end
-    end
-  end
-
-  describe "#last_event" do
-    it "returns the last event" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.last_event).to eq(events.last)
-    end
-  end
-
-  describe "#grouped_last_event" do
-    let(:grouped_by) { %w[cloud] }
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
-
-    it "returns the last events grouped by the provided group" do
-      result = event_store.grouped_last_event
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |r| r[:groups]["cloud"].nil? }
-      expect(null_group[:groups]["cloud"]).to be_nil
-      expect(null_group[:value]).to eq(4)
-      expect(null_group[:timestamp]).not_to be_nil
-
-      result.without(null_group).each do |row|
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).not_to be_nil
-        expect(row[:timestamp]).not_to be_nil
+        expect(event_store.prorated_events_values(31).map { |v| v.round(3) }).to eq(
+          [0.516, 0.968, 1.355, 1.677, 1.935]
+        )
       end
     end
 
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
-
-      it "returns the last events grouped by the provided groups" do
-        result = event_store.grouped_last_event
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |r| r[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["cloud"]).to be_nil
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value]).to eq(4)
-        expect(null_group[:timestamp]).not_to be_nil
-
-        result.without(null_group).each do |row|
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
-          expect(row[:timestamp]).not_to be_nil
-        end
-      end
-    end
-  end
-
-  describe "#prorated_events_values" do
-    it "returns the value attached to each event prorated on the provided duration" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.prorated_events_values(31).map { |v| v.round(3) }).to eq(
-        [0.516, 0.968, 1.355, 1.677, 1.935]
-      )
-    end
-  end
-
-  describe "#max" do
-    it "returns the max value" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.max).to eq(5)
-    end
-  end
-
-  describe "#grouped_max" do
-    let(:grouped_by) { %w[cloud] }
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
-
-    it "returns the max values grouped by the provided group" do
-      result = event_store.grouped_max
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |r| r[:groups]["cloud"].nil? }
-      expect(null_group[:groups]["cloud"]).to be_nil
-      expect(null_group[:value]).to eq(4)
-
-      result.without(null_group).each do |row|
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).not_to be_nil
-      end
-    end
-
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
-
-      it "returns the max values grouped by the provided groups" do
-        result = event_store.grouped_max
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |r| r[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["cloud"]).to be_nil
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value]).to eq(4)
-
-        result.without(null_group).each do |row|
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
-        end
-      end
-    end
-  end
-
-  describe "#last" do
-    it "returns the last event" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.last).to eq(5)
-    end
-  end
-
-  describe "#grouped_last" do
-    let(:grouped_by) { %w[cloud] }
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
-
-    it "returns the last value for the provided group" do
-      result = event_store.grouped_last
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |r| r[:groups]["cloud"].nil? }
-      expect(null_group[:groups]["cloud"]).to be_nil
-      expect(null_group[:value]).to eq(4)
-
-      result.without(null_group).each do |row|
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).not_to be_nil
-      end
-    end
-
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
-
-      it "returns the last value for each provided groups" do
-        result = event_store.grouped_last
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |r| r[:groups]["cloud"].nil? }
-
-        expect(null_group[:groups]["cloud"]).to be_nil
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value]).to eq(4)
-
-        result.without(null_group).each do |row|
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
-        end
-      end
-    end
-  end
-
-  describe "#sum_precise_total_amount_cents" do
-    it "returns the sum of precise_total_amount_cent values" do
-      expect(event_store.sum_precise_total_amount_cents).to eq(15)
-    end
-  end
-
-  describe "#grouped_sum_precise_total_amount_cents" do
-    let(:grouped_by) { %w[cloud] }
-
-    it "returns the sum of values grouped by the provided group" do
-      result = event_store.grouped_sum_precise_total_amount_cents
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |r| r[:groups]["cloud"].nil? }
-      expect(null_group[:groups]["cloud"]).to be_nil
-      expect(null_group[:value]).to eq(6)
-
-      result.without(null_group).each do |row|
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).not_to be_nil
-      end
-    end
-
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
-
-      it "returns the sum of values grouped by the provided groups" do
-        result = event_store.grouped_sum_precise_total_amount_cents
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |r| r[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["cloud"]).to be_nil
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value]).to eq(6)
-
-        result.without(null_group).each do |row|
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
-        end
-      end
-    end
-  end
-
-  describe "#sum" do
-    it "returns the sum of event values" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.sum).to eq(15)
-    end
-  end
-
-  describe "#grouped_sum" do
-    let(:grouped_by) { %w[cloud] }
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
-
-    it "returns the sum of values grouped by the provided group" do
-      result = event_store.grouped_sum
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |r| r[:groups]["cloud"].nil? }
-      expect(null_group[:groups]["cloud"]).to be_nil
-      expect(null_group[:value]).to eq(6)
-
-      result.without(null_group).each do |row|
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).not_to be_nil
-      end
-    end
-
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
-
-      it "returns the sum of values grouped by the provided groups" do
-        result = event_store.grouped_sum
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |r| r[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["cloud"]).to be_nil
-        expect(null_group[:groups]["region"]).to be_nil
-        expect(null_group[:value]).to eq(6)
-
-        result.without(null_group).each do |row|
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
-        end
-      end
-    end
-  end
-
-  describe "#prorated_sum" do
-    it "returns the prorated sum of event properties", transaction: false do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      expect(event_store.prorated_sum(period_duration: 31).round(5)).to eq(6.45161)
-    end
-
-    context "with persisted_duration" do
+    describe "#prorated_sum" do
       it "returns the prorated sum of event properties", transaction: false do
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
 
-        expect(event_store.prorated_sum(period_duration: 31, persisted_duration: 10).round(5)).to eq(4.83871)
+        expect(event_store.prorated_sum(period_duration: 31).round(5)).to eq(6.45161)
       end
-    end
-  end
 
-  describe "#grouped_prorated_sum" do
-    let(:grouped_by) { %w[cloud] }
+      context "with persisted_duration" do
+        it "returns the prorated sum of event properties", transaction: false do
+          event_store.aggregation_property = billable_metric.field_name
+          event_store.numeric_property = true
 
-    it "returns the prorated sum of event properties" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-
-      result = event_store.grouped_prorated_sum(period_duration: 31)
-
-      expect(result.count).to eq(4)
-
-      null_group = result.find { |r| r[:groups]["cloud"].nil? }
-      expect(null_group[:groups]["cloud"]).to be_nil
-      expect(null_group[:value].round(5)).to eq(2.64516)
-
-      result.without(null_group).each do |row|
-        expect(row[:groups]["cloud"]).not_to be_nil
-        expect(row[:value]).not_to be_nil
-      end
-    end
-
-    context "with persisted_duration" do
-      it "returns the prorated sum of event properties" do
-        event_store.aggregation_property = billable_metric.field_name
-        event_store.numeric_property = true
-
-        result = event_store.grouped_prorated_sum(period_duration: 31, persisted_duration: 10)
-
-        expect(result.count).to eq(4)
-
-        null_group = result.find { |r| r[:groups]["cloud"].nil? }
-        expect(null_group[:groups]["cloud"]).to be_nil
-        expect(null_group[:value].round(5)).to eq(1.93548)
-
-        result.without(null_group).each do |row|
-          expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:value]).not_to be_nil
+          expect(event_store.prorated_sum(period_duration: 31, persisted_duration: 10).round(5)).to eq(4.83871)
         end
       end
     end
 
-    context "with multiple groups" do
-      let(:grouped_by) { %w[cloud region] }
+    describe "#grouped_prorated_sum" do
+      let(:events) do
+        events = []
 
-      it "returns the sum of values grouped by the provided groups" do
+        5.times do |i|
+          event = build(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
+            code:,
+            timestamp: boundaries[:from_datetime] + (i + 1).days,
+            properties: {
+              billable_metric.field_name => i + 1
+            },
+            precise_total_amount_cents: i + 1
+          )
+
+          if i.even?
+            matching_filters.each { |key, values| event.properties[key] = values.first }
+
+            applied_grouped_by_values = grouped_by_values || with_grouped_by_values
+
+            if applied_grouped_by_values.present?
+              applied_grouped_by_values.each { |grouped_by, value| event.properties[grouped_by] = value }
+            elsif grouped_by.present?
+              grouped_by.each do |group|
+                event.properties[group] = "#{Faker::Fantasy::Tolkien.character}_#{i}"
+              end
+            end
+          end
+
+          event.save!
+
+          events << event
+        end
+
+        first_event = events.first
+        (ignored_filters.first || {}).each do |key, values|
+          first_event.properties[key] = values.first
+          first_event.save!
+        end
+
+        events
+      end
+      let(:grouped_by_values) { nil }
+      let(:with_grouped_by_values) { nil }
+      let(:matching_filters) { {} }
+      let(:ignored_filters) { [] }
+      let(:grouped_by) { %w[cloud] }
+
+      it "returns the prorated sum of event properties" do
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
 
@@ -1004,264 +416,269 @@ RSpec.describe Events::Stores::PostgresStore do
 
         null_group = result.find { |r| r[:groups]["cloud"].nil? }
         expect(null_group[:groups]["cloud"]).to be_nil
-        expect(null_group[:groups]["region"]).to be_nil
         expect(null_group[:value].round(5)).to eq(2.64516)
 
         result.without(null_group).each do |row|
           expect(row[:groups]["cloud"]).not_to be_nil
-          expect(row[:groups]["region"]).not_to be_nil
           expect(row[:value]).not_to be_nil
         end
       end
-    end
-  end
 
-  describe "#sum_date_breakdown" do
-    it "returns the sum grouped by day" do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
+      context "with persisted_duration" do
+        it "returns the prorated sum of event properties" do
+          event_store.aggregation_property = billable_metric.field_name
+          event_store.numeric_property = true
 
-      expect(event_store.sum_date_breakdown).to eq(
-        events.map do |e|
-          {
-            date: e.timestamp.to_date,
-            value: e.properties[billable_metric.field_name]
-          }
+          result = event_store.grouped_prorated_sum(period_duration: 31, persisted_duration: 10)
+
+          expect(result.count).to eq(4)
+
+          null_group = result.find { |r| r[:groups]["cloud"].nil? }
+          expect(null_group[:groups]["cloud"]).to be_nil
+          expect(null_group[:value].round(5)).to eq(1.93548)
+
+          result.without(null_group).each do |row|
+            expect(row[:groups]["cloud"]).not_to be_nil
+            expect(row[:value]).not_to be_nil
+          end
         end
-      )
-    end
-  end
-
-  describe "#weighted_sum" do
-    let(:started_at) { Time.zone.parse("2023-03-01") }
-
-    let(:events_values) do
-      [
-        {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2},
-        {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3},
-        {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1},
-        {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4},
-        {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2},
-        {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10},
-        {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10}
-      ]
-    end
-
-    let(:events) do
-      events = []
-
-      events_values.each do |values|
-        properties = {value: values[:value]}
-        properties[:region] = values[:region] if values[:region]
-
-        event = create(
-          :event,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          external_customer_id: customer.external_id,
-          code:,
-          timestamp: values[:timestamp],
-          properties:
-        )
-
-        events << event
       end
 
-      events
+      context "with multiple groups" do
+        let(:grouped_by) { %w[cloud region] }
+
+        it "returns the sum of values grouped by the provided groups" do
+          event_store.aggregation_property = billable_metric.field_name
+          event_store.numeric_property = true
+
+          result = event_store.grouped_prorated_sum(period_duration: 31)
+
+          expect(result.count).to eq(4)
+
+          null_group = result.find { |r| r[:groups]["cloud"].nil? }
+          expect(null_group[:groups]["cloud"]).to be_nil
+          expect(null_group[:groups]["region"]).to be_nil
+          expect(null_group[:value].round(5)).to eq(2.64516)
+
+          result.without(null_group).each do |row|
+            expect(row[:groups]["cloud"]).not_to be_nil
+            expect(row[:groups]["region"]).not_to be_nil
+            expect(row[:value]).not_to be_nil
+          end
+        end
+      end
     end
 
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
+    describe "#weighted_sum" do
+      let(:started_at) { Time.zone.parse("2023-03-01") }
 
-    it "returns the weighted sum of event properties", transaction: false do
-      expect(event_store.weighted_sum.round(5)).to eq(0.02218)
-    end
-
-    context "with a single event" do
       let(:events_values) do
         [
-          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 1000}
+          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2},
+          {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3},
+          {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1},
+          {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4},
+          {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2},
+          {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10},
+          {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10}
         ]
       end
 
+      let(:events) do
+        events = []
+
+        events_values.each do |values|
+          properties = {value: values[:value]}
+          properties[:region] = values[:region] if values[:region]
+
+          event = create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
+            code:,
+            timestamp: values[:timestamp],
+            properties:
+          )
+
+          events << event
+        end
+
+        events
+      end
+
+      before do
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
+      end
+
       it "returns the weighted sum of event properties", transaction: false do
-        expect(event_store.weighted_sum.round(5)).to eq(1000.0)
-      end
-    end
-
-    context "with no events" do
-      let(:events_values) { [] }
-
-      it "returns the weighted sum of event properties" do
-        expect(event_store.weighted_sum.round(5)).to eq(0.0)
-      end
-    end
-
-    context "with events with the same timestamp" do
-      let(:events_values) do
-        [
-          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 3},
-          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 3}
-        ]
+        expect(event_store.weighted_sum.round(5)).to eq(0.02218)
       end
 
-      it "returns the weighted sum of event properties", transaction: false do
-        expect(event_store.weighted_sum.round(5)).to eq(6.0)
+      context "with a single event" do
+        let(:events_values) do
+          [
+            {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 1000}
+          ]
+        end
+
+        it "returns the weighted sum of event properties", transaction: false do
+          expect(event_store.weighted_sum.round(5)).to eq(1000.0)
+        end
       end
-    end
 
-    context "with initial value" do
-      let(:initial_value) { 1000 }
-
-      it "uses the initial value in the aggregation", transaction: false do
-        expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.02218)
-      end
-
-      context "without events" do
+      context "with no events" do
         let(:events_values) { [] }
 
-        it "uses only the initial value in the aggregation" do
-          expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.0)
+        it "returns the weighted sum of event properties" do
+          expect(event_store.weighted_sum.round(5)).to eq(0.0)
+        end
+      end
+
+      context "with events with the same timestamp" do
+        let(:events_values) do
+          [
+            {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 3},
+            {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 3}
+          ]
+        end
+
+        it "returns the weighted sum of event properties", transaction: false do
+          expect(event_store.weighted_sum.round(5)).to eq(6.0)
+        end
+      end
+
+      context "with initial value" do
+        let(:initial_value) { 1000 }
+
+        it "uses the initial value in the aggregation", transaction: false do
+          expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.02218)
+        end
+
+        context "without events" do
+          let(:events_values) { [] }
+
+          it "uses only the initial value in the aggregation" do
+            expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.0)
+          end
+        end
+      end
+
+      context "with group" do
+        let(:matching_filters) { {region: ["europe"]} }
+
+        let(:events_values) do
+          [
+            {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 1000, region: "europe"}
+          ]
+        end
+
+        it "returns the weighted sum of event properties scoped to the group", transaction: false do
+          expect(event_store.weighted_sum.round(5)).to eq(1000.0)
         end
       end
     end
 
-    context "with group" do
-      let(:matching_filters) { {region: ["europe"]} }
+    describe "#grouped_weighted_sum" do
+      let(:grouped_by) { %w[agent_name other] }
+
+      let(:started_at) { Time.zone.parse("2023-03-01") }
 
       let(:events_values) do
         [
-          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 1000, region: "europe"}
+          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2, agent_name: "frodo"},
+          {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3, agent_name: "frodo"},
+          {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1, agent_name: "frodo"},
+          {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4, agent_name: "frodo"},
+          {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2, agent_name: "frodo"},
+          {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10, agent_name: "frodo"},
+          {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10, agent_name: "frodo"},
+
+          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2, agent_name: "aragorn"},
+          {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3, agent_name: "aragorn"},
+          {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1, agent_name: "aragorn"},
+          {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4, agent_name: "aragorn"},
+          {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2, agent_name: "aragorn"},
+          {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10, agent_name: "aragorn"},
+          {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10, agent_name: "aragorn"},
+
+          {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2},
+          {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3},
+          {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1},
+          {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4},
+          {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2},
+          {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10},
+          {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10}
         ]
       end
 
-      it "returns the weighted sum of event properties scoped to the group", transaction: false do
-        expect(event_store.weighted_sum.round(5)).to eq(1000.0)
-      end
-    end
-  end
+      let(:events) do
+        events = []
 
-  describe "#grouped_weighted_sum" do
-    let(:grouped_by) { %w[agent_name other] }
+        events_values.each do |values|
+          properties = {value: values[:value]}
+          properties[:region] = values[:region] if values[:region]
+          properties[:agent_name] = values[:agent_name] if values[:agent_name]
 
-    let(:started_at) { Time.zone.parse("2023-03-01") }
+          event = create(
+            :event,
+            organization_id: organization.id,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
+            code:,
+            timestamp: values[:timestamp],
+            properties:
+          )
 
-    let(:events_values) do
-      [
-        {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2, agent_name: "frodo"},
-        {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3, agent_name: "frodo"},
-        {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1, agent_name: "frodo"},
-        {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4, agent_name: "frodo"},
-        {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2, agent_name: "frodo"},
-        {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10, agent_name: "frodo"},
-        {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10, agent_name: "frodo"},
+          events << event
+        end
 
-        {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2, agent_name: "aragorn"},
-        {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3, agent_name: "aragorn"},
-        {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1, agent_name: "aragorn"},
-        {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4, agent_name: "aragorn"},
-        {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2, agent_name: "aragorn"},
-        {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10, agent_name: "aragorn"},
-        {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10, agent_name: "aragorn"},
-
-        {timestamp: Time.zone.parse("2023-03-01 00:00:00.000"), value: 2},
-        {timestamp: Time.zone.parse("2023-03-01 01:00:00"), value: 3},
-        {timestamp: Time.zone.parse("2023-03-01 01:30:00"), value: 1},
-        {timestamp: Time.zone.parse("2023-03-01 02:00:00"), value: -4},
-        {timestamp: Time.zone.parse("2023-03-01 04:00:00"), value: -2},
-        {timestamp: Time.zone.parse("2023-03-01 05:00:00"), value: 10},
-        {timestamp: Time.zone.parse("2023-03-01 05:30:00"), value: -10}
-      ]
-    end
-
-    let(:events) do
-      events = []
-
-      events_values.each do |values|
-        properties = {value: values[:value]}
-        properties[:region] = values[:region] if values[:region]
-        properties[:agent_name] = values[:agent_name] if values[:agent_name]
-
-        event = create(
-          :event,
-          organization_id: organization.id,
-          external_subscription_id: subscription.external_id,
-          external_customer_id: customer.external_id,
-          code:,
-          timestamp: values[:timestamp],
-          properties:
-        )
-
-        events << event
+        events
       end
 
-      events
-    end
-
-    before do
-      event_store.aggregation_property = billable_metric.field_name
-      event_store.numeric_property = true
-    end
-
-    it "returns the weighted sum of event properties" do
-      result = event_store.grouped_weighted_sum
-
-      expect(result.count).to eq(3)
-
-      null_group = result.find { |r| r[:groups]["agent_name"].nil? }
-      expect(null_group[:groups]["agent_name"]).to be_nil
-      expect(null_group[:groups]["other"]).to be_nil
-      expect(null_group[:value].round(5)).to eq(0.02218)
-
-      result.without(null_group).each do |row|
-        expect(row[:groups]["agent_name"]).not_to be_nil
-        expect(row[:groups]["other"]).to be_nil
-        expect(row[:value].round(5)).to eq(0.02218)
+      before do
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
       end
-    end
-
-    context "with no events" do
-      let(:events_values) { [] }
 
       it "returns the weighted sum of event properties" do
         result = event_store.grouped_weighted_sum
-
-        expect(result.count).to eq(0)
-      end
-    end
-
-    context "with initial values" do
-      let(:initial_values) do
-        [
-          {groups: {"agent_name" => "frodo", "other" => nil}, value: 1000},
-          {groups: {"agent_name" => "aragorn", "other" => nil}, value: 1000},
-          {groups: {"agent_name" => nil, "other" => nil}, value: 1000}
-        ]
-      end
-
-      it "uses the initial value in the aggregation" do
-        result = event_store.grouped_weighted_sum(initial_values:)
 
         expect(result.count).to eq(3)
 
         null_group = result.find { |r| r[:groups]["agent_name"].nil? }
         expect(null_group[:groups]["agent_name"]).to be_nil
         expect(null_group[:groups]["other"]).to be_nil
-        expect(null_group[:value].round(5)).to eq(1000.02218)
+        expect(null_group[:value].round(5)).to eq(0.02218)
 
         result.without(null_group).each do |row|
           expect(row[:groups]["agent_name"]).not_to be_nil
           expect(row[:groups]["other"]).to be_nil
-          expect(row[:value].round(5)).to eq(1000.02218)
+          expect(row[:value].round(5)).to eq(0.02218)
         end
       end
 
-      context "without events" do
+      context "with no events" do
         let(:events_values) { [] }
 
-        it "uses only the initial value in the aggregation" do
+        it "returns the weighted sum of event properties" do
+          result = event_store.grouped_weighted_sum
+
+          expect(result.count).to eq(0)
+        end
+      end
+
+      context "with initial values" do
+        let(:initial_values) do
+          [
+            {groups: {"agent_name" => "frodo", "other" => nil}, value: 1000},
+            {groups: {"agent_name" => "aragorn", "other" => nil}, value: 1000},
+            {groups: {"agent_name" => nil, "other" => nil}, value: 1000}
+          ]
+        end
+
+        it "uses the initial value in the aggregation" do
           result = event_store.grouped_weighted_sum(initial_values:)
 
           expect(result.count).to eq(3)
@@ -1269,12 +686,33 @@ RSpec.describe Events::Stores::PostgresStore do
           null_group = result.find { |r| r[:groups]["agent_name"].nil? }
           expect(null_group[:groups]["agent_name"]).to be_nil
           expect(null_group[:groups]["other"]).to be_nil
-          expect(null_group[:value].round(5)).to eq(1000)
+          expect(null_group[:value].round(5)).to eq(1000.02218)
 
           result.without(null_group).each do |row|
             expect(row[:groups]["agent_name"]).not_to be_nil
             expect(row[:groups]["other"]).to be_nil
-            expect(row[:value].round(5)).to eq(1000)
+            expect(row[:value].round(5)).to eq(1000.02218)
+          end
+        end
+
+        context "without events" do
+          let(:events_values) { [] }
+
+          it "uses only the initial value in the aggregation" do
+            result = event_store.grouped_weighted_sum(initial_values:)
+
+            expect(result.count).to eq(3)
+
+            null_group = result.find { |r| r[:groups]["agent_name"].nil? }
+            expect(null_group[:groups]["agent_name"]).to be_nil
+            expect(null_group[:groups]["other"]).to be_nil
+            expect(null_group[:value].round(5)).to eq(1000)
+
+            result.without(null_group).each do |row|
+              expect(row[:groups]["agent_name"]).not_to be_nil
+              expect(row[:groups]["other"]).to be_nil
+              expect(row[:value].round(5)).to eq(1000)
+            end
           end
         end
       end

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -1,0 +1,812 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "an event store" do |with_event_duplication: true|
+  subject(:event_store) do
+    described_class.new(
+      code:,
+      subscription:,
+      boundaries:,
+      filters: {
+        grouped_by:,
+        grouped_by_values:,
+        matching_filters:,
+        ignored_filters:
+      }
+    )
+  end
+
+  let(:billable_metric) { create(:billable_metric, field_name: "value", code: "bm:code") }
+  let(:organization) { billable_metric.organization }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:, started_at:) }
+
+  let(:started_at) { DateTime.parse("2023-03-15") }
+  let(:code) { billable_metric.code }
+
+  let(:subscription_started_at) { subscription.started_at.beginning_of_day }
+  let(:boundaries) do
+    {
+      from_datetime: subscription_started_at,
+      to_datetime: subscription.started_at.end_of_month.end_of_day,
+      charges_duration: 31
+    }
+  end
+
+  let(:grouped_by) { nil }
+  let(:grouped_by_values) { nil }
+  let(:with_grouped_by_values) { nil }
+  let(:matching_filters) { {} }
+  let(:ignored_filters) { [] }
+
+  let(:events) do
+    events = [
+      create_event(
+        timestamp: subscription_started_at + 1.day,
+        value: 1,
+        properties: {"region" => "europe", "country" => "france", "city" => "paris"},
+        transaction_id: SecureRandom.uuid
+      ),
+      create_event(
+        timestamp: subscription_started_at + 2.days,
+        value: 2,
+        properties: {},
+        transaction_id: SecureRandom.uuid
+      ),
+      create_event(
+        timestamp: subscription_started_at + 3.days,
+        value: 3,
+        properties: {"region" => "europe", "country" => "france"},
+        transaction_id: SecureRandom.uuid
+      ),
+      create_event(
+        timestamp: subscription_started_at + 4.days,
+        value: 4,
+        properties: {},
+        transaction_id: SecureRandom.uuid
+      ),
+      create_event(
+        timestamp: subscription_started_at + 5.days,
+        value: with_event_duplication ? 10 : 5,
+        properties: {"region" => "europe", "country" => "united kingdom", "city" => "london"},
+        transaction_id: SecureRandom.uuid
+      )
+    ]
+
+    if with_event_duplication
+      last_event = events.pop
+      events << create_event(
+        timestamp: last_event.timestamp,
+        value: 5,
+        properties: last_event.properties,
+        transaction_id: last_event.transaction_id
+      )
+    end
+
+    events
+  end
+
+  def create_european_event(country:, city:, value:, timestamp:)
+    create_event(
+      timestamp:,
+      value:,
+      properties: {"region" => "europe", "country" => country, "city" => city},
+      transaction_id: SecureRandom.uuid
+    )
+  end
+
+  def create_events_for_filters
+    create_european_event(country: "united kingdom", city: "manchester", value: -1, timestamp: subscription_started_at + 6.days)
+    create_european_event(country: "france", city: "cambridge", value: -2, timestamp: subscription_started_at + 7.days)
+    create_european_event(country: "france", city: "caen", value: -3, timestamp: subscription_started_at + 8.days)
+    create_european_event(country: "germany", city: "berlin", value: -4, timestamp: subscription_started_at + 9.days)
+    create_european_event(country: "united kingdom", city: "cambridge", value: -5, timestamp: subscription_started_at + 10.days)
+  end
+
+  before do
+    events
+    force_deduplication if respond_to?(:force_deduplication)
+  end
+
+  describe "#events" do
+    it "returns the events" do
+      retrieved_events = event_store.events.to_a
+
+      expect(retrieved_events.count).to eq(5)
+      expect(retrieved_events).to match_array(events)
+      # we need to check value because the duplicate has the same id so array equality is not sufficiant
+      expect(retrieved_events.map { |e| e.properties[billable_metric.field_name].to_s }).to match_array(["1", "2", "3", "4", "5"])
+    end
+
+    context "when ordered is true" do
+      it "returns the events ordered by timestamp" do
+        retrieved_events = event_store.events(ordered: true)
+
+        expect(retrieved_events).to eq(events)
+        # we need to check value because the duplicate has the same id so array equality is not sufficiant
+        expect(retrieved_events.map { |e| e.properties[billable_metric.field_name].to_s }).to eq(["1", "2", "3", "4", "5"])
+      end
+    end
+  end
+
+  describe "#count" do
+    it "returns the number of unique events" do
+      expect(event_store.count).to eq(5)
+    end
+
+    context "with grouped_by_values" do
+      let(:grouped_by_values) { {"region" => "europe"} }
+
+      it "returns the number of unique events" do
+        expect(event_store.count).to eq(3)
+      end
+
+      context "when grouped_by_values value is nil" do
+        let(:grouped_by_values) { {"region" => nil} }
+
+        it "returns the number of unique events" do
+          expect(event_store.count).to eq(2)
+        end
+      end
+    end
+
+    context "with filters" do
+      let(:matching_filters) { {"region" => ["europe"], "country" => ["france", "united kingdom"]} }
+      let(:ignored_filters) { [{"city" => ["caen"]}, {"city" => ["cambridge", "london"], "country" => ["united kingdom"]}] }
+
+      before { create_events_for_filters }
+
+      it "returns the number of unique events" do
+        # We include:
+        # - europe, france, <nil>
+        # - europe, france, paris
+        # - europe, france, caen
+        # - europe, france, cambridge
+        # - europe, united kingdom, cambridge
+        # - europe, united kingdom, london
+        # - europe, united kingdom, manchester
+        # Then exclude:
+        # - europe, france, caen
+        # - europe, united kingdom, cambridge
+        # - europe, united kingdom, london
+        # We should have 4 events:
+        # - europe, france, <nil>
+        # - europe, france, paris
+        # - europe, france, cambridge
+        # - europe, united kingdom, manchester
+        expect(event_store.count).to eq(4)
+      end
+    end
+
+    context "with max timestamp" do
+      let(:boundaries) do
+        {
+          from_datetime: subscription.started_at.beginning_of_day,
+          to_datetime: subscription.started_at.end_of_month.end_of_day,
+          max_timestamp: subscription.started_at.beginning_of_day.end_of_day + 2.days,
+          charges_duration: 31
+        }
+      end
+
+      it "returns the number of unique events" do
+        expect(event_store.count).to eq(2)
+      end
+    end
+
+    if with_event_duplication
+      context "with only duplicated transaction_id" do
+        before do
+          event = events.first
+
+          create_event(
+            timestamp: subscription_started_at + 5.days,
+            value: 1,
+            properties: {},
+            transaction_id: event.transaction_id
+          )
+        end
+
+        it "takes the event into account" do
+          expect(event_store.count).to eq(6)
+        end
+      end
+    end
+  end
+
+  describe "#with_grouped_by_values" do
+    let(:with_grouped_by_values) { {"region" => "europe"} }
+
+    it "applies the grouped_by_values in the block" do
+      event_store.with_grouped_by_values(with_grouped_by_values) do
+        expect(event_store.count).to eq(3)
+      end
+    end
+  end
+
+  describe "#distinct_codes" do
+    before do
+      create_event(
+        timestamp: subscription_started_at + (1..10).to_a.sample.days,
+        value: "value",
+        transaction_id: SecureRandom.uuid,
+        code: "other_code"
+      )
+    end
+
+    it "returns the distinct event codes" do
+      expect(event_store.distinct_codes).to match_array([code, "other_code"])
+    end
+  end
+
+  describe "#grouped_count" do
+    let(:grouped_by) { %w[region] }
+
+    it "returns the number of unique events grouped by the provided group" do
+      result = event_store.grouped_count
+
+      expect(result).to match_array([{groups: {"region" => nil}, value: 2}, {groups: {"region" => "europe"}, value: 3}])
+    end
+
+    context "with multiple groups" do
+      let(:grouped_by) { %w[region country] }
+
+      it "returns the number of unique events grouped by the provided groups" do
+        result = event_store.grouped_count
+
+        expect(result).to match_array([
+          {groups: {"country" => "france", "region" => "europe"}, value: 2},
+          {groups: {"country" => nil, "region" => nil}, value: 2},
+          {groups: {"country" => "united kingdom", "region" => "europe"}, value: 1}
+        ])
+      end
+    end
+  end
+
+  describe "#sum_precise_total_amount_cents" do
+    it "returns the sum of precise_total_amount_cent values" do
+      expect(event_store.sum_precise_total_amount_cents).to eq(15)
+    end
+  end
+
+  describe "#grouped_sum_precise_total_amount_cents" do
+    let(:grouped_by) { %w[region] }
+
+    it "returns the sum of values grouped by the provided group" do
+      result = event_store.grouped_sum_precise_total_amount_cents
+
+      expect(result).to match_array([{groups: {"region" => nil}, value: 6}, {groups: {"region" => "europe"}, value: 9}])
+    end
+
+    context "with multiple groups" do
+      let(:grouped_by) { %w[region country] }
+
+      it "returns the sum of values grouped by the provided groups" do
+        result = event_store.grouped_sum_precise_total_amount_cents
+
+        expect(result).to match_array([
+          {groups: {"country" => "united kingdom", "region" => "europe"}, value: 5},
+          {groups: {"country" => nil, "region" => nil}, value: 6},
+          {groups: {"country" => "france", "region" => "europe"}, value: 4}
+        ])
+      end
+    end
+
+    context "with filters" do
+      let(:matching_filters) { {"region" => ["europe"], "country" => ["france", "united kingdom"]} }
+      let(:ignored_filters) { [{"city" => ["caen"]}, {"city" => ["cambridge", "london"], "country" => ["united kingdom"]}] }
+      let(:grouped_by) { %w[region country] }
+
+      before { create_events_for_filters }
+
+      it "returns the sum filtered and grouped" do
+        result = event_store.grouped_sum_precise_total_amount_cents
+
+        # We include:
+        # - europe, france, <nil>
+        # - europe, france, paris
+        # - europe, france, caen
+        # - europe, france, cambridge
+        # - europe, united kingdom, cambridge
+        # - europe, united kingdom, london
+        # - europe, united kingdom, manchester
+        # Then exclude:
+        # - europe, france, caen
+        # - europe, united kingdom, cambridge
+        # - europe, united kingdom, london
+        # We should have 2 events:
+        # - europe, france, <nil> -> 3
+        # - europe, france, paris -> 1
+        # - europe, france, cambridge -> -2
+        # - europe, united kingdom, manchester -> -1
+        expect(result).to match_array([
+          {groups: {"country" => "united kingdom", "region" => "europe"}, value: -1},
+          {groups: {"country" => "france", "region" => "europe"}, value: 2}
+        ])
+      end
+    end
+  end
+
+  describe "#active_unique_property?" do
+    before { event_store.aggregation_property = billable_metric.field_name }
+
+    it "returns false when no previous events exist" do
+      event = create_event(timestamp: subscription_started_at + 2.days, value: 999)
+
+      expect(event_store).not_to be_active_unique_property(event)
+    end
+
+    context "when event is already active" do
+      it "returns true if the event property is active" do
+        event = create_event(timestamp: subscription_started_at + 3.days, value: 2)
+
+        expect(event_store).to be_active_unique_property(event)
+      end
+    end
+
+    context "with a previous removed event" do
+      before do
+        create_event(timestamp: subscription_started_at + 2.days + 1.hour, value: 2, properties: {operation_type: "remove"})
+      end
+
+      it "returns false" do
+        event = create_event(timestamp: subscription_started_at + 3.days, value: 2)
+
+        expect(event_store).not_to be_active_unique_property(event)
+      end
+    end
+  end
+
+  describe "#unique_count" do
+    it "returns the number of unique active event properties" do
+      create_event(timestamp: subscription_started_at + 2.days + 1.hour, value: 2, properties: {operation_type: "remove"})
+
+      event_store.aggregation_property = billable_metric.field_name
+
+      expect(event_store.unique_count).to eq(4) # 5 events added / 1 removed
+    end
+  end
+
+  describe "#grouped_unique_count" do
+    let(:grouped_by) { %w[region country city] }
+    let(:started_at) { Time.zone.parse("2023-03-01") }
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+    end
+
+    it "returns the unique count of event properties" do
+      result = event_store.grouped_unique_count
+
+      expect(result).to match_array([
+        {groups: {"city" => nil, "country" => "france", "region" => "europe"}, value: 1},
+        {groups: {"city" => "paris", "country" => "france", "region" => "europe"}, value: 1},
+        {groups: {"city" => "london", "country" => "united kingdom", "region" => "europe"}, value: 1},
+        {groups: {"city" => nil, "country" => nil, "region" => nil}, value: 2}
+      ])
+    end
+
+    context "with no events" do
+      let(:events) { [] }
+
+      it "returns the unique count of event properties" do
+        result = event_store.grouped_unique_count
+        expect(result.count).to eq(0)
+      end
+    end
+  end
+
+  describe "#events_values" do
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it "returns the value attached to each event" do
+      expect(event_store.events_values).to eq([1, 2, 3, 4, 5])
+    end
+
+    context "with limit" do
+      it "returns the value attached to each event" do
+        expect(event_store.events_values(limit: 2)).to eq([1, 2])
+      end
+    end
+
+    context "when exclude_event is true" do
+      subject(:event_store) do
+        described_class.new(
+          code:,
+          subscription:,
+          boundaries:,
+          filters: {
+            grouped_by:,
+            grouped_by_values:,
+            matching_filters:,
+            ignored_filters:,
+            event:
+          }
+        )
+      end
+
+      let(:event) do
+        create_event(timestamp: subscription_started_at + 1.day, value: 6)
+      end
+
+      it "excludes current event but returns the value attached to other events" do
+        event
+
+        expect(event_store.events_values(exclude_event: true)).to eq([1, 2, 3, 4, 5])
+      end
+    end
+  end
+
+  describe "#last_event" do
+    it "returns the last event" do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+
+      expect(event_store.last_event.transaction_id).to eq(events.last.transaction_id)
+    end
+  end
+
+  describe "#grouped_last_event" do
+    let(:grouped_by) { %w[region] }
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it "returns the last events grouped by the provided group" do
+      result = event_store.grouped_last_event
+
+      expect(result).to match_array([
+        {groups: {"region" => nil}, timestamp: format_timestamp("2023-03-19 00:00:00.000"), value: 4},
+        {groups: {"region" => "europe"}, timestamp: format_timestamp("2023-03-20 00:00:00.000"), value: 5}
+      ])
+    end
+
+    context "with multiple groups" do
+      let(:grouped_by) { %w[region country] }
+
+      it "returns the last events grouped by the provided groups" do
+        result = event_store.grouped_last_event
+
+        expect(result).to match_array([
+          {groups: {"country" => "france", "region" => "europe"}, timestamp: format_timestamp("2023-03-18 00:00:00.000"), value: 3},
+          {groups: {"country" => nil, "region" => nil}, timestamp: format_timestamp("2023-03-19 00:00:00.000"), value: 4},
+          {groups: {"country" => "united kingdom", "region" => "europe"}, timestamp: format_timestamp("2023-03-20 00:00:00.000"), value: 5}
+        ])
+      end
+    end
+
+    context "with filters" do
+      let(:matching_filters) { {"region" => ["europe"], "country" => ["france", "united kingdom"]} }
+      let(:ignored_filters) { [{"city" => ["caen"]}, {"city" => ["cambridge", "london"], "country" => ["united kingdom"]}] }
+      let(:grouped_by) { %w[region country] }
+
+      before { create_events_for_filters }
+
+      it "returns the last events filtered and grouped" do
+        result = event_store.grouped_last_event
+
+        # We include:
+        # - europe, france, <nil>
+        # - europe, france, paris
+        # - europe, france, caen
+        # - europe, france, cambridge
+        # - europe, united kingdom, cambridge
+        # - europe, united kingdom, london
+        # - europe, united kingdom, manchester
+        # Then exclude:
+        # - europe, france, caen
+        # - europe, united kingdom, cambridge
+        # - europe, united kingdom, london
+        # We should have 4 events:
+        # - europe, france, <nil>
+        # - europe, france, paris
+        # - europe, france, cambridge
+        # - europe, united kingdom, manchester
+        # We keep last event for each group:
+        # - europe, france, cambridge
+        # - europe, united kingdom, manchester
+        expect(result).to match_array(
+          [
+            {
+              groups: {"country" => "france", "region" => "europe"},
+              timestamp: format_timestamp("2023-03-22T00:00:00.000Z"),
+              value: -2
+            },
+            {
+              groups: {"country" => "united kingdom", "region" => "europe"},
+              timestamp: format_timestamp("2023-03-21T00:00:00.000Z"),
+              value: -1
+            }
+          ]
+        )
+      end
+    end
+  end
+
+  describe "#max" do
+    it "returns the max value" do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+
+      expect(event_store.max).to eq(5)
+    end
+  end
+
+  describe "#grouped_max" do
+    let(:grouped_by) { %w[region] }
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it "returns the max values grouped by the provided group" do
+      result = event_store.grouped_max
+
+      expect(result).to match_array([
+        {groups: {"region" => nil}, value: 4},
+        {groups: {"region" => "europe"}, value: 5}
+      ])
+    end
+
+    context "with multiple groups" do
+      let(:grouped_by) { %w[region country] }
+
+      it "returns the max values grouped by the provided groups" do
+        result = event_store.grouped_max
+
+        expect(result).to match_array([
+          {groups: {"country" => "france", "region" => "europe"}, value: 3},
+          {groups: {"country" => nil, "region" => nil}, value: 4},
+          {groups: {"country" => "united kingdom", "region" => "europe"}, value: 5}
+        ])
+      end
+    end
+
+    context "with filters" do
+      let(:matching_filters) { {"region" => ["europe"], "country" => ["france", "united kingdom"]} }
+      let(:ignored_filters) { [{"city" => ["caen"]}, {"city" => ["cambridge", "london"], "country" => ["united kingdom"]}] }
+      let(:grouped_by) { %w[region country] }
+
+      before { create_events_for_filters }
+
+      it "returns the max events filtered and grouped" do
+        result = event_store.grouped_max
+
+        # We include:
+        # - europe, france, <nil>
+        # - europe, france, paris
+        # - europe, france, caen
+        # - europe, france, cambridge
+        # - europe, united kingdom, cambridge
+        # - europe, united kingdom, london
+        # - europe, united kingdom, manchester
+        # Then exclude:
+        # - europe, france, caen
+        # - europe, united kingdom, cambridge
+        # - europe, united kingdom, london
+        # We should have 2 events:
+        # - europe, france, <nil>
+        # - europe, france, paris
+        # - europe, france, cambridge
+        # - europe, united kingdom, manchester
+        # We keep "max" event for each group:
+        # - europe, france, <nil>
+        # - europe, united kingdom, manchester
+        expect(result).to match_array([
+          {groups: {"country" => "united kingdom", "region" => "europe"}, value: -1},
+          {groups: {"country" => "france", "region" => "europe"}, value: 3}
+        ])
+      end
+    end
+  end
+
+  describe "#last" do
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it "returns the last event value" do
+      expect(event_store.last).to eq(5)
+    end
+
+    context "when there's no events" do
+      let(:events) { [] }
+
+      it "returns nil" do
+        expect(event_store.last).to be_nil
+      end
+    end
+
+    context "when the last event does not have a value" do
+      let(:events) do
+        [create_event(timestamp: subscription_started_at + 1.day, value: nil)]
+      end
+
+      it "returns nil" do
+        expect(event_store.last).to be_nil
+      end
+    end
+  end
+
+  describe "#grouped_last" do
+    let(:grouped_by) { %w[region] }
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it "returns the value attached to each event prorated on the provided duration" do
+      result = event_store.grouped_last
+
+      expect(result).to match_array([
+        {groups: {"region" => nil}, value: 4},
+        {groups: {"region" => "europe"}, value: 5}
+      ])
+    end
+
+    context "with multiple groups" do
+      let(:grouped_by) { %w[region country] }
+
+      it "returns the last value for each provided groups" do
+        result = event_store.grouped_last
+
+        expect(result).to match_array([
+          {groups: {"country" => nil, "region" => nil}, value: 4},
+          {groups: {"country" => "france", "region" => "europe"}, value: 3},
+          {groups: {"country" => "united kingdom", "region" => "europe"}, value: 5}
+        ])
+      end
+    end
+
+    context "with filters" do
+      let(:matching_filters) { {"region" => ["europe"], "country" => ["france", "united kingdom"]} }
+      let(:ignored_filters) { [{"city" => ["caen"]}, {"city" => ["cambridge", "london"], "country" => ["united kingdom"]}] }
+      let(:grouped_by) { %w[region country] }
+
+      before { create_events_for_filters }
+
+      it "returns the last values filtered and grouped" do
+        result = event_store.grouped_last
+
+        # We include:
+        # - europe, france, <nil>
+        # - europe, france, paris
+        # - europe, france, caen
+        # - europe, france, cambridge
+        # - europe, united kingdom, cambridge
+        # - europe, united kingdom, london
+        # - europe, united kingdom, manchester
+        # Then exclude:
+        # - europe, france, caen
+        # - europe, united kingdom, cambridge
+        # - europe, united kingdom, london
+        # We should have 2 events:
+        # - europe, france, <nil>
+        # - europe, france, paris
+        # - europe, france, cambridge
+        # - europe, united kingdom, manchester
+        # We keep last event for each group:
+        # - europe, france, cambridge
+        # - europe, united kingdom, manchester
+        expect(result).to match_array([
+          {groups: {"country" => "united kingdom", "region" => "europe"}, value: -1},
+          {groups: {"country" => "france", "region" => "europe"}, value: -2}
+        ])
+      end
+    end
+  end
+
+  describe "#sum" do
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it "returns the sum of event properties" do
+      expect(event_store.sum).to eq(15)
+    end
+
+    if with_event_duplication
+      context "with only duplicated transaction_id" do
+        before do
+          event = events.first
+
+          create_event(timestamp: subscription_started_at + 5.days, value: 100, transaction_id: event.transaction_id)
+        end
+
+        it "takes the event into account" do
+          expect(event_store.sum).to eq(115) # New event value added to the previous one
+        end
+      end
+    end
+  end
+
+  describe "#grouped_sum" do
+    let(:grouped_by) { %w[region] }
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it "returns the sum of values grouped by the provided group" do
+      result = event_store.grouped_sum
+
+      expect(result).to match_array([
+        {groups: {"region" => nil}, value: 6},
+        {groups: {"region" => "europe"}, value: 9}
+      ])
+    end
+
+    context "with multiple groups" do
+      let(:grouped_by) { %w[region country] }
+
+      it "returns the sum of values grouped by the provided groups" do
+        result = event_store.grouped_sum
+
+        expect(result).to match_array([
+          {groups: {"country" => nil, "region" => nil}, value: 6},
+          {groups: {"country" => "united kingdom", "region" => "europe"}, value: 5},
+          {groups: {"country" => "france", "region" => "europe"}, value: 4}
+        ])
+      end
+    end
+
+    context "with filters" do
+      let(:matching_filters) { {"region" => ["europe"], "country" => ["france", "united kingdom"]} }
+      let(:ignored_filters) { [{"city" => ["caen"]}, {"city" => ["cambridge", "london"], "country" => ["united kingdom"]}] }
+      let(:grouped_by) { %w[region country] }
+
+      before { create_events_for_filters }
+
+      it "returns the sum filtered and grouped" do
+        result = event_store.grouped_sum
+
+        # We include:
+        # - europe, france, <nil>
+        # - europe, france, paris
+        # - europe, france, caen
+        # - europe, france, cambridge
+        # - europe, united kingdom, cambridge
+        # - europe, united kingdom, london
+        # - europe, united kingdom, manchester
+        # Then exclude:
+        # - europe, france, caen
+        # - europe, united kingdom, cambridge
+        # - europe, united kingdom, london
+        # We should have 2 events:
+        # - europe, france, <nil> -> 3
+        # - europe, france, paris -> 1
+        # - europe, france, cambridge -> -2
+        # - europe, united kingdom, manchester -> -1
+        expect(result).to match_array([
+          {groups: {"country" => "united kingdom", "region" => "europe"}, value: -1},
+          {groups: {"country" => "france", "region" => "europe"}, value: 2}
+        ])
+      end
+    end
+  end
+
+  describe "#sum_date_breakdown" do
+    it "returns the sum grouped by day" do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+
+      expect(event_store.sum_date_breakdown).to eq(
+        events.map do |e|
+          {
+            date: e.timestamp.to_date,
+            value: e.properties[billable_metric.field_name].to_i
+          }
+        end
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

While working on fix an issue with the Clickhouse event store, I refactored the Clickhouse event store tests to make it easier to review and test. This created a discrepancy between the Postgres and Clickhouse test setup.

## Description

This extracts the updated tests into a `shared_example` and re-use it for Postgres.

Note that this change showcased two minor issues:

1. Since we're running tests in transactions and the events are created in the `events` connection, they were not available through `ActiveRecord::Base.connection.select_one`. This was replaced by `Event.connection.select_one`.
2. The Postgres store returns grouped result with a timestamp as a `Time` object and the Clickhouse store returns it as `String`.