### PR TITLE
chore(seeds): Remove `field_name` from seeds' count billable metric

### DIFF
--- a/db/seeds/01_base.rb
+++ b/db/seeds/01_base.rb
@@ -29,21 +29,20 @@ k.update_columns(value: "lago_key-hooli-1234567890") # rubocop:disable Rails/Ski
 
 # == BillableMetrics
 
-sum_bm = BillableMetric.find_or_create_by!(
-  organization:,
+sum_bm = BillableMetrics::CreateService.call!(
+  organization_id: organization.id,
   aggregation_type: "sum_agg",
   name: "Sum BM",
   code: "sum_bm",
   field_name: "custom_field"
-)
+).billable_metric
 
-count_bm = BillableMetric.find_or_create_by!(
-  organization:,
+count_bm = BillableMetrics::CreateService.call!(
+  organization_id: organization.id,
   aggregation_type: "count_agg",
   name: "Count BM",
-  code: "count_bm",
-  field_name: "customer_field"
-)
+  code: "count_bm"
+).billable_metric
 
 # == Taxes
 


### PR DESCRIPTION
## Context

The `count_bm` billable metric in the seeds currently has a `field_name` defined but `count_agg` billable metric should not have a `field_name`. This causes a visual bug on the UI.

Note that there's currently no validation ensuring that this field is `nil` when `aggregation_type` is `count_agg`.

## Description

Update the seeds to remove the `field_name` and rely on the `BillableMetrics::CreateService`.
