### PR TITLE
test(request): Remove redundant `type: :request` spec metadata

### DIFF
--- a/spec/graphql/mutations/ai_conversations/create_spec.rb
+++ b/spec/graphql/mutations/ai_conversations/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::AiConversations::Create, type: :graphql do
+RSpec.describe Mutations::AiConversations::Create do
   subject(:result) do
     execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/mutations/invoices/download_xml_spec.rb
+++ b/spec/graphql/mutations/invoices/download_xml_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Mutations::Invoices::DownloadXml, type: :graphql do
+RSpec.describe Mutations::Invoices::DownloadXml do
   let(:required_permission) { "invoices:view" }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }

--- a/spec/graphql/resolvers/customer_portal/wallet_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/wallet_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::CustomerPortal::WalletResolver, type: :graphql do
+RSpec.describe Resolvers::CustomerPortal::WalletResolver do
   let(:query) do
     <<~GQL
       query($walletId: ID!) {

--- a/spec/graphql/resolvers/data_api/usages/forecasted_resolver_spec.rb
+++ b/spec/graphql/resolvers/data_api/usages/forecasted_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Resolvers::DataApi::Usages::ForecastedResolver, type: :graphql do
+RSpec.describe Resolvers::DataApi::Usages::ForecastedResolver do
   let(:required_permission) { "data_api:view" }
   let(:query) do
     <<~GQL

--- a/spec/jobs/invoices/generate_xml_job_spec.rb
+++ b/spec/jobs/invoices/generate_xml_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::GenerateXmlJob, type: :job do
+RSpec.describe Invoices::GenerateXmlJob do
   let(:invoice) { create(:invoice) }
 
   let(:result) { BaseService::Result.new }

--- a/spec/models/concerns/organizations/authentication_methods_spec.rb
+++ b/spec/models/concerns/organizations/authentication_methods_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Organizations::AuthenticationMethods, type: :concern do
+RSpec.describe Organizations::AuthenticationMethods do
   describe "authentication_methods" do
     let(:organization) { create(:organization) }
 

--- a/spec/requests/api/v1/activity_logs_controller_spec.rb
+++ b/spec/requests/api/v1/activity_logs_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::ActivityLogsController, type: :request, clickhouse: true do
+RSpec.describe Api::V1::ActivityLogsController, clickhouse: true do
   let(:organization) { activity_log.organization }
   let(:params) { {} }
 

--- a/spec/requests/api/v1/add_ons_controller_spec.rb
+++ b/spec/requests/api/v1/add_ons_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::AddOnsController, type: :request do
+RSpec.describe Api::V1::AddOnsController do
   let(:organization) { create(:organization) }
   let(:tax) { create(:tax, organization:) }
 

--- a/spec/requests/api/v1/analytics/gross_revenues_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/gross_revenues_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Analytics::GrossRevenuesController, type: :request do
+RSpec.describe Api::V1::Analytics::GrossRevenuesController do
   describe "GET /analytics/gross_revenue" do
     subject { get_with_token(organization, "/api/v1/analytics/gross_revenue", params) }
 

--- a/spec/requests/api/v1/analytics/invoice_collections_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/invoice_collections_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Analytics::InvoiceCollectionsController, type: :request do # rubocop:disable RSpec/FilePath
+RSpec.describe Api::V1::Analytics::InvoiceCollectionsController do # rubocop:disable RSpec/FilePath
   describe "GET /analytics/invoice_collection" do
     subject { get_with_token(organization, "/api/v1/analytics/invoice_collection", params) }
 

--- a/spec/requests/api/v1/analytics/invoiced_usages_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/invoiced_usages_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Analytics::InvoicedUsagesController, type: :request do # rubocop:disable RSpec/FilePath
+RSpec.describe Api::V1::Analytics::InvoicedUsagesController do # rubocop:disable RSpec/FilePath
   describe "GET /analytics/invoiced_usage" do
     subject { get_with_token(organization, "/api/v1/analytics/invoiced_usage", params) }
 

--- a/spec/requests/api/v1/analytics/mrrs_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/mrrs_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Analytics::MrrsController, type: :request do # rubocop:disable RSpec/FilePath
+RSpec.describe Api::V1::Analytics::MrrsController do # rubocop:disable RSpec/FilePath
   describe "GET /analytics/mrr" do
     subject { get_with_token(organization, "/api/v1/analytics/mrr", params) }
 

--- a/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Analytics::OverdueBalancesController, type: :request do
+RSpec.describe Api::V1::Analytics::OverdueBalancesController do
   describe "GET /analytics/overdue_balance" do
     subject { get_with_token(organization, "/api/v1/analytics/overdue_balance", params) }
 

--- a/spec/requests/api/v1/api_logs_controller_spec.rb
+++ b/spec/requests/api/v1/api_logs_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::ApiLogsController, type: :request, clickhouse: true do
+RSpec.describe Api::V1::ApiLogsController, clickhouse: true do
   subject { get_with_token(organization, path, params) }
 
   let(:organization) { api_log.organization }

--- a/spec/requests/api/v1/applied_coupons_controller_spec.rb
+++ b/spec/requests/api/v1/applied_coupons_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::AppliedCouponsController, :with_bullet, type: :request do
+RSpec.describe Api::V1::AppliedCouponsController, :with_bullet do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/requests/api/v1/billable_metrics_controller_spec.rb
+++ b/spec/requests/api/v1/billable_metrics_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::BillableMetricsController, type: :request do
+RSpec.describe Api::V1::BillableMetricsController do
   let(:organization) { create(:organization) }
 
   describe "POST /api/v1/billable_metrics" do

--- a/spec/requests/api/v1/billing_entities_controller_spec.rb
+++ b/spec/requests/api/v1/billing_entities_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::BillingEntitiesController, type: :request do
+RSpec.describe Api::V1::BillingEntitiesController do
   let(:billing_entity1) { create(:billing_entity) }
   let(:organization) { billing_entity1.organization }
   let(:billing_entity2) { create(:billing_entity, organization:) }

--- a/spec/requests/api/v1/coupons_controller_spec.rb
+++ b/spec/requests/api/v1/coupons_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::CouponsController, type: :request do
+RSpec.describe Api::V1::CouponsController do
   let(:organization) { create(:organization) }
 
   describe "POST /api/v1/coupons" do

--- a/spec/requests/api/v1/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::CreditNotesController, type: :request do
+RSpec.describe Api::V1::CreditNotesController do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:credit_note) { create(:credit_note, invoice:, customer:) }

