### PR TITLE
fix(charge-filter): Fix `ChargeFilters::MatchingAndIgnoredService`

### DIFF
--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -31,13 +31,13 @@ class ChargeFilter < ApplicationRecord
   def to_h
     @to_h ||= values.each_with_object({}) do |filter_value, result|
       result[filter_value.billable_metric_filter.key] = filter_value.values
-    end
+    end.freeze
   end
 
   def to_h_with_discarded
     @to_h_with_discarded ||= values.with_discarded.each_with_object({}) do |filter_value, result|
       result[filter_value.billable_metric_filter.key] = filter_value.values
-    end
+    end.freeze
   end
 
   def to_h_with_all_values
@@ -46,7 +46,7 @@ class ChargeFilter < ApplicationRecord
       values = filter_value.billable_metric_filter.values if values == [ChargeFilterValue::ALL_FILTER_VALUES]
 
       result[filter_value.billable_metric_filter.key] = values
-    end
+    end.freeze
   end
 
   def pricing_group_keys

--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -38,7 +38,7 @@ module ChargeFilters
       #         }
       #       ]
       result.ignored_filters = children.map do |child|
-        res = child.to_h_with_all_values
+        res = child.to_h_with_all_values.dup
 
         if res.keys == result.matching_filters.keys
           # NOTE: when child and filter have the same keys, we need to remove the filter value from the child

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -767,41 +767,17 @@ RSpec.describe Fees::ChargeService do
             end
 
             let(:country) do
-              create(:billable_metric_filter, billable_metric:, key: "country", values: %w[france])
+              create(:billable_metric_filter, billable_metric:, key: "country", values: ["france", "germany", "united kingdom"])
             end
 
-            let(:europe_filter) { create(:charge_filter, charge:, properties: {amount: "20"}) }
-            let(:europe_filter_value) do
-              create(
-                :charge_filter_value,
-                charge_filter: europe_filter,
-                billable_metric_filter: region,
-                values: ["europe"]
-              )
-            end
+            let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:, properties: {amount: "10"}) }
 
-            let(:usa_filter) { create(:charge_filter, charge:, properties: {amount: "50"}) }
-            let(:usa_filter_value) do
-              create(:charge_filter_value, charge_filter: usa_filter, billable_metric_filter: region, values: ["usa"])
-            end
-
-            let(:france_filter) { create(:charge_filter, charge:, properties: {amount: "10.12345"}) }
-            let(:france_filter_value) do
-              create(
-                :charge_filter_value,
-                charge_filter: france_filter,
-                billable_metric_filter: country,
-                values: ["france"]
-              )
-            end
-
-            let(:charge) do
-              create(
-                :standard_charge,
-                plan: subscription.plan,
-                billable_metric:,
-                properties: {amount: "10.12345"}
-              )
+            let(:europe_filter) { create_filter(amount: "20", values: {region => ["europe"]}) }
+            let(:usa_filter) { create_filter(amount: "30", values: {region => ["usa"]}) }
+            let(:france_filter) { create_filter(amount: "40.12345", values: {region => ["europe"], country => ["france"]}) }
+            let(:all_values_filter) do
+              all_values = [ChargeFilterValue::ALL_FILTER_VALUES]
+              create_filter(amount: "50", values: {region => all_values, country => all_values})
             end
 
             let(:adjusted_fee) do
@@ -820,42 +796,46 @@ RSpec.describe Fees::ChargeService do
             end
 
             before do
-              europe_filter_value
-              usa_filter_value
-              france_filter_value
+              region
+              country
 
