### PR TITLE
fix(payment_receipt): Avoid raising when already exists

### DIFF
--- a/app/services/payment_receipts/create_service.rb
+++ b/app/services/payment_receipts/create_service.rb
@@ -31,6 +31,9 @@ module PaymentReceipts
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::RecordNotUnique
+      result.payment_receipt = payment.reload.payment_receipt
+      result
     end
 
     private


### PR DESCRIPTION
## Context

The  `PaymentReceipts::CreateJob` is sometimes raising a  `ActiveRecord::RecordNotUnique`. It happens in some rare condition when the job is enqueued multiple time or when for some reason two workers are trying to perform the same job.
The job itself is checking for the presence of a payment receipt attached to the payment, but since the jobs are processed in parallel, it is not enough and the database unicity constraint then leads to the error.

## Description

The changes simply adds a rescue of the error and reload the payment to attach the payment_receipt to the result. It then return a success result.