### PR TITLE
misc(serializers): Add total_aggregated_units to serializers

### DIFF
--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -30,6 +30,7 @@ module V1
       def current_usage_data(fees)
         {
           units: current_units(fees).to_s,
+          total_aggregated_units: total_aggregated_units(fees).to_s,
           events_count: fees.sum { |f| f.events_count.to_i },
           amount_cents: fees.sum(&:amount_cents),
           amount_currency: fees.first.amount_currency
@@ -38,6 +39,10 @@ module V1
 
       def current_units(fees)
         fees.sum { |f| BigDecimal(f.units) }
+      end
+
+      def total_aggregated_units(fees)
+        fees.sum { |f| BigDecimal(f.total_aggregated_units || 0) }
       end
 
       def past_usage?

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -37,6 +37,7 @@ module V1
         taxes_amount_cents: model.taxes_amount_cents,
         taxes_precise_amount: model.taxes_precise_amount_cents.fdiv(subunit_to_unit),
         taxes_rate: model.taxes_rate,
+        total_aggregated_units: model.total_aggregated_units,
         total_amount_cents: model.total_amount_cents,
         total_amount_currency: model.amount_currency,
         units: model.units,

--- a/spec/scenarios/charge_models/dynamic_spec.rb
+++ b/spec/scenarios/charge_models/dynamic_spec.rb
@@ -117,8 +117,8 @@ describe "Charge Models - Dynamic Pricing Scenarios", transaction: false do
 
         expect(json[:customer_usage][:charges_usage][0][:grouped_usage]).to match_array(
           [
-            {amount_cents: 902, events_count: 1, units: "10.0", grouped_by: {group_key: "value 2"}, filters: [], pricing_unit_details: nil},
-            {amount_cents: 10, events_count: 1, units: "10.0", grouped_by: {group_key: "value 1"}, filters: [], pricing_unit_details: nil}
+            {amount_cents: 902, events_count: 1, total_aggregated_units: "10.0", units: "10.0", grouped_by: {group_key: "value 2"}, filters: [], pricing_unit_details: nil},
+            {amount_cents: 10, events_count: 1, total_aggregated_units: "10.0", units: "10.0", grouped_by: {group_key: "value 1"}, filters: [], pricing_unit_details: nil}
           ]
         )
       end

--- a/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
         billable_metric: billable_metric,
         charge: charge,
         units: "10",
+        total_aggregated_units: "10",
         events_count: 12,
         amount_cents: 100,
         amount_currency: "EUR",
@@ -78,6 +79,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
           "pricing_unit_details" => nil,
           "events_count" => 12,
           "units" => "10.0",
+          "total_aggregated_units" => "10.0",
           "grouped_by" => {"card_type" => "visa"},
           "filters" => []
         }
@@ -93,6 +95,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
     it "serializes the fee" do
       expect(result["charges"].first).to include(
         "units" => "10.0",
+        "total_aggregated_units" => "10.0",
         "events_count" => 12,
         "amount_cents" => 100,
         "pricing_unit_details" => {
@@ -123,6 +126,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
             },
             "events_count" => 12,
             "units" => "10.0",
+            "total_aggregated_units" => "10.0",
             "grouped_by" => {"card_type" => "visa"},
             "filters" => []
           }

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe ::V1::FeeSerializer do
         "amount_currency" => fee.amount_currency,
         "taxes_amount_cents" => fee.taxes_amount_cents,
         "taxes_rate" => fee.taxes_rate,
+        "total_aggregated_units" => fee.total_aggregated_units,
         "total_amount_cents" => fee.total_amount_cents,
         "total_amount_currency" => fee.amount_currency,
         "precise_amount" => fee.precise_amount_cents.fdiv(100.to_d).to_s,


### PR DESCRIPTION
## Context

The "active units" value exists on fee objects (`total_aggregated_units`) but it is not exposed.

## Description

Add `total_aggregated_units` to `ChargeUsageSerializer` and `FeeSerializer`.