### PR TITLE
fix(progressive-billing): prevent validation error on zero-amount credit notes

### DIFF
--- a/app/services/credit_notes/create_from_progressive_billing_invoice.rb
+++ b/app/services/credit_notes/create_from_progressive_billing_invoice.rb
@@ -17,9 +17,13 @@ module CreditNotes
       # Important to call this method as it modifies @amount if needed
       items = calculate_items!
 
+      # Don't create credit note if final amount is not positive after tax/coupon adjustments
+      final_credit_amount = creditable_amount_cents(amount, items)
+      return result if final_credit_amount <= 0
+
       CreditNotes::CreateService.call!(
         invoice: progressive_billing_invoice,
-        credit_amount_cents: creditable_amount_cents(amount, items),
+        credit_amount_cents: final_credit_amount,
         items:,
         reason:,
         automatic: true


### PR DESCRIPTION
## Context

Invoices::FinalizeJob was failing with validation error "total_amount_must_be_positive" when processing progressive billing invoices that had coupons applied. The issue occurred during automatic credit note creation in the invoice finalization flow.

## Description

Progressive billing invoices with 100% coupon discounts were causing credit note creation to fail. When calculating the creditable amount, the formula (amount - coupon_adjustment + taxes) resulted in zero when coupons fully discounted the fees. This caused the validation to fail since credit notes require a positive total amount.

Added a guard clause in CreateFromProgressiveBillingInvoice to check if the final credit amount is positive after tax and coupon adjustments. If the amount is zero or negative, the service now returns successfully without creating a credit note, which is the correct behavior for automatic progressive billing adjustments.

Added comprehensive test coverage including the production scenario where coupon adjustments equal the base amount, as well as edge cases for very small amounts and fully credited fees.