### PR TITLE
feat(docs): Introduce Public API to expose configuration stuff (used for documentation for instance)

### DIFF
--- a/app/controllers/public/v1/base_controller.rb
+++ b/app/controllers/public/v1/base_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Public
+  module V1
+    class BaseController < ActionController::API
+      wrap_parameters false
+    end
+  end
+end

--- a/app/controllers/public/v1/permissions_controller.rb
+++ b/app/controllers/public/v1/permissions_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Public
+  module V1
+    class PermissionsController < BaseController
+      def index
+        render json: {
+          permissions: Permission::DEFAULT_ROLE_TABLE
+        }
+      end
+    end
+  end
+end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class Permission
+  UNRELEASED_PERMISSIONS = %w[
+    payment_methods:view
+    payment_methods:create
+    payment_methods:update
+    payment_methods:delete
+  ]
+
   def self.yaml_to_hash(filename)
     h = YAML.parse_file(Rails.root.join("app/config/permissions", filename)).to_ruby
     DottedHash.new(h, separator: ":").transform_values(&:present?)
@@ -16,5 +23,17 @@ class Permission
   MANAGER_PERMISSIONS_HASH = DEFAULT_PERMISSIONS_HASH.merge(yaml_to_hash("role-manager.yml")).freeze
 
   FINANCE_PERMISSIONS_HASH = DEFAULT_PERMISSIONS_HASH.merge(yaml_to_hash("role-finance.yml")).freeze
+
+  DEFAULT_ROLE_TABLE = Permission::ADMIN_PERMISSIONS_HASH.filter_map do |permission_name, admin_value|
+    next if UNRELEASED_PERMISSIONS.include?(permission_name)
+    [
+      permission_name,
+      {
+        "admin" => admin_value,
+        "manager" => Permission::MANAGER_PERMISSIONS_HASH[permission_name],
+        "finance" => Permission::FINANCE_PERMISSIONS_HASH[permission_name]
+      }
+    ]
+  end.to_h.freeze
   # rubocop:enable Layout/ClassStructure
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,12 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :public do
+    namespace :v1 do
+      resources :permissions, only: [:index]
+    end
+  end
+
   namespace :api do
     namespace :v1 do
       resources :activity_logs, param: :activity_id, only: %i[index show]

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -20,4 +20,12 @@ RSpec.describe Permission do
       expect(described_class::DEFAULT_PERMISSIONS_HASH.keys).to match_array(described_class.const_get(name).keys)
     end
   end
+
+  it "defines default role table" do
+    expect(described_class::DEFAULT_ROLE_TABLE).to be_a(Hash)
+    expect(described_class::DEFAULT_ROLE_TABLE).to be_frozen
+    expect(described_class::DEFAULT_ROLE_TABLE.keys).to all(be_a(String))
+    expect(described_class::DEFAULT_ROLE_TABLE.values.map(&:keys).flatten.uniq).to contain_exactly("admin", "manager", "finance")
+    expect(described_class::DEFAULT_ROLE_TABLE.values.map(&:values).flatten.uniq).to contain_exactly(true, false)
+  end
 end

--- a/spec/requests/public/v1/permissions_controller_spec.rb
+++ b/spec/requests/public/v1/permissions_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Public::V1::PermissionsController do
+  describe "GET /public/v1/permissions" do
+    it "returns the default role table" do
+      get "/public/v1/permissions"
+
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)["permissions"]).to eq(Permission::DEFAULT_ROLE_TABLE)
+    end
+  end
+end


### PR DESCRIPTION
The goal is to have a good way for our documentation to stay up to date with our role permissions.
There are currently **37 permissions missing** from the docs

I propose to introduce a public API for these things. **On build, the docs would call this endpoint to get the latest permissions.**

I think it will make it easier than having a token to handle. There is no reason to put auth here.
Alternatively, we can put this in the Admin API.
Another alternative is to make json file on build and serve it as a static asset 🤷‍♂️ 

The Hash, is built once and kept in memory like other permissions hash.

The response is a hash with all the permissions and value for each role, which should make it easy to build a table.

```http
GET https://api.getlago.com/public/v1/permissions
```

```json
{
    "permissions": {
        "audit_logs:view": {
            "admin": true,
            "manager": false,
            "finance": false
        },
        "analytics:overdue_balances:view": {
            "admin": true,
            "manager": true,
            "finance": true
        },
        "analytics:view": {
            "admin": true,
            "manager": false,
            "finance": true
        },
        ...
    }
}
```