### PR TITLE
fix(tax): Silent errors with parallel invoice refresh

### DIFF
--- a/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
+++ b/app/services/invoices/provider_taxes/pull_taxes_and_apply_service.rb
@@ -67,6 +67,10 @@ module Invoices
         result
       rescue ActiveRecord::RecordInvalid => e
         result.record_validation_failure!(record: e.record)
+      rescue ActiveRecord::InvalidForeignKey
+        # NOTE: A draft invoice has been refreshed while the taxes were applied
+        raise unless invoice.draft?
+        result
       rescue BaseService::FailedResult => e
         e.result
       end


### PR DESCRIPTION
## Description

The goal of this PR is to silent `ActiveRecord::InvalidForeignKey` raised from `Invoices::ProvidersTaxes::PullTaxesAndApplyJob` when a draft invoice is being refreshed in parallel of the tax process.
The error occurs because the fees are removed by the refresh process, and as such, the service is unable to persist the fees_applied_taxes.

The service keeps raising if the invoice is not in draft to avoid loosing other potential errors