--- a/spec/requests/api/v1/customers/applied_coupons_controller_spec.rb
+++ b/spec/requests/api/v1/customers/applied_coupons_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Customers::AppliedCouponsController, type: :request do
+RSpec.describe Api::V1::Customers::AppliedCouponsController do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/requests/api/v1/customers/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/customers/credit_notes_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Customers::CreditNotesController, type: :request do
+RSpec.describe Api::V1::Customers::CreditNotesController do
   describe "GET /api/v1/customers/:external_id/credit_notes" do
     it_behaves_like "a credit note index endpoint" do
       subject { get_with_token(organization, "/api/v1/customers/#{external_id}/credit_notes", params) }

--- a/spec/requests/api/v1/customers/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/customers/invoices_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Customers::InvoicesController, type: :request do
+RSpec.describe Api::V1::Customers::InvoicesController do
   describe "GET /api/v1/customers/:external_id/invoices" do
     it_behaves_like "an invoice index endpoint" do
       subject { get_with_token(organization, "/api/v1/customers/#{customer.external_id}/invoices", params) }

--- a/spec/requests/api/v1/customers/payment_methods_controller_spec.rb
+++ b/spec/requests/api/v1/customers/payment_methods_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Customers::PaymentMethodsController, type: :request do
+RSpec.describe Api::V1::Customers::PaymentMethodsController do
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }
   let(:external_id) { customer.external_id }

