### PR TITLE
fix(redis): Fix redis connection config for active_job_uniqueness

### DIFF
--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -20,7 +20,7 @@ ActiveJob::Uniqueness.configure do |config|
   }
 
   if ENV["REDIS_PASSWORD"].present? && !ENV["REDIS_PASSWORD"].empty?
-    redis_config.merge({password: ENV["REDIS_PASSWORD"]})
+    redis_config = redis_config.merge({password: ENV["REDIS_PASSWORD"]})
   end
 
   config.redlock_servers = [


### PR DESCRIPTION
- Fix `active_job_uniquness` initializer with correct `redlock_servers` options

Fixes https://github.com/getlago/lago/issues/614