### PR TITLE
feat(fixed-charges): Add invoice#different_boundaries_for_subscription_and_fixed_charges

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -356,20 +356,22 @@ class Invoice < ApplicationRecord
     end
   end
 
-  def different_boundaries_for_subscription_and_charges(subscription)
-    subscription_from = invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date
-    subscription_to = invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date
-    charges_from = invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.to_date
-    charges_to = invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.to_date
+  def has_different_boundaries_for_subscription_and_charges?(subscription)
+    invoice_subscription = invoice_subscription(subscription.id)
+    subscription_from = invoice_subscription.from_datetime_in_customer_timezone&.to_date
+    subscription_to = invoice_subscription.to_datetime_in_customer_timezone&.to_date
+    charges_from = invoice_subscription.charges_from_datetime_in_customer_timezone&.to_date
+    charges_to = invoice_subscription.charges_to_datetime_in_customer_timezone&.to_date
 
     subscription_from != charges_from && subscription_to != charges_to
   end
 
-  def different_boundaries_for_subscription_and_fixed_charges(subscription)
-    subscription_from = invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date
-    subscription_to = invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date
-    fixed_charges_from = invoice_subscription(subscription.id).fixed_charges_from_datetime_in_customer_timezone&.to_date
-    fixed_charges_to = invoice_subscription(subscription.id).fixed_charges_to_datetime_in_customer_timezone&.to_date
+  def has_different_boundaries_for_subscription_and_fixed_charges?(subscription)
+    invoice_subscription = invoice_subscription(subscription.id)
+    subscription_from = invoice_subscription.from_datetime_in_customer_timezone&.to_date
+    subscription_to = invoice_subscription.to_datetime_in_customer_timezone&.to_date
+    fixed_charges_from = invoice_subscription.fixed_charges_from_datetime_in_customer_timezone&.to_date
+    fixed_charges_to = invoice_subscription.fixed_charges_to_datetime_in_customer_timezone&.to_date
 
     subscription_from != fixed_charges_from && subscription_to != fixed_charges_to
   end

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -8,7 +8,7 @@
 
     / Subscription fee section
     - if subscription? && subscription_fees(subscription.id).subscription.any?
-      .invoice-resume.overflow-auto class="#{'mb-24' if subscription_fees(subscription.id).charge.any? && different_boundaries_for_subscription_and_charges(subscription)}"
+      .invoice-resume.overflow-auto class="#{'mb-24' if subscription_fees(subscription.id).charge.any? && has_different_boundaries_for_subscription_and_charges?(subscription)}"
         table.invoice-resume-table width="100%"
           tr.first_child
             - if subscription.plan.bill_charges_monthly? && !FeeDisplayHelper.should_display_subscription_fee?(invoice_subscription)
@@ -62,7 +62,7 @@
       - if subscription.plan.charges.where(pay_in_advance: false).any? && existing_fees_in_interval?(subscription_id: subscription.id)
         .invoice-resume.overflow-auto
           table.invoice-resume-table width="100%"
-            - if different_boundaries_for_subscription_and_charges(subscription) || subscription.plan.bill_charges_monthly?
+            - if has_different_boundaries_for_subscription_and_charges?(subscription) || subscription.plan.bill_charges_monthly?
               tr.first_child
                 td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(invoice_subscription.charges_from_datetime_in_customer_timezone&.to_date, format: :default), to_date: I18n.l(invoice_subscription.charges_to_datetime_in_customer_timezone&.to_date, format: :default))
                 td.body-2 = I18n.t('invoice.units')

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -807,8 +807,8 @@ RSpec.describe Invoice do
     end
   end
 
-  describe "#different_boundaries_for_subscription_and_charges" do
-    subject { invoice.different_boundaries_for_subscription_and_charges(subscription) }
+  describe "#has_different_boundaries_for_subscription_and_charges?" do
+    subject { invoice.has_different_boundaries_for_subscription_and_charges?(subscription) }
 
     let(:invoice) { invoice_subscription.invoice }
     let(:subscription) { invoice_subscription.subscription }
@@ -881,8 +881,8 @@ RSpec.describe Invoice do
     end
   end
 
-  describe "#different_boundaries_for_subscription_and_fixed_charges" do
-    subject { invoice.different_boundaries_for_subscription_and_fixed_charges(subscription) }
+  describe "#has_different_boundaries_for_subscription_and_fixed_charges?" do
+    subject { invoice.has_different_boundaries_for_subscription_and_fixed_charges?(subscription) }
 
     let(:invoice) { invoice_subscription.invoice }
     let(:subscription) { invoice_subscription.subscription }


### PR DESCRIPTION
`different_boundaries_for_subscription_and_fixed_charges` is required to decide how we render the invoice fixed charge fees within the invoice document.

also cover with tests invoice#different_boundaries_for_subscription_and_charge
