### PR TITLE
feat(stripe): Cancel payment on failed 3ds attempt

### DIFF
--- a/app/jobs/payment_providers/stripe/cancel_payment_intent_job.rb
+++ b/app/jobs/payment_providers/stripe/cancel_payment_intent_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    class CancelPaymentIntentJob < ApplicationJob
+      queue_as do
+        if ActiveModel::Type::Boolean.new.cast(ENV["SIDEKIQ_PAYMENTS"])
+          :payments
+        else
+          :providers
+        end
+      end
+
+      def perform(organization_id:, provider_payment_id:)
+        payment = Payment.find_by(organization_id:, provider_payment_id:)
+
+        PaymentProviders::Stripe::Payments::CancelPaymentService.call!(payment_provider: payment.payment_provider, payment_intent_id: provider_payment_id)
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/stripe/payments/cancel_payment_service.rb
+++ b/app/services/payment_providers/stripe/payments/cancel_payment_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    module Payments
+      class CancelPaymentService < BaseService
+        Result = BaseResult
+
+        def initialize(payment_provider:, payment_intent_id:)
+          @payment_intent_id = payment_intent_id
+
+          super(payment_provider)
+        end
+
+        def call
+          ::Stripe::PaymentIntent.cancel(
+            payment_intent_id,
+            {},
+            api_key: payment_provider.secret_key
+          )
+
+          result
+        rescue ::Stripe::StripeError => e
+          result.provider_failure!(provider: payment_provider, error: e)
+        end
+
+        private
+
+        attr_reader :payment_intent_id
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/stripe/webhooks/payment_intent_payment_failed_service.rb
+++ b/app/services/payment_providers/stripe/webhooks/payment_intent_payment_failed_service.rb
@@ -5,7 +5,15 @@ module PaymentProviders
     module Webhooks
       class PaymentIntentPaymentFailedService < BaseService
         def call
-          update_payment_status! "failed"
+          result = update_payment_status! "failed"
+
+          # NOTE: In case of 3DS failure, the checkout link becomes invalid so in lago, we'll create a new payment instead of a new link
+          #       for the existing payment intent.
+          if event.data.object.status == "requires_payment_method"
+            PaymentProviders::Stripe::CancelPaymentIntentJob.perform_later(organization_id: organization.id, provider_payment_id: event.data.object.id)
+          end
+
+          result
         end
       end
     end


### PR DESCRIPTION
Works on my machine ™️  but not rspec tested yet.

The job should be reused on Invoice::UpdateService when the payment status is updated via API or GQL.