### PR TITLE
fix(mailer): Use lago from email if org.email is not set

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -202,7 +202,7 @@ class Organization < ApplicationRecord
   end
 
   def from_email_address
-    return email if from_email_enabled? && email
+    return email if from_email_enabled?
 
     ENV["LAGO_FROM_EMAIL"]
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -383,11 +383,9 @@ RSpec.describe Organization do
     context "when organization from_email integration is enabled" do
       around { |test| lago_premium!(&test) }
 
-      it "returns the organization email if set" do
+      it "returns the organization email" do
         organization.update!(premium_integrations: ["from_email"])
         expect(organization.from_email_address).to eq(organization.email)
-        organization.update!(email: nil)
-        expect(organization.from_email_address).to eq("noreply@getlago.com")
       end
     end
   end


### PR DESCRIPTION
If an organization has the premium integration `from_email`, we'll use `organization.email` as a from address. If the address is not set in the organization, we should default to the lago from address.

The Admin emails should always use the lago address. **Ideally, the "public" and "internal" emails should be separated!**

This was spotted from a dead job `ArgumentError: SMTP From address may not be blank: nil` on a staging organization.