### PR TITLE
feat(estimate): Prepare Clickhouse event estimate

### DIFF
--- a/app/models/events/common.rb
+++ b/app/models/events/common.rb
@@ -1,7 +1,23 @@
 # frozen_string_literal: true
 
 module Events
-  Common = Struct.new(:id, :organization_id, :transaction_id, :external_subscription_id, :timestamp, :code, :properties, :precise_total_amount_cents) do
+  Common = Struct.new(
+    :id,
+    :organization_id,
+    :transaction_id,
+    :external_subscription_id,
+    :timestamp,
+    :code,
+    :properties,
+    :precise_total_amount_cents,
+    :persisted,
+    keyword_init: true
+  ) do
+    def initialize(**args)
+      super
+      self[:persisted] = true unless args.key?(:persisted)
+    end
+
     def event_id
       id || transaction_id
     end

--- a/app/services/base_result.rb
+++ b/app/services/base_result.rb
@@ -3,7 +3,23 @@
 class BaseResult
   include Result
 
+  class_attribute :attributes, default: [] # rubocop:disable ThreadSafety/ClassAndModuleAttributes
+
   def self.[](*attributes)
-    Class.new(BaseResult) { attr_accessor(*attributes) }
+    Class.new(BaseResult) do
+      attr_accessor(*attributes)
+
+      self.attributes = attributes
+    end
+  end
+
+  def ==(other)
+    return false unless other.class == self.class
+    return false unless failure? == other.failure?
+    return false unless other.error == error
+
+    self.class.attributes.all? do |attribute|
+      send(attribute) == other.send(attribute)
+    end
   end
 end

--- a/app/services/charge_models/factory.rb
+++ b/app/services/charge_models/factory.rb
@@ -50,5 +50,26 @@ module ChargeModels
         raise NotImplementedError, "Charge model #{chargeable.charge_model} is not implemented"
       end
     end
+
+    def self.in_advance_charge_model_class(chargeable:)
+      case chargeable.charge_model.to_sym
+      when :standard
+        ChargeModels::StandardService
+      when :graduated
+        ChargeModels::GraduatedService
+      when :graduated_percentage
+        ChargeModels::GraduatedPercentageService
+      when :package
+        ChargeModels::PackageService
+      when :percentage
+        ChargeModels::PercentageService
+      when :custom
+        ChargeModels::CustomService
+      when :dynamic
+        ChargeModels::DynamicService
+      else
+        raise NotImplementedError, "Charge model #{chargeable.charge_model} is not implemented"
+      end
+    end
   end
 end

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -26,7 +26,7 @@ module Charges
       result.count = 1
       result.amount = amount_cents
       result.precise_amount = amount * currency.subunit_to_unit.to_d
-      result.unit_amount = rounded_amount.zero? ? BigDecimal("0") : rounded_amount / compute_units
+      result.unit_amount = rounded_amount.zero? ? BigDecimal(0) : rounded_amount / compute_units
       result.amount_details = calculated_single_event_amount_details
       result
     end
@@ -36,24 +36,7 @@ module Charges
     attr_reader :charge, :aggregation_result, :properties
 
     def charge_model
-      @charge_model ||= case charge.charge_model.to_sym
-      when :standard
-        ChargeModels::StandardService
-      when :graduated
-        ChargeModels::GraduatedService
-      when :graduated_percentage
-        ChargeModels::GraduatedPercentageService
-      when :package
-        ChargeModels::PackageService
-      when :percentage
-        ChargeModels::PercentageService
-      when :custom
-        ChargeModels::CustomService
-      when :dynamic
-        ChargeModels::DynamicService
-      else
-        raise(NotImplementedError)
-      end
+      @charge_model ||= ChargeModels::Factory.in_advance_charge_model_class(chargeable: charge)
     end
 
     def applied_charge_model

--- a/spec/models/events/common_spec.rb
+++ b/spec/models/events/common_spec.rb
@@ -26,6 +26,29 @@ RSpec.describe Events::Common do
   let(:started_at) { Time.current - 3.days }
   let(:external_subscription_id) { subscription.external_id }
 
+  describe "#persisted?" do
+    it { expect(event.persisted).to be_truthy }
+
+    context "when persisted value is passed to the event" do
+      subject(:event) do
+        described_class.new(
+          id: nil,
+          organization_id: organization.id,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          timestamp:,
+          code: billable_metric.code,
+          properties: {},
+          persisted: false
+        )
+      end
+
+      it "sets the value to the instance" do
+        expect(event.persisted).to be_falsey
+      end
+    end
+  end
+
   describe "#event_id" do
     it "returns the transaction_id" do
       expect(event.event_id).to eq(event.transaction_id)

