### PR TITLE
chore(console): Add new console helpers for support

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Rails/Output
 Rails.application.console do
   if Rails.env.development?
     def gavin
@@ -70,17 +71,17 @@ Rails.application.console do
 
   def hard_delete_invoice(id)
     invoice = Invoice.find(id)
-    puts "Going to hard delete invoice from org `#{invoice.organization.name}` (id: #{invoice.id})" # rubocop:disable Rails/Output
+    puts "Going to hard delete invoice from org `#{invoice.organization.name}` (id: #{invoice.id})"
 
-    puts "Press any key to confirm deletion or CTRL+C to cancel." # rubocop:disable Rails/Output
+    puts "Press any key to confirm deletion or CTRL+C to cancel."
     c = $stdin.getch
 
     if c == "\u0003"
-      puts "Deletion cancelled." # rubocop:disable Rails/Output
+      puts "Deletion cancelled."
       return invoice
     end
 
-    puts "Deleting invoice #{invoice.id}..." # rubocop:disable Rails/Output
+    puts "Deleting invoice #{invoice.id}..."
     ActiveRecord::Base.transaction do
       invoice.invoice_subscriptions.destroy_all
       invoice.credit_notes.destroy_all
@@ -95,9 +96,9 @@ Rails.application.console do
 
     begin
       invoice.reload
-      puts "Invoice #{id} could not be deleted. Please try again." # rubocop:disable Rails/Output
+      puts "Invoice #{id} could not be deleted. Please try again."
     rescue ActiveRecord::RecordNotFound
-      puts "Invoice #{id} has been successfully deleted." # rubocop:disable Rails/Output
+      puts "Invoice #{id} has been successfully deleted."
     end
   end
 
@@ -113,19 +114,20 @@ Rails.application.console do
       role: :admin
     )
 
-    puts "Organization `#{org_name}` created with admin invite: #{result.invite_url}" # rubocop:disable Rails/Output
+    puts "Organization `#{org_name}` created with admin invite: #{result.invite_url}"
     {organization:, invite_url: result.invite_url}
   end
 
   # Often this procedure is called "regenerate invoice"
   def delete_invoice_pdf(id)
     inv = Invoice.find(id)
-    puts "Going to delete invoice pdf from org `#{inv.organization.name}` (id: #{inv.id})" # rubocop:disable Rails/Output
+    puts "Going to delete invoice pdf from org `#{inv.organization.name}` (id: #{inv.id})"
     unless inv.finalized?
-      puts "Invoice is not finalized. Skipping." # rubocop:disable Rails/Output
+      puts "Invoice is not finalized. Skipping."
       return
     end
 
     inv.file&.destroy
   end
 end
+# rubocop:enable Rails/Output


### PR DESCRIPTION
Some improvements collected from my recent support shifts.

* Using `find` now prints the organization name directly. It's often the first thing I do
* `retry_generating_invoice(i)` does not raise of error in purposed, to use it in a loop
* `current_usage(sub)` gets you the current usage without cache and witout taxes but let's you override all params

All other change is just disabling `Rails/Output` for the entire file. By design, we want to print stuff with these helpers.