### PR TITLE
chore(logging): Add timestamp to staging logs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,7 +47,6 @@ Rails.application.configure do
 
   config.logger = ActiveSupport::Logger.new($stdout)
     .tap { |logger| logger.formatter = ::Logger::Formatter.new }
-    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
   config.action_view.annotate_rendered_view_with_filenames = true
   config.action_controller.raise_on_missing_callback_actions = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -38,8 +38,8 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger = ActiveSupport::Logger.new($stdout)
-    config.logger = logger
+    config.logger = ActiveSupport::Logger.new($stdout)
+      .tap { |logger| logger.formatter = ::Logger::Formatter.new }
   end
 
   config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
## Context

Our raw staging logs currently do not include any timestamp making a bit hard to debug them.

## Description

This enables the `Logger::Formatter` for staging env and removes the tagged logging support in dev as we do not use tagged logging.