### PR TITLE
chore(cache): Reduce API key cache TTL in development environment

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,8 @@ module LagoApi
     end
 
     config.active_support.cache_format_version = 7.1
+
+    config.api_key_cache_ttl = 1.hour
   end
 end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,6 +56,7 @@ Rails.application.configure do
   config.hosts << "api"
 
   config.license_url = ENV.fetch("LAGO_LICENSE_URL", "http://license:3000")
+  config.api_key_cache_ttl = 10.seconds
 
   config.action_mailer.perform_caching = false
   config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
## Context

To optimize performance, we cache API key along with the linked organization for 1 hour. In development environment though, we might often update the organization with premium integrations or enable a specific event store. This can lead the organization to be cached with a different value and therefore to API calls behaving differently from what we might expect.

## Description

This reduces the API key TTL to 10 seconds in development environment to ensure that:

- We still rely on the cache and test it properly locally
- Ensure that any organization update will be reflected at most 10 seconds later