### PR TITLE
feat(multiple-payment-methods): add payment method support for new subscription

### DIFF
--- a/app/graphql/types/subscriptions/create_subscription_input.rb
+++ b/app/graphql/types/subscriptions/create_subscription_input.rb
@@ -15,6 +15,7 @@ module Types
       argument :plan_overrides, Types::Subscriptions::PlanOverridesInput, required: false
 
       argument :billing_time, Types::Subscriptions::BillingTimeEnum, required: true
+      argument :payment_method, Types::PaymentMethods::ReferenceInput, required: false
       argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false
     end
   end

--- a/app/services/subscriptions/plan_upgrade_service.rb
+++ b/app/services/subscriptions/plan_upgrade_service.rb
@@ -61,7 +61,7 @@ module Subscriptions
     attr_reader :current_subscription, :plan, :params, :name
 
     def new_subscription_with_overrides
-      Subscription.new(
+      new_subscription = Subscription.new(
         organization_id: current_subscription.customer.organization_id,
         customer: current_subscription.customer,
         plan: params.key?(:plan_overrides) ? override_plan : plan,
@@ -72,6 +72,13 @@ module Subscriptions
         billing_time: current_subscription.billing_time,
         ending_at: params.key?(:ending_at) ? params[:ending_at] : current_subscription.ending_at
       )
+
+      if params.key?(:payment_method)
+        new_subscription.payment_method_type = params[:payment_method][:payment_method_type] if params[:payment_method].key?(:payment_method_type)
+        new_subscription.payment_method_id = params[:payment_method][:payment_method_id] if params[:payment_method].key?(:payment_method_id)
+      end
+
+      new_subscription
     end
 
     def update_pending_subscription

--- a/schema.graphql
+++ b/schema.graphql
@@ -3087,6 +3087,7 @@ input CreateSubscriptionInput {
   endingAt: ISO8601DateTime
   externalId: String
   name: String
+  paymentMethod: PaymentMethodReferenceInput
   planId: ID!
   planOverrides: PlanOverridesInput
   subscriptionAt: ISO8601DateTime

--- a/schema.json
+++ b/schema.json
@@ -13830,6 +13830,18 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentMethod",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PaymentMethodReferenceInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "subscriptionAt",
               "description": null,
               "type": {

--- a/spec/graphql/types/subscriptions/create_subscription_input_spec.rb
+++ b/spec/graphql/types/subscriptions/create_subscription_input_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Types::Subscriptions::CreateSubscriptionInput do
     expect(subject).to accept_argument(:ending_at).of_type("ISO8601DateTime")
     expect(subject).to accept_argument(:external_id).of_type("String")
     expect(subject).to accept_argument(:customer_id).of_type("ID!")
+    expect(subject).to accept_argument(:payment_method).of_type("PaymentMethodReferenceInput")
     expect(subject).to accept_argument(:plan_id).of_type("ID!")
     expect(subject).to accept_argument(:plan_overrides).of_type("PlanOverridesInput")
     expect(subject).to accept_argument(:subscription_at).of_type("ISO8601DateTime")

--- a/spec/services/subscriptions/plan_upgrade_service_spec.rb
+++ b/spec/services/subscriptions/plan_upgrade_service_spec.rb
@@ -70,6 +70,35 @@ RSpec.describe Subscriptions::PlanUpgradeService do
       expect(result.subscription.plan.id).to eq(plan.id)
       expect(result.subscription.previous_subscription_id).to eq(subscription.id)
       expect(result.subscription.subscription_at).to eq(subscription.subscription_at)
+      expect(result.subscription.payment_method_id).to eq(nil)
+      expect(result.subscription.payment_method_type).to eq("provider")
+    end
+
+    context "with payment method" do
+      let(:payment_method) { create(:payment_method, organization: subscription.organization, customer: subscription.customer) }
+      let(:params) do
+        {
+          name: subscription_name,
+          payment_method: {
+            payment_method_id: payment_method.id,
+            payment_method_type: "provider"
+          }
+        }
+      end
+
+      before { payment_method }
+
+      it "creates a new subscription" do
+        expect(result).to be_success
+        expect(result.subscription.id).not_to eq(subscription.id)
+        expect(result.subscription).to be_active
+        expect(result.subscription.name).to eq(subscription_name)
+        expect(result.subscription.plan.id).to eq(plan.id)
+        expect(result.subscription.previous_subscription_id).to eq(subscription.id)
+        expect(result.subscription.subscription_at).to eq(subscription.subscription_at)
+        expect(result.subscription.payment_method_id).to eq(payment_method.id)
+        expect(result.subscription.payment_method_type).to eq("provider")
+      end
     end
 
     context "when new plan has fixed charges" do


### PR DESCRIPTION
## Context

Currently in Lago, there can only be one payment provider customer, with only one attached payment method.

## Description

With this feature, it will be possible to add multiple payment methods per provider customer.

This PR adds GQL support for attaching payment method to the subscription - in create flow. It also covers upgrade and downgrade cases.