### PR TITLE
feat(fixed charges): Add fixed_charge_id to adjusted fees table

### DIFF
--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -50,6 +50,7 @@ end
 #  charge_filter_id          :uuid
 #  charge_id                 :uuid
 #  fee_id                    :uuid
+#  fixed_charge_id           :uuid
 #  group_id                  :uuid
 #  invoice_id                :uuid             not null
 #  organization_id           :uuid             not null
@@ -69,6 +70,7 @@ end
 #
 #  fk_rails_...  (charge_id => charges.id)
 #  fk_rails_...  (fee_id => fees.id)
+#  fk_rails_...  (fixed_charge_id => fixed_charges.id)
 #  fk_rails_...  (group_id => groups.id)
 #  fk_rails_...  (invoice_id => invoices.id)
 #  fk_rails_...  (organization_id => organizations.id)

--- a/db/migrate/20251010092830_add_fixed_charge_id_to_adjusted_fees.rb
+++ b/db/migrate/20251010092830_add_fixed_charge_id_to_adjusted_fees.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddFixedChargeIdToAdjustedFees < ActiveRecord::Migration[8.0]
+  def change
+    add_column :adjusted_fees, :fixed_charge_id, :uuid
+    add_foreign_key :adjusted_fees, :fixed_charges, column: :fixed_charge_id, validate: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,4 +1,4 @@
-\restrict uwy5gMCwyz6S03bk4zP0gsshiPl5XKEOgy0Scb1qBiYNevro52i9kqA6gbqGMrZ
+\restrict V27QnkJyP653Nf0D8rY60zpLjqbvscF4j1Ru96P3hfiTe5NzduLHJ784aFNj37H
 
 -- Dumped from database version 14.0
 -- Dumped by pg_dump version 14.19 (Debian 14.19-1.pgdg13+1)
@@ -99,6 +99,7 @@ ALTER TABLE IF EXISTS ONLY public.fixed_charge_events DROP CONSTRAINT IF EXISTS 
 ALTER TABLE IF EXISTS ONLY public.entitlement_subscription_feature_removals DROP CONSTRAINT IF EXISTS fk_rails_95df3194c5;
 ALTER TABLE IF EXISTS ONLY public.customers DROP CONSTRAINT IF EXISTS fk_rails_94cc21031f;
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_9298b8fdad;
+ALTER TABLE IF EXISTS ONLY public.adjusted_fees DROP CONSTRAINT IF EXISTS fk_rails_91802dc891;
 ALTER TABLE IF EXISTS ONLY public.subscription_fixed_charge_units_overrides DROP CONSTRAINT IF EXISTS fk_rails_90fd72ac8f;
 ALTER TABLE IF EXISTS ONLY public.invoice_subscriptions DROP CONSTRAINT IF EXISTS fk_rails_90d93bd016;
 ALTER TABLE IF EXISTS ONLY public.data_export_parts DROP CONSTRAINT IF EXISTS fk_rails_909197908c;
@@ -1298,7 +1299,8 @@ CREATE TABLE public.adjusted_fees (
     grouped_by jsonb DEFAULT '{}'::jsonb NOT NULL,
     charge_filter_id uuid,
     unit_precise_amount_cents numeric(40,15) DEFAULT 0.0 NOT NULL,
-    organization_id uuid NOT NULL
+    organization_id uuid NOT NULL,
+    fixed_charge_id uuid
 );
 
 
@@ -9359,6 +9361,14 @@ ALTER TABLE ONLY public.subscription_fixed_charge_units_overrides
 
 
 --
+-- Name: adjusted_fees fk_rails_91802dc891; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.adjusted_fees
+    ADD CONSTRAINT fk_rails_91802dc891 FOREIGN KEY (fixed_charge_id) REFERENCES public.fixed_charges(id) NOT VALID;
+
+
+--
 -- Name: data_export_parts fk_rails_9298b8fdad; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10042,11 +10052,12 @@ ALTER TABLE ONLY public.fixed_charges_taxes
 -- PostgreSQL database dump complete
 --
 
-\unrestrict uwy5gMCwyz6S03bk4zP0gsshiPl5XKEOgy0Scb1qBiYNevro52i9kqA6gbqGMrZ
+\unrestrict V27QnkJyP653Nf0D8rY60zpLjqbvscF4j1Ru96P3hfiTe5NzduLHJ784aFNj37H
 
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20251010092830'),
 ('20251007160309'),
 ('20250926185510'),
 ('20250919124523'),


### PR DESCRIPTION
 ## Roadmap Task

 👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

 👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

 ## Context

 ### What is the current situation?

 **Option 1:** User has to create a one off invoice alongside the
 subscription, it will create 2 different invoices.

 **Option 2:** User can add a recurring billable metric and use event to
 have this fee invoice on subscription renewal, but it won’t appear on
 the first billing subscription.

 ### What problem are we trying to solve?

 At subscription creation or afterward, there is no clear way to invoice
 a fixed fee that is not tied to events, aside from the subscription fee
 itself. This fee could be either a one-time charge or a recurring one.

 ## Description

 Add reference to associate adjusted fees to fixed charges