### PR TITLE
fix(manual-payments): Fix manual payments validations

### DIFF
--- a/app/services/payments/manual_create_service.rb
+++ b/app/services/payments/manual_create_service.rb
@@ -68,12 +68,15 @@ module Payments
     end
 
     def check_preconditions
+      return result.single_validation_failure!(error_code: "value_is_mandatory", field: "invoice_id") if params[:invoice_id].blank?
+      return result.single_validation_failure!(error_code: "invalid_value", field: "amount_cents") unless valid_amount_cents?
       return result.not_found_failure!(resource: "invoice") unless invoice
       return result if invoice.invoice_type == "advance_charges"
+
       return result.forbidden_failure! if !License.premium?
       return result.forbidden_failure! unless invoice.allow_manual_payment?
+
       result.single_validation_failure!(error_code: "invalid_date", field: "paid_at") unless valid_paid_at?
-      result.single_validation_failure!(error_code: "invalid_value", field: "amount_cents") unless valid_amount_cents?
     end
 
     def valid_paid_at?

--- a/spec/services/payments/manual_create_service_spec.rb
+++ b/spec/services/payments/manual_create_service_spec.rb
@@ -86,6 +86,30 @@ RSpec.describe Payments::ManualCreateService do
         end
       end
 
+      context "when reference in missing" do
+        let(:params) { {invoice_id:, amount_cents: 123, paid_at:} }
+
+        it "returns a validation failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:reference]).to eq(["value_is_mandatory"])
+        end
+      end
+
+      context "when invoice_id in missing" do
+        let(:params) { {amount_cents: 123, paid_at:} }
+
+        it "returns a validation failure" do
+          result = service.call
+
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:invoice_id]).to eq(["value_is_mandatory"])
+        end
+      end
+
       context "when paid_at format is invalid" do
         let(:paid_at) { "invalid_date" }
 


### PR DESCRIPTION
## Context

This is a followup PR after https://github.com/getlago/lago-api/pull/4490

## Description

This PR adds some more validations to `Payments::ManualCreateService`.