### PR TITLE
fix(billing): add pending_vies_checks table for EU tax validation tracking

### DIFF
--- a/app/models/pending_vies_check.rb
+++ b/app/models/pending_vies_check.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class PendingViesCheck < ApplicationRecord
+  belongs_to :organization
+  belongs_to :billing_entity
+  belongs_to :customer
+end
+
+# == Schema Information
+#
+# Table name: pending_vies_checks
+# Database name: primary
+#
+#  id                        :uuid             not null, primary key
+#  attempts_count            :integer          default(0), not null
+#  last_attempt_at           :datetime
+#  last_error_message        :text
+#  last_error_type           :string
+#  tax_identification_number :string
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  billing_entity_id         :uuid             not null
+#  customer_id               :uuid             not null
+#  organization_id           :uuid             not null
+#
+# Indexes
+#
+#  index_pending_vies_checks_on_billing_entity_id  (billing_entity_id)
+#  index_pending_vies_checks_on_customer_id        (customer_id) UNIQUE
+#  index_pending_vies_checks_on_organization_id    (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (billing_entity_id => billing_entities.id)
+#  fk_rails_...  (customer_id => customers.id)
+#  fk_rails_...  (organization_id => organizations.id)
+#

--- a/db/migrate/20251031112354_create_pending_vies_checks.rb
+++ b/db/migrate/20251031112354_create_pending_vies_checks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreatePendingViesChecks < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pending_vies_checks, id: :uuid do |t|
+      t.references :organization, null: false, foreign_key: true, type: :uuid, index: true
+      t.references :billing_entity, null: false, foreign_key: true, type: :uuid, index: true
+      t.references :customer, null: false, foreign_key: true, type: :uuid, index: {unique: true}
+      t.integer :attempts_count, default: 0, null: false
+      t.datetime :last_attempt_at
+      t.string :tax_identification_number
+      t.string :last_error_type
+      t.text :last_error_message
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories/pending_vies_checks.rb
+++ b/spec/factories/pending_vies_checks.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :pending_vies_check do
+    organization {
+      customer&.organization || billing_entity&.organization || association(:organization)
+    }
+    billing_entity { customer&.billing_entity || association(:billing_entity) }
+    customer
+    attempts_count { 0 }
+    tax_identification_number { customer&.tax_identification_number || "EU123456789" }
+
+    trait :failed do
+      attempts_count { 3 }
+      last_attempt_at { 1.hour.ago }
+      last_error_message { "Network error" }
+      last_error_type { "TimeoutError" }
+    end
+  end
+end

--- a/spec/models/pending_vies_check_spec.rb
+++ b/spec/models/pending_vies_check_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PendingViesCheck, type: :model do
+  it { is_expected.to belong_to(:organization) }
+  it { is_expected.to belong_to(:billing_entity) }
+  it { is_expected.to belong_to(:customer) }
+end


### PR DESCRIPTION
 ## Context

When customers use EU tax management, VAT numbers must be validated with the VIES API before invoices can be finalized. The validation process can fail temporarily (timeouts, rate limits, service unavailable) requiring retries.

Currently, there's no persistent tracking of pending VIES checks, making it difficult to monitor validation status, retry attempts, or debug failures.

 ## Description

Add `pending_vies_checks` table to track customers awaiting VIES validation:

- Presence-based status: record exists = validation pending/in-progress
- Tracks retry attempts and error information for debugging
- Unique constraint on customer_id ensures one pending check per customer
- Stores denormalized tax_identification_number for quick access

Table schema:
- organization_id, billing_entity_id, customer_id (with indexes)
- attempts_count: number of retry attempts
- last_attempt_at: timestamp of last validation attempt
- tax_identification_number: VAT number being validated
- last_error_type: normalized error category (timeout, rate_limit, etc.)
- last_error_message: raw error message for debugging

This table will be used in subsequent commits to:
- Block invoice finalization during pending VIES checks
- Implement smart retry logic with exponential backoff
- Provide visibility into validation failures

No behavioral changes in this commit - only database structure.