### PR TITLE
chore: Fix brittle tests

### DIFF
--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -686,7 +686,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
 
     context "when adding a fixed charge" do
       let(:plan) { create(:plan, organization:, interval: :weekly) }
-      let(:subscription) { create(:subscription, :active, :calendar, plan:, started_at: started_at) }
+      let(:subscription) { create(:subscription, :active, :anniversary, plan:, started_at:, subscription_at: started_at) }
       let(:started_at) { 3.days.ago }
 
       before { subscription }
@@ -751,7 +751,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
           expect(json[:plan][:fixed_charges].first[:units]).to eq("100.0")
         end
 
-        xit "creates fixed charge events for all active subscriptions with next billing period timestamp" do
+        it "creates fixed charge events for all active subscriptions with next billing period timestamp" do
           expect { subject }.to change(FixedChargeEvent, :count).by(1)
 
           fixed_charge = FixedCharge.find(json[:plan][:fixed_charges].first[:lago_id])
@@ -760,7 +760,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
             subscription:,
             fixed_charge:,
             units: 100,
-            timestamp: be_within(1.second).of((started_at + 1.week).beginning_of_week)
+            timestamp: be_within(1.second).of((started_at + 7.days).beginning_of_day)
           )
         end
       end
@@ -768,7 +768,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
 
     context "when editing a fixed charge" do
       let(:plan) { create(:plan, organization:, interval: :weekly) }
-      let(:subscription) { create(:subscription, :active, :calendar, plan:, started_at: started_at) }
+      let(:subscription) { create(:subscription, :active, :anniversary, plan:, started_at:, subscription_at: started_at) }
       let(:fixed_charge) { create(:fixed_charge, plan:, add_on:, units: 1) }
       let(:started_at) { 3.days.ago }
 
@@ -826,14 +826,14 @@ RSpec.describe Api::V1::PlansController, type: :request do
           expect(json[:plan][:fixed_charges].first[:units]).to eq("25.0")
         end
 
-        xit "creates fixed charge events for all active subscriptions with next billing period timestamp" do
+        it "creates fixed charge events for all active subscriptions with next billing period timestamp" do
           expect { subject }.to change(FixedChargeEvent, :count).by(1)
 
           expect(fixed_charge.events.first).to have_attributes(
             subscription:,
             fixed_charge:,
             units: 25,
-            timestamp: be_within(1.second).of((started_at + 1.week).beginning_of_week)
+            timestamp: be_within(1.second).of((started_at + 1.week).beginning_of_day)
           )
         end
       end


### PR DESCRIPTION
Fix brittle tests base on dates calculations. Now these does not depend on current day of the week to pass.