--- a/spec/requests/api/v1/customers/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/customers/payment_requests_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Customers::PaymentRequestsController, type: :request do
+RSpec.describe Api::V1::Customers::PaymentRequestsController do
   describe "GET /api/v1/customers/:external_id/payment_requests" do
     include_examples "a payment request index endpoint" do
       subject { get_with_token(organization, "/api/v1/customers/#{external_id}/payment_requests", params) }

--- a/spec/requests/api/v1/customers/payments_controller_spec.rb
+++ b/spec/requests/api/v1/customers/payments_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Customers::PaymentsController, type: :request do
+RSpec.describe Api::V1::Customers::PaymentsController do
   describe "GET /api/v1/customers/:external_id/payments" do
     it_behaves_like "a payment index endpoint" do
       subject { get_with_token(organization, "/api/v1/customers/#{customer.external_id}/payments", params) }

--- a/spec/requests/api/v1/customers/projected_usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/projected_usage_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Customers::ProjectedUsageController, type: :request do
+RSpec.describe Api::V1::Customers::ProjectedUsageController do
   around { |test| lago_premium!(&test) }
 
   let(:customer) { create(:customer, organization:) }

--- a/spec/requests/api/v1/customers/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/customers/subscriptions_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Customers::SubscriptionsController, type: :request do
+RSpec.describe Api::V1::Customers::SubscriptionsController do
   describe "GET /api/v1/customers/:external_id/subscriptions" do
     subject { get_with_token(organization, "/api/v1/customers/#{external_id}/subscriptions", params) }
 

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Customers::UsageController, type: :request do
+RSpec.describe Api::V1::Customers::UsageController do
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }
 

--- a/spec/requests/api/v1/customers/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/customers/wallets_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Customers::WalletsController, type: :request do
+RSpec.describe Api::V1::Customers::WalletsController do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:, currency: "EUR") }
   let(:external_id) { customer.external_id }

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::CustomersController, type: :request do
+RSpec.describe Api::V1::CustomersController do
   describe "POST /api/v1/customers" do
     subject { post_with_token(organization, "/api/v1/customers", {customer: create_params}) }
 

--- a/spec/requests/api/v1/data_api/usages_controller_spec.rb
+++ b/spec/requests/api/v1/data_api/usages_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::DataApi::UsagesController, type: :request do # rubocop:disable RSpec/FilePath
+RSpec.describe Api::V1::DataApi::UsagesController do # rubocop:disable RSpec/FilePath
   describe "GET /analytics/usage" do
     subject { get_with_token(organization, "/api/v1/analytics/usage", params) }
 

--- a/spec/requests/api/v1/events_controller_spec.rb
+++ b/spec/requests/api/v1/events_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::EventsController, type: :request do
+RSpec.describe Api::V1::EventsController do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:metric) { create(:billable_metric, organization:) }

--- a/spec/requests/api/v1/features/privileges_controller_spec.rb
+++ b/spec/requests/api/v1/features/privileges_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Api::V1::Features::PrivilegesController, type: :request do
+RSpec.describe Api::V1::Features::PrivilegesController do
   let(:organization) { create(:organization) }
   let(:feature1) { create(:feature, organization:, code: "seats", name: "Number of seats", description: "Number of users of the account") }
   let(:privilege1) { create(:privilege, feature: feature1, code: "max_admins", name: "", value_type: "integer") }

--- a/spec/requests/api/v1/features_controller_spec.rb
+++ b/spec/requests/api/v1/features_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::FeaturesController, type: :request do
+RSpec.describe Api::V1::FeaturesController do
   let(:organization) { create(:organization) }
   let(:feature1) { create(:feature, organization:, code: "seats", name: "Number of seats", description: "Number of users of the account") }
   let(:feature2) { create(:feature, organization:, code: "storage", name: "Storage", description: "Storage space") }

