### PR TITLE
Revert "feat(fixed_charges): Calculate minimum commitment w. fixed charges (#4291)"

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -78,10 +78,6 @@ class Plan < ApplicationRecord
     bill_fixed_charges_monthly? && (yearly? || semiannual?)
   end
 
-  def charges_or_fixed_charges_billed_in_monthly_split_intervals?
-    charges_billed_in_monthly_split_intervals? || fixed_charges_billed_in_monthly_split_intervals?
-  end
-
   def invoice_name
     invoice_display_name.presence || name
   end

--- a/app/services/commitments/fetch_invoices_service.rb
+++ b/app/services/commitments/fetch_invoices_service.rb
@@ -29,6 +29,5 @@ module Commitments
     attr_reader :commitment, :invoice_subscription
 
     delegate :subscription, to: :invoice_subscription
-    delegate :plan, to: :subscription
   end
 end

--- a/app/services/commitments/minimum/calculate_true_up_fee_service.rb
+++ b/app/services/commitments/minimum/calculate_true_up_fee_service.rb
@@ -48,18 +48,14 @@ module Commitments
         subscription_fees.sum(:amount_cents) +
           charge_fees.sum(:amount_cents) +
           charge_in_advance_fees.sum(:amount_cents) +
-          charge_in_advance_recurring_fees.sum(:amount_cents) +
-          fixed_charge_fees.sum(:amount_cents) +
-          fixed_charge_in_advance_fees.sum(:amount_cents)
+          charge_in_advance_recurring_fees.sum(:amount_cents)
       end
 
       def fees_total_precise_amount_cents
         subscription_fees.sum(:precise_amount_cents) +
           charge_fees.sum(:precise_amount_cents) +
           charge_in_advance_fees.sum(:precise_amount_cents) +
-          charge_in_advance_recurring_fees.sum(:precise_amount_cents) +
-          fixed_charge_fees.sum(:precise_amount_cents) +
-          fixed_charge_in_advance_fees.sum(:precise_amount_cents)
+          charge_in_advance_recurring_fees.sum(:precise_amount_cents)
       end
 
       def commitment_amount_cents

--- a/app/services/commitments/minimum/in_advance/fetch_invoices_service.rb
+++ b/app/services/commitments/minimum/in_advance/fetch_invoices_service.rb
@@ -23,7 +23,7 @@ module Commitments
         end
 
         def fetch_invoices
-          unless plan.charges_or_fixed_charges_billed_in_monthly_split_intervals?
+          unless subscription.plan.charges_billed_in_monthly_split_intervals?
             return Invoice.where(id: invoice_subscription.invoice_id)
           end
 
@@ -40,10 +40,7 @@ module Commitments
           invoice_ids_query = subscription
             .invoice_subscriptions
             .where(
-              "(charges_from_datetime >= ? AND charges_to_datetime <= ?)" \
-              "OR (fixed_charges_from_datetime >= ? AND fixed_charges_to_datetime <= ?)",
-              ds.previous_beginning_of_period,
-              ds.end_of_period,
+              "charges_from_datetime >= ? AND charges_to_datetime <= ?",
               ds.previous_beginning_of_period,
               ds.end_of_period
             ).select(:invoice_id)

--- a/app/services/commitments/minimum/in_arrears/calculate_true_up_fee_service.rb
+++ b/app/services/commitments/minimum/in_arrears/calculate_true_up_fee_service.rb
@@ -20,6 +20,11 @@ module Commitments
         end
 
         def charge_fees
+          dates_service = Commitments::DatesService.new_instance(
+            commitment: minimum_commitment,
+            invoice_subscription:
+          ).call
+
           Fee
             .charge
             .joins(:charge)
@@ -38,6 +43,11 @@ module Commitments
         end
 
         def charge_in_advance_fees
+          dates_service = Commitments::DatesService.new_instance(
+            commitment: minimum_commitment,
+            invoice_subscription:
+          ).call
+
           Fee
             .charge
             .joins(:charge)
@@ -104,50 +114,6 @@ module Commitments
           # rubocop:enable Style/ConditionalAssignment
 
           scope
-        end
-
-        def fixed_charge_fees
-          Fee
-            .fixed_charge
-            .joins(:fixed_charge)
-            .where(
-              subscription_id: subscription.id,
-              fixed_charge: {pay_in_advance: false}
-            )
-            .where(
-              "(fees.properties->>'fixed_charges_from_datetime') >= ?",
-              dates_service.previous_beginning_of_period
-            )
-            .where(
-              "(fees.properties->>'fixed_charges_to_datetime') <= ?",
-              dates_service.end_of_period&.iso8601(3)
-            )
-        end
-
-        def fixed_charge_in_advance_fees
-          Fee
-            .fixed_charge
-            .joins(:fixed_charge)
-            .where(
-              subscription_id: subscription.id,
-              fixed_charge: {pay_in_advance: true},
-              pay_in_advance: true
-            )
-            .where(
-              "(fees.properties->>'fixed_charges_from_datetime') >= ?",
-              dates_service.previous_beginning_of_period
-            )
-            .where(
-              "(fees.properties->>'fixed_charges_to_datetime') <= ?",
-              dates_service.end_of_period&.iso8601(3)
-            )
-        end
-
-        def dates_service
-          @dates_service ||= Commitments::DatesService.new_instance(
-            commitment: minimum_commitment,
-            invoice_subscription:
-          ).call
         end
       end
     end

--- a/app/services/commitments/minimum/in_arrears/fetch_invoices_service.rb
+++ b/app/services/commitments/minimum/in_arrears/fetch_invoices_service.rb
@@ -23,7 +23,7 @@ module Commitments
         end
 
         def fetch_invoices
-          unless plan.charges_or_fixed_charges_billed_in_monthly_split_intervals?
+          unless subscription.plan.charges_billed_in_monthly_split_intervals?
             return Invoice.where(id: invoice_subscription.invoice_id)
           end
 

--- a/spec/factories/fixed_charges.rb
+++ b/spec/factories/fixed_charges.rb
@@ -10,10 +10,6 @@ FactoryBot.define do
     properties { {amount: Faker::Number.between(from: 100, to: 500).to_s} }
     invoice_display_name { Faker::Fantasy::Tolkien.location }
 
-    trait :pay_in_advance do
-      pay_in_advance { true }
-    end
-
     trait :graduated do
       charge_model { "graduated" }
       properties do

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -322,40 +322,6 @@ RSpec.describe Plan do
     end
   end
 
