### PR TITLE
feat(multiple-payment-methods): support filtering payment methods by deleted ones

### DIFF
--- a/app/graphql/resolvers/payment_methods_resolver.rb
+++ b/app/graphql/resolvers/payment_methods_resolver.rb
@@ -12,14 +12,16 @@ module Resolvers
     argument :external_customer_id, ID, required: true, description: "External ID of the customer"
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
+    argument :with_deleted, Boolean, required: false
 
     type Types::PaymentMethods::Object.collection_type, null: false
 
-    def resolve(page: nil, limit: nil, external_customer_id: nil)
+    def resolve(page: nil, limit: nil, external_customer_id: nil, with_deleted: nil)
       result = PaymentMethodsQuery.call(
         organization: current_organization,
         filters: {
-          external_customer_id:
+          external_customer_id:,
+          with_deleted:
         },
         pagination: {
           page:,

--- a/app/graphql/types/payment_methods/object.rb
+++ b/app/graphql/types/payment_methods/object.rb
@@ -15,6 +15,7 @@ module Types
       field :payment_provider_type, Types::PaymentProviders::ProviderTypeEnum, null: true
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
 
       def payment_provider_code

--- a/app/queries/payment_methods_query.rb
+++ b/app/queries/payment_methods_query.rb
@@ -2,7 +2,7 @@
 
 class PaymentMethodsQuery < BaseQuery
   Result = BaseResult[:payment_methods]
-  Filters = BaseFilters[:external_customer_id]
+  Filters = BaseFilters[:external_customer_id, :with_deleted]
 
   def call
     payment_methods = base_scope
@@ -10,6 +10,7 @@ class PaymentMethodsQuery < BaseQuery
 
     payment_methods = apply_consistent_ordering(payment_methods)
     payment_methods = paginate(payment_methods)
+    payment_methods = payment_methods.with_discarded if filters.with_deleted
 
     result.payment_methods = payment_methods
     result

--- a/schema.graphql
+++ b/schema.graphql
@@ -7977,6 +7977,7 @@ type PaymentCollection {
 type PaymentMethod {
   createdAt: ISO8601DateTime!
   customer: Customer!
+  deletedAt: ISO8601DateTime
   details: PaymentMethodDetails
   id: ID!
   isDefault: Boolean!
@@ -9128,6 +9129,7 @@ type Query {
     externalCustomerId: ID!
     limit: Int
     page: Int
+    withDeleted: Boolean
   ): PaymentMethodCollection!
 
   """

--- a/schema.json
+++ b/schema.json
@@ -38538,6 +38538,18 @@
               "deprecationReason": null
             },
             {
+              "name": "deletedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "details",
               "description": null,
               "args": [],
@@ -49295,6 +49307,18 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "withDeleted",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/spec/graphql/resolvers/payment_methods_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_methods_resolver_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Resolvers::PaymentMethodsResolver do
   context "when external customer id is present" do
     let(:query) do
       <<~GQL
-        query($externalCustomerId: ID!) {
-          paymentMethods(externalCustomerId: $externalCustomerId, limit: 5) {
+        query($externalCustomerId: ID!, $withDeleted: Boolean) {
+          paymentMethods(externalCustomerId: $externalCustomerId, limit: 5, withDeleted: $withDeleted) {
             collection {
               id
               customer { id }
@@ -56,6 +56,32 @@ RSpec.describe Resolvers::PaymentMethodsResolver do
       expect(payments_response["collection"].first["paymentProviderType"]).to eq("stripe")
       expect(payments_response["collection"].first["details"]["brand"]).to eq("Visa")
       expect(payments_response["collection"].first["details"]["last4"]).to eq("9876")
+    end
+
+    context "when filtering by with_deleted" do
+      let(:deleted_payment_method) { create(:payment_method, customer:, organization:, deleted_at: Time.current) }
+
+      before { deleted_payment_method }
+
+      it "returns all payment_methods including deleted ones" do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: organization,
+          permissions: required_permission,
+          query:,
+          variables: {
+            externalCustomerId: customer.external_id,
+            withDeleted: true
+          }
+        )
+        payments_response = result["data"]["paymentMethods"]
+
+        expect(payments_response["collection"].count).to eq(2)
+        expect(payments_response["collection"].map { |p| p["id"] }).to include(payment_method.id, deleted_payment_method.id)
+
+        expect(payments_response["metadata"]["currentPage"]).to eq(1)
+        expect(payments_response["metadata"]["totalCount"]).to eq(2)
+      end
     end
   end
 end

--- a/spec/graphql/types/payment_methods/object_spec.rb
+++ b/spec/graphql/types/payment_methods/object_spec.rb
@@ -15,5 +15,6 @@ RSpec.describe Types::PaymentMethods::Object do
   it { is_expected.to have_field(:payment_provider_type).of_type("ProviderTypeEnum") }
 
   it { is_expected.to have_field(:created_at).of_type("ISO8601DateTime!") }
+  it { is_expected.to have_field(:deleted_at).of_type("ISO8601DateTime") }
   it { is_expected.to have_field(:updated_at).of_type("ISO8601DateTime") }
 end

--- a/spec/queries/payment_methods_query_spec.rb
+++ b/spec/queries/payment_methods_query_spec.rb
@@ -17,13 +17,15 @@ RSpec.describe PaymentMethodsQuery do
   let(:customer) { create(:customer, organization:) }
   let(:payment_method_first) { create(:payment_method, organization:) }
   let(:payment_method_second) { create(:payment_method, organization:, customer:) }
+  let(:payment_method_third) { create(:payment_method, organization:, deleted_at: Time.current) }
 
   before do
     payment_method_first
     payment_method_second
+    payment_method_third
   end
 
-  it "returns all payment methods" do
+  it "returns all active payment methods" do
     expect(result).to be_success
     expect(returned_ids).to contain_exactly(payment_method_first.id, payment_method_second.id)
   end
@@ -68,6 +70,15 @@ RSpec.describe PaymentMethodsQuery do
     it "returns all payment methods of the customer" do
       expect(result).to be_success
       expect(returned_ids).to contain_exactly(payment_method_second.id)
+    end
+  end
+
+  context "when including deleted payment methods" do
+    let(:filters) { {with_deleted: true} }
+
+    it "returns all payment methods" do
+      expect(result).to be_success
+      expect(returned_ids).to contain_exactly(payment_method_first.id, payment_method_second.id, payment_method_third.id)
     end
   end
 end


### PR DESCRIPTION
## Context

Currently in Lago, there can only be one payment provider customer, with only one attached payment method.

## Description

With this feature, it will be possible to add multiple payment methods per provider customer.

This PR extends payment method query. With this change it will be possible to get full list of payment methods, even soft-deleted-ones.