### PR TITLE
feat(live_agg): Add a new middleware to monitor plan updates

### DIFF
--- a/app/services/plans/update_notification_middleware.rb
+++ b/app/services/plans/update_notification_middleware.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+module Plans
+  class UpdateNotificationMiddleware < Middlewares::BaseMiddleware
+    def before_call
+      return unless should_notify?
+
+      @snapshot = create_snapshot(initial_plan)
+    end
+
+    def after_call(result)
+      return unless should_notify?
+      return unless result.success?
+
+      @plan = result.plan
+
+      final_state = create_snapshot(@plan)
+      compare_and_notify(final_state)
+    rescue => e
+      # Avoid raising error from the middleware and blocking the update process
+      if defined?(Sentry)
+        Sentry.capture_exception(e)
+      else
+        Rails.logger.error("Error in Plans::UpdateNotificationMiddleware: #{e.message}")
+      end
+    end
+
+    private
+
+    def initial_plan
+      arg = kwargs[:plan]
+      return unless arg
+
+      service_instance.instance_exec(&arg)
+    end
+
+    def should_notify?
+      return false if ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"].blank?
+      return false if ENV["LAGO_KAFKA_PLAN_CONFIG_UPDATED_TOPIC"].blank?
+
+      initial_plan&.organization&.clickhouse_live_aggregation_enabled?
+    end
+
+    def create_snapshot(plan)
+      return [] unless plan
+
+      plan.charges.map do |charge|
+        {
+          id: charge.id,
+          pricing_group_keys: charge.pricing_group_keys,
+          filters: charge.filters.map { |f| {id: f.id, pricing_group_keys: f.pricing_group_keys, values: f.to_h} }
+        }
+      end
+    end
+
+    def compare_and_notify(final_state)
+      before = @snapshot.index_by { it[:id] }
+      after = final_state.index_by { it[:id] }
+
+      deleted_ids = (before.keys - after.keys)
+      notify_deleted_charge(deleted_ids) if deleted_ids.present?
+
+      created_ids = (after.keys - before.keys)
+      notify_created_charge(created_ids) if created_ids.present?
+
+      (before.keys & after.keys).each do |charge_id|
+        compare_charge_filters_and_notify(before[charge_id], after[charge_id])
+      end
+    end
+
+    def notify_deleted_charge(charge_ids)
+      Plans::UpdatedKafkaProducerService.call!(
+        plan: @plan,
+        resources_type: "charge",
+        resources_ids: charge_ids,
+        event_type: "charges.deleted",
+        timestamp: @plan.updated_at
+      )
+    end
+
+    def notify_created_charge(charge_ids)
+      Plans::UpdatedKafkaProducerService.call!(
+        plan: @plan,
+        resources_type: "charge",
+        resources_ids: charge_ids,
+        event_type: "charges.created",
+        timestamp: @plan.updated_at
+      )
+    end
+
+    def compare_charge_filters_and_notify(before, after)
+      # Filters have changed, we need to reprocess all events
+      before_values = before[:filters].map { |it| {id: it[:id], values: it[:values]} }
+      after_values = after[:filters].map { |it| {id: it[:id], values: it[:values]} }
+
+      if before_values != after_values
+        notify_updated_charge(before[:id])
+        return
+      end
+
+      # Charge's ricing group keys have changed, we need to reprocess all events for the charge without filter
+      if before[:pricing_group_keys] != after[:pricing_group_keys]
+        notify_updated_pricing_group_keys([before[:id]], "charge")
+      end
+
+      filters_after = after[:filters].index_by { it[:id] }
+      updated = before[:filters].select do |filter|
+        filter_after = filters_after[filter[:id]]
+
+        # Filter's pricing group keys have changed, we need to reprocess all events for the filter
+        filter[:pricing_group_keys] != filter_after[:pricing_group_keys]
+      end
+      notify_updated_pricing_group_keys(updated.map { |it| it[:id] }, "charge_filter") if updated.any?
+    end
+
+    def notify_updated_charge(charge_id)
+      Plans::UpdatedKafkaProducerService.call!(
+        plan: @plan,
+        resources_type: "charge",
+        resources_ids: [charge_id],
+        event_type: "charges.updated",
+        timestamp: @plan.updated_at
+      )
+    end
+
+    def notify_updated_pricing_group_keys(record_ids, record_type)
+      Plans::UpdatedKafkaProducerService.call!(
+        plan: @plan,
+        resources_type: record_type,
+        resources_ids: record_ids,
+        event_type: "#{record_type}s.pricing_group_keys_updated",
+        timestamp: @plan.updated_at
+      )
+    end
+  end
+end

