### PR TITLE
refactor(invoice): optimize fee validation with SQL queries

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -423,7 +423,7 @@ class Invoice < ApplicationRecord
   def all_charges_have_base_fees?
     !Charge.exists?(
       Charge.joins(plan: :subscriptions)
-        .where(subscriptions: { id: subscriptions.select(:id) })
+        .where(subscriptions: {id: subscriptions.select(:id)})
         .where.not(
           id: fees.charge.where(charge_filter_id: nil).select(:charge_id)
         )
@@ -434,8 +434,8 @@ class Invoice < ApplicationRecord
   # Only relevant for charges that have filters defined
   def all_charge_filters_have_fees?
     !ChargeFilter.exists?(
-      ChargeFilter.joins(charge: { plan: :subscriptions })
-        .where(subscriptions: { id: subscriptions.select(:id) })
+      ChargeFilter.joins(charge: {plan: :subscriptions})
+        .where(subscriptions: {id: subscriptions.select(:id)})
         .where.not(
           id: fees.charge.where.not(charge_filter_id: nil).select(:charge_filter_id)
         )


### PR DESCRIPTION
 ## Context

The `all_charges_have_fees?` method was using nested Ruby loops to check if all charges from subscription plans have their corresponding fees created. This involved loading all subscriptions, plans, charges, and filters into memory, then iterating through them with Ruby.

For invoices with multiple subscriptions and many charges, this approach was slow and memory-intensive.

 ## Description

Replace nested Ruby loops with two efficient SQL queries that leverage database indexes:

- `all_charges_have_base_fees?` - Checks that every charge has at least one fee without a filter (the "base" fee that every charge requires)
- `all_charge_filters_have_fees?` - Checks that every charge filter has its corresponding fee

The new implementation:
- Uses subqueries instead of loading records into memory.
- Lets the database do the work it's optimized for.
- Maintains the exact same business logic.
- Should runs 10-50x faster.

All existing tests pass without modification, confirming the refactoring preserves the original behavior.