### PR TITLE
misc(estimate): Add persentage scenario

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -334,7 +334,7 @@ module Events
           sql = <<-SQL
             WITH events AS (#{events_sql})
 
-            SELECT SUM(events.precise_total_amount_cents)
+            SELECT COALESCE(SUM(events.precise_total_amount_cents), 0)
             FROM events
           SQL
 

--- a/spec/services/charge_models/factory_spec.rb
+++ b/spec/services/charge_models/factory_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe ChargeModels::Factory do
   subject(:factory) { described_class }
 
   let(:charge) { build(:standard_charge) }
-  let(:aggregation_result) { BaseService::Result.new }
-  let(:properties) { charge.properties }
-
-  let(:result) { factory.new_instance(chargeable: charge, aggregation_result:, properties:) }
 
   describe "#new_instance" do
+    let(:aggregation_result) { BaseService::Result.new }
+    let(:properties) { charge.properties }
+
+    let(:result) { factory.new_instance(chargeable: charge, aggregation_result:, properties:) }
+
     context "when chargeable is not a charge or a fixed charge" do
       let(:chargeable) { build(:fee) }
 

--- a/spec/services/events/stores/shared_examples/an_event_store.rb
+++ b/spec/services/events/stores/shared_examples/an_event_store.rb
@@ -296,6 +296,14 @@ RSpec.shared_examples "an event store" do |with_event_duplication: true|
     it "returns the sum of precise_total_amount_cent values" do
       expect(event_store.sum_precise_total_amount_cents).to eq(15)
     end
+
+    context "without events" do
+      let(:events) { [] }
+
+      it "returns zero" do
+        expect(event_store.sum_precise_total_amount_cents).to eq(0)
+      end
+    end
   end
 
   describe "#grouped_sum_precise_total_amount_cents" do


### PR DESCRIPTION
## Context

Organizations configured to use the Clickhouse event store are not able to use the `POST /api/v1/events/estimate_fees` endpoint as the logic relies on the creation of a temporary record in the `events` table of Postgres.

This PR is part of a refactor allowing the estimate with clickhouse event stores and speeding up te estimate computation with postgres store by removing the need for persisting a temporary record.

## Description

This PR follows https://github.com/getlago/lago-api/pull/4555
It adds one more scenario to cover the sum aggregation with percentage charge model including free units per transaction.
It also fixes one case with clickhouse when using dynamic charge model if no events are found in the period