### PR TITLE
fix(progressive-billing): subtract coupons when calculating to_credit_amount

### DIFF
--- a/app/services/subscriptions/progressive_billed_amount.rb
+++ b/app/services/subscriptions/progressive_billed_amount.rb
@@ -49,15 +49,14 @@ module Subscriptions
       invoice = invoice_subscription.invoice
       result.progressive_billing_invoice = invoice
       result.progressive_billed_amount = result.progressive_billing_invoice.fees_amount_cents
+
       result.to_credit_amount = invoice.fees_amount_cents
+      result.to_credit_amount -= invoice.coupons_amount_cents
+      result.to_credit_amount -= invoice.progressive_billing_credits.sum(:amount_cents)
+      result.to_credit_amount -= invoice.credit_notes.available.sum(:credit_amount_cents)
 
-      if invoice.progressive_billing_credits.exists? || invoice.credit_notes.available.exists?
-        result.to_credit_amount -= invoice.progressive_billing_credits.sum(:amount_cents)
-        result.to_credit_amount -= invoice.credit_notes.available.sum(:credit_amount_cents)
-
-        # if for some reason this goes below zero, it should be zero.
-        result.to_credit_amount = 0 if result.to_credit_amount.negative?
-      end
+      # if for some reason this goes below zero, it should be zero.
+      result.to_credit_amount = 0 if result.to_credit_amount.negative?
 
       result
     end

--- a/spec/services/subscriptions/progressive_billed_amount_spec.rb
+++ b/spec/services/subscriptions/progressive_billed_amount_spec.rb
@@ -252,4 +252,208 @@ RSpec.describe Subscriptions::ProgressiveBilledAmount do
       end
     end
   end