--- a/spec/requests/api/v1/fees_controller_spec.rb
+++ b/spec/requests/api/v1/fees_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::FeesController, type: :request do
+RSpec.describe Api::V1::FeesController do
   let(:organization) { create(:organization) }
 
   describe "GET /api/v1/fees/:id" do

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::InvoicesController, type: :request do
+RSpec.describe Api::V1::InvoicesController do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:tax) { create(:tax, :applied_to_billing_entity, organization:, rate: 20) }

--- a/spec/requests/api/v1/organizations_controller_spec.rb
+++ b/spec/requests/api/v1/organizations_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::OrganizationsController, type: :request do
+RSpec.describe Api::V1::OrganizationsController do
   let(:organization) { create(:organization) }
   let(:webhook_url) { Faker::Internet.url }
 

--- a/spec/requests/api/v1/payment_receipts_controller_spec.rb
+++ b/spec/requests/api/v1/payment_receipts_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::PaymentReceiptsController, type: :request do
+RSpec.describe Api::V1::PaymentReceiptsController do
   let(:organization) { create(:organization) }
 
   describe "GET /api/v1/payment_receipts" do

--- a/spec/requests/api/v1/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/payment_requests_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::PaymentRequestsController, type: :request do
+RSpec.describe Api::V1::PaymentRequestsController do
   let(:organization) { create(:organization) }
 
   describe "POST /api/v1/payment_requests" do

--- a/spec/requests/api/v1/payments_controller_spec.rb
+++ b/spec/requests/api/v1/payments_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::PaymentsController, type: :request do
+RSpec.describe Api::V1::PaymentsController do
   let(:organization) { create(:organization) }
 
   describe "POST /api/v1/payments" do

--- a/spec/requests/api/v1/plans/entitlements/privileges_controller_spec.rb
+++ b/spec/requests/api/v1/plans/entitlements/privileges_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Plans::Entitlements::PrivilegesController, type: :request do
+RSpec.describe Api::V1::Plans::Entitlements::PrivilegesController do
   let(:organization) { create(:organization) }
   let(:plan) { create(:plan, organization:) }
   let(:feature) { create(:feature, organization:) }

--- a/spec/requests/api/v1/plans/entitlements_controller_spec.rb
+++ b/spec/requests/api/v1/plans/entitlements_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Plans::EntitlementsController, type: :request do
+RSpec.describe Api::V1::Plans::EntitlementsController do
   let(:organization) { create(:organization) }
   let(:plan) { create(:plan, organization:) }
   let(:feature) { create(:feature, organization:, code: "seats") }

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::PlansController, type: :request do
+RSpec.describe Api::V1::PlansController do
   let(:tax) { create(:tax, organization:) }
   let(:organization) { create(:organization) }
   let(:billable_metric) { create(:billable_metric, organization:) }

--- a/spec/requests/api/v1/subscriptions/alerts_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/alerts_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Subscriptions::AlertsController, type: :request do
+RSpec.describe Api::V1::Subscriptions::AlertsController do
   let(:external_id) { "sub+1" }
   let(:external_id_query_param) { external_id }
   let(:code) { "my-alert" }

--- a/spec/requests/api/v1/subscriptions/entitlements/privileges_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/entitlements/privileges_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Subscriptions::Entitlements::PrivilegesController, type: :request do
+RSpec.describe Api::V1::Subscriptions::Entitlements::PrivilegesController do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }

--- a/spec/requests/api/v1/subscriptions/entitlements_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/entitlements_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Subscriptions::EntitlementsController, type: :request do
+RSpec.describe Api::V1::Subscriptions::EntitlementsController do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }

--- a/spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/fixed_charges_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Subscriptions::FixedChargesController, type: :request do
+RSpec.describe Api::V1::Subscriptions::FixedChargesController do
   let(:external_id) { "sub+1" }
   let(:external_id_query_param) { external_id }
   let(:organization) { create(:organization) }

