### PR TITLE
fix(manual-payments): Fix manual payments with no amount_cents

### DIFF
--- a/app/services/payments/manual_create_service.rb
+++ b/app/services/payments/manual_create_service.rb
@@ -73,7 +73,7 @@ module Payments
       return result.forbidden_failure! if !License.premium?
       return result.forbidden_failure! unless invoice.allow_manual_payment?
       result.single_validation_failure!(error_code: "invalid_date", field: "paid_at") unless valid_paid_at?
-      result.single_validation_failure!(error_code: "value_is_mandatory", field: "amount_cents") unless valid_amount_cents?
+      result.single_validation_failure!(error_code: "invalid_value", field: "amount_cents") unless valid_amount_cents?
     end
 
     def valid_paid_at?

--- a/spec/requests/api/v1/payments_controller_spec.rb
+++ b/spec/requests/api/v1/payments_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Api::V1::PaymentsController, type: :request do
 
       include_examples "requires API permission", "payment", "write"
 
-      it "delegates to Payments::ManualCreateService", :aggregate_failures do
+      it "delegates to Payments::ManualCreateService" do
         subject
 
         expect(Payments::ManualCreateService).to have_received(:call).with(organization:, params:)
@@ -55,7 +55,7 @@ RSpec.describe Api::V1::PaymentsController, type: :request do
         }
       end
 
-      let(:error_details) { {amount_cents: %w[value_is_mandatory]} }
+      let(:error_details) { {amount_cents: %w[invalid_value]} }
 
       around { |test| lago_premium!(&test) }
 

--- a/spec/services/payments/manual_create_service_spec.rb
+++ b/spec/services/payments/manual_create_service_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Payments::ManualCreateService do
 
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:amount_cents]).to eq(["value_is_mandatory"])
+          expect(result.error.messages[:amount_cents]).to eq(["invalid_value"])
         end
       end
 


### PR DESCRIPTION
## Context

When calling the endpoint for creating a manual payment: `POST /api/v1/payments`
It failed if `amount_cents` was missing or misspelled e.g.: `amount_in_cents`.

## Description

This PR addresses the issue with returning `422` error.

```
error_code: "value_is_mandatory", field: "amount_cents"
```