-  describe "#charges_or_fixed_charges_billed_in_monthly_split_intervals?" do
-    subject(:method_call) { plan.charges_or_fixed_charges_billed_in_monthly_split_intervals? }
-
-    let(:plan) { build_stubbed(:plan, interval: :yearly, bill_charges_monthly:, bill_fixed_charges_monthly:) }
-
-    context "when charges and fixed charges billed in monthly split intervals are false" do
-      let(:bill_charges_monthly) { false }
-      let(:bill_fixed_charges_monthly) { false }
-
-      it { is_expected.to be false }
-    end
-
-    context "when charges and fixed charges billed in monthly split intervals are true" do
-      let(:bill_charges_monthly) { true }
-      let(:bill_fixed_charges_monthly) { true }
-
-      it { is_expected.to be true }
-    end
-
-    context "when charges billed in monthly split intervals is true" do
-      let(:bill_charges_monthly) { true }
-      let(:bill_fixed_charges_monthly) { false }
-
-      it { is_expected.to be true }
-    end
-
-    context "when fixed charges billed in monthly split intervals is true" do
-      let(:bill_charges_monthly) { false }
-      let(:bill_fixed_charges_monthly) { true }
-
-      it { is_expected.to be true }
-    end
-  end
-
   describe "#yearly_amount_cents" do
     subject(:method_call) { plan.yearly_amount_cents }
 

--- a/spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb
+++ b/spec/services/commitments/minimum/calculate_true_up_fee_service_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
       to_datetime:,
       charges_from_datetime:,
       charges_to_datetime:,
-      fixed_charges_from_datetime:,
-      fixed_charges_to_datetime:,
       timestamp:
     )
   end
