### PR TITLE
fix(pricing-group-keys): Fix `pricing_group_keys` on charge with filters

### DIFF
--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -85,7 +85,8 @@ module Fees
       end
 
       # NOTE: Create a fee for events not matching any filters.
-      init_charge_fees(properties: charge.properties, charge_filter: ChargeFilter.new(charge:))
+      charge_filter = ChargeFilter.new(charge:, properties: {"pricing_group_keys" => charge.pricing_group_keys})
+      init_charge_fees(properties: charge.properties, charge_filter:)
     end
 
     def init_charge_fees(properties:, charge_filter: nil)


### PR DESCRIPTION
## Context

When a charge has both filters and `pricing_group_keys`, the `pricing_group_keys` were not being used to create the fees matching the charge but not the filters.

I added a test to reproduce the issue:

```
  1) Fees::ChargeService.call without filters with pricing_group_keys and standard charge with filters creates a fee for each group
     Got 1 failure and 1 other error:

     1.1) Failure/Error: expect(result.fees.count).to eq(6)

            expected: 6
                 got: 5

            (compared using ==)
          # ./spec/services/fees/charge_service_spec.rb:384:in 'block (6 levels) in <top (required)>'
          # ./spec/support/license_helper.rb:6:in 'LicenseHelper#lago_premium!'
          # ./spec/services/fees/charge_service_spec.rb:10:in 'block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:218:in 'block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:210:in 'block (3 levels) in <top (required)>'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/null_strategy.rb:17:in 'DatabaseCleaner::NullStrategy#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in 'DatabaseCleaner::Cleaners#cleaning'
          # ./spec/spec_helper.rb:209:in 'block (2 levels) in <top (required)>'
          # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'

     1.2) Failure/Error: sorted_fees = result.fees.sort_by { [it.grouped_by["region"], it.grouped_by["country"]] }

          ArgumentError:
            comparison of Array with Array failed
          # ./spec/services/fees/charge_service_spec.rb:386:in 'Enumerable#sort_by'
          # ./spec/services/fees/charge_service_spec.rb:386:in 'block (6 levels) in <top (required)>'
          # ./spec/support/license_helper.rb:6:in 'LicenseHelper#lago_premium!'
          # ./spec/services/fees/charge_service_spec.rb:10:in 'block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:218:in 'block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:210:in 'block (3 levels) in <top (required)>'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/null_strategy.rb:17:in 'DatabaseCleaner::NullStrategy#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
          # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in 'DatabaseCleaner::Cleaners#cleaning'
          # ./spec/spec_helper.rb:209:in 'block (2 levels) in <top (required)>'
          # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'

Finished in 0.70143 seconds (files took 3.13 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/services/fees/charge_service_spec.rb:381 # Fees::ChargeService.call without filters with pricing_group_keys and standard charge with filters creates a fee for each group
```

## Description

I fixed it by setting the `pricing_group_keys` to the fake `ChargeFilter` used when creating the fees for the charge itself.