### PR TITLE
fix(webhooks): Improve Webhook and InboundWebhook cleanup tasks

### DIFF
--- a/app/jobs/clock/inbound_webhooks_cleanup_job.rb
+++ b/app/jobs/clock/inbound_webhooks_cleanup_job.rb
@@ -3,7 +3,7 @@
 module Clock
   class InboundWebhooksCleanupJob < ClockJob
     def perform
-      InboundWebhook.where("updated_at < ?", 90.days.ago).destroy_all
+      InboundWebhook.where("updated_at < ?", 90.days.ago).delete_all
     end
   end
 end

--- a/app/jobs/clock/webhooks_cleanup_job.rb
+++ b/app/jobs/clock/webhooks_cleanup_job.rb
@@ -3,7 +3,7 @@
 module Clock
   class WebhooksCleanupJob < ClockJob
     def perform
-      Webhook.where("updated_at < ?", 90.days.ago).destroy_all
+      Webhook.where("updated_at < ?", 90.days.ago).delete_all
     end
   end
 end

--- a/spec/jobs/clock/webhooks_cleanup_job_spec.rb
+++ b/spec/jobs/clock/webhooks_cleanup_job_spec.rb
@@ -6,14 +6,18 @@ describe Clock::WebhooksCleanupJob, job: true do
   subject(:webhooks_cleanup_job) { described_class }
 
   describe ".perform" do
-    before do
+    it "removes all old webhooks" do
       create(:webhook, :succeeded, updated_at: 100.days.ago)
+
+      expect { webhooks_cleanup_job.perform_now }
+        .to change(Webhook, :count).to(0)
     end
 
-    it "removes all old webhooks" do
-      webhooks_cleanup_job.perform_now
+    it "does not delete recent webhooks" do
+      create(:webhook, updated_at: 89.days.ago)
 
-      expect(Webhook.all.count).to be_zero
+      expect { webhooks_cleanup_job.perform_now }
+        .not_to change(Webhook, :count)
     end
   end
 end


### PR DESCRIPTION
Currently we have failing jobs for Webhook cleanup clock jobs, while the error does not return any message back, just job failing, we see there are a big number of webhooks that should have been deleted and are not.

This change makes deletion faster as "#destroy_all" was loading each record in memory and running `#destroy` on each. However, `delete_all` runs a single SQL query to delete them all.

Webhooks and InboundWebhooks does not have callbacks, nor associations to be considered on deletion. Hence, this is safe and faster.