-              create(
-                :event,
-                organization: subscription.organization,
-                subscription:,
-                code: charge.billable_metric.code,
-                timestamp: Time.zone.parse("2022-03-16"),
-                properties: {region: "usa", foo_bar: 12}
-              )
-              create(
-                :event,
-                organization: subscription.organization,
-                subscription:,
-                code: charge.billable_metric.code,
-                timestamp: Time.zone.parse("2022-03-16"),
-                properties: {region: "europe", foo_bar: 10}
-              )
-              create(
-                :event,
-                organization: subscription.organization,
-                subscription:,
-                code: charge.billable_metric.code,
-                timestamp: Time.zone.parse("2022-03-16"),
-                properties: {region: "europe", foo_bar: 5}
-              )
-              create(
-                :event,
-                organization: subscription.organization,
-                subscription:,
-                code: charge.billable_metric.code,
-                timestamp: Time.zone.parse("2022-03-16"),
-                properties: {country: "france", foo_bar: 5}
-              )
+              europe_filter
+              usa_filter
+              france_filter
+              all_values_filter
+
+              # usa filter events
+              create_event(properties: {region: "usa", foo_bar: 12})
+
+              # europe filter events
+              create_event(properties: {region: "europe", foo_bar: 10})
+              create_event(properties: {region: "europe", foo_bar: 2})
+              create_event(properties: {region: "europe", country: "italy", foo_bar: 3})
+
+              # france filter events
+              create_event(properties: {region: "europe", country: "france", foo_bar: 5})
+
+              # All values filter events
+              create_event(properties: {region: "europe", country: "united kingdom", foo_bar: 5})
+              create_event(properties: {region: "europe", country: "germany", foo_bar: 5})
+
+              # No filter events
+              create_event(properties: {region: "asia", country: "japan", foo_bar: 3})
+              create_event(properties: {foo_bar: 2})
+            end
+
+            def create_event(properties:)
+              organization = subscription.organization
+              code = charge.billable_metric.code
+              create(:event, organization:, subscription:, code:, timestamp: Time.zone.parse("2022-03-16"), properties:)
+            end
+
+            def create_filter(amount:, values:)
+              filter = create(:charge_filter, charge:, properties: {amount:})
+              values.each do |billable_metric_filter, values|
+                create(:charge_filter_value, charge_filter: filter, billable_metric_filter:, values:)
+              end
+              filter
             end
 
             it "creates expected fees for sum_agg aggregation type" do
@@ -865,13 +845,24 @@ RSpec.describe Fees::ChargeService do
               created_fees = result.fees
 
               aggregate_failures do
-                expect(created_fees.count).to eq(3)
+                expect(created_fees.count).to eq(5)
                 expect(created_fees).to all(
                   have_attributes(
                     invoice_id: invoice.id,
                     charge_id: charge.id,
                     amount_currency: "EUR"
                   )
+                )
+
+                usa_fee = created_fees.find { |f| f.charge_filter == usa_filter }
+                expect(usa_fee).to have_attributes(
+                  charge_filter: usa_filter,
+                  amount_cents: 9_000,
+                  precise_amount_cents: 9_000.0,
+                  taxes_precise_amount_cents: 0.0,
+                  units: 3,
+                  unit_amount_cents: 3000,
+                  precise_unit_amount: 30
                 )
 
                 europe_fee = created_fees.find { |f| f.charge_filter == europe_filter }
@@ -885,26 +876,37 @@ RSpec.describe Fees::ChargeService do
                   precise_unit_amount: 20
                 )
 
