### PR TITLE
test(query): Remove unused `type: :query` spec metadata

### DIFF
--- a/spec/queries/activity_logs_query_spec.rb
+++ b/spec/queries/activity_logs_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ActivityLogsQuery, type: :query, clickhouse: true do
+RSpec.describe ActivityLogsQuery, clickhouse: true do
   subject(:result) do
     described_class.call(organization:, pagination:, filters:)
   end

--- a/spec/queries/add_ons_query_spec.rb
+++ b/spec/queries/add_ons_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AddOnsQuery, type: :query do
+RSpec.describe AddOnsQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, search_term:)
   end

--- a/spec/queries/api_logs_query_spec.rb
+++ b/spec/queries/api_logs_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ApiLogsQuery, type: :query, clickhouse: true do
+RSpec.describe ApiLogsQuery, clickhouse: true do
   subject(:result) do
     described_class.call(organization:, pagination:, filters:)
   end

--- a/spec/queries/applied_coupons_query_spec.rb
+++ b/spec/queries/applied_coupons_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AppliedCouponsQuery, type: :query do
+RSpec.describe AppliedCouponsQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, filters:)
   end

--- a/spec/queries/billable_metrics_query_spec.rb
+++ b/spec/queries/billable_metrics_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe BillableMetricsQuery, type: :query do
+RSpec.describe BillableMetricsQuery do
   subject(:result) do
     described_class.call(organization:, search_term:, pagination:, filters:)
   end

--- a/spec/queries/coupons_query_spec.rb
+++ b/spec/queries/coupons_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CouponsQuery, type: :query do
+RSpec.describe CouponsQuery do
   subject(:result) do
     described_class.call(organization:, search_term:, pagination:, filters:)
   end

--- a/spec/queries/credit_notes_query_spec.rb
+++ b/spec/queries/credit_notes_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CreditNotesQuery, type: :query do
+RSpec.describe CreditNotesQuery do
   subject(:result) do
     described_class.call(organization:, search_term:, pagination:, filters:)
   end

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CustomersQuery, type: :query do
+RSpec.describe CustomersQuery do
   subject(:result) do
     described_class.call(organization:, search_term:, pagination:, filters:)
   end

--- a/spec/queries/dunning_campaigns_query_spec.rb
+++ b/spec/queries/dunning_campaigns_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DunningCampaignsQuery, type: :query do
+RSpec.describe DunningCampaignsQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, search_term:, filters:, order:)
   end

--- a/spec/queries/events_query_spec.rb
+++ b/spec/queries/events_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe EventsQuery, type: :query do
+RSpec.describe EventsQuery do
   subject(:events_query) { described_class.new(organization:, pagination:, filters:) }
 
   let(:organization) { create(:organization) }

--- a/spec/queries/fees_query_spec.rb
+++ b/spec/queries/fees_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FeesQuery, type: :query do
+RSpec.describe FeesQuery do
   subject(:fees_query) { described_class.new(organization:, pagination:, filters:) }
 
   let(:organization) { create(:organization) }

--- a/spec/queries/integration_collection_mappings_query_spec.rb
+++ b/spec/queries/integration_collection_mappings_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationCollectionMappingsQuery, type: :query do
+RSpec.describe IntegrationCollectionMappingsQuery do
   subject(:result) { described_class.call(organization:, pagination:, filters:) }
 
   let(:returned_ids) { result.integration_collection_mappings.pluck(:id) }

--- a/spec/queries/integration_items_query_spec.rb
+++ b/spec/queries/integration_items_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe IntegrationItemsQuery, type: :query do
+RSpec.describe IntegrationItemsQuery do
   subject(:result) do
     described_class.call(organization:, search_term:, pagination:, filters:)
   end

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe InvoicesQuery, type: :query do
+RSpec.describe InvoicesQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, search_term:, filters:)
   end

--- a/spec/queries/past_usage_query_spec.rb
+++ b/spec/queries/past_usage_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PastUsageQuery, type: :query do
+RSpec.describe PastUsageQuery do
   subject(:result) { described_class.call(organization:, pagination:, filters:) }
 
   let(:organization) { create(:organization) }

--- a/spec/queries/payment_methods_query_spec.rb
+++ b/spec/queries/payment_methods_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentMethodsQuery, type: :query do
+RSpec.describe PaymentMethodsQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, filters:)
   end

--- a/spec/queries/payment_receipts_query_spec.rb
+++ b/spec/queries/payment_receipts_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentReceiptsQuery, type: :query do
+RSpec.describe PaymentReceiptsQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, filters:)
   end

--- a/spec/queries/payment_requests_query_spec.rb
+++ b/spec/queries/payment_requests_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentRequestsQuery, type: :query do
+RSpec.describe PaymentRequestsQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, filters:)
   end

--- a/spec/queries/payments_query_spec.rb
+++ b/spec/queries/payments_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PaymentsQuery, type: :query do
+RSpec.describe PaymentsQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, filters:, search_term:)
   end

--- a/spec/queries/plans_query_spec.rb
+++ b/spec/queries/plans_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PlansQuery, type: :query do
+RSpec.describe PlansQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, search_term:, filters:)
   end

--- a/spec/queries/pricing_units_query_spec.rb
+++ b/spec/queries/pricing_units_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe PricingUnitsQuery, type: :query do
+RSpec.describe PricingUnitsQuery do
   subject(:result) { described_class.call(organization:, search_term:, pagination:) }
 
   let(:organization) { create(:organization) }

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe SubscriptionsQuery, type: :query do
+RSpec.describe SubscriptionsQuery do
   subject(:result) { described_class.call(organization:, pagination:, filters:, search_term:) }
 
   let(:returned_ids) { result.subscriptions.pluck(:id) }

--- a/spec/queries/taxes_query_spec.rb
+++ b/spec/queries/taxes_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe TaxesQuery, type: :query do
+RSpec.describe TaxesQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, search_term:, filters:, order:)
   end

--- a/spec/queries/usage_monitoring/alerts_query_spec.rb
+++ b/spec/queries/usage_monitoring/alerts_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UsageMonitoring::AlertsQuery, type: :query do
+RSpec.describe UsageMonitoring::AlertsQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, filters:)
   end

--- a/spec/queries/wallet_transactions_query_spec.rb
+++ b/spec/queries/wallet_transactions_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WalletTransactionsQuery, type: :query do
+RSpec.describe WalletTransactionsQuery do
   subject(:result) do
     described_class.call(
       organization:,

--- a/spec/queries/wallets_query_spec.rb
+++ b/spec/queries/wallets_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WalletsQuery, type: :query do
+RSpec.describe WalletsQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, filters:)
   end

--- a/spec/queries/webhook_endpoints_query_spec.rb
+++ b/spec/queries/webhook_endpoints_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WebhookEndpointsQuery, type: :query do
+RSpec.describe WebhookEndpointsQuery do
   subject(:result) do
     described_class.call(organization:, pagination:, search_term:)
   end

--- a/spec/queries/webhooks_query_spec.rb
+++ b/spec/queries/webhooks_query_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WebhooksQuery, type: :query do
+RSpec.describe WebhooksQuery do
   subject(:result) do
     described_class.call(webhook_endpoint:, pagination:, search_term:, filters:)
   end


### PR DESCRIPTION
## Context

All query tests include the `type: :query` RSpec metadata but this metadata isn't actually used. This make the metadata more confusing than helpful.

## Description

This removes the unnecessary metadata.