--- a/app/services/plans/updated_kafka_producer_service.rb
+++ b/app/services/plans/updated_kafka_producer_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Plans
+  class UpdatedKafkaProducerService < BaseService
+    Result = BaseResult
+
+    def initialize(plan:, resources_type:, resources_ids:, event_type:, timestamp:)
+      @plan = plan
+      @resources_type = resources_type
+      @resources_ids = resources_ids
+      @event_type = event_type
+      @timestamp = timestamp
+      super
+    end
+
+    def call
+      return result if ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"].blank?
+      return result if ENV["LAGO_KAFKA_PLAN_CONFIG_UPDATED_TOPIC"].blank?
+      return result unless organization.clickhouse_live_aggregation_enabled?
+
+      Karafka.producer.produce_async(
+        topic: ENV["LAGO_KAFKA_PLAN_CONFIG_UPDATED_TOPIC"],
+        key: "#{organization.id}-#{plan.id}",
+        payload: {
+          organization_id: organization.id,
+          plan_id: plan.id,
+          resources_ids:,
+          resources_type:,
+          event_type:,
+          timestamp: timestamp.iso8601(3),
+          produced_at: Time.current.iso8601
+        }
+      )
+
+      result
+    end
+
+    private
+
+    attr_reader :plan, :resources_type, :resources_ids, :event_type, :timestamp
+
+    delegate :organization, to: :plan
+  end
+end

