### PR TITLE
fix(event): Fix Postgres event store connection

### DIFF
--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Events::Stores::PostgresStore do
     end
 
     describe "#prorated_unique_count" do
-      it "returns the number of unique active event properties", transaction: false do
+      it "returns the number of unique active event properties" do
         create(
           :event,
           organization_id: organization.id,
@@ -56,7 +56,7 @@ RSpec.describe Events::Stores::PostgresStore do
       end
 
       context "with multiple events at the same day" do
-        it "returns the number of unique active event properties merged within one day", transaction: false do
+        it "returns the number of unique active event properties merged within one day" do
           event_params = [
             {timestamp: boundaries[:from_datetime], operation_type: "remove"},
             {timestamp: boundaries[:from_datetime] + 1.hour, operation_type: "add"},
@@ -261,7 +261,7 @@ RSpec.describe Events::Stores::PostgresStore do
     end
 
     describe "#prorated_unique_count_breakdown" do
-      it "returns the breakdown of add and remove of unique event properties", transaction: false do
+      it "returns the breakdown of add and remove of unique event properties" do
         Event.create!(
           transaction_id: SecureRandom.uuid,
           organization_id: organization.id,
@@ -338,7 +338,7 @@ RSpec.describe Events::Stores::PostgresStore do
     end
 
     describe "#prorated_sum" do
-      it "returns the prorated sum of event properties", transaction: false do
+      it "returns the prorated sum of event properties" do
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
 
@@ -346,7 +346,7 @@ RSpec.describe Events::Stores::PostgresStore do
       end
 
       context "with persisted_duration" do
-        it "returns the prorated sum of event properties", transaction: false do
+        it "returns the prorated sum of event properties" do
           event_store.aggregation_property = billable_metric.field_name
           event_store.numeric_property = true
 
@@ -512,7 +512,7 @@ RSpec.describe Events::Stores::PostgresStore do
         event_store.numeric_property = true
       end
 
-      it "returns the weighted sum of event properties", transaction: false do
+      it "returns the weighted sum of event properties" do
         expect(event_store.weighted_sum.round(5)).to eq(0.02218)
       end
 
@@ -523,7 +523,7 @@ RSpec.describe Events::Stores::PostgresStore do
           ]
         end
 
-        it "returns the weighted sum of event properties", transaction: false do
+        it "returns the weighted sum of event properties" do
           expect(event_store.weighted_sum.round(5)).to eq(1000.0)
         end
       end
@@ -544,7 +544,7 @@ RSpec.describe Events::Stores::PostgresStore do
           ]
         end
 
-        it "returns the weighted sum of event properties", transaction: false do
+        it "returns the weighted sum of event properties" do
           expect(event_store.weighted_sum.round(5)).to eq(6.0)
         end
       end
@@ -552,7 +552,7 @@ RSpec.describe Events::Stores::PostgresStore do
       context "with initial value" do
         let(:initial_value) { 1000 }
 
-        it "uses the initial value in the aggregation", transaction: false do
+        it "uses the initial value in the aggregation" do
           expect(event_store.weighted_sum(initial_value:).round(5)).to eq(1000.02218)
         end
 
@@ -574,7 +574,7 @@ RSpec.describe Events::Stores::PostgresStore do
           ]
         end
 
-        it "returns the weighted sum of event properties scoped to the group", transaction: false do
+        it "returns the weighted sum of event properties scoped to the group" do
           expect(event_store.weighted_sum.round(5)).to eq(1000.0)
         end
       end


### PR DESCRIPTION
## Context

Some of the Postgres store methods used `ActiveRecord::Base.connection` which caused the tests to fail when running with `transaction` database cleaner strategy. This is due to the fact that we would create the event in a transaction of the `primary` connection and check the results in the `events` connection which could not retrieve the uncommitted data.

Note that it works properly outside of tests because both connections use the same database and we never actually try to fetch events from the store within the same transaction that create events.

## Description

This fixes it by relying on `Event.connection`. It also slightly refactors the code to limit mistakes in the future.