+
+  context "with progressive billing invoice that has 100% coupon discount" do
+    let(:invoice_subscription) { create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) }
+    let(:invoice) { invoice_subscription.invoice }
+    let(:charge) { create(:standard_charge, plan: subscription.plan) }
+    let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, amount_cents: 100, precise_coupons_amount_cents: 100, taxes_amount_cents: 0) }
+
+    before do
+      fee
+      invoice.update!(invoice_type:, fees_amount_cents: 100, coupons_amount_cents: 100, sub_total_excluding_taxes_amount_cents: 0, total_amount_cents: 0)
+    end
+
+    it "returns to_credit_amount of 0 when fees are fully discounted" do
+      result = service.call
+      expect(result.progressive_billing_invoice).to eq(invoice)
+      expect(result.progressive_billed_amount).to eq(100)
+      expect(result.to_credit_amount).to be_zero
+      expect(result.total_billed_amount_cents).to be_zero
+    end
+  end
+
+  context "with progressive billing invoice that has partial coupon discount" do
+    let(:invoice_subscription) { create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) }
+    let(:invoice) { invoice_subscription.invoice }
+    let(:charge) { create(:standard_charge, plan: subscription.plan) }
+    let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, amount_cents: 100, precise_coupons_amount_cents: 30, taxes_amount_cents: 14) }
+
+    before do
+      fee
+      invoice.update!(invoice_type:, fees_amount_cents: 100, coupons_amount_cents: 30, sub_total_excluding_taxes_amount_cents: 70, taxes_amount_cents: 14, total_amount_cents: 84)
+    end
+
+    it "returns net amount after coupons" do
+      result = service.call
+      expect(result.progressive_billing_invoice).to eq(invoice)
+      expect(result.progressive_billed_amount).to eq(100)
+      expect(result.to_credit_amount).to eq(70)
+      expect(result.total_billed_amount_cents).to eq(84)
+    end
+  end
+
+  context "with multiple progressive billing invoices with coupons" do
+    let(:invoice_subscription1) { create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) }
+    let(:invoice1) { invoice_subscription1.invoice }
+    let(:invoice_subscription2) { create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) }
+    let(:invoice2) { invoice_subscription2.invoice }
+    let(:charge) { create(:standard_charge, plan: subscription.plan) }
+    let(:fee1) { create(:charge_fee, invoice: invoice1, subscription:, charge:, amount_cents: 50, precise_coupons_amount_cents: 10, taxes_amount_cents: 0) }
+    let(:fee2) { create(:charge_fee, invoice: invoice2, subscription:, charge:, amount_cents: 100, precise_coupons_amount_cents: 20, taxes_amount_cents: 0) }
+
+    before do
+      fee1
+      fee2
+      invoice1.update!(invoice_type:, issuing_date: timestamp - 2.days, fees_amount_cents: 50, coupons_amount_cents: 10, sub_total_excluding_taxes_amount_cents: 40)
+      invoice2.update!(invoice_type:, issuing_date: timestamp - 1.day, fees_amount_cents: 100, coupons_amount_cents: 20, sub_total_excluding_taxes_amount_cents: 80)
+    end
+
+    it "returns to_credit_amount from most recent invoice after coupons" do
+      result = service.call
+      expect(result.progressive_billing_invoice).to eq(invoice2)
+      expect(result.progressive_billed_amount).to eq(100)
+      expect(result.to_credit_amount).to eq(80)
+      expect(result.total_billed_amount_cents).to eq(120)
+    end
+  end
+
+  context "with progressive billing invoice with coupons and existing credits" do
+    let(:invoice_subscription) { create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) }
+    let(:invoice) { invoice_subscription.invoice }
+    let(:charge) { create(:standard_charge, plan: subscription.plan) }
+    let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, amount_cents: 100, precise_coupons_amount_cents: 20, taxes_amount_cents: 0) }
+    let(:existing_credit) { create(:credit, invoice:, progressive_billing_invoice: invoice, amount_cents: 30) }
+
+    before do
+      fee
+      invoice.update!(invoice_type:, fees_amount_cents: 100, coupons_amount_cents: 20, sub_total_excluding_taxes_amount_cents: 80)
+      existing_credit
+    end
+
+    it "subtracts existing credits from net amount" do
+      result = service.call
+      expect(result.progressive_billing_invoice).to eq(invoice)
+      expect(result.progressive_billed_amount).to eq(100)
+      expect(result.to_credit_amount).to eq(50)
+      expect(result.total_billed_amount_cents).to eq(80)
+    end
+  end
+
+  context "with progressive billing invoice with coupons and existing credit notes" do
+    let(:invoice_subscription) { create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) }
+    let(:invoice) { invoice_subscription.invoice }
+    let(:charge) { create(:standard_charge, plan: subscription.plan) }
+    let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, amount_cents: 100, precise_coupons_amount_cents: 20, taxes_amount_cents: 0) }
+    let(:existing_credit_note) { create(:credit_note, invoice:, credit_amount_cents: 20, total_amount_cents: 20, credit_status: :available) }
+
+    before do
+      fee
+      invoice.update!(invoice_type:, fees_amount_cents: 100, coupons_amount_cents: 20, sub_total_excluding_taxes_amount_cents: 80)
+      existing_credit_note
+    end
+
+    it "subtracts existing credit notes from net amount" do
+      result = service.call
+      expect(result.progressive_billing_invoice).to eq(invoice)
+      expect(result.progressive_billed_amount).to eq(100)
+      expect(result.to_credit_amount).to eq(60)
+      expect(result.total_billed_amount_cents).to eq(80)
+    end
+  end
+
+  context "when coupons and existing credits would result in negative to_credit_amount" do
+    let(:invoice_subscription) { create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) }
+    let(:invoice) { invoice_subscription.invoice }
+    let(:charge) { create(:standard_charge, plan: subscription.plan) }
+    let(:fee) { create(:charge_fee, invoice:, subscription:, charge:, amount_cents: 100, precise_coupons_amount_cents: 60, taxes_amount_cents: 0) }
+    let(:existing_credit) { create(:credit, invoice:, progressive_billing_invoice: invoice, amount_cents: 50) }
+
+    before do
+      fee
+      invoice.update!(invoice_type:, fees_amount_cents: 100, coupons_amount_cents: 60, sub_total_excluding_taxes_amount_cents: 40)
+      existing_credit
+    end
+
+    it "returns 0 instead of negative value" do
+      result = service.call
+      expect(result.progressive_billing_invoice).to eq(invoice)
+      expect(result.progressive_billed_amount).to eq(100)
+      expect(result.to_credit_amount).to be_zero
+      expect(result.total_billed_amount_cents).to eq(40)
+    end
+  end
+
+  context "with progressive billing invoice that has credit notes with different statuses" do
+    let(:invoice_subscription) { create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) }
+    let(:invoice) { invoice_subscription.invoice }
+    let(:fee) { create(:charge_fee, invoice:, subscription:, amount_cents: 100, taxes_amount_cents: 0) }
+    let(:available_credit_note) { create(:credit_note, invoice:, credit_amount_cents: 20, total_amount_cents: 20, credit_status: :available) }
+    let(:consumed_credit_note) { create(:credit_note, invoice:, credit_amount_cents: 10, total_amount_cents: 10, credit_status: :consumed) }
+    let(:voided_credit_note) { create(:credit_note, invoice:, credit_amount_cents: 15, total_amount_cents: 15, credit_status: :voided) }
+
+    before do
+      fee
+      invoice.update!(invoice_type:, fees_amount_cents: 100)
+      available_credit_note
+      consumed_credit_note
+      voided_credit_note
+    end
+
+    it "only subtracts available credit notes from to_credit_amount" do
+      result = service.call
+      expect(result.progressive_billing_invoice).to eq(invoice)
+      expect(result.progressive_billed_amount).to eq(100)
+      expect(result.to_credit_amount).to eq(80)
+    end
+  end
+
+  context "with multiple progressive billing invoices with same issuing_date" do
+    let(:invoice_subscription1) { create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) }
+    let(:invoice1) { invoice_subscription1.invoice }
+    let(:invoice_subscription2) { create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) }
+    let(:invoice2) { invoice_subscription2.invoice }
+    let(:fee1) { create(:charge_fee, invoice: invoice1, subscription:, amount_cents: 50, taxes_amount_cents: 0) }
+    let(:fee2) { create(:charge_fee, invoice: invoice2, subscription:, amount_cents: 100, taxes_amount_cents: 0) }
+    let(:same_issuing_date) { timestamp - 1.day }
+
+    before do
+      fee1
+      fee2
+      invoice1.update!(invoice_type:, issuing_date: same_issuing_date, created_at: timestamp - 2.hours, fees_amount_cents: 50)
+      invoice2.update!(invoice_type:, issuing_date: same_issuing_date, created_at: timestamp - 1.hour, fees_amount_cents: 100)
+    end
+
+    it "returns the most recently created invoice when issuing_dates are the same" do
+      result = service.call
+      expect(result.progressive_billing_invoice).to eq(invoice2)
+      expect(result.progressive_billed_amount).to eq(100)
+      expect(result.to_credit_amount).to eq(100)
+      expect(result.total_billed_amount_cents).to eq(150)
+    end
+  end
+
+  context "with progressive billing invoice that has multiple fees with varying coupons" do
+    let(:invoice_subscription) { create(:invoice_subscription, subscription:, charges_from_datetime:, charges_to_datetime:) }
+    let(:invoice) { invoice_subscription.invoice }
+    let(:charge) { create(:standard_charge, plan: subscription.plan) }
+    let(:fee1) { create(:charge_fee, invoice:, subscription:, charge:, amount_cents: 100, precise_coupons_amount_cents: 30, taxes_amount_cents: 0) }
+    let(:fee2) { create(:charge_fee, invoice:, subscription:, charge:, amount_cents: 50, precise_coupons_amount_cents: 10, taxes_amount_cents: 0) }
+    let(:fee3) { create(:charge_fee, invoice:, subscription:, charge:, amount_cents: 30, precise_coupons_amount_cents: 0, taxes_amount_cents: 0) }
+
+    before do
+      fee1
+      fee2
+      fee3
+      invoice.update!(invoice_type:, fees_amount_cents: 180, coupons_amount_cents: 40, sub_total_excluding_taxes_amount_cents: 140)
+    end
+
+    it "correctly calculates total_billed_amount_cents from multiple fees with varying coupons" do
+      result = service.call
+      expect(result.progressive_billing_invoice).to eq(invoice)
+      expect(result.progressive_billed_amount).to eq(180)
+      expect(result.to_credit_amount).to eq(140)
+      expect(result.total_billed_amount_cents).to eq(140)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Invoices::FinalizeJob was failing with validation error "total_amount_must_be_positive" when finalizing invoices with progressive billing that had coupons applied. The root cause was that to_credit_amount used the gross fees amount instead of the net amount the customer actually paid after coupon deductions.

This caused validation failures when progressive billing invoices were fully discounted by coupons, and could lead to over-crediting or under-crediting customers in scenarios with partial coupon discounts.

## Description

Modified Subscriptions::ProgressiveBilledAmount to calculate to_credit_amount by subtracting coupons_amount_cents from fees_amount_cents. This ensures customers receive credit for exactly what they paid during progressive billing, not the gross fee amount.

The calculation now correctly reflects the net amount: to_credit_amount = fees - coupons - existing_credits - existing_credit_notes, with a floor of zero for over-credited scenarios.

Added comprehensive test coverage including fully discounted invoices, partial discounts, multiple progressive billing invoices with coupons, combinations with existing credits and credit notes, credit note status filtering, issuing_date ordering, and multiple fees with varying coupon amounts.