### PR TITLE
fix(fees): Return negative total aggregated units

### DIFF
--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -129,7 +129,7 @@ module Fees
       # Prevent trying to create a fee with negative units or amount.
       if amount_result.units.negative? || amount_result.amount.negative?
         amount_result.amount = amount_result.unit_amount = BigDecimal(0)
-        amount_result.full_units_number = amount_result.units = amount_result.total_aggregated_units = BigDecimal(0)
+        amount_result.full_units_number = amount_result.units = BigDecimal(0)
       end
 
       # NOTE: amount_result should be a BigDecimal, we need to round it

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -1219,7 +1219,7 @@ RSpec.describe Fees::ChargeService do
           )
         end
 
-        let(:billable_metric) { create(:sum_billable_metric, organization:) }
+        let(:billable_metric) { create(:weighted_sum_billable_metric, organization:) }
 
         before do
           create(
@@ -1228,7 +1228,7 @@ RSpec.describe Fees::ChargeService do
             subscription:,
             code: billable_metric.code,
             timestamp: Time.zone.parse("2022-03-16"),
-            properties: {item_id: -10}
+            properties: {value: -10}
           )
         end
 
@@ -1244,6 +1244,7 @@ RSpec.describe Fees::ChargeService do
             taxes_precise_amount_cents: 0.0,
             amount_currency: "EUR",
             units: 0,
+            total_aggregated_units: -10.0,
             unit_amount_cents: 0,
             precise_unit_amount: 0,
             events_count: 1,
@@ -1254,10 +1255,10 @@ RSpec.describe Fees::ChargeService do
                   "flat_unit_amount" => "0.01",
                   "from_value" => 0,
                   "per_unit_amount" => "0.01",
-                  "per_unit_total_amount" => "-0.1",
+                  "per_unit_total_amount" => "-0.051612903225806452",
                   "to_value" => nil,
-                  "total_with_flat_amount" => "-0.09",
-                  "units" => "-10.0"
+                  "total_with_flat_amount" => "-0.041612903225806452",
+                  "units" => "-5.1612903225806452"
                 }
               ]
             }


### PR DESCRIPTION
## Context

We recently exposed the `total_aggregated_units` field on both fees and charge_usage objects. It was made to help people knowing how many units are active on weighted sum billable metrics.
However it appears that this value is floured to 0 when the number of units is negative, making it hard for user to rely on this value.

## Description

This PR fixes the situation by always returning the real total_aggregated units even when the value is negative