### PR TITLE
fix(invoice-preview): include ending_at logic in invoice preview

### DIFF
--- a/app/services/invoices/preview/subscriptions_service.rb
+++ b/app/services/invoices/preview/subscriptions_service.rb
@@ -91,8 +91,6 @@ module Invoices
 
         if customer_subscriptions&.size == 1 && subscription_ending_in_current_period?(current_subscription)
           current_subscription.ending_at.iso8601
-        else
-          nil
         end
       end
 
@@ -107,7 +105,7 @@ module Invoices
       def subscription_ending_in_current_period?(subscription)
         return false unless subscription&.ending_at
 
-        next_billing_day =  Subscriptions::DatesService
+        next_billing_day = Subscriptions::DatesService
           .new_instance(subscription, Time.current, current_usage: true)
           .end_of_period + 1.day
 

--- a/spec/services/invoices/preview/subscriptions_service_spec.rb
+++ b/spec/services/invoices/preview/subscriptions_service_spec.rb
@@ -200,8 +200,8 @@ RSpec.describe Invoices::Preview::SubscriptionsService do
               expect(subject).to all(
                 be_a(Subscription)
                   .and(have_attributes(
-                        terminated_at: end_of_period.change(usec: 0),
-                        status: "terminated"
+                    terminated_at: end_of_period.change(usec: 0),
+                    status: "terminated"
                   ))
               )
             end
@@ -216,8 +216,8 @@ RSpec.describe Invoices::Preview::SubscriptionsService do
               expect(subject).to all(
                 be_a(Subscription)
                   .and(have_attributes(
-                      terminated_at: nil,
-                      status: "active"
+                    terminated_at: nil,
+                    status: "active"
                   ))
               )
             end


### PR DESCRIPTION
## Context

Currently invoice preview endpoint does not take into account `ending_at` field.

## Description

This PR adds changes that handles described case. It is not necessary anymore to pass `terminated_at`, but subscription is terminated automatically (in the preview context only and without any perisisting) if `ending_at` is falling in the current period.

With multiple subscriptions, we will handle it as before.