### PR TITLE
feat(estimate_fee): Add spec scenarios

### DIFF
--- a/app/services/fees/estimate_pay_in_advance_service.rb
+++ b/app/services/fees/estimate_pay_in_advance_service.rb
@@ -50,7 +50,8 @@ module Fees
         external_subscription_id: subscriptions.first&.external_id,
         properties: event_params[:properties] || {},
         transaction_id: SecureRandom.uuid,
-        timestamp: Time.current
+        timestamp: Time.current,
+        precise_total_amount_cents: event_params[:precise_total_amount_cents] || 0
       )
     end
 

--- a/spec/scenarios/estimate_events_spec.rb
+++ b/spec/scenarios/estimate_events_spec.rb
@@ -1,0 +1,717 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Estimate In Advance Events" do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:plan) { create(:plan, organization:, amount_cents: 1000) }
+
+  let(:metric) { create(:billable_metric, organization:) }
+  let(:charge) do
+    create(
+      :standard_charge,
+      plan:,
+      billable_metric: metric,
+      pay_in_advance: true,
+      properties: {amount: "10"}
+    )
+  end
+
+  before { charge }
+
+  context "with a count aggregation" do
+    it "returns the estimated price of the events, taking care of the existing ones" do
+      travel_to(Time.zone.parse("2025-09-01")) do
+        create_subscription({
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        })
+      end
+
+      subscription = customer.subscriptions.last
+
+      # Estimate event without existing events
+      travel_to(Time.zone.parse("2025-09-02")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(1000)
+        expect(fee["units"]).to eq("1.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+
+      # Create an event
+      travel_to(Time.zone.parse("2025-09-03")) do
+        create_event({
+          transaction_id: SecureRandom.uuid,
+          code: metric.code,
+          external_subscription_id: subscription.external_id
+        })
+      end
+
+      # Estimate a new event with an existing one
+      travel_to(Time.zone.parse("2025-09-04")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(1000)
+        expect(fee["units"]).to eq("1.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+    end
+  end
+
+  context "with a sum aggregation" do
+    let(:metric) { create(:sum_billable_metric, organization:) }
+
+    it "returns the estimated price of the events, taking care of the existing ones" do
+      travel_to(Time.zone.parse("2025-09-01")) do
+        create_subscription({
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        })
+      end
+
+      subscription = customer.subscriptions.last
+
+      # Estimate event without existing events
+      travel_to(Time.zone.parse("2025-09-02")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => 4}
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(4000)
+        expect(fee["units"]).to eq("4.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+
+      # Create an event
+      travel_to(Time.zone.parse("2025-09-03")) do
+        create_event({
+          transaction_id: SecureRandom.uuid,
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => 4}
+        })
+      end
+
+      # Estimate a new event with an existing one
+      travel_to(Time.zone.parse("2025-09-04")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => 4}
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(4000)
+        expect(fee["units"]).to eq("4.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+    end
+
+    context "when billable metric is recurring" do
+      let(:metric) { create(:sum_billable_metric, :recurring, organization:) }
+
+      it "returns the estimated price of the events, taking care of the existing ones" do
+        travel_to(Time.zone.parse("2024-09-01")) do
+          create_subscription({
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code
+          })
+        end
+
+        subscription = customer.subscriptions.last
+
+        # Create an event
+        travel_to(Time.zone.parse("2024-09-03")) do
+          create_event({
+            transaction_id: SecureRandom.uuid,
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => 4}
+          })
+        end
+
+        # Estimate event without existing events
+        travel_to(Time.zone.parse("2025-09-02")) do
+          result = estimate_event({
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => 4}
+          })
+
+          fee = result[:fees].first
+          expect(fee["amount_cents"]).to eq(4000)
+          expect(fee["units"]).to eq("4.0")
+          expect(fee["events_count"]).to eq(1)
+        end
+
+        # Create an event
+        travel_to(Time.zone.parse("2025-09-03")) do
+          create_event({
+            transaction_id: SecureRandom.uuid,
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => 4}
+          })
+        end
+
+        # Estimate a new event with an existing one
+        travel_to(Time.zone.parse("2025-09-04")) do
+          result = estimate_event({
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => 4}
+          })
+
+          fee = result[:fees].first
+          expect(fee["amount_cents"]).to eq(4000)
+          expect(fee["units"]).to eq("4.0")
+          expect(fee["events_count"]).to eq(1)
+        end
+      end
+    end
+
+    context "when charge model is dynamic" do
+      let(:charge) do
+        create(
+          :dynamic_charge,
+          plan:,
+          billable_metric: metric,
+          pay_in_advance: true
+        )
+      end
+
+      it "returns the estimated price of the events, taking care of the existing ones" do
+        travel_to(Time.zone.parse("2025-09-01")) do
+          create_subscription({
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code
+          })
+        end
+
+        subscription = customer.subscriptions.last
+
+        # Estimate event without existing events
+        travel_to(Time.zone.parse("2025-09-02")) do
+          result = estimate_event({
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => 1},
+            precise_total_amount_cents: 200
+          })
+
+          fee = result[:fees].first
+          expect(fee["amount_cents"]).to eq(200)
+          expect(fee["units"]).to eq("1.0")
+          expect(fee["events_count"]).to eq(1)
+        end
+
+        # Create an event
+        travel_to(Time.zone.parse("2025-09-03")) do
+          create_event({
+            transaction_id: SecureRandom.uuid,
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => 1},
+            precise_total_amount_cents: 200
+          })
+        end
+
+        # Estimate a new event with an existing one
+        travel_to(Time.zone.parse("2025-09-04")) do
+          result = estimate_event({
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => 1},
+            precise_total_amount_cents: 200
+          })
+
+          fee = result[:fees].first
+          expect(fee["amount_cents"]).to eq(200)
+          expect(fee["units"]).to eq("1.0")
+          expect(fee["events_count"]).to eq(1)
+        end
+      end
+    end
+
+    context "when charge model is percentage", :premium do
+      let(:charge) do
+        create(
+          :percentage_charge,
+          plan:,
+          billable_metric: metric,
+          pay_in_advance: true,
+          properties: {rate: "0.5", per_transaction_min_amount: "12"}
+        )
+      end
+
+      it "returns the estimated price of the events, taking care of the existing ones" do
+        travel_to(Time.zone.parse("2025-09-01")) do
+          create_subscription({
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code
+          })
+        end
+
+        subscription = customer.subscriptions.last
+
+        # Estimate event without existing events
+        travel_to(Time.zone.parse("2025-09-02")) do
+          result = estimate_event({
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => 4}
+          })
+
+          fee = result[:fees].first
+          expect(fee["amount_cents"]).to eq(1200)
+          expect(fee["units"]).to eq("4.0")
+          expect(fee["events_count"]).to eq(1)
+        end
+
+        # Create an event
+        travel_to(Time.zone.parse("2025-09-03")) do
+          create_event({
+            transaction_id: SecureRandom.uuid,
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => 4}
+          })
+        end
+
+        # Estimate a new event with an existing one
+        travel_to(Time.zone.parse("2025-09-04")) do
+          result = estimate_event({
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => 20_000}
+          })
+
+          fee = result[:fees].first
+          expect(fee["amount_cents"]).to eq(10_000)
+          expect(fee["units"]).to eq("20000.0")
+          expect(fee["events_count"]).to eq(1)
+        end
+      end
+
+      context "when billable metric is recurring" do
+        let(:metric) { create(:sum_billable_metric, :recurring, organization:) }
+
+        it "returns the estimated price of the events, taking care of the existing ones" do
+          travel_to(Time.zone.parse("2024-09-01")) do
+            create_subscription({
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan.code
+            })
+          end
+
+          subscription = customer.subscriptions.last
+
+          # Create an event
+          travel_to(Time.zone.parse("2024-09-03")) do
+            create_event({
+              transaction_id: SecureRandom.uuid,
+              code: metric.code,
+              external_subscription_id: subscription.external_id,
+              properties: {metric.field_name => 4}
+            })
+          end
+
+          # Estimate event without existing events
+          travel_to(Time.zone.parse("2025-09-02")) do
+            result = estimate_event({
+              code: metric.code,
+              external_subscription_id: subscription.external_id,
+              properties: {metric.field_name => 4}
+            })
+
+            fee = result[:fees].first
+            expect(fee["amount_cents"]).to eq(1200)
+            expect(fee["units"]).to eq("4.0")
+            expect(fee["events_count"]).to eq(1)
+          end
+
+          # Create an event
+          travel_to(Time.zone.parse("2025-09-03")) do
+            create_event({
+              transaction_id: SecureRandom.uuid,
+              code: metric.code,
+              external_subscription_id: subscription.external_id,
+              properties: {metric.field_name => 4}
+            })
+          end
+
+          # Estimate a new event with an existing one
+          travel_to(Time.zone.parse("2025-09-04")) do
+            result = estimate_event({
+              code: metric.code,
+              external_subscription_id: subscription.external_id,
+              properties: {metric.field_name => 20_000}
+            })
+
+            fee = result[:fees].first
+            expect(fee["amount_cents"]).to eq(10_000)
+            expect(fee["units"]).to eq("20000.0")
+            expect(fee["events_count"]).to eq(1)
+          end
+        end
+      end
+    end
+  end
+
+  context "with a prorated sum aggregation" do
+    let(:metric) { create(:sum_billable_metric, :recurring, organization:) }
+    let(:charge) do
+      create(
+        :standard_charge,
+        plan:,
+        billable_metric: metric,
+        pay_in_advance: true,
+        properties: {amount: "10"},
+        prorated: true
+      )
+    end
+
+    it "returns the estimated price of the events, taking care of the existing ones" do
+      travel_to(Time.zone.parse("2025-09-01")) do
+        create_subscription({
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        })
+      end
+
+      subscription = customer.subscriptions.last
+
+      # Estimate event without existing events
+      travel_to(Time.zone.parse("2025-09-02")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => 4}
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(3867)
+        expect(fee["units"]).to eq("4.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+
+      # Create an event
+      travel_to(Time.zone.parse("2025-09-03")) do
+        create_event({
+          transaction_id: SecureRandom.uuid,
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => 4}
+        })
+      end
+
+      # Estimate a new event with an existing one
+      travel_to(Time.zone.parse("2025-09-04")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => 4}
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(3600)
+        expect(fee["units"]).to eq("4.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+    end
+  end
+
+  context "with a unique_count aggregation" do
+    let(:metric) { create(:unique_count_billable_metric, organization:) }
+
+    it "returns the estimated price of the events, taking care of the existing ones" do
+      travel_to(Time.zone.parse("2025-09-01")) do
+        create_subscription({
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        })
+      end
+
+      subscription = customer.subscriptions.last
+
+      # Estimate event without existing events
+      travel_to(Time.zone.parse("2025-09-02")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => "1234"}
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(1000)
+        expect(fee["units"]).to eq("1.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+
+      # Create an event
+      travel_to(Time.zone.parse("2025-09-03")) do
+        create_event({
+          transaction_id: SecureRandom.uuid,
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => "1234"}
+        })
+      end
+
+      # Estimate a new event with an existing one
+      travel_to(Time.zone.parse("2025-09-04")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => "1234"}
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(0)
+        expect(fee["units"]).to eq("0.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+
+      travel_to(Time.zone.parse("2025-09-05")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => "5678"}
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(1000)
+        expect(fee["units"]).to eq("1.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+
+      travel_to(Time.zone.parse("2025-09-05")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => "1234", :operation_type => "remove"}
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(0)
+        expect(fee["units"]).to eq("0.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+    end
+
+    context "when billable metric is recurring" do
+      let(:metric) { create(:unique_count_billable_metric, :recurring, organization:) }
+
+      it "returns the estimated price of the events, taking care of the existing ones" do
+        travel_to(Time.zone.parse("2024-09-01")) do
+          create_subscription({
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code
+          })
+        end
+
+        subscription = customer.subscriptions.last
+
+        # Create an event
+        travel_to(Time.zone.parse("2024-09-03")) do
+          create_event({
+            transaction_id: SecureRandom.uuid,
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => "1234"}
+          })
+        end
+
+        # Estimate event with a pre-existing one
+        travel_to(Time.zone.parse("2025-09-02")) do
+          result = estimate_event({
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => "1234"}
+          })
+
+          fee = result[:fees].first
+          expect(fee["amount_cents"]).to eq(0)
+          expect(fee["units"]).to eq("0.0")
+          expect(fee["events_count"]).to eq(1)
+        end
+
+        # Estimate event without a pre-existing one
+        travel_to(Time.zone.parse("2025-09-02")) do
+          result = estimate_event({
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => "9876"}
+          })
+
+          fee = result[:fees].first
+          expect(fee["amount_cents"]).to eq(1000)
+          expect(fee["units"]).to eq("1.0")
+          expect(fee["events_count"]).to eq(1)
+        end
+
+        # Create an event
+        travel_to(Time.zone.parse("2025-09-03")) do
+          create_event({
+            transaction_id: SecureRandom.uuid,
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => "1234"}
+          })
+        end
+
+        # Estimate a new event with an existing one
+        travel_to(Time.zone.parse("2025-09-04")) do
+          result = estimate_event({
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => "1234"}
+          })
+
+          fee = result[:fees].first
+          expect(fee["amount_cents"]).to eq(0)
+          expect(fee["units"]).to eq("0.0")
+          expect(fee["events_count"]).to eq(1)
+        end
+
+        travel_to(Time.zone.parse("2025-09-05")) do
+          result = estimate_event({
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => "5678"}
+          })
+
+          fee = result[:fees].first
+          expect(fee["amount_cents"]).to eq(1000)
+          expect(fee["units"]).to eq("1.0")
+          expect(fee["events_count"]).to eq(1)
+        end
+
+        travel_to(Time.zone.parse("2025-09-05")) do
+          result = estimate_event({
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {metric.field_name => "1234", :operation_type => "remove"}
+          })
+
+          fee = result[:fees].first
+          expect(fee["amount_cents"]).to eq(0)
+          expect(fee["units"]).to eq("0.0")
+          expect(fee["events_count"]).to eq(1)
+        end
+      end
+    end
+  end
+
+  context "with a prorated unique_count aggregation" do
+    let(:metric) { create(:unique_count_billable_metric, :recurring, organization:) }
+    let(:charge) do
+      create(
+        :standard_charge,
+        plan:,
+        billable_metric: metric,
+        pay_in_advance: true,
+        properties: {amount: "10"},
+        prorated: true
+      )
+    end
+
+    it "returns the estimated price of the events, taking care of the existing ones" do
+      travel_to(Time.zone.parse("2025-09-01")) do
+        create_subscription({
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code
+        })
+      end
+
+      subscription = customer.subscriptions.last
+
+      # Estimate event without existing events
+      travel_to(Time.zone.parse("2025-09-02")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => "1234"}
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(967)
+        expect(fee["units"]).to eq("1.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+
+      # Create an event
+      travel_to(Time.zone.parse("2025-09-03")) do
+        create_event({
+          transaction_id: SecureRandom.uuid,
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => "1234"}
+        })
+      end
+
+      # Estimate a new event with an existing one
+      travel_to(Time.zone.parse("2025-09-04")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => "1234"}
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(0)
+        expect(fee["units"]).to eq("0.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+
+      travel_to(Time.zone.parse("2025-09-05")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => "5678"}
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(867)
+        expect(fee["units"]).to eq("1.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+
+      travel_to(Time.zone.parse("2025-09-05")) do
+        result = estimate_event({
+          code: metric.code,
+          external_subscription_id: subscription.external_id,
+          properties: {metric.field_name => "1234", :operation_type => "remove"}
+        })
+
+        fee = result[:fees].first
+        expect(fee["amount_cents"]).to eq(0)
+        expect(fee["units"]).to eq("0.0")
+        expect(fee["events_count"]).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -279,6 +279,12 @@ module ScenariosHelper
     end
   end
 
+  def estimate_event(params, **kwargs)
+    api_call(**kwargs) do
+      post_with_token(organization, "/api/v1/events/estimate_fees", {event: params})
+    end
+  end
+
   ### Credit notes
 
   def create_credit_note(params, **kwargs)


### PR DESCRIPTION
## Context

Organizations configured to use the Clickhouse event store are not able to use the `POST /api/v1/events/estimate_fees` endpoint as the logic relies on the creation of a temporary record in the `events` table of Postgres.

This PR is part of a refactor allowing the estimate with clickhouse event stores and speeding up te estimate computation with postgres store by removing the need for persisting a temporary record.

## Description

- This PR is adding spec scenarios covering as much use case as possible of the estimate endpoint. It will ease the refactor and the clickhouse support implementation by reducing the risk of breaking changes.

The support of the dynamic charge model is also added to the estimate endpoint as it was missing.