### PR TITLE
chore(open-struct): Introduce ::Integrations::Aggregator::SubsidiariesService::Subsidiary

### DIFF
--- a/app/services/integrations/aggregator/subsidiaries_service.rb
+++ b/app/services/integrations/aggregator/subsidiaries_service.rb
@@ -3,6 +3,8 @@
 module Integrations
   module Aggregator
     class SubsidiariesService < BaseService
+      Subsidiary = Data.define(:external_id, :external_name)
+
       def action_path
         "v1/#{provider}/subsidiaries"
       end
@@ -27,7 +29,7 @@ module Integrations
 
       def handle_subsidiaries(subsidiaries)
         subsidiaries.map do |subsidiary|
-          OpenStruct.new(external_id: subsidiary["id"], external_name: subsidiary["name"])
+          Subsidiary.new(external_id: subsidiary["id"], external_name: subsidiary["name"])
         end
       end
     end

--- a/spec/services/integrations/aggregator/subsidiaries_service_spec.rb
+++ b/spec/services/integrations/aggregator/subsidiaries_service_spec.rb
@@ -35,12 +35,11 @@ RSpec.describe Integrations::Aggregator::SubsidiariesService do
     it "successfully fetches subsidiaries" do
       result = subsidiaries_service.call
 
-      aggregate_failures do
-        expect(LagoHttpClient::Client).to have_received(:new).with(subsidiaries_endpoint, retries_on: [OpenSSL::SSL::SSLError])
-        expect(lago_client).to have_received(:get)
-        expect(result.subsidiaries.count).to eq(4)
-        expect(result.subsidiaries.first.external_id).to eq("1")
-      end
+      expect(LagoHttpClient::Client).to have_received(:new).with(subsidiaries_endpoint, retries_on: [OpenSSL::SSL::SSLError])
+      expect(lago_client).to have_received(:get)
+      expect(result.subsidiaries.count).to eq(4)
+      expect(result.subsidiaries.first.external_id).to eq("1")
+      expect(result.subsidiaries.first.external_name).to eq("Holo, Inc.")
     end
   end
 end


### PR DESCRIPTION
This is only used in the GQL layer in a resolver. The mapping object only has these 2 fields.