### PR TITLE
chore(cache): Ensure cache store DB consistency in dev environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.consider_all_requests_local = true
   config.server_timing = true
 
-  config.cache_store = :redis_cache_store, {url: ENV["LAGO_REDIS_CACHE_URL"], db: 3}
+  config.cache_store = :redis_cache_store, {url: ENV["LAGO_REDIS_CACHE_URL"], db: ENV.fetch("LAGO_REDIS_CACHE_DB", 0)}
   config.action_controller.perform_caching = false
 
   config.active_storage.service = if ENV["LAGO_USE_AWS_S3"].present? && ENV["LAGO_USE_AWS_S3"] == "true"


### PR DESCRIPTION
## Context

https://github.com/getlago/lago/commit/3cd78f1cdfd94dda9ea0c248bd074d8a20f868a7 fixed the `events-processor` cache Redis DB in development environment. But if someone were to change the `.env.development.default`, we would again have discrepancy between the `events-processor` and `lago-api` cache Redis DB.

## Description

This ensure we have consistency between the two services in development environment by relying on the `LAGO_REDIS_CACHE_DB` env variable for `lago-api` as well and defaulting to the DB `0`.

Note that this could cause the cache to switch to DB `0` if the `lago` repository is not up-to-date with `main`. This is acceptable in development environment.