### PR TITLE
chore(karafka): Ensure karafka producer close

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -47,11 +47,11 @@ workers ENV.fetch("WEB_CONCURRENCY", 0)
 
 # Ensure we flush and close Karafka producer when puma is shutting down
 if ENV.fetch("WEB_CONCURRENCY", 0).to_i > 0
-  before_worker_shutdown do
+  on_worker_shutdown do
     ::Karafka.producer.close
   end
 else
-  after_stopped do
+  on_stopped do
     ::Karafka.producer.close
   end
 end


### PR DESCRIPTION
- When a puma worker (in cluster mode) or puma itself (in single mode) is shutting down, we should ensure that karafka producer is flushing all async messages.