### PR TITLE
feat(billable_metric): Define BillableMetrics::Aggregations::Result

### DIFF
--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -3,6 +3,8 @@
 module BillableMetrics
   module Breakdown
     class SumService < BillableMetrics::ProratedAggregations::SumService
+      Result = BaseResult[:aggregator, :breakdown]
+
       def breakdown
         breakdown = persisted_breakdown
         breakdown += period_breakdown

--- a/app/services/billable_metrics/breakdown/unique_count_service.rb
+++ b/app/services/billable_metrics/breakdown/unique_count_service.rb
@@ -3,6 +3,8 @@
 module BillableMetrics
   module Breakdown
     class UniqueCountService < BillableMetrics::ProratedAggregations::UniqueCountService
+      Result = BaseResult[:aggregator, :breakdown]
+
       def breakdown
         breakdown = event_store.prorated_unique_count_breakdown(with_remove: true)
           .group_by { |r| r["property"] }


### PR DESCRIPTION
## Description

This PR is replacing the `LegacyResult` (OpenStruct) in `BillableMetrics::Aggregations::BaseService` with a proper `Result` class defining all possible fields.

It also uses it as an opportunity to document the fields

The PR also adds a new `pay_in_advance_event` value attached to the result instances in pay in advance and estimate scenarios, it will be used later to fix the fee estimate service with clickhouse event store