### PR TITLE
feat(subscription): Expose subscription_at in milliseconds

### DIFF
--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -13,7 +13,7 @@ module V1
         status: model.status,
         billing_time: model.billing_time,
         subscription_at: model.subscription_at&.iso8601,
-        started_at: model.started_at&.iso8601,
+        started_at: model.started_at&.iso8601(3),
         trial_ended_at: model.trial_ended_at&.iso8601,
         ending_at: model.ending_at&.iso8601,
         terminated_at: model.terminated_at&.iso8601,

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ::V1::SubscriptionSerializer do
   subject(:serializer) { described_class.new(subscription, root_name: "subscription", includes: %i[customer plan entitlements]) }
 
-  let(:started_at) { Time.zone.parse("2024-04-23 10:00") }
+  let(:started_at) { Time.zone.parse("2024-04-23 10:02:03") }
   let(:ending_at) { Time.zone.parse("2024-06-30") }
   let(:subscription) do
     create(:subscription, created_at: started_at, started_at:, ending_at:)
@@ -30,9 +30,10 @@ RSpec.describe ::V1::SubscriptionSerializer do
             "plan_code" => subscription.plan.code,
             "status" => subscription.status,
             "billing_time" => subscription.billing_time,
-            "created_at" => started_at.iso8601,
+            "created_at" => "2024-04-23T10:02:03Z",
             "ending_at" => ending_at.iso8601,
             "trial_ended_at" => nil,
+            "started_at" => "2024-04-23T10:02:03.000Z",
             "current_billing_period_started_at" => "2024-05-01T00:00:00Z",
             "current_billing_period_ending_at" => "2024-05-31T23:59:59Z"
           )


### PR DESCRIPTION
When retrieving events to be billed, we'll only consider events sent after the `subscription.started_at`.

On Subscription model, we store `started_at` with nanoseconds precision: `2024-04-23T10:01:09.123456Z`
On Event model in CH, we store the `timestamp` at the millisecond precision: `2024-04-23T10:01:09.123Z`
On Event model in PG, we store the `timestamp` at the nanoseconds precision: `2024-04-23T10:01:09.123456Z`, but in the service, converting the timestamp to a ruby datetime will lose some precision.

This means for a subscription started at 10:01:09.666, an event sent at 10:01:09.000 will not be counted. This is not a bug, nor recent, but our API only expose the `started_at` at the second precision so this is impossible to know if an event at the same second will be counted or not.

**Adding precision is not a breaking change because this is still `iso8601` format**, but with more precision.

This PR adds precision down to the microseconds (3 places).