### PR TITLE
misc(sidekiq): Build internal image with Sidekiq Pro

### DIFF
--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -4,7 +4,12 @@ on:
     branches:
       - main
   workflow_dispatch:
-permissions: { }
+    inputs:
+      sidekiq_pro:
+        type: boolean
+        default: true
+        description: Enable Sidekiq Pro
+permissions: {}
 jobs:
   build-api-image:
     runs-on: ubuntu-latest
@@ -41,3 +46,7 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.docker_tag.outputs.tag }}
+          build-args: |
+            BUNDLE_WITH=${{ (github.event_name == 'push' || github.event.inputs.sidekiq_pro == 'true') && 'sidekiq-pro' || '' }}
+          secrets: |
+            "BUNDLE_GEMS__CONTRIBSYS__COM=${{ secrets.BUNDLE_GEMS__CONTRIBSYS__COM }}"


### PR DESCRIPTION
## Context

Today, we are using Sidekiq to handle our background jobs. While it works well for most of our needs, we are reaching some limitations with the open-source version, particularly around job reliability during high load.

Sidekiq uses `BRPOP` to fetch a job from the queue in Redis. This is very efficient and simple but it has one drawback: the job is now removed from Redis. If Sidekiq crashes while processing that job, it is lost forever.

## Description

This is a follow up of https://github.com/getlago/lago-api/commit/0e95df4c4688feec5b2cd942b42b27bfd45efc1d. It updated the `Dockerfile` to:

1. Accept a `BUNDLE_WITH` which can be used to conditionally enabled Sidekiq Pro when the value is `sidekiq-pro`.
2. Mount the `BUNDLE_GEMS__CONTRIBSYS__COM` variable as a Docker secret as it's only required during the build and is a sensitive information.

This builds the internal image using Sidekiq Pro by default.