### PR TITLE
feat(multiple-payment-methods): add payment method model and table

### DIFF
--- a/app/models/payment_method.rb
+++ b/app/models/payment_method.rb
@@ -8,8 +8,9 @@ class PaymentMethod < ApplicationRecord
   default_scope -> { kept }
 
   belongs_to :organization
-  belongs_to :customer
-  belongs_to :payment_provider_customer, class_name: "PaymentProviderCustomers::BaseCustomer"
+  belongs_to :customer, -> { with_discarded }
+  belongs_to :payment_provider, optional: true, class_name: "PaymentProviders::BaseProvider"
+  belongs_to :payment_provider_customer, optional: true, class_name: "PaymentProviderCustomers::BaseCustomer"
 
   validates :provider_method_id, presence: true
   validates :is_default, inclusion: {in: [true, false]}
@@ -28,7 +29,8 @@ end
 #  updated_at                   :datetime         not null
 #  customer_id                  :uuid             not null
 #  organization_id              :uuid             not null
-#  payment_provider_customer_id :uuid             not null
+#  payment_provider_customer_id :uuid
+#  payment_provider_id          :uuid
 #  provider_method_id           :string           not null
 #
 # Indexes
@@ -36,6 +38,7 @@ end
 #  index_payment_methods_on_customer_id                   (customer_id)
 #  index_payment_methods_on_organization_id               (organization_id)
 #  index_payment_methods_on_payment_provider_customer_id  (payment_provider_customer_id)
+#  index_payment_methods_on_payment_provider_id           (payment_provider_id)
 #  index_payment_methods_on_provider_method_type          (provider_method_type)
 #  unique_default_payment_method_per_customer             (customer_id) UNIQUE WHERE ((is_default = true) AND (deleted_at IS NULL))
 #
@@ -44,4 +47,5 @@ end
 #  fk_rails_...  (customer_id => customers.id)
 #  fk_rails_...  (organization_id => organizations.id)
 #  fk_rails_...  (payment_provider_customer_id => payment_provider_customers.id)
+#  fk_rails_...  (payment_provider_id => payment_providers.id)
 #

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -15,6 +15,7 @@ module PaymentProviderCustomers
     belongs_to :organization
 
     has_many :payments
+    has_many :payment_methods, foreign_key: :payment_provider_customer_id
     has_many :refunds, foreign_key: :payment_provider_customer_id
 
     validates :customer_id, uniqueness: {conditions: -> { where(deleted_at: nil) }, scope: :type}

--- a/app/models/payment_providers/base_provider.rb
+++ b/app/models/payment_providers/base_provider.rb
@@ -20,6 +20,7 @@ module PaymentProviders
 
     has_many :customers, through: :payment_provider_customers
     has_many :payments, dependent: :nullify, foreign_key: :payment_provider_id
+    has_many :payment_methods, dependent: :nullify, foreign_key: :payment_provider_id
     has_many :refunds, dependent: :nullify, foreign_key: :payment_provider_id
 
     validates :code, uniqueness: {conditions: -> { kept }, scope: :organization_id}

--- a/db/migrate/20251007160309_create_payment_methods.rb
+++ b/db/migrate/20251007160309_create_payment_methods.rb
@@ -5,7 +5,8 @@ class CreatePaymentMethods < ActiveRecord::Migration[8.0]
     create_table :payment_methods, id: :uuid do |t|
       t.references :organization, type: :uuid, null: false, foreign_key: true
       t.references :customer, type: :uuid, null: false, foreign_key: true
-      t.references :payment_provider_customer, type: :uuid, null: false, foreign_key: true
+      t.references :payment_provider, type: :uuid, foreign_key: true
+      t.references :payment_provider_customer, type: :uuid, foreign_key: true
 
       t.string :provider_method_id, null: false
       t.string :provider_method_type, null: true, index: true

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,4 +1,4 @@
-\restrict jMENvENKEbDacbpayQy5NpihGcOIUP8hn5akatTuxOZMLvel7yhmW3kf9p8gAzE
+\restrict uwy5gMCwyz6S03bk4zP0gsshiPl5XKEOgy0Scb1qBiYNevro52i9kqA6gbqGMrZ
 
 -- Dumped from database version 14.0
 -- Dumped by pg_dump version 14.19 (Debian 14.19-1.pgdg13+1)
@@ -255,6 +255,7 @@ ALTER TABLE IF EXISTS ONLY public.billing_entities_taxes DROP CONSTRAINT IF EXIS
 ALTER TABLE IF EXISTS ONLY public.invoices DROP CONSTRAINT IF EXISTS fk_rails_06b7046ec3;
 ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_0480ef4ad3;
 ALTER TABLE IF EXISTS ONLY public.wallet_transactions DROP CONSTRAINT IF EXISTS fk_rails_01a4c0c7db;