--- a/spec/requests/api/v1/subscriptions/lifetime_usages_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions/lifetime_usages_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::Subscriptions::LifetimeUsagesController, type: :request do
+RSpec.describe Api::V1::Subscriptions::LifetimeUsagesController do
   let!(:lifetime_usage) { create(:lifetime_usage, organization:, subscription:) }
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::SubscriptionsController, type: :request do
+RSpec.describe Api::V1::SubscriptionsController do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:, amount_cents: 500, description: "desc") }

--- a/spec/requests/api/v1/taxes_controller_spec.rb
+++ b/spec/requests/api/v1/taxes_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::TaxesController, type: :request do
+RSpec.describe Api::V1::TaxesController do
   let(:organization) { create(:organization) }
 
   describe "POST /api/v1/taxes" do

--- a/spec/requests/api/v1/wallet_transactions_controller_spec.rb
+++ b/spec/requests/api/v1/wallet_transactions_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::WalletTransactionsController, type: :request do
+RSpec.describe Api::V1::WalletTransactionsController do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::WalletsController, type: :request do
+RSpec.describe Api::V1::WalletsController do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:, currency: "EUR") }
   let(:subscription) { create(:subscription, customer:) }

--- a/spec/requests/api/v1/webhook_endpoints_controller_spec.rb
+++ b/spec/requests/api/v1/webhook_endpoints_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::WebhookEndpointsController, type: :request do
+RSpec.describe Api::V1::WebhookEndpointsController do
   describe "POST /api/v1/webhook_endpoints" do
     subject do
       post_with_token(

--- a/spec/requests/api/v1/webhooks_controller_spec.rb
+++ b/spec/requests/api/v1/webhooks_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Api::V1::WebhooksController, type: :request do
+RSpec.describe Api::V1::WebhooksController do
   let(:organization) { create(:organization) }
 
   describe "GET /api/v1/webhooks/public_key" do

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ApplicationController, type: :request do
+RSpec.describe ApplicationController do
   describe "GET /health" do
     it "returns the application health check" do
       get "/health"

--- a/spec/requests/data_api/v1/charges_controller_spec.rb
+++ b/spec/requests/data_api/v1/charges_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::V1::ChargesController, type: :request do # rubocop:disable RSpec/FilePath
+RSpec.describe DataApi::V1::ChargesController do # rubocop:disable RSpec/FilePath
   def post_with_data_api_key(path, params = {})
     headers = {
       "Content-Type" => "application/json",

--- a/spec/requests/graphql_controller_spec.rb
+++ b/spec/requests/graphql_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe GraphqlController, type: :request do
+RSpec.describe GraphqlController do
   describe "POST /graphql" do
     before do
       allow(CurrentContext).to receive(:source=)

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe WebhooksController, type: :request do
+RSpec.describe WebhooksController do
   describe "POST /stripe" do
     let(:organization_id) { Faker::Internet.uuid }
     let(:code) { "stripe_1" }

--- a/spec/scenarios/credit_notes/credit_note_rounding_spec.rb
+++ b/spec/scenarios/credit_notes/credit_note_rounding_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "Credit note rounding issues Scenarios", :scenarios, type: :request do
+describe "Credit note rounding issues Scenarios" do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
+++ b/spec/scenarios/dunning/dunning_campaign_v1_spec.rb
@@ -43,7 +43,6 @@ describe "Dunning Campaign v1" do
 
   include_context "with webhook tracking"
 
-  # TODO: make it a test metadata `:scenarios, type: :request, premium: true`
   around { |test| lago_premium!(&test) }
 
   before do

--- a/spec/services/charges/bulk_forecasted_usage_amount_service_spec.rb
+++ b/spec/services/charges/bulk_forecasted_usage_amount_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Charges::BulkForecastedUsageAmountService, type: :service do
+RSpec.describe Charges::BulkForecastedUsageAmountService do
   subject(:service) { described_class.new(charges_data: charges_data) }
 
   let(:organization) { create(:organization) }

--- a/spec/services/data_api/usages/forecasted_service_spec.rb
+++ b/spec/services/data_api/usages/forecasted_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe DataApi::Usages::ForecastedService, type: :service do
+RSpec.describe DataApi::Usages::ForecastedService do
   let(:service) { described_class.new(organization, **params) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }

--- a/spec/services/e_invoices/invoices/factur_x/create_service_spec.rb
+++ b/spec/services/e_invoices/invoices/factur_x/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe EInvoices::Invoices::FacturX::CreateService, type: :service do
+RSpec.describe EInvoices::Invoices::FacturX::CreateService do
   let(:invoice) { create(:invoice) }
   let(:xml_builder_double) { instance_double(Nokogiri::XML::Builder, to_xml: xml_content) }
   let(:xml_content) { "<xml>content</xml>" }

--- a/spec/services/e_invoices/invoices/ubl/create_service_spec.rb
+++ b/spec/services/e_invoices/invoices/ubl/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe EInvoices::Invoices::Ubl::CreateService, type: :service do
+RSpec.describe EInvoices::Invoices::Ubl::CreateService do
   let(:invoice) { create(:invoice) }
   let(:xml_builder_double) { instance_double(Nokogiri::XML::Builder, to_xml: xml_content) }
   let(:xml_content) { "<xml>content</xml>" }

--- a/spec/services/fixed_charges/emit_events_for_active_subscriptions_service_spec.rb
+++ b/spec/services/fixed_charges/emit_events_for_active_subscriptions_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FixedCharges::EmitEventsForActiveSubscriptionsService, type: :service do
+RSpec.describe FixedCharges::EmitEventsForActiveSubscriptionsService do
   subject(:service) { described_class.new(fixed_charge:, subscription:) }
 
   let(:subscription) { nil }

--- a/spec/services/invoices/generate_xml_service_spec.rb
+++ b/spec/services/invoices/generate_xml_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Invoices::GenerateXmlService, type: :service do
+RSpec.describe Invoices::GenerateXmlService do
   let(:context) { "graphql" }
   let(:organization) { create(:organization, name: "LAGO") }
   let(:billing_entity) { create(:billing_entity, organization:, country: "FR", einvoicing:) }

--- a/spec/services/subscriptions/emit_fixed_charge_events_service_spec.rb
+++ b/spec/services/subscriptions/emit_fixed_charge_events_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Subscriptions::EmitFixedChargeEventsService, type: :service do
+RSpec.describe Subscriptions::EmitFixedChargeEventsService do
   subject(:service) { described_class.new(subscriptions:, timestamp:) }
 
   let(:timestamp) { Time.current }

--- a/spec/views/app/views/templates/credit_notes/credit_note.slim_spec.rb
+++ b/spec/views/app/views/templates/credit_notes/credit_note.slim_spec.rb
@@ -7,7 +7,7 @@ require "rails_helper"
 #
 # To update a snapshot, either delete it, or run the tests with `UPDATE_SNAPSHOTS=true` environment variable.
 
-RSpec.describe "templates/credit_notes/credit_note.slim", type: :view do
+RSpec.describe "templates/credit_notes/credit_note.slim" do
   subject(:rendered_template) do
     Slim::Template.new(template, 1, pretty: true).render(credit_note)
   end

--- a/spec/views/app/views/templates/invoices/v4.slim_spec.rb
+++ b/spec/views/app/views/templates/invoices/v4.slim_spec.rb
@@ -7,7 +7,7 @@ require "rails_helper"
 #
 # To update a snapshot, either delete it, or run the tests with `UPDATE_SNAPSHOTS=true` environment variable.
 
-RSpec.describe "templates/invoices/v4.slim", type: :view do
+RSpec.describe "templates/invoices/v4.slim" do
   subject(:rendered_template) do
     Slim::Template.new(template, 1, pretty: true).render(invoice)
   end


### PR DESCRIPTION
## Context

All model tests have the `type: :request` RSpec metadata but this metadata is already infered due to the `config.infer_spec_type_from_file_location!` setting (see the doc [here](https://rspec.info/features/8-0/rspec-rails/directory-structure/)).

## Description

This removes the redundant metadata and any left-over of the other metadata cleanup.