### PR TITLE
feat(integration): Raise BadGatewayError on 502 errors

### DIFF
--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -7,7 +7,7 @@ module Integrations
     class BaseService < BaseService
       BASE_URL = "https://api.nango.dev/"
       REQUEST_LIMIT_ERROR_CODE = "SSS_REQUEST_LIMIT_EXCEEDED"
-      BAD_REQUEST_ERROR = "502 Bad Gateway"
+      BAD_GATEWAY_ERROR = "502 Bad Gateway"
 
       def initialize(integration:, options: {})
         @integration = integration
@@ -162,14 +162,15 @@ module Integrations
       end
 
       def bad_gateway_error?(http_error)
-        http_error.error_body.include?(BAD_REQUEST_ERROR)
+        http_error.error_code.to_s == "502" ||
+          http_error.error_body.include?(BAD_GATEWAY_ERROR)
       end
 
       def parse_response(response)
         JSON.parse(response.body)
       rescue JSON::ParserError
-        if response.body.include?(BAD_REQUEST_ERROR)
-          # NOTE: Sometimes, Anrock is responding with an HTTP 200 with a payload containing a 502 error...
+        if response.body.include?(BAD_GATEWAY_ERROR)
+          # NOTE: Sometimes, Anrok is responding with an HTTP 200 with a payload containing a 502 error...
           raise(Integrations::Aggregator::BadGatewayError.new(response.body, http_client.uri))
         end
 

--- a/app/services/integrations/aggregator/taxes/invoices/create_draft_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_draft_service.rb
@@ -23,7 +23,7 @@ module Integrations
             result
           rescue LagoHttpClient::HttpError => e
             raise RequestLimitError(e) if request_limit_error?(e)
-            raise e if bad_gateway_error?(e)
+            raise Integrations::Aggregator::BadGatewayError.new(e.error_body, e.uri) if bad_gateway_error?(e)
 
             code = code(e)
             message = message(e)

--- a/app/services/integrations/aggregator/taxes/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/create_service.rb
@@ -25,7 +25,7 @@ module Integrations
             result
           rescue LagoHttpClient::HttpError => e
             raise Integrations::Aggregator::RequestLimitError(e) if request_limit_error?(e)
-            raise e if bad_gateway_error?(e)
+            raise Integrations::Aggregator::BadGatewayError.new(e.error_body, e.uri) if bad_gateway_error?(e)
 
             code = code(e)
             message = message(e)


### PR DESCRIPTION
If Anrok returns a Bad Gateway error with a 200 status, we handle this by raising a custom `Integrations::Aggregator::BadGatewayError`. See https://github.com/getlago/lago-api/pull/3234

This error can be use to retry the job, like for RefreshOngoingBalanceJob
https://github.com/getlago/lago-api/blob/b1596cd6af82b0e9871949b5fd25438732bb2e49/app/jobs/wallets/refresh_ongoing_balance_job.rb#L11

Unfortunately, of the error is a return with a 502 status, we'll raise a regular `LagoHttpClient::HttpError`, which is not retrie

<img width="2456" height="612" alt="CleanShot 2025-10-15 at 15 50 43@2x" src="https://github.com/user-attachments/assets/0ded4d2c-0bd9-40e7-be44-990ac735463f" />



This PR aligns the behavior to always raise this custom error.

Notice that this custom error extends the HttpError:
https://github.com/getlago/lago-api/blob/b1596cd6af82b0e9871949b5fd25438732bb2e49/app/services/integrations/aggregator/bad_gateway_error.rb#L5


## Main changes

1. refactor tests to use webmock instead of mocking the client
2. rename `BAD_REQUEST_ERROR` to `BAD_GATEWAY_ERROR`
3. make bad_gateway_error?(e) return true if status is 502 (not just content grepping)
4. raise `BadGatewayError` instead of `HttpError`