-                usa_fee = created_fees.find { |f| f.charge_filter == usa_filter }
-                expect(usa_fee).to have_attributes(
-                  charge_filter: usa_filter,
-                  amount_cents: 15_000,
-                  precise_amount_cents: 15_000.0,
-                  taxes_precise_amount_cents: 0.0,
-                  units: 3,
-                  unit_amount_cents: 5000,
-                  precise_unit_amount: 50
-                )
-
                 france_fee = created_fees.find { |f| f.charge_filter == france_filter }
                 expect(france_fee).to have_attributes(
                   charge_filter: france_filter,
-                  amount_cents: 5062,
-                  precise_amount_cents: 5061.725,
+                  amount_cents: 20062,
+                  precise_amount_cents: 20061.725,
                   taxes_precise_amount_cents: 0.0,
                   units: 5,
-                  unit_amount_cents: 1012,
-                  precise_unit_amount: 10.12345
+                  unit_amount_cents: 4012,
+                  precise_unit_amount: 40.12345
+                )
+
+                all_filter_fee = created_fees.find { |f| f.charge_filter == all_values_filter }
+                expect(all_filter_fee).to have_attributes(
+                  charge_filter: all_values_filter,
+                  amount_cents: 50000,
+                  precise_amount_cents: 50000.0,
+                  taxes_precise_amount_cents: 0.0,
+                  units: 10,
+                  unit_amount_cents: 5000,
+                  precise_unit_amount: 50.0
+                )
+
+                no_filter_fee = created_fees.find { |f| f.charge_filter.blank? }
+                expect(no_filter_fee).to have_attributes(
+                  charge_filter: nil,
+                  amount_cents: 5000,
+                  precise_amount_cents: 5000.0,
+                  taxes_precise_amount_cents: 0.0,
+                  units: 5,
+                  unit_amount_cents: 1000,
+                  precise_unit_amount: 10.0
                 )
               end
             end


### PR DESCRIPTION
## Context

The `ChargeFilters::MatchingAndIgnoredService` was modifying the hash returned by `ChargeFilter#to_h_with_all_values` directly. Since this value is memoized and we iterate on each filter when generating fees, there are cases where the values of one filter got modified while processing other filters.

This caused some events to no longer match a specific filter and be counted as part of the default charge/fee.

I added a complete test to reproduce this issue:

```ruby
  1) Fees::ChargeService.call without filters when there is adjusted fee with adjusted units with standard charge, all types of aggregation and presence of filters creates expected fees for sum_agg aggregation type
     Got 2 failures from failure aggregation block.
     # ./spec/services/fees/charge_service_spec.rb:847:in 'block (7 levels) in <top (required)>'
     # ./spec/support/license_helper.rb:6:in 'LicenseHelper#lago_premium!'
     # ./spec/services/fees/charge_service_spec.rb:10:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:218:in 'block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:210:in 'block (3 levels) in <top (required)>'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in 'DatabaseCleaner::Strategy#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/null_strategy.rb:17:in 'DatabaseCleaner::NullStrategy#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in 'block (2 levels) in DatabaseCleaner::Cleaners#cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in 'DatabaseCleaner::Cleaners#cleaning'
     # ./spec/spec_helper.rb:209:in 'block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.23.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <main>'

     1.1) Failure/Error: expect(created_fees.count).to eq(5)

            expected: 5
                 got: 4

            (compared using ==)
          # ./spec/services/fees/charge_service_spec.rb:848:in 'block (8 levels) in <top (required)>'

     1.2) Failure/Error:
            expect(all_filter_fee).to have_attributes(
              charge_filter: all_values_filter,
              amount_cents: 50000,
              precise_amount_cents: 50000.0,
              taxes_precise_amount_cents: 0.0,
              units: 10,
              unit_amount_cents: 5000,
              precise_unit_amount: 50.0
            )

            expected nil to respond to :charge_filter, :amount_cents, :precise_amount_cents, :taxes_precise_amount_cents, :units, :unit_amount_cents, :precise_unit_amount with 0 arguments
          # ./spec/services/fees/charge_service_spec.rb:902:in 'block (8 levels) in <top (required)>'

Finished in 9.05 seconds (files took 2.53 seconds to load)
78 examples, 1 failure

Failed examples:

rspec ./spec/services/fees/charge_service_spec.rb:841 # Fees::ChargeService.call without filters when there is adjusted fee with adjusted units with standard charge, all types of aggregation and presence of filters creates expected fees for sum_agg aggregation type
```

## Description

This fixes the issue by:

1. Freezing the values returned by the memoized methods of `ChargeFilter`.
2. Using `.dup` before modifying the value.