### PR TITLE
fix(health): add readiness probe for graceful shutdown

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,14 @@ class ApplicationController < ActionController::API
     )
   end
 
+  def ready
+    if $shutdown_requested # rubocop:disable Style/GlobalVars
+      render json: {status: "shutting down"}, status: :service_unavailable
+    else
+      render json: {status: "ok"}
+    end
+  end
+
   def not_found
     not_found_error(resource: "resource")
   end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -16,6 +16,16 @@ threads min_threads_count, max_threads_count
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 worker_timeout 12 if ENV.fetch("RAILS_ENV", "production") == "production"
 
+worker_shutdown_timeout 30
+on_worker_boot do
+  $shutdown_requested = false # rubocop:disable Style/GlobalVars
+end
+
+on_worker_shutdown do
+  $shutdown_requested = true # rubocop:disable Style/GlobalVars
+  sleep 5  # let k8s remove from endpoints
+end
+
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
 port ENV.fetch("PORT", 3000)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   # Health Check status
   get "/health", to: "application#health"
+  get "/ready", to: "application#ready"
 
   namespace :data_api do
     namespace :v1 do


### PR DESCRIPTION
Add /ready endpoint to prevent 502 errors during pod termination. When Kubernetes sends SIGTERM, the endpoint returns HTTP 503, causing the pod to be removed from service endpoints before connections are closed.

Changes:
- Add /ready endpoint that checks $shutdown_requested flag
- Set $shutdown_requested in Puma's on_worker_shutdown hook