### PR TITLE
feat(live-agg): Add missing distinc_codes in preagg event store

### DIFF
--- a/app/services/events/stores/aggregated_clickhouse_store.rb
+++ b/app/services/events/stores/aggregated_clickhouse_store.rb
@@ -84,6 +84,16 @@ module Events
         query.project(select).to_sql
       end
 
+      def distinct_codes
+        Events::Stores::Utils::ClickhouseConnection.with_retry do
+          ::Clickhouse::EventsEnrichedExpanded
+            .where(external_subscription_id: subscription.external_id)
+            .where(organization_id: subscription.organization.id)
+            .where(timestamp: from_datetime..applicable_to_datetime)
+            .pluck("DISTINCT(code)")
+        end
+      end
+
       def distinct_charge_filter_ids
         ::Clickhouse::EventsEnrichedExpanded
           .where(subscription_id: subscription.id)


### PR DESCRIPTION
## Context

This PR is part of the Pre-aggregation epic

The main goal of this feature is to setup a complete aggregation pipeline that will be leveraged to compute the customer usage without re-querying the full set of events.

## Description

This PR add the missing `distinct_codes` method in the `Events::Stores::AggregatedClickhouseStore`. It's goal is to avoid performing events aggregation on billable metrics that did not received any events in a period