@@ -23,21 +21,15 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
   let(:to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
   let(:charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
   let(:charges_to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
-  let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-  let(:fixed_charges_to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
   let(:timestamp) { DateTime.parse("2025-01-01T10:00:00") }
   let(:subscription) { create(:subscription, customer:, plan:, billing_time:, subscription_at:) }
   let(:customer) { create(:customer, organization:) }
   let(:subscription_at) { DateTime.parse("2024-01-01T00:00:00") }
   let(:organization) { create(:organization) }
-  let(:plan) { create(:plan, organization:, pay_in_advance:, interval:, bill_charges_monthly:, bill_fixed_charges_monthly:) }
+  let(:plan) { create(:plan, organization:, pay_in_advance:, interval: :yearly) }
   let(:billing_time) { :calendar }
   let(:bill_charges_monthly) { false }
-  let(:bill_fixed_charges_monthly) { false }
   let(:pay_in_advance) { false }
-  let(:interval) { :yearly }
-  let(:fixed_charge) { create(:fixed_charge, plan:, pay_in_advance: false) }
-  let(:fixed_charge_pay_in_advance) { create(:fixed_charge, :pay_in_advance, plan:) }
 
   describe "#call" do
     subject(:service_call) { service.call }
@@ -54,24 +46,29 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
       context "when plan has minimum commitment" do
         let(:commitment) { create(:commitment, plan:, amount_cents: commitment_amount_cents) }
         let(:commitment_amount_cents) { 200 }
+        let(:calculated_commitment_amount_cents) { service.__send__(:commitment_amount_cents) }
+
+        let(:true_up_fee_amount_cents) do
+          calculated_commitment_amount_cents - invoice_subscription.total_amount_cents
+        end
 
         before { commitment }
 
         context "when there are no fees" do
           it "returns result with amount cents" do
-            expect(service_call.amount_cents).to eq(commitment_amount_cents)
+            expect(service_call.amount_cents).to eq(calculated_commitment_amount_cents)
           end
         end
 
         context "when there are subscription fees" do
+          let(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, pay_in_advance:) }
           let(:charge) { create(:standard_charge) }
 
           before do
             create(
               :fee,
               subscription: invoice_subscription.subscription,
-              invoice: invoice_subscription.invoice,
-              amount_cents: 200
+              invoice: invoice_subscription.invoice
             )
 
             create(
@@ -85,18 +82,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                 charges_to_datetime:
               }
             )
-
-            create(
-              :fixed_charge_fee,
-              subscription: invoice_subscription.subscription,
-              invoice: invoice_subscription.invoice,
-              fixed_charge:,
-              amount_cents: 150,
-              properties: {
-                fixed_charges_from_datetime:,
-                fixed_charges_to_datetime:
-              }
-            )
           end
 
           context "when subscription is anniversary" do
@@ -108,8 +93,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
               let(:to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
               let(:charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
               let(:charges_to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
-              let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-              let(:fixed_charges_to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
               let(:timestamp) { DateTime.parse("2025-01-01T10:00:00") }
 
               context "when plan is billed yearly" do
@@ -139,7 +122,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     end
 
                     it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(9_350)
+                      expect(service_call.amount_cents).to eq(9_500)
                     end
                   end
 
@@ -160,7 +143,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     end
 
                     it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
+                      expect(service_call.amount_cents).to eq(9_000)
                     end
                   end
 
@@ -177,72 +160,13 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     end
 
                     it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(9_350)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for the next period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: fixed_charges_from_datetime + 1.year,
-                          fixed_charges_to_datetime: fixed_charges_to_datetime + 1.year
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(9_350)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for current period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime:,
-                          fixed_charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge from another period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(9_350)
+                      expect(service_call.amount_cents).to eq(9_500)
                     end
                   end
                 end
               end
 
-              context "when charges are billed monthly" do
+              context "when plan is billed monthly" do
                 let(:bill_charges_monthly) { true }
                 let(:commitment_amount_cents) { 10_000 }
 
@@ -254,8 +178,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
                     charges_from_datetime: DateTime.parse("2024-01-01T00:00:00"),
                     charges_to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                    fixed_charges_from_datetime: DateTime.parse("2024-01-01T00:00:00"),
-                    fixed_charges_to_datetime: DateTime.parse("2024-12-31T23:59:59.999"),
                     timestamp: DateTime.parse("2024-02-01T10:00:00")
                   )
                 end
@@ -264,129 +186,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   before do
                     create(
                       :charge_fee,
-                      invoice: invoice_subscription_previous.invoice,
-                      subscription: invoice_subscription_previous.subscription,
-                      pay_in_advance: true,
-                      charge: create(:standard_charge, :pay_in_advance),
-                      amount_cents: 500,
-                      properties: {
-                        charges_from_datetime: charges_from_datetime + 1.year,
-                        charges_to_datetime: charges_to_datetime + 1.year
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance charge for current period" do
-                  before do
-                    create(
-                      :charge_fee,
-                      invoice: invoice_subscription_previous.invoice,
-                      subscription: invoice_subscription_previous.subscription,
-                      pay_in_advance: true,
-                      charge: create(:standard_charge, :pay_in_advance),
-                      amount_cents: 500,
-                      properties: {
-                        charges_from_datetime:,
-                        charges_to_datetime:
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
-                  end
-                end
-
-                context "with an in-advance charge from another period" do
-                  before do
-                    create(
-                      :charge_fee,
-                      invoice: invoice_subscription_previous.invoice,
-                      subscription: invoice_subscription_previous.subscription,
-                      pay_in_advance: true,
-                      charge: create(:standard_charge, :pay_in_advance),
-                      amount_cents: 500
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for the next period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: invoice_subscription_previous.invoice,
-                      subscription: invoice_subscription_previous.subscription,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime: fixed_charges_from_datetime + 1.year,
-                        fixed_charges_to_datetime: fixed_charges_to_datetime + 1.year
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for current period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: invoice_subscription_previous.invoice,
-                      subscription: invoice_subscription_previous.subscription,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime:,
-                        fixed_charges_to_datetime:
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
-                  end
-                end
-
-                context "with an in-advance fixed charge from another period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: invoice_subscription_previous.invoice,
-                      subscription: invoice_subscription_previous.subscription,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-              end
-
-              context "when fixed charges are billed monthly" do
-                let(:bill_fixed_charges_monthly) { true }
-                let(:commitment_amount_cents) { 10_000 }
-
-                context "with an in-advance charge for the next period" do
-                  before do
-                    create(
-                      :charge_fee,
                       invoice: nil,
                       subscription:,
                       pay_in_advance: true,
@@ -400,7 +199,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
 
@@ -421,7 +220,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
+                    expect(service_call.amount_cents).to eq(9_000)
                   end
                 end
 
@@ -438,466 +237,8 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
-                end
-
-                context "with an in-advance fixed charge for the next period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime: fixed_charges_from_datetime + 1.year,
-                        fixed_charges_to_datetime: fixed_charges_to_datetime + 1.year
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for current period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime:,
-                        fixed_charges_to_datetime:
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
-                  end
-                end
-
-                context "with an in-advance fixed charge from another period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-              end
-            end
-
-            context "when plan has semiannual interval" do
-              let(:interval) { :semiannual }
-              let(:from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-              let(:to_datetime) { DateTime.parse("2024-06-30T23:59:59.999") }
-              let(:charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-              let(:charges_to_datetime) { DateTime.parse("2024-06-30T23:59:59.999") }
-              let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-              let(:fixed_charges_to_datetime) { DateTime.parse("2024-06-30T23:59:59.999") }
-              let(:timestamp) { DateTime.parse("2024-07-01T10:00:00") }
-
-              context "when fees total amount is greater or equal than the commitment amount" do
-                it "returns result with zero amount cents" do
-                  expect(service_call.amount_cents).to eq(0)
-                end
-              end
-
-              context "when fees total amount is smaller than the commitment amount" do
-                let(:commitment_amount_cents) { 10_000 }
-
-                context "with an in-advance charge for the next period" do
-                  before do
-                    create(
-                      :charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      charge: create(:standard_charge, :pay_in_advance),
-                      amount_cents: 500,
-                      properties: {
-                        charges_from_datetime: charges_from_datetime + 6.months,
-                        charges_to_datetime: charges_to_datetime + 6.months
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance charge for current period" do
-                  before do
-                    create(
-                      :charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      charge: create(:standard_charge, :pay_in_advance),
-                      amount_cents: 500,
-                      properties: {
-                        charges_from_datetime:,
-                        charges_to_datetime:
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
-                  end
-                end
-
-                context "with an in-advance charge from another period" do
-                  before do
-                    create(
-                      :charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      charge: create(:standard_charge, :pay_in_advance),
-                      amount_cents: 500
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for the next period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime: fixed_charges_from_datetime + 6.months,
-                        fixed_charges_to_datetime: fixed_charges_to_datetime + 6.months
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for current period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime:,
-                        fixed_charges_to_datetime:
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
-                  end
-                end
-
-                context "with an in-advance fixed charge from another period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-              end
-            end
-
-            context "when charges are billed monthly" do
-              let(:bill_charges_monthly) { true }
-              let(:commitment_amount_cents) { 10_000 }
-
-              let(:invoice_subscription_previous) do
-                create(
-                  :invoice_subscription,
-                  subscription:,
-                  from_datetime: DateTime.parse("2024-01-01T00:00:00"),
-                  to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                  charges_from_datetime: DateTime.parse("2024-01-01T00:00:00"),
-                  charges_to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                  fixed_charges_from_datetime: DateTime.parse("2024-01-01T00:00:00"),
-                  fixed_charges_to_datetime: DateTime.parse("2024-06-30T23:59:59.999"),
-                  timestamp: DateTime.parse("2024-07-01T10:00:00")
-                )
-              end
-
-              context "with an in-advance charge for the next period" do
-                before do
-                  create(
-                    :charge_fee,
-                    invoice: invoice_subscription_previous.invoice,
-                    subscription: invoice_subscription_previous.subscription,
-                    pay_in_advance: true,
-                    charge: create(:standard_charge, :pay_in_advance),
-                    amount_cents: 500,
-                    properties: {
-                      charges_from_datetime: charges_from_datetime + 6.months,
-                      charges_to_datetime: charges_to_datetime + 6.months
-                    }
-                  )
-                end
-
-                it "returns result with amount cents" do
-                  expect(service_call.amount_cents).to eq(9_350)
-                end
-              end
-
-              context "with an in-advance charge for current period" do
-                before do
-                  create(
-                    :charge_fee,
-                    invoice: invoice_subscription_previous.invoice,
-                    subscription: invoice_subscription_previous.subscription,
-                    pay_in_advance: true,
-                    charge: create(:standard_charge, :pay_in_advance),
-                    amount_cents: 500,
-                    properties: {
-                      charges_from_datetime:,
-                      charges_to_datetime:
-                    }
-                  )
-                end
-
-                it "returns result with amount cents" do
-                  expect(service_call.amount_cents).to eq(8_850)
-                end
-              end
-
-              context "with an in-advance charge from another period" do
-                before do
-                  create(
-                    :charge_fee,
-                    invoice: invoice_subscription_previous.invoice,
-                    subscription: invoice_subscription_previous.subscription,
-                    pay_in_advance: true,
-                    charge: create(:standard_charge, :pay_in_advance),
-                    amount_cents: 500
-                  )
-                end
-
-                it "returns result with amount cents" do
-                  expect(service_call.amount_cents).to eq(9_350)
-                end
-              end
-
-              context "with an in-advance fixed charge for the next period" do
-                before do
-                  create(
-                    :fixed_charge_fee,
-                    invoice: invoice_subscription_previous.invoice,
-                    subscription: invoice_subscription_previous.subscription,
-                    pay_in_advance: true,
-                    fixed_charge: fixed_charge_pay_in_advance,
-                    amount_cents: 500,
-                    properties: {
-                      fixed_charges_from_datetime: fixed_charges_from_datetime + 6.months,
-                      fixed_charges_to_datetime: fixed_charges_to_datetime + 6.months
-                    }
-                  )
-                end
-
-                it "returns result with amount cents" do
-                  expect(service_call.amount_cents).to eq(9_350)
-                end
-              end
-
-              context "with an in-advance fixed charge for current period" do
-                before do
-                  create(
-                    :fixed_charge_fee,
-                    invoice: invoice_subscription_previous.invoice,
-                    subscription: invoice_subscription_previous.subscription,
-                    pay_in_advance: true,
-                    fixed_charge: fixed_charge_pay_in_advance,
-                    amount_cents: 500,
-                    properties: {
-                      fixed_charges_from_datetime:,
-                      fixed_charges_to_datetime:
-                    }
-                  )
-                end
-
-                it "returns result with amount cents" do
-                  expect(service_call.amount_cents).to eq(8_850)
-                end
-              end
-
-              context "with an in-advance fixed charge from another period" do
-                before do
-                  create(
-                    :fixed_charge_fee,
-                    invoice: invoice_subscription_previous.invoice,
-                    subscription: invoice_subscription_previous.subscription,
-                    pay_in_advance: true,
-                    fixed_charge: fixed_charge_pay_in_advance,
-                    amount_cents: 500
-                  )
-                end
-
-                it "returns result with amount cents" do
-                  expect(service_call.amount_cents).to eq(9_350)
-                end
-              end
-            end
-
-            context "when fixed charges are billed monthly" do
-              let(:bill_fixed_charges_monthly) { true }
-              let(:commitment_amount_cents) { 10_000 }
-
-              context "with an in-advance charge for the next period" do
-                before do
-                  create(
-                    :charge_fee,
-                    invoice: nil,
-                    subscription:,
-                    pay_in_advance: true,
-                    charge: create(:standard_charge, :pay_in_advance),
-                    amount_cents: 500,
-                    properties: {
-                      charges_from_datetime: charges_from_datetime + 6.months,
-                      charges_to_datetime: charges_to_datetime + 6.months
-                    }
-                  )
-                end
-
-                it "returns result with amount cents" do
-                  expect(service_call.amount_cents).to eq(9_350)
-                end
-              end
-
-              context "with an in-advance charge for current period" do
-                before do
-                  create(
-                    :charge_fee,
-                    invoice: nil,
-                    subscription:,
-                    pay_in_advance: true,
-                    charge: create(:standard_charge, :pay_in_advance),
-                    amount_cents: 500,
-                    properties: {
-                      charges_from_datetime:,
-                      charges_to_datetime:
-                    }
-                  )
-                end
-
-                it "returns result with amount cents" do
-                  expect(service_call.amount_cents).to eq(8_850)
-                end
-              end
-
-              context "with an in-advance charge from another period" do
-                before do
-                  create(
-                    :charge_fee,
-                    invoice: nil,
-                    subscription:,
-                    pay_in_advance: true,
-                    charge: create(:standard_charge, :pay_in_advance),
-                    amount_cents: 500
-                  )
-                end
-
-                it "returns result with amount cents" do
-                  expect(service_call.amount_cents).to eq(9_350)
-                end
-              end
-
-              context "with an in-advance fixed charge for the next period" do
-                before do
-                  create(
-                    :fixed_charge_fee,
-                    invoice: nil,
-                    subscription:,
-                    pay_in_advance: true,
-                    fixed_charge: fixed_charge_pay_in_advance,
-                    amount_cents: 500,
-                    properties: {
-                      fixed_charges_from_datetime: fixed_charges_from_datetime + 6.months,
-                      fixed_charges_to_datetime: fixed_charges_to_datetime + 6.months
-                    }
-                  )
-                end
-
-                it "returns result with amount cents" do
-                  expect(service_call.amount_cents).to eq(9_350)
-                end
-              end
-
-              context "with an in-advance fixed charge for current period" do
-                before do
-                  create(
-                    :fixed_charge_fee,
-                    invoice: nil,
-                    subscription:,
-                    pay_in_advance: true,
-                    fixed_charge: fixed_charge_pay_in_advance,
-                    amount_cents: 500,
-                    properties: {
-                      fixed_charges_from_datetime:,
-                      fixed_charges_to_datetime:
-                    }
-                  )
-                end
-
-                it "returns result with amount cents" do
-                  expect(service_call.amount_cents).to eq(8_850)
-                end
-              end
-
-              context "with an in-advance fixed charge from another period" do
-                before do
-                  create(
-                    :fixed_charge_fee,
-                    invoice: nil,
-                    subscription:,
-                    pay_in_advance: true,
-                    fixed_charge: fixed_charge_pay_in_advance,
-                    amount_cents: 500
-                  )
-                end
-
-                it "returns result with amount cents" do
-                  expect(service_call.amount_cents).to eq(9_350)
                 end
               end
             end
@@ -908,8 +249,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
               let(:to_datetime) { DateTime.parse("2024-03-31T23:59:59.999") }
               let(:charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
               let(:charges_to_datetime) { DateTime.parse("2024-03-31T23:59:59.999") }
-              let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-              let(:fixed_charges_to_datetime) { DateTime.parse("2024-03-31T23:59:59.999") }
               let(:timestamp) { DateTime.parse("2024-04-01T10:00:00") }
 
               context "when fees total amount is greater or equal than the commitment amount" do
@@ -938,7 +277,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
 
@@ -959,7 +298,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
+                    expect(service_call.amount_cents).to eq(9_000)
                   end
                 end
 
@@ -976,66 +315,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for the next period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime: fixed_charges_from_datetime + 3.months,
-                        fixed_charges_to_datetime: fixed_charges_to_datetime + 3.months
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for current period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime:,
-                        fixed_charges_to_datetime:
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
-                  end
-                end
-
-                context "with an in-advance fixed charge from another period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
               end
@@ -1047,8 +327,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
               let(:to_datetime) { DateTime.parse("2024-02-29T23:59:59.999") }
               let(:charges_from_datetime) { DateTime.parse("2024-02-01T00:00:00") }
               let(:charges_to_datetime) { DateTime.parse("2024-02-29T23:59:59.999") }
-              let(:fixed_charges_from_datetime) { DateTime.parse("2024-02-01T00:00:00") }
-              let(:fixed_charges_to_datetime) { DateTime.parse("2024-02-29T23:59:59.999") }
               let(:timestamp) { DateTime.parse("2024-03-01T10:00:00") }
 
               context "when fees total amount is greater or equal than the commitment amount" do
@@ -1077,7 +355,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
 
@@ -1098,7 +376,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
+                    expect(service_call.amount_cents).to eq(9_000)
                   end
                 end
 
@@ -1115,66 +393,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for the next period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime: fixed_charges_from_datetime + 1.month,
-                        fixed_charges_to_datetime: fixed_charges_to_datetime + 1.month
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for current period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime:,
-                        fixed_charges_to_datetime:
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
-                  end
-                end
-
-                context "with an in-advance fixed charge from another period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
               end
@@ -1186,8 +405,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
               let(:to_datetime) { DateTime.parse("2024-02-11T23:59:59.999") }
               let(:charges_from_datetime) { DateTime.parse("2024-02-05T00:00:00") }
               let(:charges_to_datetime) { DateTime.parse("2024-02-11T23:59:59.999") }
-              let(:fixed_charges_from_datetime) { DateTime.parse("2024-02-05T00:00:00") }
-              let(:fixed_charges_to_datetime) { DateTime.parse("2024-02-11T23:59:59.999") }
               let(:timestamp) { DateTime.parse("2024-02-12T10:00:00") }
 
               context "when fees total amount is greater or equal than the commitment amount" do
@@ -1216,7 +433,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
 
@@ -1237,7 +454,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
+                    expect(service_call.amount_cents).to eq(9_000)
                   end
                 end
 
@@ -1254,66 +471,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for the next period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime: fixed_charges_from_datetime + 1.week,
-                        fixed_charges_to_datetime: fixed_charges_to_datetime + 1.week
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for current period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime:,
-                        fixed_charges_to_datetime:
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
-                  end
-                end
-
-                context "with an in-advance fixed charge from another period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
               end
@@ -1329,8 +487,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
               let(:to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
               let(:charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
               let(:charges_to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
-              let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-              let(:fixed_charges_to_datetime) { DateTime.parse("2024-12-31T23:59:59.999") }
               let(:timestamp) { DateTime.parse("2025-01-01T10:00:00") }
 
               context "when plan is billed yearly" do
@@ -1360,7 +516,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     end
 
                     it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(9_350)
+                      expect(service_call.amount_cents).to eq(9_500)
                     end
                   end
 
@@ -1381,7 +537,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     end
 
                     it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
+                      expect(service_call.amount_cents).to eq(9_000)
                     end
                   end
 
@@ -1398,72 +554,13 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     end
 
                     it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(9_350)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for the next period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: fixed_charges_from_datetime + 1.year,
-                          fixed_charges_to_datetime: fixed_charges_to_datetime + 1.year
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(9_350)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for current period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime:,
-                          fixed_charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge from another period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(9_350)
+                      expect(service_call.amount_cents).to eq(9_500)
                     end
                   end
                 end
               end
 
-              context "when charges are billed monthly" do
+              context "when plan is billed monthly" do
                 let(:bill_charges_monthly) { true }
                 let(:commitment_amount_cents) { 10_000 }
 
@@ -1475,8 +572,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
                     charges_from_datetime: DateTime.parse("2024-01-01T00:00:00"),
                     charges_to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                    fixed_charges_from_datetime: DateTime.parse("2024-01-01T00:00:00"),
-                    fixed_charges_to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
                     timestamp: DateTime.parse("2024-02-01T10:00:00")
                   )
                 end
@@ -1521,7 +616,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     end
 
                     it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
+                      expect(service_call.amount_cents).to eq(9_000)
                     end
                   end
 
@@ -1542,7 +637,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     end
 
                     it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_350)
+                      expect(service_call.amount_cents).to eq(8_500)
                     end
                   end
 
@@ -1559,66 +654,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     end
 
                     it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for the next period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: fixed_charges_from_datetime + 1.year,
-                          fixed_charges_to_datetime: fixed_charges_to_datetime + 1.year
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for current period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime:,
-                          fixed_charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_350)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge from another period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
+                      expect(service_call.amount_cents).to eq(9_000)
                     end
                   end
                 end
@@ -1643,7 +679,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     end
 
                     it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_823)
+                      expect(service_call.amount_cents).to eq(8_973)
                     end
                   end
 
@@ -1664,7 +700,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     end
 
                     it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_323)
+                      expect(service_call.amount_cents).to eq(8_473)
                     end
                   end
 
@@ -1681,1056 +717,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     end
 
                     it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_823)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for the next period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: fixed_charges_from_datetime + 1.year,
-                          fixed_charges_to_datetime: fixed_charges_to_datetime + 1.year
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_823)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for current period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime:,
-                          fixed_charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_323)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge from another period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_823)
-                    end
-                  end
-                end
-              end
-
-              context "when fixed charges are billed monthly" do
-                let(:bill_fixed_charges_monthly) { true }
-                let(:commitment_amount_cents) { 10_000 }
-
-                let(:invoice_subscription_previous) do
-                  create(
-                    :invoice_subscription,
-                    subscription:,
-                    from_datetime:,
-                    to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                    charges_from_datetime: DateTime.parse("2024-01-01T00:00:00"),
-                    charges_to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                    fixed_charges_from_datetime: DateTime.parse("2024-01-01T00:00:00"),
-                    fixed_charges_to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                    timestamp: DateTime.parse("2024-02-01T10:00:00")
-                  )
-                end
-
-                before do
-                  create(
-                    :fee,
-                    subscription: invoice_subscription_previous.subscription,
-                    invoice: invoice_subscription_previous.invoice
-                  )
-
-                  create(
-                    :charge_fee,
-                    subscription: invoice_subscription_previous.subscription,
-                    invoice: invoice_subscription_previous.invoice,
-                    charge:,
-                    amount_cents: 300,
-                    properties: {
-                      charges_from_datetime:,
-                      charges_to_datetime:
-                    }
-                  )
-                end
-
-                context "when subscription starts at the beginning of the period" do
-                  let(:from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-
-                  context "with an in-advance charge for the next period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime: charges_from_datetime + 1.year,
-                          charges_to_datetime: charges_to_datetime + 1.year
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance charge for current period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime:,
-                          charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_350)
-                    end
-                  end
-
-                  context "with an in-advance charge from another period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for the next period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: fixed_charges_from_datetime + 1.year,
-                          fixed_charges_to_datetime: fixed_charges_to_datetime + 1.year
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for current period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime:,
-                          fixed_charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_350)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge from another period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-                end
-
-                context "when subscription does not start at the beginning of the period" do
-                  let(:from_datetime) { DateTime.parse("2024-01-02T00:00:00") }
-
-                  context "with an in-advance charge for the next period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime: charges_from_datetime + 1.year,
-                          charges_to_datetime: charges_to_datetime + 1.year
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_823)
-                    end
-                  end
-
-                  context "with an in-advance charge for current period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime:,
-                          charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_323)
-                    end
-                  end
-
-                  context "with an in-advance charge from another period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_823)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for the next period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: fixed_charges_from_datetime + 1.year,
-                          fixed_charges_to_datetime: fixed_charges_to_datetime + 1.year
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_823)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for current period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime:,
-                          fixed_charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_323)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge from another period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_823)
-                    end
-                  end
-                end
-              end
-            end
-
-            context "when plan has semiannual interval" do
-              let(:interval) { :semiannual }
-              let(:from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-              let(:to_datetime) { DateTime.parse("2024-06-30T23:59:59.999") }
-              let(:charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-              let(:charges_to_datetime) { DateTime.parse("2024-06-30T23:59:59.999") }
-              let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-              let(:fixed_charges_to_datetime) { DateTime.parse("2024-06-30T23:59:59.999") }
-              let(:timestamp) { DateTime.parse("2024-07-01T10:00:00") }
-
-              context "when plan is billed semiannually" do
-                context "when fees total amount is greater or equal than the commitment amount" do
-                  it "returns result with zero amount cents" do
-                    expect(service_call.amount_cents).to eq(0)
-                  end
-                end
-
-                context "when fees total amount is smaller than the commitment amount" do
-                  let(:commitment_amount_cents) { 10_000 }
-
-                  context "with an in-advance charge for the next period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime: charges_from_datetime + 6.months,
-                          charges_to_datetime: charges_to_datetime + 6.months
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(9_350)
-                    end
-                  end
-
-                  context "with an in-advance charge for current period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime:,
-                          charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance charge from another period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(9_350)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for the next period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: fixed_charges_from_datetime + 6.months,
-                          fixed_charges_to_datetime: fixed_charges_to_datetime + 6.months
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(9_350)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for current period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime:,
-                          fixed_charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge from another period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(9_350)
-                    end
-                  end
-                end
-              end
-
-              context "when charges are billed monthly" do
-                let(:bill_charges_monthly) { true }
-                let(:commitment_amount_cents) { 10_000 }
-
-                let(:invoice_subscription_previous) do
-                  create(
-                    :invoice_subscription,
-                    subscription:,
-                    from_datetime:,
-                    to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                    charges_from_datetime: DateTime.parse("2024-01-01T00:00:00"),
-                    charges_to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                    fixed_charges_from_datetime: DateTime.parse("2024-01-01T00:00:00"),
-                    fixed_charges_to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                    timestamp: DateTime.parse("2024-02-01T10:00:00")
-                  )
-                end
-
-                before do
-                  create(
-                    :fee,
-                    subscription: invoice_subscription_previous.subscription,
-                    invoice: invoice_subscription_previous.invoice
-                  )
-
-                  create(
-                    :charge_fee,
-                    subscription: invoice_subscription_previous.subscription,
-                    invoice: invoice_subscription_previous.invoice,
-                    charge:,
-                    amount_cents: 300,
-                    properties: {
-                      charges_from_datetime:,
-                      charges_to_datetime:
-                    }
-                  )
-                end
-
-                context "when subscription starts at the beginning of the period" do
-                  let(:from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-
-                  context "with an in-advance charge for the next period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime: charges_from_datetime + 6.months,
-                          charges_to_datetime: charges_to_datetime + 6.months
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance charge for current period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime:,
-                          charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_350)
-                    end
-                  end
-
-                  context "with an in-advance charge from another period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for the next period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: fixed_charges_from_datetime + 6.months,
-                          fixed_charges_to_datetime: fixed_charges_to_datetime + 6.months
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for current period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime:,
-                          fixed_charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_350)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge from another period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-                end
-
-                context "when subscription does not start at the beginning of the period" do
-                  let(:from_datetime) { DateTime.parse("2024-01-02T00:00:00") }
-
-                  context "with an in-advance charge for the next period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime: charges_from_datetime + 6.months,
-                          charges_to_datetime: charges_to_datetime + 6.months
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_795)
-                    end
-                  end
-
-                  context "with an in-advance charge for current period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime:,
-                          charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_295)
-                    end
-                  end
-
-                  context "with an in-advance charge from another period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_795)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for the next period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: fixed_charges_from_datetime + 6.months,
-                          fixed_charges_to_datetime: fixed_charges_to_datetime + 6.months
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_795)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for current period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime:,
-                          fixed_charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_295)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge from another period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_795)
-                    end
-                  end
-                end
-              end
-
-              context "when fixed charges are billed monthly" do
-                let(:bill_fixed_charges_monthly) { true }
-                let(:commitment_amount_cents) { 10_000 }
-
-                let(:invoice_subscription_previous) do
-                  create(
-                    :invoice_subscription,
-                    subscription:,
-                    from_datetime:,
-                    to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                    charges_from_datetime: DateTime.parse("2024-01-01T00:00:00"),
-                    charges_to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                    fixed_charges_from_datetime: DateTime.parse("2024-01-01T00:00:00"),
-                    fixed_charges_to_datetime: DateTime.parse("2024-01-31T23:59:59.999"),
-                    timestamp: DateTime.parse("2024-02-01T10:00:00")
-                  )
-                end
-
-                before do
-                  create(
-                    :fee,
-                    subscription: invoice_subscription_previous.subscription,
-                    invoice: invoice_subscription_previous.invoice
-                  )
-
-                  create(
-                    :charge_fee,
-                    subscription: invoice_subscription_previous.subscription,
-                    invoice: invoice_subscription_previous.invoice,
-                    charge:,
-                    amount_cents: 300,
-                    properties: {
-                      charges_from_datetime:,
-                      charges_to_datetime:
-                    }
-                  )
-                end
-
-                context "when subscription starts at the beginning of the period" do
-                  let(:from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-
-                  context "with an in-advance charge for the next period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime: charges_from_datetime + 6.months,
-                          charges_to_datetime: charges_to_datetime + 6.months
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance charge for current period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime:,
-                          charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_350)
-                    end
-                  end
-
-                  context "with an in-advance charge from another period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for the next period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: fixed_charges_from_datetime + 6.months,
-                          fixed_charges_to_datetime: fixed_charges_to_datetime + 6.months
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for current period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime:,
-                          fixed_charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_350)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge from another period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_850)
-                    end
-                  end
-                end
-
-                context "when subscription does not start at the beginning of the period" do
-                  let(:from_datetime) { DateTime.parse("2024-01-02T00:00:00") }
-
-                  context "with an in-advance charge for the next period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime: charges_from_datetime + 6.months,
-                          charges_to_datetime: charges_to_datetime + 6.months
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_795)
-                    end
-                  end
-
-                  context "with an in-advance charge for current period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500,
-                        properties: {
-                          charges_from_datetime:,
-                          charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_295)
-                    end
-                  end
-
-                  context "with an in-advance charge from another period" do
-                    before do
-                      create(
-                        :charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        charge: create(:standard_charge, :pay_in_advance),
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_795)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for the next period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: fixed_charges_from_datetime + 6.months,
-                          fixed_charges_to_datetime: fixed_charges_to_datetime + 6.months
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_795)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge for current period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime:,
-                          fixed_charges_to_datetime:
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_295)
-                    end
-                  end
-
-                  context "with an in-advance fixed charge from another period" do
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 500
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(8_795)
+                      expect(service_call.amount_cents).to eq(8_973)
                     end
                   end
                 end