--- a/spec/services/plans/update_notification_middleware_spec.rb
+++ b/spec/services/plans/update_notification_middleware_spec.rb
@@ -1,0 +1,425 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Plans::UpdateNotificationMiddleware do
+  subject(:middleware) do
+    described_class.new(service_instance, next_middleware, *args, **kwargs)
+  end
+
+  let(:service_class) do
+    Class.new(BaseService) do
+      const_set(:Result, BaseResult[:plan])
+
+      def initialize(plan:)
+        @plan = plan
+        super()
+      end
+
+      def call(&block)
+        result.plan = plan
+        result
+      end
+
+      private
+
+      attr_reader :plan
+    end
+  end
+
+  let(:organization) { create(:organization, premium_integrations:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:charges) { create_list(:standard_charge, 3, plan:, organization:) }
+
+  let(:service_instance) { service_class.new(plan:) }
+  let(:next_middleware) { lambda { plan } }
+  let(:args) { [] }
+  let(:kwargs) { {plan: lambda { plan }} }
+
+  let(:premium_integrations) { [] }
+
+  before { charges }
+
+  describe ".call" do
+    context "with Kafka config", :premium do
+      let(:premium_integrations) { ["clickhouse_live_aggregation"] }
+
+      before do
+        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = "kafka"
+        ENV["LAGO_KAFKA_PLAN_CONFIG_UPDATED_TOPIC"] = "plan_config_updated"
+      end
+
+      it "creates an initial snapshot of the plan" do
+        middleware.call
+
+        snapshot = middleware.instance_variable_get(:@snapshot)
+        expect(snapshot).not_to be_nil
+        expect(snapshot).to eq(charges.map { {id: it.id, pricing_group_keys: nil, filters: []} })
+      end
+
+      context "when clickhouse live aggregation is not enabled" do
+        let(:premium_integrations) { [] }
+
+        it "does not create a snapshot" do
+          middleware.call
+
+          snapshot = middleware.instance_variable_get(:@snapshot)
+          expect(snapshot).to be_nil
+        end
+      end
+
+      context "when a charge is removed" do
+        let(:next_middleware) {
+          lambda {
+            charge.destroy
+            BaseResult[:plan].new.tap { it.plan = plan.reload }
+          }
+        }
+        let(:charge) { plan.charges.last }
+
+        before do
+          allow(Plans::UpdatedKafkaProducerService).to receive(:call!)
+        end
+
+        it "notify the removal of the charge" do
+          middleware.call
+
+          expect(Plans::UpdatedKafkaProducerService)
+            .to have_received(:call!)
+            .with(
+              plan:,
+              resources_type: "charge",
+              resources_ids: [charge.id],
+              event_type: "charges.deleted",
+              timestamp: plan.updated_at
+            )
+        end
+      end
+
+      context "when a charge is added" do
+        let(:next_middleware) {
+          lambda {
+            charge
+            BaseResult[:plan].new.tap { it.plan = plan.reload }
+          }
+        }
+        let(:charge) { create(:standard_charge, plan:) }
+
+        before do
+          allow(Plans::UpdatedKafkaProducerService).to receive(:call!)
+        end
+
+        it "notify the removal of the charge" do
+          middleware.call
+
+          expect(Plans::UpdatedKafkaProducerService)
+            .to have_received(:call!)
+            .with(
+              plan:,
+              resources_type: "charge",
+              resources_ids: [charge.id],
+              event_type: "charges.created",
+              timestamp: plan.updated_at
+            )
+        end
+      end
+
+      context "when a pricing group key is added to the charge" do
+        let(:next_middleware) {
+          lambda {
+            charge.properties["pricing_group_keys"] = ["country"]
+            charge.save!
+            BaseResult[:plan].new.tap { it.plan = plan.reload }
+          }
+        }
+        let(:charge) { plan.charges.last }
+
+        before do
+          allow(Plans::UpdatedKafkaProducerService).to receive(:call!)
+        end
+
+        it "notify the update of the pricing group keys" do
+          middleware.call
+
+          expect(Plans::UpdatedKafkaProducerService)
+            .to have_received(:call!)
+            .with(
+              plan:,
+              resources_type: "charge",
+              resources_ids: [charge.id],
+              event_type: "charges.pricing_group_keys_updated",
+              timestamp: plan.updated_at
+            )
+        end
+      end
+
+      context "when a pricing group key is removed from the charge" do
+        let(:next_middleware) {
+          lambda {
+            charge.properties["pricing_group_keys"] = ["country"]
+            charge.save!
+            BaseResult[:plan].new.tap { it.plan = plan.reload }
+          }
+        }
+        let(:charge) do
+          charge = plan.charges.last
+          charge.properties["pricing_group_keys"] = ["country", "region"]
+          charge.save!
+          charge
+        end
+
+        before do
+          allow(Plans::UpdatedKafkaProducerService).to receive(:call!)
+        end
+
+        it "notify the update of the pricing group keys" do
+          middleware.call
+
+          expect(Plans::UpdatedKafkaProducerService)
+            .to have_received(:call!)
+            .with(
+              plan:,
+              resources_type: "charge",
+              resources_ids: [charge.id],
+              event_type: "charges.pricing_group_keys_updated",
+              timestamp: plan.updated_at
+            )
+        end
+      end
+
+      context "when a pricing group key is changed" do
+        let(:next_middleware) {
+          lambda {
+            charge.properties["pricing_group_keys"] = ["zone"]
+            charge.save!
+            BaseResult[:plan].new.tap { it.plan = plan.reload }
+          }
+        }
+        let(:charge) do
+          charge = plan.charges.last
+          charge.properties["pricing_group_keys"] = ["country"]
+          charge.save!
+          charge
+        end
+
+        before do
+          allow(Plans::UpdatedKafkaProducerService).to receive(:call!)
+        end
+
+        it "notify the update of the pricing group keys" do
+          middleware.call
+
+          expect(Plans::UpdatedKafkaProducerService)
+            .to have_received(:call!)
+            .with(
+              plan:,
+              resources_type: "charge",
+              resources_ids: [charge.id],
+              event_type: "charges.pricing_group_keys_updated",
+              timestamp: plan.updated_at
+            )
+        end
+      end
+
+      context "when a filter is added to the charge" do
+        let(:next_middleware) {
+          lambda {
+            charge_filter_value
+            BaseResult[:plan].new.tap { it.plan = plan.reload }
+          }
+        }
+        let(:charge) { plan.charges.last }
+        let(:charge_filter) { create(:charge_filter, charge:, organization:) }
+        let(:charge_filter_value) { create(:charge_filter_value, charge_filter:, values: ["aws"], billable_metric_filter:) }
+
+        let(:billable_metric) { charge.billable_metric }
+        let(:billable_metric_filter) do
+          create(:billable_metric_filter, billable_metric:, organization:, values: ["aws", "gcp", "azure"])
+        end
+
+        before do
+          allow(Plans::UpdatedKafkaProducerService).to receive(:call!)
+        end
+
+        it "notify the removal of the charge" do
+          middleware.call
+
+          expect(Plans::UpdatedKafkaProducerService)
+            .to have_received(:call!)
+            .with(
+              plan:,
+              resources_type: "charge",
+              resources_ids: [charge.id],
+              event_type: "charges.updated",
+              timestamp: plan.updated_at
+            )
+        end
+      end
+
+      context "when a filter is removed from the charge" do
+        let(:next_middleware) {
+          lambda {
+            charge_filter.destroy!
+            BaseResult[:plan].new.tap { it.plan = plan.reload }
+          }
+        }
+        let(:charge) { plan.charges.last }
+        let(:charge_filter) { create(:charge_filter, charge:, organization:) }
+        let(:charge_filter_value) { create(:charge_filter_value, charge_filter:, values: ["aws"], billable_metric_filter:) }
+
+        let(:billable_metric) { charge.billable_metric }
+        let(:billable_metric_filter) do
+          create(:billable_metric_filter, billable_metric:, organization:, values: ["aws", "gcp", "azure"])
+        end
+
+        before do
+          allow(Plans::UpdatedKafkaProducerService).to receive(:call!)
+          charge_filter_value
+        end
+
+        it "notify the removal of the charge" do
+          middleware.call
+
+          expect(Plans::UpdatedKafkaProducerService)
+            .to have_received(:call!)
+            .with(
+              plan:,
+              resources_type: "charge",
+              resources_ids: [charge.id],
+              event_type: "charges.updated",
+              timestamp: plan.updated_at
+            )
+        end
+      end
+
+      context "when filters are changed on the charge" do
+        let(:next_middleware) {
+          lambda {
+            charge_filter1.destroy!
+            charge_filter_value2
+            BaseResult[:plan].new.tap { it.plan = plan.reload }
+          }
+        }
+        let(:charge) { plan.charges.last }
+        let(:billable_metric) { charge.billable_metric }
+        let(:billable_metric_filter) do
+          create(:billable_metric_filter, billable_metric:, organization:, values: ["aws", "gcp", "azure"])
+        end
+
+        let(:charge_filter1) { create(:charge_filter, charge:, organization:) }
+        let(:charge_filter_value1) { create(:charge_filter_value, charge_filter: charge_filter1, values: ["aws"], billable_metric_filter:) }
+
+        let(:charge_filter2) { create(:charge_filter, charge:, organization:) }
+        let(:charge_filter_value2) { create(:charge_filter_value, charge_filter: charge_filter2, values: ["gcp"], billable_metric_filter:) }
+
+        before do
+          allow(Plans::UpdatedKafkaProducerService).to receive(:call!)
+          charge_filter_value1
+        end
+
+        it "notify the removal of the charge" do
+          middleware.call
+
+          expect(Plans::UpdatedKafkaProducerService)
+            .to have_received(:call!)
+            .with(
+              plan:,
+              resources_type: "charge",
+              resources_ids: [charge.id],
+              event_type: "charges.updated",
+              timestamp: plan.updated_at
+            )
+        end
+      end
+
+      context "when filters are changed on the charge but not values" do
+        let(:next_middleware) {
+          lambda {
+            charge_filter1.destroy!
+            charge_filter_value2
+            BaseResult[:plan].new.tap { it.plan = plan.reload }
+          }
+        }
+        let(:charge) { plan.charges.last }
+        let(:billable_metric) { charge.billable_metric }
+        let(:billable_metric_filter) do
+          create(:billable_metric_filter, billable_metric:, organization:, values: ["aws", "gcp", "azure"])
+        end
+
+        let(:charge_filter1) { create(:charge_filter, charge:, organization:) }
+        let(:charge_filter_value1) { create(:charge_filter_value, charge_filter: charge_filter1, values: ["aws"], billable_metric_filter:) }
+
+        let(:charge_filter2) { create(:charge_filter, charge:, organization:) }
+        let(:charge_filter_value2) { create(:charge_filter_value, charge_filter: charge_filter2, values: ["aws"], billable_metric_filter:) }
+
+        before do
+          allow(Plans::UpdatedKafkaProducerService).to receive(:call!)
+          charge_filter_value1
+        end
+
+        it "notify the removal of the charge" do
+          middleware.call
+
+          expect(Plans::UpdatedKafkaProducerService)
+            .to have_received(:call!)
+            .with(
+              plan:,
+              resources_type: "charge",
+              resources_ids: [charge.id],
+              event_type: "charges.updated",
+              timestamp: plan.updated_at
+            )
+        end
+      end
+
+      context "when filter's pricing group keys is changed" do
+        let(:next_middleware) {
+          lambda {
+            charge_filter.properties["pricing_group_keys"] = ["zone"]
+            charge_filter.save!
+            BaseResult[:plan].new.tap { it.plan = plan.reload }
+          }
+        }
+        let(:charge) { plan.charges.last }
+        let(:charge_filter) { create(:charge_filter, charge:, organization:) }
+
+        before do
+          allow(Plans::UpdatedKafkaProducerService).to receive(:call!)
+          charge_filter
+        end
+
+        it "notify the removal of the charge" do
+          middleware.call
+
+          expect(Plans::UpdatedKafkaProducerService)
+            .to have_received(:call!)
+            .with(
+              plan:,
+              resources_type: "charge_filter",
+              resources_ids: [charge_filter.id],
+              event_type: "charge_filters.pricing_group_keys_updated",
+              timestamp: plan.updated_at
+            )
+        end
+      end
+    end
+
+    context "when not premium" do
+      it "does not create a snapshot" do
+        middleware.call
+
+        snapshot = middleware.instance_variable_get(:@snapshot)
+        expect(snapshot).to be_nil
+      end
+    end
+
+    context "without Kafka config", :premium do
+      it "does not create a snapshot" do
+        middleware.call
+
+        snapshot = middleware.instance_variable_get(:@snapshot)
+        expect(snapshot).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/plans/updated_kafka_producer_service_spec.rb
+++ b/spec/services/plans/updated_kafka_producer_service_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Plans::UpdatedKafkaProducerService do
+  subject(:producer_service) do
+    described_class.new(
+      plan:,
+      resources_type: "charge",
+      resources_ids: [resource.id],
+      event_type:,
+      timestamp:
+    )
+  end
+
+  let(:organization) { create(:organization, premium_integrations:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:resource) { create(:standard_charge, plan:, organization:) }
+  let(:event_type) { "charge.deleted" }
+  let(:timestamp) { Time.current }
+
+  let(:premium_integrations) { [] }
+  let(:karafka_producer) { instance_double(WaterDrop::Producer) }
+
+  describe "#call" do
+    before do
+      allow(Karafka).to receive(:producer).and_return(karafka_producer)
+      allow(karafka_producer).to receive(:produce_async)
+    end
+
+    context "with Kafka config", :premium do
+      before do
+        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = "kafka"
+        ENV["LAGO_KAFKA_PLAN_CONFIG_UPDATED_TOPIC"] = "plan_config_updated"
+      end
+
+      let(:premium_integrations) { ["clickhouse_live_aggregation"] }
+
+      it "produces the message on kafka" do
+        freeze_time do
+          producer_service.call
+
+          expect(karafka_producer).to have_received(:produce_async)
+            .with(
+              topic: "plan_config_updated",
+              key: "#{organization.id}-#{plan.id}",
+              payload: {
+                organization_id: organization.id,
+                plan_id: plan.id,
+                resources_type: "charge",
+                resources_ids: [resource.id],
+                event_type:,
+                timestamp: timestamp.iso8601(3),
+                produced_at: Time.current.iso8601
+              }
+            )
+        end
+      end
+
+      context "when the clickhouse live aggregation is not enabled" do
+        let(:premium_integrations) { [] }
+
+        it "does not produce the message on kafka" do
+          freeze_time do
+            producer_service.call
+
+            expect(karafka_producer).not_to have_received(:produce_async)
+          end
+        end
+      end
+    end
+
+    context "without kafka config" do
+      before do
+        ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"] = nil
+        ENV["LAGO_KAFKA_PLAN_CONFIG_UPDATED_TOPIC"] = nil
+      end
+
+      it "does not produce the event on kafka" do
+        freeze_time do
+          producer_service.call
+
+          expect(karafka_producer).not_to have_received(:produce_async)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic. It replaces https://github.com/getlago/lago-api/pull/4402

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This PR is the first step of the "Pre-aggregation refresh" part of the feature.
- It adds a new Kafka producer  responsible from notifying the events processor about plan config (charge/charge filter) refresh
- It adds a new `Plans::UpdateNotificationMiddleware` that will be plugged in plan-related services
