### PR TITLE
chore(database): Allow to easily customize DB pool in dev env

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -8,6 +8,7 @@ development:
     username: lago
     password: changeme
     database: lago
+    pool: <%= ENV.fetch('DATABASE_POOL', 5) %>
     port: 5432
   events:
     <<: *default
@@ -15,11 +16,13 @@ development:
     username: lago
     password: changeme
     database: lago
+    pool: <%= ENV.fetch('DATABASE_POOL', 5) %>
     port: 5432
   clickhouse:
     adapter: clickhouse
     database: default
     host: clickhouse
+    pool: <%= ENV.fetch('DATABASE_POOL', 5) %>
     port: 8123
     username: default
     password: default


### PR DESCRIPTION
## Context

When debugging performance issue in dev environment, you may be limited by the size of the database connection pool.

## Description

This allows to easily change the pool size using the `DATABASE_POOL` env variable.