@@ -2743,8 +730,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
               let(:to_datetime) { DateTime.parse("2024-03-31T23:59:59.999") }
               let(:charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
               let(:charges_to_datetime) { DateTime.parse("2024-03-31T23:59:59.999") }
-              let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-01T00:00:00") }
-              let(:fixed_charges_to_datetime) { DateTime.parse("2024-03-31T23:59:59.999") }
               let(:timestamp) { DateTime.parse("2024-04-01T10:00:00") }
 
               context "when fees total amount is greater or equal than the commitment amount" do
@@ -2773,7 +758,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
 
@@ -2794,7 +779,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
+                    expect(service_call.amount_cents).to eq(9_000)
                   end
                 end
 
@@ -2811,66 +796,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for the next period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime: fixed_charges_from_datetime + 3.months,
-                        fixed_charges_to_datetime: fixed_charges_to_datetime + 3.months
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for current period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime:,
-                        fixed_charges_to_datetime:
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
-                  end
-                end
-
-                context "with an in-advance fixed charge from another period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
               end
@@ -2882,8 +808,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
               let(:to_datetime) { DateTime.parse("2024-02-29T23:59:59.999") }
               let(:charges_from_datetime) { DateTime.parse("2024-02-01T00:00:00") }
               let(:charges_to_datetime) { DateTime.parse("2024-02-29T23:59:59.999") }
-              let(:fixed_charges_from_datetime) { DateTime.parse("2024-02-01T00:00:00") }
-              let(:fixed_charges_to_datetime) { DateTime.parse("2024-02-29T23:59:59.999") }
               let(:timestamp) { DateTime.parse("2024-03-01T10:00:00") }
 
               context "when fees total amount is greater or equal than the commitment amount" do
@@ -2912,7 +836,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
 
@@ -2933,7 +857,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
+                    expect(service_call.amount_cents).to eq(9_000)
                   end
                 end
 
@@ -2950,66 +874,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for the next period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime: DateTime.parse("2024-03-01T00:00:00"),
-                        fixed_charges_to_datetime: DateTime.parse("2024-03-31T23:59:59.999")
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for current period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime:,
-                        fixed_charges_to_datetime:
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
-                  end
-                end
-
-                context "with an in-advance fixed charge from another period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
               end
@@ -3021,8 +886,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
               let(:to_datetime) { DateTime.parse("2024-02-11T23:59:59.999") }
               let(:charges_from_datetime) { DateTime.parse("2024-02-05T00:00:00") }
               let(:charges_to_datetime) { DateTime.parse("2024-02-11T23:59:59.999") }
-              let(:fixed_charges_from_datetime) { DateTime.parse("2024-02-05T00:00:00") }
-              let(:fixed_charges_to_datetime) { DateTime.parse("2024-02-11T23:59:59.999") }
               let(:timestamp) { DateTime.parse("2024-02-12T10:00:00") }
 
               context "when fees total amount is greater or equal than the commitment amount" do
@@ -3051,7 +914,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
 
@@ -3072,7 +935,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
+                    expect(service_call.amount_cents).to eq(9_000)
                   end
                 end
 
@@ -3089,66 +952,7 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                   end
 
                   it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for the next period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime: DateTime.parse("2024-02-12T00:00:00"),
-                        fixed_charges_to_datetime: DateTime.parse("2024-02-18T23:59:59.999")
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
-                  end
-                end
-
-                context "with an in-advance fixed charge for current period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500,
-                      properties: {
-                        fixed_charges_from_datetime:,
-                        fixed_charges_to_datetime:
-                      }
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(8_850)
-                  end
-                end
-
-                context "with an in-advance fixed charge from another period" do
-                  before do
-                    create(
-                      :fixed_charge_fee,
-                      invoice: nil,
-                      subscription:,
-                      pay_in_advance: true,
-                      fixed_charge: fixed_charge_pay_in_advance,
-                      amount_cents: 500
-                    )
-                  end
-
-                  it "returns result with amount cents" do
-                    expect(service_call.amount_cents).to eq(9_350)
+                    expect(service_call.amount_cents).to eq(9_500)
                   end
                 end
               end
@@ -3170,10 +974,17 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
       context "when plan has minimum commitment" do
         let(:commitment) { create(:commitment, plan:, amount_cents: commitment_amount_cents) }
         let(:commitment_amount_cents) { 3_000 }
+        let(:calculated_commitment_amount_cents) { service.__send__(:commitment_amount_cents) }
+
+        let(:true_up_fee_amount_cents) do
+          calculated_commitment_amount_cents - invoice_subscription.total_amount_cents
+        end
 
         before { commitment }
 
         context "when there are subscription fees" do
+          let(:plan) { create(:plan, organization:, interval:, bill_charges_monthly:, pay_in_advance:) }
+
           before do
             create(
               :fee,
@@ -3202,8 +1013,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     let(:to_datetime) { DateTime.parse("2024-01-07T23:59:59.999") }
                     let(:charges_from_datetime) { DateTime.parse("2024-01-02T00:00:00") }
                     let(:charges_to_datetime) { DateTime.parse("2024-01-07T23:59:59.999") }
-                    let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-02T00:00:00") }
-                    let(:fixed_charges_to_datetime) { DateTime.parse("2024-01-07T23:59:59.999") }
                     let(:timestamp) { DateTime.parse("2024-02-02T10:00:00") }
 
                     before do
@@ -3248,8 +1057,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                         to_datetime: DateTime.parse("2024-01-07T23:59:59.999"),
                         charges_from_datetime: DateTime.parse("2024-01-02T00:00:00"),
                         charges_to_datetime: DateTime.parse("2024-01-07T23:59:59.999"),
-                        fixed_charges_from_datetime: DateTime.parse("2024-01-02T00:00:00"),
-                        fixed_charges_to_datetime: DateTime.parse("2024-01-07T23:59:59.999"),
                         timestamp: DateTime.parse("2024-01-02T10:00:00")
                       )
                     end
@@ -3258,8 +1065,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                     let(:to_datetime) { DateTime.parse("2024-01-14T23:59:59.999") }
                     let(:charges_from_datetime) { DateTime.parse("2024-01-08T00:00:00") }
                     let(:charges_to_datetime) { DateTime.parse("2024-01-14T23:59:59.999") }
-                    let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-08T00:00:00") }
-                    let(:fixed_charges_to_datetime) { DateTime.parse("2024-01-14T23:59:59.999") }
                     let(:timestamp) { DateTime.parse("2024-02-08T10:00:00") }
 
                     before do
@@ -3292,112 +1097,6 @@ RSpec.describe Commitments::Minimum::CalculateTrueUpFeeService do
                         properties: {
                           charges_from_datetime: previous_invoice_subscription.charges_from_datetime,
                           charges_to_datetime: previous_invoice_subscription.charges_to_datetime
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(514)
-                    end
-                  end
-                end
-
-                context "with an in-advance fixed charge from the period" do
-                  context "with no previous period" do
-                    let(:from_datetime) { DateTime.parse("2024-01-02T00:00:00") }
-                    let(:to_datetime) { DateTime.parse("2024-01-07T23:59:59.999") }
-                    let(:charges_from_datetime) { DateTime.parse("2024-01-02T00:00:00") }
-                    let(:charges_to_datetime) { DateTime.parse("2024-01-07T23:59:59.999") }
-                    let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-02T00:00:00") }
-                    let(:fixed_charges_to_datetime) { DateTime.parse("2024-01-07T23:59:59.999") }
-                    let(:timestamp) { DateTime.parse("2024-02-02T10:00:00") }
-
-                    before do
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 700,
-                        properties: {
-                          fixed_charges_from_datetime: invoice_subscription.fixed_charges_from_datetime,
-                          fixed_charges_to_datetime: invoice_subscription.fixed_charges_to_datetime
-                        }
-                      )
-
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: false,
-                        fixed_charge: fixed_charge,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: invoice_subscription.fixed_charges_from_datetime,
-                          fixed_charges_to_datetime: invoice_subscription.fixed_charges_to_datetime
-                        }
-                      )
-                    end
-
-                    it "returns result with amount cents" do
-                      expect(service_call.amount_cents).to eq(0)
-                    end
-                  end
-
-                  context "with previous period" do
-                    let(:previous_invoice_subscription) do
-                      create(
-                        :invoice_subscription,
-                        subscription:,
-                        from_datetime: DateTime.parse("2024-01-02T00:00:00"),
-                        to_datetime: DateTime.parse("2024-01-07T23:59:59.999"),
-                        charges_from_datetime: DateTime.parse("2024-01-02T00:00:00"),
-                        charges_to_datetime: DateTime.parse("2024-01-07T23:59:59.999"),
-                        fixed_charges_from_datetime: DateTime.parse("2024-01-02T00:00:00"),
-                        fixed_charges_to_datetime: DateTime.parse("2024-01-07T23:59:59.999"),
-                        timestamp: DateTime.parse("2024-01-02T10:00:00")
-                      )
-                    end
-
-                    let(:from_datetime) { DateTime.parse("2024-01-08T00:00:00") }
-                    let(:to_datetime) { DateTime.parse("2024-01-14T23:59:59.999") }
-                    let(:charges_from_datetime) { DateTime.parse("2024-01-08T00:00:00") }
-                    let(:charges_to_datetime) { DateTime.parse("2024-01-14T23:59:59.999") }
-                    let(:fixed_charges_from_datetime) { DateTime.parse("2024-01-08T00:00:00") }
-                    let(:fixed_charges_to_datetime) { DateTime.parse("2024-01-14T23:59:59.999") }
-                    let(:timestamp) { DateTime.parse("2024-02-08T10:00:00") }
-
-                    before do
-                      create(
-                        :fee,
-                        subscription: previous_invoice_subscription.subscription,
-                        invoice: previous_invoice_subscription.invoice
-                      )
-
-                      create(
-                        :fixed_charge_fee,
-                        invoice: nil,
-                        subscription:,
-                        pay_in_advance: true,
-                        fixed_charge: fixed_charge_pay_in_advance,
-                        amount_cents: 700,
-                        properties: {
-                          fixed_charges_from_datetime: previous_invoice_subscription.fixed_charges_from_datetime,
-                          fixed_charges_to_datetime: previous_invoice_subscription.fixed_charges_to_datetime
-                        }
-                      )
-
-                      create(
-                        :fixed_charge_fee,
-                        invoice: invoice_subscription.invoice,
-                        subscription:,
-                        pay_in_advance: false,
-                        fixed_charge: fixed_charge,
-                        amount_cents: 500,
-                        properties: {
-                          fixed_charges_from_datetime: previous_invoice_subscription.fixed_charges_from_datetime,
-                          fixed_charges_to_datetime: previous_invoice_subscription.fixed_charges_to_datetime
                         }
                       )
                     end


### PR DESCRIPTION
This reverts commit cc1ebdf5706c4b4a108f4d7e5f156b2924cdda4e.

The changes in the original PR are a key part of fixed charges and needed to have a complete billing run, however, we plan to re-apply them soon after we got the rest of the fixed charge billing running to de-risk introducing bugs on current billing calculations, or performance issues.


Fixed charges will be hidden behind a feature flag until the feature is ready to be live.