### PR TITLE
misc(sidekiq): Add `sidekiq-pro` as an optional dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:3.4.7-slim AS build
 
+ARG BUNDLE_WITH
+
 WORKDIR /app
 
 RUN apt update && apt upgrade -y
@@ -7,9 +9,9 @@ RUN apt install nodejs curl build-essential git pkg-config libpq-dev libclang-de
   curl https://sh.rustup.rs -sSf | bash -s -- -y
 
 RUN curl -L https://github.com/pdfcpu/pdfcpu/releases/download/v0.11.0/pdfcpu_0.11.0_Linux_x86_64.tar.xz -o pdfcpu.tar.xz \
-    && tar -xf pdfcpu.tar.xz \
-    && install -m 755 pdfcpu_0.11.0_Linux_x86_64/pdfcpu /usr/local/bin/ \
-    && rm -rf pdfcpu.tar.xz pdfcpu_0.11.0_Linux_x86_64
+  && tar -xf pdfcpu.tar.xz \
+  && install -m 755 pdfcpu_0.11.0_Linux_x86_64/pdfcpu /usr/local/bin/ \
+  && rm -rf pdfcpu.tar.xz pdfcpu_0.11.0_Linux_x86_64
 
 COPY ./Gemfile /app/Gemfile
 COPY ./Gemfile.lock /app/Gemfile.lock
@@ -18,10 +20,16 @@ ENV BUNDLER_VERSION='2.6.8'
 ENV PATH="$PATH:/root/.cargo/bin/"
 RUN gem install bundler --no-document -v '2.6.8'
 
-RUN bundle config build.nokogiri --use-system-libraries &&\
-  bundle install --jobs=3 --retry=3 --without development test
+ENV BUNDLE_WITH=${BUNDLE_WITH:-}
+ENV BUNDLE_WITHOUT="development test"
+RUN --mount=type=secret,id=BUNDLE_GEMS__CONTRIBSYS__COM,env=BUNDLE_GEMS__CONTRIBSYS__COM \
+  bundle config build.nokogiri --use-system-libraries &&\
+  bundle install --jobs=3 --retry=3
 
 FROM ruby:3.4.7-slim
+
+ARG BUNDLE_WITH
+
 RUN apt update && apt upgrade -y
 RUN apt install git libpq-dev curl postgresql-client -y
 
@@ -32,6 +40,9 @@ ARG GOCARDLESS_CLIENT_SECRET
 ENV SEGMENT_WRITE_KEY=$SEGMENT_WRITE_KEY
 ENV GOCARDLESS_CLIENT_ID=$GOCARDLESS_CLIENT_ID
 ENV GOCARDLESS_CLIENT_SECRET=$GOCARDLESS_CLIENT_SECRET
+
+ENV BUNDLE_WITH=${BUNDLE_WITH:-}
+ENV BUNDLE_WITHOUT="development test"
 
 COPY --from=build /usr/local/bundle/ /usr/local/bundle
 COPY --from=build /usr/local/bin/pdfcpu /usr/local/bin/pdfcpu

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,11 @@ gem "puma", "~> 6.5"
 gem "rails", "~> 8.0"
 gem "redis"
 gem "sidekiq"
+group :'sidekiq-pro', optional: true do
+  source "https://gems.contribsys.com/" do
+    gem "sidekiq-pro"
+  end
+end
 gem "sidekiq-throttled", "1.4.0" # '1.5.0' was losing some jobs
 gem "throttling"
 gem "dry-validation"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,12 @@ GIT
       railties
 
 GEM
+  remote: https://gems.contribsys.com/
+  specs:
+    sidekiq-pro (7.3.6)
+      sidekiq (>= 7.3.7, < 8)
+
+GEM
   remote: https://rubygems.org/
   specs:
     aasm (5.5.0)
@@ -1115,6 +1121,7 @@ DEPENDENCIES
   sentry-sidekiq
   shoulda-matchers
   sidekiq
+  sidekiq-pro!
   sidekiq-throttled (= 1.4.0)
   simplecov
   slim


### PR DESCRIPTION
## Context

Today, we are using Sidekiq to handle our background jobs. While it works well for most of our needs, we are reaching some limitations with the open-source version, particularly around job reliability during high load.

Sidekiq uses `BRPOP` to fetch a job from the queue in Redis. This is very efficient and simple but it has one drawback: the job is now removed from Redis. If Sidekiq crashes while processing that job, it is lost forever.

## Description

This adds `sidekiq-pro` as an optional dependency which can be install when building the Docker image.

This also updated the `Dockerfile` to:

1. Accept a `BUNDLE_WITH` which can be used to conditionally enabled Sidekiq Pro when the value is `sidekiq-pro`.
2. Mount the `BUNDLE_GEMS__CONTRIBSYS__COM` variable as a Docker secret as it's only required during the build and is a sensitive information.
3. Rely on `BUNDLE_WITHOUT` env variable instead of the `--without` command line option to be consistent and because it is deprecated:

    ```
    [DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set without 'test'`, and stop using this flag
    ```

Note that we also added a `LAGO_SIDEKIQ_PRO_REQUIRED` env variable which will cause the app to not boot if Sidekiq Pro is not properly installed.