### PR TITLE
fix(credit_notes): Take rouding into account with credit notes validation

### DIFF
--- a/app/services/credit_notes/validate_service.rb
+++ b/app/services/credit_notes/validate_service.rb
@@ -93,16 +93,22 @@ module CreditNotes
         add_error(field: :credit_amount_cents, error_code: "cannot_credit_invoice")
       end
 
-      return true if credit_note.credit_amount_cents <= invoice.fee_total_amount_cents - credited_invoice_amount_cents
+      creditable = invoice.fee_total_amount_cents - credited_invoice_amount_cents
+      return true if credit_note.credit_amount_cents <= creditable
 
-      add_error(field: :credit_amount_cents, error_code: "higher_than_remaining_invoice_amount")
+      if (credit_note.credit_amount_cents - creditable).abs > 1
+        add_error(field: :credit_amount_cents, error_code: "higher_than_remaining_invoice_amount")
+      end
     end
 
     # NOTE: Check if total amount is less than or equal to invoice fee amount
     def valid_remaining_invoice_amount?
-      return true if total_amount_cents <= invoice.fee_total_amount_cents - invoice_credit_note_total_amount_cents
+      remaining = invoice.fee_total_amount_cents - invoice_credit_note_total_amount_cents
+      return true if total_amount_cents <= remaining
 
-      add_error(field: :base, error_code: "higher_than_remaining_invoice_amount")
+      if (total_amount_cents - remaining).abs > 1
+        add_error(field: :base, error_code: "higher_than_remaining_invoice_amount")
+      end
     end
 
     # NOTE: Check if total amount is greater than 0

--- a/spec/scenarios/credit_notes/credit_note_rounding_spec.rb
+++ b/spec/scenarios/credit_notes/credit_note_rounding_spec.rb
@@ -149,4 +149,95 @@ describe "Credit note rounding issues Scenarios", :scenarios, type: :request do
       )
     end
   end
+
+  context "with existing credit note" do
+    let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }
+    let(:amount_cents) { 769_00 }
+
+    it "handles the rounding issues" do
+      # Creates the subscription
+      travel_to(Time.zone.parse("2025-09-18T16:00:00Z")) do
+        create_subscription({
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time: :anniversary
+        })
+      end
+
+      # subscription = customer.subscriptions.last
+      invoice = customer.invoices.last
+      expect(invoice.fees_amount_cents).to eq(769_00)
+      expect(invoice.taxes_amount_cents).to eq(153_80)
+      expect(invoice.total_amount_cents).to eq(922_80)
+
+      # Finalize the invoice
+      travel_to(Time.zone.parse("2025-09-19T16:30:00Z")) do
+        update_invoice(invoice, {payment_status: "succeeded"})
+      end
+
+      # Create a credit note
+      travel_to(Time.zone.parse("2025-09-20T16:30:00Z")) do
+        create_credit_note({
+          reason: :other,
+          invoice_id: invoice.id,
+          credit_amount_cents: 872_24,
+          refund_amount_cents: 0,
+          items: [
+            {
+              fee_id: invoice.fees.first.id,
+              amount_cents: 726_86
+            }
+          ]
+        })
+      end
+
+      credit_note = invoice.credit_notes.first
+      expect(credit_note).to have_attributes(
+        sub_total_excluding_taxes_amount_cents: 726_86,
+        taxes_amount_cents: 145_37,
+        refund_amount_cents: 0,
+        total_amount_cents: 872_23,
+        coupons_adjustment_amount_cents: 0
+      )
+
+      # Credit note was created before the rounding fix, so it has a different total amount
+      credit_note.update(total_amount_cents: 872_24, credit_amount_cents: 872_24)
+
+      estimate = estimate_credit_note({
+        invoice_id: invoice.id,
+        items: [
+          {
+            fee_id: invoice.fees.first.id,
+            amount_cents: 42_14
+          }
+        ]
+      })
+
+      # Create a new credit note with the remaining amount
+      travel_to(Time.zone.parse("2025-09-22T16:30:00Z")) do
+        create_credit_note({
+          reason: :other,
+          invoice_id: invoice.id,
+          credit_amount_cents: estimate.dig("estimated_credit_note", "max_creditable_amount_cents"), # 50_57
+          refund_amount_cents: 0,
+          items: [
+            {
+              fee_id: invoice.fees.first.id,
+              amount_cents: 42_14
+            }
+          ]
+        })
+      end
+
+      credit_note = invoice.credit_notes.order(created_at: :desc).first
+      expect(credit_note).to have_attributes(
+        sub_total_excluding_taxes_amount_cents: 42_14,
+        taxes_amount_cents: 8_43,
+        refund_amount_cents: 0,
+        total_amount_cents: 50_57,
+        coupons_adjustment_amount_cents: 0
+      )
+    end
+  end
 end

--- a/spec/services/credit_notes/validate_service_spec.rb
+++ b/spec/services/credit_notes/validate_service_spec.rb
@@ -104,6 +104,15 @@ RSpec.describe CreditNotes::ValidateService do
         expect(result.error).to be_a(BaseService::ValidationFailure)
         expect(result.error.messages[:credit_amount_cents]).to eq(["higher_than_remaining_invoice_amount"])
       end
+
+      context "when the difference is due to rounding" do
+        let(:credit_amount_cents) { 241 }
+        let(:amount_cents) { 239 }
+
+        it "passes the validation" do
+          expect(validator).to be_valid
+        end
+      end
     end
 
     context "when refund amount is higher than invoice amount" do
@@ -247,6 +256,19 @@ RSpec.describe CreditNotes::ValidateService do
       let(:amount_cents) { 19333 }
       let(:credit_amount_cents) { 24166 }
       let(:precise_taxes_amount_cents) { 4833.3333 }
+
+      it "passes the validation" do
+        expect(validator).to be_valid
+      end
+    end
+
+    context "when the difference is due to rounding" do
+      let(:credit_amount_cents) { 241 }
+      let(:amount_cents) { 239 }
+
+      before do
+        create(:fee, invoice:, amount_cents: 100, taxes_rate: 20, taxes_amount_cents: 20)
+      end
 
       it "passes the validation" do
         expect(validator).to be_valid


### PR DESCRIPTION
## Context

This PR is related to the recent changes around taxes and rounding on credit notes:
- https://github.com/getlago/lago-api/pull/4373
-  https://github.com/getlago/lago-api/pull/4411
- https://github.com/getlago/lago-api/pull/4449

Some credit notes created before the fix might be affected by a validation issue when the `credit_amount` is 1 cent above max creditable invoice value (due to past rounding issues). This could also potentially affect new consecutive credit notes emitted on an invoice because of the +/- that we are applying on the total/credit_amount

## Description

This fix updates the validations so that the `credit_amount` and `total_amount` are not considered invalid if they are 1 cents at most above the max creditable amount.
