### PR TITLE
fix(self-hosted): Make sure that event_id removal on cached_aggregation is safe

### DIFF
--- a/app/models/cached_aggregation.rb
+++ b/app/models/cached_aggregation.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CachedAggregation < ApplicationRecord
+  self.ignored_columns += %w[event_id]
+
   belongs_to :organization
   belongs_to :charge
   belongs_to :group, optional: true

--- a/db/migrate/20251020090137_remove_event_id_from_cached_aggregation.rb
+++ b/db/migrate/20251020090137_remove_event_id_from_cached_aggregation.rb
@@ -2,8 +2,13 @@
 
 class RemoveEventIdFromCachedAggregation < ActiveRecord::Migration[8.0]
   def up
-    safety_assured do
-      remove_column :cached_aggregations, :event_id
+    # This migration has been removed to allow safe upgrade for self hosted instances
+    # It will be replaced with an other migration after a first phase of cleanup to make sure that no
+    # code relies on the event_id column anymore
+    unless Rails.env.production?
+      safety_assured do
+        remove_column :cached_aggregations, :event_id
+      end
     end
   end
 end

--- a/db/migrate/20251020142629_add_index_on_cached_aggregation_created_at.rb
+++ b/db/migrate/20251020142629_add_index_on_cached_aggregation_created_at.rb
@@ -4,7 +4,7 @@ class AddIndexOnCachedAggregationCreatedAt < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
   def up
-    remove_index :cached_aggregations, name: :idx_aggregation_lookup_with_transaction_id, if_exists: true
+    remove_index :cached_aggregations, name: :idx_aggregation_lookup_with_transaction_id, if_exists: true, algorithm: :concurrently
 
     safety_assured do
       add_index(
@@ -28,7 +28,7 @@ class AddIndexOnCachedAggregationCreatedAt < ActiveRecord::Migration[8.0]
         algorithm: :concurrently
       )
 
-      remove_index :cached_aggregations, name: :idx_cached_agg_comprehensive
+      remove_index :cached_aggregations, name: :idx_cached_agg_comprehensive, algorithm: :concurrently
     end
   end
 end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/4506

The removal of the `cached_aggregations.event_id` column was not made in a safe way as it was removing the column and the code relying on it in the same migration.

## Description

This PR reworks the approach to make sure it can be released for self hosted instances in a safe way.

It:
- "void" the database migration removing the column
- Add the event_id column in the "ignored" list on the `CachedAggregation` model

A new PR will come later in a new release to finally remove the column (if it exists)