### PR TITLE
fix(rubocop): Fix eager loading in development environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,10 +13,6 @@ Rails.application.configure do
   config.middleware.use(ActionDispatch::Session::CookieStore, key: "_lago_dev")
   config.middleware.use(Rack::MethodOverride)
 
-  config.eager_load_paths += %W[
-    #{config.root}/dev
-  ]
-
   config.action_cable.disable_request_forgery_protection = true
   config.action_cable.allowed_request_origins = [ENV["LAGO_API_URL"]]
 

--- a/dev/cops/service_call_cop.rb
+++ b/dev/cops/service_call_cop.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rubocop"
+
 module Cops
   class ServiceCallCop < ::RuboCop::Cop::Base
     def_node_matcher :base_service_subclass?, <<~PATTERN


### PR DESCRIPTION
## Context

When `config.eager_load` is set to `true` in `config/environments/development.rb`, the app will fail to boot with the following error:

```sh
/app/dev/cops/service_call_cop.rb:6:in '<module:Cops>': uninitialized constant RuboCop (NameError)

  class ServiceCallCop < ::RuboCop::Cop::Base
                         ^^^^^^^^^
        from /app/dev/cops/service_call_cop.rb:5:in '<main>'
```

This occurs for two reasons:

- The file depends on `rubocop` but does not `require` it.
- This file shouldn't be eager loaded at all as it's only needed by Rubocop and already required in the `.rubocop.yml`

## Description

This fixes the issue by:

- Requiring `rubocop` within the file.
- Removing the `dev` folder from eager load list.

I also confirmed the cop is still properly loaded:

```sh
⋊> lago exec api bundle exec rubocop app/services/integration_mappings/create_service.rb

Inspecting 1 file
C

Offenses:

app/services/integration_mappings/create_service.rb:5:5: C: Lago/ServiceCall: Subclasses of Baseservice should have #call without arguments
    def call(**args) ...
    ^^^^^^^^^^^^^^^^
```