--- a/spec/services/base_result_spec.rb
+++ b/spec/services/base_result_spec.rb
@@ -28,4 +28,51 @@ RSpec.describe BaseResult do
       end
     end
   end
+
+  describe ".==" do
+    subject(:result) { result_class.new.tap { it.property = "value" } }
+
+    let(:result_class) { described_class[:property] }
+    let(:other_result) { result_class.new.tap { it.property = "value" } }
+
+    it { expect(result).to eq(other_result) }
+
+    context "when the properties are different" do
+      let(:other_result) { result_class.new.tap { it.property = "different_value" } }
+
+      it { expect(result).not_to eq(other_result) }
+    end
+
+    context "when the properties are nil" do
+      let(:other_result) { result_class.new }
+
+      it { expect(result).not_to eq(other_result) }
+    end
+
+    context "when one result is a failure" do
+      let(:other_result) { result_class.new.not_found_failure!(resource: "property") }
+
+      it { expect(result).not_to eq(other_result) }
+    end
+
+    context "when results are the same failed result" do
+      it "returns true" do
+        expect(result.not_found_failure!(resource: "property"))
+          .to eq(other_result.not_found_failure!(resource: "property"))
+      end
+    end
+
+    context "when one result is an other failure" do
+      let(:other_result) { result_class.new.not_found_failure!(resource: "property") }
+
+      it { expect(result.not_found_failure!(resource: "values")).not_to eq(other_result) }
+    end
+
+    context "when one result is a different result class" do
+      let(:other_result_class) { described_class[:another_property] }
+      let(:other_result) { other_result_class.new.tap { it.another_property = "value" } }
+
+      it { expect(result).not_to eq(other_result) }
+    end
+  end
 end

--- a/spec/services/charge_models/factory_spec.rb
+++ b/spec/services/charge_models/factory_spec.rb
@@ -101,4 +101,56 @@ RSpec.describe ChargeModels::Factory do
       end
     end
   end
+
+  describe ".in_advance_charge_model_class" do
+    let(:result) { factory.in_advance_charge_model_class(chargeable: charge) }
+
+    context "when chargeable is a charge" do
+      context "with standard charge model" do
+        it { expect(result).to eq(ChargeModels::StandardService) }
+      end
+
+      context "with graduated charge model" do
+        let(:charge) { build(:graduated_charge) }
+
+        it { expect(result).to eq(ChargeModels::GraduatedService) }
+      end
+
+      context "with graduated_percentage charge model" do
+        let(:charge) { build(:graduated_percentage_charge) }
+
+        it { expect(result).to eq(ChargeModels::GraduatedPercentageService) }
+      end
+
+      context "with package charge model" do
+        let(:charge) { build(:package_charge) }
+
+        it { expect(result).to eq(ChargeModels::PackageService) }
+      end
+
+      context "with percentage charge model" do
+        let(:charge) { build(:percentage_charge) }
+
+        it { expect(result).to eq(ChargeModels::PercentageService) }
+      end
+
+      context "with volume charge model" do
+        let(:charge) { build(:volume_charge) }
+
+        it { expect { result }.to raise_error(NotImplementedError) }
+      end
+
+      context "with dynamic charge model" do
+        let(:charge) { build(:dynamic_charge) }
+
+        it { expect(result).to eq(ChargeModels::DynamicService) }
+      end
+
+      context "with custom charge model" do
+        let(:charge) { build(:custom_charge) }
+
+        it { expect(result).to eq(ChargeModels::CustomService) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Organizations configured to use the Clickhouse event store are not able to use the `POST /api/v1/events/estimate_fees` endpoint as the logic relies on the creation of a temporary record in the `events` table of Postgres.

This PR is part of a refactor allowing the estimate with clickhouse event stores and speeding up te estimate computation with postgres store by removing the need for persisting a temporary record.

## Description

Since the change requires a lot of file update, it will be split in multiple parts.
This first part:
- Adds a new `persisted` attribute to the `Events::Common` structure, with a default value to true. It will allow us to mark define an event as "temporary"
- Define the `==` method on the `BaseResult` class, to allow comparison of result states and values in specs
- Extract the charge model class initialization for in advance billing from `Charges::ApplyPayInAdvanceChargeModelService` to `ChargeModels::Factory`
