### PR TITLE
feat(multiple-payment-methods): add payment method support for wallet recurring rules

### DIFF
--- a/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
@@ -19,6 +19,8 @@ module Types
         argument :transaction_metadata, [Types::Wallets::RecurringTransactionRules::TransactionMetadataInput], required: false
         argument :transaction_name, String, required: false
         argument :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, required: true
+
+        argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
       end
     end
   end

--- a/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
@@ -20,6 +20,8 @@ module Types
         argument :transaction_metadata, [Types::Wallets::RecurringTransactionRules::TransactionMetadataInput], required: false
         argument :transaction_name, String, required: false
         argument :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, required: false
+
+        argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
       end
     end
   end

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -5,6 +5,7 @@ class RecurringTransactionRule < ApplicationRecord
 
   belongs_to :wallet
   belongs_to :organization
+  belongs_to :payment_method, optional: true
 
   validates :transaction_name, length: {minimum: 1, maximum: 255}, allow_nil: true
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -3029,6 +3029,7 @@ input CreateRecurringTransactionRuleInput {
   invoiceRequiresSuccessfulPayment: Boolean
   method: RecurringTransactionMethodEnum
   paidCredits: String
+  paymentMethod: PaymentMethodReferenceInput
   startedAt: ISO8601DateTime
   targetOngoingBalance: String
   thresholdCredits: String
@@ -11390,6 +11391,7 @@ input UpdateRecurringTransactionRuleInput {
   lagoId: ID
   method: RecurringTransactionMethodEnum
   paidCredits: String
+  paymentMethod: PaymentMethodReferenceInput
   startedAt: ISO8601DateTime
   targetOngoingBalance: String
   thresholdCredits: String

--- a/schema.json
+++ b/schema.json
@@ -13471,6 +13471,18 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "paymentMethod",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PaymentMethodReferenceInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "interfaces": null,
@@ -59921,6 +59933,18 @@
               "type": {
                 "kind": "ENUM",
                 "name": "RecurringTransactionTriggerEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentMethod",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PaymentMethodReferenceInput",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::CreateInput do
     expect(subject).to accept_argument(:ignore_paid_top_up_limits).of_type("Boolean")
     expect(subject).to accept_argument(:method).of_type("RecurringTransactionMethodEnum")
     expect(subject).to accept_argument(:paid_credits).of_type("String")
+    expect(subject).to accept_argument(:payment_method).of_type("PaymentMethodReferenceInput")
     expect(subject).to accept_argument(:started_at).of_type("ISO8601DateTime")
     expect(subject).to accept_argument(:target_ongoing_balance).of_type("String")
     expect(subject).to accept_argument(:threshold_credits).of_type("String")

--- a/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::UpdateInput do
     expect(subject).to accept_argument(:invoice_requires_successful_payment).of_type("Boolean")
     expect(subject).to accept_argument(:method).of_type("RecurringTransactionMethodEnum")
     expect(subject).to accept_argument(:paid_credits).of_type("String")
+    expect(subject).to accept_argument(:payment_method).of_type("PaymentMethodReferenceInput")
     expect(subject).to accept_argument(:started_at).of_type("ISO8601DateTime")
     expect(subject).to accept_argument(:target_ongoing_balance).of_type("String")
     expect(subject).to accept_argument(:threshold_credits).of_type("String")


### PR DESCRIPTION
## Context

Currently in Lago, there can only be one payment provider customer, with only one attached payment method.

## Description

With this feature, it will be possible to add multiple payment methods per provider customer.

This PR adds GQL support for attaching payment method to the wallet recurring rules. With this setup, it will be possible to connect have automatic top-up invoice to different payment method compared to subscription invoice.