### PR TITLE
fix(credit-note): Regenerate number after finalizing

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -179,11 +179,15 @@ class CreditNote < ApplicationRecord
   private
 
   def ensure_number
-    return if number.present?
+    return if number.present? && !status_changed_to_finalized?
 
     formatted_sequential_id = format("%03d", sequential_id)
 
     self.number = "#{invoice.number}-CN#{formatted_sequential_id}"
+  end
+
+  def status_changed_to_finalized?
+    status_changed?(from: "draft", to: "finalized")
   end
 end
 


### PR DESCRIPTION
## Context

When a draft credit note is finalized, there was a bug that prevented to regenerate the number, so it remained as e.g.: `LAG-C123-DRAFT-CN001`

## Description

This PR fixes `CreditNote#ensure_number` so that the number is regenerated.