### PR TITLE
chore(seeds): Update seeds to avoid events in future

### DIFF
--- a/db/seeds/21_events.rb
+++ b/db/seeds/21_events.rb
@@ -29,11 +29,11 @@ end
 # NOTE: Assigns valid events
 6.times do |offset|
   5.times do
-    create_event(code: sum_bm.code, time: (offset.month - rand(1..20).days).ago)
+    create_event(code: sum_bm.code, time: (offset.month + rand(1..20).days).ago)
   end
 
   2.times do
-    create_event(code: count_bm.code, time: (offset.month - rand(1..20).days).ago)
+    create_event(code: count_bm.code, time: (offset.month + rand(1..20).days).ago)
   end
 end
 


### PR DESCRIPTION
## Context

The seeds currently generate events with timestamp `(offset.month - rand(1..20).days).ago` when `offset` goes from `0` to `5`. This means that for offset `0`, the timestamp will be in the future. I believe this is a bug introduced in https://github.com/getlago/lago-api/commit/7aa074069298da6c094b26447cd3669995105e8d as we previously defined the timestamp as `Time.current - offset.month - rand(1..20).days`.

## Description

This changes the events creation to ensure all events are in the past.