### PR TITLE
feat(multiple-payment-methods): add new information in payment method gql type

### DIFF
--- a/app/graphql/types/payment_methods/details.rb
+++ b/app/graphql/types/payment_methods/details.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module PaymentMethods
+    class Details < Types::BaseObject
+      graphql_name "PaymentMethodDetails"
+
+      field :brand, String, null: true
+      field :expiration_month, String, null: true
+      field :expiration_year, String, null: true
+      field :last4, String, null: true
+      field :type, String, null: true
+    end
+  end
+end

--- a/app/graphql/types/payment_methods/object.rb
+++ b/app/graphql/types/payment_methods/object.rb
@@ -8,6 +8,7 @@ module Types
       field :id, ID, null: false
 
       field :customer, Types::Customers::Object, null: false
+      field :details, Types::PaymentMethods::Details, null: true
       field :is_default, Boolean, null: false
       field :payment_provider_code, String, null: true
       field :payment_provider_customer_id, ID, null: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -7975,6 +7975,7 @@ type PaymentCollection {
 type PaymentMethod {
   createdAt: ISO8601DateTime!
   customer: Customer!
+  details: PaymentMethodDetails
   id: ID!
   isDefault: Boolean!
   paymentProviderCode: String
@@ -7996,6 +7997,14 @@ type PaymentMethodCollection {
   Pagination Metadata for navigating the Pagination
   """
   metadata: CollectionMetadata!
+}
+
+type PaymentMethodDetails {
+  brand: String
+  expirationMonth: String
+  expirationYear: String
+  last4: String
+  type: String
 }
 
 union PaymentProvider = AdyenProvider | CashfreeProvider | FlutterwaveProvider | GocardlessProvider | MoneyhashProvider | StripeProvider

--- a/schema.json
+++ b/schema.json
@@ -38514,6 +38514,18 @@
               "deprecationReason": null
             },
             {
+              "name": "details",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PaymentMethodDetails",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "args": [],
@@ -38640,6 +38652,77 @@
                   "name": "CollectionMetadata",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PaymentMethodDetails",
+          "description": null,
+          "fields": [
+            {
+              "name": "brand",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "expirationMonth",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "expirationYear",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "last4",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/resolvers/payment_methods_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_methods_resolver_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Resolvers::PaymentMethodsResolver do
               isDefault
               paymentProviderCode
               paymentProviderType
+              details { brand last4 }
             }
             metadata { currentPage, totalCount }
           }
@@ -53,6 +54,8 @@ RSpec.describe Resolvers::PaymentMethodsResolver do
       expect(payments_response["collection"].count).to eq(1)
       expect(payments_response["collection"].first["paymentProviderCode"]).to eq(payment_method.payment_provider.code)
       expect(payments_response["collection"].first["paymentProviderType"]).to eq("stripe")
+      expect(payments_response["collection"].first["details"]["brand"]).to eq("Visa")
+      expect(payments_response["collection"].first["details"]["last4"]).to eq("9876")
     end
   end
 end

--- a/spec/graphql/types/payment_methods/details_spec.rb
+++ b/spec/graphql/types/payment_methods/details_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Types::PaymentMethods::Details do
+  subject { described_class }
+
+  it { is_expected.to have_field(:brand).of_type("String") }
+  it { is_expected.to have_field(:expiration_month).of_type("String") }
+  it { is_expected.to have_field(:expiration_year).of_type("String") }
+  it { is_expected.to have_field(:last4).of_type("String") }
+  it { is_expected.to have_field(:type).of_type("String") }
+end

--- a/spec/graphql/types/payment_methods/object_spec.rb
+++ b/spec/graphql/types/payment_methods/object_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::PaymentMethods::Object do
   it { is_expected.to have_field(:id).of_type("ID!") }
 
   it { is_expected.to have_field(:customer).of_type("Customer!") }
+  it { is_expected.to have_field(:details).of_type("PaymentMethodDetails") }
   it { is_expected.to have_field(:is_default).of_type("Boolean!") }
   it { is_expected.to have_field(:payment_provider_code).of_type("String") }
   it { is_expected.to have_field(:payment_provider_customer_id).of_type("ID") }


### PR DESCRIPTION
## Context

Currently in Lago, there can only be one payment provider customer, with only one attached payment method.

## Description

With this feature, it will be possible to add multiple payment methods per provider customer.

This PR extends payment method GQL type with details such as last 4 card numbers or card type