### PR TITLE
fix(event): Add back transaction_id presence validation

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,6 +9,7 @@ class Event < EventsRecord
 
   belongs_to :organization
 
+  validates :transaction_id, presence: true
   validates :code, presence: true
 
   default_scope -> { kept }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Event do
+  subject { build(:event) }
+
+  it { is_expected.to validate_presence_of(:transaction_id) }
+  it { is_expected.to validate_presence_of(:code) }
+
   describe "#customer" do
     let(:organization) { create(:organization) }
     let(:customer) { create(:customer, organization:) }


### PR DESCRIPTION
## Context

`transaction_id` presence validation on event was removed by mistake with https://github.com/getlago/lago-api/pull/4133.
The initial intention was only to remove the uniqueness validation.

## Description

This PR add back the presence validation to avoid `PG::NotNullViolation` to be raised when trying to create an event without the transaction_id value