### PR TITLE
feat(payment-methods): add GQL support for attaching payment method on subscription edit

### DIFF
--- a/app/graphql/types/subscriptions/update_subscription_input.rb
+++ b/app/graphql/types/subscriptions/update_subscription_input.rb
@@ -9,6 +9,7 @@ module Types
 
       argument :ending_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :name, String, required: false
+      argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
       argument :plan_overrides, Types::Subscriptions::PlanOverridesInput, required: false
       argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false
     end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -8,6 +8,7 @@ class Subscription < ApplicationRecord
   belongs_to :plan, -> { with_discarded }
   belongs_to :previous_subscription, class_name: "Subscription", optional: true
   belongs_to :organization
+  belongs_to :payment_method, optional: true
 
   has_one :billing_entity, through: :customer
   has_many :next_subscriptions, class_name: "Subscription", foreign_key: :previous_subscription_id

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -10,6 +10,7 @@ module Subscriptions
       valid_ending_at?
       valid_on_termination_credit_note?
       valid_on_termination_invoice?
+      valid_payment_method?
 
       if errors?
         result.validation_failure!(errors:)
@@ -91,6 +92,15 @@ module Subscriptions
       else
         args[:subscription_at]
       end
+    end
+
+    def valid_payment_method?
+      return true if args[:payment_method].blank?
+      return true if PaymentMethods::ValidateService.new(result, **args).valid?
+
+      add_error(field: :payment_method, error_code: "invalid_payment_method")
+
+      false
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -11456,6 +11456,7 @@ input UpdateSubscriptionInput {
   endingAt: ISO8601DateTime
   id: ID!
   name: String
+  paymentMethod: PaymentMethodReferenceInput
   planOverrides: PlanOverridesInput
   subscriptionAt: ISO8601DateTime
 }

--- a/schema.json
+++ b/schema.json
@@ -60256,6 +60256,18 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentMethod",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PaymentMethodReferenceInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "planOverrides",
               "description": null,
               "type": {

--- a/spec/graphql/types/subscriptions/update_subscription_input_spec.rb
+++ b/spec/graphql/types/subscriptions/update_subscription_input_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Types::Subscriptions::UpdateSubscriptionInput do
     expect(subject).to accept_argument(:id).of_type("ID!")
     expect(subject).to accept_argument(:ending_at).of_type("ISO8601DateTime")
     expect(subject).to accept_argument(:name).of_type("String")
+    expect(subject).to accept_argument(:payment_method).of_type("PaymentMethodReferenceInput")
     expect(subject).to accept_argument(:plan_overrides).of_type("PlanOverridesInput")
     expect(subject).to accept_argument(:subscription_at).of_type("ISO8601DateTime")
   end

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -193,5 +193,78 @@ RSpec.describe Subscriptions::ValidateService do
         expect(validate_service).to be_valid
       end
     end
+
+    context "with payment method" do
+      let(:payment_method) { create(:payment_method, customer:, organization:) }
+      let(:payment_method_params) do
+        {
+          payment_method_id: payment_method.id,
+          payment_method_type: "provider"
+        }
+      end
+      let(:args) do
+        {
+          customer:,
+          plan:,
+          subscription_at:,
+          ending_at:,
+          on_termination_credit_note:,
+          on_termination_invoice:,
+          payment_method: payment_method_params
+        }
+      end
+
+      context "when provider payment method is valid" do
+        before do
+          result.payment_method = payment_method
+        end
+
+        it "returns true and result has no errors" do
+          expect(validate_service).to be_valid
+          expect(result.error).to be_nil
+        end
+      end
+
+      context "when manual payment method is valid" do
+        let(:payment_method_params) do
+          {
+            payment_method_type: "manual"
+          }
+        end
+
+        it "returns true and result has no errors" do
+          expect(validate_service).to be_valid
+          expect(result.error).to be_nil
+        end
+      end
+
+      context "with invalid payment method type" do
+        let(:payment_method_params) do
+          {
+            payment_method_id: payment_method.id,
+            payment_method_type: "invalid"
+          }
+        end
+
+        it "returns false and result has errors" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:payment_method]).to eq(["invalid_payment_method"])
+        end
+      end
+
+      context "with invalid payment method reference" do
+        let(:payment_method_params) do
+          {
+            payment_method_id: "invalid",
+            payment_method_type: "provider"
+          }
+        end
+
+        it "returns false and result has errors" do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:payment_method]).to eq(["invalid_payment_method"])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Currently in Lago, there can only be one payment provider customer, with only one attached payment method.

## Description

With this feature, it will be possible to add multiple payment methods per provider customer.

This PR adds GQL support for attaching payment method to the subscription - in edit flow.