+ALTER TABLE IF EXISTS ONLY public.payment_methods DROP CONSTRAINT IF EXISTS fk_rails_00e7a45b0b;
 DROP TRIGGER IF EXISTS before_payment_receipt_insert ON public.payment_receipts;
 CREATE OR REPLACE VIEW public.flat_filters AS
 SELECT
@@ -376,6 +377,7 @@ DROP INDEX IF EXISTS public.index_payment_provider_customers_on_payment_provider
 DROP INDEX IF EXISTS public.index_payment_provider_customers_on_organization_id;
 DROP INDEX IF EXISTS public.index_payment_provider_customers_on_customer_id_and_type;
 DROP INDEX IF EXISTS public.index_payment_methods_on_provider_method_type;
+DROP INDEX IF EXISTS public.index_payment_methods_on_payment_provider_id;
 DROP INDEX IF EXISTS public.index_payment_methods_on_payment_provider_customer_id;
 DROP INDEX IF EXISTS public.index_payment_methods_on_organization_id;
 DROP INDEX IF EXISTS public.index_payment_methods_on_customer_id;
@@ -3825,7 +3827,8 @@ CREATE TABLE public.payment_methods (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     organization_id uuid NOT NULL,
     customer_id uuid NOT NULL,
-    payment_provider_customer_id uuid NOT NULL,
+    payment_provider_id uuid,
+    payment_provider_customer_id uuid,
     provider_method_id character varying NOT NULL,
     provider_method_type character varying,
     is_default boolean DEFAULT false NOT NULL,
@@ -7365,6 +7368,13 @@ CREATE INDEX index_payment_methods_on_payment_provider_customer_id ON public.pay
 
 
 --
+-- Name: index_payment_methods_on_payment_provider_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_payment_methods_on_payment_provider_id ON public.payment_methods USING btree (payment_provider_id);
+
+
+--
 -- Name: index_payment_methods_on_provider_method_type; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8090,6 +8100,14 @@ CREATE OR REPLACE VIEW public.flat_filters AS
 --
 
 CREATE TRIGGER before_payment_receipt_insert BEFORE INSERT ON public.payment_receipts FOR EACH ROW EXECUTE FUNCTION public.set_payment_receipt_number();
+
+
+--
+-- Name: payment_methods fk_rails_00e7a45b0b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.payment_methods
+    ADD CONSTRAINT fk_rails_00e7a45b0b FOREIGN KEY (payment_provider_id) REFERENCES public.payment_providers(id);
 
 
 --
@@ -10024,7 +10042,7 @@ ALTER TABLE ONLY public.fixed_charges_taxes
 -- PostgreSQL database dump complete
 --
 
-\unrestrict jMENvENKEbDacbpayQy5NpihGcOIUP8hn5akatTuxOZMLvel7yhmW3kf9p8gAzE
+\unrestrict uwy5gMCwyz6S03bk4zP0gsshiPl5XKEOgy0Scb1qBiYNevro52i9kqA6gbqGMrZ
 
 SET search_path TO "$user", public;
 

--- a/spec/factories/payment_methods.rb
+++ b/spec/factories/payment_methods.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :payment_method do
     association :payment_provider_customer, factory: :stripe_customer
+    payment_provider { payment_provider_customer&.payment_provider || association(:stripe_provider) }
     organization { payment_provider_customer&.organization || association(:organization) }
     customer { payment_provider_customer&.customer || association(:customer) }
     provider_method_id { "ext_123" }

--- a/spec/models/payment_method_spec.rb
+++ b/spec/models/payment_method_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe PaymentMethod do
 
   it { is_expected.to belong_to(:organization) }
   it { is_expected.to belong_to(:customer) }
-  it { is_expected.to belong_to(:payment_provider_customer).class_name("PaymentProviderCustomers::BaseCustomer") }
+  it { is_expected.to belong_to(:payment_provider).class_name("PaymentProviders::BaseProvider").optional }
+  it { is_expected.to belong_to(:payment_provider_customer).class_name("PaymentProviderCustomers::BaseCustomer").optional }
 
   it { expect(described_class).to be_soft_deletable }
 


### PR DESCRIPTION
## Context

Currently in Lago, there can be only one payment provider customer and also only one payment method.

## Description

With this feature, it will be possible to add multiple provider customers and also attach many payment methods to it.

This is the first PR for this feature, that adds `payment_methods` table and model
