### PR TITLE
feat(fixed charges): Add fixed charge to GraphQL AdjustedFee and Fee types

### DIFF
--- a/app/graphql/types/adjusted_fees/create_input.rb
+++ b/app/graphql/types/adjusted_fees/create_input.rb
@@ -10,9 +10,10 @@ module Types
       # NOTE: adjust an existing fee
       argument :fee_id, ID, required: false
 
-      # NOTE: adjust a empty charge fee
+      # NOTE: adjust a empty charge or fixed charge fee
       argument :charge_filter_id, ID, required: false
       argument :charge_id, ID, required: false
+      argument :fixed_charge_id, ID, required: false
       argument :subscription_id, ID, required: false
 
       argument :invoice_display_name, String, required: false

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -12,6 +12,7 @@ module Types
       field :charge, Types::Charges::Object, null: true
       field :currency, Types::CurrencyEnum, null: false
       field :description, String, null: true
+      field :fixed_charge, Types::FixedCharges::Object, null: true
       field :grouped_by, GraphQL::Types::JSON, null: false
       field :invoice_display_name, String, null: true
       field :invoice_name, String, null: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -2408,6 +2408,7 @@ input CreateAdjustedFeeInput {
   """
   clientMutationId: String
   feeId: ID
+  fixedChargeId: ID
   invoiceDisplayName: String
   invoiceId: ID!
   invoiceSubscriptionId: ID
@@ -5164,6 +5165,7 @@ type Fee implements InvoiceItem {
   description: String
   eventsCount: BigInt
   feeType: FeeTypesEnum!
+  fixedCharge: FixedCharge
   groupedBy: JSON!
   id: ID!
   invoiceDisplayName: String
@@ -8157,6 +8159,7 @@ input PreviewAdjustedFeeInput {
   """
   clientMutationId: String
   feeId: ID
+  fixedChargeId: ID
   invoiceDisplayName: String
   invoiceId: ID!
   invoiceSubscriptionId: ID

--- a/schema.json
+++ b/schema.json
@@ -8972,6 +8972,18 @@
               "deprecationReason": null
             },
             {
+              "name": "fixedChargeId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "subscriptionId",
               "description": null,
               "type": {
@@ -24408,6 +24420,18 @@
                   "name": "FeeTypesEnum",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fixedCharge",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FixedCharge",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -41183,6 +41207,18 @@
             },
             {
               "name": "chargeId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fixedChargeId",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/spec/graphql/types/adjusted_fees/create_input_spec.rb
+++ b/spec/graphql/types/adjusted_fees/create_input_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Types::AdjustedFees::CreateInput do
     expect(subject).to accept_argument(:fee_id).of_type("ID")
     expect(subject).to accept_argument(:charge_id).of_type("ID")
     expect(subject).to accept_argument(:charge_filter_id).of_type("ID")
+    expect(subject).to accept_argument(:fixed_charge_id).of_type("ID")
     expect(subject).to accept_argument(:subscription_id).of_type("ID")
     expect(subject).to accept_argument(:invoice_display_name).of_type("String")
     expect(subject).to accept_argument(:unit_precise_amount).of_type("String")

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Types::Fees::Object do
     expect(subject).to have_field(:currency).of_type("CurrencyEnum!")
     expect(subject).to have_field(:description).of_type("String")
     expect(subject).to have_field(:grouped_by).of_type("JSON!")
+    expect(subject).to have_field(:fixed_charge).of_type("FixedCharge")
     expect(subject).to have_field(:invoice_display_name).of_type("String")
     expect(subject).to have_field(:invoice_name).of_type("String")
     expect(subject).to have_field(:subscription).of_type("Subscription")


### PR DESCRIPTION
 ## Roadmap Task

 👉 https://getlago.canny.io/feature-requests/p/allow-add-ons-to-be-added-to-subscription-invoices

 👉 https://getlago.canny.io/feature-requests/p/define-quantities-for-plan-charges

 ## Context

 ### What is the current situation?

 **Option 1:** User has to create a one off invoice alongside the
 subscription, it will create 2 different invoices.

 **Option 2:** User can add a recurring billable metric and use event to
 have this fee invoice on subscription renewal, but it won’t appear on
 the first billing subscription.

 ### What problem are we trying to solve?

 At subscription creation or afterward, there is no clear way to invoice
 a fixed fee that is not tied to events, aside from the subscription fee
 itself. This fee could be either a one-time charge or a recurring one.

 ## Description

 Add FixedCharge and/or its id to Fee and AdjustFee GraphQL types