### PR TITLE
feat(wt): Expose invoice_id and credit_note_id for WalletTransaction

### DIFF
--- a/app/serializers/v1/wallet_transaction_serializer.rb
+++ b/app/serializers/v1/wallet_transaction_serializer.rb
@@ -6,6 +6,8 @@ module V1
       payload = {
         lago_id: model.id,
         lago_wallet_id: model.wallet_id,
+        lago_invoice_id: model.invoice_id,
+        lago_credit_note_id: model.credit_note_id,
         status: model.status,
         source: model.source,
         transaction_status: model.transaction_status,

--- a/spec/factories/wallet_transactions.rb
+++ b/spec/factories/wallet_transactions.rb
@@ -24,5 +24,13 @@ FactoryBot.define do
 
       invoice { association(:invoice, customer:, organization: customer.organization) }
     end
+
+    trait :with_credit_note do
+      transient do
+        customer { association(:customer) }
+      end
+
+      credit_note { association(:credit_note, customer:, invoice:, organization: customer.organization) }
+    end
   end
 end

--- a/spec/serializers/v1/wallet_transaction_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_serializer_spec.rb
@@ -8,16 +8,17 @@ RSpec.describe ::V1::WalletTransactionSerializer do
   end
 
   let(:wallet_transaction) { create(:wallet_transaction) }
+  let(:includes) { [] }
 
   context "when includes is empty" do
-    let(:includes) { [] }
-
     it "serializes the object" do
       result = JSON.parse(serializer.to_json)
 
       expect(result["wallet_transaction"]).to include(
         "lago_id" => wallet_transaction.id,
         "lago_wallet_id" => wallet_transaction.wallet_id,
+        "lago_invoice_id" => nil,
+        "lago_credit_note_id" => nil,
         "status" => wallet_transaction.status,
         "source" => wallet_transaction.source,
         "transaction_status" => wallet_transaction.transaction_status,
@@ -30,6 +31,19 @@ RSpec.describe ::V1::WalletTransactionSerializer do
         "invoice_requires_successful_payment" => wallet_transaction.invoice_requires_successful_payment?,
         "metadata" => wallet_transaction.metadata,
         "name" => "Custom Transaction Name"
+      )
+    end
+  end
+
+  context "when transaction has an invoice and a credit note" do
+    let(:wallet_transaction) { create(:wallet_transaction, :with_invoice, :with_credit_note) }
+
+    it "serializes the invoice id" do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result["wallet_transaction"]).to include(
+        "lago_invoice_id" => wallet_transaction.invoice.id,
+        "lago_credit_note_id" => wallet_transaction.credit_note.id
       )
     end
   end


### PR DESCRIPTION
Expose invoice_id and credit_note_id for WalletTransaction in the serializer. ISSUE-1201

The ids are stored directly in the wallet transaction objects so no extra db query is needed.