### PR TITLE
fix(audit_logs_period): Set to audit_logs_period to nil on factory

### DIFF
--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
 
     name { Faker::Company.name }
     default_currency { "USD" }
+    audit_logs_period { nil }
 
     email { Faker::Internet.email }
     email_settings { ["invoice.finalized", "credit_note.created"] }


### PR DESCRIPTION
This sets the audit logs retention for tests to `nil`, which looks for all records, independent of creation time.