### PR TITLE
feat(fixed-charges): GraphQL: Invoice all fixed charges has fees flag

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -45,6 +45,7 @@ module Types
       field :payment_overdue, Boolean, null: false
 
       field :all_charges_have_fees, Boolean, null: false, method: :all_charges_have_fees?
+      field :all_fixed_charges_have_fees, Boolean, null: false, method: :all_fixed_charges_have_fees?
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -356,6 +356,18 @@ class Invoice < ApplicationRecord
     end
   end
 
+  def all_fixed_charges_have_fees?
+    return true unless subscription?
+
+    !FixedCharge.exists?(
+      FixedCharge.joins(plan: :subscriptions)
+      .where(subscriptions: {id: subscriptions.select(:id)})
+      .where.not(
+        id: fees.fixed_charge.select(:fixed_charge_id)
+      )
+    )
+  end
+
   def has_different_boundaries_for_subscription_and_charges?(subscription)
     invoice_subscription = invoice_subscription(subscription.id)
     subscription_from = invoice_subscription.from_datetime_in_customer_timezone&.to_date

--- a/schema.graphql
+++ b/schema.graphql
@@ -5862,6 +5862,7 @@ Invoice
 type Invoice {
   activityLogs: [ActivityLog!]
   allChargesHaveFees: Boolean!
+  allFixedChargesHaveFees: Boolean!
   appliedTaxes: [InvoiceAppliedTax!]
   associatedActiveWalletPresent: Boolean!
   availableToCreditAmountCents: BigInt!

--- a/schema.json
+++ b/schema.json
@@ -29429,6 +29429,22 @@
               "deprecationReason": null
             },
             {
+              "name": "allFixedChargesHaveFees",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "appliedTaxes",
               "description": null,
               "args": [],

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Types::Invoices::Object do
     expect(subject).to have_field(:payment_due_date).of_type("ISO8601Date!")
     expect(subject).to have_field(:payment_overdue).of_type("Boolean!")
     expect(subject).to have_field(:all_charges_have_fees).of_type("Boolean!")
+    expect(subject).to have_field(:all_fixed_charges_have_fees).of_type("Boolean!")
 
     expect(subject).to have_field(:created_at).of_type("ISO8601DateTime!")
     expect(subject).to have_field(:updated_at).of_type("ISO8601DateTime!")

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -2008,6 +2008,35 @@ RSpec.describe Invoice do
     end
   end
 
+  describe "#all_fixed_charges_have_fees?" do
+    let(:invoice) { create(:invoice, :subscription, subscriptions: [subscription]) }
+    let(:plan) { create(:plan) }
+    let(:subscription) { create(:subscription, plan:) }
+    let(:fixed_charge1) { create(:fixed_charge, plan:) }
+    let(:fixed_charge2) { create(:fixed_charge, plan:) }
+
+    before do
+      create(:fixed_charge_fee, fixed_charge: fixed_charge1, invoice:)
+      fixed_charge2
+    end
+
+    it { expect(invoice).not_to be_all_fixed_charges_have_fees }
+
+    context "when all fixed charges have fees" do
+      before do
+        create(:fixed_charge_fee, fixed_charge: fixed_charge2, invoice:)
+      end
+
+      it { expect(invoice).to be_all_fixed_charges_have_fees }
+    end
+
+    context "without subscription" do
+      let(:invoice) { create(:invoice) }
+
+      it { expect(invoice).to be_all_fixed_charges_have_fees }
+    end
+  end
+
   describe "should_apply_provider_tax?" do
     subject { invoice.should_apply_provider_tax? }
 


### PR DESCRIPTION
To allow users to add fees of fixed charges with zero units on draft invoices, graphQL Invoice object type should expose a flag to indicate if invoice has fixed charges without a fee.